### PR TITLE
Handle unknown env config paths gracefully

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -404,19 +404,38 @@ _ALIAS_MAP: Dict[str, List[str]] = {
 
 
 def _apply_env_overrides(cfg: Config) -> None:
-    """Apply environment variable overrides to ``cfg``."""
+    """Apply environment variable overrides to ``cfg``.
+
+    Environment variables that do not map to known configuration paths are
+    ignored and generate a warning.
+    """
 
     prefix = "CHEMBL_DA"
     for env_key, env_val in os.environ.items():
         key = env_key.upper()
         if key in _ALIAS_MAP:
-            _set_by_path(cfg, _ALIAS_MAP[key], env_val)
+            path = _ALIAS_MAP[key]
+            try:
+                _set_by_path(cfg, path, env_val)
+            except KeyError:
+                logger.warning(
+                    "Environment variable %s ignored: unknown config path %s",
+                    key,
+                    ".".join(path),
+                )
             continue
         if not key.startswith(prefix + "__"):
             continue
         parts = key.split("__")[1:]
         path_parts = [p.lower() for p in parts]
-        _set_by_path(cfg, path_parts, env_val)
+        try:
+            _set_by_path(cfg, path_parts, env_val)
+        except KeyError:
+            logger.warning(
+                "Environment variable %s ignored: unknown config path %s",
+                key,
+                ".".join(path_parts),
+            )
 
 
 def _serialize_paths(data: Any) -> Any:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -201,3 +201,16 @@ def test_invalid_urls_raise(tmp_path: Path, snippet: str, match: str) -> None:
     path.write_text(snippet)
     with pytest.raises(ValueError, match=match):
         load_config(path)
+
+
+def test_unknown_env_var_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    monkeypatch.setenv("CHEMBL_DA__FOO__BAR", "1")
+    with caplog.at_level(logging.WARNING, logger="library.config"):
+        load_config(path)
+    assert "Environment variable CHEMBL_DA__FOO__BAR ignored" in caplog.text


### PR DESCRIPTION
## Summary
- warn rather than raise when environment variables target unknown config paths
- test that unknown env variables are ignored with a warning

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py`
- `pytest tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1c5589d748324ba9390efcf209aa5