### PR TITLE
feat: warn on unknown config keys

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -18,12 +18,16 @@ sections and keys are joined by double underscores. Short aliases such as
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, is_dataclass
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
 from urllib.parse import urlparse
+
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -245,20 +249,39 @@ def _coerce(value: str, current: Any) -> Any:
 
 
 def _update_from_dict(
-    obj: Any, data: Dict[str, Any], path: List[str] | None = None
+    obj: Any,
+    data: Dict[str, Any],
+    path: List[str] | None = None,
+    *,
+    unknown_keys: List[str] | None = None,
 ) -> None:
-    """Recursively update dataclass ``obj`` with ``data`` validating types."""
+    """Recursively update dataclass ``obj`` with ``data`` validating types.
+
+    Parameters
+    ----------
+    obj:
+        Dataclass instance to update.
+    data:
+        Mapping of field names to values.
+    path:
+        Current traversal path used for error reporting.
+    unknown_keys:
+        Collects dotted-path names of keys not present on ``obj``.
+    """
 
     path = [] if path is None else path
+    if unknown_keys is None:
+        unknown_keys = []
     for key, val in data.items():
         if not hasattr(obj, key):
+            unknown_keys.append(".".join(path + [key]))
             continue
         current = getattr(obj, key)
         if is_dataclass(current):
             if not isinstance(val, dict):
                 joined = ".".join(path + [key])
                 raise TypeError(f"{joined} must be a mapping")
-            _update_from_dict(current, val, path + [key])
+            _update_from_dict(current, val, path + [key], unknown_keys=unknown_keys)
             continue
         if isinstance(val, str):
             try:
@@ -423,7 +446,10 @@ def ensure_dirs(cfg: Config) -> None:
 
 
 def load_config(
-    path: str | Path = "config.yaml", cli_overrides: Dict[str, Any] | None = None
+    path: str | Path = "config.yaml",
+    cli_overrides: Dict[str, Any] | None = None,
+    *,
+    strict: bool = False,
 ) -> Config:
     """Load configuration from ``path`` applying environment and CLI overrides.
 
@@ -434,6 +460,9 @@ def load_config(
     cli_overrides:
         Mapping of ``"section.key"`` paths to values coming from the command
         line.
+    strict:
+        When ``True`` raise :class:`ValueError` for unknown configuration keys;
+        otherwise a warning is emitted.
 
     Returns
     -------
@@ -442,12 +471,20 @@ def load_config(
     """
 
     cfg = Config()
+    unknown_keys: List[str] = []
     if path and Path(path).is_file():
         with Path(path).open("r", encoding="utf8") as fh:
             data = yaml.safe_load(fh) or {}
         if not isinstance(data, dict):
             raise TypeError("top-level structure in config file must be a mapping")
-        _update_from_dict(cfg, data)
+        _update_from_dict(cfg, data, unknown_keys=unknown_keys)
+
+    if unknown_keys:
+        joined = ", ".join(sorted(unknown_keys))
+        msg = f"Unknown configuration key(s) in {path}: {joined}"
+        if strict:
+            raise ValueError(msg)
+        logger.warning(msg)
 
     _apply_env_overrides(cfg)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -85,3 +86,18 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert not out.exists() and not cache.exists()
     ensure_dirs(cfg)
     assert out.is_dir() and cache.is_dir()
+
+
+def test_unknown_key_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("unknown: 1\napi:\n  rps: 1\n")
+    with caplog.at_level(logging.WARNING, logger="library.config"):
+        load_config(path)
+    assert "Unknown configuration key" in caplog.text
+
+
+def test_unknown_key_error(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("unknown: 1\n")
+    with pytest.raises(ValueError, match="Unknown configuration key"):
+        load_config(path, strict=True)


### PR DESCRIPTION
## Summary
- track unknown keys while loading configuration
- warn or error for unexpected keys via new strict flag
- test detection of unknown configuration keys

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3287d488324b23709d47dde4375