### PR TITLE
Handle YAML parsing errors

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -443,8 +443,13 @@ def load_config(
 
     cfg = Config()
     if path and Path(path).is_file():
-        with Path(path).open("r", encoding="utf8") as fh:
-            data = yaml.safe_load(fh) or {}
+        try:
+            with Path(path).open("r", encoding="utf8") as fh:
+                data = yaml.safe_load(fh) or {}
+        except yaml.YAMLError as err:
+            raise ValueError(
+                f"Failed to parse YAML configuration at {path}: {err}"
+            ) from err
         if not isinstance(data, dict):
             raise TypeError("top-level structure in config file must be a mapping")
         _update_from_dict(cfg, data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,3 +85,13 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert not out.exists() and not cache.exists()
     ensure_dirs(cfg)
     assert out.is_dir() and cache.is_dir()
+
+
+def test_yaml_error_includes_path(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("api: [\n")  # malformed YAML
+    with pytest.raises(ValueError) as excinfo:
+        load_config(path)
+    msg = str(excinfo.value)
+    assert str(path) in msg
+    assert "while parsing" in msg


### PR DESCRIPTION
## Summary
- raise a ValueError with file path when `load_config` encounters invalid YAML
- test that malformed YAML surfaces the file path and original parsing error

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b349ba948324b72b858f7a242f38