### PR TITLE
Add centralized configuration support for CLI tools

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import requests
@@ -11,6 +12,7 @@ import requests
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
+from library.config import load_config
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -69,7 +71,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=float,
-        default=30.0,
+        default=None,
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)
@@ -80,6 +82,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.timeout is None:
+        args.timeout = float(config.get("timeouts", {}).get("read", 30.0))
+    if args.output_csv is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import requests
@@ -12,6 +13,7 @@ from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
+from library.config import load_config
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.output_csv is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -40,6 +40,7 @@ from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
+from library.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +279,12 @@ def build_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(description="Document data utilities")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     pubmed = sub.add_parser("pubmed", help="Fetch data from PubMed and related APIs")
@@ -301,7 +308,7 @@ def build_parser() -> argparse.ArgumentParser:
     pubmed.add_argument("--sep", default=",", help="CSV delimiter")
     pubmed.add_argument("--encoding", default="utf8", help="File encoding")
     pubmed.add_argument(
-        "--sleep", type=float, default=5.0, help="Seconds to sleep between requests"
+        "--sleep", type=float, default=None, help="Seconds to sleep between requests"
     )
     pubmed.add_argument(
         "--workers", type=int, default=1, help="Number of concurrent requests"
@@ -365,7 +372,7 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.add_argument(
         "--sleep",
         type=float,
-        default=5.0,
+        default=None,
         help="Seconds to sleep between PubMed requests",
     )
     all_cmd.add_argument(
@@ -386,6 +393,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if hasattr(args, "output_csv") and getattr(args, "output_csv") is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
+    if getattr(args, "sleep", None) is None:
+        rate = config.get("rate_limits", {}).get("max_requests_per_second")
+        if rate:
+            args.sleep = 1 / rate
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
     return args.func(args)
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -14,6 +14,7 @@ from typing import Iterable
 import pandas as pd
 
 from library.document_type_classifier import compute_scores, decide_label
+from library.config import load_config
 
 
 def _split_terms(value: object) -> Iterable[str]:
@@ -74,10 +75,17 @@ def main() -> int:  # pragma: no cover - simple CLI
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
     parser.add_argument("--input", type=Path, required=True, help="Input CSV")
     parser.add_argument("--output", type=Path, required=True, help="Output CSV")
     args = parser.parse_args()
 
+    load_config(args.config)
     df_in = pd.read_csv(args.input)
     df_out = classify_dataframe(df_in)
     df_out.to_csv(args.output, index=False)

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -16,6 +16,7 @@ from typing import Sequence
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
+from library.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
+    parser.add_argument(
         "--same-doc", type=Path, required=True, help="Path to same document workbook"
     )
     parser.add_argument(
@@ -98,9 +105,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path("dictionary"),
         help="Directory with targets_type.csv, citation_fraction.csv and status.csv",
     )
-    parser.add_argument(
-        "--out-dir", type=Path, default=Path("."), help="Output directory"
-    )
+    parser.add_argument("--out-dir", type=Path, default=None, help="Output directory")
     parser.add_argument(
         "--format", choices=["csv"], default="csv", help="Output format"
     )
@@ -118,6 +123,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.out_dir is None:
+        args.out_dir = Path(config.get("output", {}).get("data_dir", "."))
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -18,6 +18,7 @@ from library import target_postprocessing as tp
 from library import uniprot_library as uu
 from library.cli import configure_logging
 from library.table_quality import analyze_table_quality
+from library.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING)",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -565,6 +572,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if hasattr(args, "output_csv") and args.output_csv is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
     configure_logging(args.log_level)
     if hasattr(args, "func"):
         return args.func(args)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
@@ -13,6 +14,7 @@ from library import chembl_library as cl
 from library import pubchem_library as pl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
+from library.config import load_config
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -159,6 +161,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.output_csv is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -53,6 +53,12 @@ def build_parser(
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
+    parser.add_argument(
         "--input",
         dest="input_csv",
         type=Path,

--- a/library/config.py
+++ b/library/config.py
@@ -1,0 +1,40 @@
+"""Configuration loading utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str | Path) -> Dict[str, Any]:
+    """Load a YAML configuration file.
+
+    Parameters
+    ----------
+    path:
+        Location of the configuration file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Parsed configuration settings. An empty dictionary is returned if the
+        file does not exist.
+
+    Raises
+    ------
+    ValueError
+        If the file exists but contains invalid YAML.
+    """
+    cfg_path = Path(path)
+    if not cfg_path.exists():
+        return {}
+    try:
+        with cfg_path.open("r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
+        raise ValueError(
+            f"failed to parse configuration file {cfg_path}: {exc}"
+        ) from exc
+    return data or {}

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from pathlib import Path
 from typing import Sequence
 from urllib.error import URLError
 
@@ -11,6 +12,7 @@ import pandas as pd
 
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
+from library.config import load_config
 from library.mapper_library import map_chembl_to_uniprot
 
 logger = logging.getLogger(__name__)
@@ -80,6 +82,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.output_csv is None:
+        out_dir = config.get("output", {}).get("data_dir")
+        if out_dir:
+            args.output_csv = (
+                Path(out_dir) / io.default_output_path(args.input_csv).name
+            )
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest>=7.0
 black>=23.0
 ruff>=0.0.290
 mypy>=1.8
+PyYAML>=6.0
 
 openpyxl>=3.1
 pyarrow>=12.0

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -11,6 +11,7 @@ from typing import Sequence
 import pandas as pd
 
 from library.table_quality import analyze_table_quality
+from library.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Table quality analysis")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
+    parser.add_argument(
         "--input",
         dest="input_csv",
         type=Path,
@@ -65,7 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         dest="output_dir",
         type=Path,
-        default=Path("."),
+        default=None,
         help="Directory to store generated reports",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")
@@ -84,6 +91,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    config = load_config(args.config)
+    if args.output_dir is None:
+        args.output_dir = Path(config.get("output", {}).get("data_dir", "."))
     configure_logging(args.log_level)
     return args.func(args)
 

--- a/tests/data/sample_config.yaml
+++ b/tests/data/sample_config.yaml
@@ -1,0 +1,3 @@
+foo: bar
+nested:
+  value: 42

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from library.config import load_config
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def test_load_config_reads_yaml() -> None:
+    path = DATA_DIR / "sample_config.yaml"
+    cfg = load_config(path)
+    assert cfg["foo"] == "bar"
+    assert cfg["nested"]["value"] == 42
+
+
+def test_load_config_missing_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "missing.yaml"
+    cfg = load_config(path)
+    assert cfg == {}


### PR DESCRIPTION
## Summary
- Add `--config` option to shared CLI parser
- Load YAML configuration in each script and use it for default timeouts and output paths
- Introduce `library.config.load_config` with tests and add PyYAML dependency

## Testing
- `python -m black library/config.py library/cli.py get_activity_data.py get_assay_data.py get_document_data.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py get_document_type.py tests/test_config.py`
- `ruff check library/config.py library/cli.py get_activity_data.py get_assay_data.py get_document_data.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py get_document_type.py tests/test_config.py`
- `mypy library/config.py library/cli.py get_activity_data.py get_assay_data.py get_document_data.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py get_document_type.py tests/test_config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1a8e44bd083249badade4b97b0dc3