### PR TITLE
Import base parser for document type CLI

### DIFF
--- a/get_document_type.py
+++ b/get_document_type.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 
 from typing import Iterable, Sequence
 
-import argparse
 import logging
-from pathlib import Path
 
 import pandas as pd
 from library.config import Config, ensure_dirs
-from library.cli import apply_config_overrides, configure_logging
+from library.cli import (
+    apply_config_overrides,
+    build_parser as base_parser,
+    configure_logging,
+)
 from library import io
 
 from library.document_type_classifier import compute_scores, decide_label
@@ -74,13 +76,11 @@ def classify_dataframe(
 def main(argv: Sequence[str] | None = None) -> int:
     """Command-line entry point for document type classification."""
 
-
     parser = base_parser(__doc__ or "Document type classification", column="chembl_id")
     args = parser.parse_args(argv)
     cfg: Config = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-
 
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
     df_out = classify_dataframe(df_in)


### PR DESCRIPTION
## Summary
- fix get_document_type CLI import to include base parser
- clean up unused imports

## Testing
- `black get_document_type.py`
- `ruff check get_document_type.py`
- `mypy get_document_type.py`
- `pytest` *(fails: TypeError on malformed config, AssertionError for OpenAlex & CrossRef URLs)*
- `python get_document_type.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c1c44ba3048324a456d1ffc907f0c7