### PR TITLE
Serialize config paths in meta sidecars

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -19,7 +19,7 @@ import yaml
 
 
 from . import validation
-from .config import Config, IoCfg
+from .config import Config, IoCfg, _serialize_paths
 
 
 def read_ids(
@@ -182,12 +182,17 @@ def _git_sha() -> str:
 
 
 def _write_meta(path: Path, cfg: Config) -> None:
+    """Write YAML metadata alongside the output file.
+
+    Paths inside the configuration are converted to plain strings so that the
+    resulting YAML does not contain :class:`~pathlib.Path` objects.
+    """
 
     meta = {
         "git_sha": _git_sha(),
         "command": " ".join(sys.argv),
-        "config": cfg.to_dict(),
+        "config": _serialize_paths(cfg.to_dict()),
     }
-    meta_path = Path(str(path) + ".meta.yaml")
+    meta_path = Path(f"{path}.meta.yaml")
     with meta_path.open("w", encoding="utf8") as fh:
         yaml.safe_dump(meta, fh, sort_keys=False)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,11 +4,11 @@ import csv
 from pathlib import Path
 
 import pandas as pd
-
 import pytest
+import yaml
 
 from library import io
-from library.config import IoCfg, Config
+from library.config import Config, IoCfg
 
 
 def test_read_csv_validates_columns(tmp_path: Path) -> None:
@@ -52,3 +52,15 @@ def test_write_csv_creates_single_metadata_file(
     assert len(calls) == 1
     assert path.exists()
     assert meta_path.exists()
+
+
+def test_write_meta_serialises_paths(tmp_path: Path) -> None:
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "out.csv"
+    cfg = Config()
+    io.write_csv(df, path, cfg=cfg)
+
+    meta_path = Path(f"{path}.meta.yaml")
+    meta = yaml.safe_load(meta_path.read_text())
+    assert isinstance(meta["config"]["io"]["output_dir"], str)
+    assert meta["config"]["io"]["output_dir"] == str(cfg.io.output_dir)


### PR DESCRIPTION
## Summary
- ensure `_write_meta` converts `Config` paths to strings before dumping metadata
- test that metadata files contain serialized path strings

## Testing
- `black library/io.py tests/test_io.py`
- `ruff check library/io.py tests/test_io.py`
- `mypy library/io.py tests/test_io.py`
- `pytest` *(fails: tests/test_pubmed_library.py::test_fetch_openalex_uses_cfg, tests/test_pubmed_library.py::test_fetch_crossref_uses_cfg)*
- `pytest tests/test_io.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1d42fb71c8324a0e3cb1c696db550