### PR TITLE
Guard CLI config parsing against malformed settings

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -87,20 +87,19 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(
-        args,
-        parser,
-        args.config,
-        mapping={"timeout": "api.timeout_read"},
-    )
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={"timeout": "api.timeout_read"},
+        )
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -81,15 +81,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -401,15 +401,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -9,16 +9,19 @@ from __future__ import annotations
 
 from typing import Iterable
 
+import logging
 import pandas as pd
+import argparse
+from pathlib import Path
+
 from library.config import ensure_dirs
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logging,
-)
+from library.cli import apply_config_overrides, configure_logging
 from library import io
 
 from library.document_type_classifier import compute_scores, decide_label
+
+
+logger = logging.getLogger(__name__)
 
 
 def _split_terms(value: object) -> Iterable[str]:
@@ -88,9 +91,13 @@ def main() -> int:  # pragma: no cover - simple CLI
     parser.add_argument("--log-level", default="INFO")
 
     args = parser.parse_args()
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
 
     df_in = pd.read_csv(
         args.input_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -123,29 +123,28 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(
-        args,
-        parser,
-        args.config,
-        mapping={
-            "same_doc": "init.same_doc",
-            "all_doc": "init.all_doc",
-            "out_dir": "init.output_dir",
-        },
-    )
-    ensure_dirs(cfg)
+    try:
+        cfg = apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={
+                "same_doc": "init.same_doc",
+                "all_doc": "init.all_doc",
+                "out_dir": "init.output_dir",
+            },
+        )
+        ensure_dirs(cfg)
 
-    args.same_doc = Path(args.same_doc)
-    args.all_doc = Path(args.all_doc)
-    args.out_dir = Path(args.out_dir)
+        args.same_doc = Path(args.same_doc)
+        args.all_doc = Path(args.all_doc)
+        args.out_dir = Path(args.out_dir)
 
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -17,11 +17,7 @@ from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logging,
-)
+from library.cli import apply_config_overrides, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -76,8 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Logging level (DEBUG, INFO, WARNING)",
     )
 
-
- #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
+    #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -581,9 +576,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     if hasattr(args, "func"):
         return args.func(cfg, args)
     parser.print_help()

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -166,15 +166,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -86,14 +86,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -71,18 +71,17 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    if args.print_config:
-        print(cfg.to_yaml())
-        return 0
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        if args.print_config:
+            print(cfg.to_yaml())
+            return 0
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("invalid configuration: %s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -1,0 +1,57 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+import get_activity_data as gad
+import get_assay_data as gas
+import get_document_data as gdd
+import get_input_initialisation as gii
+import get_target_data as gtd
+import get_testitem_data as gti
+import mapper_main as mp
+import table_quality_main as tq
+import get_document_type as gdt
+
+CLI_MODULES = [
+    (gad, []),
+    (gas, []),
+    (gdd, ["pubmed"]),
+    (gii, []),
+    (gtd, ["uniprot"]),
+    (gti, []),
+    (mp, []),
+    (tq, ["--table-name", "demo"]),
+]
+
+
+@pytest.mark.parametrize("module,args", CLI_MODULES)
+def test_main_invalid_config_returns_nonzero(tmp_path: Path, module, args, caplog):
+    """Ensure CLI exits with non-zero code for malformed configuration."""
+    bad_cfg = tmp_path / "config.yaml"
+    bad_cfg.write_text("jobs:\n  concurrency: bad\n", encoding="utf8")
+    caplog.set_level(logging.ERROR)
+    exit_code = module.main(["--config", str(bad_cfg)] + args)
+    assert exit_code == 1
+    assert "invalid configuration" in caplog.text
+
+
+def test_document_type_invalid_config(tmp_path: Path, monkeypatch, caplog) -> None:
+    """Special handling for get_document_type.main lacking argv parameter."""
+    bad_cfg = tmp_path / "config.yaml"
+    bad_cfg.write_text("jobs:\n  concurrency: bad\n", encoding="utf8")
+    caplog.set_level(logging.ERROR)
+    argv = [
+        "prog",
+        "--config",
+        str(bad_cfg),
+        "--input",
+        "in.csv",
+        "--output",
+        "out.csv",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    exit_code = gdt.main()
+    assert exit_code == 1
+    assert "invalid configuration" in caplog.text


### PR DESCRIPTION
## Summary
- handle invalid configuration in all CLI entry points
- add regression tests ensuring malformed configs exit with an error

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_input_initialisation.py get_testitem_data.py mapper_main.py table_quality_main.py tests/test_cli_bad_config.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py tests/test_cli_bad_config.py`
- `python -m mypy get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py mapper_main.py table_quality_main.py tests/test_cli_bad_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b8e3947483248d35092988b8385c