### PR TITLE
Validate required contact info in API settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ api:
   backoff_factor: 0.5  # Exponential backoff multiplier
   rps: 5  # Requests per second limit (env: CHEMBL_DA__API__RPS / CHEMBL_DA_RPS)
   burst: 5  # Burst size for token bucket limiter
-  user_agent: "chembl-da/0.1 (+contact: unset)"  # Custom User-Agent header
+  user_agent: "chembl-da/0.1 (mailto:info@example.org)"  # Custom User-Agent header; must include contact info in the form "app/version (mailto:email@example.org)"
 
 openalex:
   base: "https://api.openalex.org"  # OpenAlex API root URL
@@ -24,7 +24,7 @@ openalex:
   retries: 3  # Retry attempts
   rps: 4  # Requests per second limit (env: CHEMBL_DA_OPENALEX_RPS)
   burst: 5  # Burst size for rate limiter (env: CHEMBL_DA_OPENALEX_BURST)
-  mailto: ""  # Contact email per API guidelines
+  mailto: "info@example.org"  # Contact email per API guidelines; required valid email address
 
 crossref:
   base: "https://api.crossref.org"  # CrossRef API root URL
@@ -33,7 +33,7 @@ crossref:
   retries: 3
   rps: 4  # (env: CHEMBL_DA_CROSSREF_RPS)
   burst: 5  # (env: CHEMBL_DA_CROSSREF_BURST)
-  mailto: ""
+  mailto: "info@example.org"  # Contact email per API guidelines; required valid email address
 
 uniprot:
   base: "https://rest.uniprot.org"  # UniProt REST API root

--- a/library/config.py
+++ b/library/config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field, is_dataclass
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -30,6 +31,9 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+
+
 # ---------------------------------------------------------------------------
 # Dataclass definitions
 # ---------------------------------------------------------------------------
@@ -37,7 +41,11 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ApiCfg:
-    """Settings for ChEMBL API access."""
+    """Settings for ChEMBL API access.
+
+    The ``user_agent`` must include contact information such as an e-mail
+    address, e.g. ``"chembl-da/0.1 (mailto:info@example.org)"``.
+    """
 
     chembl_base: str = "https://www.ebi.ac.uk/chembl/api/data"
     timeout_connect: int = 5
@@ -46,12 +54,15 @@ class ApiCfg:
     backoff_factor: float = 0.5
     rps: int = 5
     burst: int = 5
-    user_agent: str = "chembl-da/0.1 (+contact: unset)"
+    user_agent: str = "chembl-da/0.1 (mailto:info@example.org)"
 
 
 @dataclass
 class OpenAlexCfg:
-    """Settings for the OpenAlex API."""
+    """Settings for the OpenAlex API.
+
+    ``mailto`` is required by the service and must be a valid e-mail address.
+    """
 
     base: str = "https://api.openalex.org"
     timeout_connect: int = 5
@@ -59,12 +70,15 @@ class OpenAlexCfg:
     retries: int = 3
     rps: int = 4
     burst: int = 5
-    mailto: str = ""
+    mailto: str = "info@example.org"
 
 
 @dataclass
 class CrossRefCfg:
-    """Settings for the CrossRef API."""
+    """Settings for the CrossRef API.
+
+    ``mailto`` must be supplied and contain a valid e-mail address.
+    """
 
     base: str = "https://api.crossref.org"
     timeout_connect: int = 5
@@ -72,7 +86,7 @@ class CrossRefCfg:
     retries: int = 3
     rps: int = 4
     burst: int = 5
-    mailto: str = ""
+    mailto: str = "info@example.org"
 
 
 @dataclass
@@ -390,6 +404,10 @@ def _validate(cfg: Config) -> None:
         )
     if cfg.api.rps <= 0 or cfg.api.burst <= 0:
         raise ValueError("api.rps and api.burst must be positive")
+    if not _EMAIL_RE.search(cfg.api.user_agent):
+        raise ValueError(
+            "api.user_agent must include contact information such as an email"
+        )
 
     services: list[tuple[str, Any]] = [
         ("openalex", cfg.openalex),
@@ -407,6 +425,13 @@ def _validate(cfg: Config) -> None:
             raise ValueError(f"{name}.retries must be non-negative")
         if service.rps <= 0 or service.burst <= 0:
             raise ValueError(f"{name}.rps and {name}.burst must be positive")
+
+    for name, mail in [
+        ("openalex", cfg.openalex.mailto),
+        ("crossref", cfg.crossref.mailto),
+    ]:
+        if not mail or not _EMAIL_RE.fullmatch(mail):
+            raise ValueError(f"{name}.mailto must be a valid email address")
 
     if cfg.jobs.concurrency <= 0 or cfg.jobs.chunk_size <= 0:
         raise ValueError("jobs.concurrency and jobs.chunk_size must be positive")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,7 @@ def test_unknown_key_error(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Unknown configuration key"):
         load_config(path, strict=True)
 
+
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api: [\n")  # malformed YAML
@@ -111,3 +112,29 @@ def test_yaml_error_includes_path(tmp_path: Path) -> None:
     assert str(path) in msg
     assert "while parsing" in msg
 
+
+def test_user_agent_must_include_contact(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        "api:\n  user_agent: chembl-da/0.1\n"
+        "openalex:\n  mailto: info@example.org\n"
+        "crossref:\n  mailto: info@example.org\n"
+    )
+    with pytest.raises(ValueError, match="user_agent"):
+        load_config(path)
+
+
+def test_openalex_mailto_required(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        "openalex:\n  mailto: ''\n" "crossref:\n  mailto: info@example.org\n"
+    )
+    with pytest.raises(ValueError, match="openalex.mailto"):
+        load_config(path)
+
+
+def test_crossref_mailto_format(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("crossref:\n  mailto: not-an-email\n")
+    with pytest.raises(ValueError, match="crossref.mailto"):
+        load_config(path)


### PR DESCRIPTION
## Summary
- clarify contact email requirements in default configuration
- validate `user_agent` and `mailto` fields and document defaults
- test config validation for missing or malformed contact information

## Testing
- `python -m black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `python -m mypy --ignore-missing-imports library/config.py tests/test_config.py`
- `pytest tests/test_config.py::test_user_agent_must_include_contact tests/test_config.py::test_openalex_mailto_required tests/test_config.py::test_crossref_mailto_format`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7a159fc8324a3df0f0217d10f87