### PR TITLE
Add typed YAML configuration system

### DIFF
--- a/chembl_da/__init__.py
+++ b/chembl_da/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for chembl_da utilities."""

--- a/chembl_da/library/__init__.py
+++ b/chembl_da/library/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration utilities for the ``chembl_da`` project."""
+
+from .config import APIConfig, IOConfig, JobsConfig, Config, load_config
+
+__all__ = ["APIConfig", "IOConfig", "JobsConfig", "Config", "load_config"]

--- a/chembl_da/library/config.py
+++ b/chembl_da/library/config.py
@@ -1,0 +1,244 @@
+"""YAML-based configuration handling for ``chembl_da``.
+
+This module provides a typed configuration system for command-line
+utilities. Settings are loaded from ``config.yaml`` and may be overridden
+via environment variables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+from typing import Any, Dict
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Dataclass definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class APIConfig:
+    """Settings for external API access."""
+
+    chembl_base: str
+    timeout_connect: int
+    timeout_read: int
+    rps: int
+    burst: int
+
+
+@dataclass
+class IOConfig:
+    """Directories used for input/output and caching."""
+
+    output_dir: str
+    cache_dir: str
+
+
+@dataclass
+class JobsConfig:
+    """Parallel execution parameters."""
+
+    concurrency: int
+    chunk_size: int
+
+
+@dataclass
+class Config:
+    """Top-level configuration container."""
+
+    api: APIConfig
+    io: IOConfig
+    jobs: JobsConfig
+
+    # Proxy attributes for convenient access -------------------------------
+    @property
+    def chembl_base(self) -> str:
+        return self.api.chembl_base
+
+    @property
+    def rps(self) -> int:
+        return self.api.rps
+
+    @property
+    def burst(self) -> int:
+        return self.api.burst
+
+    @property
+    def output_dir(self) -> str:
+        return self.io.output_dir
+
+    @property
+    def cache_dir(self) -> str:
+        return self.io.cache_dir
+
+    @property
+    def concurrency(self) -> int:
+        return self.jobs.concurrency
+
+    @property
+    def chunk_size(self) -> int:
+        return self.jobs.chunk_size
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "api": {
+        "chembl_base": "https://www.ebi.ac.uk/chembl/api/data",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "rps": 5,
+        "burst": 5,
+    },
+    "io": {"output_dir": "data/output", "cache_dir": ".cache"},
+    "jobs": {"concurrency": 8, "chunk_size": 500},
+}
+
+# Mapping of short environment aliases to configuration keys
+_ALIAS_MAP: Dict[str, tuple[str, str]] = {
+    "CHEMBL_DA_OUTDIR": ("io", "output_dir"),
+    "CHEMBL_DA_CACHEDIR": ("io", "cache_dir"),
+    "CHEMBL_DA_RPS": ("api", "rps"),
+    "CHEMBL_DA_BURST": ("api", "burst"),
+    "CHEMBL_DA_TIMEOUT_CONNECT": ("api", "timeout_connect"),
+    "CHEMBL_DA_TIMEOUT_READ": ("api", "timeout_read"),
+    "CHEMBL_DA_BASE": ("api", "chembl_base"),
+    "CHEMBL_DA_CONCURRENCY": ("jobs", "concurrency"),
+    "CHEMBL_DA_CHUNK_SIZE": ("jobs", "chunk_size"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _deep_update(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``updates`` into ``base``."""
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _cast(value: str, current: Any) -> Any:
+    """Cast environment ``value`` to the type of ``current``."""
+    target = type(current)
+    if target is int:
+        return int(value)
+    if target is bool:
+        val = value.lower()
+        if val in {"1", "true", "yes"}:
+            return True
+        if val in {"0", "false", "no"}:
+            return False
+        raise ValueError(f"invalid boolean value: {value}")
+    return value
+
+
+def _apply_env_hierarchical(cfg: Dict[str, Dict[str, Any]]) -> None:
+    """Apply hierarchical ``CHEMBL_DA__SECTION__KEY`` overrides."""
+    prefix = "CHEMBL_DA__"
+    for env, value in os.environ.items():
+        if not env.startswith(prefix):
+            continue
+        parts = env.split("__", 2)
+        if len(parts) != 3:
+            continue
+        section, key = parts[1].lower(), parts[2].lower()
+        if section in cfg and key in cfg[section]:
+            cfg[section][key] = _cast(value, cfg[section][key])
+
+
+def _apply_env_aliases(cfg: Dict[str, Dict[str, Any]]) -> None:
+    """Apply short alias environment variable overrides."""
+    for env, (section, key) in _ALIAS_MAP.items():
+        if env in os.environ:
+            cfg[section][key] = _cast(os.environ[env], cfg[section][key])
+
+
+def _validate(cfg: Config) -> None:
+    """Validate the configuration values.
+
+    Raises
+    ------
+    ValueError
+        If any configuration value is invalid.
+    """
+    if not cfg.api.chembl_base or not cfg.api.chembl_base.startswith(
+        ("http://", "https://")
+    ):
+        raise ValueError("api.chembl_base must start with http:// or https://")
+    if cfg.api.timeout_connect <= 0:
+        raise ValueError("api.timeout_connect must be positive")
+    if cfg.api.timeout_read <= 0:
+        raise ValueError("api.timeout_read must be positive")
+    if cfg.api.rps <= 0:
+        raise ValueError("api.rps must be positive")
+    if cfg.api.burst <= 0:
+        raise ValueError("api.burst must be positive")
+    if cfg.io.output_dir == "":
+        raise ValueError("io.output_dir must not be empty")
+    if cfg.io.cache_dir == "":
+        raise ValueError("io.cache_dir must not be empty")
+    if cfg.jobs.concurrency <= 0:
+        raise ValueError("jobs.concurrency must be positive")
+    if cfg.jobs.chunk_size <= 0:
+        raise ValueError("jobs.chunk_size must be positive")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_config(path: str = "config.yaml") -> Config:
+    """Load configuration from ``path`` and environment variables.
+
+    Parameters
+    ----------
+    path:
+        Location of the YAML configuration file. If the file does not exist,
+        built-in defaults are used.
+
+    Returns
+    -------
+    Config
+        Parsed configuration object.
+
+    Raises
+    ------
+    ValueError
+        If configuration values are invalid or environment overrides are
+        malformed.
+    """
+    config_dict: Dict[str, Dict[str, Any]] = {
+        section: values.copy() for section, values in _DEFAULTS.items()
+    }
+    config_path = Path(path)
+    if config_path.exists():
+        data = yaml.safe_load(config_path.read_text()) or {}
+        if not isinstance(data, dict):
+            raise ValueError(
+                "configuration file must contain a mapping at the top level"
+            )
+        _deep_update(config_dict, data)
+
+    _apply_env_hierarchical(config_dict)
+    _apply_env_aliases(config_dict)
+
+    cfg = Config(
+        api=APIConfig(**config_dict["api"]),
+        io=IOConfig(**config_dict["io"]),
+        jobs=JobsConfig(**config_dict["jobs"]),
+    )
+    _validate(cfg)
+    return cfg

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,14 @@
+api:
+  chembl_base: "https://www.ebi.ac.uk/chembl/api/data"
+  timeout_connect: 5
+  timeout_read: 30
+  rps: 5
+  burst: 5
+
+io:
+  output_dir: "data/output"
+  cache_dir: ".cache"
+
+jobs:
+  concurrency: 8
+  chunk_size: 500

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import requests
 
