### PR TITLE
feat(config): centralize configuration via config.yaml + typed loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ Running the CLI saves ``data_quality_report_table.csv`` and
 
 All scripts share a common set of flags:
 
+## Configuration
+
+Default settings live in `config.yaml`. Values can be overridden via environment variables using the `CHEMBL_DA__SECTION__KEY` pattern or short aliases like `CHEMBL_DA_RPS`.
+
+Example usage:
+
+```bash
+python get_activity_data.py --config config.yaml
+CHEMBL_DA__API__RPS=2 python get_assay_data.py
+```
+
+| Script | Config sections |
+| --- | --- |
+| get_activity_data.py | api, io, jobs, quality, log |
+| get_assay_data.py | api, io, jobs, quality, log |
+| get_document_data.py | api, io, jobs, quality, log |
+| get_document_type.py | io, log |
+| get_target_data.py | api, uniprot, iuphar, io, jobs, quality, log |
+| get_testitem_data.py | api, pubchem, io, jobs, quality, log |
+| get_input_initialisation.py | init, io, quality, log |
+| mapper_main.py | mapper, io, jobs, log |
+| table_quality_main.py | io, quality, log |
+
+
 * ``--input`` – input CSV file (default ``input.csv``)
 * ``--output`` – destination CSV file (default: auto-generated next to the input)
 * ``--log-level`` – logging verbosity (default ``INFO``)
@@ -76,6 +100,11 @@ Each command validates required columns before querying external APIs and
 writes the resulting table to the specified output file.
 
 Example merging initialisation tables::
