### PR TITLE
feat: support env overrides and yaml aliases in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,12 @@
 # comment explaining its purpose and the fallback applied when the value is
 # missing. Individual scripts may override any setting via command-line
 # arguments or environment variables.
+#
+# Environment variables override YAML values when present. For example,
+# ``CHEMBL_API_BASE_URL`` replaces the value of ``api.chembl_base_url`` and
+# ``TIMEOUT_CONNECT`` updates ``timeouts.connect``. Short aliases are also
+# recognised for convenience; e.g. ``api.chembl.url`` maps to
+# ``api.chembl_base_url``.
 
 api:
   timeout: 30.0

--- a/library/config.py
+++ b/library/config.py
@@ -1,40 +1,29 @@
-
 """Configuration utilities for data acquisition scripts.
 
-This module centralises configuration options such as timeouts, rate limits
-and output directories. Settings are loaded from ``config.yaml`` when
-available, otherwise built-in defaults are used.
-
-The :class:`Config` dataclass performs validation in ``__post_init__`` to
-ensure supplied values are sensible.  Invalid values raise
-:class:`ConfigError`.
-
+This module centralises configuration handling for the project.  Settings are
+loaded from a YAML file and validated using dataclasses.  Values in the YAML can
+be overridden by environment variables such as ``CHEMBL_API_BASE_URL`` or
+``TIMEOUT_CONNECT``.  Short aliases may also be used in the YAML for brevity,
+e.g. ``api.chembl.url`` which maps to ``APISettings.chembl_base_url``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import os
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Tuple, Type
 from urllib.parse import urlparse
-
 
 import yaml
 
 
-
-def load_config(path: str | Path) -> Dict[str, Any]:
-    """Load a YAML configuration file.
-
 class ConfigError(ValueError):
     """Raised when configuration values are invalid."""
- 
 
 
 @dataclass
 class APISettings:
-
     """Base URLs for external services."""
 
     chembl_base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
@@ -68,11 +57,12 @@ class RateLimitSettings:
 class OutputPaths:
     """Output directory configuration."""
 
-    data_dir: Path | str = Path("data")
-    logs_dir: Path | str = Path("logs")
-    tmp_dir: Path | str = Path("tmp")
+    data_dir: Path = Path("data")
+    logs_dir: Path = Path("logs")
+    tmp_dir: Path = Path("tmp")
 
     def __post_init__(self) -> None:
+        # Accept ``str`` inputs but store as :class:`Path`.
         self.data_dir = Path(self.data_dir)
         self.logs_dir = Path(self.logs_dir)
         self.tmp_dir = Path(self.tmp_dir)
@@ -80,7 +70,7 @@ class OutputPaths:
 
 @dataclass
 class Config:
-    """Application configuration loaded from ``config.yaml``.
+    """Validated application configuration.
 
     Parameters
     ----------
@@ -99,14 +89,8 @@ class Config:
     rate_limits: RateLimitSettings = field(default_factory=RateLimitSettings)
     output: OutputPaths = field(default_factory=OutputPaths)
 
-    def __post_init__(self) -> None:
-        """Validate configuration values.
-
-        Raises
-        ------
-        ConfigError
-            If any configuration value is invalid.
-        """
+    def __post_init__(self) -> None:  # noqa: D401 - short description inherited
+        """Validate configuration values."""
 
         # Validate timeouts
         for name, value in vars(self.timeouts).items():
@@ -131,68 +115,139 @@ class Config:
         for path in [self.output.data_dir, self.output.logs_dir, self.output.tmp_dir]:
             try:
                 path.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
+            except OSError as exc:  # pragma: no cover - filesystem errors rare
                 raise ConfigError(f"failed to create directory: {path}") from exc
             if not os.access(path, os.W_OK):
                 raise ConfigError(f"directory not writable: {path}")
 
 
