### PR TITLE
Use configuration for external API requests

### DIFF
--- a/get_document_data.py
+++ b/get_document_data.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, OpenAlexCfg, CrossRefCfg
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -53,6 +53,8 @@ logger = logging.getLogger(__name__)
 def fetch_pubmed_records(
     pmids: list[str],
     sleep: float,
+    openalex_cfg: OpenAlexCfg,
+    crossref_cfg: CrossRefCfg,
     max_workers: int = 1,
     batch_size: int = 100,
 ) -> pd.DataFrame:
@@ -63,7 +65,11 @@ def fetch_pubmed_records(
     pmids:
         Identifiers to query.
     sleep:
-        Seconds to pause between API requests.
+        Seconds to pause between PubMed and Semantic Scholar requests.
+    openalex_cfg:
+        Configuration for OpenAlex API access.
+    crossref_cfg:
+        Configuration for CrossRef API access.
     max_workers:
         Maximum number of concurrent threads.
     batch_size:
@@ -104,9 +110,9 @@ def fetch_pubmed_records(
                     semsch = semsch_map.get(pmid, {})
 
                     # Still fetching these individually for now
-                    openalex = ocl.fetch_openalex(session, pmid, sleep)
+                    openalex = ocl.fetch_openalex(session, pmid, openalex_cfg)
                     doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
-                    crossref = ocl.fetch_crossref(session, doi, sleep)
+                    crossref = ocl.fetch_crossref(session, doi, crossref_cfg)
 
                     combined: dict[str, str] = {}
                     combined.update(pubmed)
@@ -163,7 +169,14 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             sep=args.sep,
             encoding=args.encoding,
         )
-        df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
+        df = fetch_pubmed_records(
+            pmids,
+            args.sleep,
+            cfg.openalex,
+            cfg.crossref,
+            args.workers,
+            args.batch_size,
+        )
         output = args.output_csv or io.default_output_path(args.input_csv)
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -289,7 +302,14 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
     pubmed_ids = pd.to_numeric(doc_df["pubmed_id"], errors="coerce").astype("Int64")
     pmids = pubmed_ids.dropna().astype(str).tolist()
-    pub_df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
+    pub_df = fetch_pubmed_records(
+        pmids,
+        args.sleep,
+        cfg.openalex,
+        cfg.crossref,
+        args.workers,
+        args.batch_size,
+    )
     doc_df["pubmed_id"] = pubmed_ids.astype(str)
     if not pub_df.empty and "PubMed.PMID" in pub_df.columns:
         pub_df["PubMed.PMID"] = (

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -321,6 +321,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
                 input_csv=str(tmp_path),
                 output_csv=str(output),
                 data_dir=str(args.data_dir),
+                cfg=cfg.uniprot,
                 sep=args.sep,
                 encoding=args.encoding,
             )

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -18,9 +18,14 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 import logging
+import time
+from urllib.parse import quote
+import io
 
 import pandas as pd
 import requests
+
+from .config import IupharCfg
 
 
 logger = logging.getLogger(__name__)
@@ -537,17 +542,29 @@ class IUPHARData:
     # Web search
     # ------------------------------------------------------------------
 
-    def websearch_gene_to_id(self, gene_name: str) -> dict:
-        """Query the IUPHAR web API for *gene_name*.
+    def websearch_gene_to_id(self, gene_name: str, cfg: IupharCfg) -> dict:
+        """Query the IUPHAR web API for ``gene_name``.
 
-        Returns a dictionary with the first hit or an empty dict on failure.
+        Parameters
+        ----------
+        gene_name:
+            Gene symbol to search for.
+        cfg:
+            API configuration controlling base URL, timeouts and rate limits.
+
+        Returns
+        -------
+        dict
+            First result dictionary or an empty dict on failure.
         """
-        url = (
-            "https://www.guidetopharmacology.org/services/targets/?geneSymbol="
-            + gene_name
-        )
+        delay = 1 / cfg.rps if cfg.rps else 0
+        time.sleep(delay)
+        base = cfg.base.rstrip("/")
+        url = f"{base}/targets/?geneSymbol={quote(gene_name)}"
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(
+                url, timeout=(cfg.timeout_connect, cfg.timeout_read)
+            )
             response.raise_for_status()
             data = response.json()
             return data[0] if data else {}
@@ -559,17 +576,41 @@ class IUPHARData:
     # IUPHAR upload processing
     # ------------------------------------------------------------------
 
-    def iuphar_upload(self) -> pd.DataFrame:
+    def iuphar_upload(self, cfg: IupharCfg) -> pd.DataFrame:
         """Reproduce the ``IUPHAR_upload`` transformation.
+
+        Parameters
+        ----------
+        cfg:
+            API configuration controlling base URL, timeouts and rate limits.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Combined mapping of IUPHAR targets and families.
 
         The function downloads mapping files from the IUPHAR service and
         combines them with the local target and family tables.
         """
-        uni_url = "https://www.guidetopharmacology.org/DATA/GtP_to_UniProt_mapping.csv"
-        hgnc_url = "https://www.guidetopharmacology.org/DATA/GtP_to_HGNC_mapping.csv"
-
-        uni_df = pd.read_csv(uni_url)
-        hgnc_df = pd.read_csv(hgnc_url)
+        base_root = cfg.base.rstrip("/")
+        if base_root.endswith("services"):
+            base_root = base_root.rsplit("/", 1)[0]
+        data_base = f"{base_root}/DATA"
+        delay = 1 / cfg.rps if cfg.rps else 0
+        time.sleep(delay)
+        uni_resp = requests.get(
+            f"{data_base}/GtP_to_UniProt_mapping.csv",
+            timeout=(cfg.timeout_connect, cfg.timeout_read),
+        )
+        uni_resp.raise_for_status()
+        uni_df = pd.read_csv(io.StringIO(uni_resp.text))
+        time.sleep(delay)
+        hgnc_resp = requests.get(
+            f"{data_base}/GtP_to_HGNC_mapping.csv",
+            timeout=(cfg.timeout_connect, cfg.timeout_read),
+        )
+        hgnc_resp.raise_for_status()
+        hgnc_df = pd.read_csv(io.StringIO(hgnc_resp.text))
         hgnc_df = hgnc_df.rename(columns={"IUPHAR ID": "GtoPdb IUPHAR ID"})
         mapping = pd.merge(
             hgnc_df,

--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -11,6 +11,7 @@ import logging
 
 import requests
 
+from .config import CrossRefCfg, OpenAlexCfg
 from . import pubmed_library as _pl
 
 logger = logging.getLogger(__name__)
@@ -19,9 +20,7 @@ logger = logging.getLogger(__name__)
 def fetch_openalex(
     session: requests.Session,
     pmid: str,
-    sleep: float,
-    *,
-    timeout: float = _pl.TIMEOUT,
+    cfg: OpenAlexCfg,
 ) -> Dict[str, str]:
     """Return OpenAlex metadata for ``pmid``.
 
@@ -31,10 +30,8 @@ def fetch_openalex(
         Session used for the HTTP request.
     pmid: str
         PubMed identifier.
-    sleep: float
-        Delay before making the request in seconds.
-    timeout: float, optional
-        Maximum seconds to wait for the HTTP response.
+    cfg: OpenAlexCfg
+        Configuration specifying base URL, timeouts and rate limits.
 
     Returns
     -------
@@ -48,15 +45,13 @@ def fetch_openalex(
 
     """
 
-    return _pl.fetch_openalex(session, pmid, sleep, timeout=timeout)
+    return _pl.fetch_openalex(session, pmid, cfg=cfg)
 
 
 def fetch_crossref(
     session: requests.Session,
     doi: str,
-    sleep: float,
-    *,
-    timeout: float = _pl.TIMEOUT,
+    cfg: CrossRefCfg,
 ) -> Dict[str, str]:
     """Return CrossRef metadata for ``doi``.
 
@@ -66,10 +61,8 @@ def fetch_crossref(
         Session used for the HTTP request.
     doi: str
         Digital Object Identifier of the article.
-    sleep: float
-        Delay before making the request in seconds.
-    timeout: float, optional
-        Maximum seconds to wait for the HTTP response.
+    cfg: CrossRefCfg
+        Configuration specifying base URL, timeouts and rate limits.
 
     Returns
     -------
@@ -83,4 +76,4 @@ def fetch_crossref(
 
     """
 
-    return _pl.fetch_crossref(session, doi, sleep, timeout=timeout)
+    return _pl.fetch_crossref(session, doi, cfg=cfg)

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -18,6 +18,8 @@ import requests
 from xml.etree import ElementTree as ET
 from urllib.parse import quote
 
+from .config import CrossRefCfg, OpenAlexCfg
+
 ENCODINGS = ["utf-8-sig", "cp1251", "latin1"]
 TIMEOUT = 10
 
@@ -51,7 +53,7 @@ def _do_request(
     expect_json: bool = True,
     retries: int = 2,
     method: str = "GET",
-    timeout: float = TIMEOUT,
+    timeout: float | tuple[float, float] = TIMEOUT,
     **kwargs: Any,
 ) -> Tuple[Union[Dict[str, Any], str, None], str]:
     """Perform an HTTP request with retry and error handling.
@@ -71,7 +73,8 @@ def _do_request(
     method:
         HTTP method to use, either "GET" or "POST".
     timeout:
-        Maximum seconds to wait for each HTTP request.
+        Maximum seconds to wait for each HTTP request. May be a single float
+        or a ``(connect, read)`` tuple.
     **kwargs:
         Additional parameters passed to ``session.get`` or ``session.post``.
 
@@ -523,9 +526,8 @@ def fetch_semantic_scholar_batch(
 def fetch_openalex(
     session: requests.Session,
     pmid: str,
-    sleep: float,
     *,
-    timeout: float = TIMEOUT,
+    cfg: OpenAlexCfg,
 ) -> Dict[str, str]:
     """Retrieve OpenAlex metadata for ``pmid``.
 
@@ -535,10 +537,8 @@ def fetch_openalex(
         Active :class:`requests.Session`.
     pmid:
         PubMed identifier to query.
-    sleep:
-        Seconds to pause before making the request.
-    timeout:
-        Maximum seconds to wait for the HTTP response. Defaults to ``TIMEOUT``.
+    cfg:
+        OpenAlex configuration providing base URL, timeouts and rate limits.
 
     Returns
     -------
@@ -546,8 +546,12 @@ def fetch_openalex(
         Mapping of OpenAlex fields and any error encountered.
 
     """
-    url = f"https://api.openalex.org/works/pmid:{pmid}"
-    data, error = _do_request(session, url, sleep, timeout=timeout)
+    delay = 1 / cfg.rps if cfg.rps else 0
+    time.sleep(delay)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(session, url, delay, timeout=timeout)
     if error or not isinstance(data, dict):
         return {
             "OpenAlex.PublicationTypes": "",
@@ -585,9 +589,8 @@ def fetch_openalex(
 def fetch_crossref(
     session: requests.Session,
     doi: str,
-    sleep: float,
     *,
-    timeout: float = TIMEOUT,
+    cfg: CrossRefCfg,
 ) -> Dict[str, str]:
     """Retrieve Crossref metadata for a given DOI.
 
@@ -597,10 +600,8 @@ def fetch_crossref(
         Active :class:`requests.Session`.
     doi:
         Digital Object Identifier to query.
-    sleep:
-        Seconds to pause before making the request.
-    timeout:
-        Maximum seconds to wait for the HTTP response. Defaults to ``TIMEOUT``.
+    cfg:
+        CrossRef configuration providing base URL, timeouts and rate limits.
 
     Returns
     -------
@@ -618,8 +619,12 @@ def fetch_crossref(
             "crossref.Error": "Missing DOI",
         }
 
-    url = f"https://api.crossref.org/works/{quote(doi, safe='')}"
-    data, error = _do_request(session, url, sleep, timeout=timeout)
+    delay = 1 / cfg.rps if cfg.rps else 0
+    time.sleep(delay)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/works/{quote(doi, safe='')}?mailto={quote(cfg.mailto)}"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(session, url, delay, timeout=timeout)
     if error or not isinstance(data, dict):
         return {
             "crossref.Type": "",
@@ -713,9 +718,9 @@ def main() -> None:
                 semsch = semsch_map.get(pmid, {})
 
                 # Still fetching these individually
-                openalex = fetch_openalex(session, pmid, args.sleep)
+                openalex = fetch_openalex(session, pmid, cfg=OpenAlexCfg())
                 doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
-                crossref = fetch_crossref(session, doi, args.sleep)
+                crossref = fetch_crossref(session, doi, cfg=CrossRefCfg())
 
                 combined: Dict[str, str] = {}
                 combined.update(pubmed)

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -38,12 +38,15 @@ import csv
 import json
 import logging
 import os
+import time
 from typing import Any, Dict, Iterable, List, Set
 
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+from .config import UniprotCfg
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +60,6 @@ _retry = Retry(
 _session: Session = requests.Session()
 _session.mount("http://", HTTPAdapter(max_retries=_retry))
 _session.mount("https://", HTTPAdapter(max_retries=_retry))
-
-API_URL = "https://rest.uniprot.org/uniprotkb/{id}.json"
 
 __all__ = [
     "fetch_uniprot",
@@ -85,15 +86,15 @@ class UniProtFetchError(RuntimeError):
     """Raised when a UniProt record cannot be retrieved or decoded."""
 
 
-def fetch_uniprot(uniprot_id: str, *, timeout: float = 30.0) -> Dict[str, Any]:
+def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> Dict[str, Any]:
     """Fetch a UniProt JSON record from the public REST API.
 
     Parameters
     ----------
     uniprot_id:
         UniProt accession identifier to retrieve.
-    timeout:
-        Maximum seconds to wait for the HTTP response. Defaults to ``30``.
+    cfg:
+        UniProt configuration providing base URL, timeouts and rate limits.
 
     Returns
     -------
@@ -106,7 +107,11 @@ def fetch_uniprot(uniprot_id: str, *, timeout: float = 30.0) -> Dict[str, Any]:
         If the request fails or the payload cannot be decoded as JSON.
 
     """
-    url = API_URL.format(id=uniprot_id)
+    delay = 1 / cfg.rps if cfg.rps else 0
+    time.sleep(delay)
+    base = cfg.base.rstrip("/")
+    url = f"{base}/uniprotkb/{uniprot_id}.json"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
     try:
         with _session.get(url, timeout=timeout) as resp:
             resp.raise_for_status()
@@ -391,7 +396,7 @@ def extract_gene_name(data: Any) -> str | None:
     return None
 
 
-def extract_names_for_secondary_accessions(data: Any) -> str:
+def extract_names_for_secondary_accessions(data: Any, *, cfg: UniprotCfg) -> str:
     """Return protein names for secondary accessions listed in ``data``.
 
     The function looks up each secondary accession via :func:`fetch_uniprot`
@@ -414,7 +419,7 @@ def extract_names_for_secondary_accessions(data: Any) -> str:
     names: Set[str] = set()
     for acc in extract_secondary_accessions(data):
         try:
-            entry = fetch_uniprot(acc)
+            entry = fetch_uniprot(acc, cfg=cfg)
         except UniProtFetchError as exc:  # pragma: no cover - network errors
             logger.warning("failed to fetch secondary accession %s: %s", acc, exc)
             continue
@@ -818,14 +823,23 @@ def iter_ids(csv_path: str, sep: str = ",", encoding: str = "utf-8") -> Iterable
         raise ValueError(f"malformed CSV in file: {csv_path}: {exc}") from exc
 
 
-def collect_info(uid: str, data_dir: str = "uniprot") -> Dict[str, Any]:
+def collect_info(
+    uid: str, data_dir: str = "uniprot", *, cfg: UniprotCfg
+) -> Dict[str, Any]:
     """Return names, organism, keyword, PTM, isoform, cross-ref, and activity data for ``uid``.
 
-    Args:
-        uid: UniProt accession identifier.
-        data_dir: Directory containing ``<uid>.json`` files with UniProt data.
+    Parameters
+    ----------
+    uid:
+        UniProt accession identifier.
+    data_dir:
+        Directory containing ``<uid>.json`` files with UniProt data.
+    cfg:
+        UniProt configuration used for downloading missing records.
 
-    Returns:
+    Returns
+    -------
+    dict
         A dictionary with keys ``uniprot_id``, ``names``, organism taxonomy
         fields, keyword categories, EC numbers, subcellular location data,
         membrane features, post-translational modification flags, isoform
@@ -878,7 +892,7 @@ def collect_info(uid: str, data_dir: str = "uniprot") -> Dict[str, Any]:
     except FileNotFoundError:
         logger.info("downloading UniProt JSON for %s", uid)
         try:
-            data = fetch_uniprot(uid)
+            data = fetch_uniprot(uid, cfg=cfg)
         except UniProtFetchError as exc:
             logger.warning("failed to retrieve UniProt JSON for %s: %s", uid, exc)
             return result
@@ -930,7 +944,9 @@ def collect_info(uid: str, data_dir: str = "uniprot") -> Dict[str, Any]:
     result["secondaryAccessions"] = extract_secondary_accessions(data)
     result["recommendedName"] = extract_recommended_name(data)
     result["geneName"] = extract_gene_name(data)
-    result["secondaryAccessionNames"] = extract_names_for_secondary_accessions(data)
+    result["secondaryAccessionNames"] = extract_names_for_secondary_accessions(
+        data, cfg=cfg
+    )
     return result
 
 
@@ -939,6 +955,7 @@ def process(
     output_csv: str,
     data_dir: str = "uniprot",
     *,
+    cfg: UniprotCfg,
     sep: str = ",",
     encoding: str = "utf-8",
 ) -> None:
@@ -957,6 +974,9 @@ def process(
         Destination path for the output CSV file.
     data_dir:
         Directory where JSON files for each ID are stored.
+    cfg:
+        UniProt configuration used for network requests when local files are
+        missing.
     sep:
         Field delimiter used for both input and output CSV files. Defaults to a comma.
     encoding:
@@ -1016,7 +1036,7 @@ def process(
             writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter=sep)
             writer.writeheader()
             for uid in iter_ids(input_csv, sep=sep, encoding=encoding):
-                info = collect_info(uid, data_dir)
+                info = collect_info(uid, data_dir, cfg=cfg)
                 info["secondaryAccessions"] = "|".join(info["secondaryAccessions"])
                 writer.writerow(info)
     except OSError as exc:

--- a/tests/test_iuphar_library.py
+++ b/tests/test_iuphar_library.py
@@ -1,0 +1,83 @@
+import pandas as pd
+import pytest
+
+from library import iuphar_library as ii
+from library.config import IupharCfg
+
+
+def test_websearch_gene_to_id_uses_cfg(monkeypatch):
+    data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
+    called = {}
+
+    def fake_get(url: str, timeout: tuple[int, int]):
+        called["url"] = url
+        called["timeout"] = timeout
+
+        class Resp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return [{"id": 1}]
+
+        return Resp()
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(ii.requests, "get", fake_get)
+    monkeypatch.setattr(ii.time, "sleep", lambda s: sleeps.append(s))
+
+    cfg = IupharCfg(
+        base="https://example.org/services",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=5,
+        burst=5,
+    )
+    result = data.websearch_gene_to_id("GENE", cfg)
+    assert result == {"id": 1}
+    assert called["url"] == "https://example.org/services/targets/?geneSymbol=GENE"
+    assert called["timeout"] == (1, 2)
+    assert sleeps and sleeps[0] == pytest.approx(0.2)
+
+
+def test_iuphar_upload_uses_cfg(monkeypatch):
+    target_df = pd.DataFrame({"target_id": [1], "family_id": ["F1"]})
+    family_df = pd.DataFrame(
+        {"family_id": ["F1"], "family_name": ["Fam"], "parent_family_id": [pd.NA]}
+    )
+    data = ii.IUPHARData(target_df=target_df, family_df=family_df)
+    calls: list[tuple[str, tuple[int, int]]] = []
+
+    uni_csv = "GtoPdb IUPHAR ID,IUPHAR ID,UniProtKB ID\n1,1,P12345\n"
+    hgnc_csv = "GtoPdb IUPHAR ID,HGNC ID,IUPHAR Name\n1,HG1,Name\n"
+
+    def fake_get(url: str, timeout: tuple[int, int]):
+        calls.append((url, timeout))
+        text = uni_csv if "UniProt" in url else hgnc_csv
+
+        class Resp:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+            def raise_for_status(self):
+                return None
+
+        return Resp(text)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(ii.requests, "get", fake_get)
+    monkeypatch.setattr(ii.time, "sleep", lambda s: sleeps.append(s))
+
+    cfg = IupharCfg(
+        base="https://example.org/services",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=10,
+        burst=5,
+    )
+    df = data.iuphar_upload(cfg)
+    assert not df.empty
+    assert calls[0][0] == "https://example.org/DATA/GtP_to_UniProt_mapping.csv"
+    assert calls[0][1] == (1, 2)
+    assert calls[1][0] == "https://example.org/DATA/GtP_to_HGNC_mapping.csv"
+    assert sleeps and sleeps[0] == pytest.approx(0.1)

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -1,0 +1,59 @@
+import requests
+import pytest
+
+from library import openalex_crossref_library as ocl
+from library.config import OpenAlexCfg, CrossRefCfg
+
+
+def test_fetch_openalex_uses_cfg(monkeypatch):
+    called = {}
+
+    def fake_do_request(session, url, sleep, timeout=(), **kwargs):
+        called["url"] = url
+        called["sleep"] = sleep
+        called["timeout"] = timeout
+        return {}, ""
+
+    monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
+    sleeps: list[float] = []
+    monkeypatch.setattr("library.pubmed_library.time.sleep", lambda s: sleeps.append(s))
+
+    cfg = OpenAlexCfg(
+        base="https://example.org",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=2,
+        burst=5,
+        mailto="x@y.com",
+    )
+    ocl.fetch_openalex(requests.Session(), "123", cfg)
+    assert called["url"] == "https://example.org/works/pmid:123?mailto=x%40y.com"
+    assert called["timeout"] == (1, 2)
+    assert sleeps and sleeps[0] == pytest.approx(0.5)
+
+
+def test_fetch_crossref_uses_cfg(monkeypatch):
+    called = {}
+
+    def fake_do_request(session, url, sleep, timeout=(), **kwargs):
+        called["url"] = url
+        called["sleep"] = sleep
+        called["timeout"] = timeout
+        return {}, ""
+
+    monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
+    sleeps: list[float] = []
+    monkeypatch.setattr("library.pubmed_library.time.sleep", lambda s: sleeps.append(s))
+
+    cfg = CrossRefCfg(
+        base="https://cr.example.org",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=4,
+        burst=5,
+        mailto="z@e.com",
+    )
+    ocl.fetch_crossref(requests.Session(), "10.1/abc", cfg)
+    assert called["url"] == "https://cr.example.org/works/10.1%2Fabc?mailto=z%40e.com"
+    assert called["timeout"] == (1, 2)
+    assert sleeps and sleeps[0] == pytest.approx(0.25)

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -1,0 +1,39 @@
+from library import pubchem_library as pl
+
+
+def test_get_cid_from_smiles_uses_base(monkeypatch):
+    called = {}
+
+    def fake_request(url: str, cfg: pl.PubChemCfg, delay: float = 3.0):
+        called["url"] = url
+        return {"IdentifierList": {"CID": [1]}}
+
+    monkeypatch.setattr(pl, "make_request", fake_request)
+    cfg = pl.PubChemCfg(base="https://example.org/api")
+    cid = pl.get_cid_from_smiles("C", cfg)
+    assert called["url"] == "https://example.org/api/compound/smiles/C/cids/JSON"
+    assert cid == "1"
+
+
+def test_make_request_uses_timeout(monkeypatch):
+    called = {}
+
+    def fake_get(url: str, timeout: tuple[int, int]):
+        called["timeout"] = timeout
+
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {}
+
+        return Resp()
+
+    monkeypatch.setattr(pl._session, "get", fake_get)
+    monkeypatch.setattr(pl.time, "sleep", lambda s: None)
+    cfg = pl.PubChemCfg(timeout_connect=1, timeout_read=2)
+    pl.make_request("https://example.org", cfg, delay=0)
+    assert called["timeout"] == (1, 2)

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import time
 import requests
 import pytest
 
 from library import uniprot_library as ul
+from library.config import UniprotCfg
 
 
 def test_extract_names() -> None:
@@ -51,7 +53,7 @@ def test_fetch_uniprot_network_error(monkeypatch) -> None:
 
     monkeypatch.setattr(ul._session, "get", fake_get)
     with pytest.raises(ul.UniProtFetchError):
-        ul.fetch_uniprot("P12345")
+        ul.fetch_uniprot("P12345", cfg=UniprotCfg())
 
 
 def test_fetch_uniprot_bad_json(monkeypatch) -> None:
@@ -62,4 +64,29 @@ def test_fetch_uniprot_bad_json(monkeypatch) -> None:
 
     monkeypatch.setattr(ul._session, "get", fake_get)
     with pytest.raises(ul.UniProtFetchError):
-        ul.fetch_uniprot("P12345")
+        ul.fetch_uniprot("P12345", cfg=UniprotCfg())
+
+
+def test_fetch_uniprot_uses_cfg(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> _DummyResponse:
+        called["url"] = url
+        called["timeout"] = timeout
+        return _DummyResponse()
+
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(ul._session, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    cfg = UniprotCfg(
+        base="https://example.org/api",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=2,
+        burst=5,
+    )
+    ul.fetch_uniprot("P12345", cfg=cfg)
+    assert called["url"] == "https://example.org/api/uniprotkb/P12345.json"
+    assert called["timeout"] == (1, 2)
+    assert sleeps and sleeps[0] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- route OpenAlex and CrossRef lookups through configurable API settings
- drive UniProt and IUPHAR network calls with `*Cfg` options
- propagate CLI configuration to data fetch helpers and add coverage

## Testing
- `black library/openalex_crossref_library.py library/pubmed_library.py library/uniprot_library.py library/iuphar_library.py get_document_data.py get_target_data.py tests/test_uniprot_library.py tests/test_openalex_crossref_library.py tests/test_iuphar_library.py tests/test_pubchem_library.py`
- `ruff check library/openalex_crossref_library.py library/pubmed_library.py library/uniprot_library.py library/iuphar_library.py get_document_data.py get_target_data.py tests/test_uniprot_library.py tests/test_openalex_crossref_library.py tests/test_iuphar_library.py tests/test_pubchem_library.py`
- `mypy library/openalex_crossref_library.py library/pubmed_library.py library/uniprot_library.py library/iuphar_library.py get_document_data.py get_target_data.py tests/test_uniprot_library.py tests/test_openalex_crossref_library.py tests/test_iuphar_library.py tests/test_pubchem_library.py` *(fails: Library stubs not installed for "pandas", "requests", "yaml", "jsonschema" and more)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1bea83674832498acb5b532b81e89