+from chembl_da.library.config import load_config
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
@@ -30,6 +32,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -42,11 +45,16 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_activities(ids, chunk_size=args.chunk_size, timeout=args.timeout)
+        chunk_size = args.chunk_size or cfg.chunk_size
+        timeout = args.timeout or cfg.api.timeout_read
+        df = cl.get_activities(ids, chunk_size=chunk_size, timeout=timeout)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -63,13 +71,11 @@ def run_chembl(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     """Create the command-line argument parser."""
-    parser = base_parser(
-        "ChEMBL activity data utilities", column="activity_id", chunk_size=5
-    )
+    parser = base_parser("ChEMBL activity data utilities", column="activity_id")
     parser.add_argument(
         "--timeout",
         type=float,
-        default=30.0,
+        default=None,
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import requests
 
+from chembl_da.library.config import load_config
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
@@ -31,6 +33,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -43,12 +46,16 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_assays(ids, chunk_size=args.chunk_size)
+        chunk_size = args.chunk_size or cfg.chunk_size
+        df = cl.get_assays(ids, chunk_size=chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
     df = ap.postprocess_assays(df)
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -65,9 +72,7 @@ def run_chembl(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     """Create the command-line argument parser."""
-    parser = base_parser(
-        "ChEMBL assay data utilities", column="assay_chembl_id", chunk_size=10
-    )
+    parser = base_parser("ChEMBL assay data utilities", column="assay_chembl_id")
     parser.set_defaults(func=run_chembl)
     return parser
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -33,6 +33,7 @@ import pandas as pd
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from chembl_da.library.config import load_config
 from library import chembl_library as cl
 from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
@@ -135,6 +136,7 @@ def fetch_pubmed_records(
 
 def run_pubmed(args: argparse.Namespace) -> int:
     """Execute the ``pubmed`` sub-command."""
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         pmids = io.read_ids(
             args.input_csv,
@@ -143,7 +145,10 @@ def run_pubmed(args: argparse.Namespace) -> int:
             encoding=args.encoding,
         )
         df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = (
+            args.output_csv
+            or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+        )
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
     except (FileNotFoundError, ValueError, OSError) as exc:
@@ -159,6 +164,7 @@ def run_pubmed(args: argparse.Namespace) -> int:
 
 def run_chembl(args: argparse.Namespace) -> int:
     """Execute the ``chembl`` sub-command."""
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv, column=args.column, sep=args.sep, encoding=args.encoding
@@ -168,11 +174,15 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        chunk_size = args.chunk_size or cfg.chunk_size
+        df = cl.get_documents(ids, chunk_size=chunk_size)  # type: ignore[attr-defined]
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -189,6 +199,7 @@ def run_chembl(args: argparse.Namespace) -> int:
 
 def run_all(args: argparse.Namespace) -> int:
     """Run ChEMBL and PubMed pipelines and merge their outputs."""
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv, column=args.column, sep=args.sep, encoding=args.encoding
@@ -198,11 +209,15 @@ def run_all(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        chunk_size = args.chunk_size or cfg.chunk_size
+        doc_df = cl.get_documents(ids, chunk_size=chunk_size)  # type: ignore[attr-defined]
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     if doc_df.empty or "pubmed_id" not in doc_df:
         processed = dp.postprocess_documents(doc_df)
         # Merge any columns not covered by ``postprocess_documents`` back
@@ -278,6 +293,9 @@ def build_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(description="Document data utilities")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to YAML configuration file"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     pubmed = sub.add_parser("pubmed", help="Fetch data from PubMed and related APIs")
@@ -335,7 +353,7 @@ def build_parser() -> argparse.ArgumentParser:
     chembl.add_argument("--sep", default=",", help="CSV delimiter")
     chembl.add_argument("--encoding", default="utf8", help="File encoding")
     chembl.add_argument(
-        "--chunk-size", type=int, default=5, help="Maximum number of IDs per request"
+        "--chunk-size", type=int, default=None, help="Maximum number of IDs per request"
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -360,7 +378,7 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.add_argument("--sep", default=",", help="CSV delimiter")
     all_cmd.add_argument("--encoding", default="utf8", help="File encoding")
     all_cmd.add_argument(
-        "--chunk-size", type=int, default=5, help="Maximum IDs per request"
+        "--chunk-size", type=int, default=None, help="Maximum IDs per request"
     )
     all_cmd.add_argument(
         "--sleep",

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -13,6 +13,7 @@ from typing import Iterable
 
 import pandas as pd
 
+from chembl_da.library.config import load_config
 from library.document_type_classifier import compute_scores, decide_label
 
 
@@ -76,8 +77,12 @@ def main() -> int:  # pragma: no cover - simple CLI
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, required=True, help="Input CSV")
     parser.add_argument("--output", type=Path, required=True, help="Output CSV")
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to YAML configuration file"
+    )
     args = parser.parse_args()
 
+    load_config(getattr(args, "config", "config.yaml"))
     df_in = pd.read_csv(args.input)
     df_out = classify_dataframe(df_in)
     df_out.to_csv(args.output, index=False)

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import Sequence
 
+from chembl_da.library.config import load_config
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
 
@@ -34,11 +35,13 @@ def run(args: argparse.Namespace) -> int:
         Zero on success, non-zero otherwise.
 
     """
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         if not args.same_doc.exists():
             raise FileNotFoundError(f"{args.same_doc} does not exist")
         if not args.all_doc.exists():
             raise FileNotFoundError(f"{args.all_doc} does not exist")
+        args.out_dir = args.out_dir or Path(cfg.output_dir)
         args.out_dir.mkdir(parents=True, exist_ok=True)
 
         logger.info("Loading source workbooks")
@@ -98,11 +101,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path("dictionary"),
         help="Directory with targets_type.csv, citation_fraction.csv and status.csv",
     )
-    parser.add_argument(
-        "--out-dir", type=Path, default=Path("."), help="Output directory"
-    )
+    parser.add_argument("--out-dir", type=Path, default=None, help="Output directory")
     parser.add_argument(
         "--format", choices=["csv"], default="csv", help="Output format"
+    )
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to YAML configuration file"
     )
     parser.set_defaults(func=run)
     return parser

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -11,6 +11,7 @@ from typing import Sequence
 import pandas as pd
 import requests
 
+from chembl_da.library.config import load_config
 from library import chembl_library as cl
 from library import io
 from library import iuphar_library as ii
@@ -64,6 +65,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING)",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to YAML configuration file",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -300,6 +306,7 @@ def run_uniprot(args: argparse.Namespace) -> int:
     :mod:`tests.test_target_postprocessing`.
 
     """
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         df = pd.read_csv(
             args.input_csv, sep=args.sep, encoding=args.encoding, dtype=str
@@ -323,7 +330,10 @@ def run_uniprot(args: argparse.Namespace) -> int:
                 writer.writerow({"uniprot_id": uid})
             tmp_path = Path(tmp.name)
 
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = (
+            args.output_csv
+            or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+        )
         try:
             uu.process(
                 input_csv=str(tmp_path),
@@ -352,6 +362,7 @@ def run_uniprot(args: argparse.Namespace) -> int:
 
 def run_chembl(args: argparse.Namespace) -> int:
     """Execute the ``chembl`` sub-command."""
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv, column=args.column, sep=args.sep, encoding=args.encoding
@@ -365,7 +376,10 @@ def run_chembl(args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -382,13 +396,17 @@ def run_chembl(args: argparse.Namespace) -> int:
 
 def run_iuphar(args: argparse.Namespace) -> int:
     """Execute the ``iuphar`` sub-command."""
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         data = ii.IUPHARData.from_files(
             target_path=args.target_csv,
             family_path=args.family_csv,
             encoding=args.encoding,
         )
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = (
+            args.output_csv
+            or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+        )
         data.map_uniprot_file(
             input_path=args.input_csv,
             output_path=output,

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
 import requests
 
+from chembl_da.library.config import load_config
 from library import chembl_library as cl
 from library import pubchem_library as pl
 from library import io
@@ -107,6 +109,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    cfg = load_config(getattr(args, "config", "config.yaml"))
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -119,9 +122,10 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     logger.info("Retrieved %d identifiers", len(ids))
-    logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
+    chunk_size = args.chunk_size or cfg.chunk_size
+    logger.info("Fetching ChEMBL data in chunks of %d", chunk_size)
     try:
-        df = cl.get_testitem(ids, chunk_size=args.chunk_size)
+        df = cl.get_testitem(ids, chunk_size=chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
@@ -129,7 +133,10 @@ def run_chembl(args: argparse.Namespace) -> int:
     logger.info("Augmenting results with PubChem data")
     df = add_pubchem_data(df)
     logger.info("PubChem augmentation completed")
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = (
+        args.output_csv
+        or Path(cfg.output_dir) / io.default_output_path(args.input_csv).name
+    )
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -149,7 +156,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser = base_parser(
         "ChEMBL and PubChem compound data utilities",
         column="molecule_chembl_id",
-        chunk_size=5,
     )
     parser.set_defaults(func=run_chembl)
     return parser

--- a/library/cli.py
+++ b/library/cli.py
@@ -35,9 +35,7 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
-def build_parser(
-    description: str, *, column: str, chunk_size: int = 10
-) -> argparse.ArgumentParser:
+def build_parser(description: str, *, column: str) -> argparse.ArgumentParser:
     """Return an argument parser with shared options.
 
     Parameters
@@ -46,9 +44,6 @@ def build_parser(
         Text used in the parser description.
     column:
         Default column name for identifier extraction.
-    chunk_size:
-        Default chunk size for API requests.
-
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
@@ -76,8 +71,13 @@ def build_parser(
     parser.add_argument(
         "--chunk-size",
         type=_positive_int,
-        default=chunk_size,
+        default=None,
         help="Maximum IDs per request",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to YAML configuration file",
     )
     return parser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mypy>=1.8
 
 openpyxl>=3.1
 pyarrow>=12.0
+PyYAML>=6.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from chembl_da.library.config import load_config
+
+
+def test_load_defaults(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config("nonexistent.yaml")
+    assert cfg.api.timeout_connect == 5
+    assert cfg.jobs.chunk_size == 500
+
+
+def test_load_from_yaml(tmp_path: Path):
+    yaml_path = tmp_path / "conf.yaml"
+    yaml_path.write_text(
+        """
+api:
+  rps: 10
+io:
+  output_dir: "out"
+"""
+    )
+    cfg = load_config(str(yaml_path))
+    assert cfg.api.rps == 10
+    assert cfg.io.output_dir == "out"
+
+
+def test_env_override_precedence(tmp_path: Path, monkeypatch):
+    yaml_path = tmp_path / "conf.yaml"
+    yaml_path.write_text("api:\n  rps: 8\n")
+    monkeypatch.setenv("CHEMBL_DA__API__RPS", "9")
+    monkeypatch.setenv("CHEMBL_DA_RPS", "11")
+    cfg = load_config(str(yaml_path))
+    assert cfg.api.rps == 11
+
+
+def test_env_cast_int(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CHEMBL_DA__JOBS__CHUNK_SIZE", "42")
+    cfg = load_config(str(tmp_path / "missing.yaml"))
+    assert cfg.jobs.chunk_size == 42
+
+
+def test_validation_negative(tmp_path: Path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("jobs:\n  chunk_size: -1\n")
+    with pytest.raises(ValueError):
+        load_config(str(bad))


### PR DESCRIPTION
## Summary
- implement dataclass-backed config loader with YAML defaults, env overrides and validation
- expose config in all get_* CLI scripts and add --config option
- provide sample config.yaml and tests for configuration logic

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py chembl_da/library/config.py chembl_da/library/__init__.py tests/test_config.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py chembl_da/library/config.py chembl_da/library/__init__.py tests/test_config.py`
- `mypy --ignore-missing-imports get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py chembl_da/library/config.py chembl_da/library/__init__.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c099b844448324a98ca6b2e061f8f3