### PR TITLE
Add document post-processing pipeline

### DIFF
--- a/get_document_data.py
+++ b/get_document_data.py
@@ -37,6 +37,7 @@ from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
 from library import openalex_crossref_library as ocl
 from library import io
+from library import document_postprocessing as dp
 
 logger = logging.getLogger(__name__)
 
@@ -186,9 +187,10 @@ def run_all(args: argparse.Namespace) -> int:
     doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)
     output = args.output_csv or io.default_output_path(args.input_csv)
     if doc_df.empty or "pubmed_id" not in doc_df:
+        processed = dp.postprocess_documents(doc_df)
         try:
-            io.write_csv(doc_df, output, sep=args.sep, encoding=args.encoding)
-            logger.info("Wrote %d rows to %s", len(doc_df), output)
+            io.write_csv(processed, output, sep=args.sep, encoding=args.encoding)
+            logger.info("Wrote %d rows to %s", len(processed), output)
             return 0
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
@@ -210,9 +212,10 @@ def run_all(args: argparse.Namespace) -> int:
         )
     else:
         merged = doc_df
+    processed = dp.postprocess_documents(merged)
     try:
-        io.write_csv(merged, output, sep=args.sep, encoding=args.encoding)
-        logger.info("Wrote %d rows to %s", len(merged), output)
+        io.write_csv(processed, output, sep=args.sep, encoding=args.encoding)
+        logger.info("Wrote %d rows to %s", len(processed), output)
         return 0
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)

