### PR TITLE
Refactor assay retrieval and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# ChEMBL_data_acquisition
+# ChEMBL data acquisition
+
+Utilities for collecting target, assay, and document information from the
+[ChEMBL](https://www.ebi.ac.uk/chembl/) API and related services.  The
+repository provides reusable library functions along with small command line
+wrappers for bulk data retrieval.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Assay data
+
+```bash
+python csv/python/get_assay_data.py assays.csv output.csv
+```
+
+The input CSV must contain a column named `assay_chembl_id` with ChEMBL assay
+identifiers.  Additional options such as delimiter or encoding can be adjusted
+via command line flags (`--sep`, `--encoding`).
+
+### Document data
+
+```bash
+python get_document_data.py documents.csv output.csv
+```
+
+By default the script reads the `document_chembl_id` column from the input
+file.  Use `--column` to override the field name.
+
+## Development
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+Recommended quality tools:
+
+```bash
+black .
+ruff .
+mypy .
+```
+
+## License
+
+This project is provided under the MIT license.  See `LICENSE` for details.

--- a/csv/python/get_assay_data.py
+++ b/csv/python/get_assay_data.py
@@ -87,7 +87,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    df = cl.get_assays_all(ids, chunk_size=args.chunk_size)
+    df = cl.get_assays(ids, chunk_size=args.chunk_size)
     try:
         df.to_csv(args.output_csv, index=False, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), args.output_csv)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -282,7 +282,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     chembl.add_argument("output_csv", type=Path, help="Destination CSV file")
     chembl.add_argument(
-        "--column", default="chembl_id", help="Column name containing identifiers"
+        "--column", default="document_chembl_id", help="Column name containing identifiers"
     )
     chembl.add_argument("--sep", default=",", help="CSV delimiter")
     chembl.add_argument("--encoding", default="utf8", help="File encoding")
@@ -297,7 +297,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     all_cmd.add_argument("output_csv", type=Path, help="Destination CSV file")
     all_cmd.add_argument(
-        "--column", default="chembl_id", help="Column in the input CSV"
+        "--column", default="document_chembl_id", help="Column in the input CSV"
     )
     all_cmd.add_argument("--sep", default=",", help="CSV delimiter")
     all_cmd.add_argument("--encoding", default="utf8", help="File encoding")

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for data acquisition from public APIs."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas>=2.0
+requests>=2.31
+pytest>=7.0
+requests-mock>=1.10

--- a/tests/data/assays.json
+++ b/tests/data/assays.json
@@ -1,0 +1,9 @@
+{
+  "assays": [
+    {
+      "assay_chembl_id": "CHEMBL123",
+      "assay_type": "B",
+      "description": "dummy assay"
+    }
+  ]
+}

--- a/tests/test_chembl_library.py
+++ b/tests/test_chembl_library.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import requests_mock
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from library import chembl_library as cl
+
+
+def test_get_assays_returns_dataframe(requests_mock: requests_mock.Mocker) -> None:
+    data_path = Path(__file__).parent / "data/assays.json"
+    payload = json.loads(data_path.read_text())
+    url = (
+        "https://www.ebi.ac.uk/chembl/api/data/assay.json?format=json&assay_chembl_id__in=CHEMBL123"
+    )
+    requests_mock.get(url, json=payload)
+
+    df = cl.get_assays(["CHEMBL123"])
+
+    assert not df.empty
+    assert df.loc[0, "assay_chembl_id"] == "CHEMBL123"
+
+
+def test_get_assays_with_variants_adds_filter(requests_mock: requests_mock.Mocker) -> None:
+    url = (
+        "https://www.ebi.ac.uk/chembl/api/data/assay.json?format=json&variant_sequence__isnull=false&assay_chembl_id__in=CHEMBL123"
+    )
+    requests_mock.get(url, json={"assays": []})
+
+    df = cl.get_assays_with_variants(["CHEMBL123"])
+
+    assert df.empty
+    assert requests_mock.called
+    assert requests_mock.last_request.url == url
+
+
+def test_get_assays_empty_ids_returns_empty_dataframe() -> None:
+    df = cl.get_assays(["", "#N/A"])
+    assert df.empty


### PR DESCRIPTION
## Summary
- consolidate ChEMBL assay fetching into reusable helper with variant filtering and timeout handling
- add unit tests and requirements file
- expand README with installation and usage instructions

## Testing
- `python -m py_compile csv/python/get_assay_data.py get_document_data.py library/chembl_library.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41c6019348324813261f7aeecbbc3