### PR TITLE
Handle configuration errors gracefully in CLI

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -89,20 +89,19 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(
-        args,
-        parser,
-        args.config,
-        mapping={"timeout": "api.timeout_read"},
-    )
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={"timeout": "api.timeout_read"},
+        )
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -83,15 +83,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -443,15 +443,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -9,16 +9,18 @@ from __future__ import annotations
 
 from typing import Iterable
 
+import argparse
+import logging
+from pathlib import Path
+
 import pandas as pd
 from library.config import Config, ensure_dirs
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logging,
-)
+from library.cli import apply_config_overrides, configure_logging
 from library import io
 
 from library.document_type_classifier import compute_scores, decide_label
+
+logger = logging.getLogger(__name__)
 
 
 def _split_terms(value: object) -> Iterable[str]:
@@ -88,9 +90,13 @@ def main() -> int:  # pragma: no cover - simple CLI
     parser.add_argument("--log-level", default="INFO")
 
     args = parser.parse_args()
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
 
     df_in = pd.read_csv(
         args.input_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -125,29 +125,28 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(
-        args,
-        parser,
-        args.config,
-        mapping={
-            "same_doc": "init.same_doc",
-            "all_doc": "init.all_doc",
-            "out_dir": "init.output_dir",
-        },
-    )
-    ensure_dirs(cfg)
+    try:
+        cfg: Config = apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={
+                "same_doc": "init.same_doc",
+                "all_doc": "init.all_doc",
+                "out_dir": "init.output_dir",
+            },
+        )
+        ensure_dirs(cfg)
 
-    args.same_doc = Path(args.same_doc)
-    args.all_doc = Path(args.all_doc)
-    args.out_dir = Path(args.out_dir)
+        args.same_doc = Path(args.same_doc)
+        args.all_doc = Path(args.all_doc)
+        args.out_dir = Path(args.out_dir)
 
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -17,11 +17,7 @@ from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logging,
-)
+from library.cli import apply_config_overrides, configure_logging
 from library.table_quality import analyze_table_quality
 
 logger = logging.getLogger(__name__)
@@ -76,8 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Logging level (DEBUG, INFO, WARNING)",
     )
 
-
- #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
+    #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -613,9 +608,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     if hasattr(args, "func"):
         return args.func(cfg, args)
     parser.print_help()

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -168,15 +168,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -88,14 +88,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -73,18 +73,17 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
-    cfg: Config = apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    if args.print_config:
-        print(cfg.to_yaml())
-        return 0
-    configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    try:
+        cfg: Config = apply_config_overrides(args, parser, args.config)
+        ensure_dirs(cfg)
+        if args.print_config:
+            print(cfg.to_yaml())
+            return 0
+        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        return 1
     return args.func(cfg, args)
 
 

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -1,0 +1,44 @@
+import logging
+import sys
+from pathlib import Path
+
+import get_activity_data as gad
+import get_assay_data as gas
+import get_document_data as gdd
+import get_testitem_data as gtdt
+import mapper_main as mapper
+import table_quality_main as tqm
+import get_input_initialisation as gii
+import get_target_data as gtd
+import get_document_type as gdoctype
+import pytest
+
+
+CLIS = [
+    (gad.main, [], False),
+    (gas.main, [], False),
+    (gdd.main, ["chembl"], False),
+    (gtdt.main, [], False),
+    (mapper.main, [], False),
+    (tqm.main, ["--table-name", "demo"], False),
+    (gii.main, [], False),
+    (gtd.main, ["chembl"], False),
+    (gdoctype.main, ["--input", "in.csv", "--output", "out.csv"], True),
+]
+
+
+@pytest.mark.parametrize("entry, extra, use_sys", CLIS)
+def test_malformed_config_exits(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, entry, extra, use_sys, monkeypatch
+) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("jobs:\n  chunk_size: bad\n")
+    argv = ["--config", str(cfg), *extra]
+    with caplog.at_level(logging.ERROR):
+        if use_sys:
+            monkeypatch.setattr(sys, "argv", ["prog", *argv])
+            rc = entry()
+        else:
+            rc = entry(argv)
+    assert rc != 0
+    assert "jobs.chunk_size" in caplog.text


### PR DESCRIPTION
## Summary
- ensure every CLI validates configuration in a try/except block and logs concise errors
- remove duplicate `--config` arguments from parsers to avoid conflicts
- add regression test covering malformed configuration handling across CLI entry points

## Testing
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_testitem_data.py mapper_main.py table_quality_main.py get_input_initialisation.py get_target_data.py get_document_type.py tests/test_cli_bad_config.py`
- `mypy --disable-error-code name-defined get_activity_data.py get_assay_data.py get_document_data.py get_testitem_data.py mapper_main.py table_quality_main.py get_input_initialisation.py get_target_data.py get_document_type.py tests/test_cli_bad_config.py`
- `pytest tests/test_cli_bad_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1bb1a841483248941abea7185bd20