### PR TITLE
Add table quality profiling module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ Individual scripts provide specialised data retrieval utilities:
 * ``get_testitem_data.py`` – download compound data and enrich with PubChem.
 * ``get_input_initialisation.py`` – merge ChEMBL initialisation workbooks.
 
+### Table quality analysis
+
+``table_quality_main.py`` profiles arbitrary CSV files and reports column
+statistics along with correlations between numeric fields. Example usage:
+
+```python
+import pandas as pd
+from library.table_quality import analyze_table_quality
+
+df = pd.read_csv("data.csv", encoding="utf-8-sig")
+quality, corr = analyze_table_quality(df, table_name="data")
+```
+
+Running the CLI saves ``data_quality_report_table.csv`` and
+``data_data_correlation_report_table.csv`` in the current working directory::
+
+    python table_quality_main.py --input data.csv --table-name data
+
 All scripts share a common set of flags:
 
 * ``--input`` – input CSV file (default ``input.csv``)
@@ -44,6 +62,11 @@ Example merging initialisation tables::
       --same-doc path/to/ChEMBL_same_document_20_05.xlsx \
       --all-doc  path/to/ChEMBL_all_10_05_step5.xlsx \
       --out-dir  ./out
+
+The script also profiles each exported table and writes
+``<name>_quality_report_table.csv`` and
+``<name>_data_correlation_report_table.csv`` alongside the original CSVs
+in ``--out-dir``.
 
 ## Development
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Sequence
 
 from library import input_initialisation_library as lib
+from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,15 @@ def run(args: argparse.Namespace) -> int:
         missing = [str(p) for p in paths.values() if not p.exists()]
         if missing:
             raise RuntimeError("failed to write output files: " + ", ".join(missing))
-        logger.info("Saved %d tables to %s", len(paths), args.out_dir)
+
+        logger.info("Generating data quality reports")
+        for entity, path in paths.items():
+            logger.info("Profiling %s", entity)
+            analyze_table_quality(path, table_name=str(path.with_suffix("")))
+
+        logger.info(
+            "Saved %d tables and quality reports to %s", len(paths), args.out_dir
+        )
         return 0
     except Exception as exc:
         logger.error("%s", exc)

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Dict, Literal
+from typing import Any, Dict, Literal
 
 import pandas as pd
 
@@ -262,7 +262,7 @@ def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
 
 
 def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
-    def mapper(value: object) -> object:
+    def mapper(value: Any) -> object:
         if pd.isna(value):
             return pd.NA
         if isinstance(value, str):

