### PR TITLE
Add env override support to config loader and expand tests

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1,14 +1,10 @@
-
 """Configuration utilities for data acquisition scripts.
 
 This module centralises configuration options such as timeouts, rate limits
 and output directories. Settings are loaded from ``config.yaml`` when
-available, otherwise built-in defaults are used.
-
-The :class:`Config` dataclass performs validation in ``__post_init__`` to
-ensure supplied values are sensible.  Invalid values raise
-:class:`ConfigError`.
-
+available, otherwise built-in defaults are used. Values can be overridden
+using environment variables prefixed with ``CHEMBL_``. Nested fields are
+separated by double underscores, e.g. ``CHEMBL_TIMEOUTS__CONNECT``.
 """
 
 from __future__ import annotations
@@ -16,25 +12,18 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Type
 from urllib.parse import urlparse
-
 
 import yaml
 
 
-
-def load_config(path: str | Path) -> Dict[str, Any]:
-    """Load a YAML configuration file.
-
 class ConfigError(ValueError):
     """Raised when configuration values are invalid."""
- 
 
 
 @dataclass
 class APISettings:
-
     """Base URLs for external services."""
 
     chembl_base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
@@ -68,11 +57,12 @@ class RateLimitSettings:
 class OutputPaths:
     """Output directory configuration."""
 
-    data_dir: Path | str = Path("data")
-    logs_dir: Path | str = Path("logs")
-    tmp_dir: Path | str = Path("tmp")
+    data_dir: Path = Path("data")
+    logs_dir: Path = Path("logs")
+    tmp_dir: Path = Path("tmp")
 
     def __post_init__(self) -> None:
+        # Allow providing string paths but store as ``Path`` instances.
         self.data_dir = Path(self.data_dir)
         self.logs_dir = Path(self.logs_dir)
         self.tmp_dir = Path(self.tmp_dir)
@@ -131,73 +121,87 @@ class Config:
         for path in [self.output.data_dir, self.output.logs_dir, self.output.tmp_dir]:
             try:
                 path.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
+            except OSError as exc:  # pragma: no cover - unlikely on CI
                 raise ConfigError(f"failed to create directory: {path}") from exc
             if not os.access(path, os.W_OK):
                 raise ConfigError(f"directory not writable: {path}")
 
 
-def load_config(path: str | Path | None = None) -> Config:
-    """Return configuration loaded from ``path`` or defaults.
+def _apply_env_overrides(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge environment variable overrides into ``data``.
 
+    Environment variable names must start with ``CHEMBL_``. Nested configuration
+    sections are separated by double underscores. For example::
+
+        CHEMBL_TIMEOUTS__CONNECT=5
 
     Parameters
     ----------
-    path:
-
-        Location of the configuration file.
+    data:
+        Configuration mapping to update in place.
 
     Returns
     -------
     dict[str, Any]
-        Parsed configuration settings. An empty dictionary is returned if the
-        file does not exist.
-
-    Raises
-    ------
-    ValueError
-        If the file exists but contains invalid YAML.
+        The updated mapping.
     """
-    cfg_path = Path(path)
-    if not cfg_path.exists():
-        return {}
-    try:
-        with cfg_path.open("r", encoding="utf8") as fh:
-            data = yaml.safe_load(fh)
-    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
-        raise ValueError(
-            f"failed to parse configuration file {cfg_path}: {exc}"
-        ) from exc
-    return data or {}
+
+    prefix = "CHEMBL_"
+    for key, value in os.environ.items():
+        if not key.startswith(prefix):
+            continue
+        path = key[len(prefix) :].lower().split("__")
+        current = data
+        for part in path[:-1]:
+            current = current.setdefault(part, {})
+        current[path[-1]] = yaml.safe_load(value)
+    return data
 
 
-        Optional path to a YAML configuration file. When omitted, ``config.yaml``
-        located at the repository root is used. Missing files result in the
-        default configuration being returned.
+def _filter_kwargs(data: Dict[str, Any], cls: Type[Any]) -> Dict[str, Any]:
+    """Return mapping of keys in ``data`` that match ``cls`` fields."""
 
+    valid_keys = set(getattr(cls, "__dataclass_fields__", {}))
+    return {k: v for k, v in data.items() if k in valid_keys}
+
+
+def load_config(path: str | Path | None = None) -> Config:
+    """Return configuration loaded from ``path`` or defaults.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a YAML configuration file. When omitted,
+        ``config.yaml`` located at the repository root is used. Missing files
+        result in the default configuration being returned.
 
     Returns
     -------
     Config
-
         Parsed configuration object.
     """
+
     cfg_path = Path(path) if path is not None else Path("config.yaml")
     data: Dict[str, Any] = {}
     if cfg_path.exists():
         with cfg_path.open("r", encoding="utf8") as fh:
             data = yaml.safe_load(fh) or {}
 
+    data = _apply_env_overrides(data)
+
     return Config(
-        api=APISettings(**data.get("api", {})),
-        timeouts=TimeoutSettings(**data.get("timeouts", {})),
-        rate_limits=RateLimitSettings(**data.get("rate_limits", {})),
-        output=OutputPaths(**data.get("output", {})),
+        api=APISettings(**_filter_kwargs(data.get("api", {}), APISettings)),
+        timeouts=TimeoutSettings(
+            **_filter_kwargs(data.get("timeouts", {}), TimeoutSettings)
+        ),
+        rate_limits=RateLimitSettings(
+            **_filter_kwargs(data.get("rate_limits", {}), RateLimitSettings)
+        ),
+        output=OutputPaths(**_filter_kwargs(data.get("output", {}), OutputPaths)),
     )
 
 
 DEFAULT_CONFIG = load_config()
-
 
 __all__ = [
     "Config",
@@ -209,5 +213,3 @@ __all__ = [
     "RateLimitSettings",
     "OutputPaths",
 ]
-
-

--- a/tests/data/invalid_url.yaml
+++ b/tests/data/invalid_url.yaml
@@ -1,0 +1,2 @@
+api:
+  chembl_base_url: "not-a-url"

--- a/tests/data/negative_timeout.yaml
+++ b/tests/data/negative_timeout.yaml
@@ -1,0 +1,2 @@
+timeouts:
+  connect: -5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,52 +1,85 @@
+"""Tests for configuration loading and validation."""
 
-from pathlib import Path
-
-from library.config import load_config
-
-DATA_DIR = Path(__file__).resolve().parent / "data"
-
-
-def test_load_config_reads_yaml() -> None:
-    path = DATA_DIR / "sample_config.yaml"
-    cfg = load_config(path)
-    assert cfg["foo"] == "bar"
-    assert cfg["nested"]["value"] == 42
-
-
-def test_load_config_missing_returns_empty(tmp_path: Path) -> None:
-    path = tmp_path / "missing.yaml"
-    cfg = load_config(path)
-    assert cfg == {}
-
+from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-
-from library.config import (
-    APISettings,
-    Config,
-    ConfigError,
-    OutputPaths,
-    TimeoutSettings,
-)
+from library.config import Config, ConfigError, load_config
 
 
-def test_negative_timeout_raises() -> None:
-    with pytest.raises(ConfigError):
-        Config(timeouts=TimeoutSettings(connect=-1, read=10))
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def test_load_config_applies_values(tmp_path: Path) -> None:
+    """Values from the YAML file should populate the dataclass."""
+
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(
+        f"""
+api:
+  chembl_base_url: https://example.com/api
+timeouts:
+  connect: 5
+rate_limits:
+  max_requests_per_second: 10
+output:
+  data_dir: {tmp_path / 'out'}
+"""
+    )
+
+    cfg = load_config(cfg_file)
+    assert cfg.api.chembl_base_url == "https://example.com/api"
+    assert cfg.timeouts.connect == 5
+    assert cfg.rate_limits.max_requests_per_second == 10
+    assert cfg.output.data_dir == tmp_path / "out"
+
+
+def test_load_config_missing_returns_defaults(tmp_path: Path) -> None:
+    """Missing config files should return default settings."""
+
+    cfg = load_config(tmp_path / "missing.yaml")
+    assert isinstance(cfg, Config)
+    assert cfg.timeouts.connect == 10.0
 
 
 def test_invalid_url_raises() -> None:
-    api = APISettings(chembl_base_url="not-a-url")
+    """Invalid URLs in the YAML file should raise ``ConfigError``."""
+
     with pytest.raises(ConfigError):
-        Config(api=api)
+        load_config(DATA_DIR / "invalid_url.yaml")
+
+
+def test_negative_timeout_raises() -> None:
+    """Negative timeout values should raise ``ConfigError``."""
+
+    with pytest.raises(ConfigError):
+        load_config(DATA_DIR / "negative_timeout.yaml")
+
+
+def test_environment_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables should override YAML values."""
+
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("timeouts:\n  connect: 5\n")
+
+    monkeypatch.setenv("CHEMBL_TIMEOUTS__CONNECT", "15")
+    monkeypatch.setenv("CHEMBL_OUTPUT__DATA_DIR", str(tmp_path / "env_out"))
+
+    cfg = load_config(cfg_file)
+    assert cfg.timeouts.connect == 15
+    assert cfg.output.data_dir == tmp_path / "env_out"
 
 
 def test_non_writable_directory_raises(tmp_path: Path) -> None:
-    bad_path = tmp_path / "file"
-    bad_path.write_text("x")
-    with pytest.raises(ConfigError):
-        Config(output=OutputPaths(data_dir=bad_path))
+    """Directories specified as files should raise ``ConfigError``."""
 
+    bad_file = tmp_path / "file"
+    bad_file.write_text("x")
+
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text(f"output:\n  data_dir: {bad_file}\n")
+
+    with pytest.raises(ConfigError):
+        load_config(cfg_file)


### PR DESCRIPTION
## Summary
- support environment variable overrides and ignore unknown keys when loading config
- add tests for config loading, validation errors, and environment overrides
- add YAML fixtures for invalid URLs and negative timeouts

## Testing
- `python -m black library/config.py tests/test_config.py`
- `python -m ruff check library/config.py tests/test_config.py`
- `python -m mypy --ignore-missing-imports library/config.py tests/test_config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1af5b12c883248e1f900dd37178cf