### PR TITLE
Add URL validation helper and tests

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -29,6 +29,7 @@ import os
 import re
 from pathlib import Path
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 
 import yaml
 import jsonschema
@@ -37,12 +38,29 @@ import jsonschema
 logger = logging.getLogger(__name__)
 
 
-
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+
+
+def _valid_url(url: str) -> bool:
+    """Check that a URL contains both a scheme and network location.
+
+    Parameters
+    ----------
+    url:
+        URL string to validate.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``url`` contains scheme and netloc components.
+    """
+
+    parsed = urlparse(url)
+    return bool(parsed.scheme and parsed.netloc)
+
 
 class ConfigError(RuntimeError):
     """Raised when configuration loading fails."""
-
 
 
 # ---------------------------------------------------------------------------
@@ -683,7 +701,6 @@ CONFIG_SCHEMA: Dict[str, Any] = {
 
 
 def _validate(cfg: Config) -> None:
- 
     """Validate ``cfg`` against :data:`CONFIG_SCHEMA`."""
 
     validator = jsonschema.Draft202012Validator(
@@ -691,7 +708,7 @@ def _validate(cfg: Config) -> None:
     )
     # ``cfg`` contains ``Path`` instances; convert them to strings before validation
     validator.validate(_serialize_paths(cfg.to_dict()))
- 
+
     """Basic sanity checks for configuration values."""
     if not _valid_url(cfg.api.chembl_base):
         raise ValueError("api.chembl_base must be a valid URL")
@@ -742,7 +759,6 @@ def _validate(cfg: Config) -> None:
         raise ValueError(
             "retry.max_attempts must be positive and backoff_factor non-negative"
         )
- 
 
     out_dir = cfg.io.output_dir
     cache_dir = cfg.io.cache_dir

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,7 +156,6 @@ def test_yaml_error_includes_path(tmp_path: Path) -> None:
     assert "while parsing" in msg
 
 
-
 def test_user_agent_must_include_contact(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text(
@@ -181,4 +180,24 @@ def test_crossref_mailto_format(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("crossref:\n  mailto: not-an-email\n")
     with pytest.raises(ValueError, match="crossref.mailto"):
+        load_config(path)
+
+
+@pytest.mark.parametrize(
+    ("snippet", "match"),
+    [
+        ("api:\n  chembl_base: https://\n", "api.chembl_base"),
+        ("openalex:\n  base: https://\n", "openalex.base"),
+        ("crossref:\n  base: https://\n", "crossref.base"),
+        ("uniprot:\n  base: https://\n", "uniprot.base"),
+        ("iuphar:\n  base: https://\n", "iuphar.base"),
+        ("pubchem:\n  base: https://\n", "pubchem.base"),
+    ],
+)
+def test_invalid_urls_raise(tmp_path: Path, snippet: str, match: str) -> None:
+    """Invalid base URLs should trigger :class:`ValueError`."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text(snippet)
+    with pytest.raises(ValueError, match=match):
         load_config(path)


### PR DESCRIPTION
## Summary
- add `_valid_url` helper using `urllib.parse.urlparse`
- validate service base URLs via new helper
- test that invalid URLs raise `ValueError`

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1bd20e87083249b5bc146c8653080