### PR TITLE
Centralize runtime configuration

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -12,6 +12,7 @@ from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
 from library.table_quality import analyze_table_quality
+from library.config import DEFAULT_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=float,
-        default=30.0,
+        default=DEFAULT_CONFIG.timeouts.read,
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -10,12 +10,14 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from .config import DEFAULT_CONFIG
+
 logger = logging.getLogger(__name__)
 
-# Configure session with retry/backoff for robustness
+# Configure session with retry/backoff for robustness using shared config
 _retry = Retry(
-    total=3,
-    backoff_factor=1.0,
+    total=DEFAULT_CONFIG.rate_limits.max_retries,
+    backoff_factor=DEFAULT_CONFIG.rate_limits.backoff_factor,
     status_forcelist=[500, 502, 503, 504],
     allowed_methods=["GET"],
 )
@@ -25,15 +27,16 @@ _session.mount("http://", _adapter)
 _session.mount("https://", _adapter)
 
 
-def request_json(url: str, *, timeout: float = 30.0) -> dict[str, Any]:
-    """Return JSON content from *url*.
+def request_json(url: str, *, timeout: float | None = None) -> dict[str, Any]:
+    """Return JSON content from ``url``.
 
     Parameters
     ----------
     url:
         API endpoint to query.
     timeout:
-        Maximum number of seconds to wait for the response.
+        Maximum number of seconds to wait for the response. Defaults to
+        :data:`library.config.DEFAULT_CONFIG.timeouts.read` when ``None``.
 
     Returns
     -------