--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -1,0 +1,271 @@
+"""Post-processing utilities for document metadata.
+
+This module normalises and enriches the combined document information
+produced by :mod:`get_document_data.py`.  The transformation is a
+translation of a Power Query script into ``pandas`` operations.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Columns that should be treated as text
+TEXT_COLUMNS: list[str] = [
+    "document_chembl_id",
+    "title",
+    "abstract",
+    "doi",
+    "journal",
+    "journal_abbrev",
+    "authors",
+    "source",
+    "PubMed.DOI",
+    "PubMed.ArticleTitle",
+    "PubMed.Abstract",
+    "PubMed.JournalTitle",
+    "PubMed.ISSN",
+    "PubMed.PublicationType",
+    "PubMed.MeSH_Descriptors",
+    "PubMed.MeSH_Qualifiers",
+    "PubMed.ChemicalList",
+    "PubMed.DayRevised",
+    "PubMed.MonthRevised",
+    "PubMed.YearRevised",
+    "PubMed.YearCompleted",
+    "PubMed.MonthCompleted",
+    "PubMed.DayCompleted",
+    "PubMed.Error",
+    "scholar.Venue",
+    "scholar.PublicationTypes",
+    "scholar.SemanticScholarId",
+    "scholar.ExternalIds",
+    "scholar.DOI",
+    "scholar.Error",
+    "OpenAlex.PublicationTypes",
+    "OpenAlex.TypeCrossref",
+    "OpenAlex.Genre",
+    "OpenAlex.Id",
+    "OpenAlex.Venue",
+    "OpenAlex.MeshDescriptors",
+    "OpenAlex.MeshQualifiers",
+    "OpenAlex.Error",
+    "crossref.Type",
+    "crossref.Subtype",
+    "crossref.Title",
+    "crossref.Subtitle",
+    "crossref.Subject",
+    "crossref.Error",
+]
+
+# Columns that should be converted to integers
+INT_COLUMNS: list[str] = [
+    "year",
+    "volume",
+    "issue",
+    "first_page",
+    "last_page",
+    "pubmed_id",
+    "PubMed.PMID",
+    "PubMed.Volume",
+    "PubMed.Issue",
+    "PubMed.StartPage",
+    "PubMed.EndPage",
+    "scholar.PMID",
+]
+
+# Final column ordering of the exported table
+COLUMN_ORDER: list[str] = [
+    "document_chembl_id",
+    "title",
+    "abstract",
+    "doi",
+    "year",
+    "journal",
+    "journal_abbrev",
+    "volume",
+    "issue",
+    "first_page",
+    "last_page",
+    "pubmed_id",
+    "authors",
+    "source",
+    "PubMed.PMID",
+    "PubMed.DOI",
+    "PubMed.ArticleTitle",
+    "PubMed.Abstract",
+    "PubMed.JournalTitle",
+    "PubMed.Volume",
+    "PubMed.Issue",
+    "PubMed.StartPage",
+    "PubMed.EndPage",
+    "PubMed.MeSH_Descriptors",
+    "PubMed.MeSH_Qualifiers",
+    "PubMed.ChemicalList",
+    "PubMed.DayRevised",
+    "PubMed.MonthRevised",
+    "PubMed.YearRevised",
+    "PubMed.YearCompleted",
+    "PubMed.MonthCompleted",
+    "PubMed.DayCompleted",
+    "PubMed.Error",
+    "scholar.PMID",
+    "scholar.Venue",
+    "scholar.SemanticScholarId",
+    "scholar.ExternalIds",
+    "scholar.DOI",
+    "scholar.Error",
+    "OpenAlex.TypeCrossref",
+    "OpenAlex.Genre",
+    "OpenAlex.Id",
+    "OpenAlex.Venue",
+    "OpenAlex.MeshDescriptors",
+    "OpenAlex.MeshQualifiers",
+    "OpenAlex.Error",
+    "crossref.Type",
+    "crossref.Subtype",
+    "crossref.Title",
+    "crossref.Subtitle",
+    "crossref.Subject",
+    "crossref.Error",
+    "PubMed.ISSN",
+    "date_code",
+    "Index",
+    "PubMed.is_review",
+    "scholar.is_review",
+    "OpenAlex.is_review",
+]
+
+
+DATE_COLUMNS: Iterable[str] = [
+    "PubMed.DayCompleted",
+    "PubMed.MonthCompleted",
+    "PubMed.YearCompleted",
+    "PubMed.DayRevised",
+    "PubMed.MonthRevised",
+    "PubMed.YearRevised",
+]
+
+
+def _safe_numeric(series: pd.Series) -> pd.Series:
+    """Return ``series`` as ``Int64`` with invalid values set to ``<NA>``."""
+
+    return pd.to_numeric(series, errors="coerce").astype("Int64")
+
+
+def postprocess_documents(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean and enrich document metadata.
+
+    Parameters
+    ----------
+    df:
+        Combined table produced by :mod:`get_document_data.py`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised table with derived fields.
+    """
+
+    result = df.copy()
+    if result.empty:
+        return result
+
+    # --- type conversions -----------------------------------------------------
+    for col in TEXT_COLUMNS:
+        if col in result.columns:
+            result[col] = result[col].astype(str)
+    for col in INT_COLUMNS:
+        if col in result.columns:
+            result[col] = _safe_numeric(result[col])
+
+    for col in DATE_COLUMNS:
+        if col not in result.columns:
+            result[col] = ""
+        else:
+            result[col] = result[col].astype(str)
+
+    # --- compute date_code ----------------------------------------------------
+    def build_date_code(row: pd.Series) -> str:
+        day_completed = row["PubMed.DayCompleted"]
+        if day_completed and day_completed != "0":
+            return f"{row['PubMed.YearCompleted']}-{row['PubMed.MonthCompleted']}-{day_completed}"
+        day_revised = row["PubMed.DayRevised"]
+        if day_revised and day_revised != "0":
+            return f"{row['PubMed.YearRevised']}-{row['PubMed.MonthRevised']}-{day_revised}"
+        return f"{row['PubMed.YearCompleted']}-{row['PubMed.MonthCompleted']}-01"
+
+    result["date_code"] = result.apply(build_date_code, axis=1)
+
+    # --- sort and add running index ------------------------------------------
+    result = result.sort_values(
+        "date_code", ascending=True, na_position="last"
+    ).reset_index(drop=True)
+    result["Index"] = result.index
+
+    # --- review flags ---------------------------------------------------------
+    def contains_review(series: pd.Series) -> pd.Series:
+        return series.str.contains("review", case=False, na=False)
+
+    if "OpenAlex.PublicationTypes" in result.columns:
+        result["OpenAlex.is_review"] = contains_review(
+            result["OpenAlex.PublicationTypes"]
+        )
+        result = result.drop(columns=["OpenAlex.PublicationTypes"])
+    else:
+        result["OpenAlex.is_review"] = False
+
+    if "PubMed.PublicationType" in result.columns:
+        result["PubMed.is_review"] = contains_review(result["PubMed.PublicationType"])
+        result = result.drop(columns=["PubMed.PublicationType"])
+    else:
+        result["PubMed.is_review"] = False
+
+    if "scholar.PublicationTypes" in result.columns:
+        result["scholar.is_review"] = contains_review(
+            result["scholar.PublicationTypes"]
+        )
+        result = result.drop(columns=["scholar.PublicationTypes"])
+    else:
+        result["scholar.is_review"] = False
+
+    # --- final column ordering ------------------------------------------------
+    existing = [c for c in COLUMN_ORDER if c in result.columns]
+    result = result[existing]
+
+    # --- format index ---------------------------------------------------------
+    if "Index" in result.columns:
+        result["Index"] = result["Index"].astype(int).astype(str).str.zfill(4)
+
+    return result
+
+
+def postprocess_file(
+    input_path: Path | str,
+    output_path: Path | str,
+    *,
+    sep: str = ",",
+    encoding: str = "utf8",
+) -> None:
+    """Read a CSV, apply :func:`postprocess_documents` and write result.
+
+    Parameters
+    ----------
+    input_path:
+        CSV file produced by ``get_document_data.py all``.
+    output_path:
+        Destination for the cleaned CSV file.
+    sep:
+        Field delimiter of the CSV files.
+    encoding:
+        Text encoding of the CSV files.
+    """
+
+    df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
+    processed = postprocess_documents(df)
+    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/tests/data/documents_postprocess.csv
+++ b/tests/data/documents_postprocess.csv
@@ -1,0 +1,3 @@
+document_chembl_id,PubMed.YearCompleted,PubMed.MonthCompleted,PubMed.DayCompleted,PubMed.YearRevised,PubMed.MonthRevised,PubMed.DayRevised,PubMed.PublicationType,scholar.PublicationTypes,OpenAlex.PublicationTypes
+DOC1,2020,05,12,2021,07,0,Journal Article|Review,Review,review-article
+DOC2,2019,06,0,2018,08,15,Letter,,other

