### PR TITLE
Split pair table into independent segments

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -4,6 +4,8 @@ Exports pair tables without merging:
 
 - ``pairs_same_document.csv`` from sheet ``pairs_same_doc`` in ``--same-doc``
 - ``pairs.csv`` from sheet ``pairs_step5`` in ``--all-doc``
+- ``pairs_independent.csv`` and ``pairs_non_independent.csv`` derived from
+  ``pairs`` based on the ``INDEPENDENT`` flag
 """
 
 from __future__ import annotations

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -675,6 +675,22 @@ def build_combined_tables(
     combined["pairs_same_document"] = df_pairs_same
     combined["pairs"] = df_pairs
 
+    if "INDEPENDENT" in df_pairs.columns:
+        indep_series = _safe_to_bool(df_pairs["INDEPENDENT"], "INDEPENDENT").fillna(
+            False
+        )
+        df_pairs_independent = normalize_pair_columns(df_pairs[indep_series].copy())
+        df_pairs_non_independent = normalize_pair_columns(
+            df_pairs[~indep_series].copy()
+        )
+    else:
+        logger.warning("INDEPENDENT column missing; creating empty pair segments")
+        df_pairs_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
+        df_pairs_non_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
+
+    combined["pairs_independent"] = df_pairs_independent
+    combined["pairs_non_independent"] = df_pairs_non_independent
+
     if dictionary_dir is not None:
         status_df = load_status_table(dictionary_dir)
         status_api = build_status_helpers(status_df)
@@ -682,7 +698,14 @@ def build_combined_tables(
             combined["activity"], status_api
         )
 
-        for pair_key in ("pairs", "pairs_same_document"):
+        pair_keys = (
+            "pairs",
+            "pairs_same_document",
+            "pairs_independent",
+            "pairs_non_independent",
+        )
+
+        for pair_key in pair_keys:
             if pair_key not in combined:
                 logger.warning("skip initialize_pairs: table '%s' missing", pair_key)
                 continue
@@ -701,7 +724,7 @@ def build_combined_tables(
                 )
 
         pair_table = None
-        for pair_key in ("pairs", "pairs_same_document"):
+        for pair_key in pair_keys:
             if pair_key in combined and {"Filtered1", "Filtered2"}.issubset(
                 combined[pair_key].columns
             ):
@@ -1040,10 +1063,8 @@ def aggregate_activity(
     missing = [m for m in metrics if m not in df_pairs.columns]
     if missing:
         logger.warning(
-
             "pair table missing %s %s; filling with zeros",
             "column" if len(missing) == 1 else "columns",
-
             ", ".join(missing),
         )
         for col in missing:
@@ -1092,7 +1113,6 @@ def aggregate_activity(
         system_status["target_id"] = split[1]
         system_status["standard_type"] = split[2]
 
-
     if "testitem_id" in merged.columns:
         testitem_status = _aggregate_entity(merged, "testitem_id", status_api)
     elif "testitem_id" not in missing_sys:
@@ -1108,7 +1128,6 @@ def aggregate_activity(
         testitem_status = pd.DataFrame(
             columns=["testitem_id", "Filtered.new", *metrics]
         )
-
 
     if "target_id" in merged.columns:
         target_status = _aggregate_entity(merged, "target_id", status_api)

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -19,6 +19,8 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
         "activity": pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]}),
         "pairs": pd.DataFrame({"id": [1, 2]}),
         "pairs_same_document": pd.DataFrame({"id": [3, 4]}),
+        "pairs_independent": pd.DataFrame({"id": [5]}),
+        "pairs_non_independent": pd.DataFrame({"id": [6]}),
     }
 
     def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -100,7 +100,7 @@ def test_build_combined_tables_adds_pair_metrics() -> None:
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame(),
         "pairs_same_document": pd.DataFrame(
-            {"INDEPENDENT": [False], "mesurement_type": ["Ki"]}
+            {"INDEPENDENT": [False], "standard_type": ["Ki"]}
         ),
     }
     all_: TableDict = {
@@ -109,11 +109,13 @@ def test_build_combined_tables_adds_pair_metrics() -> None:
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame(),
-        "pairs": pd.DataFrame({"INDEPENDENT": [True], "mesurement_type": ["IC50"]}),
+        "pairs": pd.DataFrame({"INDEPENDENT": [True], "standard_type": ["IC50"]}),
     }
     combined = build_combined_tables(same, all_)
     assert combined["pairs"].loc[0, "independent_IC50"] == 1
     assert combined["pairs_same_document"].loc[0, "non_independent_Ki"] == 1
+    assert len(combined["pairs_independent"]) == 1
+    assert len(combined["pairs_non_independent"]) == 0
 
 
 def test_build_combined_tables_handles_status(
@@ -208,6 +210,54 @@ def test_build_combined_tables_initializes_pair_tables(
         "bad",
         "good",
     ]
+
+
+def test_build_combined_tables_initializes_pair_segments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Derived pair segments should receive Filtered columns."""
+
+    same: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [1]}),
+        "pairs_same_document": pd.DataFrame(),
+    }
+    all_: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [2]}),
+        "pairs": pd.DataFrame(
+            {
+                "INDEPENDENT": [True, False],
+                "activity_id1": [1, 2],
+                "activity_id2": [2, 1],
+            }
+        ),
+    }
+
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\n" "good,null,null,0,0\n"
+    )
+
+    monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
+
+    def fake_init(df: pd.DataFrame, _api: object) -> pd.DataFrame:
+        mapping = {1: "good", 2: "good"}
+        return df.assign(**{"Filtered.init": df["activity_id"].map(mapping)})
+
+    monkeypatch.setattr(lib, "initialize_activity_status", fake_init)
+    monkeypatch.setattr(lib, "aggregate_activity", lambda *_: {})
+
+    combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
+    assert len(combined["pairs_independent"]) == 1
+    assert len(combined["pairs_non_independent"]) == 1
+    for key in ("pairs_independent", "pairs_non_independent"):
+        assert {"Filtered1", "Filtered2", "Filtered"}.issubset(combined[key].columns)
 
 
 def test_build_combined_tables_normalizes_pair_column_names(
@@ -320,12 +370,12 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
     expected_cols = [
         "activity_id",
         "saltform_id",
-        "molecule_id",
+        "testitem_id",
         "target_id",
         "assay_id",
         "document_id",
         "bao_endpoint",
-        "mesurement_type",
+        "standard_type",
         "standard_value",
         "pA_value",
         "bao_format",


### PR DESCRIPTION
## Summary
- Split pairs table into `pairs_independent` and `pairs_non_independent` segments after loading
- Process new pair segments through status initialization and aggregation
- Document new output tables in CLI help and extend tests

## Testing
- `ruff check library/input_initialisation_library.py get_input_initialisation.py tests/test_input_initialisation_library.py tests/test_get_input_initialisation.py`
- `mypy library/input_initialisation_library.py get_input_initialisation.py tests/test_input_initialisation_library.py tests/test_get_input_initialisation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02d6cdac88324bd873fcf6592efe8