### PR TITLE
Add jsonschema dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest>=7.0
+black>=23.0
+ruff>=0.0.290
+mypy>=1.8
+jsonschema>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ mypy>=1.8
 
 openpyxl>=3.1
 pyarrow>=12.0
-jsonschema>=4.0
+jsonschema>=4.0  # Required for configuration validation


### PR DESCRIPTION
## Summary
- include `jsonschema` to the development requirements to prevent configuration crashes
- document `jsonschema` usage in main requirements for clarity

## Testing
- `pip install -r requirements.txt`
- `black --check .` *(fails: would reformat library/io.py, tests/test_table_quality.py, tests/test_status_processing.py, tests/test_input_initialisation_library.py)*
- `ruff check .`
- `mypy library` *(fails: library stubs not installed for several packages)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1becc836883248c5f9a5c11f16d8d