### PR TITLE
Handle empty rows in status table

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -26,6 +26,11 @@ EntityName = Literal[
     "pairs_same_document",
 ]
 
+# Mapping of entity names to their corresponding dataframes.  The dictionary
+# may contain additional keys such as ``"activity_status"`` produced during
+# processing, hence the generic ``str`` key type.
+TableDict = Dict[str, pd.DataFrame]
+
 
 # Mapping of sheet names to entity identifiers
 SAME_DOC_SHEETS: dict[str, EntityName] = {
@@ -566,7 +571,7 @@ def build_combined_tables(
 ) -> TableDict:
     """Combine entity tables from ``same`` and ``all_`` sources."""
 
-    combined: Dict[EntityName, pd.DataFrame] = {}
+    combined: TableDict = {}
 
     # --- regular entities -------------------------------------------------
     regular_entities: tuple[EntityName, ...] = (
@@ -587,7 +592,7 @@ def build_combined_tables(
             len(df),
         )
         combined[entity] = df
- 
+
     if dictionary_dir is not None:
         status_df = load_status_table(dictionary_dir)
         status_api = build_status_helpers(status_df)
@@ -607,8 +612,7 @@ def build_combined_tables(
             combined.update({f"{k}_status": v for k, v in aggregates.items()})
         else:
 
-            logger.warning('pair table not found; skipping status aggregation')
- 
+            logger.warning("pair table not found; skipping status aggregation")
 
     # --- activity --------------------------------------------------------
     df_same_act = unify_dtypes(same["activity"])
@@ -641,7 +645,6 @@ def build_combined_tables(
     logger.info("Entity pairs: rows=%d", len(df_pairs))
     combined["pairs_same_document"] = df_pairs_same
     combined["pairs"] = df_pairs
- 
 
     return combined
 
@@ -781,8 +784,27 @@ def load_status_table(dictionary_dir: Path | str) -> pd.DataFrame:
             "score": "Int64",
         },
     )
-    df["order"] = df["order"].astype(int)
-    df["score"] = df["score"].astype(int)
+
+    # Remove rows that are completely empty in the CSV.  The source file may
+    # contain trailing empty lines which ``pandas.read_csv`` represents as rows
+    # filled with ``NA``.  Such rows would later cause ``astype(int)`` to raise
+    # ``ValueError``.
+    df = df.dropna(how="all")
+
+    # Ensure mandatory numeric columns are present and convertible to plain
+    # integers.  ``Int64`` allows ``NA`` values, so we explicitly check for
+    # missing values to provide a clearer error message than the default
+    # ``cannot convert NA to integer``.
+    required = ["order", "score"]
+    if df[required].isna().any().any():
+        missing = df[df[required].isna().any(axis=1)].index.tolist()
+        raise ValueError(
+            "status.csv contains missing numeric values in rows: "
+            + ", ".join(str(i + 2) for i in missing)  # account for header
+        )
+
+    df["order"] = pd.to_numeric(df["order"], errors="raise").astype(int)
+    df["score"] = pd.to_numeric(df["score"], errors="raise").astype(int)
     return df.sort_values("order").reset_index(drop=True)
 
 

--- a/tests/test_status_processing.py
+++ b/tests/test_status_processing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from library.input_initialisation_library import (
@@ -73,3 +75,15 @@ def test_status_pipeline(tmp_path):
     agg = aggregate_activity(pair_df, activity, api)
     assert agg["activity"].set_index("activity_id").loc[1, "Filtered.new"] == "bad"
     assert agg["assay"].loc[0, "independent_IC50"] == 1
+
+
+def test_load_status_table_skips_empty_rows(tmp_path: Path) -> None:
+    """``load_status_table`` should ignore completely empty CSV lines."""
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\n"
+        "good,null,null,0,1\n"
+        "\n"
+        "bad,null,null,1,2\n"
+    )
+    df = load_status_table(tmp_path)
+    assert df["status"].tolist() == ["good", "bad"]


### PR DESCRIPTION
## Summary
- ignore blank rows and validate numeric fields in `load_status_table`
- add regression test ensuring empty status rows are skipped

## Testing
- `python -m black library/input_initialisation_library.py tests/test_status_processing.py`
- `python -m ruff check library/input_initialisation_library.py tests/test_status_processing.py`
- `python -m mypy library/input_initialisation_library.py tests/test_status_processing.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd8545c2c8324853ead9cac922dc7