### PR TITLE
Annotate configuration usage in CLI scripts

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -26,6 +26,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args : argparse.Namespace
         Parsed command-line arguments.
 
@@ -85,10 +87,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(
+    cfg: Config = apply_config_overrides(
         args,
         parser,
         args.config,

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -27,6 +27,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args : argparse.Namespace
         Parsed command-line arguments.
 
@@ -79,10 +81,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -140,7 +140,21 @@ def fetch_pubmed_records(
 
 
 def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
-    """Execute the ``pubmed`` sub-command."""
+    """Execute the ``pubmed`` sub-command.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration.
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+
+    """
     try:
         pmids = io.read_ids(
             args.input_csv,
@@ -165,7 +179,21 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
-    """Execute the ``chembl`` sub-command."""
+    """Execute the ``chembl`` sub-command.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration.
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+
+    """
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -199,7 +227,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def run_all(cfg: Config, args: argparse.Namespace) -> int:
-    """Run ChEMBL and PubMed pipelines and merge their outputs."""
+    """Run ChEMBL and PubMed pipelines and merge their outputs.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration.
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+
+    """
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -399,10 +441,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Iterable
 
 import pandas as pd
-from library.config import ensure_dirs
+from library.config import Config, ensure_dirs
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
@@ -70,7 +70,7 @@ def classify_dataframe(
 
 
 def main() -> int:  # pragma: no cover - simple CLI
-    """Command-line entry point for document type classification.
+    """Command-line entry point for document type classification using :class:`Config`.
 
     Returns
     -------
@@ -80,7 +80,7 @@ def main() -> int:  # pragma: no cover - simple CLI
     """
     parser = base_parser(__doc__ or "Document type classification", column="chembl_id")
     args = parser.parse_args()
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -32,6 +32,8 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args:
         Parsed command line arguments.
 
@@ -121,10 +123,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry point."""
+    """Entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(
+    cfg: Config = apply_config_overrides(
         args,
         parser,
         args.config,

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -268,6 +268,8 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args:
         Parsed command-line arguments specific to the ``uniprot`` sub-command.
 
@@ -333,7 +335,21 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
-    """Execute the ``chembl`` sub-command."""
+    """Execute the ``chembl`` sub-command.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration.
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+
+    """
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -367,7 +383,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
-    """Execute the ``iuphar`` sub-command."""
+    """Execute the ``iuphar`` sub-command.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration.
+    args : argparse.Namespace
+        Parsed command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+
+    """
     try:
         data = ii.IUPHARData.from_files(
             target_path=args.target_csv,
@@ -402,6 +432,8 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args:
         Parsed command-line arguments specific to the ``all`` sub-command.
 
@@ -565,10 +597,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     if hasattr(args, "func"):

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -105,6 +105,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args : argparse.Namespace
         Parsed command-line arguments.
 
@@ -164,10 +166,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -26,6 +26,8 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args:
         Parsed command-line arguments.
 
@@ -84,10 +86,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     return args.func(cfg, args)

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -26,6 +26,8 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     Parameters
     ----------
+    cfg : Config
+        Application configuration.
     args:
         Parsed command-line arguments.
 
@@ -69,10 +71,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point."""
+    """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     if args.print_config:
         print(cfg.to_yaml())


### PR DESCRIPTION
## Summary
- import `Config` into root CLI scripts and type annotate config variables
- mention `Config` in CLI docstrings for clarity

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py`
- `ruff check .`
- `mypy .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1b7a5ba608324b181b859b4ae42b8