### PR TITLE
Avoid duplicate metadata writes in write_csv

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -146,9 +146,6 @@ def write_csv(
     df.to_csv(path, index=False, sep=sep, encoding=encoding)
     _write_meta(Path(path), cfg)
 
-    _write_meta(Path(path), cfg)
-
-
 
 def default_output_path(input_path: str | Path) -> Path:
     """Return the default output path for ``input_path``.
@@ -173,7 +170,6 @@ def _git_sha() -> str:
         return result.stdout.strip()
     except Exception:  # pragma: no cover - git may be unavailable
         return "unknown"
-
 
 
 def _write_meta(path: Path, cfg: Config) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
+import pandas as pd
+
 import pytest
 
 from library import io
-from library.config import IoCfg
+from library.config import IoCfg, Config
 
 
 def test_read_csv_validates_columns(tmp_path: Path) -> None:
@@ -27,3 +29,26 @@ def test_read_csv_missing_column(tmp_path: Path) -> None:
         writer.writerow(["1"])
     with pytest.raises(ValueError):
         io.read_csv(path, cfg=IoCfg(), required_columns=["a", "b"])
+
+
+def test_write_csv_creates_single_metadata_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "out.csv"
+    cfg = Config()
+
+    calls: list[Path] = []
+
+    def spy(p: Path, cfg: Config) -> None:
+        calls.append(p)
+        # Create a dummy metadata file to emulate the original behaviour
+        Path(str(p) + ".meta.yaml").touch()
+
+    monkeypatch.setattr(io, "_write_meta", spy)
+    io.write_csv(df, path, cfg=cfg)
+
+    meta_path = Path(str(path) + ".meta.yaml")
+    assert len(calls) == 1
+    assert path.exists()
+    assert meta_path.exists()


### PR DESCRIPTION
## Summary
- avoid writing metadata twice when exporting CSVs
- add regression test ensuring only one metadata file is created

## Testing
- `black library/io.py tests/test_io.py`
- `ruff check library/io.py tests/test_io.py`
- `mypy library/io.py tests/test_io.py`
- `pytest tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1be5fda748324a7ec86bd0621d9f2