@@ -48,7 +51,8 @@ def request_json(url: str, *, timeout: float = 30.0) -> dict[str, Any]:
         If the response body is not valid JSON.
 
     """
-    with _session.get(url, timeout=timeout) as response:
+    effective_timeout = timeout if timeout is not None else DEFAULT_CONFIG.timeouts.read
+    with _session.get(url, timeout=effective_timeout) as response:
         response.raise_for_status()
         return response.json()
 

--- a/library/config.py
+++ b/library/config.py
@@ -1,0 +1,173 @@
+"""Configuration utilities for data acquisition scripts.
+
+This module centralises configuration options such as timeouts, rate limits
+and output directories. Settings are loaded from ``config.yaml`` when
+available, otherwise built-in defaults are used.
+
+The :class:`Config` dataclass performs validation in ``__post_init__`` to
+ensure supplied values are sensible.  Invalid values raise
+:class:`ConfigError`.
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+import yaml
+
+
+class ConfigError(ValueError):
+    """Raised when configuration values are invalid."""
+
+
+@dataclass
+class APISettings:
+    """Base URLs for external services."""
+
+    chembl_base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
+    pubchem_base_url: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    uniprot_base_url: str = "https://rest.uniprot.org"
+    eutils_base_url: str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+    semanticscholar_base_url: str = "https://api.semanticscholar.org/graph/v1"
+    openalex_base_url: str = "https://api.openalex.org"
+    crossref_base_url: str = "https://api.crossref.org"
+    gtp_base_url: str = "https://www.guidetopharmacology.org"
+
+
+@dataclass
+class TimeoutSettings:
+    """Network timeout configuration."""
+
+    connect: float = 10.0
+    read: float = 30.0
+
+
+@dataclass
+class RateLimitSettings:
+    """HTTP rate limiting and retry settings."""
+
+    max_requests_per_second: float = 5.0
+    max_retries: int = 3
+    backoff_factor: float = 1.0
+
+
+@dataclass
+class OutputPaths:
+    """Output directory configuration."""
+
+    data_dir: Path | str = Path("data")
+    logs_dir: Path | str = Path("logs")
+    tmp_dir: Path | str = Path("tmp")
+
+    def __post_init__(self) -> None:
+        self.data_dir = Path(self.data_dir)
+        self.logs_dir = Path(self.logs_dir)
+        self.tmp_dir = Path(self.tmp_dir)
+
+
+@dataclass
+class Config:
+    """Application configuration loaded from ``config.yaml``.
+
+    Parameters
+    ----------
+    api:
+        Base URLs for external services.
+    timeouts:
+        Network timeout configuration.
+    rate_limits:
+        HTTP rate limiting and retry configuration.
+    output:
+        Output directory configuration.
+    """
+
+    api: APISettings = field(default_factory=APISettings)
+    timeouts: TimeoutSettings = field(default_factory=TimeoutSettings)
+    rate_limits: RateLimitSettings = field(default_factory=RateLimitSettings)
+    output: OutputPaths = field(default_factory=OutputPaths)
+
+    def __post_init__(self) -> None:
+        """Validate configuration values.
+
+        Raises
+        ------
+        ConfigError
+            If any configuration value is invalid.
+        """
+
+        # Validate timeouts
+        for name, value in vars(self.timeouts).items():
+            if value <= 0:
+                raise ConfigError(f"timeout '{name}' must be > 0")
+
+        # Validate rate limits
+        if self.rate_limits.max_requests_per_second <= 0:
+            raise ConfigError("max_requests_per_second must be > 0")
+        if self.rate_limits.max_retries < 0:
+            raise ConfigError("max_retries must be >= 0")
+        if self.rate_limits.backoff_factor < 0:
+            raise ConfigError("backoff_factor must be >= 0")
+
+        # Validate URLs
+        for name, url in vars(self.api).items():
+            parsed = urlparse(url)
+            if not parsed.scheme or not parsed.netloc:
+                raise ConfigError(f"invalid URL for {name}: {url}")
+
+        # Validate output directories
+        for path in [self.output.data_dir, self.output.logs_dir, self.output.tmp_dir]:
+            try:
+                path.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                raise ConfigError(f"failed to create directory: {path}") from exc
+            if not os.access(path, os.W_OK):
+                raise ConfigError(f"directory not writable: {path}")
+
+
+def load_config(path: str | Path | None = None) -> Config:
+    """Return configuration loaded from ``path`` or defaults.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a YAML configuration file. When omitted, ``config.yaml``
+        located at the repository root is used. Missing files result in the
+        default configuration being returned.
+
+    Returns
+    -------
+    Config
+        Parsed configuration object.
+    """
+    cfg_path = Path(path) if path is not None else Path("config.yaml")
+    data: Dict[str, Any] = {}
+    if cfg_path.exists():
+        with cfg_path.open("r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh) or {}
+
+    return Config(
+        api=APISettings(**data.get("api", {})),
+        timeouts=TimeoutSettings(**data.get("timeouts", {})),
+        rate_limits=RateLimitSettings(**data.get("rate_limits", {})),
+        output=OutputPaths(**data.get("output", {})),
+    )
+
+
+DEFAULT_CONFIG = load_config()
+
+
+__all__ = [
+    "Config",
+    "ConfigError",
+    "load_config",
+    "DEFAULT_CONFIG",
+    "APISettings",
+    "TimeoutSettings",
+    "RateLimitSettings",
+    "OutputPaths",
+]

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -18,8 +18,10 @@ import requests
 from xml.etree import ElementTree as ET
 from urllib.parse import quote
 
+from .config import DEFAULT_CONFIG
+
 ENCODINGS = ["utf-8-sig", "cp1251", "latin1"]
-TIMEOUT = 10
+TIMEOUT = DEFAULT_CONFIG.timeouts.read
 
 
 def read_pmids(path: Union[str, Path]) -> List[str]:
@@ -49,7 +51,7 @@ def _do_request(
     url: str,
     sleep: float,
     expect_json: bool = True,
-    retries: int = 2,
+    retries: int = DEFAULT_CONFIG.rate_limits.max_retries,
     method: str = "GET",
     timeout: float = TIMEOUT,
     **kwargs: Any,
@@ -67,7 +69,8 @@ def _do_request(
     expect_json:
         Whether to parse the response as JSON.
     retries:
-        Number of additional attempts after the initial one.
+        Number of additional attempts after the initial one. Defaults to
+        :data:`library.config.DEFAULT_CONFIG.rate_limits.max_retries`.
     method:
         HTTP method to use, either "GET" or "POST".
     timeout:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mypy>=1.8
 
 openpyxl>=3.1
 pyarrow>=12.0
+pyyaml>=6.0

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -11,6 +11,7 @@ from typing import Sequence
 import pandas as pd
 
 from library.table_quality import analyze_table_quality
+from library.config import DEFAULT_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         dest="output_dir",
         type=Path,
-        default=Path("."),
+        default=DEFAULT_CONFIG.output.data_dir,
         help="Directory to store generated reports",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from library.config import (
+    APISettings,
+    Config,
+    ConfigError,
+    OutputPaths,
+    TimeoutSettings,
+)
+
+
+def test_negative_timeout_raises() -> None:
+    with pytest.raises(ConfigError):
+        Config(timeouts=TimeoutSettings(connect=-1, read=10))
+
+
+def test_invalid_url_raises() -> None:
+    api = APISettings(chembl_base_url="not-a-url")
+    with pytest.raises(ConfigError):
+        Config(api=api)
+
+
+def test_non_writable_directory_raises(tmp_path: Path) -> None:
+    bad_path = tmp_path / "file"
+    bad_path.write_text("x")
+    with pytest.raises(ConfigError):
+        Config(output=OutputPaths(data_dir=bad_path))


### PR DESCRIPTION
## Summary
- add `Config` dataclass to load timeouts, rate limits, and output directories with validation
- reuse `Config` in HTTP utilities and CLI defaults
- test invalid configuration cases

## Testing
- `black get_activity_data.py library/chembl_client.py library/pubmed_library.py table_quality_main.py library/config.py tests/test_config.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a76c8b948324825d818db9793fc5