+
+    python get_input_initialisation.py --config config.yaml
+
+The ``same_doc`` and ``all_doc`` workbook paths default to values from
+``config.yaml`` but can be overridden on the command line::
 
     python get_input_initialisation.py \
       --same-doc path/to/ChEMBL_same_document_20_05.xlsx \

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,184 @@
+api:
+  # Base URL for ChEMBL API
+  chembl_base: "https://www.ebi.ac.uk/chembl/api/data"
+  # Timeout for establishing a connection (seconds)
+  timeout_connect: 5
+  # Timeout for reading a response (seconds)
+  timeout_read: 30
+  # Number of retries on failure
+  retries: 3
+  # Backoff factor for exponential retry delays
+  backoff_factor: 0.5
+  # Requests per second for ChEMBL client.
+  # NOTE: ChEMBL public guidance commonly observed ~1 rps without key; set conservatively.
+  # Documented page-size (not RPS): max 1000 per page.
+  rps: 5
+  # Allowed burst of requests above the RPS before throttling (client-side only; no official "burst")
+  burst: 5
+  # Custom User-Agent header for API calls
+  user_agent: "chembl-da/0.1 (+contact: unset)"
+openalex:
+  # Base URL for OpenAlex API
+  base: "https://api.openalex.org"
+  timeout_connect: 5
+  timeout_read: 30
+  retries: 3
+  # Requests per second. OpenAlex hard limit = 10 rps; daily cap = 100,000 requests.
+  rps: 4
+  # Client-side burst (OpenAlex does not document "burst"; keep small to avoid 429)
+  burst: 5
+  # Email contact recommended by OpenAlex for polite API use (improves throttling behavior)
+  mailto: ""
+crossref:
+  # Base URL for Crossref API
+  base: "https://api.crossref.org"
+  timeout_connect: 5
+  timeout_read: 30
+  retries: 3
+  # Requests per second. Crossref advertises active limits in X-Rate-Limit headers (often ~50 rps);
+  # treat this value as conservative default and honor response headers.
+  rps: 4
+  # Client-side burst; keep modest because Crossref limits can change dynamically
+  burst: 5
+  # Email contact recommended by Crossref
+  mailto: ""
+uniprot:
+  # Base URL for UniProt REST API
+  base: "https://rest.uniprot.org"
+  timeout_connect: 5
+  timeout_read: 30
+  retries: 3
+  # Requests per second. No official fixed RPS published for this REST API; back off on 429.
+  # Max page size in recent docs ~500; keep RPS low if fetching large pages.
+  rps: 4
+  # Client-side burst; keep small to avoid 429 during spikes
+  burst: 5
+iuphar:
+  # Base URL for IUPHAR Guide to Pharmacology
+  base: "https://www.guidetopharmacology.org/services"
+  timeout_connect: 5
+  timeout_read: 30
+  retries: 3
+  # Requests per second. No official rate-limit figures; be conservative and monitor 429/503.
+  rps: 4
+  # Client-side burst; keep small since server-side limits are undocumented
+  burst: 5
+pubchem:
+  # Base URL for PubChem PUG REST API
+  base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+  timeout_connect: 5
+  # PubChem has a standard ~30 s time limit per request → longer read timeout recommended
+  timeout_read: 60
+  retries: 3
+  # Requests per second. PubChem policy requests ≤5 rps per user/app.
+  rps: 3
+  # Client-side burst; keep small to respect the 5 rps guidance
+  burst: 5
+io:
+  # Directory for output files
+  output_dir: "data/output"
+  # Directory for cache and temporary files
+  cache_dir: ".cache"
+  # Column separator for CSV files
+  csv_sep: ","
+  # Encoding for CSV files
+  csv_encoding: "utf-8-sig"
+  # Save pandas index when writing CSV (usually false)
+  csv_index: false
+  # Engine for reading/writing Excel files
+  xlsx_engine: "openpyxl"
+  # Minimum required version of openpyxl
+  xlsx_min_version: "3.1.0"
+  # Automatically create directories if they don't exist
+  exist_ok: true
+  # Compression for output files ("" = none, or "gzip")
+  compression: ""
+jobs:
+  # Number of workers/threads for parallel jobs (CPU-bound or I/O-bound depending on your code)
+  concurrency: 8
+  # Chunk size for splitting data in local processing pipelines (NOT an API page size).
+  # Reference API page-size ceilings to choose safe values:
+  # - ChEMBL: up to 1000 per page
+  # - OpenAlex: 1–200 per page
+  # - Crossref: default 20, up to 1000 rows per page (check headers/offset constraints)
+  # - UniProt REST: up to 500 per page
+  # - IUPHAR: no published page-size cap; keep modest
+  # - PubChem PUG REST: varies by operation; large queries hit ~30 s time limit
+  chunk_size: 500
+batch:
+  # Batch size for processing records at once (internal batching).
+  # Keep this ≤ effective API page sizes above when batches map 1:1 to requests.
+  size: 1000
+  # Pause between processing batches (seconds)
+  pause: 0
+  # Maximum number of batches processed in parallel
+  concurrency: 2
+  # Whether to stop immediately on first batch error
+  fail_fast: true
+  # Retry failed batches (true/false)
+  retry_failed: true
+quality:
+  # Number of rows to sample for profiling (0 = use all data)
+  sample_rows: 0
+  # Correlation method for numeric columns
+  corr_method: "pearson"
+  # Maximum unique values to show in categorical previews
+  max_unique_preview: 50
+  # Number of bins for numeric histograms
+  bin_count: 20
+mapper:
+  # Enable cache for mapping operations
+  enable_cache: true
+  # Require strict schema (fail if expected columns are missing)
+  strict_schema: true
+  # Warn when casting datatypes
+  warn_on_cast: true
+init:
+  # Path to same document workbook
+  same_doc: "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"
+  # Path to all document workbook
+  all_doc: "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
+  # Required sheets in input Excel files
+  required_sheets_same_doc:
+    - "assay_step5_same_doc"
+    - "activity_step5_same_doc"
+    - "document_step5_same_doc"
+    - "target_step5_same_doc"
+    - " molecule_step5_same_doc"
+    - "pairs_same_doc"
+
+  required_sheets_all_doc:
+    - "assay_step5"
+    - "activity_step5"
+    - "document_step5"
+    - "targets_step5"
+    - "molecule_step5"
+    - "step5_pairs"
+
+  # Directory for saving initialized datasets
+  output_dir: "data/output/ChEMBL/processed"
+  # Save pairs/pairs_same_doc sheets without merging
+  save_pairs_sheets: true
+  # Stop immediately if a critical error occurs
+  fail_fast: true
+rate:
+  # Global requests per second across all API clients (respect the strictest API among those you call)
+  global_rps: 8
+  # Global request burst capacity (client-side); keep modest if mixing APIs with low limits
+  global_burst: 8
+retry:
+  # Maximum retry attempts for failed requests
+  max_attempts: 3
+  # Backoff factor for exponential retry delays
+  backoff_factor: 0.5
+  # HTTP status codes that should trigger a retry
+  status_forcelist: [429, 500, 502, 503, 504]
+log:
+  # Logging level (DEBUG, INFO, WARNING, ERROR)
+  level: "INFO"
+  # Logging message format
+  format: "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+  # Date format for logs
+  datefmt: "%Y-%m-%d %H:%M:%S"
+  # Enable colored output in console logs
+  color: true

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -7,6 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
+from library.config import Config, load_config
 
 from library import chembl_library as cl
 from library import io
