### PR TITLE
Initialize pair tables with status metadata

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -593,11 +593,6 @@ def build_combined_tables(
         )
         combined[entity] = df
 
-
-
-
-
-
     # --- activity --------------------------------------------------------
     df_same_act = unify_dtypes(same["activity"])
     df_all_act = unify_dtypes(all_["activity"])
@@ -630,27 +625,40 @@ def build_combined_tables(
     combined["pairs_same_document"] = df_pairs_same
     combined["pairs"] = df_pairs
 
-
     if dictionary_dir is not None:
         status_df = load_status_table(dictionary_dir)
         status_api = build_status_helpers(status_df)
         combined["activity"] = initialize_activity_status(
             combined["activity"], status_api
         )
+
+        for pair_key in ("pairs", "pairs_same_document"):
+            if pair_key in combined and {"activity_id1", "activity_id2"}.issubset(
+                combined[pair_key].columns
+            ):
+                combined[pair_key] = initialize_pairs(
+                    combined[pair_key], combined["activity"], status_api
+                )
+            else:
+                logger.warning(
+                    "skip initialize_pairs: table '%s' missing or has no activity_id1/activity_id2",
+                    pair_key,
+                )
+
         pair_table = None
-        for table in combined.values():
-            if {"activity_id1", "activity_id2"}.issubset(table.columns):
-                pair_table = table.copy()
+        for pair_key in ("pairs", "pairs_same_document"):
+            if pair_key in combined and {"Filtered1", "Filtered2"}.issubset(
+                combined[pair_key].columns
+            ):
+                pair_table = combined[pair_key]
                 break
         if pair_table is not None:
-            pair_table = initialize_pairs(pair_table, combined["activity"], status_api)
             aggregates = aggregate_activity(
                 pair_table, combined["activity"], status_api
             )
             combined.update({f"{k}_status": v for k, v in aggregates.items()})
         else:
             logger.warning("pair table not found; skipping status aggregation")
-
 
     return combined
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -130,6 +130,61 @@ def test_build_combined_tables_handles_status(
     assert "Filtered.init" in combined["activity"].columns
 
 
+def test_build_combined_tables_initializes_pair_tables(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Pair tables should receive Filtered columns via ``initialize_pairs``."""
+    same: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [1]}),
+        "pairs_same_document": pd.DataFrame({"activity_id1": [1], "activity_id2": [2]}),
+    }
+    all_: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [2]}),
+        "pairs": pd.DataFrame({"activity_id1": [2], "activity_id2": [1]}),
+    }
+
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\n"
+        "good,null,null,0,0\n"
+        "bad,null,null,1,0\n"
+    )
+
+    monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
+
+    def fake_init(df: pd.DataFrame, _api: object) -> pd.DataFrame:
+        mapping = {1: "good", 2: "bad"}
+        return df.assign(**{"Filtered.init": df["activity_id"].map(mapping)})
+
+    monkeypatch.setattr(lib, "initialize_activity_status", fake_init)
+    monkeypatch.setattr(lib, "aggregate_activity", lambda *_: {})
+
+    combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
+    pairs = combined["pairs"].iloc[0]
+    assert [pairs["Filtered1"], pairs["Filtered2"], pairs["Filtered"]] == [
+        "bad",
+        "good",
+        "good",
+    ]
+    pairs_same = combined["pairs_same_document"].iloc[0]
+    assert [
+        pairs_same["Filtered1"],
+        pairs_same["Filtered2"],
+        pairs_same["Filtered"],
+    ] == [
+        "good",
+        "bad",
+        "good",
+    ]
+
+
 def test_save_tables_writes_files(tmp_path: Path) -> None:
     tables: TableDict = {
         "activity": pd.DataFrame({"id": [1]}),


### PR DESCRIPTION
## Summary
- ensure pair status initialization for both `pairs` and `pairs_same_document`
- warn when pair tables missing required activity ids
- test that pair tables contain Filtered status columns

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe94436e48324aba64ca389123aaf