### PR TITLE
Add review classification pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+pytest_cache/
+output_dir/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # ChEMBL_data_acquisition
+
+## Review classification
+
+This repository now includes a small, reproducible pipeline for classifying
+publications as **review**, **non_review**, or **uncertain**.
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Usage
+
+```bash
+python main.py --input tests/data/sample_records.json --output output
+```
+
+Artifacts are written to the specified output directory using the structure
+outlined in the project documentation.
+
+### Quality tools
+
+The following tools are recommended:
+
+```bash
+black .
+ruff .
+mypy .
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ pip install -r requirements.txt
 
 ```bash
 python main.py --input tests/data/sample_records.json --output output
+# explicit encoding can be supplied if needed
+python main.py --input non_utf8.json --output output --encoding cp1252
 ```
+
+The same CLI is also available as ``get_document_classification.py`` for
+compatibility with existing scripts.
 
 Artifacts are written to the specified output directory using the structure
 outlined in the project documentation.

--- a/get_document_classification.py
+++ b/get_document_classification.py
@@ -1,0 +1,8 @@
+"""Wrapper script for review classification CLI.
+
+Provides backward-compatible command name.
+"""
+from main import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,37 @@
+"""CLI entry point for review classification."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import List
+
+from review_classifier.pipeline import process_records
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Classify publications as reviews or not")
+    parser.add_argument("--input", type=Path, required=True, help="Path to NDJSON input file")
+    parser.add_argument("--output", type=Path, required=True, help="Directory for artifacts")
+    parser.add_argument(
+        "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"], help="Logging level"
+    )
+    return parser.parse_args()
+
+
+def load_records(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh]
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    logger = logging.getLogger("review_classifier")
+    records = load_records(args.input)
+    process_records(records, args.output, logger)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -11,25 +11,60 @@ from review_classifier.pipeline import process_records
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Classify publications as reviews or not")
     parser.add_argument("--input", type=Path, required=True, help="Path to NDJSON input file")
     parser.add_argument("--output", type=Path, required=True, help="Directory for artifacts")
+    parser.add_argument("--encoding", default="utf-8", help="Encoding of the input file")
     parser.add_argument(
         "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"], help="Logging level"
     )
     return parser.parse_args()
 
 
-def load_records(path: Path) -> List[dict]:
-    with path.open("r", encoding="utf-8") as fh:
-        return [json.loads(line) for line in fh]
+def load_records(path: Path, encoding: str) -> List[dict]:
+    """Load NDJSON records from ``path`` using ``encoding``.
+
+    Parameters
+    ----------
+    path : Path
+        Location of the NDJSON file.
+    encoding : str
+        Text encoding used by ``path``.
+
+    Returns
+    -------
+    list of dict
+        Parsed records from the input file.
+
+    Raises
+    ------
+    ValueError
+        If the file cannot be decoded or contains malformed JSON.
+    FileNotFoundError
+        If ``path`` does not exist.
+    """
+    try:
+        with path.open("r", encoding=encoding) as fh:
+            return [json.loads(line) for line in fh]
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"failed to decode {path} with encoding '{encoding}'") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed JSON in {path}: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"input file not found: {path}") from exc
 
 
 def main() -> None:
+    """Command-line interface for document classification."""
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
     logger = logging.getLogger("review_classifier")
-    records = load_records(args.input)
+    try:
+        records = load_records(args.input, args.encoding)
+    except (ValueError, FileNotFoundError) as exc:
+        logger.error("%s", exc)
+        raise SystemExit(1)
     process_records(records, args.output, logger)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.1
+pyarrow>=14.0

--- a/review_classifier/__init__.py
+++ b/review_classifier/__init__.py
@@ -1,0 +1,8 @@
+"""Review classification package."""
+
+__all__ = [
+    "constants",
+    "normalization",
+    "scoring",
+    "pipeline",
+]

--- a/review_classifier/constants.py
+++ b/review_classifier/constants.py
@@ -1,0 +1,91 @@
+"""Constants and mappings for review classification."""
+from __future__ import annotations
+
+from typing import Dict, List, Mapping
+
+# Source weights compensate for varying accuracy of publication type fields
+SRC_WEIGHTS: Mapping[str, float] = {
+    "pubmed": 1.0,
+    "crossref": 0.7,
+    "openalex": 0.7,
+    "scholar": 0.5,
+}
+
+# Publication types signalling a review
+REVIEW_PUBLICATION_TYPES: Mapping[str, int] = {
+    "REVIEW": 3,
+    "SYSTEMATIC_REVIEW": 4,
+    "META_ANALYSIS": 5,
+    "SCOPING_REVIEW": 3,
+}
+
+# Publication types indicating non-review content
+NONREVIEW_PUBLICATION_TYPES: Mapping[str, int] = {
+    "RCT": 3,
+    "CLINICAL_TRIAL": 3,
+    "CASE_REPORT": 3,
+    "PRECLINICAL": 3,
+    "IN_VITRO": 3,
+    "IN_VIVO": 3,
+}
+
+# MeSH descriptor markers for review-like content
+MESH_REVIEW_MARKERS: Mapping[str, int] = {
+    "review literature as topic": 4,
+    "systematic reviews as topic": 4,
+    "meta-analysis as topic": 4,
+    "practice guidelines as topic": 4,
+    "evidence-based practice": 4,
+}
+
+# Strong MeSH descriptors indicating experimental/non-review work
+MESH_NONREVIEW_STRONG: Mapping[str, int] = {
+    "in vitro techniques": 3,
+    "cell line": 3,
+    "animals": 3,
+    "disease models, animal": 3,
+    "randomized controlled trial as topic": 3,
+    "double-blind method": 3,
+    "treatment outcome": 3,
+}
+
+# MeSH qualifiers signalling experimental work
+MESH_EXPERIMENTAL_QUALIFIERS: List[str] = [
+    "methods",
+    "drug therapy",
+    "adverse effects",
+    "chemistry",
+    "metabolism",
+    "pharmacology",
+    "radiation effects",
+    "ultrastructure",
+    "genetics",
+    "immunology",
+]
+
+# Mapping of source specific publication type labels to normalized ones
+PUBLICATION_TYPE_MAPPING: Dict[str, Dict[str, str]] = {
+    "pubmed": {
+        "Review": "REVIEW",
+        "Systematic Review": "SYSTEMATIC_REVIEW",
+        "Meta-Analysis": "META_ANALYSIS",
+        "Scoping Review": "SCOPING_REVIEW",
+        "Clinical Trial": "CLINICAL_TRIAL",
+        "Randomized Controlled Trial": "RCT",
+        "Case Reports": "CASE_REPORT",
+    },
+    "crossref": {
+        "review": "REVIEW",
+        "meta-analysis": "META_ANALYSIS",
+        "journal-article": "OTHER",
+    },
+    "openalex": {
+        "review": "REVIEW",
+        "meta_analysis": "META_ANALYSIS",
+        "clinical_trial": "CLINICAL_TRIAL",
+    },
+    "scholar": {
+        "Review": "REVIEW",
+        "Meta Analysis": "META_ANALYSIS",
+    },
+}

--- a/review_classifier/normalization.py
+++ b/review_classifier/normalization.py
@@ -1,0 +1,68 @@
+"""Normalization utilities for publication data."""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Mapping, Sequence, Tuple
+
+from .constants import PUBLICATION_TYPE_MAPPING
+
+
+def normalize_publication_types(
+    raw: Mapping[str, Sequence[str]],
+) -> Dict[str, List[str]]:
+    """Normalize publication type labels from multiple sources.
+
+    Parameters
+    ----------
+    raw:
+        Mapping of source name to list of raw publication type strings.
+
+    Returns
+    -------
+    dict
+        Mapping of source name to list of normalized publication type strings.
+    """
+    normalized: Dict[str, List[str]] = {}
+    for source, pts in raw.items():
+        mapping = PUBLICATION_TYPE_MAPPING.get(source, {})
+        norm_pts = []
+        for pt in pts:
+            mapped = mapping.get(pt)
+            if mapped:
+                norm_pts.append(mapped)
+        if norm_pts:
+            normalized[source] = norm_pts
+    return normalized
+
+
+def _clean(text: str) -> str:
+    """Normalize text by lowering case and stripping punctuation."""
+    lowered = text.lower()
+    cleaned = re.sub(r"[\-\._]", " ", lowered)
+    cleaned = re.sub(r"[^a-z0-9\s]", "", cleaned)
+    return cleaned.strip()
+
+
+def normalize_mesh(
+    descriptors: Mapping[str, Sequence[str]],
+    qualifiers: Mapping[str, Sequence[str]],
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+    """Normalize MeSH descriptors and qualifiers.
+
+    Parameters
+    ----------
+    descriptors, qualifiers:
+        Mapping of source name to list of descriptor/qualifier strings.
+
+    Returns
+    -------
+    tuple(dict, dict)
+        Two dictionaries with normalized descriptors and qualifiers.
+    """
+    norm_desc: Dict[str, List[str]] = {}
+    norm_qual: Dict[str, List[str]] = {}
+    for source, items in descriptors.items():
+        norm_desc[source] = [_clean(d) for d in items]
+    for source, items in qualifiers.items():
+        norm_qual[source] = [_clean(q) for q in items]
+    return norm_desc, norm_qual

--- a/review_classifier/pipeline.py
+++ b/review_classifier/pipeline.py
@@ -1,0 +1,104 @@
+"""Batch processing pipeline for review classification."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+import pandas as pd
+
+from .normalization import normalize_mesh, normalize_publication_types
+from .scoring import Record, score_record
+
+
+def _make_uid(ids: Mapping[str, str]) -> str:
+    """Combine available identifiers into a single uid."""
+    for key in ("doi", "pmid", "pmcid", "openalexid"):
+        if ids.get(key):
+            return ids[key]
+    # fallback to joined ids
+    return "|".join(f"{k}:{v}" for k, v in ids.items())
+
+
+def process_records(records: Sequence[Mapping[str, object]], output_dir: Path, logger: logging.Logger) -> None:
+    """Process an iterable of raw records and persist artifacts.
+
+    Parameters
+    ----------
+    records:
+        Sequence of raw record dictionaries.
+    output_dir:
+        Base directory where artifacts are written.
+    logger:
+        Logger for decision trail output.
+    """
+    raw_dir = output_dir / "raw"
+    norm_dir = output_dir / "normalized"
+    feat_dir = output_dir / "features"
+    score_dir = output_dir / "scores"
+    decision_dir = output_dir / "decisions"
+    log_dir = output_dir / "logs"
+
+    for d in [raw_dir, norm_dir, feat_dir, score_dir, decision_dir, log_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    raw_path = raw_dir / "records.ndjson"
+    with raw_path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+    pt_rows: List[Dict[str, object]] = []
+    mesh_rows: List[Dict[str, object]] = []
+    score_rows: List[Dict[str, object]] = []
+    label_rows: List[Dict[str, object]] = []
+
+    for rec in records:
+        ids = rec.get("ids", {})
+        uid = _make_uid(ids)
+        raw_pt = rec.get("publication_types", {})
+        raw_mesh = rec.get("mesh_terms", {})
+        raw_desc = {k: v.get("descriptors", []) for k, v in raw_mesh.items()}
+        raw_qual = {k: v.get("qualifiers", []) for k, v in raw_mesh.items()}
+
+        norm_pt = normalize_publication_types(raw_pt)
+        norm_desc, norm_qual = normalize_mesh(raw_desc, raw_qual)
+
+        for src, pts in norm_pt.items():
+            for pt in pts:
+                pt_rows.append({"uid": uid, "source": src, "pub_type": pt})
+        for src, descs in norm_desc.items():
+            for dsc in descs:
+                mesh_rows.append({"uid": uid, "kind": "descriptor", "value": dsc})
+        for src, quals in norm_qual.items():
+            for q in quals:
+                mesh_rows.append({"uid": uid, "kind": "qualifier", "value": q})
+
+        record_obj = Record(ids=ids, pts=norm_pt, mesh_desc=norm_desc, mesh_qual=norm_qual)
+        result = score_record(record_obj, logger)
+
+        score_rows.append(
+            {
+                "uid": uid,
+                "score_review": result.score_review,
+                "score_non_review": result.score_non_review,
+            }
+        )
+        label_rows.append(
+            {
+                "uid": uid,
+                "label": result.label,
+                "reason": result.reason,
+            }
+        )
+
+    pd.DataFrame(pt_rows).to_parquet(norm_dir / "publication_type.parquet")
+    pd.DataFrame(mesh_rows).to_parquet(feat_dir / "mesh.parquet")
+    pd.DataFrame(score_rows).to_parquet(score_dir / "scores.parquet")
+    pd.DataFrame(label_rows).to_parquet(decision_dir / "labels.parquet")
+
+    run_meta = {
+        "rules": "v1",
+        "records": len(records),
+    }
+    (output_dir / "run_meta.json").write_text(json.dumps(run_meta, indent=2), encoding="utf-8")

--- a/review_classifier/scoring.py
+++ b/review_classifier/scoring.py
@@ -1,0 +1,130 @@
+"""Scoring logic for review classification."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Tuple
+
+from .constants import (
+    MESH_EXPERIMENTAL_QUALIFIERS,
+    MESH_NONREVIEW_STRONG,
+    MESH_REVIEW_MARKERS,
+    NONREVIEW_PUBLICATION_TYPES,
+    REVIEW_PUBLICATION_TYPES,
+    SRC_WEIGHTS,
+)
+
+
+@dataclass
+class Record:
+    """Normalized information required for classification."""
+
+    ids: Mapping[str, str]
+    pts: Mapping[str, List[str]]
+    mesh_desc: Mapping[str, List[str]]
+    mesh_qual: Mapping[str, List[str]]
+
+
+@dataclass
+class ScoreResult:
+    """Outcome of scoring for a record."""
+
+    label: str
+    score_review: float
+    score_non_review: float
+    reason: str
+    contrib: Dict[str, List[Tuple[str, str, str, float]]] = field(default_factory=dict)
+
+
+def score_record(record: Record, logger: logging.Logger) -> ScoreResult:
+    """Score a normalized record and return the classification label.
+
+    Parameters
+    ----------
+    record:
+        Normalized record to be classified.
+    logger:
+        Logger for emitting decision trail information.
+
+    Returns
+    -------
+    ScoreResult
+        Dataclass containing the decision and detailed scores.
+    """
+    contrib: Dict[str, List[Tuple[str, str, str, float]]] = {"review": [], "non_review": []}
+    s_review = 0.0
+    s_non = 0.0
+
+    # Publication type contribution
+    for src, pts in record.pts.items():
+        weight = SRC_WEIGHTS.get(src, 0.5)
+        for pt in pts:
+            if pt in REVIEW_PUBLICATION_TYPES:
+                val = REVIEW_PUBLICATION_TYPES[pt] * weight
+                s_review += val
+                contrib["review"].append(("PT", src, pt, val))
+            if pt in NONREVIEW_PUBLICATION_TYPES:
+                val = NONREVIEW_PUBLICATION_TYPES[pt] * weight
+                s_non += val
+                contrib["non_review"].append(("PT", src, pt, val))
+
+    # Merge MeSH across sources
+    desc = {d for lst in record.mesh_desc.values() for d in lst}
+    qual = {q for lst in record.mesh_qual.values() for q in lst}
+
+    for d in desc:
+        if d in MESH_REVIEW_MARKERS:
+            val = float(MESH_REVIEW_MARKERS[d])
+            s_review += val
+            contrib["review"].append(("MeSHD", "any", d, val))
+        if d in MESH_NONREVIEW_STRONG:
+            val = float(MESH_NONREVIEW_STRONG[d])
+            s_non += val
+            contrib["non_review"].append(("MeSHD", "any", d, val))
+
+    for q in qual:
+        if q in MESH_EXPERIMENTAL_QUALIFIERS:
+            val = 2.0
+            s_non += val
+            contrib["non_review"].append(("MeSHQ", "any", q, val))
+
+    has_meta = any("META_ANALYSIS" in pts for pts in record.pts.values())
+    has_exp = len(qual.intersection(MESH_EXPERIMENTAL_QUALIFIERS)) > 0
+
+    if has_meta and not has_exp:
+        label = "review"
+        reason = "PT META_ANALYSIS without experimental MeSH"
+    else:
+        if s_review - s_non >= 3.0:
+            label = "review"
+            reason = "score_gap>=3"
+        elif s_non - s_review >= 3.0:
+            label = "non_review"
+            reason = "score_gap>=3"
+        else:
+            label = "uncertain"
+            reason = "scores_too_close"
+
+    result = ScoreResult(
+        label=label,
+        score_review=s_review,
+        score_non_review=s_non,
+        reason=reason,
+        contrib=contrib,
+    )
+
+    logger.info(
+        {
+            "event": "scoring",
+            "ids": record.ids,
+            "score_review": s_review,
+            "score_non_review": s_non,
+            "label": label,
+            "reason": reason,
+            "contrib": sorted(
+                contrib["review"] + contrib["non_review"], key=lambda x: -x[3]
+            )[:10],
+        }
+    )
+
+    return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for path adjustments."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/data/sample_records.json
+++ b/tests/data/sample_records.json
@@ -1,0 +1,2 @@
+{"ids": {"pmid": "1"}, "publication_types": {"pubmed": ["Systematic Review"], "crossref": ["journal-article"]}, "mesh_terms": {"pubmed": {"descriptors": ["systematic reviews as topic"], "qualifiers": []}}}
+{"ids": {"pmid": "2"}, "publication_types": {"pubmed": ["Clinical Trial"], "openalex": ["review"]}, "mesh_terms": {"pubmed": {"descriptors": ["double-blind method", "treatment outcome"], "qualifiers": ["methods"]}}}

--- a/tests/data/sample_records_cp1252.json
+++ b/tests/data/sample_records_cp1252.json
@@ -1,0 +1,1 @@
+{"ids": {"pmid": "1"}, "pts": {}, "mesh_desc": {}, "mesh_qual": {}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+"""Tests for CLI helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from main import load_records
+
+
+def test_load_records_encoding(tmp_path: Path) -> None:
+    path = tmp_path / "cp.json"
+    content = '{"ids": {}, "pts": {}, "mesh_desc": {}, "mesh_qual": {}}\n'
+    path.write_bytes(content.encode("cp1252"))
+    data = load_records(path, "cp1252")
+    assert data[0]["ids"] == {}

--- a/tests/test_review_classifier.py
+++ b/tests/test_review_classifier.py
@@ -1,0 +1,40 @@
+"""Unit tests for review classification pipeline."""
+from __future__ import annotations
+
+import logging
+
+from review_classifier.normalization import normalize_publication_types
+from review_classifier.scoring import Record, score_record
+
+
+def test_normalize_publication_types() -> None:
+    raw = {"pubmed": ["Systematic Review"], "crossref": ["meta-analysis", "journal-article"]}
+    norm = normalize_publication_types(raw)
+    assert norm["pubmed"] == ["SYSTEMATIC_REVIEW"]
+    assert "META_ANALYSIS" in norm["crossref"]
+
+
+def test_score_record_review() -> None:
+    logger = logging.getLogger("test")
+    logger.addHandler(logging.NullHandler())
+    record = Record(
+        ids={"pmid": "1"},
+        pts={"pubmed": ["SYSTEMATIC_REVIEW"]},
+        mesh_desc={"pubmed": ["systematic reviews as topic"]},
+        mesh_qual={},
+    )
+    result = score_record(record, logger)
+    assert result.label == "review"
+
+
+def test_score_record_non_review() -> None:
+    logger = logging.getLogger("test")
+    logger.addHandler(logging.NullHandler())
+    record = Record(
+        ids={"pmid": "2"},
+        pts={"pubmed": ["CLINICAL_TRIAL"], "openalex": ["REVIEW"]},
+        mesh_desc={"pubmed": ["double-blind method"]},
+        mesh_qual={"pubmed": ["methods"]},
+    )
+    result = score_record(record, logger)
+    assert result.label == "non_review"


### PR DESCRIPTION
## Summary
- implement deterministic review vs non-review scoring logic
- provide CLI entry point and persistence pipeline
- document usage and add unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python main.py --input tests/data/sample_records.json --output output_dir`


------
https://chatgpt.com/codex/tasks/task_e_68b4346f26d88324b1692a8b9751a343