### PR TITLE
Add timeout CLI option across data retrieval scripts

### DIFF
--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -51,7 +51,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_assays(ids, cfg=cfg.api, chunk_size=args.chunk_size)
+        df = cl.get_assays(
+            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
@@ -76,6 +78,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = base_parser(
         "ChEMBL assay data utilities", column="assay_chembl_id", chunk_size=10
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     parser.set_defaults(func=run_chembl)
     return parser
 
@@ -85,7 +93,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         if args.print_config:
             print_config(cfg)
             return 0

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -225,7 +225,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        df = cl.get_documents(
+            ids,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )  # type: ignore[attr-defined]
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -273,7 +278,12 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(ids, chunk_size=args.chunk_size)  # type: ignore[attr-defined]
+        doc_df = cl.get_documents(
+            ids,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
+        )  # type: ignore[attr-defined]
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -420,6 +430,12 @@ def build_parser() -> argparse.ArgumentParser:
     chembl.add_argument(
         "--chunk-size", type=int, default=5, help="Maximum number of IDs per request"
     )
+    chembl.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     chembl.set_defaults(func=run_chembl)
 
     all_cmd = sub.add_parser("all", help="Run both ChEMBL and PubMed pipelines")
@@ -460,6 +476,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=50,
         help="Maximum PMIDs per PubMed request",
     )
+    all_cmd.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     all_cmd.set_defaults(func=run_all)
 
     return parser
@@ -470,7 +492,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         if args.print_config:
             print_config(cfg)
             return 0

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -160,6 +160,12 @@ def build_parser() -> argparse.ArgumentParser:
         default="utf8",
         help="File encoding for input and output CSV files",
     )
+    chembl.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     chembl.set_defaults(func=run_chembl)
 
     # ----------------------------
@@ -257,6 +263,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path("dictionary/_IUPHAR/_IUPHAR_family.csv"),
         help="Path to the _IUPHAR_family.csv file",
+    )
+    all_cmd.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
     )
     all_cmd.add_argument(
         "--organism-csv",
@@ -382,7 +394,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_targets(ids, cfg=cfg.api)
+        df = cl.get_targets(ids, cfg=cfg.api, timeout=args.timeout)
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
@@ -480,6 +492,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             column="chembl_id",
             sep=args.sep,
             encoding=args.encoding,
+            timeout=args.timeout,
         )
         if run_chembl(cfg, chembl_args) != 0:
             return 1
@@ -620,7 +633,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         if args.print_config:
             print_config(cfg)
             return 0

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -131,7 +131,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
-        df = cl.get_testitem(ids, cfg=cfg.api, chunk_size=args.chunk_size)
+        df = cl.get_testitem(
+            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
@@ -161,6 +163,12 @@ def build_parser() -> argparse.ArgumentParser:
         column="molecule_chembl_id",
         chunk_size=5,
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds for each HTTP request",
+    )
     parser.set_defaults(func=run_chembl)
     return parser
 
@@ -170,7 +178,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = apply_config_overrides(
+            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+        )
         if args.print_config:
             print_config(cfg)
             return 0

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+import get_assay_data as gas
+import get_document_data as gdd
+import get_testitem_data as gtdt
+import get_target_data as gtd
+from library import chembl_library as cl, io
+from library.config import Config
+
+
+def _create_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+    )
+    return cfg
+
+
+def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
+    input_csv = tmp_path / "assay.csv"
+    input_csv.write_text("assay_chembl_id\na1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["a1"])
+    monkeypatch.setattr(
+        gas, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
+    )
+
+    def fake_get_assays(ids, cfg, chunk_size, timeout):
+        called["timeout"] = timeout
+        return pd.DataFrame({"assay_chembl_id": ids})
+
+    monkeypatch.setattr(cl, "get_assays", fake_get_assays)
+    monkeypatch.setattr(gas.ap, "postprocess_assays", lambda df: df)
+    monkeypatch.setattr(io, "write_csv", lambda *a, **k: None)
+    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    rc = gas.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--timeout",
+            "5",
+        ]
+    )
+    assert rc == 0
+    assert called["timeout"] == 5
+
+
+def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
+    input_csv = tmp_path / "doc.csv"
+    input_csv.write_text("chembl_id\nd1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["d1"])
+    monkeypatch.setattr(
+        gdd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
+    )
+
+    def fake_get_documents(ids, cfg, chunk_size, timeout):
+        called["timeout"] = timeout
+        return pd.DataFrame({"document_chembl_id": ids})
+
+    monkeypatch.setattr(cl, "get_documents", fake_get_documents, raising=False)
+    monkeypatch.setattr(io, "write_csv", lambda *a, **k: None)
+    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    rc = gdd.main(
+        [
+            "--config",
+            str(config_path),
+            "chembl",
+            "--input",
+            str(input_csv),
+            "--timeout",
+            "7",
+        ]
+    )
+    assert rc == 0
+    assert called["timeout"] == 7
+
+
+def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
+    input_csv = tmp_path / "testitem.csv"
+    input_csv.write_text("molecule_chembl_id\nt1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
+    monkeypatch.setattr(
+        gtdt, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
+    )
+
+    def fake_get_testitem(ids, cfg, chunk_size, timeout):
+        called["timeout"] = timeout
+        return pd.DataFrame({"molecule_chembl_id": ids})
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+    monkeypatch.setattr(gtdt, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(io, "write_csv", lambda *a, **k: None)
+    monkeypatch.setattr(gtdt, "analyze_table_quality", lambda df, table_name: None)
+    rc = gtdt.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--timeout",
+            "9",
+        ]
+    )
+    assert rc == 0
+    assert called["timeout"] == 9
+
+
+def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
+    input_csv = tmp_path / "target.csv"
+    input_csv.write_text("chembl_id\nt1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
+    monkeypatch.setattr(
+        gtd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
+    )
+
+    def fake_get_targets(ids, cfg, timeout):
+        called["timeout"] = timeout
+        return pd.DataFrame({"target_chembl_id": ids})
+
+    monkeypatch.setattr(cl, "get_targets", fake_get_targets)
+    monkeypatch.setattr(io, "write_csv", lambda *a, **k: None)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    rc = gtd.main(
+        [
+            "--config",
+            str(config_path),
+            "chembl",
+            "--input",
+            str(input_csv),
+            "--timeout",
+            "11",
+        ]
+    )
+    assert rc == 0
+    assert called["timeout"] == 11


### PR DESCRIPTION
## Summary
- add `--timeout` CLI option for assay, document, testitem and target data utilities
- forward CLI timeout to API calls and config overrides
- test timeout overrides for all four CLIs

## Testing
- `ruff check get_assay_data.py get_document_data.py get_testitem_data.py get_target_data.py tests/test_cli_timeout_override.py`
- `mypy get_assay_data.py get_document_data.py get_testitem_data.py get_target_data.py` *(fails: missing type stubs and attr-defined for cl.get_documents)*
- `pytest tests/test_cli_timeout_override.py -q`
- `pytest -q` *(fails: 2 tests in tests/test_pubmed_library.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1da8bc8832494a1bc324c455019