@@ -14,6 +15,7 @@ from library.cli import build_parser as base_parser, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def run_chembl(args: argparse.Namespace) -> int:
@@ -79,8 +81,28 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+
+    default_chunk = parser.get_default("chunk_size")
+    if args.chunk_size == default_chunk:
+        args.chunk_size = cfg.jobs.chunk_size
+    default_sep = parser.get_default("sep")
+    if args.sep == default_sep:
+        args.sep = cfg.io.csv_sep
+    default_encoding = parser.get_default("encoding")
+    if args.encoding == default_encoding:
+        args.encoding = cfg.io.csv_encoding
+    if hasattr(args, "timeout"):
+        default_timeout = parser.get_default("timeout")
+        if args.timeout == default_timeout:
+            args.timeout = cfg.api.timeout_read
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,6 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
+from library.config import Config, load_config
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -15,6 +16,7 @@ from library.cli import build_parser as base_parser, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def run_chembl(args: argparse.Namespace) -> int:
@@ -75,8 +77,24 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+
+    default_chunk = parser.get_default("chunk_size")
+    if args.chunk_size == default_chunk:
+        args.chunk_size = cfg.jobs.chunk_size
+    default_sep = parser.get_default("sep")
+    if args.sep == default_sep:
+        args.sep = cfg.io.csv_sep
+    default_encoding = parser.get_default("encoding")
+    if args.encoding == default_encoding:
+        args.encoding = cfg.io.csv_encoding
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
+from library.config import Config, load_config
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -40,8 +41,10 @@ from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
+from library.cli import configure_logging
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def fetch_pubmed_records(
@@ -385,8 +388,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    global cfg
+    cfg = load_config(args.config)
+
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -12,8 +12,13 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+from library.config import Config, load_config
+from library.cli import configure_logging
 
 from library.document_type_classifier import compute_scores, decide_label
+
+
+cfg: Config = load_config()
 
 
 def _split_terms(value: object) -> Iterable[str]:
@@ -74,13 +79,22 @@ def main() -> int:  # pragma: no cover - simple CLI
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="config.yaml")
     parser.add_argument("--input", type=Path, required=True, help="Input CSV")
     parser.add_argument("--output", type=Path, required=True, help="Output CSV")
+    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
+    global cfg
+    cfg = load_config(args.config)
+    if args.log_level == "INFO":
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
 
-    df_in = pd.read_csv(args.input)
+    df_in = pd.read_csv(args.input, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding)
     df_out = classify_dataframe(df_in)
