### PR TITLE
fix: clarify ChEMBL API base comment

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,8 @@
 #   export CHEMBL_DA_BASE=https://dev.example/chembl  # short alias
 
 api:
-  chembl_base: "https://www.ebi.ac.uk/chembl/api/data"  # Base URL for ChEMBL API (env: CHEMBL_DA__API__CHEMBL_BASE / CHEMBL_DA_BASE)
+  # Base URL for ChEMBL API (env: CHEMBL_DA__API__CHEMBL_BASE / CHEMBL_DA_BASE)
+  chembl_base: "https://www.ebi.ac.uk/chembl/api/data"
   timeout_connect: 5  # Seconds to wait for a connection
   timeout_read: 30  # Seconds to wait for a response
   retries: 3  # HTTP retry attempts


### PR DESCRIPTION
## Summary
- clarify environment variables for ChEMBL API base URL in `config.yaml`

## Testing
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d40292e08324a3467ea894a19fb3