### PR TITLE
Add aliases for API base and timeouts in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ configuration looks like::
 Environment variables override values from the YAML file. Variables use the
 ``CHEMBL_DA__SECTION__KEY`` pattern and also support short aliases:
 
+* ``CHEMBL_DA__API__CHEMBL_BASE`` / ``CHEMBL_DA_BASE``
+* ``CHEMBL_DA__API__TIMEOUT_CONNECT`` / ``CHEMBL_DA_TIMEOUT_CONNECT``
+* ``CHEMBL_DA__API__TIMEOUT_READ`` / ``CHEMBL_DA_TIMEOUT_READ``
 * ``CHEMBL_DA__API__RPS`` / ``CHEMBL_DA_RPS``
 
 * ``CHEMBL_DA__OPENALEX__RPS``

--- a/library/config.py
+++ b/library/config.py
@@ -8,7 +8,11 @@ command line options. The order of precedence is:
 
 Environment variables follow the ``CHEMBL_DA__SECTION__KEY`` pattern where
 sections and keys are joined by double underscores. Short aliases such as
-``CHEMBL_DA_RPS`` are also recognised.
+``CHEMBL_DA_RPS`` are also recognised. Additional convenience aliases include:
+
+* ``CHEMBL_DA_BASE`` → ``api.chembl_base``
+* ``CHEMBL_DA_TIMEOUT_CONNECT`` → ``api.timeout_connect``
+* ``CHEMBL_DA_TIMEOUT_READ`` → ``api.timeout_read``
 """
 
 from __future__ import annotations
@@ -289,6 +293,9 @@ def _set_by_path(cfg: Config, path: List[str], value: Any) -> None:
 _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_RPS": ["api", "rps"],
     "CHEMBL_DA_BURST": ["api", "burst"],
+    "CHEMBL_DA_BASE": ["api", "chembl_base"],
+    "CHEMBL_DA_TIMEOUT_CONNECT": ["api", "timeout_connect"],
+    "CHEMBL_DA_TIMEOUT_READ": ["api", "timeout_read"],
     "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
     "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
     "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,28 @@ def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert cfg.openalex.rps == 6
 
 
+def test_alias_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure shorthand environment variables map to the correct fields."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        "api:\n"
+        "  chembl_base: https://www.ebi.ac.uk/chembl/api/data\n"
+        "  timeout_connect: 1\n"
+        "  timeout_read: 1\n"
+    )
+
+    monkeypatch.setenv("CHEMBL_DA_BASE", "https://example.org")
+    monkeypatch.setenv("CHEMBL_DA_TIMEOUT_CONNECT", "10")
+    monkeypatch.setenv("CHEMBL_DA_TIMEOUT_READ", "20")
+    cfg = load_config(path)
+
+    assert cfg.api.chembl_base == "https://example.org"
+    assert cfg.api.timeout_connect == 10
+    assert cfg.api.timeout_read == 20
+    assert cfg.api.rps == 5
+
+
 def test_cli_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api:\n  rps: 1\n")
@@ -36,4 +58,3 @@ def test_type_validation(tmp_path: Path) -> None:
     path.write_text("api:\n  rps: fast\n")
     with pytest.raises(TypeError, match="api.rps must be int"):
         load_config(path)
-


### PR DESCRIPTION
## Summary
- support short environment variable aliases for API base URL and timeouts
- document new aliases in README and config module
- test that alias variables override configuration fields

## Testing
- `python -m black library/config.py tests/test_config.py`
- `python -m ruff check library/config.py tests/test_config.py`
- `python -m mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a32217588324b128ce6cbd09f9a5