### PR TITLE
Apply target post-processing to merged target dataset

### DIFF
--- a/get_target_data.py
+++ b/get_target_data.py
@@ -11,9 +11,10 @@ from typing import Sequence
 import pandas as pd
 
 from library import chembl_library as cl
-from library import iuphar_library as ii
-from library import uniprot_library as uu
 from library import io
+from library import iuphar_library as ii
+from library import target_postprocessing as tp
+from library import uniprot_library as uu
 
 logger = logging.getLogger(__name__)
 
@@ -285,6 +286,11 @@ def run_uniprot(args: argparse.Namespace) -> int:
     -------
     int
         Zero on success, non-zero on failure.
+
+    Tests
+    -----
+    The post-processing step is covered by
+    :mod:`tests.test_target_postprocessing`.
     """
     try:
         df = pd.read_csv(
@@ -377,6 +383,10 @@ def run_iuphar(args: argparse.Namespace) -> int:
 def run_all(args: argparse.Namespace) -> int:
     """Run ChEMBL, UniProt and IUPHAR pipelines and merge their outputs.
 
+    The merged table is post-processed using
+    :func:`library.target_postprocessing.postprocess_targets` before
+    being written to disk.
+
     Parameters
     ----------
     args:
@@ -386,6 +396,11 @@ def run_all(args: argparse.Namespace) -> int:
     -------
     int
         Zero on success, non-zero on failure.
+    
+    Tests
+    -----
+    The post-processing step is covered by
+    :mod:`tests.test_target_postprocessing`.
     """
 
     try:
@@ -517,8 +532,10 @@ def run_all(args: argparse.Namespace) -> int:
         iuphar_df = iuphar_df[["uniprot_id", *classification_cols]]
 
         merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+        # Apply domain-specific clean-up before exporting
+        processed = tp.postprocess_targets(merged)
 
-        io.write_csv(merged, output, sep=args.sep, encoding=args.encoding)
+        io.write_csv(processed, output, sep=args.sep, encoding=args.encoding)
         return 0
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("%s", exc)

--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 import logging
-import time
 
 import pandas as pd
 import requests
@@ -133,12 +132,11 @@ def _parse_uniprot_id(xrefs: list[dict[str, str]], chembl_id: str) -> tuple[str,
                 uniprot_id = ident
                 break
     try:
-        mapping_uniprot_id = map_chembl_to_uniprot(chembl_id)
+        mapping_uniprot_id = map_chembl_to_uniprot(chembl_id) or ""
     except Exception as exc:  # pragma: no cover - network failure paths
         logger.warning("UniProt mapping request failed for %s: %s", chembl_id, exc)
         mapping_uniprot_id = ""
     return uniprot_id, mapping_uniprot_id
-
 
 
 def _parse_hgnc(xrefs: list[dict[str, str]]) -> tuple[str, str]:
@@ -438,6 +436,7 @@ def get_assays_all(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
     df = pd.concat(records, ignore_index=True)
     return df.reindex(columns=ASSAY_COLUMNS)
 
+
 def get_assays_notNull(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
     """Fetch assay records for ``ids``.
 
@@ -490,6 +489,8 @@ def get_assays_notNull(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
 
     df = pd.concat(records, ignore_index=True)
     return df.reindex(columns=ASSAY_COLUMNS)
+
+
 # ----------------------------
 # Activity utilities
 # ----------------------------
@@ -512,18 +513,15 @@ ACTIVITY_COLUMNS = [
     "type",
     "value",
     "units",
-    "relation"
-    "qudt_units"
-    "pchembl_value",
+    "relation" "qudt_units" "pchembl_value",
     "activity_comment",
     "data_validity_comment",
-    "data_validity_description"
-    "potential_duplicate",
+    "data_validity_description" "potential_duplicate",
     "bao_label",
     "src_id",
     "src_assay_id",
     "assay_variant_accession",
-    "assay_variant_mutation",  
+    "assay_variant_mutation",
 ]
 
 
@@ -646,7 +644,7 @@ def get_testitem(ids: Iterable[str], chunk_size: int = 5) -> pd.DataFrame:
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items))
- # Drop empty or all-NA frames to avoid deprecation warnings in pandas
+    # Drop empty or all-NA frames to avoid deprecation warnings in pandas
     records = [r for r in records if not r.empty and not r.isna().all().all()]
     if not records:
         return pd.DataFrame(columns=TESTITEM_COLUMNS)

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -52,6 +52,10 @@ def _first_token(value: str | float | None) -> str:
 def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
     """Clean and reshape merged target information.
 
+    The function normalises UniProt identifiers, resolves gene names and
+    synonyms, fills optional columns and standardises the output ordering so
+    that the resulting table is ready for downstream export.
+
     Parameters
     ----------
     df:
@@ -62,6 +66,11 @@ def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
     -------
     pandas.DataFrame
         Normalised table ready for export.
+
+    Tests
+    -----
+    Behaviour is exercised in
+    :func:`tests.test_target_postprocessing.test_postprocess_targets_merges_and_normalises`.
     """
 
     df = df.copy()