--- a/tests/test_document_postprocessing.py
+++ b/tests/test_document_postprocessing.py
@@ -1,0 +1,34 @@
+"""Tests for :mod:`library.document_postprocessing`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library import document_postprocessing as dp
+
+
+def test_postprocess_documents_creates_flags_and_sorts() -> None:
+    """``postprocess_documents`` sorts rows and detects review articles."""
+
+    path = Path("tests/data/documents_postprocess.csv")
+    df = pd.read_csv(path, dtype=str)
+    result = dp.postprocess_documents(df)
+
+    # Rows sorted by computed date_code
+    assert result["document_chembl_id"].tolist() == ["DOC2", "DOC1"]
+    assert result["date_code"].tolist() == ["2018-08-15", "2020-05-12"]
+    # Index column is zero-padded
+    assert result["Index"].tolist() == ["0000", "0001"]
+    # Review detection from multiple sources
+    assert result["PubMed.is_review"].tolist() == [False, True]
+    assert result["scholar.is_review"].tolist() == [False, True]
+    assert result["OpenAlex.is_review"].tolist() == [False, True]
+    # Original publication type columns have been removed
+    for col in [
+        "PubMed.PublicationType",
+        "scholar.PublicationTypes",
+        "OpenAlex.PublicationTypes",
+    ]:
+        assert col not in result.columns


### PR DESCRIPTION
## Summary
- add `postprocess_documents` helper for review flags, date sorting, and index formatting
- apply document post-processing in `get_document_data.py`
- test document post-processing on sample data

## Testing
- `black library/document_postprocessing.py get_document_data.py tests/test_document_postprocessing.py`
- `ruff check library/document_postprocessing.py get_document_data.py tests/test_document_postprocessing.py`
- `mypy --ignore-missing-imports library/document_postprocessing.py`
- `mypy --ignore-missing-imports get_document_data.py` *(fails: Library stubs not installed for "requests" [import-untyped])* 
- `pytest tests/test_document_postprocessing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be659affd08324bfb8cdf5a611fc3e