### PR TITLE
Fix document type imports and add classification test

### DIFF
--- a/get_document_type.py
+++ b/get_document_type.py
@@ -4,6 +4,7 @@ The script reads a CSV file with publication metadata, assigns each record to
 ``review``, ``experimental`` or ``unknown`` class and writes results to a new
 CSV file with additional debug columns.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -14,7 +15,7 @@ from typing import Sequence
 import pandas as pd
 
 from library.document_type_classifier import compute_scores, decide_label
-from library.document_type_terms.terms import parse_terms
+from library.document_type_terms import parse_terms
 
 REQUIRED_COLUMNS = [
     "title",
@@ -31,7 +32,9 @@ def _is_empty(series: pd.Series) -> pd.Series:
     return series.isna() | (series.astype(str).str.strip() == "")
 
 
-def _read_csv_auto(path: str, encodings: Sequence[str], seps: Sequence[str]) -> tuple[pd.DataFrame, str, str]:
+def _read_csv_auto(
+    path: str, encodings: Sequence[str], seps: Sequence[str]
+) -> tuple[pd.DataFrame, str, str]:
     """Read a CSV file trying multiple encodings and separators."""
     last_error: Exception | None = None
     for enc in encodings:
@@ -43,7 +46,9 @@ def _read_csv_auto(path: str, encodings: Sequence[str], seps: Sequence[str]) -> 
                 continue
             if set(REQUIRED_COLUMNS).issubset(df.columns):
                 return df, enc, sep
-    raise ValueError(f"Cannot read input file with provided encodings/separators: {last_error}")
+    raise ValueError(
+        f"Cannot read input file with provided encodings/separators: {last_error}"
+    )
 
 
 def classify_dataframe(
@@ -131,10 +136,20 @@ def main() -> None:
     pubmed_empty = _is_empty(df["PubMed.PublicationType"]).mean() * 100
     scholar_empty = _is_empty(df["scholar.PublicationTypes"]).mean() * 100
     openalex_empty = (
-        _is_empty(df["OpenAlex.PublicationTypes"]) & _is_empty(df["OpenAlex.TypeCrossref"])
+        _is_empty(df["OpenAlex.PublicationTypes"])
+        & _is_empty(df["OpenAlex.TypeCrossref"])
     ).mean() * 100
     zero_signals = (
-        (classified[["debug.scores.review", "debug.scores.experimental", "debug.scores.unknown"]].sum(axis=1) == 0)
+        (
+            classified[
+                [
+                    "debug.scores.review",
+                    "debug.scores.experimental",
+                    "debug.scores.unknown",
+                ]
+            ].sum(axis=1)
+            == 0
+        )
     ).sum()
 
     logging.info(

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -1,8 +1,20 @@
-"""Utility libraries for data acquisition and processing."""
+"""Utility libraries for data acquisition and processing.
+
+This package exposes commonly used helper functions and submodules. The
+original implementation used absolute imports which fail when the package is
+executed as part of a larger project.  The imports are now explicitly relative
+so that ``python`` can resolve them correctly regardless of the working
+directory.
+"""
 
 from . import io, validation
-from  document_type_terms import parse_terms, REVIEW_TERMS, EXPERIMENTAL_TERMS, UNKNOWN_TERMS
-from  document_type_classifier import compute_scores, decide_label
+from .document_type_terms import (
+    EXPERIMENTAL_TERMS,
+    REVIEW_TERMS,
+    UNKNOWN_TERMS,
+    parse_terms,
+)
+from .document_type_classifier import compute_scores, decide_label
 
 __all__ = [
     "parse_terms",
@@ -12,6 +24,5 @@ __all__ = [
     "compute_scores",
     "decide_label",
     "io",
-    "validation"
+    "validation",
 ]
-

--- a/tests/test_get_document_type.py
+++ b/tests/test_get_document_type.py
@@ -1,0 +1,31 @@
+"""Tests for :mod:`get_document_type` utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from get_document_type import classify_dataframe
+
+
+def test_classify_dataframe_basic() -> None:
+    """Basic smoke test for :func:`classify_dataframe`."""
+
+    df = pd.DataFrame(
+        {
+            "title": ["t"],
+            "abstract": ["a"],
+            "PubMed.PublicationType": ["review"],
+            "scholar.PublicationTypes": [""],
+            "OpenAlex.PublicationTypes": [""],
+            "OpenAlex.TypeCrossref": [""],
+        }
+    )
+
+    result = classify_dataframe(
+        df,
+        min_review_score=1,
+        min_unknown_score=1,
+        min_experimental_score=1,
+    )
+
+    assert result.loc[0, "class_label"] == "review"


### PR DESCRIPTION
## Summary
- fix relative imports for document type utilities
- correct get_document_type import path
- add smoke test for classify_dataframe

## Testing
- `python get_document_type.py --input data/output/output.documents_20250905.csv --output /tmp/out.csv`
- `python -m black get_document_type.py library/__init__.py`
- `python -m black tests/test_get_document_type.py`
- `python -m ruff check get_document_type.py library/__init__.py tests/test_get_document_type.py`
- `python -m mypy get_document_type.py library/__init__.py tests/test_get_document_type.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2dab129c8324875375f75dff6f06