### PR TITLE
Improve CLI robustness and logging isolation

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -6,6 +6,8 @@ import argparse
 import logging
 from typing import Sequence
 
+import requests
+
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
@@ -38,7 +40,11 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    df = cl.get_activities(ids, chunk_size=args.chunk_size, timeout=args.timeout)
+    try:
+        df = cl.get_activities(ids, chunk_size=args.chunk_size, timeout=args.timeout)
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve activities: %s", exc)
+        return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -6,6 +6,8 @@ import argparse
 import logging
 from typing import Sequence
 
+import requests
+
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
@@ -39,7 +41,11 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    df = cl.get_assays(ids, chunk_size=args.chunk_size)
+    try:
+        df = cl.get_assays(ids, chunk_size=args.chunk_size)
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve assays: %s", exc)
+        return 1
     df = ap.postprocess_assays(df)
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -168,7 +168,11 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+    try:
+        df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve documents: %s", exc)
+        return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
@@ -195,7 +199,11 @@ def run_all(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+    try:
+        doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve documents: %s", exc)
+        return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
     if doc_df.empty or "pubmed_id" not in doc_df:
         processed = dp.postprocess_documents(doc_df)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
+import requests
 
 from library import chembl_library as cl
 from library import io
@@ -360,7 +361,11 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    df = cl.get_targets(ids)
+    try:
+        df = cl.get_targets(ids)
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve targets: %s", exc)
+        return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -7,6 +7,7 @@ import logging
 from typing import Sequence
 
 import pandas as pd
+import requests
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -118,7 +119,11 @@ def run_chembl(args: argparse.Namespace) -> int:
 
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
-    df = cl.get_testitem(ids, chunk_size=args.chunk_size)
+    try:
+        df = cl.get_testitem(ids, chunk_size=args.chunk_size)
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("failed to retrieve compounds: %s", exc)
+        return 1
     logger.info("Retrieved %d rows from ChEMBL", len(df))
     logger.info("Augmenting results with PubChem data")
     df = add_pubchem_data(df)

--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -44,13 +44,12 @@ def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
             "target_chembl_id": "object",
         },
     )