-    df_out.to_csv(args.output, index=False)
+    df_out.to_csv(
+        args.output, index=False, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding
+    )
     return 0
 
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
+from library.config import Config, load_config
+from library.cli import configure_logging
 from typing import Sequence
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def run(args: argparse.Namespace) -> int:
@@ -87,10 +90,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
-        "--same-doc", type=Path, required=True, help="Path to same document workbook"
+        "--same-doc",
+        type=Path,
+        help="Path to same document workbook (default: config init.same_doc)",
     )
     parser.add_argument(
-        "--all-doc", type=Path, required=True, help="Path to all document workbook"
+        "--all-doc",
+        type=Path,
+        help="Path to all document workbook (default: config init.all_doc)",
     )
     parser.add_argument(
         "--dictionary-dir",
@@ -99,7 +106,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory with targets_type.csv, citation_fraction.csv and status.csv",
     )
     parser.add_argument(
-        "--out-dir", type=Path, default=Path("."), help="Output directory"
+        "--out-dir",
+        type=Path,
+        help="Output directory (default: config init.output_dir)",
     )
     parser.add_argument(
         "--format", choices=["csv"], default="csv", help="Output format"
@@ -108,17 +117,23 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def configure_logging(level: str) -> None:
-    """Configure logging at ``level``."""
-    numeric = getattr(logging, level.upper(), logging.INFO)
-    logging.basicConfig(level=numeric)
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+    if args.same_doc is None:
+        args.same_doc = Path(cfg.init.same_doc)
+    if args.all_doc is None:
+        args.all_doc = Path(cfg.init.all_doc)
+    if args.out_dir is None:
+        args.out_dir = Path(cfg.init.output_dir)
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -10,6 +10,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
+from library.config import Config, load_config
 
 from library import chembl_library as cl
 from library import io
@@ -20,6 +21,7 @@ from library.cli import configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:
@@ -61,6 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
     merges their outputs.
     """
     parser = argparse.ArgumentParser(description="Target data utilities")
+    parser.add_argument("--config", default="config.yaml")
     parser.add_argument(
         "--log-level",
         default="INFO",
@@ -565,7 +568,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     if hasattr(args, "func"):
         return args.func(args)
     parser.print_help()

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
+from library.config import Config, load_config
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -16,6 +17,7 @@ from library.cli import build_parser as base_parser, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def add_pubchem_data(df: pd.DataFrame) -> pd.DataFrame:
@@ -158,8 +160,24 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+
+    default_chunk = parser.get_default("chunk_size")
+    if args.chunk_size == default_chunk:
+        args.chunk_size = cfg.jobs.chunk_size
+    default_sep = parser.get_default("sep")
+    if args.sep == default_sep:
+        args.sep = cfg.io.csv_sep
+    default_encoding = parser.get_default("encoding")
+    if args.encoding == default_encoding:
+        args.encoding = cfg.io.csv_encoding
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -82,7 +82,9 @@ def build_parser(
     return parser
 
 
-def configure_logging(level: str) -> None:
+def configure_logging(
+    level: str, *, fmt: str | None = None, datefmt: str | None = None
+) -> None:
     """Configure root logging for command-line utilities.
 
     Parameters
@@ -92,4 +94,9 @@ def configure_logging(level: str) -> None:
 
     """
     numeric = getattr(logging, level.upper(), logging.INFO)
-    logging.basicConfig(level=numeric, force=True)
+    logging.basicConfig(
+        level=numeric,
+        format=fmt or "%(levelname)s: %(message)s",
+        datefmt=datefmt,
+        force=True,
+    )

--- a/library/config.py
+++ b/library/config.py
@@ -1,0 +1,330 @@
+"""Typed configuration loader with environment overrides."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import dataclasses
+from pathlib import Path
+from typing import Any, Dict, List
+import os
+import yaml
+from urllib.parse import urlparse
+
+
+# ---------------------------------------------------------------------------
+# Dataclass definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApiConfig:
+    chembl_base: str = "https://www.ebi.ac.uk/chembl/api/data"
+    timeout_connect: int = 5
+    timeout_read: int = 30
+    retries: int = 3
+    backoff_factor: float = 0.5
+    rps: int = 5
+    burst: int = 5
+    user_agent: str = "chembl-da/0.1 (+contact: unset)"
+
+
+@dataclass
+class OpenAlexConfig:
+    base: str = "https://api.openalex.org"
+    timeout_connect: int = 5
+    timeout_read: int = 30
+    retries: int = 3
+    rps: int = 4
+    burst: int = 5
+    mailto: str = ""
+
+
+@dataclass
+class CrossrefConfig:
+    base: str = "https://api.crossref.org"
+    timeout_connect: int = 5
+    timeout_read: int = 30
+    retries: int = 3
+    rps: int = 4
+    burst: int = 5
+    mailto: str = ""
+
+
+@dataclass
+class UniProtConfig:
+    base: str = "https://rest.uniprot.org"
+    timeout_connect: int = 5
+    timeout_read: int = 30
+    retries: int = 3
+    rps: int = 4
+    burst: int = 5
+
+
+@dataclass
+class IupharConfig:
+    base: str = "https://www.guidetopharmacology.org/services"
+    timeout_connect: int = 5
+    timeout_read: int = 30
+    retries: int = 3
+    rps: int = 4
+    burst: int = 5
+
+
+@dataclass
+class PubChemConfig:
+    base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    timeout_connect: int = 5
+    timeout_read: int = 60
+    retries: int = 3
+    rps: int = 3
+    burst: int = 5
+
+
+@dataclass
+class IoConfig:
+    output_dir: str = "data/output"
+    cache_dir: str = ".cache"
+    csv_sep: str = ","
+    csv_encoding: str = "utf-8-sig"
+    csv_index: bool = False
+    xlsx_engine: str = "openpyxl"
+    xlsx_min_version: str = "3.1.0"
+    exist_ok: bool = True
+    compression: str = ""
+
+
+@dataclass
+class JobsConfig:
+    concurrency: int = 8
+    chunk_size: int = 500
+
+
+@dataclass
+class BatchConfig:
+    size: int = 1000
+    pause: int = 0
+    concurrency: int = 2
+    fail_fast: bool = True
+    retry_failed: bool = True
+
+
+@dataclass
+class QualityConfig:
+    sample_rows: int = 0
+    corr_method: str = "pearson"
+    max_unique_preview: int = 50
+    bin_count: int = 20
+
+
+@dataclass
+class MapperConfig:
+    enable_cache: bool = True
+    strict_schema: bool = True
+    warn_on_cast: bool = True
+
+
+@dataclass
+class InitConfig:
+    same_doc: str = "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"
+    all_doc: str = "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
+    required_sheets_same_doc: List[str] = field(
+        default_factory=lambda: [
+            "assay_step5_same_doc",
+            "activity_step5_same_doc",
+            "document_step5_same_doc",
+            "target_step5_same_doc",
+            " molecule_step5_same_doc",
+            "pairs_same_doc",
+        ]
+    )
+    required_sheets_all_doc: List[str] = field(
+        default_factory=lambda: [
+            "assay_step5",
+            "activity_step5",
+            "document_step5",
+            "targets_step5",
+            "molecule_step5",
+            "step5_pairs",
+        ]
+    )
+    output_dir: str = "data/output/ChEMBL/processed"
+    save_pairs_sheets: bool = True
+    fail_fast: bool = True
+
+
+@dataclass
+class RateConfig:
+    global_rps: int = 8
+    global_burst: int = 8
+
+
+@dataclass
+class RetryConfig:
+    max_attempts: int = 3
+    backoff_factor: float = 0.5
+    status_forcelist: List[int] = field(
+        default_factory=lambda: [429, 500, 502, 503, 504]
+    )
+
+
+@dataclass
+class LogConfig:
+    level: str = "INFO"
+    format: str = "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+    datefmt: str = "%Y-%m-%d %H:%M:%S"
+    color: bool = True
+
+
+@dataclass
+class Config:
+    api: ApiConfig = field(default_factory=ApiConfig)
+    openalex: OpenAlexConfig = field(default_factory=OpenAlexConfig)
+    crossref: CrossrefConfig = field(default_factory=CrossrefConfig)
+    uniprot: UniProtConfig = field(default_factory=UniProtConfig)
+    iuphar: IupharConfig = field(default_factory=IupharConfig)
+    pubchem: PubChemConfig = field(default_factory=PubChemConfig)
+    io: IoConfig = field(default_factory=IoConfig)
+    jobs: JobsConfig = field(default_factory=JobsConfig)
+    batch: BatchConfig = field(default_factory=BatchConfig)
+    quality: QualityConfig = field(default_factory=QualityConfig)
+    mapper: MapperConfig = field(default_factory=MapperConfig)
+    init: InitConfig = field(default_factory=InitConfig)
+    rate: RateConfig = field(default_factory=RateConfig)
+    retry: RetryConfig = field(default_factory=RetryConfig)
+    log: LogConfig = field(default_factory=LogConfig)
+
+    @property
+    def chembl_base(self) -> str:
+        return self.api.chembl_base
+
+    @property
+    def rps(self) -> int:
+        return self.api.rps
+
+    @property
+    def burst(self) -> int:
+        return self.api.burst
+
+    @property
+    def concurrency(self) -> int:
+        return self.jobs.concurrency
+
+    @property
+    def chunk_size(self) -> int:
+        return self.jobs.chunk_size
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _coerce(value: str, current: Any) -> Any:
+    if isinstance(current, bool):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(current, int):
+        return int(value)
+    if isinstance(current, float):
+        return float(value)
+    return value
+
+
+def _update_from_dict(obj: Any, data: Dict[str, Any]) -> None:
+    for key, val in data.items():
+        if not hasattr(obj, key):
+            continue
+        current = getattr(obj, key)
+        if dataclasses.is_dataclass(current):
+            if isinstance(val, dict):
+                _update_from_dict(current, val)
+            continue
+        setattr(obj, key, val)
+
+
+def _set_by_path(cfg: Config, path: List[str], value: str) -> None:
+    obj: Any = cfg
+    for name in path[:-1]:
+        obj = getattr(obj, name, None)
+        if obj is None:
+            return
+    field_name = path[-1]
+    if not hasattr(obj, field_name):
+        return
+    current = getattr(obj, field_name)
+    setattr(obj, field_name, _coerce(value, current))
+
+
+_ALIAS_MAP: Dict[str, List[str]] = {
+    "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
+    "CHEMBL_DA_RPS": ["api", "rps"],
+    "CHEMBL_DA_BURST": ["api", "burst"],
+    "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
+    "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _valid_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _validate(cfg: Config) -> None:
+    if not _valid_url(cfg.api.chembl_base):
+        raise ValueError("invalid ChEMBL base URL")
+    sections: list[Any] = [
+        cfg.api,
+        cfg.openalex,
+        cfg.crossref,
+        cfg.uniprot,
+        cfg.iuphar,
+        cfg.pubchem,
+    ]
+    for section in sections:
+        base = getattr(section, "base", None)
+        if base and not _valid_url(base):
+            raise ValueError(f"invalid URL: {base}")
+        if section.timeout_connect <= 0 or section.timeout_read <= 0:
+            raise ValueError("timeouts must be positive")
+        if section.rps <= 0 or section.burst <= 0:
+            raise ValueError("rps and burst must be positive")
+    if cfg.jobs.concurrency <= 0 or cfg.jobs.chunk_size <= 0:
+        raise ValueError("concurrency and chunk_size must be positive")
+    if not cfg.io.output_dir.strip() or not cfg.io.cache_dir.strip():
+        raise ValueError("directories must not be empty")
+    if not cfg.init.same_doc.strip() or not cfg.init.all_doc.strip():
+        raise ValueError("init.same_doc and init.all_doc must not be empty")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_config(path: str | Path | None = "config.yaml") -> Config:
+    cfg = Config()
+    if path and Path(path).is_file():
+        with Path(path).open("r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if isinstance(data, dict):
+            _update_from_dict(cfg, data)
+    prefix = "CHEMBL_DA"
+    for env_key, env_val in os.environ.items():
+        key = env_key.upper()
+        if key in _ALIAS_MAP:
+            _set_by_path(cfg, _ALIAS_MAP[key], env_val)
+            continue
+        if not key.startswith(prefix + "__"):
+            continue
+        parts = key.split("__")[1:]  # drop prefix
+        path_parts = [p.lower() for p in parts]
+        _set_by_path(cfg, path_parts, env_val)
+    _validate(cfg)
+    return cfg
+
+
+__all__ = ["Config", "load_config"]

--- a/library/io.py
+++ b/library/io.py
@@ -13,16 +13,18 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
-
 from . import validation
+from .config import Config, load_config
+
+cfg: Config = load_config()
 
 
 def read_ids(
     path: str | Path,
     *,
     column: str,
-    sep: str = ",",
-    encoding: str = "utf8",
+    sep: str = cfg.io.csv_sep,
+    encoding: str = cfg.io.csv_encoding,
 ) -> list[str]:
     """Return identifier values from ``column`` in ``path``.
 
@@ -71,8 +73,8 @@ def read_ids(
 def read_csv(
     path: str | Path,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    sep: str = cfg.io.csv_sep,
+    encoding: str = cfg.io.csv_encoding,
     required_columns: Iterable[str] | None = None,
 ) -> pd.DataFrame:
     """Load a CSV file into a :class:`pandas.DataFrame` with optional schema validation.
@@ -105,8 +107,8 @@ def write_csv(
     df: pd.DataFrame,
     path: str | Path,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    sep: str = cfg.io.csv_sep,
+    encoding: str = cfg.io.csv_encoding,
 ) -> None:
     """Write ``df`` to ``path`` as CSV.
 

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -8,12 +8,14 @@ from typing import Sequence
 from urllib.error import URLError
 
 import pandas as pd
+from library.config import Config, load_config
 
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
 from library.mapper_library import map_chembl_to_uniprot
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def run(args: argparse.Namespace) -> int:
@@ -79,8 +81,21 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+
+    default_sep = parser.get_default("sep")
+    if args.sep == default_sep:
+        args.sep = cfg.io.csv_sep
+    default_encoding = parser.get_default("encoding")
+    if args.encoding == default_encoding:
+        args.encoding = cfg.io.csv_encoding
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -9,10 +9,13 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
+from library.config import Config, load_config
+from library.cli import configure_logging
 
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
+cfg: Config = load_config()
 
 
 def run(args: argparse.Namespace) -> int:
@@ -74,17 +77,24 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def configure_logging(level: str) -> None:
-    """Configure basic logging."""
-    numeric_level = getattr(logging, level.upper(), logging.INFO)
-    logging.basicConfig(level=numeric_level)
-
-
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
+    parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    configure_logging(args.log_level)
+    global cfg
+    cfg = load_config(args.config)
+
+    default_sep = parser.get_default("sep")
+    if args.sep == default_sep:
+        args.sep = cfg.io.csv_sep
+    default_encoding = parser.get_default("encoding")
+    if args.encoding == default_encoding:
+        args.encoding = cfg.io.csv_encoding
+    default_log = parser.get_default("log_level")
+    if args.log_level == default_log:
+        args.log_level = cfg.log.level
+    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(args)
 
 

--- a/tests/fixtures/config.min.yaml
+++ b/tests/fixtures/config.min.yaml
@@ -1,0 +1,2 @@
+log:
+  level: "ERROR"

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from table_quality_main import main
+
+
+def test_table_quality_cli_with_config(tmp_path: Path) -> None:
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("a\n1\n")
+    config = Path("tests/fixtures/config.min.yaml")
+    rc = main(
+        [
+            "--config",
+            str(config),
+            "--input",
+            str(csv_path),
+            "--table-name",
+            "demo",
+            "--output",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.config import load_config
+
+
+def test_defaults_without_file(tmp_path: Path) -> None:
+    cfg = load_config(tmp_path / "missing.yaml")
+    assert cfg.api.rps == 5
+    assert cfg.io.output_dir == "data/output"
+
+
+def test_yaml_overrides(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("api:\n  rps: 2\n")
+    cfg = load_config(path)
+    assert cfg.api.rps == 2
+
+
+def test_env_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("api:\n  rps: 1\n")
+    monkeypatch.setenv("CHEMBL_DA__API__RPS", "7")
+    monkeypatch.setenv("CHEMBL_DA_OUTDIR", "out")
+    cfg = load_config(path)
+    assert cfg.api.rps == 7
+    assert cfg.io.output_dir == "out"
+
+
+def test_init_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("init:\n  same_doc: custom_same.xlsx\n  all_doc: custom_all.xlsx\n")
+    monkeypatch.setenv("CHEMBL_DA__INIT__ALL_DOC", "env_all.xlsx")
+    cfg = load_config(path)
+    assert cfg.init.same_doc == "custom_same.xlsx"
+    assert cfg.init.all_doc == "env_all.xlsx"
+
+
+def test_validation(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("api:\n  rps: 0\n")
+    with pytest.raises(ValueError):
+        load_config(path)


### PR DESCRIPTION
## Summary
- add root `config.yaml` with API, IO, jobs, batch, logging and other defaults
- implement `library.config` dataclasses with YAML/env overrides and validation
- wire all CLI scripts to `--config` flag and dynamic defaults
- document configuration usage and sections in README
- add tests for config loading and CLI integration
- expose init workbooks (`same_doc`, `all_doc`) through config and use them in `get_input_initialisation.py`

## Testing
- `black get_input_initialisation.py library/config.py tests/test_config.py`
- `ruff check get_input_initialisation.py library/config.py tests/test_config.py tests/test_cli_config_integration.py`
- `mypy --ignore-missing-imports get_*.py mapper_main.py table_quality_main.py library tests/test_config.py tests/test_cli_config_integration.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c180a24e3083249542282ffce76d2c