### PR TITLE
Validate boolean env vars and test invalid values

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -278,10 +278,24 @@ class Config:
 
 
 def _coerce(value: str, current: Any) -> Any:
-    """Coerce ``value`` (from env/CLI) to the type of ``current``."""
+    """Coerce ``value`` (from env/CLI) to the type of ``current``.
+
+    When ``current`` is :class:`bool`, only a restricted set of string
+    representations is accepted. Truthy values are ``{"1", "true", "yes",
+    "on"}`` and falsy values are ``{"0", "false", "no", "off"}``.
+    Any other value raises :class:`ValueError` to avoid silently interpreting
+    unexpected input.
+    """
 
     if isinstance(current, bool):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
+        val = value.strip().lower()
+        truthy = {"1", "true", "yes", "on"}
+        falsy = {"0", "false", "no", "off"}
+        if val in truthy:
+            return True
+        if val in falsy:
+            return False
+        raise ValueError(f"Invalid boolean value: {value!r}")
     if isinstance(current, int):
         return int(value)
     if isinstance(current, float):
@@ -359,6 +373,8 @@ def _set_by_path(cfg: Config, path: List[str], value: Any) -> None:
             raise TypeError
     except Exception as exc:  # pragma: no cover - defensive
         joined = ".".join(path)
+        if isinstance(exc, ValueError):
+            raise ValueError(f"{joined}: {exc}") from exc
         raise TypeError(
             f"{joined} must be {type(current).__name__}, got {value!r}"
         ) from exc

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,6 +118,16 @@ def test_missing_dirs_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
         load_config(path)
 
 
+def test_invalid_bool_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure unknown boolean strings raise :class:`ValueError`."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    monkeypatch.setenv("CHEMBL_DA__IO__EXIST_OK", "maybe")
+    with pytest.raises(ValueError, match="Invalid boolean value"):
+        load_config(path)
+
+
 def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     out = tmp_path / "out"
     cache = tmp_path / "cache"
@@ -202,7 +212,7 @@ def test_invalid_urls_raise(tmp_path: Path, snippet: str, match: str) -> None:
     with pytest.raises(ValueError, match=match):
         load_config(path)
 
- 
+
 def test_unknown_env_var_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -214,7 +224,8 @@ def test_unknown_env_var_warning(
     with caplog.at_level(logging.WARNING, logger="library.config"):
         load_config(path)
     assert "Environment variable CHEMBL_DA__FOO__BAR ignored" in caplog.text
- 
+
+
 def test_log_level_valid(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("log:\n  level: warn\n")
@@ -227,4 +238,3 @@ def test_log_level_invalid(tmp_path: Path) -> None:
     path.write_text("log:\n  level: verbose\n")
     with pytest.raises(ValueError, match="log.level"):
         load_config(path)
- 


### PR DESCRIPTION
## Summary
- validate boolean string values in `_coerce`
- surface boolean conversion errors through `_set_by_path`
- test invalid boolean environment variables

## Testing
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c89a9804832493e76669b7bdd530