### PR TITLE
feat: centralize CLI config overrides

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -62,6 +62,15 @@ Each command supports the common flags `--sep`, `--encoding` and
 `--log-level`. The default output path mirrors the input location and can be
 manually overridden with `--output` where available.
 
+### Configuration overrides
+
+Command line flags override values from `config.yaml`. Internally the scripts
+use `library.cli.apply_config_overrides` to merge provided options into the
+runtime configuration. For example, specifying `--sep` or `--encoding`
+replaces `io.csv_sep` and `io.csv_encoding` respectively. Likewise
+`--chunk-size` maps to `jobs.chunk_size`, `--timeout` to `api.timeout_read` and
+`--log-level` to `log.level`.
+
 ## Table quality profiler
 
 ```bash

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -7,11 +7,15 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 
 from library import chembl_library as cl
 from library import io
-from library.cli import build_parser as base_parser, configure_logging
+from library.cli import (
+    apply_config_overrides,
+    build_parser as base_parser,
+    configure_logging,
+)
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -85,25 +89,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(
+        args,
+        parser,
+        args.config,
+        mapping={"timeout": "api.timeout_read"},
+    )
     ensure_dirs(cfg)
-
-    default_chunk = parser.get_default("chunk_size")
-    if args.chunk_size == default_chunk:
-        args.chunk_size = cfg.jobs.chunk_size
-    default_sep = parser.get_default("sep")
-    if args.sep == default_sep:
-        args.sep = cfg.io.csv_sep
-    default_encoding = parser.get_default("encoding")
-    if args.encoding == default_encoding:
-        args.encoding = cfg.io.csv_encoding
-    if hasattr(args, "timeout"):
-        default_timeout = parser.get_default("timeout")
-        if args.timeout == default_timeout:
-            args.timeout = cfg.api.timeout_read
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,12 +7,16 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
-from library.cli import build_parser as base_parser, configure_logging
+from library.cli import (
+    apply_config_overrides,
+    build_parser as base_parser,
+    configure_logging,
+)
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -79,21 +83,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-
-    default_chunk = parser.get_default("chunk_size")
-    if args.chunk_size == default_chunk:
-        args.chunk_size = cfg.jobs.chunk_size
-    default_sep = parser.get_default("sep")
-    if args.sep == default_sep:
-        args.sep = cfg.io.csv_sep
-    default_encoding = parser.get_default("encoding")
-    if args.encoding == default_encoding:
-        args.encoding = cfg.io.csv_encoding
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -41,7 +41,7 @@ from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
-from library.cli import configure_logging
+from library.cli import apply_config_overrides, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -400,12 +400,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
-from library.config import ensure_dirs, load_config
-from library.cli import configure_logging
+from library.config import ensure_dirs
+from library.cli import apply_config_overrides, configure_logging
 
 from library.document_type_classifier import compute_scores, decide_label
 
@@ -81,10 +81,8 @@ def main() -> int:  # pragma: no cover - simple CLI
     parser.add_argument("--output", type=Path, required=True, help="Output CSV")
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-    if args.log_level == "INFO":
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
 
     df_in = pd.read_csv(args.input, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding)

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from library.config import Config, ensure_dirs, load_config
-from library.cli import configure_logging
 from typing import Sequence
+
+from library.config import Config, ensure_dirs
+from library.cli import apply_config_overrides, configure_logging
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
@@ -121,19 +122,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(
+        args,
+        parser,
+        args.config,
+        mapping={
+            "same_doc": "init.same_doc",
+            "all_doc": "init.all_doc",
+            "out_dir": "init.output_dir",
+        },
+    )
     ensure_dirs(cfg)
-
-    if args.same_doc is None:
-        args.same_doc = Path(cfg.init.same_doc)
-    if args.all_doc is None:
-        args.all_doc = Path(cfg.init.all_doc)
-    if args.out_dir is None:
-        args.out_dir = Path(cfg.init.output_dir)
-
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
+    args.same_doc = Path(args.same_doc)
+    args.all_doc = Path(args.all_doc)
+    args.out_dir = Path(args.out_dir)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -10,14 +10,14 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 
 from library import chembl_library as cl
 from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.cli import configure_logging
+from library.cli import apply_config_overrides, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -571,11 +571,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     if hasattr(args, "func"):
         return args.func(cfg, args)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -8,12 +8,16 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
 from library import io
-from library.cli import build_parser as base_parser, configure_logging
+from library.cli import (
+    apply_config_overrides,
+    build_parser as base_parser,
+    configure_logging,
+)
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -164,21 +168,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-
-    default_chunk = parser.get_default("chunk_size")
-    if args.chunk_size == default_chunk:
-        args.chunk_size = cfg.jobs.chunk_size
-    default_sep = parser.get_default("sep")
-    if args.sep == default_sep:
-        args.sep = cfg.io.csv_sep
-    default_encoding = parser.get_default("encoding")
-    if args.encoding == default_encoding:
-        args.encoding = cfg.io.csv_encoding
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
+from typing import Any, Dict
+
+from .config import Config, load_config
 
 
 def _positive_int(value: str) -> int:
@@ -100,3 +103,91 @@ def configure_logging(
         datefmt=datefmt,
         force=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# Configuration overrides
+# ---------------------------------------------------------------------------
+
+# Mapping of common CLI argument names to configuration paths.
+_DEFAULT_OVERRIDES: Dict[str, str] = {
+    "sep": "io.csv_sep",
+    "encoding": "io.csv_encoding",
+    "log_level": "log.level",
+    "chunk_size": "jobs.chunk_size",
+    "timeout": "api.timeout_read",
+}
+
+
+def _get_cfg_value(cfg: Config, path: str) -> Any:
+    """Return the value in ``cfg`` located at ``path``.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration object.
+    path:
+        Dot separated attribute path within ``cfg``.
+    """
+
+    current: Any = cfg
+    for part in path.split("."):
+        current = getattr(current, part)
+    return current
+
+
+def apply_config_overrides(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    config_path: str | Path,
+    mapping: Dict[str, str] | None = None,
+) -> Config:
+    """Load configuration applying command line overrides.
+
+    This helper compares CLI arguments with parser defaults. Values that differ
+    from the defaults are added to ``cli_overrides`` and passed to
+    :func:`library.config.load_config`. After loading, ``args`` is updated with
+    configuration values for options that were not explicitly provided.
+
+    Parameters
+    ----------
+    args:
+        Parsed command line arguments.
+    parser:
+        Argument parser used to determine default values.
+    config_path:
+        Location of the YAML configuration file.
+    mapping:
+        Optional mapping of argument names to ``Config`` attribute paths. The
+        mapping is merged with a set of common defaults.
+
+    Returns
+    -------
+    Config
+        Loaded configuration object with overrides applied.
+    """
+
+    override_map = {**_DEFAULT_OVERRIDES, **(mapping or {})}
+
+    cli_overrides: Dict[str, Any] = {}
+    for arg, key in override_map.items():
+        if not hasattr(args, arg):
+            continue
+        value = getattr(args, arg)
+        default = parser.get_default(arg)
+        if value != default:
+            cli_overrides[key] = value
+
+    cfg = load_config(config_path, cli_overrides=cli_overrides)
+
+    for arg, key in override_map.items():
+        if not hasattr(args, arg):
+            continue
+        default = parser.get_default(arg)
+        if getattr(args, arg) == default:
+            setattr(args, arg, _get_cfg_value(cfg, key))
+
+    return cfg
+
+
+__all__ = ["build_parser", "configure_logging", "apply_config_overrides"]

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -8,10 +8,14 @@ from typing import Sequence
 from urllib.error import URLError
 
 import pandas as pd
-from library.config import Config, ensure_dirs, load_config
+from library.config import Config, ensure_dirs
 
 from library import io
-from library.cli import build_parser as base_parser, configure_logging
+from library.cli import (
+    apply_config_overrides,
+    build_parser as base_parser,
+    configure_logging,
+)
 from library.mapper_library import map_chembl_to_uniprot
 
 logger = logging.getLogger(__name__)
@@ -84,18 +88,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cfg = load_config(args.config)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-
-    default_sep = parser.get_default("sep")
-    if args.sep == default_sep:
-        args.sep = cfg.io.csv_sep
-    default_encoding = parser.get_default("encoding")
-    if args.encoding == default_encoding:
-        args.encoding = cfg.io.csv_encoding
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, ensure_dirs, load_config
-from library.cli import configure_logging
+from library.config import Config, ensure_dirs
+from library.cli import apply_config_overrides, configure_logging
 
 from library.table_quality import analyze_table_quality
 
@@ -86,27 +86,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(argv)
-    cli_overrides = {}
-    if args.sep != parser.get_default("sep"):
-        cli_overrides["io.csv_sep"] = args.sep
-    if args.encoding != parser.get_default("encoding"):
-        cli_overrides["io.csv_encoding"] = args.encoding
-
-    cfg = load_config(args.config, cli_overrides=cli_overrides)
+    cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     if args.print_config:
         print(cfg.to_yaml())
         return 0
-
-    default_sep = parser.get_default("sep")
-    if args.sep == default_sep:
-        args.sep = cfg.io.csv_sep
-    default_encoding = parser.get_default("encoding")
-    if args.encoding == default_encoding:
-        args.encoding = cfg.io.csv_encoding
-    default_log = parser.get_default("log_level")
-    if args.log_level == default_log:
-        args.log_level = cfg.log.level
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)
 

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import get_activity_data as gad
+from library import chembl_library as cl, io
+import pandas as pd
+
+
+def _create_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: '|'\n  csv_encoding: iso-8859-1\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+    )
+    return cfg
+
+
+def _run(
+    tmp_path: Path, monkeypatch, extra: list[str]
+) -> tuple[int, dict[str, object]]:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\n1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, object] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["1"])
+
+    def fake_get(ids, cfg, chunk_size, timeout):
+        called["chunk_size"] = chunk_size
+        return pd.DataFrame({"activity_id": ids})
+
+    def fake_write(df, output, cfg, sep, encoding):
+        called["sep"] = sep
+        called["encoding"] = encoding
+
+    monkeypatch.setattr(cl, "get_activities", fake_get)
+    monkeypatch.setattr(io, "write_csv", fake_write)
+    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    rc = gad.main(["--config", str(config_path), "--input", str(input_csv), *extra])
+    return rc, called
+
+
+def test_default_config_used(tmp_path: Path, monkeypatch) -> None:
+    rc, called = _run(tmp_path, monkeypatch, [])
+    assert rc == 0
+    assert called["chunk_size"] == 10
+    assert called["sep"] == "|"
+    assert called["encoding"] == "iso-8859-1"
+
+
+def test_cli_overrides(tmp_path: Path, monkeypatch) -> None:
+    rc, called = _run(
+        tmp_path,
+        monkeypatch,
+        ["--chunk-size", "3", "--sep", ";", "--encoding", "latin1"],
+    )
+    assert rc == 0
+    assert called["chunk_size"] == 3
+    assert called["sep"] == ";"
+    assert called["encoding"] == "latin1"


### PR DESCRIPTION
## Summary
- factor CLI override handling into `library.cli.apply_config_overrides`
- update command-line scripts to use centralized override logic
- document new override behaviour and add tests for activity data CLI

## Testing
- `black .`
- `ruff check .`
- `mypy --ignore-missing-imports --disable-error-code import-untyped .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4fa17c88324907822e7d40e45ae