### PR TITLE
Add input initialisation merging tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Individual scripts provide specialised data retrieval utilities:
 * ``get_document_data.py`` – gather publication metadata.
 * ``get_target_data.py`` – combine ChEMBL, UniProt and IUPHAR target data.
 * ``get_testitem_data.py`` – download compound data and enrich with PubChem.
+* ``get_input_initialisation.py`` – merge ChEMBL initialisation workbooks.
 
 All scripts share a common set of flags:
 
@@ -36,6 +37,13 @@ Example fetching assay data::
 
 Each command validates required columns before querying external APIs and
 writes the resulting table to the specified output file.
+
+Example merging initialisation tables::
+
+    python get_input_initialisation.py \
+      --same-doc path/to/ChEMBL_same_document_20_05.xlsx \
+      --all-doc  path/to/ChEMBL_all_10_05_step5.xlsx \
+      --out-dir  ./out
 
 ## Development
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -1,0 +1,90 @@
+"""CLI for combining ChEMBL initialisation Excel sources."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from library import input_initialisation_library as lib
+
+logger = logging.getLogger(__name__)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute table combination routine.
+
+    Parameters
+    ----------
+    args:
+        Parsed command line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero otherwise.
+    """
+    try:
+        if not args.same_doc.exists():
+            raise FileNotFoundError(f"{args.same_doc} does not exist")
+        if not args.all_doc.exists():
+            raise FileNotFoundError(f"{args.all_doc} does not exist")
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Loading source workbooks")
+        same = lib.load_same_doc(args.same_doc)
+        all_ = lib.load_all_doc(args.all_doc)
+
+        logger.info("Combining tables")
+        tables = lib.build_combined_tables(same, all_)
+
+        logger.info("Saving output")
+        paths = lib.save_tables(tables, args.out_dir, fmt=args.format)
+        # Ensure that files were actually written to disk
+        missing = [str(p) for p in paths.values() if not p.exists()]
+        if missing:
+            raise RuntimeError("failed to write output files: " + ", ".join(missing))
+        logger.info("Saved %d tables to %s", len(paths), args.out_dir)
+        return 0
+    except Exception as exc:
+        logger.error("%s", exc)
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--same-doc", type=Path, required=True, help="Path to same document workbook"
+    )
+    parser.add_argument(
+        "--all-doc", type=Path, required=True, help="Path to all document workbook"
+    )
+    parser.add_argument(
+        "--out-dir", type=Path, default=Path("."), help="Output directory"
+    )
+    parser.add_argument(
+        "--format", choices=["csv"], default="csv", help="Output format"
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    """Configure logging at ``level``."""
+    numeric = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(level=numeric)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1,0 +1,381 @@
+"""Utilities for combining ChEMBL initialisation input tables.
+
+This module provides helpers to read source Excel workbooks, softly cast
+common column types, merge entity tables and persist the final CSV files.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Literal
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+EntityName = Literal["activity", "assay", "document", "target", "testitem"]
+
+# Mapping of sheet names to entity identifiers
+SAME_DOC_SHEETS: dict[str, EntityName] = {
+    "assay_step5_same_doc": "assay",
+    "molecule_step5_same_doc": "testitem",
+    "target_step5_same_doc": "target",
+    "document_step5_same_doc": "document",
+    "activities_step5_same_doc": "activity",
+}
+
+ALL_DOC_SHEETS: dict[str, EntityName] = {
+    "assay_step5": "assay",
+    "molecule_step5": "testitem",
+    "target_step5": "target",
+    "document_step5": "document",
+    "activities_step5": "activity",
+}
+
+# Columns that should be removed from the combined activity table
+ACTIVITY_DROP_COLS: set[str] = {
+    "n_stereocenters",
+    "unspecified_chirality_mol",
+    "shuffled_target_assay",
+    "approx_cited_activity",
+    "exact_cited_activity_samedoc",
+    "approx_cited_activity_samedoc",
+    "survives_main_steps",
+    "num_citations",
+    "higly_correlated_cit_samedoc",
+    "higly_correlated_cit",
+    "shuffled_cit",
+    "exact_cited_activity",
+    "multmol_assay",
+    "multimol",
+    "publication_date",
+    "sort_order.document",
+    "document_contains_external_links",
+    "review_doc",
+    "year",
+    "month",
+    "day",
+    "Citation",
+    "Column1",
+    "Column2",
+    "Column3",
+    "Column4",
+    "Column5",
+    "Column6",
+    "Column7",
+    "Column8",
+    "Column9",
+    "Column10",
+    "Column11",
+    "Column12",
+    "Column13",
+    "Column14",
+    "Column15",
+    "Column16",
+    "Column17",
+    "Column18",
+    "Column19",
+    "Column20",
+    "Column21",
+    "Column22",
+    "Column23",
+    "Column24",
+    "Column25",
+    "Column26",
+    "Column27",
+    "Column28",
+    "Column29",
+    "Column30",
+    "Column31",
+    "Column32",
+    "Column33",
+    "Column34",
+    "Column35",
+    "Column36",
+    "Column37",
+    "Column38",
+    "Column39",
+    "Column40",
+    "Column41",
+    "Column42",
+    "Column43",
+    "Column44",
+}
+
+# Type hints for soft conversions
+STRING_COLS: set[str] = {
+    "assay_chembl_id",
+    "document_chembl_id",
+    "target_chembl_id",
+    "salt_chembl_id",
+    "molecule_chembl_id",
+}
+
+INT_COLS: set[str] = {
+    "isoform",
+    "version",
+    "acts_per_assay_step5",
+    "volume",
+    "last_page",
+    "pubmed_id",
+    "classification",
+    "year",
+    "month",
+    "day",
+    "citation",
+    "nActivity",
+    "nstereo",
+    "n_stereocenters",
+}
+
+BOOL_COLS: set[str] = {
+    "shuffled_target_assay",
+    "shuffled_cit",
+    "higly_correlated_cit",
+    "cited_assay_corr",
+    "error_assay_corr",
+    "document_contains_external_links",
+    "is_experimental_doc",
+}
+
+FLOAT_COLS: set[str] = {
+    "mw_freebase",
+    "standard_value",
+    "log_value",
+    "citation_fraction",
+}
+
+DATE_COLS: set[str] = {
+    "publication_date",
+}
+
+
+def _ensure_openpyxl() -> None:
+    """Ensure a supported ``openpyxl`` version is available.
+
+    Raises
+    ------
+    RuntimeError
+        If ``openpyxl`` is missing or too old.
+    """
+    try:
+        import openpyxl  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("openpyxl>=3.1 is required to read Excel files") from exc
+    version = tuple(int(v) for v in openpyxl.__version__.split(".")[:3])
+    if version < (3, 1, 0):  # pragma: no cover - defensive
+        raise RuntimeError(f"openpyxl>=3.1 is required, found {openpyxl.__version__}")
+
+
+def _read_sheet(
+    path: Path, sheet: str, *, header_promotion: bool = False
+) -> pd.DataFrame:
+    """Read ``sheet`` from an Excel file.
+
+    Parameters
+    ----------
+    path:
+        Excel workbook location.
+    sheet:
+        Sheet name to load.
+    header_promotion:
+        If ``True`` the first row is treated as header regardless of Excel's
+        stored header information.
+
+    Raises
+    ------
+    ValueError
+        If the sheet is missing.
+    """
+    _ensure_openpyxl()
+    try:
+        if header_promotion:
+            raw = pd.read_excel(path, sheet_name=sheet, header=None, engine="openpyxl")
+            if raw.empty:
+                return pd.DataFrame()
+            header = raw.iloc[0].astype(str).tolist()
+            df = raw.iloc[1:].reset_index(drop=True)
+            df.columns = header
+            return df
+        return pd.read_excel(path, sheet_name=sheet, engine="openpyxl")
+    except ValueError as exc:  # missing sheet
+        raise ValueError(f"sheet '{sheet}' not found in {path}") from exc
+
+
+def load_same_doc(xlsx_path: Path) -> Dict[EntityName, pd.DataFrame]:
+    """Load entity tables from ``ChEMBL_same_document_20_05.xlsx``.
+
+    Parameters
+    ----------
+    xlsx_path:
+        Path to the Excel workbook.
+
+    Returns
+    -------
+    dict
+        Mapping of entity names to DataFrames.
+    """
+    tables: Dict[EntityName, pd.DataFrame] = {}
+    for sheet, entity in SAME_DOC_SHEETS.items():
+        logger.info("Reading sheet '%s' from %s", sheet, xlsx_path)
+        tables[entity] = _read_sheet(xlsx_path, sheet)
+    return tables
+
+
+def load_all_doc(xlsx_path: Path) -> Dict[EntityName, pd.DataFrame]:
+    """Load entity tables from ``ChEMBL_all_10_05_step5.xlsx``.
+
+    The ``activities_step5`` sheet requires promotion of the first row to
+    header.
+    """
+    tables: Dict[EntityName, pd.DataFrame] = {}
+    for sheet, entity in ALL_DOC_SHEETS.items():
+        logger.info("Reading sheet '%s' from %s", sheet, xlsx_path)
+        promote = sheet == "activities_step5"
+        tables[entity] = _read_sheet(xlsx_path, sheet, header_promotion=promote)
+    return tables
+
+
+def _safe_to_int(series: pd.Series, col: str) -> pd.Series:
+    try:
+        return pd.to_numeric(series, errors="raise").astype("Int64")
+    except Exception as exc:  # pragma: no cover - rare
+        logger.warning("Failed to convert column '%s' to Int64: %s", col, exc)
+        return series.astype("string")
+
+
+def _safe_to_float(series: pd.Series, col: str) -> pd.Series:
+    try:
+        return pd.to_numeric(series, errors="raise").astype("float64")
+    except Exception as exc:  # pragma: no cover - rare
+        logger.warning("Failed to convert column '%s' to float: %s", col, exc)
+        return series.astype("string")
+
+
+def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
+    try:
+        return pd.to_datetime(series, errors="raise")
+    except Exception as exc:  # pragma: no cover - rare
+        logger.warning("Failed to convert column '%s' to datetime: %s", col, exc)
+        return series.astype("string")
+
+
+def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
+    def mapper(value: object) -> object:
+        if pd.isna(value):
+            return pd.NA
+        if isinstance(value, str):
+            value = value.strip().lower()
+        if value in {True, 1, "1", "true", "t"}:
+            return True
+        if value in {False, 0, "0", "false", "f"}:
+            return False
+        raise ValueError(f"invalid boolean value: {value}")
+
+    try:
+        mapped = series.map(mapper)
+        return mapped.astype("boolean")
+    except Exception as exc:  # pragma: no cover - rare
+        logger.warning("Failed to convert column '%s' to boolean: %s", col, exc)
+        return series.astype("string")
+
+
+def unify_dtypes(df: pd.DataFrame) -> pd.DataFrame:
+    """Softly cast frequent columns to expected dtypes.
+
+    Unrecognised values fall back to ``string`` dtype while emitting a warning.
+    """
+    result = df.copy()
+    for col in STRING_COLS & set(result.columns):
+        result[col] = result[col].astype("string")
+    for col in INT_COLS & set(result.columns):
+        result[col] = _safe_to_int(result[col], col)
+    for col in BOOL_COLS & set(result.columns):
+        result[col] = _safe_to_bool(result[col], col)
+    for col in FLOAT_COLS & set(result.columns):
+        result[col] = _safe_to_float(result[col], col)
+    for col in DATE_COLS & set(result.columns):
+        result[col] = _safe_to_datetime(result[col], col)
+    return result
+
+
+def append_entities(df_a: pd.DataFrame, df_b: pd.DataFrame) -> pd.DataFrame:
+    """Vertically concatenate ``df_a`` and ``df_b`` and remove duplicates."""
+    combined = pd.concat([df_a, df_b], ignore_index=True, sort=False)
+    return combined.drop_duplicates(keep="first")
+
+
+def build_combined_tables(
+    same: Dict[EntityName, pd.DataFrame],
+    all_: Dict[EntityName, pd.DataFrame],
+) -> Dict[EntityName, pd.DataFrame]:
+    """Combine entity tables from ``same`` and ``all_`` sources."""
+    combined: Dict[EntityName, pd.DataFrame] = {}
+    for entity in SAME_DOC_SHEETS.values():
+        df_same = unify_dtypes(same[entity])
+        df_all = unify_dtypes(all_[entity])
+        rows_same = len(df_same)
+        rows_all = len(df_all)
+        if entity == "activity":
+            concat = pd.concat([df_same, df_all], ignore_index=True, sort=False)
+            concat = concat.drop(
+                columns=list(ACTIVITY_DROP_COLS & set(concat.columns)),
+                errors="ignore",
+            )
+            df = concat.drop_duplicates(keep="first")
+            rows_concat = len(concat)
+            rows_after = len(df)
+        else:
+            df = append_entities(df_same, df_all)
+            rows_concat = rows_same + rows_all
+            rows_after = len(df)
+        logger.info(
+            "Entity %s: rows_same=%d rows_all=%d rows_concat=%d rows_after_dedup=%d",
+            entity,
+            rows_same,
+            rows_all,
+            rows_concat,
+            rows_after,
+        )
+        if entity == "activity":
+            remaining = ACTIVITY_DROP_COLS & set(df.columns)
+            if remaining:
+                raise ValueError(
+                    f"activity table still contains columns: {', '.join(sorted(remaining))}"
+                )
+        combined[entity] = df
+    return combined
+
+
+def save_tables(
+    tables: Dict[EntityName, pd.DataFrame],
+    out_dir: Path,
+    fmt: str = "csv",
+) -> Dict[EntityName, Path]:
+    """Persist combined tables to ``out_dir``.
+
+    Parameters
+    ----------
+    tables:
+        Mapping of entity names to DataFrames.
+    out_dir:
+        Destination directory. Created if missing.
+    fmt:
+        Output format. Only ``"csv"`` is supported.
+
+    Returns
+    -------
+    dict
+        Mapping of entity names to written file paths.
+    """
+    if fmt != "csv":
+        raise ValueError("only csv output is supported")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths: Dict[EntityName, Path] = {}
+    for entity, df in tables.items():
+        path = out_dir / f"{entity}.csv"
+        df.to_csv(path, index=False, encoding="utf-8", na_rep="")
+        logger.info("Wrote %d rows to %s", len(df), path)
+        paths[entity] = path
+    return paths

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytest>=7.0
 black>=23.0
 ruff>=0.0.290
 mypy>=1.8
+
+openpyxl>=3.1

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pandas as pd
+import sys
+from pathlib import Path
+
+import pytest
+
+from library.input_initialisation_library import (
+    _ensure_openpyxl,
+    EntityName,
+    append_entities,
+    build_combined_tables,
+    unify_dtypes,
+    save_tables,
+)
+
+
+def test_unify_dtypes_basic() -> None:
+    df = pd.DataFrame(
+        {
+            "assay_chembl_id": ["A1"],
+            "isoform": ["1"],
+            "shuffled_cit": ["1"],
+            "mw_freebase": ["10.5"],
+            "publication_date": ["2020-01-01"],
+        }
+    )
+    res = unify_dtypes(df)
+    assert res["assay_chembl_id"].dtype == "string"
+    assert str(res["isoform"].dtype) == "Int64"
+    assert res["shuffled_cit"].dtype == "boolean"
+    assert res["mw_freebase"].dtype == "float64"
+    assert str(res["publication_date"].dtype).startswith("datetime64[")
+
+
+def test_append_entities_deduplication() -> None:
+    df_a = pd.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+    df_b = pd.DataFrame({"id": [2, 3], "val": ["b", "c"]})
+    res = append_entities(df_a, df_b)
+    assert len(res) == 3
+    assert sorted(res["id"].tolist()) == [1, 2, 3]
+
+
+def test_build_combined_tables_drops_activity_cols() -> None:
+    same: dict[EntityName, pd.DataFrame] = {
+        "activity": pd.DataFrame({"id": [1], "Column1": ["a"]}),
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+    }
+    all_: dict[EntityName, pd.DataFrame] = {
+        "activity": pd.DataFrame({"id": [2], "Column1": ["b"]}),
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+    }
+    combined = build_combined_tables(same, all_)
+    assert "Column1" not in combined["activity"].columns
+    assert len(combined["activity"]) == 2
+
+
+def test_save_tables_writes_files(tmp_path: Path) -> None:
+    tables: dict[EntityName, pd.DataFrame] = {
+        "activity": pd.DataFrame({"id": [1]}),
+        "assay": pd.DataFrame({"id": [2]}),
+        "document": pd.DataFrame({"id": [3]}),
+        "target": pd.DataFrame({"id": [4]}),
+        "testitem": pd.DataFrame({"id": [5]}),
+    }
+    paths = save_tables(tables, tmp_path)
+    for entity, path in paths.items():
+        assert path.exists(), f"missing {entity} file"
+        df = pd.read_csv(path)
+        assert not df.empty
+
+
+def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = type("M", (), {"__version__": "3.0.0"})()
+    monkeypatch.setitem(sys.modules, "openpyxl", module)
+    with pytest.raises(RuntimeError):
+        _ensure_openpyxl()
+    monkeypatch.delitem(sys.modules, "openpyxl")


### PR DESCRIPTION
## Summary
- add `input_initialisation_library` for reading, type-casting and merging ChEMBL initialisation tables
- provide `get_input_initialisation.py` CLI to combine Excel sources and write CSV outputs, verifying that files were written
- include basic unit tests and openpyxl dependency
- validate `openpyxl` version before reading Excel workbooks and document CLI usage

## Testing
- `black library/input_initialisation_library.py get_input_initialisation.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py get_input_initialisation.py tests/test_input_initialisation_library.py`
- `mypy --ignore-missing-imports library/input_initialisation_library.py get_input_initialisation.py tests/test_input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea1cec81083248da7ce6b2656080a