### PR TITLE
Fix type handling in PubMed and IUPHAR modules

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -13,7 +13,7 @@ comments to aid maintenance.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -24,10 +24,6 @@ import requests
 
 
 logger = logging.getLogger(__name__)
-
-
-
-
 
 
 EXPECTED_TARGET_COLUMNS: tuple[str, ...] = (
@@ -174,7 +170,9 @@ class IUPHARData:
             ]
             if parent_series.empty:
                 break
-            parent = str(parent_series.iloc[0]) if pd.notna(parent_series.iloc[0]) else ""
+            parent = (
+                str(parent_series.iloc[0]) if pd.notna(parent_series.iloc[0]) else ""
+            )
             if not parent:
                 break
             current = parent
@@ -257,8 +255,10 @@ class IUPHARData:
 
         if not target_name:
             return ""
-        mask = self.target_df["synonyms"].fillna("").str.contains(
-            target_name, case=False, na=False, regex=False
+        mask = (
+            self.target_df["synonyms"]
+            .fillna("")
+            .str.contains(target_name, case=False, na=False, regex=False)
         )
         ids = self._select_target_ids(mask)
         return "|".join(ids) if ids else ""
@@ -454,8 +454,11 @@ class IUPHARData:
     def from_target_family_record(self, target_id: str) -> Optional[pd.Series]:
         """Return the family record associated with ``target_id``."""
 
-        mask = self.family_df["target_id"].fillna("").str.split("|").apply(
-            lambda ids: target_id in ids
+        mask = (
+            self.family_df["target_id"]
+            .fillna("")
+            .str.split("|")
+            .apply(lambda ids: target_id in ids)
         )
         rows = self.family_df[mask]
         if rows.empty:
@@ -579,12 +582,8 @@ class IUPHARData:
         combines them with the local target and family tables.
         """
 
-        uni_url = (
-            "https://www.guidetopharmacology.org/DATA/GtP_to_UniProt_mapping.csv"
-        )
-        hgnc_url = (
-            "https://www.guidetopharmacology.org/DATA/GtP_to_HGNC_mapping.csv"
-        )
+        uni_url = "https://www.guidetopharmacology.org/DATA/GtP_to_UniProt_mapping.csv"
+        hgnc_url = "https://www.guidetopharmacology.org/DATA/GtP_to_HGNC_mapping.csv"
 
         uni_df = pd.read_csv(uni_url)
         hgnc_df = pd.read_csv(hgnc_url)
@@ -634,17 +633,15 @@ class ClassificationRecord:
     IUPHAR_family_id: str = "N/A"
     IUPHAR_class: str = "Other Protein Target"
     IUPHAR_subclass: str = "Other Protein Target"
-    IUPHAR_tree: List[str] = None  # set in __post_init__
+    IUPHAR_tree: List[str] = field(default_factory=list)
     IUPHAR_type: str = "Other Protein Target.Other Protein Target"
     IUPHAR_name: str = "N/A"
-    IUPHAR_ecNumber: List[str] = None
+    IUPHAR_ecNumber: List[str] = field(default_factory=list)
     STATUS: str = "N/A"
 
     def __post_init__(self) -> None:
-        if self.IUPHAR_tree is None:
+        if not self.IUPHAR_tree:
             self.IUPHAR_tree = ["0864-1", "0864"]
-        if self.IUPHAR_ecNumber is None:
-            self.IUPHAR_ecNumber = []
 
 
 class IUPHARClassifier:
@@ -704,9 +701,7 @@ class IUPHARClassifier:
             type_val = type1
         elif self._is_valid_parameter(type2) and not self._is_valid_parameter(type1):
             type_val = type2
-        elif not (
-            self._is_valid_parameter(type1) or self._is_valid_parameter(type2)
-        ):
+        elif not (self._is_valid_parameter(type1) or self._is_valid_parameter(type2)):
             type_val = "Other Protein Target.Other Protein Target"
         elif type1 == type2:
             type_val = type1
@@ -764,9 +759,7 @@ class IUPHARClassifier:
     def _ec_number_to_type(ec_numbers: List[str]) -> str:
         if not IUPHARClassifier._is_valid_list(ec_numbers):
             return ""
-        prefixes = {
-            n.split(".")[0] for n in ec_numbers if "." in n and n.split(".")[0]
-        }
+        prefixes = {n.split(".")[0] for n in ec_numbers if "." in n and n.split(".")[0]}
         if not prefixes:
             return ""
         if len(prefixes) > 1:
@@ -804,7 +797,9 @@ class IUPHARClassifier:
             iuphar_target_id if self._is_valid_parameter(iuphar_target_id) else "N/A"
         )
         family_id = iuphar_family_id
-        if not self._is_valid_parameter(family_id) and self._is_valid_parameter(target_id):
+        if not self._is_valid_parameter(family_id) and self._is_valid_parameter(
+            target_id
+        ):
             family_id = self.data.from_target_family_id(target_id) or "N/A"
         name = iuphar_name if self._is_valid_parameter(iuphar_name) else "N/A"
         numbers = ec_numbers if ec_numbers and self._is_valid_list(ec_numbers) else []
@@ -837,7 +832,9 @@ class IUPHARClassifier:
 
         return ClassificationRecord(
             IUPHAR_target_id=target_id,
-            IUPHAR_family_id=family_id if self._is_valid_parameter(family_id) else "N/A",
+            IUPHAR_family_id=(
+                family_id if self._is_valid_parameter(family_id) else "N/A"
+            ),
             IUPHAR_class=cls_part,
             IUPHAR_subclass=sub_part,
             IUPHAR_tree=tree,
@@ -891,7 +888,10 @@ class IUPHARClassifier:
         )
         if not self._is_valid_list(numbers):
             return ClassificationRecord()
-        type_val = self._ec_number_to_type(numbers) or "Other Protein Target.Other Protein Target"
+        type_val = (
+            self._ec_number_to_type(numbers)
+            or "Other Protein Target.Other Protein Target"
+        )
         parts = type_val.split(".")
         cls_part = parts[0] if parts else "Other Protein Target"
         sub_part = parts[1] if len(parts) > 1 else "Other Protein Target"
@@ -904,10 +904,11 @@ class IUPHARClassifier:
             IUPHAR_class=cls_part,
             IUPHAR_subclass=sub_part,
             IUPHAR_tree=tree,
-            IUPHAR_name=name,
+            IUPHAR_name=name or "N/A",
             IUPHAR_ecNumber=numbers,
             STATUS="ec_number",
         )
+
     def by_molecular_function(self, function: str) -> ClassificationRecord:
         """Classify based on a UniProt ``molecular_function`` string.
 
@@ -966,8 +967,12 @@ class IUPHARClassifier:
         cls_part = parts[0] if parts else "Other Protein Target"
         sub_part = parts[1] if len(parts) > 1 else "Other Protein Target"
         return ClassificationRecord(
-            IUPHAR_target_id=target_id if self._is_valid_parameter(target_id) else "N/A",
-            IUPHAR_family_id=family_id if self._is_valid_parameter(family_id) else "N/A",
+            IUPHAR_target_id=(
+                target_id if self._is_valid_parameter(target_id) else "N/A"
+            ),
+            IUPHAR_family_id=(
+                family_id if self._is_valid_parameter(family_id) else "N/A"
+            ),
             IUPHAR_type=type_val,
             IUPHAR_class=cls_part,
             IUPHAR_subclass=sub_part,
@@ -1020,16 +1025,19 @@ class IUPHARClassifier:
             activity_df, on="task_uniprot_id", how="left", suffixes=("", "_act")
         )
         merged["activity.ec_number"] = (
-            merged.get("activity.ec_number", "").replace("EC-not-assigned", "").fillna("")
+            merged.get("activity.ec_number", pd.Series(dtype=str))
+            .replace("EC-not-assigned", "")
+            .fillna("")
         )
         merged["ec_number"] = (
             merged["activity.ec_number"].fillna("")
-            + "|" + merged.get("ec_number", "").fillna("")
+            + "|"
+            + merged.get("ec_number", pd.Series(dtype=str)).fillna("")
         )
         merged["ec_number"] = (
-            merged["ec_number"].str.split("|").apply(
-                lambda x: "|".join(sorted({i.strip() for i in x if i.strip()}))
-            )
+            merged["ec_number"]
+            .str.split("|")
+            .apply(lambda x: "|".join(sorted({i.strip() for i in x if i.strip()})))
         )
         return merged.drop(columns=["activity.ec_number"], errors="ignore")
 
@@ -1076,9 +1084,9 @@ class IUPHARClassifier:
         if db_column not in db_df.columns:
             raise ValueError(f"db_df must contain '{db_column}' column")
         merged = target_df.merge(db_df, on="task_uniprot_id", how="left")
-        merged["guidetopharmacology_family"] = merged["guidetopharmacology_family"].fillna(
-            merged.get("guidetopharmacology_family_y")
-        )
+        merged["guidetopharmacology_family"] = merged[
+            "guidetopharmacology_family"
+        ].fillna(merged.get("guidetopharmacology_family_y"))
         merged["guidetopharmacology_type"] = merged["guidetopharmacology_type"].fillna(
             merged.get("guidetopharmacology_type_y")
         )
@@ -1098,7 +1106,9 @@ class IUPHARClassifier:
     ) -> pd.DataFrame:
         """Derive a database-specific classification lookup table."""
 
-        valid = family_table[family_table[db_column].notna() & (family_table[db_column] != "N/A")]
+        valid = family_table[
+            family_table[db_column].notna() & (family_table[db_column] != "N/A")
+        ]
         merged = valid.merge(name_table, on="task_uniprot_id", how="left")
         records = []
         for key, group in merged.groupby(db_column):
@@ -1107,8 +1117,10 @@ class IUPHARClassifier:
                 if not group["guidetopharmacology_family"].dropna().empty
                 else ""
             )