@@ -221,6 +230,11 @@ def postprocess_file(
         Field delimiter of the CSV files.
     encoding:
         Text encoding of the CSV files.
+
+    Tests
+    -----
+    Verified in
+    :func:`tests.test_target_postprocessing.test_postprocess_file_roundtrip`.
     """
 
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -1,0 +1,85 @@
+"""Tests for :mod:`library.target_postprocessing`.
+
+The suite covers :func:`library.target_postprocessing.postprocess_targets` and
+its convenience wrapper :func:`library.target_postprocessing.postprocess_file`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library import target_postprocessing as tp
+
+
+def test_postprocess_targets_merges_and_normalises() -> None:
+    """``postprocess_targets`` merges fields and normalises tokens."""
+
+    df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniProtkbId": ["P12345-2_SOMETHING"],
+            "uniprot_id": ["P12345"],
+            "secondaryAccessions": ["S12345|S67890"],
+            "pref_name": ["Protein kinase"],
+            "gene_name_x": ["g1"],
+            "geneName": [""],
+            "gene": ["g2|g3"],
+            "secondaryAccessionNames": ["name2|name3"],
+            "component_description": ["desc"],
+            "chembl_alternative_name": ["alt"],
+            "recommendedName": ["Rec Name"],
+            "names": ["name1|name4"],
+            "synonyms_x": ["synX"],
+            "synonyms": ["syn1|syn2"],
+            "ec_number": ["1.1.1.1"],
+            "ec_code": ["2.2.2.2"],
+        }
+    )
+    out = tp.postprocess_targets(df)
+
+    row = out.iloc[0]
+    assert row["uniprotkb_Id"] == "P12345"
+    assert row["secondary_uniprot_id"] == "S12345|S67890"
+    assert row["recommended_name"] == "Protein kinase"
+    assert row["gene_name"] == "G1"
+    assert row["ec_number"] == "1.1.1.1|2.2.2.2"
+    assert row["isoform_names"] == "-"
+    assert row["synonyms"].startswith("g2|g3|g1|name2|name3")
+
+
+def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
+    """Ensure ``postprocess_file`` writes the same result as ``postprocess_targets``."""
+
+    df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniProtkbId": ["P12345-2_SOMETHING"],
+            "uniprot_id": ["P12345"],
+            "secondaryAccessions": ["S12345|S67890"],
+            "pref_name": ["Protein kinase"],
+            "gene_name_x": ["g1"],
+            "geneName": [""],
+            "gene": ["g2|g3"],
+            "secondaryAccessionNames": ["name2|name3"],
+            "component_description": ["desc"],
+            "chembl_alternative_name": ["alt"],
+            "recommendedName": ["Rec Name"],
+            "names": ["name1|name4"],
+            "synonyms_x": ["synX"],
+            "synonyms": ["syn1|syn2"],
+            "ec_number": ["1.1.1.1"],
+            "ec_code": ["2.2.2.2"],
+        }
+    )
+
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "out.csv"
+
+    tp.postprocess_file(input_path, output_path)
+
+    expected = tp.postprocess_targets(df).astype(str)
+    result = pd.read_csv(output_path, dtype=str)
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- apply target postprocessing when merging ChEMBL, UniProt and IUPHAR data
- normalize UniProt mapping output in chembl library
- add unit test for target post-processing
- document public functions and link them to tests

## Testing
- `ruff check .`
- `mypy get_target_data.py library/chembl_library.py library/target_postprocessing.py tests/test_target_postprocessing.py --follow-imports=skip`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bacd8bbc6c832493d45828d7affa11