### PR TITLE
Add deterministic document type classifier and CLI

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1,0 +1,300 @@
+"""Deterministic classifier for scientific document types.
+
+The module implements normalization, scoring and conflict resolution logic
+according to project specification. It exposes :class:`DocumentClassifier`
+which accepts :class:`io_schemas.DocumentRecord` and returns
+:class:`io_schemas.ClassificationResult`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Tuple
+
+import io_schemas as io
+from rules import (
+    LIST_SPLIT_RE,
+    MESH_A,
+    MESH_B,
+    MESH_C,
+    MESH_D,
+    MESH_E,
+    PT_CLINICAL,
+    PT_OTHER,
+    PT_REVIEW,
+    RE_BEHAV,
+    RE_CELLLINES,
+    RE_CLINICAL,
+    RE_DOSE,
+    RE_IN_VITRO,
+    RE_PROTOCOL,
+    RE_RESULTS,
+    RE_ROUTE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _norm_str(value: str) -> str:
+    """Normalize strings: lowercase, collapse whitespace, replace micro sign."""
+
+    value = value.lower().strip()
+    value = value.replace("μ", "u")
+    value = " ".join(value.split())
+    return value
+
+
+def _norm_list(values: Iterable[str]) -> List[str]:
+    """Normalize a list of strings using ``LIST_SPLIT_RE``."""
+
+    items: List[str] = []
+    for v in values:
+        for part in LIST_SPLIT_RE.split(v):
+            part = _norm_str(part)
+            if part:
+                items.append(part)
+    dedup = list(dict.fromkeys(items))
+    dedup.sort()
+    return dedup
+
+
+def _text(record: io.DocumentRecord) -> str:
+    return f"{_norm_str(record.title)} {_norm_str(record.abstract)}".strip()
+
+
+class DocumentClassifier:
+    """Main classifier implementing deterministic rules."""
+
+    def classify(self, record: io.DocumentRecord) -> io.ClassificationResult:
+        """Classify a single record.
+
+        Parameters
+        ----------
+        record: DocumentRecord
+            Input data model.
+        """
+
+        text = _text(record)
+        pubmed_pt = _norm_list(record.pubmed_publicationtype)
+        scholar_pt = _norm_list(record.scholar_publicationtypes)
+        openalex_pt = _norm_list(record.openalex_publicationtypes)
+        mesh_desc = _norm_list(
+            record.pubmed_mesh_descriptors + record.openalex_meshdescriptors
+        )
+        mesh_qual = _norm_list(
+            record.pubmed_mesh_qualifiers + record.openalex_meshqualifiers
+        )
+        chem_list = _norm_list(record.pubmed_chemicallist)
+
+        pt_class, source_priority = self._class_from_pt(
+            pubmed_pt, scholar_pt, openalex_pt
+        )
+        final_class = pt_class
+
+        if final_class is None and RE_CLINICAL.search(text) and "humans" in mesh_desc:
+            final_class = "Clinical trials"
+            source_priority = "-"
+
+        protocol_veto = bool(RE_PROTOCOL.search(text) and not RE_RESULTS.search(text))
+        if protocol_veto:
+            final_class = "Other non experimental publication"
+
+        vivo_score, vivo_hits = self._score_vivo(
+            mesh_desc, mesh_qual, text, chem_list, record.optional_experiment_kind
+        )
+        vitro_score, vitro_hits = self._score_vitro(
+            mesh_desc,
+            mesh_qual,
+            text,
+            chem_list,
+            pubmed_pt,
+            record.optional_experiment_kind,
+        )
+
+        if not protocol_veto and (
+            final_class is None or final_class == "Other non experimental publication"
+        ):
+            experimental_class = self._resolve_experimental(
+                vivo_score, vitro_score, vivo_hits, vitro_hits
+            )
+            if experimental_class:
+                final_class = experimental_class
+
+        if final_class is None:
+            final_class = "Other non experimental publication"
+
+        pt_comparative = "comparative study" in pubmed_pt
+        pt_binding = bool("binding" in text)
+
+        xrf_type = _norm_str(record.crossref_type or "")
+        xrf_is_generic = xrf_type == "journal-article"
+        xrf_is_specific = bool(xrf_type and not xrf_is_generic)
+
+        conflicts: List[str] = []
+        if final_class == "Clinical trials" and xrf_is_generic:
+            conflicts.append("xrf_generic_vs_clinical")
+        if (
+            final_class in {"Review", "Other non experimental publication"}
+            and xrf_is_generic
+            and pt_class is not None
+        ):
+            conflicts.append("xrf_generic_vs_nonexperimental")
+        if vivo_score >= 5 and vitro_score >= 4:
+            conflicts.append("vivo_vs_vitro_tie")
+
+        confidence = 100 - 20 * (
+            len([c for c in conflicts if c != "vivo_vs_vitro_tie"])
+        )
+        if "vivo_vs_vitro_tie" in conflicts:
+            confidence -= 10
+        confidence = max(0, confidence)
+
+        explain_short = f"{final_class} via {source_priority or 'rules'}"
+
+        return io.ClassificationResult(
+            final_class=final_class,
+            S_in_vivo=vivo_score,
+            S_in_vitro=vitro_score,
+            pt_comparative=pt_comparative,
+            pt_binding=pt_binding,
+            vivo_hits=vivo_hits,
+            vitro_hits=vitro_hits,
+            conflicts=conflicts,
+            confidence=confidence,
+            source_priority_used=source_priority or "-",
+            xrf_is_generic=xrf_is_generic,
+            xrf_is_specific=xrf_is_specific,
+            explain_short=explain_short,
+        )
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _class_from_pt(
+        pubmed_pt: List[str], scholar_pt: List[str], openalex_pt: List[str]
+    ) -> Tuple[str | None, str]:
+        """Determine primary class from publication types with priority."""
+
+        for pts, source in (
+            (pubmed_pt, "pubmed"),
+            (scholar_pt, "scholar"),
+            (openalex_pt, "openalex"),
+        ):
+            veterinary = "veterinary" in pts
+            for pt in pts:
+                if pt in PT_CLINICAL and not veterinary:
+                    return "Clinical trials", source
+            for pt in pts:
+                if pt in PT_REVIEW:
+                    return "Review", source
+            for pt in pts:
+                if pt in PT_OTHER:
+                    return "Other non experimental publication", source
+        return None, "-"
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _score_vivo(
+        mesh_desc: List[str],
+        mesh_qual: List[str],
+        text: str,
+        chem_list: List[str],
+        optional_kind: str | None,
+    ) -> Tuple[int, List[str]]:
+        """Compute in vivo score and collect hits."""
+
+        hits: List[str] = []
+        A = int(any(m in MESH_A for m in mesh_desc))
+        B = int(any(m in MESH_B for m in mesh_qual))
+        C = int(any(m in MESH_C for m in mesh_desc))
+        TxtRouteDose = int(bool(RE_ROUTE.search(text) or RE_DOSE.search(text)))
+        TxtBehavior = int(bool(RE_BEHAV.search(text)))
+        D_or_E = int(any(m in MESH_D or m in MESH_E for m in mesh_desc + mesh_qual))
+        Neg_vivo = int(not A and D_or_E and not TxtRouteDose)
+
+        score = (
+            2 * A + 2 * B + 1 * C + 2 * TxtRouteDose + 1 * TxtBehavior - 2 * Neg_vivo
+        )
+        if optional_kind == "F" and A:
+            score += 1
+
+        if A:
+            hits.append("A")
+        if B:
+            hits.append("B")
+        if C:
+            hits.append("C")
+        if TxtRouteDose:
+            hits.append("route/dose")
+        if TxtBehavior:
+            hits.append("behavior")
+        if Neg_vivo:
+            hits.append("neg_vivo")
+
+        return score, hits
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _score_vitro(
+        mesh_desc: List[str],
+        mesh_qual: List[str],
+        text: str,
+        chem_list: List[str],
+        pubmed_pt: List[str],
+        optional_kind: str | None,
+    ) -> Tuple[int, List[str]]:
+        """Compute in vitro score and collect hits."""
+
+        hits: List[str] = []
+        G = int(any(m in MESH_D for m in mesh_desc))
+        H = int(any(m in MESH_E for m in mesh_qual))
+        text_hits = min(
+            len(RE_IN_VITRO.findall(text)) + len(RE_CELLLINES.findall(text)), 3
+        )
+        J = int(
+            (
+                any(m in MESH_A for m in mesh_desc)
+                or bool(RE_ROUTE.search(text) or RE_BEHAV.search(text))
+            )
+            and not (G or H)
+        )
+        Chem = int(bool(chem_list))
+        pt_comparative = int("comparative study" in pubmed_pt)
+        pt_binding = int("binding" in text)
+
+        score = 2 * G + 2 * H + text_hits + Chem - 2 * J + pt_comparative + pt_binding
+        if optional_kind == "B":
+            score += 1
+
+        if G:
+            hits.append("D")
+        if H:
+            hits.append("E")
+        if text_hits:
+            hits.append("assay")
+        if Chem:
+            hits.append("chem")
+        if J:
+            hits.append("neg_vitro")
+        if pt_comparative:
+            hits.append("comparative")
+        if pt_binding:
+            hits.append("binding")
+
+        return score, hits
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_experimental(
+        vivo_score: int, vitro_score: int, vivo_hits: List[str], vitro_hits: List[str]
+    ) -> str | None:
+        """Resolve final experimental class from scores."""
+
+        if vivo_score >= 5 and vitro_score < 4:
+            return "Experimental in vivo bioactivity"
+        if vitro_score >= 4 and vivo_score < 5:
+            return "Experimental in vitro bioactivity"
+        if vivo_score >= 5 and vitro_score >= 4:
+            if "behavior" in vivo_hits:
+                return "Experimental in vivo bioactivity"
+            return "Experimental in vitro bioactivity"
+        return None

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -4,6 +4,7 @@ The script reads a CSV file with publication metadata, assigns each record to
 ``review``, ``experimental`` or ``unknown`` class and writes results to a new
 CSV file with additional debug columns.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -14,7 +15,7 @@ from typing import Sequence
 import pandas as pd
 
 from library.document_type_classifier import compute_scores, decide_label
-from library.document_type_terms.terms import parse_terms
+from library.document_type_terms import parse_terms
 
 REQUIRED_COLUMNS = [
     "title",
@@ -31,7 +32,9 @@ def _is_empty(series: pd.Series) -> pd.Series:
     return series.isna() | (series.astype(str).str.strip() == "")
 
 
-def _read_csv_auto(path: str, encodings: Sequence[str], seps: Sequence[str]) -> tuple[pd.DataFrame, str, str]:
+def _read_csv_auto(
+    path: str, encodings: Sequence[str], seps: Sequence[str]
+) -> tuple[pd.DataFrame, str, str]:
     """Read a CSV file trying multiple encodings and separators."""
     last_error: Exception | None = None
     for enc in encodings:
@@ -43,7 +46,9 @@ def _read_csv_auto(path: str, encodings: Sequence[str], seps: Sequence[str]) -> 
                 continue
             if set(REQUIRED_COLUMNS).issubset(df.columns):
                 return df, enc, sep
-    raise ValueError(f"Cannot read input file with provided encodings/separators: {last_error}")
+    raise ValueError(
+        f"Cannot read input file with provided encodings/separators: {last_error}"
+    )
 
 
 def classify_dataframe(
@@ -131,10 +136,20 @@ def main() -> None:
     pubmed_empty = _is_empty(df["PubMed.PublicationType"]).mean() * 100
     scholar_empty = _is_empty(df["scholar.PublicationTypes"]).mean() * 100
     openalex_empty = (
-        _is_empty(df["OpenAlex.PublicationTypes"]) & _is_empty(df["OpenAlex.TypeCrossref"])
+        _is_empty(df["OpenAlex.PublicationTypes"])
+        & _is_empty(df["OpenAlex.TypeCrossref"])
     ).mean() * 100
     zero_signals = (
-        (classified[["debug.scores.review", "debug.scores.experimental", "debug.scores.unknown"]].sum(axis=1) == 0)
+        (
+            classified[
+                [
+                    "debug.scores.review",
+                    "debug.scores.experimental",
+                    "debug.scores.unknown",
+                ]
+            ].sum(axis=1)
+            == 0
+        )
     ).sum()
 
     logging.info(

--- a/io_schemas.py
+++ b/io_schemas.py
@@ -1,0 +1,44 @@
+"""Pydantic data models for document classification I/O."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field  # type: ignore[import-not-found]
+
+
+class DocumentRecord(BaseModel):
+    """Normalized input record for classification."""
+
+    title: str
+    abstract: str
+    doi: str
+    pubmed_publicationtype: List[str] = Field(default_factory=list)
+    scholar_publicationtypes: List[str] = Field(default_factory=list)
+    openalex_publicationtypes: List[str] = Field(default_factory=list)
+    crossref_type: Optional[str] = None
+    openalex_typecrossref: Optional[str] = None
+    pubmed_mesh_descriptors: List[str] = Field(default_factory=list)
+    pubmed_mesh_qualifiers: List[str] = Field(default_factory=list)
+    openalex_meshdescriptors: List[str] = Field(default_factory=list)
+    openalex_meshqualifiers: List[str] = Field(default_factory=list)
+    pubmed_chemicallist: List[str] = Field(default_factory=list)
+    optional_experiment_kind: Optional[str] = None
+
+
+class ClassificationResult(BaseModel):
+    """Result of classification with detailed explanation."""
+
+    final_class: str
+    S_in_vivo: int
+    S_in_vitro: int
+    pt_comparative: bool
+    pt_binding: bool
+    vivo_hits: List[str]
+    vitro_hits: List[str]
+    conflicts: List[str]
+    confidence: int
+    source_priority_used: str
+    xrf_is_generic: bool
+    xrf_is_specific: bool
+    explain_short: str

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -1,8 +1,20 @@
-"""Utility libraries for data acquisition and processing."""
+"""Utility libraries for data acquisition and processing.
+
+This package exposes commonly used helper functions and submodules. The
+original implementation used absolute imports which fail when the package is
+executed as part of a larger project.  The imports are now explicitly relative
+so that ``python`` can resolve them correctly regardless of the working
+directory.
+"""
 
 from . import io, validation