-def load_config(path: str | Path | None = None) -> Config:
-    """Return configuration loaded from ``path`` or defaults.
+# ---------------------------------------------------------------------------
+# Aliases and environment variable overrides
+# ---------------------------------------------------------------------------
 
+# Mapping of dotted alias paths in the YAML file to canonical configuration
+# keys used by the dataclasses.
+_ALIAS_MAP: Dict[Tuple[str, ...], Tuple[str, ...]] = {
+    ("api", "chembl", "url"): ("api", "chembl_base_url"),
+    ("api", "pubchem", "url"): ("api", "pubchem_base_url"),
+    ("api", "uniprot", "url"): ("api", "uniprot_base_url"),
+    ("api", "eutils", "url"): ("api", "eutils_base_url"),
+    ("api", "semanticscholar", "url"): ("api", "semanticscholar_base_url"),
+    ("api", "openalex", "url"): ("api", "openalex_base_url"),
+    ("api", "crossref", "url"): ("api", "crossref_base_url"),
+    ("api", "gtp", "url"): ("api", "gtp_base_url"),
+}
+
+
+# Environment variables overriding configuration values.  Each entry maps the
+# variable name to a tuple of (config path, type-caster).
+_ENV_VAR_MAP: Dict[str, Tuple[Tuple[str, ...], Type[Any]]] = {
+    "CHEMBL_API_BASE_URL": (("api", "chembl_base_url"), str),
+    "PUBCHEM_API_BASE_URL": (("api", "pubchem_base_url"), str),
+    "UNIPROT_API_BASE_URL": (("api", "uniprot_base_url"), str),
+    "EUTILS_API_BASE_URL": (("api", "eutils_base_url"), str),
+    "SEMANTICSCHOLAR_API_BASE_URL": (("api", "semanticscholar_base_url"), str),
+    "OPENALEX_API_BASE_URL": (("api", "openalex_base_url"), str),
+    "CROSSREF_API_BASE_URL": (("api", "crossref_base_url"), str),
+    "GTP_API_BASE_URL": (("api", "gtp_base_url"), str),
+    "TIMEOUT_CONNECT": (("timeouts", "connect"), float),
+    "TIMEOUT_READ": (("timeouts", "read"), float),
+    "RATE_LIMIT_MAX_REQUESTS_PER_SECOND": (
+        ("rate_limits", "max_requests_per_second"),
+        float,
+    ),
+    "RATE_LIMIT_MAX_RETRIES": (("rate_limits", "max_retries"), int),
+    "RATE_LIMIT_BACKOFF_FACTOR": (("rate_limits", "backoff_factor"), float),
+    "OUTPUT_DATA_DIR": (("output", "data_dir"), str),
+    "OUTPUT_LOGS_DIR": (("output", "logs_dir"), str),
+    "OUTPUT_TMP_DIR": (("output", "tmp_dir"), str),
+}
+
+
+def _deep_get(data: Dict[str, Any], path: Tuple[str, ...]) -> Any | None:
+    """Retrieve a value from ``data`` following ``path``."""
+
+    cur: Any = data
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None
+        cur = cur[key]
+    return cur
+
+
+def _deep_set(data: Dict[str, Any], path: Tuple[str, ...], value: Any) -> None:
+    """Set ``value`` in ``data`` at ``path`` creating nested dictionaries."""
+
+    cur = data
+    for key in path[:-1]:
+        cur = cur.setdefault(key, {})
+    cur[path[-1]] = value
+
+
+def _apply_aliases(data: Dict[str, Any]) -> None:
+    """Expand short-form aliases within ``data``."""
+
+    for alias, target in _ALIAS_MAP.items():
+        value = _deep_get(data, alias)
+        if value is not None:
+            _deep_set(data, target, value)
+
+
+def _override_with_env(data: Dict[str, Any], env: Mapping[str, str]) -> None:
+    """Override ``data`` with values from ``env`` according to ``_ENV_VAR_MAP``."""
+
+    for var, (path, caster) in _ENV_VAR_MAP.items():
+        if var in env:
+            raw = env[var]
+            try:
+                value = caster(raw)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                value = raw
+            _deep_set(data, path, value)
+
+
+def _filter_section(data: Dict[str, Any], cls: Type[Any]) -> Dict[str, Any]:
+    """Return ``data`` with keys not present on ``cls`` removed."""
+
+    valid = set(cls.__dataclass_fields__.keys())
+    return {k: v for k, v in data.items() if k in valid}
+
+
+def load_config(path: str | Path | None = None) -> Config:
+    """Load configuration from ``path`` and apply overrides.
 
     Parameters
     ----------
     path:
-
-        Location of the configuration file.
-
-    Returns
-    -------
-    dict[str, Any]
-        Parsed configuration settings. An empty dictionary is returned if the
-        file does not exist.
-
-    Raises
-    ------
-    ValueError
-        If the file exists but contains invalid YAML.
-    """
-    cfg_path = Path(path)
-    if not cfg_path.exists():
-        return {}
-    try:
-        with cfg_path.open("r", encoding="utf8") as fh:
-            data = yaml.safe_load(fh)
-    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
-        raise ValueError(
-            f"failed to parse configuration file {cfg_path}: {exc}"
-        ) from exc
-    return data or {}
-
-
         Optional path to a YAML configuration file. When omitted, ``config.yaml``
-        located at the repository root is used. Missing files result in the
-        default configuration being returned.
-
+        in the repository root is used. Missing files yield the default
+        configuration.
 
     Returns
     -------
     Config
-
-        Parsed configuration object.
+        Parsed configuration object with environment variable overrides
+        applied.
     """
