### PR TITLE
Implement publication classification CLI

### DIFF
--- a/classify_publications.py
+++ b/classify_publications.py
@@ -1,0 +1,152 @@
+"""CLI tool for classifying scientific publications.
+
+The script reads a CSV file with publication metadata, assigns each record to
+``review``, ``experimental`` or ``unknown`` class and writes results to a new
+CSV file with additional debug columns.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+from typing import Sequence
+
+import pandas as pd
+
+from doc_classifier.classifier import compute_scores, decide_label
+from doc_classifier.terms import parse_terms
+
+REQUIRED_COLUMNS = [
+    "title",
+    "abstract",
+    "PubMed.PublicationType",
+    "scholar.PublicationTypes",
+    "OpenAlex.PublicationTypes",
+    "OpenAlex.TypeCrossref",
+]
+
+
+def _is_empty(series: pd.Series) -> pd.Series:
+    """Return boolean Series indicating empty strings or NaNs."""
+    return series.isna() | (series.astype(str).str.strip() == "")
+
+
+def _read_csv_auto(path: str, encodings: Sequence[str], seps: Sequence[str]) -> tuple[pd.DataFrame, str, str]:
+    """Read a CSV file trying multiple encodings and separators."""
+    last_error: Exception | None = None
+    for enc in encodings:
+        for sep in seps:
+            try:
+                df = pd.read_csv(path, sep=sep, encoding=enc)
+            except Exception as err:  # pragma: no cover - diagnostic path
+                last_error = err
+                continue
+            if set(REQUIRED_COLUMNS).issubset(df.columns):
+                return df, enc, sep
+    raise ValueError(f"Cannot read input file with provided encodings/separators: {last_error}")
+
+
+def classify_dataframe(
+    df: pd.DataFrame,
+    *,
+    min_review_score: int,
+    min_unknown_score: int,
+    min_experimental_score: int,
+) -> pd.DataFrame:
+    """Classify DataFrame rows and append debug columns."""
+    df = df.copy()
+
+    pubmed_terms = df["PubMed.PublicationType"].map(parse_terms)
+    scholar_terms = df["scholar.PublicationTypes"].map(parse_terms)
+    oa_pt = df["OpenAlex.PublicationTypes"].map(parse_terms)
+    oa_cr = df["OpenAlex.TypeCrossref"].map(parse_terms)
+    openalex_terms = oa_pt.combine(oa_cr, lambda a, b: sorted(set(a) | set(b)))
+
+    df["debug.pubmed_terms"] = pubmed_terms.map(lambda t: "|".join(t))
+    df["debug.scholar_terms"] = scholar_terms.map(lambda t: "|".join(t))
+    df["debug.openalex_terms"] = openalex_terms.map(lambda t: "|".join(t))
+
+    def classify_row(row):
+        scores = compute_scores(
+            pubmed_terms[row.name], scholar_terms[row.name], openalex_terms[row.name]
+        )
+        label = decide_label(
+            scores,
+            min_review_score=min_review_score,
+            min_unknown_score=min_unknown_score,
+            min_experimental_score=min_experimental_score,
+        )
+        return pd.Series(
+            {
+                "class_label": label,
+                "debug.scores.review": scores["review"],
+                "debug.scores.experimental": scores["experimental"],
+                "debug.scores.unknown": scores["unknown"],
+            }
+        )
+
+    results = df.apply(classify_row, axis=1)
+    df = pd.concat([df, results], axis=1)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Classify publication records")
+    parser.add_argument("--input", required=True, help="Path to input CSV file")
+    parser.add_argument("--output", required=True, help="Path to output CSV file")
+    parser.add_argument("--min-review-score", type=int, default=1)
+    parser.add_argument("--min-unknown-score", type=int, default=2)
+    parser.add_argument("--min-experimental-score", type=int, default=1)
+    parser.add_argument("--random-seed", type=int, default=0)
+    parser.add_argument("--encoding-fallbacks", default="utf-8-sig,cp1251,latin1")
+    parser.add_argument("--delimiters", default=",;|\t")
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    random.seed(args.random_seed)
+
+    encodings = [e.strip() for e in args.encoding_fallbacks.split(",") if e.strip()]
+    seps = [s for s in args.delimiters]
+    df, encoding, sep = _read_csv_auto(args.input, encodings, seps)
+
+    logging.info("Detected encoding %s and delimiter '%s'", encoding, sep)
+
+    for col in REQUIRED_COLUMNS:
+        if col not in df.columns:
+            raise ValueError(f"Required column '{col}' not found in input")
+
+    classified = classify_dataframe(
+        df,
+        min_review_score=args.min_review_score,
+        min_unknown_score=args.min_unknown_score,
+        min_experimental_score=args.min_experimental_score,
+    )
+
+    counts = classified["class_label"].value_counts().sort_index()
+    total = len(classified)
+    for label, cnt in counts.items():
+        print(f"{label}: {cnt} ({cnt / total:.1%})")
+
+    pubmed_empty = _is_empty(df["PubMed.PublicationType"]).mean() * 100
+    scholar_empty = _is_empty(df["scholar.PublicationTypes"]).mean() * 100
+    openalex_empty = (
+        _is_empty(df["OpenAlex.PublicationTypes"]) & _is_empty(df["OpenAlex.TypeCrossref"])
+    ).mean() * 100
+    zero_signals = (
+        (classified[["debug.scores.review", "debug.scores.experimental", "debug.scores.unknown"]].sum(axis=1) == 0)
+    ).sum()
+
+    logging.info(
+        "Empty fields - PubMed: %.1f%%, Scholar: %.1f%%, OpenAlex: %.1f%%",
+        pubmed_empty,
+        scholar_empty,
+        openalex_empty,
+    )
+    logging.info("Rows with zero signals: %d", zero_signals)
+
+    classified.to_csv(args.output, index=False, sep=sep, encoding=encoding)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/doc_classifier/__init__.py
+++ b/doc_classifier/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for classifying scientific publications."""
+
+from .terms import parse_terms, REVIEW_TERMS, EXPERIMENTAL_TERMS, UNKNOWN_TERMS
+from .classifier import compute_scores, decide_label
+
+__all__ = [
+    "parse_terms",
+    "REVIEW_TERMS",
+    "EXPERIMENTAL_TERMS",
+    "UNKNOWN_TERMS",
+    "compute_scores",
+    "decide_label",
+]

