### PR TITLE
Validate logging level in configuration loader

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -709,6 +709,11 @@ def _validate(cfg: Config) -> None:
     # ``cfg`` contains ``Path`` instances; convert them to strings before validation
     validator.validate(_serialize_paths(cfg.to_dict()))
 
+    # Validate logging level (case-insensitive)
+    if cfg.log.level.upper() not in logging._nameToLevel:
+        valid = ", ".join(sorted(logging._nameToLevel))
+        raise ValueError(f"log.level must be one of {valid}, got {cfg.log.level!r}")
+
     """Basic sanity checks for configuration values."""
     if not _valid_url(cfg.api.chembl_base):
         raise ValueError("api.chembl_base must be a valid URL")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -201,3 +201,17 @@ def test_invalid_urls_raise(tmp_path: Path, snippet: str, match: str) -> None:
     path.write_text(snippet)
     with pytest.raises(ValueError, match=match):
         load_config(path)
+
+
+def test_log_level_valid(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("log:\n  level: warn\n")
+    cfg = load_config(path)
+    assert cfg.log.level == "warn"
+
+
+def test_log_level_invalid(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("log:\n  level: verbose\n")
+    with pytest.raises(ValueError, match="log.level"):
+        load_config(path)


### PR DESCRIPTION
## Summary
- validate `log.level` against standard logging names
- add tests for valid and invalid logging levels

## Testing
- `python -m black library/config.py tests/test_config.py`
- `python -m ruff check library/config.py tests/test_config.py`
- `python -m mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c55b5b9c83249876cc9caf4daf70