### PR TITLE
refactor: unify configuration access

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
 from typing import Sequence
 
 import requests
@@ -12,14 +11,13 @@ import requests
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
-from library.config import load_config
+from library.config import Config, load_config
 from library.table_quality import analyze_table_quality
-from library.config import DEFAULT_CONFIG
 
 logger = logging.getLogger(__name__)
 
 
-def run_chembl(args: argparse.Namespace) -> int:
+def run_chembl(args: argparse.Namespace, cfg: Config) -> int:
     """Execute activity retrieval from the ChEMBL API.
 
     Parameters
@@ -45,7 +43,12 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_activities(ids, chunk_size=args.chunk_size, timeout=args.timeout)
+        df = cl.get_activities(
+            ids,
+            cfg=cfg,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)
         return 1
@@ -72,9 +75,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=float,
-
-        default=DEFAULT_CONFIG.timeouts.read,
-
+        default=None,
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)
@@ -85,17 +86,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.timeout is None:
-        args.timeout = float(config.get("timeouts", {}).get("read", 30.0))
+        args.timeout = cfg.timeouts.read
     if args.output_csv is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
 from typing import Sequence
 
 import requests
@@ -13,13 +12,13 @@ from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
-from library.config import load_config
+from library.config import Config, load_config
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
 
 
-def run_chembl(args: argparse.Namespace) -> int:
+def run_chembl(args: argparse.Namespace, cfg: Config) -> int:
     """Execute assay retrieval from the ChEMBL API.
 
     Parameters
