### PR TITLE
Refine configuration loader

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1,4 +1,3 @@
-
 """Configuration utilities for data acquisition scripts.
 
 This module centralises configuration options such as timeouts, rate limits
@@ -23,18 +22,12 @@ from urllib.parse import urlparse
 import yaml
 
 
-
-def load_config(path: str | Path) -> Dict[str, Any]:
-    """Load a YAML configuration file.
-
 class ConfigError(ValueError):
     """Raised when configuration values are invalid."""
- 
 
 
 @dataclass
 class APISettings:
-
     """Base URLs for external services."""
 
     chembl_base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
@@ -68,9 +61,9 @@ class RateLimitSettings:
 class OutputPaths:
     """Output directory configuration."""
 
-    data_dir: Path | str = Path("data")
-    logs_dir: Path | str = Path("logs")
-    tmp_dir: Path | str = Path("tmp")
+    data_dir: Path = Path("data")
+    logs_dir: Path = Path("logs")
+    tmp_dir: Path = Path("tmp")
 
     def __post_init__(self) -> None:
         self.data_dir = Path(self.data_dir)
@@ -138,49 +131,25 @@ class Config:
 
 
 def load_config(path: str | Path | None = None) -> Config:
-    """Return configuration loaded from ``path`` or defaults.
-
+    """Load application configuration.
 
     Parameters
     ----------
     path:
-
-        Location of the configuration file.
-
-    Returns
-    -------
-    dict[str, Any]
-        Parsed configuration settings. An empty dictionary is returned if the
-        file does not exist.
-
-    Raises
-    ------
-    ValueError
-        If the file exists but contains invalid YAML.
-    """
-    cfg_path = Path(path)
-    if not cfg_path.exists():
-        return {}
-    try:
-        with cfg_path.open("r", encoding="utf8") as fh:
-            data = yaml.safe_load(fh)
-    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
-        raise ValueError(
-            f"failed to parse configuration file {cfg_path}: {exc}"
-        ) from exc
-    return data or {}
-
-
-        Optional path to a YAML configuration file. When omitted, ``config.yaml``
-        located at the repository root is used. Missing files result in the
-        default configuration being returned.
-
+        Optional path to a YAML configuration file. Defaults to ``config.yaml``
+        in the repository root.
 
     Returns
     -------
     Config
-
         Parsed configuration object.
+
+    Raises
+    ------
+    yaml.YAMLError
+        If the configuration file contains invalid YAML.
+    ConfigError
+        If any configuration values are invalid.
     """
     cfg_path = Path(path) if path is not None else Path("config.yaml")
     data: Dict[str, Any] = {}
@@ -188,11 +157,32 @@ def load_config(path: str | Path | None = None) -> Config:
         with cfg_path.open("r", encoding="utf8") as fh:
             data = yaml.safe_load(fh) or {}
 
+    api_data = {
+        k: v
+        for k, v in data.get("api", {}).items()
+        if k in APISettings.__dataclass_fields__
+    }
+    timeouts_data = {
+        k: v
+        for k, v in data.get("timeouts", {}).items()
+        if k in TimeoutSettings.__dataclass_fields__
+    }
+    rate_limit_data = {
+        k: v
+        for k, v in data.get("rate_limits", {}).items()
+        if k in RateLimitSettings.__dataclass_fields__
+    }
+    output_data = {
+        k: v
+        for k, v in data.get("output", {}).items()
+        if k in OutputPaths.__dataclass_fields__
+    }
+
     return Config(
-        api=APISettings(**data.get("api", {})),
-        timeouts=TimeoutSettings(**data.get("timeouts", {})),
-        rate_limits=RateLimitSettings(**data.get("rate_limits", {})),
-        output=OutputPaths(**data.get("output", {})),
+        api=APISettings(**api_data),
+        timeouts=TimeoutSettings(**timeouts_data),
+        rate_limits=RateLimitSettings(**rate_limit_data),
+        output=OutputPaths(**output_data),
     )
 
 
@@ -209,5 +199,3 @@ __all__ = [
     "RateLimitSettings",
     "OutputPaths",
 ]
-
-

--- a/tests/data/sample_config.yaml
+++ b/tests/data/sample_config.yaml
@@ -1,3 +1,5 @@
-foo: bar
-nested:
-  value: 42
+api:
+  chembl_base_url: https://example.org/chembl
+timeouts:
+  connect: 5
+  read: 15

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,28 +1,8 @@
-
-from pathlib import Path
-
-from library.config import load_config
-
-DATA_DIR = Path(__file__).resolve().parent / "data"
-
-
-def test_load_config_reads_yaml() -> None:
-    path = DATA_DIR / "sample_config.yaml"
-    cfg = load_config(path)
-    assert cfg["foo"] == "bar"
-    assert cfg["nested"]["value"] == 42
-
-
-def test_load_config_missing_returns_empty(tmp_path: Path) -> None:
-    path = tmp_path / "missing.yaml"
-    cfg = load_config(path)
-    assert cfg == {}
-
+"""Tests for the configuration utilities."""
 
 from pathlib import Path
 
 import pytest
-
 
 from library.config import (
     APISettings,
@@ -30,7 +10,24 @@ from library.config import (
     ConfigError,
     OutputPaths,
     TimeoutSettings,
+    load_config,
 )
+
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def test_load_config_reads_yaml() -> None:
+    path = DATA_DIR / "sample_config.yaml"
+    cfg = load_config(path)
+    assert cfg.api.chembl_base_url == "https://example.org/chembl"
+    assert cfg.timeouts.connect == 5
+
+
+def test_load_config_missing_returns_default(tmp_path: Path) -> None:
+    path = tmp_path / "missing.yaml"
+    cfg = load_config(path)
+    assert cfg == Config()
 
 
 def test_negative_timeout_raises() -> None:
@@ -49,4 +46,3 @@ def test_non_writable_directory_raises(tmp_path: Path) -> None:
     bad_path.write_text("x")
     with pytest.raises(ConfigError):
         Config(output=OutputPaths(data_dir=bad_path))
-


### PR DESCRIPTION
## Summary
- remove stray stub of `load_config` and simplify `OutputPaths` typing
- return a validated `Config` object from `load_config`
- align tests and sample configuration with `Config` return type

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py`
- `pytest tests/test_config.py -q`
- `python -m py_compile library/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1af26a3288324bfc9294357865b5e