--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -1,0 +1,320 @@
+"""Tabular data profiling utilities.
+
+This module provides the :func:`analyze_table_quality` function which
+profiles every column in a given :class:`pandas.DataFrame` and computes
+pairwise correlations for numeric columns.  It is intended for offline
+use without external dependencies beyond :mod:`pandas` and :mod:`numpy`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Precompiled regular expressions for pattern coverage
+_DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
+_ISSN_RE = re.compile(r"^\d{4}-\d{3}[\dXx]$")
+_URL_RE = re.compile(r"^(?:https?|ftp)://|^www\.")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+BOOL_LIKE = {"true", "false", "yes", "no", "y", "n", "1", "0", "t", "f"}
+
+
+def _load_table(table: pd.DataFrame | str | Path) -> pd.DataFrame:
+    """Load a table from ``table``.
+
+    Parameters
+    ----------
+    table:
+        Either an existing :class:`pandas.DataFrame` or path to a CSV file.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    if isinstance(table, pd.DataFrame):
+        return table.copy()
+
+    path = Path(table)
+    encodings = ["utf-8-sig", "utf-8", "cp1251", "latin-1"]
+    for enc in encodings:
+        try:
+            return pd.read_csv(path, encoding=enc)
+        except UnicodeDecodeError:
+            logger.debug("failed to decode %s with %s", path, enc)
+            continue
+    raise UnicodeDecodeError("utf-8", b"", 0, 1, "Unable to decode CSV")
+
+
+def _is_isbn(value: str) -> bool:
+    """Return ``True`` if ``value`` is a valid ISBN10/13."""
+    digits = re.sub(r"[-\s]", "", value)
+    if re.fullmatch(r"\d{9}[\dXx]", digits):
+        total = sum(
+            (10 - i) * (10 if ch.upper() == "X" else int(ch))
+            for i, ch in enumerate(digits)
+        )
+        return total % 11 == 0
+    if re.fullmatch(r"\d{13}", digits):
+        total = sum(
+            (1 if i % 2 == 0 else 3) * int(ch) for i, ch in enumerate(digits[:-1])
+        )
+        check = (10 - total % 10) % 10
+        return check == int(digits[-1])
+    return False
+
+
+def _non_empty_mask(series: pd.Series) -> pd.Series:
+    """Boolean mask of values that are not empty by content."""
+
+    def is_non_empty(val: Any) -> bool:
+        if isinstance(val, str):
+            return bool(val.strip())
+        return not pd.isna(val)
+
+    return series.map(is_non_empty)
+
+
+def _string_values(series: pd.Series, mask: pd.Series) -> pd.Series:
+    """Return non-empty string values from ``series`` according to ``mask``."""
+    return (
+        series[mask & series.map(lambda x: isinstance(x, str))].astype(str).str.strip()
+    )
+
+
+def _pattern_cov(strings: pd.Series, pattern: re.Pattern[str]) -> float:
+    """Fraction of ``strings`` matching ``pattern``."""
+    if strings.empty:
+        return 0.0
+    return float(strings.str.match(pattern).mean())
+
+
+def _isbn_cov(strings: pd.Series) -> float:
+    if strings.empty:
+        return 0.0
+    return float(strings.map(_is_isbn).mean())
+
+
+def _bool_like_cov(values: pd.Series) -> float:
+    if values.empty:
+        return 0.0
+    return float(values.astype(str).str.strip().str.lower().isin(BOOL_LIKE).mean())
+
+
+def _numeric_stats(series: pd.Series) -> tuple[float, dict[str, float]]:
+    numeric = pd.to_numeric(series, errors="coerce")
+    coverage = float(numeric.notna().mean())
+    stats = {
+        "numeric_min": float(numeric.min()) if coverage else np.nan,
+        "numeric_p50": float(numeric.quantile(0.5)) if coverage else np.nan,
+        "numeric_p95": float(numeric.quantile(0.95)) if coverage else np.nan,
+        "numeric_max": float(numeric.max()) if coverage else np.nan,
+        "numeric_mean": float(numeric.mean()) if coverage else np.nan,
+        "numeric_std": float(numeric.std(ddof=0)) if coverage else np.nan,
+    }
+    return coverage, stats
+
+
+def _parse_dates(series: pd.Series) -> tuple[float, dict[str, pd.Timestamp | float]]:
+    def normalise(val: object) -> object:
+        if isinstance(val, str) and re.fullmatch(r"\d{4}", val.strip()):
+            return f"{val.strip()}-07-01"
+        return val
+
+    normalised = series.map(normalise)
+    dates = pd.to_datetime(normalised, errors="coerce", utc=True)
+    coverage = float(dates.notna().mean())
+    if coverage:
+        dt = dates.dropna().dt.tz_convert(None)
+        stats: dict[str, pd.Timestamp | float] = {
+            "date_min": dt.min(),
+            "date_p50": dt.quantile(0.5),
+            "date_max": dt.max(),
+        }
+    else:
+        stats = {"date_min": np.nan, "date_p50": np.nan, "date_max": np.nan}
+    return coverage, stats
+
+
+def _text_length_stats(series: pd.Series) -> dict[str, float]:
+    values = series.dropna().map(lambda x: str(x).strip())
+    if values.empty:
+        return {
+            "text_len_min": np.nan,
+            "text_len_p50": np.nan,
+            "text_len_p95": np.nan,
+            "text_len_max": np.nan,
+        }
+    lengths = values.map(len)
+    return {
+        "text_len_min": float(lengths.min()),
+        "text_len_p50": float(lengths.quantile(0.5)),
+        "text_len_p95": float(lengths.quantile(0.95)),
+        "text_len_max": float(lengths.max()),
+    }
+
+
+def _top_values(series: pd.Series) -> str:
+    counts = series.dropna().map(lambda x: str(x).strip()).value_counts().head(3)
+    parts = [f"{str(val)[:60]} ({cnt})" for val, cnt in counts.items()]
+    return "; ".join(parts)
+
+
+def analyze_table_quality(
+    table: pd.DataFrame | str | Path, table_name: str
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Profile ``table`` and compute correlations for numeric columns.
+
+    Parameters
+    ----------
+    table:
+        :class:`pandas.DataFrame` or path to a CSV file.
+    table_name:
+        Base name used for output files.
+
+    Returns
+    -------
+    tuple[pandas.DataFrame, pandas.DataFrame]
+        Quality report and correlation matrix.
+    """
+    df = _load_table(table)
+    rows: list[dict[str, object]] = []
+    numeric_candidates: dict[str, pd.Series] = {}
+    for column in df.columns:
+        series = df[column]
+        non_null = int(series.notna().sum())
+        mask = _non_empty_mask(series)
+        non_empty = int(mask.sum())
+        empty_pct = float(1 - non_empty / len(series)) if len(series) else 0.0
+        unique_cnt = int(series.dropna().nunique())
+        unique_pct = float(unique_cnt / non_empty) if non_empty else np.nan
+
+        strings = _string_values(series, mask)
+        pattern_cov_doi = _pattern_cov(strings, _DOI_RE)
+        pattern_cov_issn = _pattern_cov(strings, _ISSN_RE)
+        pattern_cov_isbn = _isbn_cov(strings)
+        pattern_cov_url = _pattern_cov(strings, _URL_RE)
+        pattern_cov_email = _pattern_cov(strings, _EMAIL_RE)
+
+        bool_like_cov = _bool_like_cov(strings)
+
+        numeric_cov, num_stats = _numeric_stats(series)
+        if numeric_cov >= 0.8:
+            numeric_candidates[column] = pd.to_numeric(series, errors="coerce")
+
+        date_cov, date_stats = _parse_dates(series)
+
+        text_stats = _text_length_stats(series)
+
+        roles: list[str] = []
+        if pattern_cov_url > 0:
+            roles.append("url")
+        if pattern_cov_doi > 0:
+            roles.append("doi")
+        if pattern_cov_issn > 0:
+            roles.append("issn")
+        if pattern_cov_isbn > 0:
+            roles.append("isbn")
+        if pattern_cov_email > 0:
+            roles.append("email")
+        if bool_like_cov >= 0.8:
+            roles.append("boolean")
+        if date_cov >= 0.8:
+            roles.append("date")
+        if numeric_cov >= 0.8:
+            roles.append("numeric")
+        if non_empty and unique_cnt / non_empty >= 0.98:
+            roles.append("identifier-like")
+        elif unique_cnt <= min(100, 0.05 * non_empty):
+            roles.append("categorical")
+        else:
+            roles.append("free-text")
+
+        row: dict[str, object] = {
+            "column": column,
+            "non_null": non_null,
+            "non_empty": non_empty,
+            "empty_pct": empty_pct,
+            "unique_cnt": unique_cnt,
+            "unique_pct_of_non_empty": unique_pct,
+            "pattern_cov_doi": pattern_cov_doi,
+            "pattern_cov_issn": pattern_cov_issn,
+            "pattern_cov_isbn": pattern_cov_isbn,
+            "pattern_cov_url": pattern_cov_url,
+            "pattern_cov_email": pattern_cov_email,
+            "bool_like_cov": bool_like_cov,
+            "numeric_cov": numeric_cov,
+            **num_stats,
+            "date_cov": date_cov,
+            **date_stats,
+            **text_stats,
+            "guessed_roles": "|".join(roles),
+            "top_values": _top_values(series),
+        }
+        rows.append(row)
+
+    column_order = [
+        "column",
+        "non_null",
+        "non_empty",
+        "empty_pct",
+        "unique_cnt",
+        "unique_pct_of_non_empty",
+        "pattern_cov_doi",
+        "pattern_cov_issn",
+        "pattern_cov_isbn",
+        "pattern_cov_url",
+        "pattern_cov_email",
+        "bool_like_cov",
+        "numeric_cov",
+        "numeric_min",
+        "numeric_p50",
+        "numeric_p95",
+        "numeric_max",
+        "numeric_mean",
+        "numeric_std",
+        "date_cov",
+        "date_min",
+        "date_p50",
+        "date_max",
+        "text_len_min",
+        "text_len_p50",
+        "text_len_p95",
+        "text_len_max",
+        "guessed_roles",
+        "top_values",
+    ]
+    quality_report = pd.DataFrame(rows, columns=column_order)
+    quality_path = f"{table_name}_quality_report_table.csv"
+    quality_report.to_csv(quality_path, index=False, encoding="utf-8-sig")
+
+    if numeric_candidates:
+        corr_report = pd.DataFrame(numeric_candidates).corr(method="pearson")
+        corr_path = f"{table_name}_data_correlation_report_table.csv"
+        corr_report.reset_index().to_csv(corr_path, index=False, encoding="utf-8-sig")
+    else:
+        corr_report = pd.DataFrame()
+        corr_path = f"{table_name}_data_correlation_report_table.csv"
+        corr_report.to_csv(corr_path, index=False, encoding="utf-8-sig")
+
+    return quality_report, corr_report
+
+
+if __name__ == "__main__":  # pragma: no cover - illustrative usage
+    demo = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "url": ["https://example.com", "http://test.com", None, ""],
+            "value": [10, "20", "30", "not"],
+            "year": ["2020", "1999", None, "no"],
+        }
+    )
+    analyze_table_quality(demo, table_name="demo")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas>=2.0
+numpy>=1.21
 requests>=2.31
 pytest>=7.0
 black>=23.0

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -1,0 +1,91 @@
+"""CLI entry point for table quality analysis."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from library.table_quality import analyze_table_quality
+
+logger = logging.getLogger(__name__)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the profiling workflow.
+
+    Parameters
+    ----------
+    args:
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        ``0`` on success, non-zero on failure.
+    """
+    try:
+        df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+    except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
+        logger.error("%s", exc)
+        return 1
+
+    original_cwd = Path.cwd()
+    try:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        os.chdir(args.output_dir)
+        analyze_table_quality(df, table_name=args.table_name)
+    finally:
+        os.chdir(original_cwd)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line argument parser."""
+    parser = argparse.ArgumentParser(description="Table quality analysis")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--input",
+        dest="input_csv",
+        type=Path,
+        default=Path("input.csv"),
+        help="Input CSV file",
+    )
+    parser.add_argument(
+        "--table-name",
+        required=True,
+        help="Base name used for output report files",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_dir",
+        type=Path,
+        default=Path("."),
+        help="Directory to store generated reports",
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf-8-sig", help="File encoding")
+    parser.set_defaults(func=run)
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    """Configure basic logging."""
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(level=numeric_level)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command line entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import get_input_initialisation as cli
+
+
+def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+    out_dir = tmp_path / "out"
+
+    tables = {
+        "assay": pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}),
+        "activity": pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]}),
+    }
+
+    def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_load_all_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_build_combined_tables(*_args, **_kwargs):
+        return tables
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", fake_load_same_doc)
+    monkeypatch.setattr(cli.lib, "load_all_doc", fake_load_all_doc)
+    monkeypatch.setattr(cli.lib, "build_combined_tables", fake_build_combined_tables)
+
+    args = argparse.Namespace(
+        same_doc=same_doc, all_doc=all_doc, out_dir=out_dir, format="csv"
+    )
+    result = cli.run(args)
+    assert result == 0
+
+    for name in tables:
+        quality = out_dir / f"{name}_quality_report_table.csv"
+        corr = out_dir / f"{name}_data_correlation_report_table.csv"
+        assert quality.exists(), quality
+        assert corr.exists(), corr
+        df = pd.read_csv(quality)
+        assert "column" in df.columns

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pandas as pd
+
+from library.table_quality import analyze_table_quality
+
+
+def test_analyze_table_quality(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "num": [1, 2, 3, 4],
+            "str": ["10.1234/abc", "", None, "test"],
+        }
+    )
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        quality, corr = analyze_table_quality(df, table_name="sample")
+    finally:
+        os.chdir(cwd)
+    assert set(quality["column"]) == {"num", "str"}
+    assert (tmp_path / "sample_quality_report_table.csv").exists()
+    assert (tmp_path / "sample_data_correlation_report_table.csv").exists()
+    assert corr.shape == (1, 1)


### PR DESCRIPTION
## Summary
- add `analyze_table_quality` for column profiling and numeric correlations
- expose CLI `table_quality_main.py`
- document usage and declare numpy dependency
- generate quality reports for all tables produced by `get_input_initialisation.py`

## Testing
- `black get_input_initialisation.py tests/test_get_input_initialisation.py library/input_initialisation_library.py`
- `ruff check get_input_initialisation.py table_quality_main.py library/table_quality.py library/input_initialisation_library.py tests/test_table_quality.py tests/test_get_input_initialisation.py`
- `pip install pandas-stubs`
- `mypy get_input_initialisation.py table_quality_main.py library/table_quality.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb371f7048324975dc8e00e926dbe