### PR TITLE
Add activity table processing with citation and target mapping

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -38,7 +38,7 @@ def run(args: argparse.Namespace) -> int:
         all_ = lib.load_all_doc(args.all_doc)
 
         logger.info("Combining tables")
-        tables = lib.build_combined_tables(same, all_)
+        tables = lib.build_combined_tables(same, all_, dictionary_dir=args.dictionary_dir)
 
         logger.info("Saving output")
         paths = lib.save_tables(tables, args.out_dir, fmt=args.format)
@@ -70,6 +70,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--all-doc", type=Path, required=True, help="Path to all document workbook"
+    )
+    parser.add_argument(
+        "--dictionary-dir",
+        type=Path,
+        default=Path("dictionary"),
+        help="Directory with targets_type.csv and citation_fraction.csv",
     )
     parser.add_argument(
         "--out-dir", type=Path, default=Path("."), help="Output directory"

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -38,21 +38,15 @@ ACTIVITY_DROP_COLS: set[str] = {
     "n_stereocenters",
     "unspecified_chirality_mol",
     "shuffled_target_assay",
-    "approx_cited_activity",
     "exact_cited_activity_samedoc",
     "approx_cited_activity_samedoc",
     "survives_main_steps",
     "num_citations",
     "higly_correlated_cit_samedoc",
-    "higly_correlated_cit",
-    "shuffled_cit",
-    "exact_cited_activity",
-    "multmol_assay",
     "multimol",
     "publication_date",
     "sort_order.document",
     "document_contains_external_links",
-    "review_doc",
     "year",
     "month",
     "day",
@@ -149,6 +143,229 @@ FLOAT_COLS: set[str] = {
 DATE_COLS: set[str] = {
     "publication_date",
 }
+
+
+def process_activity_table(
+    df_activity: pd.DataFrame, dictionary_dir: Path | str
+) -> pd.DataFrame:
+    """Transform the combined activity table.
+
+    Parameters
+    ----------
+    df_activity:
+        Deduplicated activity dataframe.
+    dictionary_dir:
+        Directory containing ``targets_type.csv`` and
+        ``citation_fraction.csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Processed activity table ready for CSV export.
+    """
+
+    logger.info("Processing activity table")
+    df = df_activity.copy()
+
+    # --- unknown chirality -------------------------------------------------
+    if "nstereo" in df.columns:
+        df["unknown_chirality"] = df["nstereo"].astype("Int64").ne(1)
+        df.drop(columns=["nstereo"], inplace=True)
+
+    # --- multimol assay map ------------------------------------------------
+    group_cols = [
+        "salt_chembl_id",
+        "molecule_chembl_id",
+        "target_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+    ]
+    missing = set(group_cols) - set(df.columns)
+    if missing:
+        raise KeyError(
+            "activity table missing columns for multimol grouping: "
+            + ", ".join(sorted(missing))
+        )
+
+    counts = (
+        df.groupby(group_cols, dropna=False)
+        .size()
+        .rename("Count")
+        .reset_index()
+    )
+    df = df.merge(counts, on=group_cols, how="left")
+
+    mask = (
+        df["unknown_chirality"].fillna(True).eq(False)
+        & df["multmol_assay"].isna()
+        & (df["Count"] > 1)
+    )
+    assays = set(df.loc[mask, "assay_chembl_id"].dropna().astype(str))
+    df["multimol_assay_same"] = df["assay_chembl_id"].isin(assays)
+
+    df["multmol_assay"] = (
+        df["multmol_assay"].fillna(False).astype(bool) | df["multimol_assay_same"]
+    )
+    df.drop(columns=["multimol_assay_same", "Count"], inplace=True)
+
+    # --- rename columns ----------------------------------------------------
+    df = df.rename(
+        columns={
+            "approx_cited_activity": "rounded_data_citation",
+            "shuffled_cit": "shuffled_assay",
+            "exact_cited_activity": "exact_data_citation",
+            "higly_correlated_cit": "higly_correlated_assay",
+            "review_doc": "review",
+        }
+    )
+
+    df = df.rename(
+        columns={
+            "activity_chembl_id": "activity_id",
+            "salt_chembl_id": "saltform_id",
+            "molecule_chembl_id": "molecule_id",
+            "target_chembl_id": "target_id",
+            "assay_chembl_id": "assay_id",
+            "document_chembl_id": "document_id",
+            "standard_type": "mesurement_type",
+            "log_value": "pA_value",
+        }
+    )
+
+    # --- drop unused columns -----------------------------------------------
+    drop_cols = [
+        "cited_document",
+        "acts_per_assay_step5",
+        "approx_cited_activity_samedoc",
+        "error_document",
+        "exact_cited_activity_samedoc",
+        "higly_correlated_cit_samedoc",
+        "standard_inchi_skeleton",
+        "standard_inchi_stereo",
+        "step1",
+        "step2",
+        "step3",
+        "step4",
+        "step5",
+        "step6",
+        "survives_main_steps",
+    ]
+    df.drop(columns=[c for c in drop_cols if c in df.columns], inplace=True)
+
+    # --- compute citation flags --------------------------------------------
+    bool_cols = [
+        "exact_data_citation",
+        "higly_correlated_assay",
+        "shuffled_assay",
+        "review",
+        "rounded_data_citation",
+    ]
+    for col in bool_cols:
+        if col in df.columns:
+            df[col] = df[col].fillna(False).astype(bool)
+
+    df["is_citation"] = df[bool_cols].any(axis=1)
+
+    # --- documents with significant citations ------------------------------
+    counts_doc = (
+        df.groupby("document_id")["is_citation"]
+        .agg(n_citation="sum", n_non_citation=lambda s: (~s).sum())
+        .reset_index()
+    )
+    counts_doc["N"] = counts_doc["n_citation"] + counts_doc["n_non_citation"]
+    counts_doc = counts_doc[
+        (counts_doc["n_citation"] > 0) & (counts_doc["n_non_citation"] > 0)
+    ]
+
+    cf_path = Path(dictionary_dir) / "citation_fraction.csv"
+    cf = pd.read_csv(cf_path)
+
+    counts_doc = counts_doc.merge(cf[["N", "K_min_significant"]], on="N", how="left")
+    counts_doc["high_citation_rate"] = counts_doc["K_min_significant"].notna() & (
+        counts_doc["n_citation"] >= counts_doc["K_min_significant"]
+    )
+
+    df = df.merge(
+        counts_doc[["document_id", "high_citation_rate"]],
+        on="document_id",
+        how="left",
+    )
+    df["high_citation_rate"] = df["high_citation_rate"].fillna(False)
+
+    # --- target types ------------------------------------------------------
+    targets_path = Path(dictionary_dir) / "targets_type.csv"
+    targets = pd.read_csv(targets_path, dtype={"chembl_id": "string"})
+
+    df = df.merge(
+        targets[["chembl_id", "type"]],
+        how="left",
+        left_on="target_id",
+        right_on="chembl_id",
+    )
+    mapping = {
+        "Multicellular organism": False,
+        "Viruses": True,
+        "Unicellular organism": True,
+    }
+    df["unicellular_organism"] = (
+        df["type"].map(mapping).fillna(False).astype(bool)
+    )
+    df.drop(columns=["chembl_id", "type"], inplace=True)
+
+    # --- final ordering ----------------------------------------------------
+    final_cols = [
+        "activity_id",
+        "saltform_id",
+        "molecule_id",
+        "target_id",
+        "assay_id",
+        "document_id",
+        "bao_endpoint",
+        "mesurement_type",
+        "standard_value",
+        "pA_value",
+        "bao_format",
+        "compound_key",
+        "compound_name",
+        "unknown_chirality",
+        "multmol_assay",
+        "exact_data_citation",
+        "higly_correlated_assay",
+        "shuffled_assay",
+        "review",
+        "rounded_data_citation",
+        "high_citation_rate",
+        "original_activity_approx",
+        "original_activity_exact",
+        "is_citation",
+        "unicellular_organism",
+    ]
+
+    missing_final = set(final_cols) - set(df.columns)
+    if missing_final:
+        raise KeyError(
+            "activity table missing expected columns: "
+            + ", ".join(sorted(missing_final))
+        )
+    df = df[final_cols]
+
+    # Ensure boolean dtype where appropriate
+    bool_cols_final = [
+        "unknown_chirality",
+        "multmol_assay",
+        "exact_data_citation",
+        "higly_correlated_assay",
+        "shuffled_assay",
+        "review",
+        "rounded_data_citation",
+        "high_citation_rate",
+        "is_citation",
+        "unicellular_organism",
+    ]
+    for col in bool_cols_final:
+        df[col] = df[col].astype("boolean")
+
+    return df
 
 
 def _ensure_openpyxl() -> None:
@@ -309,6 +526,7 @@ def append_entities(df_a: pd.DataFrame, df_b: pd.DataFrame) -> pd.DataFrame:
 def build_combined_tables(
     same: Dict[EntityName, pd.DataFrame],
     all_: Dict[EntityName, pd.DataFrame],
+    dictionary_dir: Path | str | None = None,
 ) -> Dict[EntityName, pd.DataFrame]:
     """Combine entity tables from ``same`` and ``all_`` sources."""
     combined: Dict[EntityName, pd.DataFrame] = {}
@@ -324,6 +542,8 @@ def build_combined_tables(
                 errors="ignore",
             )
             df = concat.drop_duplicates(keep="first")
+            if dictionary_dir is not None:
+                df = process_activity_table(df, dictionary_dir)
             rows_concat = len(concat)
             rows_after = len(df)
         else:

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -33,7 +33,11 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(cli.lib, "build_combined_tables", fake_build_combined_tables)
 
     args = argparse.Namespace(
-        same_doc=same_doc, all_doc=all_doc, out_dir=out_dir, format="csv"
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=out_dir,
+        format="csv",
+        dictionary_dir=tmp_path,
     )
     result = cli.run(args)
     assert result == 0

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -13,6 +13,7 @@ from library.input_initialisation_library import (
     build_combined_tables,
     unify_dtypes,
     save_tables,
+    process_activity_table,
 )
 
 
@@ -83,3 +84,73 @@ def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(RuntimeError):
         _ensure_openpyxl()
     monkeypatch.delitem(sys.modules, "openpyxl")
+
+
+def test_process_activity_table_basic(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "activity_chembl_id": [1, 2],
+            "salt_chembl_id": ["S1", "S1"],
+            "molecule_chembl_id": ["M1", "M1"],
+            "target_chembl_id": ["T1", "T1"],
+            "assay_chembl_id": ["A1", "A1"],
+            "document_chembl_id": ["D1", "D1"],
+            "bao_endpoint": ["e1", "e1"],
+            "standard_type": ["t", "t"],
+            "standard_value": [1.0, 2.0],
+            "log_value": [0.1, 0.2],
+            "bao_format": ["f1", "f1"],
+            "compound_key": ["ck1", "ck1"],
+            "compound_name": ["cn1", "cn1"],
+            "multmol_assay": [pd.NA, pd.NA],
+            "nstereo": [2, 1],
+            "approx_cited_activity": [pd.NA, False],
+            "exact_cited_activity": [True, False],
+            "higly_correlated_cit": [pd.NA, False],
+            "shuffled_cit": [pd.NA, False],
+            "review_doc": [False, False],
+            "original_activity_approx": [0.5, 0.6],
+            "original_activity_exact": [0.5, 0.6],
+        }
+    )
+
+    (tmp_path / "citation_fraction.csv").write_text(
+        "N,K_min_significant,test_used_at_threshold,p_value_at_threshold\n2,1,x,0.05\n"
+    )
+    (tmp_path / "targets_type.csv").write_text(
+        "chembl_id,type\nT1,Unicellular organism\n"
+    )
+
+    res = process_activity_table(df, tmp_path)
+    expected_cols = [
+        "activity_id",
+        "saltform_id",
+        "molecule_id",
+        "target_id",
+        "assay_id",
+        "document_id",
+        "bao_endpoint",
+        "mesurement_type",
+        "standard_value",
+        "pA_value",
+        "bao_format",
+        "compound_key",
+        "compound_name",
+        "unknown_chirality",
+        "multmol_assay",
+        "exact_data_citation",
+        "higly_correlated_assay",
+        "shuffled_assay",
+        "review",
+        "rounded_data_citation",
+        "high_citation_rate",
+        "original_activity_approx",
+        "original_activity_exact",
+        "is_citation",
+        "unicellular_organism",
+    ]
+    assert list(res.columns) == expected_cols
+    assert bool(res.loc[0, "is_citation"])
+    assert not bool(res.loc[1, "is_citation"])
+    assert res["high_citation_rate"].all()
+    assert res["unicellular_organism"].all()


### PR DESCRIPTION
## Summary
- enrich activity table with citation significance and target type flags
- support activity processing via new `--dictionary-dir` CLI option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0f16d51c832488cad5c6a0ad4aa8