### PR TITLE
Fix duplicated --config option in initialization CLI

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -126,10 +126,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point using :class:`Config` for defaults."""
     parser = build_parser()
 
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(
         args,


### PR DESCRIPTION
## Summary
- remove redundant `--config` argument from `get_input_initialisation.py`

## Testing
- `python -m black get_input_initialisation.py`
- `ruff check get_input_initialisation.py`
- `mypy get_input_initialisation.py` *(fails: Library stubs not installed for "pandas" and other modules; NameError `_valid_url`)*
- `pytest` *(fails: argparse conflicting option `--config` in other modules; missing `_valid_url`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bb6aed7883249d32c45fcae5e76f