### PR TITLE
Add environment aliases for retry and logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Environment variables override values from the YAML file. Variables use the
 * ``CHEMBL_DA__IO__OUTPUT_DIR`` / ``CHEMBL_DA_OUTDIR``
 * ``CHEMBL_DA__JOBS__CONCURRENCY`` / ``CHEMBL_DA_CONCURRENCY``
 * ``CHEMBL_DA__JOBS__CHUNK_SIZE`` / ``CHEMBL_DA_CHUNK_SIZE``
+* ``CHEMBL_DA__RETRY__MAX_ATTEMPTS`` / ``CHEMBL_DA_RETRY_MAX_ATTEMPTS``
+* ``CHEMBL_DA__RETRY__BACKOFF_FACTOR`` / ``CHEMBL_DA_RETRY_BACKOFF_FACTOR``
+* ``CHEMBL_DA__LOG__LEVEL`` / ``CHEMBL_DA_LOG_LEVEL``
+* ``CHEMBL_DA__LOG__FORMAT`` / ``CHEMBL_DA_LOG_FORMAT``
 
 Command line flags have the highest priority. All utilities accept ``--config``
 to point at a configuration file and ``--print-config`` to show the effective

--- a/config.yaml
+++ b/config.yaml
@@ -99,8 +99,8 @@ rate:
   global_burst: 8  # Global burst size
 
 retry:
-  max_attempts: 3  # HTTP retry attempts
-  backoff_factor: 0.5  # Base delay multiplier
+  max_attempts: 3  # HTTP retry attempts (env: CHEMBL_DA_RETRY_MAX_ATTEMPTS)
+  backoff_factor: 0.5  # Base delay multiplier (env: CHEMBL_DA_RETRY_BACKOFF_FACTOR)
   status_forcelist:
     - 429  # Too Many Requests
     - 500
@@ -109,7 +109,7 @@ retry:
     - 504
 
 log:
-  level: "INFO"  # Default logging level
-  format: "[%(asctime)s] %(levelname)s %(name)s: %(message)s"  # Logging format
+  level: "INFO"  # Default logging level (env: CHEMBL_DA_LOG_LEVEL)
+  format: "[%(asctime)s] %(levelname)s %(name)s: %(message)s"  # Logging format (env: CHEMBL_DA_LOG_FORMAT)
   datefmt: "%Y-%m-%d %H:%M:%S"  # Timestamp format
 

--- a/library/config.py
+++ b/library/config.py
@@ -354,6 +354,9 @@ _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
     "CHEMBL_DA_GLOBAL_BURST": ["rate", "global_burst"],
     "CHEMBL_DA_LOG_LEVEL": ["log", "level"],
+    "CHEMBL_DA_LOG_FORMAT": ["log", "format"],
+    "CHEMBL_DA_RETRY_MAX_ATTEMPTS": ["retry", "max_attempts"],
+    "CHEMBL_DA_RETRY_BACKOFF_FACTOR": ["retry", "backoff_factor"],
 }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,6 +45,23 @@ def test_alias_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert cfg.api.rps == 5
 
 
+def test_retry_and_log_aliases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """New environment variable aliases should override retry and log defaults."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+
+    monkeypatch.setenv("CHEMBL_DA_RETRY_MAX_ATTEMPTS", "10")
+    monkeypatch.setenv("CHEMBL_DA_RETRY_BACKOFF_FACTOR", "2.0")
+    monkeypatch.setenv("CHEMBL_DA_LOG_FORMAT", "%(levelname)s")
+
+    cfg = load_config(path)
+
+    assert cfg.retry.max_attempts == 10
+    assert cfg.retry.backoff_factor == 2.0
+    assert cfg.log.format == "%(levelname)s"
+
+
 def test_cli_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api:\n  rps: 1\n")
@@ -102,6 +119,7 @@ def test_unknown_key_error(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Unknown configuration key"):
         load_config(path, strict=True)
 
+
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api: [\n")  # malformed YAML
@@ -110,4 +128,3 @@ def test_yaml_error_includes_path(tmp_path: Path) -> None:
     msg = str(excinfo.value)
     assert str(path) in msg
     assert "while parsing" in msg
-


### PR DESCRIPTION
## Summary
- support env var aliases for retry.max_attempts, retry.backoff_factor, and log.format
- document new aliases in config.yaml and README
- test that new aliases override defaults

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check get_*.py library mapper_main.py table_quality_main.py tests/test_config.py`
- `mypy get_*.py library mapper_main.py table_quality_main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7a408ec8324b477eefb6f63eda5