--- a/doc_classifier/classifier.py
+++ b/doc_classifier/classifier.py
@@ -1,0 +1,84 @@
+"""Scoring and decision logic for publication classification."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+from .terms import REVIEW_TERMS, EXPERIMENTAL_TERMS, UNKNOWN_TERMS
+
+# Source weights used in weighted voting
+SOURCE_WEIGHTS: Mapping[str, int] = {
+    "pubmed": 4,
+    "openalex": 3,
+    "scholar": 2,
+}
+
+
+def compute_scores(
+    pubmed_terms: Iterable[str],
+    scholar_terms: Iterable[str],
+    openalex_terms: Iterable[str],
+) -> Dict[str, int]:
+    """Calculate scores for each class based on detected terms.
+
+    Parameters
+    ----------
+    pubmed_terms, scholar_terms, openalex_terms:
+        Normalised term lists from the respective sources.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping of class names (``review``, ``experimental``, ``unknown``) to
+        accumulated weights.
+    """
+    scores = {"review": 0, "experimental": 0, "unknown": 0}
+
+    def add_scores(terms: Iterable[str], weight: int) -> None:
+        for term in terms:
+            if term in REVIEW_TERMS:
+                scores["review"] += weight
+            if term in EXPERIMENTAL_TERMS:
+                scores["experimental"] += weight
+            if term in UNKNOWN_TERMS:
+                scores["unknown"] += weight
+
+    add_scores(pubmed_terms, SOURCE_WEIGHTS["pubmed"])
+    add_scores(scholar_terms, SOURCE_WEIGHTS["scholar"])
+    add_scores(openalex_terms, SOURCE_WEIGHTS["openalex"])
+    return scores
+
+
+def decide_label(
+    scores: Mapping[str, int],
+    *,
+    min_review_score: int = 1,
+    min_unknown_score: int = 2,
+    min_experimental_score: int = 1,
+) -> str:
+    """Decide final class label based on score comparison.
+
+    Parameters
+    ----------
+    scores:
+        Mapping with keys ``review``, ``experimental`` and ``unknown``.
+    min_review_score, min_unknown_score, min_experimental_score:
+        Minimum scores required for the respective classes.
+
+    Returns
+    -------
+    str
+        One of ``review``, ``experimental`` or ``unknown``.
+    """
+    r = scores.get("review", 0)
+    e = scores.get("experimental", 0)
+    u = scores.get("unknown", 0)
+
+    if r > max(e, u) and r >= min_review_score:
+        return "review"
+    if u > max(r, e) and u >= min_unknown_score:
+        return "unknown"
+    if e > max(r, u) and e >= min_experimental_score:
+        return "experimental"
+    if r == 0 and e == 0 and u > 0:
+        return "unknown"
+    return "unknown"

--- a/doc_classifier/terms.py
+++ b/doc_classifier/terms.py
@@ -1,0 +1,127 @@
+"""Term dictionaries and normalization utilities for publication classification.
+
+This module defines term sets used for classification and provides functions to
+normalise publication type fields.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+# Term dictionaries -----------------------------------------------------------------
+
+REVIEW_TERMS: set[str] = {
+    "review",
+    "systematic review",
+    "meta-analysis",
+    "scoping review",
+    "umbrella review",
+    "mini-review",
+    "survey",
+    "overview",
+    "state of the art",
+    "bibliometric analysis",
+    # OpenAlex specific
+    "review-article",
+}
+
+EXPERIMENTAL_TERMS: set[str] = {
+    "comparative study",
+    "evaluation study",
+    "case-control study",
+    "cohort study",
+    "proceedings-article",
+    "posted-content",
+    "preprint",
+}
+
+UNKNOWN_TERMS: set[str] = {
+    "clinical trial",
+    "randomized controlled trial",
+    "clinical study",
+    "case-control study",
+    "cohort study",
+    "editorial",
+    "letter",
+    "comment",
+    "news",
+    "book review",
+    "note",
+    "correction",
+    "erratum",
+    "retraction",
+    "data paper",
+    "perspective",
+    "opinion",
+    "short survey",
+}
+
+# Normalisation utilities ------------------------------------------------------------
+
+# Map various synonyms and fused forms to canonical tokens.
+_SYNONYMS: dict[str, str] = {
+    "review article": "review",
+    "review-article": "review",
+    "mini review": "review",
+    "mini-review": "review",
+    "meta analysis": "meta-analysis",
+    "meta-analysis": "meta-analysis",
+    "journal article": "journal-article",
+    "journal-article": "journal-article",
+    "journalarticle": "journal-article",
+    "slr": "systematic review",
+    "state-of-the-art": "state of the art",
+}
+
+_DELIMITERS_RE = re.compile(r"[|;,/]")
+
+
+def _normalise_token(token: str) -> str:
+    """Return canonical representation of a token.
+
+    Parameters
+    ----------
+    token:
+        Raw token extracted from a publication type field.
+
+    Returns
+    -------
+    str
+        Canonical form or an empty string if token is empty after processing.
+    """
+    token = token.strip().lower()
+    if not token:
+        return ""
+    token = _SYNONYMS.get(token, token)
+    return token
+
+
+def parse_terms(value: object) -> List[str]:
+    """Split and normalise a publication type field.
+
+    Parameters
+    ----------
+    value:
+        Field value which may be a string or missing (NaN/None).
+
+    Returns
+    -------
+    list[str]
+        Sorted list of unique canonical tokens. Empty list if no valid tokens.
+    """
+    if not isinstance(value, str):
+        return []
+
+    parts = _DELIMITERS_RE.split(value)
+    tokens = [_normalise_token(p) for p in parts]
+    tokens = [t for t in tokens if t]
+
+    # Remove duplicates while preserving order, then sort for deterministic output
+    unique = []
+    seen = set()
+    for t in tokens:
+        if t not in seen:
+            unique.append(t)
+            seen.add(t)
+
+    return sorted(unique)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,19 +1,17 @@
-import pytest
-
-from doc_classifier.normalize import split_and_canon
+from doc_classifier.terms import parse_terms
 
 
 def test_split_and_canon_basic():
     text = "Review Article; Meta-Analysis / randomized Controlled Trial"
