### PR TITLE
feat: add configuration print option

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -7,7 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 
 from library import chembl_library as cl
 from library import io
@@ -97,6 +97,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.config,
             mapping={"timeout": "api.timeout_read"},
         )
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,7 +7,7 @@ import logging
 from typing import Sequence
 
 import requests
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -86,6 +86,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -31,7 +31,7 @@ from typing import Sequence
 
 import pandas as pd
 
-from library.config import Config, ensure_dirs, OpenAlexCfg, CrossRefCfg
+from library.config import Config, ensure_dirs, OpenAlexCfg, CrossRefCfg, print_config
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -471,6 +471,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -12,7 +12,7 @@ from typing import Iterable, Sequence
 import logging
 
 import pandas as pd
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
@@ -81,6 +81,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -14,7 +14,7 @@ import logging
 from pathlib import Path
 from typing import Sequence
 
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
@@ -138,6 +138,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "out_dir": "init.output_dir",
             },
         )
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
 
         args.same_doc = Path(args.same_doc)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 
 from library import chembl_library as cl
 from library import io
@@ -75,6 +75,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING)",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
     )
 
     #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
@@ -616,6 +621,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -171,6 +171,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/library/cli.py
+++ b/library/cli.py
@@ -93,6 +93,11 @@ def build_parser(
         default=Path("config.yaml"),
         help="YAML configuration file",
     )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
     return parser
 
 

--- a/library/config.py
+++ b/library/config.py
@@ -468,6 +468,42 @@ def _serialize_paths(data: Any) -> Any:
     return data
 
 
+def _mask_secrets(data: Any) -> Any:
+    """Recursively mask values for keys that look like secrets.
+
+    Keys containing common secret keywords (``key``, ``token``, ``secret``,
+    ``password``) have their values replaced with ``"***"``. The check is
+    case-insensitive and operates on nested mappings.
+    """
+
+    secret_tokens = {"key", "token", "secret", "password"}
+    if isinstance(data, dict):
+        masked: Dict[str, Any] = {}
+        for k, v in data.items():
+            if any(tok in k.lower() for tok in secret_tokens):
+                masked[k] = "***"
+            else:
+                masked[k] = _mask_secrets(v)
+        return masked
+    if isinstance(data, list):
+        return [_mask_secrets(v) for v in data]
+    return data
+
+
+def print_config(cfg: Config) -> None:
+    """Print ``cfg`` in YAML format masking secret values.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration object to serialise.
+    """
+
+    data = _serialize_paths(cfg.to_dict())
+    masked = _mask_secrets(data)
+    print(yaml.safe_dump(masked, sort_keys=False))
+
+
 # JSON schema describing the configuration structure.
 CONFIG_SCHEMA: Dict[str, Any] = {
     "type": "object",
@@ -931,4 +967,5 @@ __all__ = [
     "ConfigError",
     "ensure_dirs",
     "load_config",
+    "print_config",
 ]

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -8,7 +8,7 @@ from typing import Sequence
 from urllib.error import URLError
 
 import pandas as pd
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 
 from library import io
 from library.cli import (
@@ -92,6 +92,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
+        if args.print_config:
+            print_config(cfg)
+            return 0
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
@@ -61,11 +61,6 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Base name used for output report files",
     )
-    parser.add_argument(
-        "--print-config",
-        action="store_true",
-        help="Print effective configuration and exit",
-    )
     parser.set_defaults(func=run, output_csv=Path("."), encoding="utf-8-sig")
     return parser
 
@@ -76,10 +71,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
-        ensure_dirs(cfg)
         if args.print_config:
-            print(cfg.to_yaml())
+            print_config(cfg)
             return 0
+        ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)

--- a/tests/test_print_config.py
+++ b/tests/test_print_config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from table_quality_main import main
+
+
+def test_print_config_cli(tmp_path: Path, monkeypatch, capsys) -> None:
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("chembl_id\nCHEMBL1\n")
+    config = Path("tests/fixtures/config.min.yaml")
+    monkeypatch.setenv("CHEMBL_DA__API__RPS", "7")
+    monkeypatch.setenv("CHEMBL_DA__LOG__LEVEL", "INFO")
+    rc = main(
+        [
+            "--config",
+            str(config),
+            "--input",
+            str(csv_path),
+            "--table-name",
+            "demo",
+            "--log-level",
+            "DEBUG",
+            "--output",
+            str(tmp_path / "out"),
+            "--print-config",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = yaml.safe_load(out)
+    assert data["api"]["rps"] == 7
+    assert data["log"]["level"] == "DEBUG"
+    assert not (tmp_path / "out").exists()


### PR DESCRIPTION
## Summary
- add `--print-config` flag to shared CLI parser
- implement `print_config` to dump merged config with secret masking
- early exit in scripts when printing config
- cover feature with unit test

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py library/config.py mapper_main.py table_quality_main.py tests/test_print_config.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py library/config.py mapper_main.py table_quality_main.py tests/test_print_config.py`
- `mypy --ignore-missing-imports get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/cli.py library/config.py mapper_main.py table_quality_main.py tests/test_print_config.py`
- `pytest` *(fails: tests/test_pubmed_library.py::test_fetch_openalex_uses_cfg, tests/test_pubmed_library.py::test_fetch_crossref_uses_cfg)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3e2945c8324a7550897be81b39a