### PR TITLE
Handle missing metrics in activity aggregation

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -925,10 +925,14 @@ def initialize_pairs(
     """Merge activity statuses into ``pair_df``."""
     df = pair_df.copy()
     mapping = activity_df[["activity_id", "Filtered.init"]]
-    df = df.merge(mapping, left_on="activity_chembl_id1", right_on="activity_id", how="left")
+    df = df.merge(
+        mapping, left_on="activity_chembl_id1", right_on="activity_id", how="left"
+    )
     df.rename(columns={"Filtered.init": "Filtered1"}, inplace=True)
     df.drop(columns=["activity_id"], inplace=True)
-    df = df.merge(mapping, left_on="activity_chembl_id2", right_on="activity_id", how="left")
+    df = df.merge(
+        mapping, left_on="activity_chembl_id2", right_on="activity_id", how="left"
+    )
     df.rename(columns={"Filtered.init": "Filtered2"}, inplace=True)
     df.drop(columns=["activity_id"], inplace=True)
 
@@ -964,7 +968,11 @@ def _aggregate_entity(
 def aggregate_activity(
     pair_df: pd.DataFrame, activity_df: pd.DataFrame, status_api: StatusAPI
 ) -> Dict[str, pd.DataFrame]:
-    """Aggregate status metrics across entities."""
+    """Aggregate status metrics across entities.
+
+    Missing metric columns in ``pair_df`` are created and filled with zeros
+    to ensure consistent output schemas.
+    """
     metrics = [
         "independent_IC50",
         "non_independent_IC50",
@@ -972,10 +980,20 @@ def aggregate_activity(
         "non_independent_Ki",
     ]
 
-    left = pair_df.rename(
+    df_pairs = pair_df.copy()
+    missing = [m for m in metrics if m not in df_pairs.columns]
+    if missing:
+        logger.warning(
+            "pair table missing columns %s; filling with zeros",
+            ", ".join(missing),
+        )
+        for col in missing:
+            df_pairs[col] = 0
+
+    left = df_pairs.rename(
         columns={"activity_chembl_id1": "activity_id", "Filtered1": "Filtered.new"}
     )[["activity_id", "Filtered.new", *metrics]]
-    right = pair_df.rename(
+    right = df_pairs.rename(
         columns={"activity_chembl_id2": "activity_id", "Filtered2": "Filtered.new"}
     )[["activity_id", "Filtered.new", *metrics]]
     activity_pairs = pd.concat([left, right], ignore_index=True)

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -185,7 +185,6 @@ def test_build_combined_tables_initializes_pair_tables(
     ]
 
 
- 
 def test_build_combined_tables_normalizes_pair_column_names(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -224,15 +223,14 @@ def test_build_combined_tables_normalizes_pair_column_names(
     combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
     for key in ("pairs", "pairs_same_document"):
         assert {
-            "activity_id1",
-            "activity_id2",
+            "activity_chembl_id1",
+            "activity_chembl_id2",
             "Filtered1",
             "Filtered2",
             "Filtered",
         }.issubset(combined[key].columns)
 
 
- 
 def test_save_tables_writes_files(tmp_path: Path) -> None:
     tables: TableDict = {
         "activity": pd.DataFrame({"id": [1]}),

--- a/tests/test_status_processing.py
+++ b/tests/test_status_processing.py
@@ -59,8 +59,8 @@ def test_status_pipeline(tmp_path):
 
     pair_df = pd.DataFrame(
         {
-            "activity_id1": [1],
-            "activity_id2": [2],
+            "activity_chembl_id1": [1],
+            "activity_chembl_id2": [2],
             "testitem_id": ["T1"],
             "target_id": ["TG1"],
             "mesurement_type": ["IC50"],
@@ -87,3 +87,45 @@ def test_load_status_table_skips_empty_rows(tmp_path: Path) -> None:
     )
     df = load_status_table(tmp_path)
     assert df["status"].tolist() == ["good", "bad"]
+
+
+def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
+    """``aggregate_activity`` should default missing metric columns to zeros."""
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\n" "good,null,null,0,0\n"
+    )
+    status_df = load_status_table(tmp_path)
+    api = build_status_helpers(status_df)
+    activity = pd.DataFrame(
+        {
+            "activity_id": [1, 2],
+            "assay_id": ["A1", "A1"],
+            "document_id": ["D1", "D1"],
+            "testitem_id": ["T1", "T2"],
+            "target_id": ["TG1", "TG1"],
+            "mesurement_type": ["IC50", "IC50"],
+            "high_citation_rate": [False, False],
+            "unicellular_organism": [False, False],
+        }
+    )
+    activity = initialize_activity_status(activity, api)
+    pair_df = pd.DataFrame(
+        {
+            "activity_chembl_id1": [1],
+            "activity_chembl_id2": [2],
+            "testitem_id": ["T1"],
+            "target_id": ["TG1"],
+            "mesurement_type": ["IC50"],
+        }
+    )
+    pair_df = initialize_pairs(pair_df, activity, api)
+    agg = aggregate_activity(pair_df, activity, api)
+    activity_status = agg["activity"].set_index("activity_id")
+    for col in [
+        "independent_IC50",
+        "non_independent_IC50",
+        "independent_Ki",
+        "non_independent_Ki",
+    ]:
+        assert col in activity_status.columns
+        assert activity_status[col].eq(0).all()


### PR DESCRIPTION
## Summary
- prevent `aggregate_activity` from crashing when pair tables lack metric columns
- update status tests to use normalized column names and cover missing metrics

## Testing
- `black library/input_initialisation_library.py tests/test_status_processing.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_status_processing.py tests/test_input_initialisation_library.py`
- `python -m mypy library/input_initialisation_library.py`
- `python -m mypy tests/test_status_processing.py`
- `python -m mypy tests/test_input_initialisation_library.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff9867ba48324ae16ba7d62c92d65