### PR TITLE
refactor: parameterize API URLs

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -44,7 +44,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_activities(ids, chunk_size=args.chunk_size, timeout=args.timeout)
+        df = cl.get_activities(
+            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)
         return 1

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -45,7 +45,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_assays(ids, chunk_size=args.chunk_size)
+        df = cl.get_assays(ids, cfg=cfg.api, chunk_size=args.chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -19,7 +19,7 @@ from library.table_quality import analyze_table_quality
 logger = logging.getLogger(__name__)
 
 
-def add_pubchem_data(df: pd.DataFrame) -> pd.DataFrame:
+def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -31,6 +31,8 @@ def add_pubchem_data(df: pd.DataFrame) -> pd.DataFrame:
     ----------
     df:
         Data frame returned by :func:`library.chembl_library.get_testitem`.
+    cfg:
+        PubChem configuration options.
 
     Returns
     -------
@@ -56,10 +58,10 @@ def add_pubchem_data(df: pd.DataFrame) -> pd.DataFrame:
     records: dict[str, dict[str, str]] = {}
     for idx, smi in enumerate(unique_smiles, start=1):
         logger.info("PubChem lookup %d/%d", idx, total)
-        cid = pl.get_cid_from_smiles(smi) or ""
+        cid = pl.get_cid_from_smiles(smi, cfg) or ""
         first_cid = cid.split("|")[0] if cid else ""
         if first_cid:
-            props = pl.get_properties(first_cid)
+            props = pl.get_properties(first_cid, cfg)
             records[smi] = {
                 "pubchem_cid": first_cid,
                 "pubchem_iupac_name": props.IUPACName,
@@ -123,13 +125,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
-        df = cl.get_testitem(ids, chunk_size=args.chunk_size)
+        df = cl.get_testitem(ids, cfg=cfg.api, chunk_size=args.chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
     logger.info("Retrieved %d rows from ChEMBL", len(df))
     logger.info("Augmenting results with PubChem data")
-    df = add_pubchem_data(df)
+    df = add_pubchem_data(df, cfg.pubchem)
     logger.info("PubChem augmentation completed")
     output = args.output_csv or io.default_output_path(args.input_csv)
     try:

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -9,10 +9,9 @@ import logging
 import pandas as pd
 
 from .chembl_client import _chunked, request_json
+from .config import ApiCfg
 
 logger = logging.getLogger(__name__)
-
-ASSAY_URL = "https://www.ebi.ac.uk/chembl/api/data/assay/{id}?format=json"
 ASSAY_COLUMNS = [
     "aidx",
     "assay_category",
@@ -75,7 +74,6 @@ ACTIVITY_COLUMNS = [
     "assay_variant_mutation",
 ]
 
-TESTITEM_URL = "https://www.ebi.ac.uk/chembl/api/data/molecule/{id}?format=json"
 TESTITEM_COLUMNS = [
     "molecule_chembl_id",
     "pref_name",
@@ -93,12 +91,32 @@ TESTITEM_COLUMNS = [
 ]
 
 
-def get_assay(chembl_assay_id: str, *, timeout: float = 30.0) -> pd.DataFrame:
-    """Retrieve assay information as a DataFrame."""
+def get_assay(
+    chembl_assay_id: str, *, cfg: ApiCfg, timeout: float | None = None
+) -> pd.DataFrame:
+    """Retrieve assay information as a DataFrame.
+
+    Parameters
+    ----------
+    chembl_assay_id:
+        Identifier of the assay to fetch.
+    cfg:
+        API configuration providing base URL and timeouts.
+    timeout:
+        Optional override for the read timeout in seconds.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised assay information or an empty frame when ``chembl_assay_id``
+        is empty or the record is missing.
+    """
     if chembl_assay_id in {"", "#N/A"}:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
-    url = ASSAY_URL.format(id=chembl_assay_id)
-    data = request_json(url, timeout=timeout)
+    base = cfg.chembl_base.rstrip("/")
+    url = f"{base}/assay/{chembl_assay_id}?format=json"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+    data = request_json(url, timeout=effective_timeout)
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
@@ -111,8 +129,9 @@ def get_assay(chembl_assay_id: str, *, timeout: float = 30.0) -> pd.DataFrame:
 def get_assays(
     ids: Iterable[str],
     *,
+    cfg: ApiCfg,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
     require_variant_sequence: bool = False,
 ) -> pd.DataFrame:
     """Fetch assay records for *ids*.
@@ -121,10 +140,12 @@ def get_assays(
     ----------
     ids:
         Assay identifiers to retrieve.
+    cfg:
+        API configuration providing base URL and timeouts.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
-        Timeout in seconds for each HTTP request.
+        Optional override for the read timeout in seconds.
     require_variant_sequence:
         If ``True``, only assays with a non-null ``variant_sequence`` are returned.
 
@@ -139,12 +160,13 @@ def get_assays(
         return pd.DataFrame(columns=ASSAY_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = "https://www.ebi.ac.uk/chembl/api/data/assay.json?format=json"
+    base = f"{cfg.chembl_base.rstrip('/')}/assay.json?format=json"
     if require_variant_sequence:
         base += "&variant_sequence__isnull=false"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&assay_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(url, timeout=effective_timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
             df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
@@ -161,8 +183,9 @@ def get_assays(
 def get_activities(
     ids: Iterable[str],
     *,
+    cfg: ApiCfg,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Fetch activity records for *ids*.
 
@@ -170,26 +193,28 @@ def get_activities(
     ----------
     ids:
         Activity identifiers to retrieve.
+    cfg:
+        API configuration providing base URL and timeouts.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
-        Timeout in seconds for each HTTP request.
+        Optional override for the read timeout in seconds.
 
     Returns
     -------
     pandas.DataFrame
         Combined activity records.
-
     """
     valid = [i for i in ids if i not in {"", "#N/A"}]
     if not valid:
         return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = "https://www.ebi.ac.uk/chembl/api/data/activity.json?format=json"
+    base = f"{cfg.chembl_base.rstrip('/')}/activity.json?format=json"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&activity_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(url, timeout=effective_timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
@@ -202,19 +227,38 @@ def get_activities(
 def get_testitem(
     ids: Iterable[str],
     *,
+    cfg: ApiCfg,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
-    """Fetch compound records for *ids*."""
+    """Fetch compound records for *ids*.
+
+    Parameters
+    ----------
+    ids:
+        Molecule identifiers to retrieve.
+    cfg:
+        API configuration providing base URL and timeouts.
+    chunk_size:
+        Maximum number of IDs per HTTP request.
+    timeout:
+        Optional override for the read timeout in seconds.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Combined compound records.
+    """
     valid = [i for i in ids if i not in {"", "#N/A"}]
     if not valid:
         return pd.DataFrame(columns=TESTITEM_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = "https://www.ebi.ac.uk/chembl/api/data/molecule.json?format=json"
+    base = f"{cfg.chembl_base.rstrip('/')}/molecule.json?format=json"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&molecule_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(url, timeout=effective_timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -17,6 +17,8 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from .config import PubChemCfg
+
 
 logger = logging.getLogger(__name__)
 
@@ -56,13 +58,15 @@ def _cids_from_identifier_list(data: Dict[str, Any]) -> List[str]:
     return [str(cid) for cid in data.get("IdentifierList", {}).get("CID", [])]
 
 
-def get_cid_from_smiles(smiles: str) -> Optional[str]:
+def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> Optional[str]:
     """Retrieve PubChem CID(s) for a SMILES string.
 
     Parameters
     ----------
     smiles: str
         SMILES representation of a compound.
+    cfg:
+        API configuration providing base URL and timeouts.
 
     Returns
     -------
@@ -72,11 +76,9 @@ def get_cid_from_smiles(smiles: str) -> Optional[str]:
 
     """
     safe_smiles = url_encode(smiles)
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/"
-        f"{safe_smiles}/cids/JSON"
-    )
-    response = make_request(url)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/compound/smiles/{safe_smiles}/cids/JSON"
+    response = make_request(url, cfg)
     if not response:
         return None
     cids = _cids_from_identifier_list(response)
@@ -84,13 +86,15 @@ def get_cid_from_smiles(smiles: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def get_cid_from_inchi(inchi: str) -> Optional[str]:
+def get_cid_from_inchi(inchi: str, cfg: PubChemCfg) -> Optional[str]:
     """Retrieve PubChem CID(s) for an InChI string.
 
     Parameters
     ----------
     inchi:
         InChI representation of a compound.
+    cfg:
+        API configuration providing base URL and timeouts.
 
     Returns
     -------
@@ -100,11 +104,9 @@ def get_cid_from_inchi(inchi: str) -> Optional[str]:
 
     """
     safe_inchi = url_encode(inchi)
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/inchi/"
-        f"{safe_inchi}/cids/JSON"
-    )
-    response = make_request(url)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/compound/inchi/{safe_inchi}/cids/JSON"
+    response = make_request(url, cfg)
     if not response:
         return None
     cids = _cids_from_identifier_list(response)
@@ -112,14 +114,26 @@ def get_cid_from_inchi(inchi: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def get_cid_from_inchikey(inchikey: str) -> Optional[str]:
-    """Retrieve PubChem CID(s) for an InChIKey."""
+def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> Optional[str]:
+    """Retrieve PubChem CID(s) for an InChIKey.
+
+    Parameters
+    ----------
+    inchikey:
+        InChIKey representation of a compound.
+    cfg:
+        API configuration providing base URL and timeouts.
+
+    Returns
+    -------
+    str or None
+        Pipe-separated list of CIDs or ``None`` if the structure is
+        unknown to PubChem.
+    """
     safe_inchikey = url_encode(inchikey)
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/inchikey/"
-        f"{safe_inchikey}/cids/JSON"
-    )
-    response = make_request(url)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/compound/inchikey/{safe_inchikey}/cids/JSON"
+    response = make_request(url, cfg)
     if not response:
         return None
     cids = _cids_from_identifier_list(response)
@@ -127,7 +141,9 @@ def get_cid_from_inchikey(inchikey: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def make_request(url: str, delay: float = 3.0) -> Optional[Dict[str, Any]]:
+def make_request(
+    url: str, cfg: PubChemCfg, delay: float = 3.0
+) -> Optional[Dict[str, Any]]:
     """Make an HTTP GET request and return parsed JSON.
 
     The function sleeps for ``delay`` seconds before issuing the request in
@@ -138,6 +154,8 @@ def make_request(url: str, delay: float = 3.0) -> Optional[Dict[str, Any]]:
     ----------
     url:
         Endpoint URL to query.
+    cfg:
+        API configuration providing base URL and timeouts.
     delay:
         Time in seconds to wait before making the request. Defaults to three
         seconds.
@@ -151,7 +169,7 @@ def make_request(url: str, delay: float = 3.0) -> Optional[Dict[str, Any]]:
     """
     time.sleep(delay)
     try:
-        response = _session.get(url, timeout=10)
+        response = _session.get(url, timeout=(cfg.timeout_connect, cfg.timeout_read))
         if response.status_code == 404:
             logger.warning("Request returned 404 for url %s", url)
             return None
@@ -206,13 +224,15 @@ def _extract_cids(bindings: List[Dict[str, Any]]) -> List[str]:
     return cids
 
 
-def get_cid(compound_name: str) -> Optional[str]:
+def get_cid(compound_name: str, cfg: PubChemCfg) -> Optional[str]:
     """Retrieve PubChem CID(s) for *compound_name* (exact match).
 
     Parameters
     ----------
     compound_name: str
         Compound name to query.
+    cfg:
+        API configuration providing base URL and timeouts.
 
     Returns
     -------
@@ -221,11 +241,9 @@ def get_cid(compound_name: str) -> Optional[str]:
 
     """
     safe_name = url_encode(compound_name)
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/rdf/query?graph=synonym&"
-        f"return=cid&format=json&name={safe_name}"
-    )
-    response = make_request(url)
+    rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
+    url = f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={safe_name}"
+    response = make_request(url, cfg)
     if not response:
         return None
     bindings = response.get("results", {}).get("bindings", [])
@@ -234,14 +252,25 @@ def get_cid(compound_name: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def get_all_cid(compound_name: str) -> Optional[str]:
-    """Retrieve PubChem CID(s) for *compound_name* (partial match)."""
+def get_all_cid(compound_name: str, cfg: PubChemCfg) -> Optional[str]:
+    """Retrieve PubChem CID(s) for *compound_name* (partial match).
+
+    Parameters
+    ----------
+    compound_name: str
+        Compound name to query.
+    cfg:
+        API configuration providing base URL and timeouts.
+
+    Returns
+    -------
+    str or None
+        Pipe-separated list of CIDs or ``None`` if not found.
+    """
     safe_name = url_encode(compound_name)
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/rdf/query?graph=synonym&"
-        f"return=cid&format=json&name={safe_name}&contain=true"
-    )
-    response = make_request(url)
+    rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
+    url = f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={safe_name}&contain=true"
+    response = make_request(url, cfg)
     if not response:
         return None
     bindings = response.get("results", {}).get("bindings", [])
@@ -250,16 +279,27 @@ def get_all_cid(compound_name: str) -> Optional[str]:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def get_standard_name(cid: str) -> Optional[str]:
-    """Retrieve the standard compound name for a given CID."""
+def get_standard_name(cid: str, cfg: PubChemCfg) -> Optional[str]:
+    """Retrieve the standard compound name for a given CID.
+
+    Parameters
+    ----------
+    cid: str
+        Candidate CID.
+    cfg:
+        API configuration providing base URL and timeouts.
+
+    Returns
+    -------
+    str or None
+        Standard compound name or ``None`` if ``cid`` is invalid or unknown.
+    """
     validated = validate_cid(cid)
     if not validated:
         return None
-    url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/"
-        f"{validated}/description/JSON"
-    )
-    response = make_request(url)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/compound/cid/{validated}/description/JSON"
+    response = make_request(url, cfg)
     if not response:
         return None
     info = response.get("InformationList", {}).get("Information", [])
@@ -280,19 +320,32 @@ class Properties:
     InChIKey: str
 
 
-def get_properties(cid: str) -> Properties:
-    """Retrieve chemical properties for a compound by CID."""
+def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
+    """Retrieve chemical properties for a compound by CID.
+
+    Parameters
+    ----------
+    cid: str
+        Candidate CID.
+    cfg:
+        API configuration providing base URL and timeouts.
+
+    Returns
+    -------
+    Properties
+        Chemical property record. Missing values are returned as ``"Not Found"``.
+    """
     validated = validate_cid(cid)
     if not validated:
         return Properties(
             "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
         )
+    base = cfg.base.rstrip("/")
     url = (
-        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/"
-        f"{validated}/property/MolecularFormula,IUPACName,IsomericSMILES,"
+        f"{base}/compound/cid/{validated}/property/MolecularFormula,IUPACName,IsomericSMILES,"
         "CanonicalSMILES,InChI,InChIKey/JSON"
     )
-    response = make_request(url)
+    response = make_request(url, cfg)
     if not response:
         return Properties(
             "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
@@ -313,13 +366,15 @@ def get_properties(cid: str) -> Properties:
     )
 
 
-def process_compound(compound_name: str) -> Dict[str, str]:
+def process_compound(compound_name: str, cfg: PubChemCfg) -> Dict[str, str]:
     """Process *compound_name* into a structured record.
 
     Parameters
     ----------
     compound_name: str
         Name of the compound to look up.
+    cfg:
+        API configuration providing base URL and timeouts.
 
     Returns
     -------
@@ -327,10 +382,10 @@ def process_compound(compound_name: str) -> Dict[str, str]:
         Dictionary containing compound details.
 
     """
-    cid = get_cid(compound_name)
-    standard = get_standard_name(cid) if cid else None
+    cid = get_cid(compound_name, cfg)
+    standard = get_standard_name(cid, cfg) if cid else None
     props = (
-        get_properties(cid)
+        get_properties(cid, cfg)
         if cid
         else Properties(
             "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"


### PR DESCRIPTION
## Summary
- route all ChEMBL assay helpers through configured base URL and timeouts
- use PubChem configuration for base URLs and timeouts
- pass config sections to command-line helpers

## Testing
- `black library/chembl_assay.py library/pubchem_library.py get_assay_data.py get_activity_data.py get_testitem_data.py`
- `ruff check library/chembl_assay.py library/pubchem_library.py get_assay_data.py get_activity_data.py get_testitem_data.py`
- `mypy library/chembl_assay.py library/pubchem_library.py get_assay_data.py get_activity_data.py get_testitem_data.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a236efac83248db118049c62867c