@@ -45,7 +44,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_assays(ids, chunk_size=args.chunk_size)
+        df = cl.get_assays(ids, cfg=cfg, chunk_size=args.chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
@@ -78,15 +77,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.output_csv is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -40,7 +40,7 @@ from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
-from library.config import load_config
+from library.config import Config, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,8 @@ def fetch_pubmed_records(
     sleep: float,
     max_workers: int = 1,
     batch_size: int = 100,
+    *,
+    cfg: Config,
 ) -> pd.DataFrame:
     """Retrieve metadata for a list of PubMed identifiers.
 
@@ -82,12 +84,12 @@ def fetch_pubmed_records(
         """
         try:
             with requests.Session() as session:
-                pubmed_list = pl.fetch_pubmed_batch(session, batch, sleep)
+                pubmed_list = pl.fetch_pubmed_batch(session, batch, sleep, cfg)
                 pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
 
                 # Fetch Semantic Scholar data in a single batch
                 semsch_list = ssl.fetch_semantic_scholar_batch(
-                    session, pmids_in_batch, sleep
+                    session, pmids_in_batch, sleep, cfg
                 )
 
                 # Create a map for easy lookup
@@ -99,9 +101,9 @@ def fetch_pubmed_records(
                     semsch = semsch_map.get(pmid, {})
 
                     # Still fetching these individually for now
-                    openalex = ocl.fetch_openalex(session, pmid, sleep)
+                    openalex = ocl.fetch_openalex(session, pmid, sleep, cfg=cfg)
                     doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
-                    crossref = ocl.fetch_crossref(session, doi, sleep)
+                    crossref = ocl.fetch_crossref(session, doi, sleep, cfg=cfg)
 
                     combined: dict[str, str] = {}
                     combined.update(pubmed)
@@ -134,7 +136,7 @@ def fetch_pubmed_records(
     return pd.DataFrame(records)
 
 
-def run_pubmed(args: argparse.Namespace) -> int:
+def run_pubmed(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the ``pubmed`` sub-command."""
     try:
         pmids = io.read_ids(
@@ -143,7 +145,9 @@ def run_pubmed(args: argparse.Namespace) -> int:
             sep=args.sep,
             encoding=args.encoding,
         )
-        df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
+        df = fetch_pubmed_records(
+            pmids, args.sleep, args.workers, args.batch_size, cfg=cfg
+        )
         output = args.output_csv or io.default_output_path(args.input_csv)
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -158,7 +162,7 @@ def run_pubmed(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_chembl(args: argparse.Namespace) -> int:
+def run_chembl(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the ``chembl`` sub-command."""
     try:
         ids = io.read_ids(
@@ -169,7 +173,9 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        df = cl.get_documents(  # type: ignore[attr-defined]
+            ids, cfg=cfg, chunk_size=args.chunk_size
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -188,7 +194,7 @@ def run_chembl(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_all(args: argparse.Namespace) -> int:
+def run_all(args: argparse.Namespace, cfg: Config) -> int:
     """Run ChEMBL and PubMed pipelines and merge their outputs."""
     try:
         ids = io.read_ids(
@@ -199,7 +205,9 @@ def run_all(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        doc_df = cl.get_documents(  # type: ignore[attr-defined]
+            ids, cfg=cfg, chunk_size=args.chunk_size
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -231,7 +239,9 @@ def run_all(args: argparse.Namespace) -> int:
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
     pubmed_ids = pd.to_numeric(doc_df["pubmed_id"], errors="coerce").astype("Int64")
     pmids = pubmed_ids.dropna().astype(str).tolist()
-    pub_df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
+    pub_df = fetch_pubmed_records(
+        pmids, args.sleep, args.workers, args.batch_size, cfg=cfg
+    )
     doc_df["pubmed_id"] = pubmed_ids.astype(str)
     if not pub_df.empty and "PubMed.PMID" in pub_df.columns:
         pub_df["PubMed.PMID"] = (
@@ -393,19 +403,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if hasattr(args, "output_csv") and getattr(args, "output_csv") is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     if getattr(args, "sleep", None) is None:
-        rate = config.get("rate_limits", {}).get("max_requests_per_second")
-        if rate:
-            args.sleep = 1 / rate
+        args.sleep = 1 / cfg.rate_limits.max_requests_per_second
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -16,12 +16,12 @@ from typing import Sequence
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
-from library.config import load_config
+from library.config import Config, load_config
 
 logger = logging.getLogger(__name__)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace, cfg: Config) -> int:
     """Execute table combination routine.
 
     Parameters
@@ -123,11 +123,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.out_dir is None:
-        args.out_dir = Path(config.get("output", {}).get("data_dir", "."))
+        args.out_dir = cfg.output.data_dir
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -18,7 +18,7 @@ from library import target_postprocessing as tp
 from library import uniprot_library as uu
 from library.cli import configure_logging
 from library.table_quality import analyze_table_quality
-from library.config import load_config
+from library.config import Config, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -271,7 +271,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def run_uniprot(args: argparse.Namespace) -> int:
+def run_uniprot(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the ``uniprot`` sub-command.
 
     Parameters
@@ -340,7 +340,7 @@ def run_uniprot(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_chembl(args: argparse.Namespace) -> int:
+def run_chembl(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the ``chembl`` sub-command."""
     try:
         ids = io.read_ids(
@@ -351,7 +351,7 @@ def run_chembl(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_targets(ids)
+        df = cl.get_targets(ids, cfg=cfg)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
@@ -370,7 +370,7 @@ def run_chembl(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_iuphar(args: argparse.Namespace) -> int:
+def run_iuphar(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the ``iuphar`` sub-command."""
     try:
         data = ii.IUPHARData.from_files(
@@ -396,7 +396,7 @@ def run_iuphar(args: argparse.Namespace) -> int:
     return 0
 
 
-def run_all(args: argparse.Namespace) -> int:
+def run_all(args: argparse.Namespace, cfg: Config) -> int:
     """Run ChEMBL, UniProt and IUPHAR pipelines and merge their outputs.
 
     The merged table is cleaned and normalised using
@@ -434,7 +434,7 @@ def run_all(args: argparse.Namespace) -> int:
             sep=args.sep,
             encoding=args.encoding,
         )
-        if run_chembl(chembl_args) != 0:
+        if run_chembl(chembl_args, cfg) != 0:
             return 1
         chembl_df = pd.read_csv(
             chembl_out, sep=args.sep, encoding=args.encoding, dtype=str
@@ -467,7 +467,7 @@ def run_all(args: argparse.Namespace) -> int:
             column="uniprot_id",
         )
         try:
-            if run_uniprot(uniprot_args) != 0:
+            if run_uniprot(uniprot_args, cfg) != 0:
                 return 1
         finally:
             tmp_path.unlink(missing_ok=True)
@@ -533,7 +533,7 @@ def run_all(args: argparse.Namespace) -> int:
             encoding=args.encoding,
         )
         try:
-            if run_iuphar(iuphar_args) != 0:
+            if run_iuphar(iuphar_args, cfg) != 0:
                 return 1
         finally:
             iuphar_input.unlink(missing_ok=True)
@@ -572,16 +572,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if hasattr(args, "output_csv") and args.output_csv is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     configure_logging(args.log_level)
     if hasattr(args, "func"):
-        return args.func(args)
+        return args.func(args, cfg)
     parser.print_help()
     return 1
 

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
@@ -14,7 +13,7 @@ from library import chembl_library as cl
 from library import pubchem_library as pl
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
-from library.config import load_config
+from library.config import Config, load_config
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -95,7 +94,7 @@ def add_pubchem_data(df: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([df.reset_index(drop=True), pubchem_df], axis=1)
 
 
-def run_chembl(args: argparse.Namespace) -> int:
+def run_chembl(args: argparse.Namespace, cfg: Config) -> int:
     """Execute compound retrieval from the ChEMBL API and augment with PubChem data.
 
     Parameters
@@ -123,7 +122,7 @@ def run_chembl(args: argparse.Namespace) -> int:
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
-        df = cl.get_testitem(ids, chunk_size=args.chunk_size)
+        df = cl.get_testitem(ids, cfg=cfg, chunk_size=args.chunk_size)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
@@ -161,15 +160,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.output_csv is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -8,7 +8,7 @@ directory.
 """
 
 from . import io, validation
-from .config import Config, get_config
+from .config import Config
 from .document_type_terms import (
     EXPERIMENTAL_TERMS,
     REVIEW_TERMS,
@@ -27,5 +27,4 @@ __all__ = [
     "io",
     "validation",
     "Config",
-    "get_config",
 ]

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -9,6 +9,7 @@ import logging
 import pandas as pd
 
 from .chembl_client import _chunked, request_json
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -93,12 +94,17 @@ TESTITEM_COLUMNS = [
 ]
 
 
-def get_assay(chembl_assay_id: str, *, timeout: float = 30.0) -> pd.DataFrame:
+def get_assay(
+    chembl_assay_id: str,
+    *,
+    cfg: Config,
+    timeout: float | None = None,
+) -> pd.DataFrame:
     """Retrieve assay information as a DataFrame."""
     if chembl_assay_id in {"", "#N/A"}:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
     url = ASSAY_URL.format(id=chembl_assay_id)
-    data = request_json(url, timeout=timeout)
+    data = request_json(cfg, url, timeout=timeout)
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
@@ -111,8 +117,9 @@ def get_assay(chembl_assay_id: str, *, timeout: float = 30.0) -> pd.DataFrame:
 def get_assays(
     ids: Iterable[str],
     *,
+    cfg: Config,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
     require_variant_sequence: bool = False,
 ) -> pd.DataFrame:
     """Fetch assay records for *ids*.
@@ -144,7 +151,7 @@ def get_assays(
         base += "&variant_sequence__isnull=false"
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&assay_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(cfg, url, timeout=timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
             df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
@@ -161,8 +168,9 @@ def get_assays(
 def get_activities(
     ids: Iterable[str],
     *,
+    cfg: Config,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Fetch activity records for *ids*.
 
@@ -189,7 +197,7 @@ def get_activities(
     base = "https://www.ebi.ac.uk/chembl/api/data/activity.json?format=json"
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&activity_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(cfg, url, timeout=timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
@@ -202,8 +210,9 @@ def get_activities(
 def get_testitem(
     ids: Iterable[str],
     *,
+    cfg: Config,
     chunk_size: int = 5,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Fetch compound records for *ids*."""
     valid = [i for i in ids if i not in {"", "#N/A"}]
@@ -214,7 +223,7 @@ def get_testitem(
     base = "https://www.ebi.ac.uk/chembl/api/data/molecule.json?format=json"
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&molecule_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(cfg, url, timeout=timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -10,33 +10,25 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .config import DEFAULT_CONFIG
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
-# Configure session with retry/backoff for robustness using shared config
-_retry = Retry(
-    total=DEFAULT_CONFIG.rate_limits.max_retries,
-    backoff_factor=DEFAULT_CONFIG.rate_limits.backoff_factor,
-    status_forcelist=[500, 502, 503, 504],
-    allowed_methods=["GET"],
-)
-_session = requests.Session()
-_adapter = HTTPAdapter(max_retries=_retry)
-_session.mount("http://", _adapter)
-_session.mount("https://", _adapter)
 
-
-def request_json(url: str, *, timeout: float | None = None) -> dict[str, Any]:
+def request_json(
+    cfg: Config, url: str, *, timeout: float | None = None
+) -> dict[str, Any]:
     """Return JSON content from ``url``.
 
     Parameters
     ----------
+    cfg:
+        Application configuration containing timeout and retry settings.
     url:
         API endpoint to query.
     timeout:
-        Maximum number of seconds to wait for the response. Defaults to
-        :data:`library.config.DEFAULT_CONFIG.timeouts.read` when ``None``.
+        Maximum number of seconds to wait for the response. When ``None`` the
+        value from :attr:`cfg.timeouts.read` is used.
 
     Returns
     -------
@@ -50,9 +42,26 @@ def request_json(url: str, *, timeout: float | None = None) -> dict[str, Any]:
     ValueError
         If the response body is not valid JSON.
 
+    Notes
+    -----
+    A new :class:`requests.Session` is created for each call with retry
+    behaviour configured according to ``cfg``. This keeps the function
+    stateless and avoids hidden global configuration.
     """
-    effective_timeout = timeout if timeout is not None else DEFAULT_CONFIG.timeouts.read
-    with _session.get(url, timeout=effective_timeout) as response:
+
+    retry = Retry(
+        total=cfg.rate_limits.max_retries,
+        backoff_factor=cfg.rate_limits.backoff_factor,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    effective_timeout = timeout if timeout is not None else cfg.timeouts.read
+    with session.get(url, timeout=effective_timeout) as response:
         response.raise_for_status()
         return response.json()
 

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from .chembl_client import _chunked, request_json
 from .mapper_library import map_chembl_to_uniprot
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -138,14 +139,19 @@ def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
     return res
 
 
-def get_target(chembl_target_id: str, *, timeout: float = 30.0) -> dict[str, str]:
+def get_target(
+    chembl_target_id: str,
+    *,
+    cfg: Config,
+    timeout: float | None = None,
+) -> dict[str, str]:
     """Fetch target information for a single ChEMBL identifier."""
     if chembl_target_id in {"", "#N/A"}:
         return dict(EMPTY_TARGET)
     url = "https://www.ebi.ac.uk/chembl/api/data/target/{id}.json".format(
         id=chembl_target_id
     )
-    data = request_json(url, timeout=timeout)
+    data = request_json(cfg, url, timeout=timeout)
     target_list = _get_items(data, "target")
     if not target_list:
         return dict(EMPTY_TARGET)
@@ -153,7 +159,11 @@ def get_target(chembl_target_id: str, *, timeout: float = 30.0) -> dict[str, str
 
 
 def get_targets(
-    ids: Iterable[str], *, chunk_size: int = 5, timeout: float = 30.0
+    ids: Iterable[str],
+    *,
+    cfg: Config,
+    chunk_size: int = 5,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Fetch target records for ``ids``."""
     valid = [i for i in ids if i not in {"", "#N/A"}]
@@ -164,7 +174,7 @@ def get_targets(
     base = "https://www.ebi.ac.uk/chembl/api/data/target.json?format=json"
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, timeout=timeout)
+        data = request_json(cfg, url, timeout=timeout)
         items = data.get("targets") or data.get("target") or []
         records.extend(_parse_target_record(item) for item in items)
     if not records:
@@ -174,7 +184,7 @@ def get_targets(
 
 
 def extend_target(
-    df: pd.DataFrame, *, id_column: str = "target_chembl_id"
+    df: pd.DataFrame, *, cfg: Config, id_column: str = "target_chembl_id"
 ) -> pd.DataFrame:
     """Augment ``df`` with columns returned from :func:`get_target`.
 
@@ -188,7 +198,7 @@ def extend_target(
     """
     if id_column not in df.columns:
         raise ValueError(f"missing required column: {id_column}")
-    targets = [get_target(i) for i in df[id_column].fillna("")]
+    targets = [get_target(i, cfg=cfg) for i in df[id_column].fillna("")]
     extra = pd.DataFrame(targets)
     return pd.concat([df.reset_index(drop=True), extra], axis=1)
 

--- a/library/config.py
+++ b/library/config.py
@@ -1,15 +1,4 @@
-
-"""Configuration utilities for data acquisition scripts.
-
-This module centralises configuration options such as timeouts, rate limits
-and output directories. Settings are loaded from ``config.yaml`` when
-available, otherwise built-in defaults are used.
-
-The :class:`Config` dataclass performs validation in ``__post_init__`` to
-ensure supplied values are sensible.  Invalid values raise
-:class:`ConfigError`.
-
-"""
+"""Configuration utilities for data acquisition scripts."""
 
 from __future__ import annotations
 
@@ -19,22 +8,15 @@ from pathlib import Path
 from typing import Any, Dict
 from urllib.parse import urlparse
 
-
 import yaml
 
 
-
-def load_config(path: str | Path) -> Dict[str, Any]:
-    """Load a YAML configuration file.
-
 class ConfigError(ValueError):
     """Raised when configuration values are invalid."""
- 
 
 
 @dataclass
 class APISettings:
-
     """Base URLs for external services."""
 
     chembl_base_url: str = "https://www.ebi.ac.uk/chembl/api/data"
@@ -76,23 +58,16 @@ class OutputPaths:
         self.data_dir = Path(self.data_dir)
         self.logs_dir = Path(self.logs_dir)
         self.tmp_dir = Path(self.tmp_dir)
+        for path in (self.data_dir, self.logs_dir, self.tmp_dir):
+            try:
+                path.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:  # pragma: no cover - rare
+                raise ConfigError(f"failed to create directory: {path}") from exc
 
 
 @dataclass
 class Config:
-    """Application configuration loaded from ``config.yaml``.
-
-    Parameters
-    ----------
-    api:
-        Base URLs for external services.
-    timeouts:
-        Network timeout configuration.
-    rate_limits:
-        HTTP rate limiting and retry configuration.
-    output:
-        Output directory configuration.
-    """
+    """Application configuration loaded from ``config.yaml``."""
 
     api: APISettings = field(default_factory=APISettings)
     timeouts: TimeoutSettings = field(default_factory=TimeoutSettings)
@@ -100,20 +75,12 @@ class Config:
     output: OutputPaths = field(default_factory=OutputPaths)
 
     def __post_init__(self) -> None:
-        """Validate configuration values.
+        """Validate configuration values."""
 
-        Raises
-        ------
-        ConfigError
-            If any configuration value is invalid.
-        """
-
-        # Validate timeouts
         for name, value in vars(self.timeouts).items():
             if value <= 0:
                 raise ConfigError(f"timeout '{name}' must be > 0")
 
-        # Validate rate limits
         if self.rate_limits.max_requests_per_second <= 0:
             raise ConfigError("max_requests_per_second must be > 0")
         if self.rate_limits.max_retries < 0:
@@ -121,93 +88,32 @@ class Config:
         if self.rate_limits.backoff_factor < 0:
             raise ConfigError("backoff_factor must be >= 0")
 
-        # Validate URLs
         for name, url in vars(self.api).items():
             parsed = urlparse(url)
             if not parsed.scheme or not parsed.netloc:
                 raise ConfigError(f"invalid URL for {name}: {url}")
 
-        # Validate output directories
-        for path in [self.output.data_dir, self.output.logs_dir, self.output.tmp_dir]:
-            try:
-                path.mkdir(parents=True, exist_ok=True)
-            except OSError as exc:
-                raise ConfigError(f"failed to create directory: {path}") from exc
+        for path in (self.output.data_dir, self.output.logs_dir, self.output.tmp_dir):
+            if not path.exists() and not path.is_dir():
+                try:
+                    path.mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    raise ConfigError(f"failed to create directory: {path}") from exc
             if not os.access(path, os.W_OK):
                 raise ConfigError(f"directory not writable: {path}")
 
 
 def load_config(path: str | Path | None = None) -> Config:
-    """Return configuration loaded from ``path`` or defaults.
+    """Return configuration loaded from ``path`` or defaults."""
 
-
-    Parameters
-    ----------
-    path:
-
-        Location of the configuration file.
-
-    Returns
-    -------
-    dict[str, Any]
-        Parsed configuration settings. An empty dictionary is returned if the
-        file does not exist.
-
-    Raises
-    ------
-    ValueError
-        If the file exists but contains invalid YAML.
-    """
-    cfg_path = Path(path)
-    if not cfg_path.exists():
-        return {}
-    try:
-        with cfg_path.open("r", encoding="utf8") as fh:
-            data = yaml.safe_load(fh)
-    except yaml.YAMLError as exc:  # pragma: no cover - parse errors are rare
-        raise ValueError(
-            f"failed to parse configuration file {cfg_path}: {exc}"
-        ) from exc
-    return data or {}
-
-
-        Optional path to a YAML configuration file. When omitted, ``config.yaml``
-        located at the repository root is used. Missing files result in the
-        default configuration being returned.
-
-
-    Returns
-    -------
-    Config
-
-        Parsed configuration object.
-    """
     cfg_path = Path(path) if path is not None else Path("config.yaml")
     data: Dict[str, Any] = {}
     if cfg_path.exists():
         with cfg_path.open("r", encoding="utf8") as fh:
             data = yaml.safe_load(fh) or {}
-
     return Config(
         api=APISettings(**data.get("api", {})),
         timeouts=TimeoutSettings(**data.get("timeouts", {})),
         rate_limits=RateLimitSettings(**data.get("rate_limits", {})),
         output=OutputPaths(**data.get("output", {})),
     )
-
-
-DEFAULT_CONFIG = load_config()
-
-
-__all__ = [
-    "Config",
-    "ConfigError",
-    "load_config",
-    "DEFAULT_CONFIG",
-    "APISettings",
-    "TimeoutSettings",
-    "RateLimitSettings",
-    "OutputPaths",
-]
-
-

--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -12,6 +12,7 @@ import logging
 import requests
 
 from . import pubmed_library as _pl
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ def fetch_openalex(
     pmid: str,
     sleep: float,
     *,
-    timeout: float = _pl.TIMEOUT,
+    cfg: Config,
+    timeout: float | None = None,
 ) -> Dict[str, str]:
     """Return OpenAlex metadata for ``pmid``.
 
@@ -48,7 +50,7 @@ def fetch_openalex(
 
     """
 
-    return _pl.fetch_openalex(session, pmid, sleep, timeout=timeout)
+    return _pl.fetch_openalex(session, pmid, sleep, cfg=cfg, timeout=timeout)
 
 
 def fetch_crossref(
@@ -56,7 +58,8 @@ def fetch_crossref(
     doi: str,
     sleep: float,
     *,
-    timeout: float = _pl.TIMEOUT,
+    cfg: Config,
+    timeout: float | None = None,
 ) -> Dict[str, str]:
     """Return CrossRef metadata for ``doi``.
 
@@ -83,4 +86,4 @@ def fetch_crossref(
 
     """
 
-    return _pl.fetch_crossref(session, doi, sleep, timeout=timeout)
+    return _pl.fetch_crossref(session, doi, sleep, cfg=cfg, timeout=timeout)

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -18,10 +18,9 @@ import requests
 from xml.etree import ElementTree as ET
 from urllib.parse import quote
 
-from .config import DEFAULT_CONFIG
+from .config import Config, load_config
 
 ENCODINGS = ["utf-8-sig", "cp1251", "latin1"]
-TIMEOUT = DEFAULT_CONFIG.timeouts.read
 
 
 def read_pmids(path: Union[str, Path]) -> List[str]:
@@ -50,10 +49,11 @@ def _do_request(
     session: requests.Session,
     url: str,
     sleep: float,
+    *,
+    cfg: Config,
     expect_json: bool = True,
-    retries: int = DEFAULT_CONFIG.rate_limits.max_retries,
     method: str = "GET",
-    timeout: float = TIMEOUT,
+    timeout: float | None = None,
     **kwargs: Any,
 ) -> Tuple[Union[Dict[str, Any], str, None], str]:
     """Perform an HTTP request with retry and error handling.
@@ -68,13 +68,13 @@ def _do_request(
         Base number of seconds to sleep between attempts.
     expect_json:
         Whether to parse the response as JSON.
-    retries:
-        Number of additional attempts after the initial one. Defaults to
-        :data:`library.config.DEFAULT_CONFIG.rate_limits.max_retries`.
+    cfg:
+        Application configuration controlling retries and timeouts.
     method:
         HTTP method to use, either "GET" or "POST".
     timeout:
-        Maximum seconds to wait for each HTTP request.
+        Maximum seconds to wait for each HTTP request. When ``None`` the value
+        from :attr:`cfg.timeouts.read` is used.
     **kwargs:
         Additional parameters passed to ``session.get`` or ``session.post``.
 
@@ -85,6 +85,8 @@ def _do_request(
         string is empty on success.
 
     """
+    retries = cfg.rate_limits.max_retries
+    effective_timeout = timeout if timeout is not None else cfg.timeouts.read
     for attempt in range(retries + 1):
         if attempt:
             time.sleep(sleep * attempt)
@@ -94,7 +96,7 @@ def _do_request(
                 request: Callable[..., requests.Response] = session.post
             else:
                 request = session.get
-            with request(url, timeout=timeout, **kwargs) as resp:
+            with request(url, timeout=effective_timeout, **kwargs) as resp:
                 status_code = resp.status_code
                 text = resp.text
                 try:
@@ -127,7 +129,10 @@ def _do_request(
 
 
 def fetch_pubmed_batch(
-    session: requests.Session, pmids: List[str], sleep: float
+    session: requests.Session,
+    pmids: List[str],
+    sleep: float,
+    cfg: Config,
 ) -> List[Dict[str, str]]:
     """Fetch metadata for multiple PMIDs using a single API request.
 
@@ -151,7 +156,7 @@ def fetch_pubmed_batch(
         "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id="
         f"{ids}&retmode=xml"
     )
-    text, error = _do_request(session, url, sleep, expect_json=False)
+    text, error = _do_request(session, url, sleep, cfg=cfg, expect_json=False)
     results: List[Dict[str, str]] = []
     if error:
         for pid in pmids:
@@ -359,13 +364,15 @@ EMPTY_PUBMED: Dict[str, str] = {
 }
 
 
-def fetch_pubmed(session: requests.Session, pmid: str, sleep: float) -> Dict[str, str]:
+def fetch_pubmed(
+    session: requests.Session, pmid: str, sleep: float, cfg: Config
+) -> Dict[str, str]:
     """Fetch metadata for a PMID from the PubMed API."""
     url = (
         "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id="
         f"{pmid}&retmode=xml"
     )
-    text, error = _do_request(session, url, sleep, expect_json=False)
+    text, error = _do_request(session, url, sleep, cfg=cfg, expect_json=False)
     result = EMPTY_PUBMED.copy()
     if error:
         result["PubMed.Error"] = error
@@ -384,7 +391,7 @@ def fetch_pubmed(session: requests.Session, pmid: str, sleep: float) -> Dict[str
 
 
 def fetch_semantic_scholar(
-    session: requests.Session, pmid: str, sleep: float
+    session: requests.Session, pmid: str, sleep: float, cfg: Config
 ) -> Dict[str, str]:
     """Retrieve Semantic Scholar metadata for a single PMID.
 
@@ -410,6 +417,7 @@ def fetch_semantic_scholar(
         session,
         url,
         sleep * 5,
+        cfg=cfg,
         headers=headers,
         params={"fields": fields},
     )
@@ -438,7 +446,10 @@ def fetch_semantic_scholar(
 
 
 def fetch_semantic_scholar_batch(
-    session: requests.Session, pmids: List[str], sleep: float
+    session: requests.Session,
+    pmids: List[str],
+    sleep: float,
+    cfg: Config,
 ) -> List[Dict[str, str]]:
     """Fetch metadata for multiple PMIDs using Semantic Scholar's batch API."""
     if not pmids:
@@ -454,6 +465,7 @@ def fetch_semantic_scholar_batch(
         session,
         url,
         sleep * 5,
+        cfg=cfg,
         headers=headers,
         params={"fields": fields},
         json={"ids": prefixed_pmids},
@@ -528,7 +540,8 @@ def fetch_openalex(
     pmid: str,
     sleep: float,
     *,
-    timeout: float = TIMEOUT,
+    cfg: Config,
+    timeout: float | None = None,
 ) -> Dict[str, str]:
     """Retrieve OpenAlex metadata for ``pmid``.
 
@@ -550,7 +563,7 @@ def fetch_openalex(
 
     """
     url = f"https://api.openalex.org/works/pmid:{pmid}"
-    data, error = _do_request(session, url, sleep, timeout=timeout)
+    data, error = _do_request(session, url, sleep, cfg=cfg, timeout=timeout)
     if error or not isinstance(data, dict):
         return {
             "OpenAlex.PublicationTypes": "",
@@ -590,7 +603,8 @@ def fetch_crossref(
     doi: str,
     sleep: float,
     *,
-    timeout: float = TIMEOUT,
+    cfg: Config,
+    timeout: float | None = None,
 ) -> Dict[str, str]:
     """Retrieve Crossref metadata for a given DOI.
 
@@ -622,7 +636,7 @@ def fetch_crossref(
         }
 
     url = f"https://api.crossref.org/works/{quote(doi, safe='')}"
-    data, error = _do_request(session, url, sleep, timeout=timeout)
+    data, error = _do_request(session, url, sleep, cfg=cfg, timeout=timeout)
     if error or not isinstance(data, dict):
         return {
             "crossref.Type": "",
@@ -696,8 +710,15 @@ def main() -> None:
     parser.add_argument(
         "--sleep", type=float, default=5.0, help="Sleep between requests"
     )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to YAML configuration file",
+    )
     args = parser.parse_args()
 
+    cfg = load_config(args.config)
     pmids = read_pmids(args.input)
     records: List[Dict[str, str]] = []
     batch_size = 100  # A reasonable batch size
@@ -706,8 +727,10 @@ def main() -> None:
             batch_pmids = pmids[i : i + batch_size]
 
             # Batch fetch PubMed and Semantic Scholar
-            pubmed_list = fetch_pubmed_batch(session, batch_pmids, args.sleep)
-            semsch_list = fetch_semantic_scholar_batch(session, batch_pmids, args.sleep)
+            pubmed_list = fetch_pubmed_batch(session, batch_pmids, args.sleep, cfg)
+            semsch_list = fetch_semantic_scholar_batch(
+                session, batch_pmids, args.sleep, cfg
+            )
 
             semsch_map = {s.get("scholar.PMID"): s for s in semsch_list}
 
@@ -716,9 +739,9 @@ def main() -> None:
                 semsch = semsch_map.get(pmid, {})
 
                 # Still fetching these individually
-                openalex = fetch_openalex(session, pmid, args.sleep)
+                openalex = fetch_openalex(session, pmid, args.sleep, cfg=cfg)
                 doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
-                crossref = fetch_crossref(session, doi, args.sleep)
+                crossref = fetch_crossref(session, doi, args.sleep, cfg=cfg)
 
                 combined: Dict[str, str] = {}
                 combined.update(pubmed)

--- a/library/semantic_scholar_library.py
+++ b/library/semantic_scholar_library.py
@@ -14,12 +14,13 @@ import logging
 import requests
 
 from . import pubmed_library as _pl
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
 
 def fetch_semantic_scholar(
-    session: requests.Session, pmid: str, sleep: float
+    session: requests.Session, pmid: str, sleep: float, cfg: Config
 ) -> Dict[str, str]:
     """Return Semantic Scholar metadata for ``pmid``.
 
@@ -41,11 +42,11 @@ def fetch_semantic_scholar(
         returned dictionary and never raise exceptions.
 
     """
-    return _pl.fetch_semantic_scholar(session, pmid, sleep)
+    return _pl.fetch_semantic_scholar(session, pmid, sleep, cfg)
 
 
 def fetch_semantic_scholar_batch(
-    session: requests.Session, pmids: List[str], sleep: float
+    session: requests.Session, pmids: List[str], sleep: float, cfg: Config
 ) -> List[Dict[str, str]]:
     """Return Semantic Scholar metadata for a batch of ``pmids``.
 
@@ -65,4 +66,4 @@ def fetch_semantic_scholar_batch(
         dictionary and never raise exceptions.
 
     """
-    return _pl.fetch_semantic_scholar_batch(session, pmids, sleep)
+    return _pl.fetch_semantic_scholar_batch(session, pmids, sleep, cfg)

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-from pathlib import Path
 from typing import Sequence
 from urllib.error import URLError
 
@@ -12,13 +11,13 @@ import pandas as pd
 
 from library import io
 from library.cli import build_parser as base_parser, configure_logging
-from library.config import load_config
+from library.config import Config, load_config
 from library.mapper_library import map_chembl_to_uniprot
 
 logger = logging.getLogger(__name__)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace, cfg: Config) -> int:
     """Map ChEMBL target identifiers to UniProt accessions.
 
     Parameters
@@ -82,15 +81,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.output_csv is None:
-        out_dir = config.get("output", {}).get("data_dir")
-        if out_dir:
-            args.output_csv = (
-                Path(out_dir) / io.default_output_path(args.input_csv).name
-            )
+        args.output_csv = (
+            cfg.output.data_dir / io.default_output_path(args.input_csv).name
+        )
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -12,13 +12,13 @@ import pandas as pd
 
 from library.table_quality import analyze_table_quality
 
-from library.config import DEFAULT_CONFIG load_config
+from library.config import Config, load_config
 
 
 logger = logging.getLogger(__name__)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace, cfg: Config) -> int:
     """Execute the profiling workflow.
 
     Parameters
@@ -74,9 +74,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         dest="output_dir",
         type=Path,
-
-        default=DEFAULT_CONFIG.output.data_dir,
-
+        default=None,
         help="Directory to store generated reports",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")
@@ -95,11 +93,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    config = load_config(args.config)
+    cfg = load_config(args.config)
     if args.output_dir is None:
-        args.output_dir = Path(config.get("output", {}).get("data_dir", "."))
+        args.output_dir = cfg.output.data_dir
     configure_logging(args.log_level)
-    return args.func(args)
+    return args.func(args, cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -6,6 +6,7 @@ import requests
 
 import get_activity_data as gad
 from library import chembl_library as cl, io
+from library.config import Config
 
 
 def test_run_chembl_handles_request_error(monkeypatch, caplog) -> None:
@@ -25,6 +26,6 @@ def test_run_chembl_handles_request_error(monkeypatch, caplog) -> None:
 
     monkeypatch.setattr(cl, "get_activities", _raise)
     with caplog.at_level(logging.ERROR):
-        result = gad.run_chembl(args)
+        result = gad.run_chembl(args, Config())
     assert result == 1
     assert "boom" in caplog.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,28 +1,6 @@
-
-from pathlib import Path
-
-from library.config import load_config
-
-DATA_DIR = Path(__file__).resolve().parent / "data"
-
-
-def test_load_config_reads_yaml() -> None:
-    path = DATA_DIR / "sample_config.yaml"
-    cfg = load_config(path)
-    assert cfg["foo"] == "bar"
-    assert cfg["nested"]["value"] == 42
-
-
-def test_load_config_missing_returns_empty(tmp_path: Path) -> None:
-    path = tmp_path / "missing.yaml"
-    cfg = load_config(path)
-    assert cfg == {}
-
-
 from pathlib import Path
 
 import pytest
-
 
 from library.config import (
     APISettings,
@@ -30,7 +8,22 @@ from library.config import (
     ConfigError,
     OutputPaths,
     TimeoutSettings,
+    load_config,
 )
+
+
+def test_load_config_reads_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("timeouts:\n  read: 1\n")
+    cfg = load_config(path)
+    assert isinstance(cfg, Config)
+    assert cfg.timeouts.read == 1
+
+
+def test_load_config_missing_returns_defaults(tmp_path: Path) -> None:
+    path = tmp_path / "missing.yaml"
+    cfg = load_config(path)
+    assert isinstance(cfg, Config)
 
 
 def test_negative_timeout_raises() -> None:
@@ -49,4 +42,3 @@ def test_non_writable_directory_raises(tmp_path: Path) -> None:
     bad_path.write_text("x")
     with pytest.raises(ConfigError):
         Config(output=OutputPaths(data_dir=bad_path))
-

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 import get_input_initialisation as cli
+from library.config import Config
 
 
 def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
@@ -20,9 +21,7 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
         "pairs_same_document": pd.DataFrame({"id": [3, 4]}),
         "pairs_independent": pd.DataFrame({"id": [5]}),
         "pairs_non_independent": pd.DataFrame({"id": [6]}),
-
         "activity_independent_status": pd.DataFrame({"id": [7]}),
-
     }
 
     def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub
@@ -45,14 +44,12 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch):
         format="csv",
         dictionary_dir=tmp_path,
     )
-    result = cli.run(args)
+    result = cli.run(args, Config())
     assert result == 0
-
 
     assert (
         out_dir / "status" / "independent" / "activity_independent_status.csv"
     ).exists()
-
 
     for name in tables:
         quality = out_dir / "data_validity_report" / f"{name}_quality_report_table.csv"
@@ -95,6 +92,6 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch, caplog) ->
         dictionary_dir=tmp_path,
     )
     with caplog.at_level("ERROR"):
-        result = cli.run(args)
+        result = cli.run(args, Config())
     assert result == 1
     assert "required table 'activity' missing" in caplog.text

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -247,9 +247,7 @@ def test_build_combined_tables_initializes_pair_segments(
     }
 
     (tmp_path / "status.csv").write_text(
-
         "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
-
     )
 
     monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
@@ -268,36 +266,30 @@ def test_build_combined_tables_initializes_pair_segments(
         assert {"Filtered1", "Filtered2", "Filtered"}.issubset(combined[key].columns)
 
 
-
 def test_build_combined_tables_aggregates_all_pair_segments(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Status aggregation should run for all pair tables."""
-
 
     same: TableDict = {
         "assay": pd.DataFrame(),
         "document": pd.DataFrame(),
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
-
         "activity": pd.DataFrame({"activity_id": [1, 2]}),
         "pairs_same_document": pd.DataFrame({"activity_id1": [1], "activity_id2": [2]}),
-
     }
     all_: TableDict = {
         "assay": pd.DataFrame(),
         "document": pd.DataFrame(),
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
-
         "activity": pd.DataFrame({"activity_id": [3]}),
         "pairs": pd.DataFrame(
             {
                 "INDEPENDENT": [True, False],
                 "activity_id1": [1, 2],
                 "activity_id2": [2, 1],
-
             }
         ),
     }
@@ -313,7 +305,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         lambda df, _api: df.assign(**{"Filtered.init": "good"}),
     )
 
-
     def fake_init_pairs(pair_df: pd.DataFrame, *_args, **_kwargs) -> pd.DataFrame:
         return pair_df.assign(Filtered1="good", Filtered2="good", Filtered="good")
 
@@ -325,7 +316,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         captured.append(pair_df)
         return {"activity": pd.DataFrame({"id": [1]})}
 
-
     monkeypatch.setattr(lib, "aggregate_activity", fake_aggregate)
 
     combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
@@ -336,7 +326,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
     assert "activity_independent_status" in combined
     assert "activity_non_independent_status" in combined
     assert "activity_same_document_status" in combined
-
 
 
 def test_build_combined_tables_normalizes_pair_column_names(
@@ -397,11 +386,9 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         "pairs_same_document": pd.DataFrame({"id": [1]}),
         "pairs_independent": pd.DataFrame({"id": [1]}),
         "pairs_non_independent": pd.DataFrame({"id": [2]}),
-
         "activity_independent_status": pd.DataFrame({"id": [1]}),
         "activity_non_independent_status": pd.DataFrame({"id": [1]}),
         "activity_same_document_status": pd.DataFrame({"id": [1]}),
-
     }
     paths = save_tables(tables, tmp_path)
     for entity, path in paths.items():
@@ -420,7 +407,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         paths["activity_same_document_status"].parent
         == tmp_path / "status" / "same_document"
     )
-
 
 
 def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_status_processing.py
+++ b/tests/test_status_processing.py
@@ -166,4 +166,3 @@ def test_aggregate_activity_handles_missing_testitem_id(tmp_path: Path) -> None:
     assert agg["system"].empty
     assert agg["testitem"].empty
     assert agg["target"].set_index("target_id").loc["TG1", "independent_IC50"] == 1
-

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -14,9 +14,7 @@ def test_analyze_table_quality(tmp_path: Path) -> None:
         {
             "num": [1, 2, 3, 4],
             "str": ["10.1234/abc", "", None, "test"],
-
             "flag": pd.Series([True, False, True, False], dtype="boolean"),
-
         }
     )
     cwd = os.getcwd()
@@ -46,4 +44,3 @@ def test_analyze_table_quality_suppresses_warnings(tmp_path: Path) -> None:
         os.chdir(cwd)
 
     assert (tmp_path / "mixed_quality_report_table.csv").exists()
-


### PR DESCRIPTION
## Summary
- switch to dataclass-backed configuration with attribute access
- plumb `Config` objects through library helpers and CLI entry points
- drop DEFAULT_CONFIG globals and clean up imports

## Testing
- `black --exclude 'library/config.py' .`
- `ruff check .`
- `mypy .` *(fails: missing stubs for third-party packages)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae2c2e90832480892dfbfdda910b