### PR TITLE
Respect configured output directory for outputs

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -56,7 +56,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -56,7 +56,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
     df = ap.postprocess_assays(df)
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -182,7 +182,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             args.workers,
             args.batch_size,
         )
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
     except (FileNotFoundError, ValueError, OSError) as exc:
@@ -229,7 +229,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -277,7 +277,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     if doc_df.empty or "pubmed_id" not in doc_df:
         processed = dp.postprocess_documents(doc_df)
         # Merge any columns not covered by ``postprocess_documents`` back
@@ -309,6 +309,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
+        args.sleep,
         cfg.openalex,
         cfg.crossref,
         args.workers,

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -90,10 +90,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         return 1
 
-
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
     df_out = classify_dataframe(df_in)
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
     return 0
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -320,7 +320,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
                 writer.writerow({"uniprot_id": uid})
             tmp_path = Path(tmp.name)
 
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         try:
             uu.process(
                 input_csv=str(tmp_path),
@@ -381,7 +381,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -418,7 +418,7 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
             family_path=args.family_csv,
             encoding=args.encoding,
         )
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         data.map_uniprot_file(
             input_path=args.input_csv,
             output_path=output,
@@ -463,7 +463,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     try:
-        output = args.output_csv or io.default_output_path(args.input_csv)
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         chembl_out = args.chembl_out or output.with_name(output.stem + "_chembl.csv")
         uniprot_out = args.uniprot_out or output.with_name(output.stem + "_uniprot.csv")
         iuphar_out = args.iuphar_out or output.with_name(output.stem + "_iuphar.csv")

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -139,7 +139,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Augmenting results with PubChem data")
     df = add_pubchem_data(df, cfg.pubchem)
     logger.info("PubChem augmentation completed")
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/library/io.py
+++ b/library/io.py
@@ -147,16 +147,25 @@ def write_csv(
     _write_meta(Path(path), cfg)
 
 
-def default_output_path(input_path: str | Path) -> Path:
+def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     """Return the default output path for ``input_path``.
 
-    The generated name follows the pattern
-    ``output_<stem>_YYYYMMDD.csv`` and is placed next to
-    ``input_path``.
+    Parameters
+    ----------
+    input_path:
+        Source file path used only for deriving the stem name.
+    cfg:
+        I/O configuration providing the base directory for generated files.
+
+    Returns
+    -------
+    pathlib.Path
+        Path pointing inside ``cfg.output_dir`` following the
+        ``output_<stem>_YYYYMMDD.csv`` naming scheme.
     """
     inp = Path(input_path)
     date_str = datetime.now().strftime("%Y%m%d")
-    return inp.with_name(f"output_{inp.stem}_{date_str}.csv")
+    return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
 
 
 def _git_sha() -> str:

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -64,7 +64,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             logger.warning("failed to map %s: %s", chembl_id, exc)
             uniprot_ids.append(None)
     df["mapping_uniprot_id"] = uniprot_ids
-    output = args.output_csv or io.default_output_path(args.input_csv)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("wrote %s", output)

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+
+import pandas as pd
+import pytest
+
+from library import io
+from library.config import Config, IoCfg
+import mapper_main
+
+
+def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:
+    cfg = IoCfg(output_dir=tmp_path)
+    result = io.default_output_path(tmp_path / "input.csv", cfg)
+    assert result.parent == tmp_path
+    assert result.name.startswith("output_input_")
+
+
+def test_mapper_run_defaults_to_io_output_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    input_path = tmp_path / "data.csv"
+    input_path.write_text("chembl_id\nCHEMBL1\n")
+
+    cfg = Config()
+    cfg.io.output_dir = tmp_path / "results"
+
+    args = argparse.Namespace(
+        input_csv=input_path,
+        output_csv=None,
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+    )
+
+    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _: "P12345")
+    monkeypatch.setattr(io, "_write_meta", lambda *_a, **_k: None)
+
+    rc = mapper_main.run(cfg, args)
+    assert rc == 0
+
+    expected = io.default_output_path(input_path, cfg.io)
+    assert expected.exists()
+    df = pd.read_csv(expected)
+    assert "mapping_uniprot_id" in df.columns


### PR DESCRIPTION
## Summary
- route default_output_path through IoCfg so outputs land under cfg.output_dir
- pass cfg.io to default_output_path in all CLI entry points
- test that default output paths honour io.output_dir

## Testing
- `ruff check library/io.py mapper_main.py get_document_type.py get_target_data.py get_document_data.py get_testitem_data.py get_activity_data.py get_assay_data.py tests/test_default_output_dir.py tests/test_io.py`
- `black library/io.py mapper_main.py get_document_type.py get_target_data.py get_document_data.py get_testitem_data.py get_activity_data.py get_assay_data.py tests/test_default_output_dir.py tests/test_io.py`
- `mypy library/io.py mapper_main.py get_document_type.py get_target_data.py get_document_data.py get_testitem_data.py get_activity_data.py get_assay_data.py tests/test_default_output_dir.py tests/test_io.py`
- `pytest tests/test_default_output_dir.py tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c898d8f4832496a39ba923c0c044