-            type_series = group["guidetopharmacology_id"].dropna().apply(
-                self.data.from_target_type
+            type_series = (
+                group["guidetopharmacology_id"]
+                .dropna()
+                .apply(self.data.from_target_type)
             )
             type_val = type_series.mode().iloc[0] if not type_series.empty else ""
             records.append(

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -70,7 +70,7 @@ def _do_request(
     for attempt in range(retries + 1):
         if attempt:
             time.sleep(sleep * attempt)
-        
+
         try:
             if method.upper() == "POST":
                 resp = session.post(url, timeout=TIMEOUT, **kwargs)
@@ -99,6 +99,8 @@ def _do_request(
                 return None, f"Invalid JSON: {exc}"
         return resp.text, ""
     return None, "Request failed"
+
+
 def fetch_pubmed_batch(
     session: requests.Session, pmids: List[str], sleep: float
 ) -> List[Dict[str, str]]:
@@ -209,11 +211,13 @@ def parse_pubmed_article(art: ET.Element) -> Dict[str, Any]:
                 doi = doi[4:].strip()
             for pref in ("https://doi.org/", "http://doi.org/", "doi.org/"):
                 if doi.lower().startswith(pref):
-                    doi = doi[len(pref):].strip()
+                    doi = doi[len(pref) :].strip()
                     break
 
     article_title = (
-        text_or_none(find_one(article, "./ArticleTitle")) if article is not None else None
+        text_or_none(find_one(article, "./ArticleTitle"))
+        if article is not None
+        else None
     )
 
     # Abstract: join all segments, preserve label when present.
@@ -229,7 +233,9 @@ def parse_pubmed_article(art: ET.Element) -> Dict[str, Any]:
                     parts.append(f"{label}: {seg_text}" if label else seg_text)
             article_abstract = " ".join(parts) if parts else None
         if article_abstract is None:
-            article_abstract = text_or_none(find_one(article, "./Abstract/AbstractText"))
+            article_abstract = text_or_none(
+                find_one(article, "./Abstract/AbstractText")
+            )
 
     journal_title = text_or_none(find_one(journal, "./Title"))
     issn = text_or_none(find_one(journal, "./ISSN"))
@@ -239,8 +245,14 @@ def parse_pubmed_article(art: ET.Element) -> Dict[str, Any]:
     start_page = text_or_none(find_one(pagination, "./StartPage"))
     end_page = text_or_none(find_one(pagination, "./EndPage"))
 
-    pubtypes = [text_or_none(x) for x in find_all(article, "./PublicationTypeList/PublicationType")]
-    pubtypes = [p for p in pubtypes if p] if pubtypes else []
+    pubtypes = [
+        p
+        for p in (
+            text_or_none(x)
+            for x in find_all(article, "./PublicationTypeList/PublicationType")
+        )
+        if p
+    ]
 
     mh_list = find_one(mc, "./MeshHeadingList")
     mesh_descriptors: List[str] = []
@@ -346,7 +358,9 @@ def fetch_pubmed(session: requests.Session, pmid: str, sleep: float) -> Dict[str
     return result
 
 
-def fetch_semantic_scholar(session: requests.Session, pmid: str, sleep: float) -> Dict[str, str]:
+def fetch_semantic_scholar(
+    session: requests.Session, pmid: str, sleep: float
+) -> Dict[str, str]:
     fields = "publicationTypes,externalIds,paperId,venue"
     headers = {"Accept": "application/json"}
     url = f"https://api.semanticscholar.org/graph/v1/paper/PMID:{pmid}"
@@ -391,9 +405,9 @@ def fetch_semantic_scholar_batch(
     fields = "publicationTypes,externalIds,paperId,venue"
     headers = {"Accept": "application/json"}
     url = "https://api.semanticscholar.org/graph/v1/paper/batch"
-    
+
     prefixed_pmids = [f"PMID:{pmid}" for pmid in pmids]
-    
+
     data, error = _do_request(
         session,
         url,
@@ -401,7 +415,7 @@ def fetch_semantic_scholar_batch(
         headers=headers,
         params={"fields": fields},
         json={"ids": prefixed_pmids},
-        method="POST"
+        method="POST",
     )
 
     if error:
@@ -418,34 +432,38 @@ def fetch_semantic_scholar_batch(
             for pmid in pmids
         ]
 
-    results = []
+    results: List[Dict[str, str]] = []
     if isinstance(data, list) and len(data) == len(pmids):
         for pmid, item in zip(pmids, data):
             if item is None:
-                results.append({
-                    "scholar.PMID": pmid,
-                    "scholar.Venue": "",
-                    "scholar.PublicationTypes": "",
-                    "scholar.SemanticScholarId": "",
-                    "scholar.ExternalIds": "",
-                    "scholar.DOI": "",
-                    "scholar.Error": "Not found",
-                })
+                results.append(
+                    {
+                        "scholar.PMID": pmid,
+                        "scholar.Venue": "",
+                        "scholar.PublicationTypes": "",
+                        "scholar.SemanticScholarId": "",
+                        "scholar.ExternalIds": "",
+                        "scholar.DOI": "",
+                        "scholar.Error": "Not found",
+                    }
+                )
                 continue
 
             external_ids = item.get("externalIds") or {}
             doi = external_ids.get("DOI") or ""
             pubtypes = item.get("publicationTypes") or []
-            
-            results.append({
-                "scholar.PMID": pmid,
-                "scholar.Venue": item.get("venue", ""),
-                "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
-                "scholar.SemanticScholarId": item.get("paperId", ""),
-                "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
-                "scholar.DOI": doi,
-                "scholar.Error": "",
-            })
+
+            results.append(
+                {
+                    "scholar.PMID": pmid,
+                    "scholar.Venue": item.get("venue", ""),
+                    "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
+                    "scholar.SemanticScholarId": item.get("paperId", ""),
+                    "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
+                    "scholar.DOI": doi,
+                    "scholar.Error": "",
+                }
+            )
     else:
         return [
             {
@@ -459,11 +477,13 @@ def fetch_semantic_scholar_batch(
             }
             for pmid in pmids
         ]
-        
+
     return results
 
 
-def fetch_openalex(session: requests.Session, pmid: str, sleep: float) -> Dict[str, str]:
+def fetch_openalex(
+    session: requests.Session, pmid: str, sleep: float
+) -> Dict[str, str]:
     url = f"https://api.openalex.org/works/pmid:{pmid}"
     data, error = _do_request(session, url, sleep)
     if error or not isinstance(data, dict):
@@ -569,12 +589,14 @@ def print_results(records: List[Dict[str, str]]):
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Fetch publication metadata by PMID"
+    parser = argparse.ArgumentParser(description="Fetch publication metadata by PMID")
+    parser.add_argument(
+        "-i", "--input", required=True, help="Input CSV path with PMID column"
     )
-    parser.add_argument("-i", "--input", required=True, help="Input CSV path with PMID column")
     parser.add_argument("-o", "--output", required=True, help="Output CSV path")
-    parser.add_argument("--sleep", type=float, default=5.0, help="Sleep between requests")
+    parser.add_argument(
+        "--sleep", type=float, default=5.0, help="Sleep between requests"
+    )
     args = parser.parse_args()
 
     pmids = read_pmids(args.input)
@@ -582,33 +604,33 @@ def main() -> None:
     batch_size = 100  # A reasonable batch size
     with requests.Session() as session:
         for i in range(0, len(pmids), batch_size):
-            batch_pmids = pmids[i:i + batch_size]
-            
+            batch_pmids = pmids[i : i + batch_size]
+
             # Batch fetch PubMed and Semantic Scholar
             pubmed_list = fetch_pubmed_batch(session, batch_pmids, args.sleep)
             semsch_list = fetch_semantic_scholar_batch(session, batch_pmids, args.sleep)
-            
+
             semsch_map = {s.get("scholar.PMID"): s for s in semsch_list}
 
             for pubmed in pubmed_list:
                 pmid = pubmed.get("PubMed.PMID", "")
                 semsch = semsch_map.get(pmid, {})
-                
+
                 # Still fetching these individually
                 openalex = fetch_openalex(session, pmid, args.sleep)
                 doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
                 crossref = fetch_crossref(session, doi, args.sleep)
-                
+
                 combined: Dict[str, str] = {}
                 combined.update(pubmed)
                 combined.update(semsch)
                 combined.update(openalex)
                 combined.update(crossref)
-                
+
                 print_results([combined])
                 records.append(combined)
 
-    all_keys = set()
+    all_keys: set[str] = set()
     for rec in records:
         all_keys.update(rec.keys())
     fieldnames = sorted(all_keys)


### PR DESCRIPTION
## Summary
- ensure PubMed publication type parsing returns only strings
- add missing type annotations in PubMed utilities
- replace mutable default arguments and handle optional names in IUPHAR classifier
- robustly merge catalytic activity data with explicit Series defaults

## Testing
- `ruff check library/pubmed_library.py library/iuphar_library.py table_quality_main.py`
- `mypy library/pubmed_library.py library/iuphar_library.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fa2b5bc83248bab6c4f61bfb3a6