### PR TITLE
Add robust configuration loader

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -8,6 +8,7 @@ directory.
 """
 
 from . import io, validation
+from .config import ConfigError, DEFAULT_PATH, load_config
 from .document_type_terms import (
     EXPERIMENTAL_TERMS,
     REVIEW_TERMS,
@@ -25,4 +26,7 @@ __all__ = [
     "decide_label",
     "io",
     "validation",
+    "load_config",
+    "ConfigError",
+    "DEFAULT_PATH",
 ]

--- a/library/cli.py
+++ b/library/cli.py
@@ -1,10 +1,18 @@
-"""Shared command-line helpers."""
+"""Shared command-line helpers.
+
+The parsers built by :func:`build_parser` expose a ``--config`` option whose
+value can be passed to :func:`library.config.load_config`.  If the configuration
+file is missing or malformed, calling :func:`~library.config.load_config` will
+raise :class:`library.config.ConfigError`.
+"""
 
 from __future__ import annotations
 
 import argparse
 import logging
 from pathlib import Path
+
+from .config import DEFAULT_PATH
 
 
 def _positive_int(value: str) -> int:
@@ -49,6 +57,14 @@ def build_parser(
     chunk_size:
         Default chunk size for API requests.
 
+    Notes
+    -----
+    The returned parser defines common arguments used across scripts,
+    including ``--config`` for specifying the path to a YAML configuration
+    file.  Consumers should load the file with
+    :func:`library.config.load_config` and handle
+    :class:`library.config.ConfigError` for missing or malformed files.
+
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
@@ -78,6 +94,12 @@ def build_parser(
         type=_positive_int,
         default=chunk_size,
         help="Maximum IDs per request",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_PATH,
+        help="Path to configuration YAML file",
     )
     return parser
 

--- a/library/config.py
+++ b/library/config.py
@@ -1,0 +1,56 @@
+"""Load project configuration from YAML files.
+
+This module provides a small helper to load the optional ``config.yaml``
+file located at the repository root.  Consumers can supply a custom path if
+desired.  Failure to read or parse the configuration results in a
+:class:`ConfigError` exception.
+
+The configuration file is expected to be valid YAML.  If the file is missing
+or contains malformed content, :func:`load_config` raises :class:`ConfigError`
+with a descriptive message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ConfigError(Exception):
+    """Raised when the configuration file cannot be loaded."""
+
+
+# Default location of the configuration file at the project root
+DEFAULT_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+
+
+def load_config(path: str | Path = DEFAULT_PATH) -> dict[str, Any]:
+    """Return configuration settings from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of the configuration file. Defaults to the repository's
+        ``config.yaml``.
+
+    Returns
+    -------
+    dict[str, Any]
+        Mapping loaded from the YAML document. Empty files result in an empty
+        dictionary.
+
+    Raises
+    ------
+    ConfigError
+        If ``path`` does not exist or contains invalid YAML.
+    """
+    try:
+        with Path(path).open("r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except FileNotFoundError as exc:
+        raise ConfigError(f"configuration file not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"invalid YAML in configuration file: {path}") from exc
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest>=7.0
 black>=23.0
 ruff>=0.0.290
 mypy>=1.8
+PyYAML>=6.0
 
 openpyxl>=3.1
 pyarrow>=12.0

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,6 +1,9 @@
 import pytest
 
+from pathlib import Path
+
 from library.cli import build_parser
+from library.config import DEFAULT_PATH
 
 
 def test_chunk_size_positive() -> None:
@@ -13,3 +16,9 @@ def test_chunk_size_non_positive() -> None:
     parser = build_parser("desc", column="id")
     with pytest.raises(SystemExit):
         parser.parse_args(["--chunk-size", "0"])
+
+
+def test_config_default_path() -> None:
+    parser = build_parser("desc", column="id")
+    args = parser.parse_args([])
+    assert args.config == Path(DEFAULT_PATH)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for the configuration loader."""
+
+from pathlib import Path
+
+import pytest
+
+from library.config import ConfigError, load_config
+
+
+def test_load_config_success(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("key: value\n", encoding="utf8")
+    cfg = load_config(cfg_path)
+    assert cfg == {"key": "value"}
+
+
+def test_load_config_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yaml"
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(missing)
+    assert "configuration file not found" in str(excinfo.value)
+
+
+def test_load_config_invalid_yaml(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("key: [1, 2", encoding="utf8")  # malformed YAML
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(bad)
+    assert "invalid YAML" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add `load_config` helper with clear error reporting
- expose `--config` option in shared CLI parser
- document and test configuration failure modes

## Testing
- `black library/config.py library/cli.py library/__init__.py tests/test_cli_validation.py tests/test_config.py`
- `ruff check library/config.py library/cli.py library/__init__.py tests/test_cli_validation.py tests/test_config.py`
- `mypy library/config.py library/cli.py library/__init__.py tests/test_cli_validation.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a82fcbcc83248fbe307c0b778547