### PR TITLE
Use Path objects for configurable directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ but not created when loading the configuration. Scripts that need these paths
 can call :func:`library.config.ensure_dirs` after :func:`load_config` to create
 them if they are missing and ``io.exist_ok`` permits it.
 
+Path values such as ``io.output_dir``, ``io.cache_dir`` and the ``init``
+workbook paths are exposed as :class:`pathlib.Path` objects. String values in
+``config.yaml`` or overrides from the environment and command line are
+automatically converted.
+
 
 Common flags shared by scripts include:
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -125,11 +125,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     ensure_dirs(cfg)
 
     if args.same_doc is None:
-        args.same_doc = Path(cfg.init.same_doc)
+        args.same_doc = cfg.init.same_doc
     if args.all_doc is None:
-        args.all_doc = Path(cfg.init.all_doc)
+        args.all_doc = cfg.init.all_doc
     if args.out_dir is None:
-        args.out_dir = Path(cfg.init.output_dir)
+        args.out_dir = cfg.init.output_dir
 
     default_log = parser.get_default("log_level")
     if args.log_level == default_log:

--- a/library/config.py
+++ b/library/config.py
@@ -111,8 +111,8 @@ class PubChemCfg:
 class IoCfg:
     """Input/output defaults."""
 
-    output_dir: str = "data/output"
-    cache_dir: str = ".cache"
+    output_dir: Path = Path("data/output")
+    cache_dir: Path = Path(".cache")
     csv_sep: str = ","
     csv_encoding: str = "utf-8-sig"
     csv_index: bool = False
@@ -140,9 +140,9 @@ class LogCfg:
 class InitCfg:
     """Workbook paths for ``get_input_initialisation``."""
 
-    same_doc: str = "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"
-    all_doc: str = "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
-    output_dir: str = "data/output/ChEMBL/processed"
+    same_doc: Path = Path("data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx")
+    all_doc: Path = Path("data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx")
+    output_dir: Path = Path("data/output/ChEMBL/processed")
 
 
 @dataclass
@@ -239,6 +239,8 @@ def _coerce(value: str, current: Any) -> Any:
         return int(value)
     if isinstance(current, float):
         return float(value)
+    if isinstance(current, Path):
+        return Path(value)
     return value
 
 
@@ -258,10 +260,17 @@ def _update_from_dict(
                 raise TypeError(f"{joined} must be a mapping")
             _update_from_dict(current, val, path + [key])
             continue
-        expected = type(current)
-        if not isinstance(val, expected):
+        if isinstance(val, str):
+            try:
+                val = _coerce(val, current)
+            except Exception as exc:  # pragma: no cover - defensive
+                joined = ".".join(path + [key])
+                raise TypeError(
+                    f"{joined} must be {type(current).__name__}, got {val!r}"
+                ) from exc
+        if not isinstance(val, type(current)):
             joined = ".".join(path + [key])
-            raise TypeError(f"{joined} must be {expected.__name__}, got {val!r}")
+            raise TypeError(f"{joined} must be {type(current).__name__}, got {val!r}")
         setattr(obj, key, val)
 
 
@@ -367,15 +376,15 @@ def _validate(cfg: Config) -> None:
             "retry.max_attempts must be positive and backoff_factor non-negative"
         )
 
-    out_dir = Path(cfg.io.output_dir)
-    cache_dir = Path(cfg.io.cache_dir)
+    out_dir = cfg.io.output_dir
+    cache_dir = cfg.io.cache_dir
     for path in (out_dir, cache_dir):
         if not path.exists() and not cfg.io.exist_ok:
             raise FileNotFoundError(f"{path} does not exist")
         elif path.exists() and not path.is_dir():
             raise NotADirectoryError(f"{path} is not a directory")
 
-    if not cfg.init.same_doc.strip() or not cfg.init.all_doc.strip():
+    if not cfg.init.same_doc.name or not cfg.init.all_doc.name:
         raise ValueError("init.same_doc and init.all_doc must not be empty")
 
 
@@ -400,8 +409,8 @@ def ensure_dirs(cfg: Config) -> None:
         If an existing path is not a directory.
     """
 
-    out_dir = Path(cfg.io.output_dir)
-    cache_dir = Path(cfg.io.cache_dir)
+    out_dir = cfg.io.output_dir
+    cache_dir = cfg.io.cache_dir
     for path in (out_dir, cache_dir):
         if path.exists():
             if not path.is_dir():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,12 +53,19 @@ def test_cli_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert cfg.api.rps == 4
 
 
+def test_cli_path_override(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    out = tmp_path / "out"
+    cfg = load_config(path, cli_overrides={"io.output_dir": str(out)})
+    assert cfg.io.output_dir == out
+
+
 def test_type_validation(tmp_path: Path) -> None:
     path = tmp_path / "bad.yaml"
     path.write_text("api:\n  rps: fast\n")
     with pytest.raises(TypeError, match="api.rps must be int"):
         load_config(path)
-
 
 
 def test_missing_dirs_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,4 +85,3 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert not out.exists() and not cache.exists()
     ensure_dirs(cfg)
     assert out.is_dir() and cache.is_dir()
-


### PR DESCRIPTION
## Summary
- represent `io.output_dir`, `io.cache_dir`, and `init` workbook paths as `Path` objects
- coerce string overrides to `Path` and update CLI to use typed paths
- document path handling and test CLI path overrides

## Testing
- `black get_input_initialisation.py library/config.py tests/test_config.py`
- `ruff check get_input_initialisation.py library/config.py tests/test_config.py`
- `mypy get_input_initialisation.py library/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4eed34883248a5f655a49ebcc52