-from  document_type_terms import parse_terms, REVIEW_TERMS, EXPERIMENTAL_TERMS, UNKNOWN_TERMS
-from  document_type_classifier import compute_scores, decide_label
+from .document_type_terms import (
+    EXPERIMENTAL_TERMS,
+    REVIEW_TERMS,
+    UNKNOWN_TERMS,
+    parse_terms,
+)
+from .document_type_classifier import compute_scores, decide_label
 
 __all__ = [
     "parse_terms",
@@ -12,6 +24,5 @@ __all__ = [
     "compute_scores",
     "decide_label",
     "io",
-    "validation"
+    "validation",
 ]
-

--- a/main.py
+++ b/main.py
@@ -1,0 +1,99 @@
+"""Command-line interface for deterministic document classifier."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime
+from typing import Iterable, List
+
+from classifier import DocumentClassifier
+from io_schemas import ClassificationResult, DocumentRecord
+
+logger = logging.getLogger(__name__)
+
+LIST_FIELDS = [
+    "pubmed_publicationtype",
+    "scholar_publicationtypes",
+    "openalex_publicationtypes",
+    "pubmed_mesh_descriptors",
+    "pubmed_mesh_qualifiers",
+    "openalex_meshdescriptors",
+    "openalex_meshqualifiers",
+    "pubmed_chemicallist",
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deterministic document classifier")
+    parser.add_argument("--input", "--in", dest="input", default="input.csv")
+    parser.add_argument("--output", "--out", dest="output")
+    parser.add_argument("--in-format", choices=["csv", "jsonl"], default="jsonl")
+    parser.add_argument("--out-format", choices=["csv", "jsonl"], default="jsonl")
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args()
+
+
+def _norm_list_field(value: str) -> List[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split("|") if v.strip()]
+
+
+def read_records(path: str, fmt: str) -> Iterable[DocumentRecord]:
+    with open(path, "r", encoding="utf-8") as fh:
+        if fmt == "jsonl":
+            for line in fh:
+                data = json.loads(line)
+                for field in LIST_FIELDS:
+                    data[field] = _norm_list_field(data.get(field, ""))
+                yield DocumentRecord(**data)
+        else:
+            import csv
+
+            reader = csv.DictReader(fh)
+            for row in reader:
+                data = {k: v for k, v in row.items()}
+                for field in LIST_FIELDS:
+                    data[field] = _norm_list_field(data.get(field, ""))
+                yield DocumentRecord(**data)
+
+
+def write_records(records: Iterable[ClassificationResult], path: str, fmt: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        if fmt == "jsonl":
+            for rec in records:
+                fh.write(rec.model_dump_json() + "\n")
+        else:
+            import csv
+
+            writer = None
+            for rec in records:
+                data = rec.model_dump()
+                if writer is None:
+                    writer = csv.DictWriter(fh, fieldnames=list(data.keys()))
+                    writer.writeheader()
+                for field in ["vivo_hits", "vitro_hits", "conflicts"]:
+                    data[field] = "|".join(data[field])
+                assert writer is not None
+                writer.writerow(data)
+
+
+def main() -> None:
+    args = _parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    if not args.output:
+        dt = datetime.now().strftime("%Y%m%d")
+        args.output = f"output_{args.input}_{dt}.{args.out_format}"
+
+    classifier = DocumentClassifier()
+    results = [
+        classifier.classify(rec) for rec in read_records(args.input, args.in_format)
+    ]
+    write_records(results, args.output, args.out_format)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest>=7.0
 black>=23.0
 ruff>=0.0.290
 mypy>=1.8
+pydantic>=2.0

--- a/rules.py
+++ b/rules.py
@@ -1,0 +1,157 @@
+"""Rule definitions for deterministic document classifier.
+
+This module centralizes regex patterns and keyword sets so that the
+classifier logic can remain readable. All terms are stored in lowercase
+for case-insensitive comparisons.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Pattern, Set
+
+# Regular expressions used by text scoring
+RE_IN_VITRO: Final[Pattern[str]] = re.compile(
+    r"\b(in\s*vitro|cell[-\s]?based|cell[-\s]?free|enzyme assay|biochemical assay|"
+    r"binding assay|spr|itc|fluorescence polarization|reporter assay|luciferase|"
+    r"western blot|flow cytometry|ic50|ec50|ki|kd|patch clamp|whole[-\s]?cell)\b",
+    re.I,
+)
+RE_CELLLINES: Final[Pattern[str]] = re.compile(
+    r"\b(hek\s*293|hepg2|hela|cho|u2os|mcf[-\s]?7|thp[-\s]?1|293t|nhdf|huh[-\s]?7|"
+    r"sf9|primary\s+(?:cells|neurons)|organoid[s]?)\b",
+    re.I,
+)
+RE_ROUTE: Final[Pattern[str]] = re.compile(
+    r"\b(ip|iv|po|sc|im|intrathecal|gavage)\b", re.I
+)
+RE_DOSE: Final[Pattern[str]] = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:mg|u?g)\s*/\s*kg\b", re.I
+)
+RE_BEHAV: Final[Pattern[str]] = re.compile(
+    r"\b(von\s+frey|hot\s*plate|tail\s*flick|formalin|rotarod|paw\s*edema|"
+    r"allodynia|hyperalgesia|carrageenan|cfa)\b",
+    re.I,
+)
+RE_PROTOCOL: Final[Pattern[str]] = re.compile(
+    r"\b(protocol|study protocol|statistical analysis plan|sap|trial registration)\b",
+    re.I,
+)
+RE_RESULTS: Final[Pattern[str]] = re.compile(
+    r"\b(result|observed|measured|significant|p\s*[<≤]\s*0?\.\d+|dose[-\s]?response|"
+    r"endpoint[s]?)\b",
+    re.I,
+)
+RE_CLINICAL: Final[Pattern[str]] = re.compile(
+    r"\b(randomized|placebo|double[-\s]?blind|single[-\s]?blind|phase\s*(?:i|ii|iii|iv)\b|"
+    r"multicenter|participants|subjects|cohort|arm[s]?)\b",
+    re.I,
+)
+
+# Publication type mappings
+PT_CLINICAL: Final[Set[str]] = {
+    "randomized controlled trial",
+    "controlled clinical trial",
+    "clinical trial",
+    "clinical trial phase i",
+    "clinical trial phase ii",
+    "clinical trial phase iii",
+    "clinical trial phase iv",
+    "pragmatic clinical trial",
+    "multicenter study",
+    "double-blind method",
+    "single-blind method",
+}
+PT_REVIEW: Final[Set[str]] = {
+    "review",
+    "systematic review",
+    "scoping review",
+    "umbrella review",
+    "literature review",
+}
+PT_OTHER: Final[Set[str]] = {
+    "meta-analysis",
+    "guideline",
+    "practice guideline",
+    "consensus",
+    "editorial",
+    "comment",
+    "letter",
+    "news",
+    "erratum",
+    "study protocol",
+    "protocol",
+    "statistical analysis plan",
+    "case report",
+    "case series",
+}
+
+# MeSH descriptor/qualifier keyword sets
+MESH_A: Final[Set[str]] = {
+    "animals",
+    "mouse",
+    "mice",
+    "rat",
+    "rabbit",
+    "dog",
+    "swine",
+    "zebrafish",
+    "hamster",
+    "primate",
+    "disease models",
+    "animal",
+}
+MESH_B: Final[Set[str]] = {
+    "pharmacology",
+    "drug effects",
+    "administration & dosage",
+    "therapeutic use",
+    "toxicity",
+    "adverse effects",
+    "pharmacokinetics",
+    "metabolism",
+}
+MESH_C: Final[Set[str]] = {
+    "pain measurement",
+    "nociceptors",
+    "hyperalgesia",
+    "allodynia",
+    "edema",
+    "inflammation",
+}
+MESH_D: Final[Set[str]] = {
+    "cells, cultured",
+    "cell line",
+    "recombinant proteins",
+    "enzymes",
+    "hek293",
+    "hepg2",
+    "hela",
+    "cho",
+    "u2os",
+    "mcf-7",
+    "thp-1",
+    "293t",
+    "nhdf",
+    "huh7",
+    "sf9",
+    "organoid",
+    "primary cell",
+}
+MESH_E: Final[Set[str]] = {
+    "in vitro techniques",
+    "pharmacology",
+    "drug effects",
+    "enzyme activation",
+    "enzyme inhibition",
+    "binding sites",
+    "affinity",
+}
+MESH_F: Final[Set[str]] = {
+    "kinetics",
+    "dose-response relationship, drug",
+    "signal transduction",
+}
+
+# Utility regex for splitting list fields
+LIST_SPLIT_RE: Final[Pattern[str]] = re.compile(r"[;,|/]+")

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,110 @@
+from classifier import DocumentClassifier
+from io_schemas import DocumentRecord
+
+
+def make_record(**kwargs):
+    base = {
+        "title": "",
+        "abstract": "",
+        "doi": "",
+        "pubmed_publicationtype": [],
+        "scholar_publicationtypes": [],
+        "openalex_publicationtypes": [],
+        "crossref_type": None,
+        "openalex_typecrossref": None,
+        "pubmed_mesh_descriptors": [],
+        "pubmed_mesh_qualifiers": [],
+        "openalex_meshdescriptors": [],
+        "openalex_meshqualifiers": [],
+        "pubmed_chemicallist": [],
+        "optional_experiment_kind": None,
+    }
+    base.update(kwargs)
+    return DocumentRecord(**base)
+
+
+classifier = DocumentClassifier()
+
+
+def test_protocol_veto_overrides_clinical():
+    record = make_record(
+        title="Randomized Controlled Trial",
+        abstract="This study protocol evaluates...",
+        pubmed_publicationtype=["Randomized Controlled Trial"],
+        pubmed_mesh_descriptors=["humans"],
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Other non experimental publication"
+
+
+def test_review_crossref_conflict():
+    record = make_record(
+        title="A review of therapy",
+        pubmed_publicationtype=["Review"],
+        crossref_type="journal-article",
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Review"
+    assert "xrf_generic_vs_nonexperimental" in result.conflicts
+
+
+def test_veterinary_trial_in_vivo():
+    record = make_record(
+        title="Dose response in mice",
+        abstract="IP 10 mg/kg reduced pain in rats",
+        pubmed_publicationtype=["Clinical Trial, Veterinary"],
+        pubmed_mesh_descriptors=["animals", "mice", "pain measurement"],
+        pubmed_mesh_qualifiers=["pharmacology"],
+        optional_experiment_kind="F",
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Experimental in vivo bioactivity"
+
+
+def test_clean_in_vitro():
+    record = make_record(
+        title="Binding assay in cell line",
+        abstract="In vitro binding assay using HEK293 cells showed IC50",
+        pubmed_publicationtype=["Comparative Study"],
+        pubmed_mesh_descriptors=["cell line"],
+        pubmed_mesh_qualifiers=["in vitro techniques"],
+        pubmed_chemicallist=["aspirin"],
+        optional_experiment_kind="B",
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Experimental in vitro bioactivity"
+    assert result.pt_comparative
+
+
+def test_review_with_mouse_not_in_vivo():
+    record = make_record(
+        title="Review of mouse cell lines",
+        abstract="We discuss mouse models and HEK293 cells in vitro",
+        pubmed_publicationtype=["Review"],
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Review"
+
+
+def test_tie_with_behavior_goes_vivo():
+    record = make_record(
+        title="Effects in mice and cells",
+        abstract="IP 5 mg/kg reduced paw edema and in vitro assay on HEK293 cells",
+        pubmed_mesh_descriptors=["animals", "pain measurement", "cell line"],
+        pubmed_mesh_qualifiers=["pharmacology", "in vitro techniques"],
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Experimental in vivo bioactivity"
+    assert "vivo_vs_vitro_tie" in result.conflicts
+
+
+def test_tie_without_behavior_goes_vitro():
+    record = make_record(
+        title="Animal cell line kinetics",
+        abstract="Study on mice cell line kinetics in vitro",
+        pubmed_mesh_descriptors=["animals", "pain measurement", "cell line"],
+        pubmed_mesh_qualifiers=["pharmacology", "in vitro techniques"],
+    )
+    result = classifier.classify(record)
+    assert result.final_class == "Experimental in vitro bioactivity"
+    assert "vivo_vs_vitro_tie" in result.conflicts

--- a/tests/test_get_document_type.py
+++ b/tests/test_get_document_type.py
@@ -1,0 +1,31 @@
+"""Tests for :mod:`get_document_type` utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from get_document_type import classify_dataframe
+
+
+def test_classify_dataframe_basic() -> None:
+    """Basic smoke test for :func:`classify_dataframe`."""
+
+    df = pd.DataFrame(
+        {
+            "title": ["t"],
+            "abstract": ["a"],
+            "PubMed.PublicationType": ["review"],
+            "scholar.PublicationTypes": [""],
+            "OpenAlex.PublicationTypes": [""],
+            "OpenAlex.TypeCrossref": [""],
+        }
+    )
+
+    result = classify_dataframe(
+        df,
+        min_review_score=1,
+        min_unknown_score=1,
+        min_experimental_score=1,
+    )
+
+    assert result.loc[0, "class_label"] == "review"


### PR DESCRIPTION
## Summary
- introduce rule module with regex patterns and publication-type mappings for document classification
- implement deterministic `DocumentClassifier` with Pydantic schemas and in vivo/in vitro scoring
- provide CLI for CSV/JSONL files and comprehensive pytest coverage of classification scenarios

## Testing
- `python -m black rules.py classifier.py io_schemas.py main.py tests/test_classifier.py`
- `python -m ruff check rules.py classifier.py io_schemas.py main.py tests/test_classifier.py`
- `python -m mypy rules.py classifier.py io_schemas.py main.py tests/test_classifier.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb2dab129c8324875375f75dff6f06