### PR TITLE
Improve documentation and logging utilities

### DIFF
--- a/get_target_data.py
+++ b/get_target_data.py
@@ -16,6 +16,7 @@ from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
+from library.cli import configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -261,24 +262,6 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.set_defaults(func=run_all)
 
     return parser
-
-
-def configure_logging(level: str) -> None:
-    """Configure basic logging.
-
-    Parameters
-    ----------
-    level:
-        Logging verbosity such as ``"INFO"`` or ``"DEBUG"``.
-
-    Returns
-    -------
-    None
-        This function configures the root logger in-place and does not
-        return a value.
-
-    """
-    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
 
 
 def run_uniprot(args: argparse.Namespace) -> int:

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -625,6 +625,21 @@ def load_all_doc(xlsx_path: Path) -> TableDict:
 
 
 def _safe_to_int(series: pd.Series, col: str) -> pd.Series:
+    """Safely cast ``series`` to ``Int64``.
+
+    Parameters
+    ----------
+    series:
+        Column values to convert.
+    col:
+        Column name used in warning messages.
+
+    Returns
+    -------
+    pandas.Series
+        ``Int64`` typed series or ``string`` on failure.
+    """
+
     try:
         return pd.to_numeric(series, errors="raise").astype("Int64")
     except Exception as exc:  # pragma: no cover - rare
@@ -633,6 +648,21 @@ def _safe_to_int(series: pd.Series, col: str) -> pd.Series:
 
 
 def _safe_to_float(series: pd.Series, col: str) -> pd.Series:
+    """Safely cast ``series`` to ``float64``.
+
+    Parameters
+    ----------
+    series:
+        Column values to convert.
+    col:
+        Column name used in warning messages.
+
+    Returns
+    -------
+    pandas.Series
+        ``float64`` typed series or ``string`` on failure.
+    """
+
     try:
         return pd.to_numeric(series, errors="raise").astype("float64")
     except Exception as exc:  # pragma: no cover - rare
@@ -641,6 +671,21 @@ def _safe_to_float(series: pd.Series, col: str) -> pd.Series:
 
 
 def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
+    """Safely cast ``series`` to pandas ``datetime64``.
+
+    Parameters
+    ----------
+    series:
+        Column values to convert.
+    col:
+        Column name used in warning messages.
+
+    Returns
+    -------
+    pandas.Series
+        ``datetime64`` typed series or ``string`` on failure.
+    """
+
     try:
         return pd.to_datetime(series, errors="raise")
     except Exception as exc:  # pragma: no cover - rare
@@ -649,6 +694,21 @@ def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
 
 
 def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
+    """Safely cast ``series`` to pandas ``boolean``.
+
+    Parameters
+    ----------
+    series:
+        Column values to convert.
+    col:
+        Column name used in warning messages.
+
+    Returns
+    -------
+    pandas.Series
+        ``boolean`` typed series or ``string`` on failure.
+    """
+
     def mapper(value: Any) -> object:
         if pd.isna(value):
             return pd.NA

--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -36,7 +36,18 @@ def fetch_openalex(
     timeout: float, optional
         Maximum seconds to wait for the HTTP response.
 
+    Returns
+    -------
+    dict
+        Metadata returned by the OpenAlex API.
+
+    Raises
+    ------
+    requests.RequestException
+        Propagated if the HTTP request fails.
+
     """
+
     return _pl.fetch_openalex(session, pmid, sleep, timeout=timeout)
 
 
@@ -60,5 +71,16 @@ def fetch_crossref(
     timeout: float, optional
         Maximum seconds to wait for the HTTP response.
 
+    Returns
+    -------
+    dict
+        Metadata returned by the CrossRef API.
+
+    Raises
+    ------
+    requests.RequestException
+        Propagated if the HTTP request fails.
+
     """
+
     return _pl.fetch_crossref(session, doi, sleep, timeout=timeout)

--- a/tests/test_get_target_data_helpers.py
+++ b/tests/test_get_target_data_helpers.py
@@ -1,0 +1,18 @@
+"""Tests for helper utilities in :mod:`get_target_data`."""
+
+from get_target_data import _pipe_merge, _first_token
+
+
+def test_pipe_merge_deduplicates_and_sorts() -> None:
+    values = ["b|a", "C|a", None, "", "b"]
+    assert _pipe_merge(values) == "C|a|b"
+
+
+def test_pipe_merge_handles_empty() -> None:
+    assert _pipe_merge([None, "", " "]) == ""
+
+
+def test_first_token_extracts_head() -> None:
+    assert _first_token("a|b|c") == "a"
+    assert _first_token(None) == ""
+    assert _first_token("") == ""


### PR DESCRIPTION
## Summary
- document type-conversion helpers and OpenAlex/CrossRef wrappers
- reuse shared logging configuration in `get_target_data`
- test edge cases for `_pipe_merge` and `_first_token`

## Testing
- `python -m black library/input_initialisation_library.py library/openalex_crossref_library.py get_target_data.py tests/test_get_target_data_helpers.py`
- `python -m ruff check library/input_initialisation_library.py library/openalex_crossref_library.py get_target_data.py tests/test_get_target_data_helpers.py`
- `python -m mypy library/input_initialisation_library.py library/openalex_crossref_library.py get_target_data.py tests/test_get_target_data_helpers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09a025f2883249c0abfa13af21a91