-    tokens = split_and_canon(text)
+    tokens = parse_terms(text)
     assert tokens == [
-        "review",
         "meta-analysis",
         "randomized controlled trial",
+        "review",
     ]
 
 
 def test_split_and_canon_synonyms():
     text = "Mini Review | SLR, JournalArticle"
-    tokens = split_and_canon(text)
-    assert tokens == ["review", "systematic review", "journal-article"]
+    tokens = parse_terms(text)
+    assert tokens == ["journal-article", "review", "systematic review"]

--- a/tests/test_vote.py
+++ b/tests/test_vote.py
@@ -1,26 +1,39 @@
-from doc_classifier import normalize, signals, vote
+from doc_classifier.classifier import compute_scores, decide_label
+from doc_classifier.terms import parse_terms
 
 
-def classify_pt(value: str, source: str):
-    tokens = normalize.split_and_canon(value)
-    sigs = signals.extract_pt_signals(tokens, source)
-    scores = vote.score(sigs)
-    label = vote.decide(scores)
+def classify(pubmed: str, scholar: str, openalex: str):
+    scores = compute_scores(
+        parse_terms(pubmed), parse_terms(scholar), parse_terms(openalex)
+    )
+    label = decide_label(scores)
     return label, scores
 
 
-def test_review_from_scholar():
-    label, scores = classify_pt("Narrative Review", "scholar")
+def test_review_from_pubmed():
+    label, scores = classify("Journal Article|Review", "", "")
     assert label == "review"
-    assert scores["review"] > scores["nonreview"]
+    assert scores["review"] > 0
 
 
-def test_nonreview_from_pubmed():
-    label, scores = classify_pt("Clinical Trial", "pubmed")
-    assert label == "non-review"
-    assert scores["nonreview"] > scores["review"]
-
-
-def test_unknown_no_signal():
-    label, _ = classify_pt("Journal Article", "pubmed")
+def test_unknown_editorial():
+    label, scores = classify("Editorial", "", "")
     assert label == "unknown"
+    assert scores["unknown"] > 0
+
+
+def test_experimental_proceedings():
+    label, scores = classify("", "", "proceedings-article")
+    assert label == "experimental"
+    assert scores["experimental"] > 0
+
+
+def test_unknown_empty():
+    label, scores = classify("", "", "")
+    assert label == "unknown"
+    assert scores == {"review": 0, "experimental": 0, "unknown": 0}
+
+
+def test_conflict_review_and_posted():
+    label, scores = classify("Review", "", "posted-content")
+    assert label == "review"


### PR DESCRIPTION
## Summary
- Add `doc_classifier` package with term normalisation and scoring logic for review/experimental/unknown classes
- Provide `classify_publications.py` CLI to classify CSV records and emit debug fields
- Document usage and development practices in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b56f22d9fc832489b779cc324e83d6