### PR TITLE
Expose CLI timeout option

### DIFF
--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -51,7 +51,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_assays(ids, cfg=cfg.api, chunk_size=args.chunk_size)
+        df = cl.get_assays(
+            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
@@ -76,6 +78,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = base_parser(
         "ChEMBL assay data utilities", column="assay_chembl_id", chunk_size=10
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     parser.set_defaults(func=run_chembl)
     return parser
 
@@ -85,7 +93,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -225,7 +225,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        df = cl.get_documents(  # type: ignore[attr-defined]
+            ids,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -273,7 +278,12 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        doc_df = cl.get_documents(  # type: ignore[attr-defined]
+            ids,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -361,6 +371,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     """
     parser = base_parser("Document data utilities", column="chembl_id", chunk_size=5)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     pubmed = sub.add_parser("pubmed", help="Fetch data from PubMed and related APIs")
@@ -470,7 +486,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -76,6 +76,12 @@ def build_parser() -> argparse.ArgumentParser:
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING)",
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
 
     #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
 
@@ -377,7 +383,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_targets(ids, cfg=cfg.api)
+        df = cl.get_targets(ids, cfg=cfg.api, timeout=args.timeout)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
@@ -475,6 +481,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             column="chembl_id",
             sep=args.sep,
             encoding=args.encoding,
+            timeout=args.timeout,
         )
         if run_chembl(cfg, chembl_args) != 0:
             return 1
@@ -615,7 +622,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -131,7 +131,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
-        df = cl.get_testitem(ids, cfg=cfg.api, chunk_size=args.chunk_size)
+        df = cl.get_testitem(
+            ids,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
@@ -161,6 +166,12 @@ def build_parser() -> argparse.ArgumentParser:
         column="molecule_chembl_id",
         chunk_size=5,
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     parser.set_defaults(func=run_chembl)
     return parser
 
@@ -170,7 +181,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         ensure_dirs(cfg)
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from library import io
+
+
+def _create_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+    )
+    return cfg
+
+
+@pytest.mark.parametrize(
+    "module_name, func_name, extra",
+    [
+        ("get_assay_data", "get_assays", []),
+        ("get_document_data", "get_documents", ["chembl"]),
+        ("get_testitem_data", "get_testitem", []),
+        ("get_target_data", "get_targets", ["chembl"]),
+    ],
+)
+def test_cli_timeout_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    func_name: str,
+    extra: list[str],
+) -> None:
+    mod = importlib.import_module(module_name)
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("id\n1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, object] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["1"])
+
+    def fake_apply(args, parser, config_path, mapping=None):
+        return SimpleNamespace(
+            api=SimpleNamespace(),
+            io=SimpleNamespace(output_dir=tmp_path, cache_dir=tmp_path),
+            log=SimpleNamespace(format="", datefmt=""),
+            pubchem=SimpleNamespace(),
+        )
+
+    def fake_get(*args, **kwargs):
+        called["timeout"] = kwargs.get("timeout")
+        return pd.DataFrame({"id": ["1"]})
+
+    monkeypatch.setattr(getattr(mod, "cl"), func_name, fake_get, raising=False)
+    monkeypatch.setattr(mod, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(mod, "ensure_dirs", lambda cfg: None)
+    if hasattr(mod, "ap"):
+        monkeypatch.setattr(mod.ap, "postprocess_assays", lambda df: df)
+    monkeypatch.setattr(io, "write_csv", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "analyze_table_quality", lambda *a, **k: None)
+    args = [
+        "--config",
+        str(config_path),
+        "--timeout",
+        "5",
+        *extra,
+        "--input",
+        str(input_csv),
+    ]
+    rc = mod.main(args)
+    assert rc == 0
+    assert called["timeout"] == 5.0


### PR DESCRIPTION
## Summary
- add `--timeout` CLI option to all ChEMBL data scripts
- map CLI timeout to `api.timeout_read` and forward to HTTP requests
- test CLI timeout overrides

## Testing
- `python -m black get_assay_data.py get_document_data.py get_testitem_data.py get_target_data.py tests/test_cli_timeout_override.py`
- `python -m ruff check get_assay_data.py get_document_data.py get_testitem_data.py get_target_data.py tests/test_cli_timeout_override.py`
- `python -m mypy --ignore-missing-imports --disable-error-code=import-untyped get_assay_data.py get_document_data.py get_testitem_data.py get_target_data.py tests/test_cli_timeout_override.py`
- `pytest tests/test_cli_timeout_override.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1d434c77c832485e52e0d4529b974