### PR TITLE
feat: count assays per document-target pair

### DIFF
--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Sequence
 
+from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
 
@@ -38,6 +39,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     df = cl.get_assays_all(ids, chunk_size=args.chunk_size)
+    df = ap.postprocess_assays(df)
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)

--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -1,0 +1,95 @@
+"""Assay table post-processing utilities.
+
+This module provides helper functions to transform assay data retrieved from
+ChEMBL.  The main feature adds an ``assay_with_same_target`` column that counts
+how many assays share the same ``document_chembl_id`` and
+``target_chembl_id`` combination.  The transformation mimics the behaviour of a
+Power Query script used in the original workflow.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
+    """Ensure that *df* contains all *required* columns.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to validate.
+    required:
+        Iterable of mandatory column names.
+
+    Raises
+    ------
+    ValueError
+        If any of the required columns is missing from ``df``.
+    """
+
+    missing = set(required) - set(df.columns)
+    if missing:
+        raise ValueError(f"missing required columns: {', '.join(sorted(missing))}")
+
+
+def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
+    """Augment assay data with per-target assay counts.
+
+    The function adds a new column named ``assay_with_same_target`` to ``df``.  The
+    value represents how many assays share the same ``document_chembl_id`` and
+    ``target_chembl_id`` pair as the current row.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by :func:`library.chembl_library.get_assays_all`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Copy of the input with the additional ``assay_with_same_target`` column.
+    """
+
+    _validate_columns(df, ["document_chembl_id", "target_chembl_id"])
+    df = df.copy()
+    counts = (
+        df.groupby(["document_chembl_id", "target_chembl_id"])
+        .size()
+        .rename("assay_with_same_target")
+    )
+    logger.debug("Calculated counts for %d document/target groups", len(counts))
+    df = df.merge(counts, on=["document_chembl_id", "target_chembl_id"], how="left")
+    return df
+
+
+def postprocess_file(
+    input_path: Path | str,
+    output_path: Path | str,
+    *,
+    sep: str = ",",
+    encoding: str = "utf8",
+) -> None:
+    """Read an assay CSV, post-process and write the result.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the CSV file produced by ``get_assay_data.py``.
+    output_path:
+        Destination path for the cleaned CSV file.
+    sep:
+        Field delimiter of the CSV files.
+    encoding:
+        Text encoding of the CSV files.
+    """
+
+    df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
+    processed = postprocess_assays(df)
+    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/tests/test_assay_postprocessing.py
+++ b/tests/test_assay_postprocessing.py
@@ -1,0 +1,46 @@
+"""Tests for :mod:`library.assay_postprocessing`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library import assay_postprocessing as ap
+
+
+def test_postprocess_assays_counts() -> None:
+    """``postprocess_assays`` adds per-target counts."""
+
+    df = pd.DataFrame(
+        {
+            "document_chembl_id": ["doc1", "doc1", "doc1", "doc2"],
+            "target_chembl_id": ["t1", "t1", "t2", "t1"],
+            "assay_chembl_id": ["a1", "a2", "a3", "a4"],
+        }
+    )
+    out = ap.postprocess_assays(df)
+
+    assert out.loc[0, "assay_with_same_target"] == 2
+    assert out.loc[2, "assay_with_same_target"] == 1
+    assert out.loc[3, "assay_with_same_target"] == 1
+
+
+def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
+    """``postprocess_file`` reads, processes and writes data."""
+
+    df = pd.DataFrame(
+        {
+            "document_chembl_id": ["doc1", "doc1"],
+            "target_chembl_id": ["t1", "t1"],
+            "assay_chembl_id": ["a1", "a2"],
+        }
+    )
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "out.csv"
+
+    ap.postprocess_file(input_path, output_path)
+
+    result = pd.read_csv(output_path)
+    assert list(result["assay_with_same_target"]) == [2, 2]


### PR DESCRIPTION
## Summary
- add `assay_postprocessing` module to append `assay_with_same_target` counts
- run this post-processing in `get_assay_data.py`
- cover new functionality with unit tests

## Testing
- `python -m black get_assay_data.py library/assay_postprocessing.py tests/test_assay_postprocessing.py`
- `python -m ruff check get_assay_data.py library/assay_postprocessing.py tests/test_assay_postprocessing.py`
- `python -m mypy get_assay_data.py library/assay_postprocessing.py --ignore-missing-imports --follow-imports=skip`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be708ca79c8324a8b22102c4dc837f