### PR TITLE
Remove duplicate config arguments from CLI

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -89,11 +89,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(
         args,

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -83,11 +83,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -443,11 +443,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -7,7 +7,7 @@ scoring logic.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import pandas as pd
 from library.config import Config, ensure_dirs
@@ -69,35 +69,19 @@ def classify_dataframe(
     return result
 
 
-def main() -> int:  # pragma: no cover - simple CLI
-    """Command-line entry point for document type classification using :class:`Config`.
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command-line entry point for document type classification."""
 
-    Returns
-    -------
-    int
-        Zero on success, non-zero on failure.
-
-    """
-
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-    parser.add_argument("--input", type=Path, required=True, help="Input CSV")
-    parser.add_argument("--output", type=Path, required=True, help="Output CSV")
-    parser.add_argument("--log-level", default="INFO")
-
-    args = parser.parse_args()
+    parser = base_parser(__doc__ or "Document type classification", column="chembl_id")
+    args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
 
-    df_in = pd.read_csv(
-        args.input_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding
-    )
+    df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
     df_out = classify_dataframe(df_in)
     output = args.output_csv or io.default_output_path(args.input_csv)
-    df_out.to_csv(output, index=False, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding)
+    df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
     return 0
 
 

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -168,11 +168,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -88,9 +88,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
 
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -73,11 +73,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
-
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
-    )
-
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)


### PR DESCRIPTION
## Summary
- remove redundant `--config` CLI arguments so only the base parser defines it
- update `get_document_type.py` to use the shared base parser

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_testitem_data.py mapper_main.py table_quality_main.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_testitem_data.py mapper_main.py table_quality_main.py`
- `mypy get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_testitem_data.py mapper_main.py table_quality_main.py`
- `pytest tests/test_cli.py::test_apply_config_overrides_missing_config`


------
https://chatgpt.com/codex/tasks/task_e_68c1be36d0b88324a7a22889a53ae80a