### PR TITLE
Split pair table into independent segments

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -3,7 +3,8 @@
 Exports pair tables without merging:
 
 - ``pairs_same_document.csv`` from sheet ``pairs_same_doc`` in ``--same-doc``
-- ``pairs.csv`` from sheet ``pairs_step5`` in ``--all-doc``
+- ``pairs_independent.csv`` and ``pairs_non_independent.csv`` derived from
+  ``step5_pairs`` in ``--all-doc`` based on the ``INDEPENDENT`` flag
 """
 
 from __future__ import annotations
@@ -56,9 +57,11 @@ def run(args: argparse.Namespace) -> int:
             raise RuntimeError("failed to write output files: " + ", ".join(missing))
 
         logger.info("Generating data quality reports")
+        report_dir = args.out_dir / "data_validity_report"
+        report_dir.mkdir(parents=True, exist_ok=True)
         for entity, path in paths.items():
             logger.info("Profiling %s", entity)
-            analyze_table_quality(path, table_name=str(path.with_suffix("")))
+            analyze_table_quality(path, table_name=str(report_dir / path.stem))
 
         logger.info(
             "Saved %d tables and quality reports to %s", len(paths), args.out_dir

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -192,7 +192,6 @@ def process_activity_table(
 
     # --- unknown chirality -------------------------------------------------
     if "nstereo" in df.columns:
-
         df["unknown_chirality"] = df["nstereo"].astype("Int64").ne(1).fillna(True)
         df.drop(columns=["nstereo"], inplace=True)
 
@@ -288,7 +287,6 @@ def process_activity_table(
     ]
     for col in bool_cols:
         if col in df.columns:
-
             df[col] = df[col].astype("boolean").fillna(False).astype(bool)
 
     df["is_citation"] = df[bool_cols].any(axis=1)
@@ -673,7 +671,22 @@ def build_combined_tables(
     logger.info("Entity pairs_same_document: rows=%d", len(df_pairs_same))
     logger.info("Entity pairs: rows=%d", len(df_pairs))
     combined["pairs_same_document"] = df_pairs_same
-    combined["pairs"] = df_pairs
+
+    if "INDEPENDENT" in df_pairs.columns:
+        indep_series = _safe_to_bool(df_pairs["INDEPENDENT"], "INDEPENDENT").fillna(
+            False
+        )
+        df_pairs_independent = normalize_pair_columns(df_pairs[indep_series].copy())
+        df_pairs_non_independent = normalize_pair_columns(
+            df_pairs[~indep_series].copy()
+        )
+    else:
+        logger.warning("INDEPENDENT column missing; creating empty pair segments")
+        df_pairs_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
+        df_pairs_non_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
+
+    combined["pairs_independent"] = df_pairs_independent
+    combined["pairs_non_independent"] = df_pairs_non_independent
 
     if dictionary_dir is not None:
         status_df = load_status_table(dictionary_dir)
@@ -682,7 +695,13 @@ def build_combined_tables(
             combined["activity"], status_api
         )
 
-        for pair_key in ("pairs", "pairs_same_document"):
+        pair_keys = (
+            "pairs_same_document",
+            "pairs_independent",
+            "pairs_non_independent",
+        )
+
+        for pair_key in pair_keys:
             if pair_key not in combined:
                 logger.warning("skip initialize_pairs: table '%s' missing", pair_key)
                 continue
@@ -700,20 +719,18 @@ def build_combined_tables(
                     pair_key,
                 )
 
-        pair_table = None
-        for pair_key in ("pairs", "pairs_same_document"):
-            if pair_key in combined and {"Filtered1", "Filtered2"}.issubset(
-                combined[pair_key].columns
-            ):
-                pair_table = combined[pair_key]
-                break
-        if pair_table is not None:
+        pair_table = combined.get("pairs_independent")
+        if pair_table is not None and {"Filtered1", "Filtered2"}.issubset(
+            pair_table.columns
+        ):
             aggregates = aggregate_activity(
                 pair_table, combined["activity"], status_api
             )
             combined.update({f"{k}_status": v for k, v in aggregates.items()})
         else:
-            logger.warning("pair table not found; skipping status aggregation")
+            logger.warning(
+                "pairs_independent table missing or lacks Filtered columns; skipping status aggregation"
+            )
 
     return combined
 
@@ -744,7 +761,9 @@ def save_tables(
     out_dir.mkdir(parents=True, exist_ok=True)
     paths: Dict[str, Path] = {}
     for entity, df in tables.items():
-        path = out_dir / f"{entity}.csv"
+        sub_dir = out_dir / "status" if entity.endswith("_status") else out_dir
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        path = sub_dir / f"{entity}.csv"
         df.to_csv(path, index=False, encoding="utf-8", na_rep="")
         logger.info("Wrote %d rows to %s", len(df), path)
         paths[entity] = path
@@ -1040,10 +1059,8 @@ def aggregate_activity(
     missing = [m for m in metrics if m not in df_pairs.columns]
     if missing:
         logger.warning(
-
             "pair table missing %s %s; filling with zeros",
             "column" if len(missing) == 1 else "columns",
-
             ", ".join(missing),
         )
         for col in missing:
@@ -1077,7 +1094,6 @@ def aggregate_activity(
         )
         system_status = pd.DataFrame(columns=["system_id", "Filtered.new", *metrics])
     else:
-
         system_src = merged.copy()
         system_src["system_id"] = (
             system_src["testitem_id"].astype("string")
@@ -1092,11 +1108,9 @@ def aggregate_activity(
         system_status["target_id"] = split[1]
         system_status["standard_type"] = split[2]
 
-
     if "testitem_id" in merged.columns:
         testitem_status = _aggregate_entity(merged, "testitem_id", status_api)
     elif "testitem_id" not in missing_sys:
-
         logger.warning(
             "activity table missing column testitem_id; skipping testitem aggregation"
         )
@@ -1108,7 +1122,6 @@ def aggregate_activity(
         testitem_status = pd.DataFrame(
             columns=["testitem_id", "Filtered.new", *metrics]
         )
-
 
     if "target_id" in merged.columns:
         target_status = _aggregate_entity(merged, "target_id", status_api)

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -17,8 +17,10 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
     tables = {
         "assay": pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}),
         "activity": pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3]}),
-        "pairs": pd.DataFrame({"id": [1, 2]}),
         "pairs_same_document": pd.DataFrame({"id": [3, 4]}),
+        "pairs_independent": pd.DataFrame({"id": [5]}),
+        "pairs_non_independent": pd.DataFrame({"id": [6]}),
+        "activity_status": pd.DataFrame({"id": [7]}),
     }
 
     def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub
@@ -44,9 +46,15 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
     result = cli.run(args)
     assert result == 0
 
+    assert (out_dir / "status" / "activity_status.csv").exists()
+
     for name in tables:
-        quality = out_dir / f"{name}_quality_report_table.csv"
-        corr = out_dir / f"{name}_data_correlation_report_table.csv"
+        quality = out_dir / "data_validity_report" / f"{name}_quality_report_table.csv"
+        corr = (
+            out_dir
+            / "data_validity_report"
+            / f"{name}_data_correlation_report_table.csv"
+        )
         assert quality.exists(), quality
         assert corr.exists(), corr
         df = pd.read_csv(quality)

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -65,7 +65,9 @@ def test_build_combined_tables_drops_activity_cols() -> None:
     assert "Column1" not in combined["activity"].columns
     assert len(combined["activity"]) == 2
     assert "pairs_same_document" in combined
-    assert "pairs" in combined
+    assert "pairs_independent" in combined
+    assert "pairs_non_independent" in combined
+    assert "pairs" not in combined
 
 
 def test_build_combined_tables_pairs_no_merge() -> None:
@@ -88,7 +90,9 @@ def test_build_combined_tables_pairs_no_merge() -> None:
     }
     combined = build_combined_tables(same, all_)
     assert len(combined["pairs_same_document"]) == 3
-    assert len(combined["pairs"]) == 5
+    assert len(combined["pairs_independent"]) == 0
+    assert len(combined["pairs_non_independent"]) == 0
+    assert "pairs" not in combined
 
 
 def test_build_combined_tables_adds_pair_metrics() -> None:
@@ -100,7 +104,7 @@ def test_build_combined_tables_adds_pair_metrics() -> None:
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame(),
         "pairs_same_document": pd.DataFrame(
-            {"INDEPENDENT": [False], "mesurement_type": ["Ki"]}
+            {"INDEPENDENT": [False], "standard_type": ["Ki"]}
         ),
     }
     all_: TableDict = {
@@ -109,11 +113,13 @@ def test_build_combined_tables_adds_pair_metrics() -> None:
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame(),
-        "pairs": pd.DataFrame({"INDEPENDENT": [True], "mesurement_type": ["IC50"]}),
+        "pairs": pd.DataFrame({"INDEPENDENT": [True], "standard_type": ["IC50"]}),
     }
     combined = build_combined_tables(same, all_)
-    assert combined["pairs"].loc[0, "independent_IC50"] == 1
+    assert combined["pairs_independent"].loc[0, "independent_IC50"] == 1
     assert combined["pairs_same_document"].loc[0, "non_independent_Ki"] == 1
+    assert len(combined["pairs_independent"]) == 1
+    assert len(combined["pairs_non_independent"]) == 0
 
 
 def test_build_combined_tables_handles_status(
@@ -139,7 +145,7 @@ def test_build_combined_tables_handles_status(
 
     # Minimal status.csv to satisfy loader
     (tmp_path / "status.csv").write_text(
-        "status,condition_field,condition_value,order,score\n" "ok,null,null,0,0\n"
+        "status,condition_field,condition_value,order,score\nok,null,null,0,0\n"
     )
 
     # Simplify heavy processing steps
@@ -173,7 +179,9 @@ def test_build_combined_tables_initializes_pair_tables(
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame({"activity_id": [2]}),
-        "pairs": pd.DataFrame({"activity_id1": [2], "activity_id2": [1]}),
+        "pairs": pd.DataFrame(
+            {"INDEPENDENT": [True], "activity_id1": [2], "activity_id2": [1]}
+        ),
     }
 
     (tmp_path / "status.csv").write_text(
@@ -192,7 +200,7 @@ def test_build_combined_tables_initializes_pair_tables(
     monkeypatch.setattr(lib, "aggregate_activity", lambda *_: {})
 
     combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
-    pairs = combined["pairs"].iloc[0]
+    pairs = combined["pairs_independent"].iloc[0]
     assert [pairs["Filtered1"], pairs["Filtered2"], pairs["Filtered"]] == [
         "bad",
         "good",
@@ -208,6 +216,105 @@ def test_build_combined_tables_initializes_pair_tables(
         "bad",
         "good",
     ]
+
+
+def test_build_combined_tables_initializes_pair_segments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Derived pair segments should receive Filtered columns."""
+
+    same: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [1]}),
+        "pairs_same_document": pd.DataFrame(),
+    }
+    all_: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [2]}),
+        "pairs": pd.DataFrame(
+            {
+                "INDEPENDENT": [True, False],
+                "activity_id1": [1, 2],
+                "activity_id2": [2, 1],
+            }
+        ),
+    }
+
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
+    )
+
+    monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
+
+    def fake_init(df: pd.DataFrame, _api: object) -> pd.DataFrame:
+        mapping = {1: "good", 2: "good"}
+        return df.assign(**{"Filtered.init": df["activity_id"].map(mapping)})
+
+    monkeypatch.setattr(lib, "initialize_activity_status", fake_init)
+    monkeypatch.setattr(lib, "aggregate_activity", lambda *_: {})
+
+    combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
+    assert len(combined["pairs_independent"]) == 1
+    assert len(combined["pairs_non_independent"]) == 1
+    for key in ("pairs_independent", "pairs_non_independent"):
+        assert {"Filtered1", "Filtered2", "Filtered"}.issubset(combined[key].columns)
+
+
+def test_build_combined_tables_aggregates_from_pairs_independent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Status aggregation should use only ``pairs_independent``."""
+
+    same: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [1]}),
+        "pairs_same_document": pd.DataFrame(),
+    }
+    all_: TableDict = {
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "activity": pd.DataFrame({"activity_id": [2]}),
+        "pairs": pd.DataFrame(
+            {
+                "INDEPENDENT": [True],
+                "activity_id1": [1],
+                "activity_id2": [2],
+            }
+        ),
+    }
+
+    (tmp_path / "status.csv").write_text(
+        "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
+    )
+
+    monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
+    monkeypatch.setattr(
+        lib,
+        "initialize_activity_status",
+        lambda df, _api: df.assign(**{"Filtered.init": "good"}),
+    )
+
+    captured: dict[str, pd.DataFrame] = {}
+
+    def fake_aggregate(pair_df: pd.DataFrame, *_args, **_kwargs):
+        captured["pair_df"] = pair_df
+        return {}
+
+    monkeypatch.setattr(lib, "aggregate_activity", fake_aggregate)
+
+    combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
+    assert captured["pair_df"] is combined["pairs_independent"]
 
 
 def test_build_combined_tables_normalizes_pair_column_names(
@@ -229,11 +336,13 @@ def test_build_combined_tables_normalizes_pair_column_names(
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
         "activity": pd.DataFrame({"activity_id": [2]}),
-        "pairs": pd.DataFrame({"ACTIVITY_ID_1": [2], "ACTIVITY_ID_2": [1]}),
+        "pairs": pd.DataFrame(
+            {"INDEPENDENT": [True], "ACTIVITY_ID_1": [2], "ACTIVITY_ID_2": [1]}
+        ),
     }
 
     (tmp_path / "status.csv").write_text(
-        "status,condition_field,condition_value,order,score\n" "good,null,null,0,0\n"
+        "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
     )
 
     monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
@@ -246,7 +355,7 @@ def test_build_combined_tables_normalizes_pair_column_names(
     monkeypatch.setattr(lib, "aggregate_activity", lambda *_: {})
 
     combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
-    for key in ("pairs", "pairs_same_document"):
+    for key in ("pairs_independent", "pairs_same_document"):
         assert {
             "activity_chembl_id1",
             "activity_chembl_id2",
@@ -264,13 +373,16 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         "target": pd.DataFrame({"id": [4]}),
         "testitem": pd.DataFrame({"id": [5]}),
         "pairs_same_document": pd.DataFrame({"id": [1]}),
-        "pairs": pd.DataFrame({"id": [1]}),
+        "pairs_independent": pd.DataFrame({"id": [1]}),
+        "pairs_non_independent": pd.DataFrame({"id": [2]}),
+        "activity_status": pd.DataFrame({"id": [1]}),
     }
     paths = save_tables(tables, tmp_path)
     for entity, path in paths.items():
         assert path.exists(), f"missing {entity} file"
         df = pd.read_csv(path)
         assert not df.empty
+    assert paths["activity_status"].parent == tmp_path / "status"
 
 
 def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -320,12 +432,12 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
     expected_cols = [
         "activity_id",
         "saltform_id",
-        "molecule_id",
+        "testitem_id",
         "target_id",
         "assay_id",
         "document_id",
         "bao_endpoint",
-        "mesurement_type",
+        "standard_type",
         "standard_value",
         "pA_value",
         "bao_format",


### PR DESCRIPTION
## Summary
- Split pairs into `pairs_independent` and `pairs_non_independent` without retaining the original `pairs` table
- Aggregate statuses from `pairs_independent` only and save status tables under `status/`
- Emit data correlation and quality reports to `data_validity_report/` and document the new outputs in the CLI

## Testing
- `ruff check library/input_initialisation_library.py get_input_initialisation.py tests/test_get_input_initialisation.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py get_input_initialisation.py tests/test_get_input_initialisation.py tests/test_input_initialisation_library.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02d6cdac88324bd873fcf6592efe8