### PR TITLE
Ensure configuration directories are created explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ values after all overrides have been applied. The final precedence is::
 Only the top-level command line scripts read the configuration file. Modules
 under ``library/`` expect a :class:`Config` (or one of its subsections) to be
 passed explicitly, making dependencies clear and avoiding hidden global state.
+The directories referenced by ``io.output_dir`` and ``io.cache_dir`` are checked
+but not created when loading the configuration. Scripts that need these paths
+can call :func:`library.config.ensure_dirs` after :func:`load_config` to create
+them if they are missing and ``io.exist_ok`` permits it.
 
 
 Common flags shared by scripts include:

--- a/config.yaml
+++ b/config.yaml
@@ -59,7 +59,7 @@ io:
   csv_sep: ","  # CSV field separator
   csv_encoding: "utf-8-sig"  # Encoding for CSV files
   csv_index: false  # Include index column when writing CSV
-  exist_ok: true  # Create directories if missing
+  exist_ok: true  # Create directories with ensure_dirs if missing
 
 jobs:
   concurrency: 8  # Number of parallel workers

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,6 +4,10 @@ This guide demonstrates how to run the command line tools on the bundled
 "smoke" datasets. Each example writes output next to the input file with a
 prefix of `output_` followed by the input stem and current date.
 
+All scripts call :func:`library.config.ensure_dirs` after loading the
+configuration so that the configured output and cache directories exist before
+processing begins.
+
 ## Activity data
 
 ```bash

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -7,7 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 
 from library import chembl_library as cl
 from library import io
@@ -84,6 +84,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     default_chunk = parser.get_default("chunk_size")
     if args.chunk_size == default_chunk:

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,7 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -80,6 +80,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     default_chunk = parser.get_default("chunk_size")
     if args.chunk_size == default_chunk:

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -401,6 +401,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     default_log = parser.get_default("log_level")
     if args.log_level == default_log:

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
-from library.config import load_config
+from library.config import ensure_dirs, load_config
 from library.cli import configure_logging
 
 from library.document_type_classifier import compute_scores, decide_label
@@ -82,6 +82,7 @@ def main() -> int:  # pragma: no cover - simple CLI
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
     if args.log_level == "INFO":
         args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 from library.cli import configure_logging
 from typing import Sequence
 
@@ -122,6 +122,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     if args.same_doc is None:
         args.same_doc = Path(cfg.init.same_doc)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 
 from library import chembl_library as cl
 from library import io
@@ -572,6 +572,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
     default_log = parser.get_default("log_level")
     if args.log_level == default_log:
         args.log_level = cfg.log.level

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -163,6 +163,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     default_chunk = parser.get_default("chunk_size")
     if args.chunk_size == default_chunk:

--- a/library/config.py
+++ b/library/config.py
@@ -362,13 +362,10 @@ def _validate(cfg: Config) -> None:
 
     out_dir = Path(cfg.io.output_dir)
     cache_dir = Path(cfg.io.cache_dir)
-    for path in [out_dir, cache_dir]:
-        if not path.exists():
-            if cfg.io.exist_ok:
-                path.mkdir(parents=True, exist_ok=True)
-            else:
-                raise FileNotFoundError(f"{path} does not exist")
-        elif not path.is_dir():
+    for path in (out_dir, cache_dir):
+        if not path.exists() and not cfg.io.exist_ok:
+            raise FileNotFoundError(f"{path} does not exist")
+        elif path.exists() and not path.is_dir():
             raise NotADirectoryError(f"{path} is not a directory")
 
     if not cfg.init.same_doc.strip() or not cfg.init.all_doc.strip():
@@ -378,6 +375,35 @@ def _validate(cfg: Config) -> None:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def ensure_dirs(cfg: Config) -> None:
+    """Create I/O directories if required.
+
+    Parameters
+    ----------
+    cfg : Config
+        Configuration settings containing ``io`` paths.
+
+    Raises
+    ------
+    FileNotFoundError
+        If a directory is missing and ``cfg.io.exist_ok`` is ``False``.
+    NotADirectoryError
+        If an existing path is not a directory.
+    """
+
+    out_dir = Path(cfg.io.output_dir)
+    cache_dir = Path(cfg.io.cache_dir)
+    for path in (out_dir, cache_dir):
+        if path.exists():
+            if not path.is_dir():
+                raise NotADirectoryError(f"{path} is not a directory")
+        else:
+            if cfg.io.exist_ok:
+                path.mkdir(parents=True, exist_ok=True)
+            else:
+                raise FileNotFoundError(f"{path} does not exist")
 
 
 def load_config(
@@ -434,5 +460,6 @@ __all__ = [
     "RetryCfg",
     "LogCfg",
     "Config",
+    "ensure_dirs",
     "load_config",
 ]

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -8,7 +8,7 @@ from typing import Sequence
 from urllib.error import URLError
 
 import pandas as pd
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
@@ -85,6 +85,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
     cfg = load_config(args.config)
+    ensure_dirs(cfg)
 
     default_sep = parser.get_default("sep")
     if args.sep == default_sep:

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, load_config
+from library.config import Config, ensure_dirs, load_config
 from library.cli import configure_logging
 
 from library.table_quality import analyze_table_quality
@@ -93,6 +93,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         cli_overrides["io.csv_encoding"] = args.encoding
 
     cfg = load_config(args.config, cli_overrides=cli_overrides)
+    ensure_dirs(cfg)
     if args.print_config:
         print(cfg.to_yaml())
         return 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from library.config import load_config
+from library.config import ensure_dirs, load_config
 
 
 def test_load_minimal_config(tmp_path: Path) -> None:
@@ -37,3 +37,21 @@ def test_type_validation(tmp_path: Path) -> None:
     with pytest.raises(TypeError, match="api.rps must be int"):
         load_config(path)
 
+
+def test_missing_dirs_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHEMBL_DA_OUTDIR", str(tmp_path / "out"))
+    monkeypatch.setenv("CHEMBL_DA__IO__CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("CHEMBL_DA__IO__EXIST_OK", "false")
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / "cfg.yaml")
+
+
+def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    out = tmp_path / "out"
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("CHEMBL_DA_OUTDIR", str(out))
+    monkeypatch.setenv("CHEMBL_DA__IO__CACHE_DIR", str(cache))
+    cfg = load_config(tmp_path / "cfg.yaml")
+    assert not out.exists() and not cache.exists()
+    ensure_dirs(cfg)
+    assert out.is_dir() and cache.is_dir()


### PR DESCRIPTION
## Summary
- Prevent automatic output/cache directory creation during config validation
- Add `ensure_dirs` helper to create configured directories on demand
- Update CLI scripts, docs, and tests to use the new helper

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a30dfe7c8324af68f38a0ac2aa72