### PR TITLE
Raise ConfigError on config load failures

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -12,6 +12,7 @@ from library.config import Config, ensure_dirs
 from library import chembl_library as cl
 from library import io
 from library.cli import (
+    add_config_argument,
     apply_config_overrides,
     build_parser as base_parser,
     configure_logging,
@@ -87,7 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(
         args,

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -13,6 +13,7 @@ from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import io
 from library.cli import (
+    add_config_argument,
     apply_config_overrides,
     build_parser as base_parser,
     configure_logging,
@@ -81,7 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -41,7 +41,7 @@ from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import add_config_argument, apply_config_overrides, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +398,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -13,7 +13,7 @@ from typing import Iterable
 
 import pandas as pd
 from library.config import ensure_dirs
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import add_config_argument, apply_config_overrides, configure_logging
 
 from library.document_type_classifier import compute_scores, decide_label
 
@@ -76,7 +76,7 @@ def main() -> int:  # pragma: no cover - simple CLI
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     parser.add_argument("--input", type=Path, required=True, help="Input CSV")
     parser.add_argument("--output", type=Path, required=True, help="Output CSV")
     parser.add_argument("--log-level", default="INFO")

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Sequence
 
 from library.config import Config, ensure_dirs
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import add_config_argument, apply_config_overrides, configure_logging
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
@@ -120,7 +120,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(
         args,

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -17,7 +17,7 @@ from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import add_config_argument, apply_config_overrides, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def build_parser() -> argparse.ArgumentParser:
     merges their outputs.
     """
     parser = argparse.ArgumentParser(description="Target data utilities")
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     parser.add_argument(
         "--log-level",
         default="INFO",

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -14,6 +14,7 @@ from library import chembl_library as cl
 from library import pubchem_library as pl
 from library import io
 from library.cli import (
+    add_config_argument,
     apply_config_overrides,
     build_parser as base_parser,
     configure_logging,
@@ -166,7 +167,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/library/cli.py
+++ b/library/cli.py
@@ -1,4 +1,8 @@
-"""Shared command-line helpers."""
+"""Shared command-line helpers.
+
+Configuration loading errors are converted to user-facing messages using
+``argparse.ArgumentParser.error``.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict
 
-from .config import Config, load_config
+from .config import Config, ConfigError, load_config
 
 
 def _positive_int(value: str) -> int:
@@ -105,6 +109,29 @@ def configure_logging(
     )
 
 
+def add_config_argument(parser: argparse.ArgumentParser) -> None:
+    """Ensure a ``--config`` option is present.
+
+    Parameters
+    ----------
+    parser:
+        Parser to which the option will be added.
+
+    Notes
+    -----
+    Adding an argument with ``argparse`` that already exists results in an
+    ``ArgumentError``.  This helper allows repeated calls without raising by
+    first checking whether ``--config`` is already defined.
+    """
+
+    for action in parser._actions:
+        if "--config" in action.option_strings:
+            return
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to YAML configuration file"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Configuration overrides
 # ---------------------------------------------------------------------------
@@ -165,6 +192,11 @@ def apply_config_overrides(
     -------
     Config
         Loaded configuration object with overrides applied.
+
+    Raises
+    ------
+    SystemExit
+        If the configuration file cannot be loaded.
     """
 
     override_map = {**_DEFAULT_OVERRIDES, **(mapping or {})}
@@ -178,7 +210,10 @@ def apply_config_overrides(
         if value != default:
             cli_overrides[key] = value
 
-    cfg = load_config(config_path, cli_overrides=cli_overrides)
+    try:
+        cfg = load_config(config_path, cli_overrides=cli_overrides)
+    except ConfigError as exc:
+        parser.error(str(exc))
 
     for arg, key in override_map.items():
         if not hasattr(args, arg):
@@ -190,4 +225,9 @@ def apply_config_overrides(
     return cfg
 
 
-__all__ = ["build_parser", "configure_logging", "apply_config_overrides"]
+__all__ = [
+    "build_parser",
+    "configure_logging",
+    "apply_config_overrides",
+    "add_config_argument",
+]

--- a/library/config.py
+++ b/library/config.py
@@ -13,6 +13,12 @@ sections and keys are joined by double underscores. Short aliases such as
 * ``CHEMBL_DA_BASE`` → ``api.chembl_base``
 * ``CHEMBL_DA_TIMEOUT_CONNECT`` → ``api.timeout_connect``
 * ``CHEMBL_DA_TIMEOUT_READ`` → ``api.timeout_read``
+
+Failure modes
+-------------
+``load_config`` raises :class:`ConfigError` when the configuration file is
+missing or cannot be parsed. Type and value mismatches are reported via the
+appropriate built-in exceptions during validation.
 """
 
 from __future__ import annotations
@@ -28,6 +34,10 @@ from urllib.parse import urlparse
 
 
 logger = logging.getLogger(__name__)
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration loading fails."""
 
 
 # ---------------------------------------------------------------------------
@@ -488,21 +498,31 @@ def load_config(
     -------
     Config
         Fully populated configuration object.
+
+    Raises
+    ------
+    ConfigError
+        If ``path`` does not exist or contains invalid YAML.
+    ValueError
+        If ``strict`` is ``True`` and unknown configuration keys are present.
+    TypeError
+        If configuration values have incorrect types.
     """
 
     cfg = Config()
     unknown_keys: List[str] = []
-    if path and Path(path).is_file():
-        try:
-            with Path(path).open("r", encoding="utf8") as fh:
-                data = yaml.safe_load(fh) or {}
-        except yaml.YAMLError as err:
-            raise ValueError(
-                f"Failed to parse YAML configuration at {path}: {err}"
-            ) from err
-        if not isinstance(data, dict):
-            raise TypeError("top-level structure in config file must be a mapping")
-        _update_from_dict(cfg, data, unknown_keys=unknown_keys)
+    try:
+        with Path(path).open("r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except FileNotFoundError as err:
+        raise ConfigError(f"configuration file not found: {path}") from err
+    except yaml.YAMLError as err:
+        raise ConfigError(
+            f"failed to parse YAML configuration at {path}: {err}"
+        ) from err
+    if not isinstance(data, dict):
+        raise TypeError("top-level structure in config file must be a mapping")
+    _update_from_dict(cfg, data, unknown_keys=unknown_keys)
 
     if unknown_keys:
         joined = ", ".join(sorted(unknown_keys))
@@ -538,6 +558,7 @@ __all__ = [
     "RetryCfg",
     "LogCfg",
     "Config",
+    "ConfigError",
     "ensure_dirs",
     "load_config",
 ]

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -12,6 +12,7 @@ from library.config import Config, ensure_dirs
 
 from library import io
 from library.cli import (
+    add_config_argument,
     apply_config_overrides,
     build_parser as base_parser,
     configure_logging,
@@ -86,7 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 import pandas as pd
 from library.config import Config, ensure_dirs
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import add_config_argument, apply_config_overrides, configure_logging
 
 from library.table_quality import analyze_table_quality
 
@@ -84,7 +84,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point."""
     parser = build_parser()
-    parser.add_argument("--config", default="config.yaml")
+    add_config_argument(parser)
     args = parser.parse_args(argv)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from library.cli import add_config_argument, apply_config_overrides
+
+
+def test_apply_config_overrides_missing_config(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    parser = argparse.ArgumentParser()
+    add_config_argument(parser)
+    args = parser.parse_args(["--config", str(tmp_path / "missing.yaml")])
+    with pytest.raises(SystemExit) as excinfo:
+        apply_config_overrides(args, parser, args.config)
+    assert excinfo.value.code == 2
+    assert "configuration file not found" in capsys.readouterr().err

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,14 +3,20 @@ import logging
 
 import pytest
 
-from library.config import ensure_dirs, load_config
+from library.config import ConfigError, ensure_dirs, load_config
 
 
 def test_load_minimal_config(tmp_path: Path) -> None:
-    cfg = load_config(tmp_path / "missing.yaml")
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    cfg = load_config(path)
     assert cfg.api.rps == 5
-
     assert cfg.openalex.rps == 4
+
+
+def test_missing_config_raises(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="configuration file not found"):
+        load_config(tmp_path / "missing.yaml")
 
 
 def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -73,8 +79,10 @@ def test_missing_dirs_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("CHEMBL_DA_OUTDIR", str(tmp_path / "out"))
     monkeypatch.setenv("CHEMBL_DA__IO__CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setenv("CHEMBL_DA__IO__EXIST_OK", "false")
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
     with pytest.raises(FileNotFoundError):
-        load_config(tmp_path / "cfg.yaml")
+        load_config(path)
 
 
 def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -82,7 +90,9 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     cache = tmp_path / "cache"
     monkeypatch.setenv("CHEMBL_DA_OUTDIR", str(out))
     monkeypatch.setenv("CHEMBL_DA__IO__CACHE_DIR", str(cache))
-    cfg = load_config(tmp_path / "cfg.yaml")
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    cfg = load_config(path)
     assert not out.exists() and not cache.exists()
     ensure_dirs(cfg)
     assert out.is_dir() and cache.is_dir()
@@ -102,12 +112,12 @@ def test_unknown_key_error(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Unknown configuration key"):
         load_config(path, strict=True)
 
+
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api: [\n")  # malformed YAML
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ConfigError) as excinfo:
         load_config(path)
     msg = str(excinfo.value)
     assert str(path) in msg
     assert "while parsing" in msg
-


### PR DESCRIPTION
## Summary
- add `ConfigError` and raise on missing or malformed configuration files
- surface `ConfigError` through CLI helpers and document failure modes
- expand `--config` help across entry points and add CLI regression test
- add `add_config_argument` to prevent duplicate `--config` registrations

## Testing
- `ruff check get_*.py library mapper_main.py table_quality_main.py tests`
- `mypy get_*.py library mapper_main.py table_quality_main.py tests/test_cli.py tests/test_config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b54cf3e08324b55b77f5bbd0fbda