### PR TITLE
Fix configuration imports and expose load_config

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -8,7 +8,7 @@ directory.
 """
 
 from . import io, validation
-from .config import Config, get_config
+from .config import Config, load_config
 from .document_type_terms import (
     EXPERIMENTAL_TERMS,
     REVIEW_TERMS,
@@ -27,5 +27,5 @@ __all__ = [
     "io",
     "validation",
     "Config",
-    "get_config",
+    "load_config",
 ]

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from library.table_quality import analyze_table_quality
 
-from library.config import DEFAULT_CONFIG load_config
+from library.config import DEFAULT_CONFIG, load_config
 
 
 logger = logging.getLogger(__name__)
@@ -74,9 +74,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         dest="output_dir",
         type=Path,
-
         default=DEFAULT_CONFIG.output.data_dir,
-
         help="Directory to store generated reports",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")


### PR DESCRIPTION
## Summary
- expose `load_config` instead of deprecated `get_config`
- fix table quality script config import

## Testing
- `python -m black library/__init__.py table_quality_main.py`
- `ruff check library/__init__.py table_quality_main.py`
- `mypy --follow-imports=skip library/__init__.py table_quality_main.py`
- `python -m py_compile library/__init__.py table_quality_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae3c899483249fc07779da617b6f