+
     cfg_path = Path(path) if path is not None else Path("config.yaml")
     data: Dict[str, Any] = {}
     if cfg_path.exists():
         with cfg_path.open("r", encoding="utf8") as fh:
             data = yaml.safe_load(fh) or {}
 
+    _apply_aliases(data)
+    _override_with_env(data, os.environ)
+
     return Config(
-        api=APISettings(**data.get("api", {})),
-        timeouts=TimeoutSettings(**data.get("timeouts", {})),
-        rate_limits=RateLimitSettings(**data.get("rate_limits", {})),
-        output=OutputPaths(**data.get("output", {})),
+        api=APISettings(**_filter_section(data.get("api", {}), APISettings)),
+        timeouts=TimeoutSettings(
+            **_filter_section(data.get("timeouts", {}), TimeoutSettings)
+        ),
+        rate_limits=RateLimitSettings(
+            **_filter_section(data.get("rate_limits", {}), RateLimitSettings)
+        ),
+        output=OutputPaths(**_filter_section(data.get("output", {}), OutputPaths)),
     )
 
 
@@ -202,12 +257,10 @@ DEFAULT_CONFIG = load_config()
 __all__ = [
     "Config",
     "ConfigError",
-    "load_config",
-    "DEFAULT_CONFIG",
     "APISettings",
     "TimeoutSettings",
     "RateLimitSettings",
     "OutputPaths",
+    "load_config",
+    "DEFAULT_CONFIG",
 ]
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,28 +1,11 @@
+"""Tests for configuration loading and validation."""
 
-from pathlib import Path
+from __future__ import annotations
 
-from library.config import load_config
-
-DATA_DIR = Path(__file__).resolve().parent / "data"
-
-
-def test_load_config_reads_yaml() -> None:
-    path = DATA_DIR / "sample_config.yaml"
-    cfg = load_config(path)
-    assert cfg["foo"] == "bar"
-    assert cfg["nested"]["value"] == 42
-
-
-def test_load_config_missing_returns_empty(tmp_path: Path) -> None:
-    path = tmp_path / "missing.yaml"
-    cfg = load_config(path)
-    assert cfg == {}
-
-
+import textwrap
 from pathlib import Path
 
 import pytest
-
 
 from library.config import (
     APISettings,
@@ -30,23 +13,64 @@ from library.config import (
     ConfigError,
     OutputPaths,
     TimeoutSettings,
+    load_config,
 )
 
 
+def test_alias_expansion(tmp_path: Path) -> None:
+    """Short-form aliases in YAML map to canonical keys."""
+
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(
+        textwrap.dedent(
+            """
+            api:
+              chembl:
+                url: https://example.org/api
+            """
+        )
+    )
+    cfg = load_config(cfg_file)
+    assert cfg.api.chembl_base_url == "https://example.org/api"
+
+
+def test_env_var_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables override YAML values."""
+
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("timeouts:\n  connect: 5")
+    monkeypatch.setenv("TIMEOUT_CONNECT", "99")
+    cfg = load_config(cfg_file)
+    assert cfg.timeouts.connect == 99.0
+
+
+def test_missing_file_returns_defaults(tmp_path: Path) -> None:
+    """Loading a missing file yields default settings."""
+
+    path = tmp_path / "missing.yaml"
+    cfg = load_config(path)
+    assert cfg.api.chembl_base_url == APISettings().chembl_base_url
+
+
 def test_negative_timeout_raises() -> None:
+    """Validation rejects negative timeout values."""
+
     with pytest.raises(ConfigError):
         Config(timeouts=TimeoutSettings(connect=-1, read=10))
 
 
 def test_invalid_url_raises() -> None:
+    """Validation fails on malformed URLs."""
+
     api = APISettings(chembl_base_url="not-a-url")
     with pytest.raises(ConfigError):
         Config(api=api)
 
 
 def test_non_writable_directory_raises(tmp_path: Path) -> None:
+    """Non-writable output directories are rejected."""
+
     bad_path = tmp_path / "file"
     bad_path.write_text("x")
     with pytest.raises(ConfigError):
         Config(output=OutputPaths(data_dir=bad_path))
-


### PR DESCRIPTION
## Summary
- allow YAML config keys to be overridden by environment variables
- add short YAML aliases like `api.chembl.url`
- document override and alias behaviour

## Testing
- `ruff check library/config.py tests/test_config.py`
- `black library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1af2112a08324a9f08b71ed17a6f1