-    counts = (
-        df.groupby(["document_chembl_id", "target_chembl_id"])
-        .size()
-        .rename("assay_with_same_target")
-    )
-    logger.debug("Calculated counts for %d document/target groups", len(counts))
-    return df.merge(counts, on=["document_chembl_id", "target_chembl_id"], how="left")
+    group_cols = ["document_chembl_id", "target_chembl_id"]
+    groups = df.groupby(group_cols)
+    logger.debug("Calculated counts for %d document/target groups", groups.ngroups)
+    result = df.copy()
+    result["assay_with_same_target"] = groups["document_chembl_id"].transform("size")
+    return result
 
 
 def postprocess_file(
@@ -74,6 +73,15 @@ def postprocess_file(
         Text encoding of the CSV files.
     """
 
-    df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
+    try:
+        df = pd.read_csv(
+            input_path,
+            sep=sep,
+            encoding=encoding,
+            dtype=str,
+            dtype_backend="pyarrow",
+        )
+    except ImportError:  # pragma: no cover - pyarrow optional
+        df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_assays(df)
     processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/library/cli.py
+++ b/library/cli.py
@@ -7,10 +7,38 @@ import logging
 from pathlib import Path
 
 
+def _positive_int(value: str) -> int:
+    """Return ``value`` as a positive integer for ``argparse``.
+
+    Parameters
+    ----------
+    value:
+        String representation of the integer.
+
+    Returns
+    -------
+    int
+        The parsed positive integer.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If ``value`` is not a positive integer.
+    """
+
+    try:
+        ivalue = int(value)
+    except ValueError as exc:  # pragma: no cover - handled by argparse
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("chunk size must be a positive integer")
+    return ivalue
+
+
 def build_parser(
     description: str, *, column: str, chunk_size: int = 10
 ) -> argparse.ArgumentParser:
-    """Return a parser with common arguments.
+    """Return an argument parser with shared options.
 
     Parameters
     ----------
@@ -39,17 +67,29 @@ def build_parser(
         help="Destination CSV file (default: auto-generate)",
     )
     parser.add_argument(
-        "--column", default=column, help="Identifier column in input CSV"
+        "--column",
+        default=column,
+        help="Identifier column in input CSV",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")
     parser.add_argument("--encoding", default="utf8", help="File encoding")
     parser.add_argument(
-        "--chunk-size", type=int, default=chunk_size, help="Maximum IDs per request"
+        "--chunk-size",
+        type=_positive_int,
+        default=chunk_size,
+        help="Maximum IDs per request",
     )
     return parser
 
 
 def configure_logging(level: str) -> None:
-    """Configure basic logging for CLI entry points."""
+    """Configure root logging for command-line utilities.
+
+    Parameters
+    ----------
+    level:
+        Textual logging level (e.g. ``"INFO"``, ``"DEBUG"``).
+    """
+
     numeric = getattr(logging, level.upper(), logging.INFO)
-    logging.basicConfig(level=numeric)
+    logging.basicConfig(level=numeric, force=True)

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -7,15 +7,12 @@ import logging
 import time
 import urllib.parse
 import urllib.request
+from typing import Any, Callable, Optional
 from urllib.error import HTTPError
-from typing import Optional, Callable, Any
-import argparse
-import pandas as pd
 
 API_BASE = "https://rest.uniprot.org/idmapping"
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def map_chembl_to_uniprot(
@@ -129,54 +126,3 @@ def map_chembl_to_uniprot(
         raise ValueError("Unexpected response format from UniProt ID mapping API")
 
     return accession
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Map ChEMBL IDs to UniProt accessions in a CSV file."
-    )
-    parser.add_argument("csv_file", help="Path to the CSV file to process.")
-    parser.add_argument(
-        "chembl_id_column", help="Name of the column containing ChEMBL IDs."
-    )
-    args = parser.parse_args()
-
-    try:
-        df = pd.read_csv(args.csv_file)
-    except FileNotFoundError:
-        logging.error(f"Error: The file '{args.csv_file}' was not found.")
-        exit(1)
-    except Exception as e:
-        logging.error(f"Error reading CSV file: {e}")
-        exit(1)
-
-    if args.chembl_id_column not in df.columns:
-        logging.error(
-            f"Error: Column '{args.chembl_id_column}' not found in the CSV file."
-        )
-        exit(1)
-
-    uniprot_ids: list[str | None] = []
-    for chembl_id in df[args.chembl_id_column]:
-        if pd.isna(chembl_id) or not str(chembl_id).strip():
-            uniprot_ids.append(None)
-            continue
-        try:
-            uniprot_id = map_chembl_to_uniprot(str(chembl_id))
-            uniprot_ids.append(uniprot_id)
-            if uniprot_id:
-                logging.info(f"Successfully mapped {chembl_id} to {uniprot_id}")
-            else:
-                logging.warning(f"No UniProt ID found for {chembl_id}")
-        except (ValueError, TimeoutError) as e:
-            logging.warning(f"Failed to map {chembl_id}: {e}")
-            uniprot_ids.append(None)
-
-    df["mapping_uniprot_id"] = uniprot_ids
-
-    try:
-        df.to_csv(args.csv_file, index=False)
-        logging.info(f"Successfully updated '{args.csv_file}' with UniProt IDs.")
-    except Exception as e:
-        logging.error(f"Error writing to CSV file: {e}")
-        exit(1)

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -1,0 +1,87 @@
+"""Command line interface for mapping ChEMBL target IDs to UniProt accessions."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Sequence
+from urllib.error import URLError
+
+import pandas as pd
+
+from library import io
+from library.cli import build_parser as base_parser, configure_logging
+from library.mapper_library import map_chembl_to_uniprot
+
+logger = logging.getLogger(__name__)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Map ChEMBL target identifiers to UniProt accessions.
+
+    Parameters
+    ----------
+    args:
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+    """
+    try:
+        df = io.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+    except (FileNotFoundError, OSError) as exc:
+        logger.error("%s", exc)
+        return 1
+    if args.column not in df.columns:
+        logger.error("column '%s' not found in %s", args.column, args.input_csv)
+        return 1
+
+    uniprot_ids: list[str | None] = []
+    for chembl_id in df[args.column]:
+        if pd.isna(chembl_id) or not str(chembl_id).strip():
+            uniprot_ids.append(None)
+            continue
+        try:
+            uniprot_id = map_chembl_to_uniprot(str(chembl_id))
+            uniprot_ids.append(uniprot_id)
+            if uniprot_id:
+                logger.info("mapped %s -> %s", chembl_id, uniprot_id)
+            else:
+                logger.warning("no UniProt ID for %s", chembl_id)
+        except (ValueError, TimeoutError, URLError) as exc:
+            logger.warning("failed to map %s: %s", chembl_id, exc)
+            uniprot_ids.append(None)
+    df["mapping_uniprot_id"] = uniprot_ids
+    output = args.output_csv or io.default_output_path(args.input_csv)
+    try:
+        io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
+        logger.info("wrote %s", output)
+    except OSError as exc:
+        logger.error("failed to write output CSV: %s", exc)
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line argument parser."""
+    parser = base_parser(
+        "Map ChEMBL target IDs to UniProt accessions",
+        column="chembl_id",
+        chunk_size=1,
+    )
+    parser.set_defaults(func=run)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command line entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -1,0 +1,30 @@
+import argparse
+import logging
+from pathlib import Path
+
+import requests
+
+import get_activity_data as gad
+from library import chembl_library as cl, io
+
+
+def test_run_chembl_handles_request_error(monkeypatch, caplog) -> None:
+    args = argparse.Namespace(
+        input_csv=Path("dummy.csv"),
+        output_csv=None,
+        column="activity_id",
+        sep=",",
+        encoding="utf8",
+        chunk_size=5,
+        timeout=30.0,
+    )
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["1"])
+
+    def _raise(*_a, **_k):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(cl, "get_activities", _raise)
+    with caplog.at_level(logging.ERROR):
+        result = gad.run_chembl(args)
+    assert result == 1
+    assert "boom" in caplog.text

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,15 @@
+import pytest
+
+from library.cli import build_parser
+
+
+def test_chunk_size_positive() -> None:
+    parser = build_parser("desc", column="id")
+    args = parser.parse_args(["--chunk-size", "3"])
+    assert args.chunk_size == 3
+
+
+def test_chunk_size_non_positive() -> None:
+    parser = build_parser("desc", column="id")
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--chunk-size", "0"])

--- a/tests/test_mapper_logging.py
+++ b/tests/test_mapper_logging.py
@@ -1,0 +1,15 @@
+import importlib
+import logging
+import sys
+
+
+def test_mapper_library_has_no_logging_side_effect() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    assert not root.handlers
+    module_name = "library.mapper_library"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    importlib.import_module(module_name)
+    assert not root.handlers


### PR DESCRIPTION
## Summary
- validate `--chunk-size` and centralize logging config in CLI helpers
- handle network errors across data retrieval scripts
- optimize assay postprocessing and add UniProt mapping CLI entry point

## Testing
- `black library/assay_postprocessing.py library/cli.py library/mapper_library.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py mapper_main.py tests/test_cli_validation.py tests/test_activity_cli_error.py tests/test_mapper_logging.py`
- `ruff check library/assay_postprocessing.py library/cli.py library/mapper_library.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py mapper_main.py tests/test_cli_validation.py tests/test_activity_cli_error.py tests/test_mapper_logging.py`
- `mypy library/assay_postprocessing.py library/cli.py library/mapper_library.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py mapper_main.py tests/test_cli_validation.py tests/test_activity_cli_error.py tests/test_mapper_logging.py` *(fails: Library stubs not installed for "pandas", "requests"...)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c05300ede88324b3edcaea969446aa