### PR TITLE
feat: share root CLI options across subcommands

### DIFF
--- a/get_document_data.py
+++ b/get_document_data.py
@@ -12,11 +12,11 @@ provides three sub-commands:
 ``all``
     Run the ChEMBL and PubMed pipelines and merge the results.
 
-Example:
+Example
 -------
 Fetch PubMed metadata for identifiers listed in ``pmids.csv``::
 
-    python get_document_data.py pubmed pmids.csv output.csv
+    python get_document_data.py pubmed --config config.yaml --input pmids.csv --output output.csv
 
 The input file must contain a ``PMID`` column.
 
@@ -45,7 +45,7 @@ from library import document_postprocessing as dp
 from library.table_quality import analyze_table_quality
 from library.cli import (
     apply_config_overrides,
-    build_parser as base_parser,
+    build_root_parser,
     configure_logging,
 )
 
@@ -225,12 +225,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(
+        df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
             chunk_size=args.chunk_size,
             timeout=args.timeout,
-        )  # type: ignore[attr-defined]
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -278,12 +278,12 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(
+        doc_df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
             chunk_size=args.chunk_size,
             timeout=args.timeout,
-        )  # type: ignore[attr-defined]
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
@@ -370,10 +370,15 @@ def build_parser() -> argparse.ArgumentParser:
         Parser populated with all sub-commands.
 
     """
-    parser = base_parser("Document data utilities", column="chembl_id", chunk_size=5)
+    root = build_root_parser()
+    parser = argparse.ArgumentParser(
+        description="Document data utilities", parents=[root]
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    pubmed = sub.add_parser("pubmed", help="Fetch data from PubMed and related APIs")
+    pubmed = sub.add_parser(
+        "pubmed", parents=[root], help="Fetch data from PubMed and related APIs"
+    )
     pubmed.add_argument(
         "--input",
         dest="input_csv",
@@ -407,7 +412,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pubmed.set_defaults(func=run_pubmed)
 
-    chembl = sub.add_parser("chembl", help="Fetch document information from ChEMBL")
+    chembl = sub.add_parser(
+        "chembl", parents=[root], help="Fetch document information from ChEMBL"
+    )
     chembl.add_argument(
         "--input",
         dest="input_csv",
@@ -438,7 +445,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     chembl.set_defaults(func=run_chembl)
 
-    all_cmd = sub.add_parser("all", help="Run both ChEMBL and PubMed pipelines")
+    all_cmd = sub.add_parser(
+        "all", parents=[root], help="Run both ChEMBL and PubMed pipelines"
+    )
     all_cmd.add_argument(
         "--input",
         dest="input_csv",
@@ -484,6 +493,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     all_cmd.set_defaults(func=run_all)
 
+    setattr(
+        parser,
+        "subparsers_map",
+        {"pubmed": pubmed, "chembl": chembl, "all": all_cmd},
+    )
+
     return parser
 
 
@@ -491,9 +506,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    subparser_map = getattr(parser, "subparsers_map", {})
+    subparser = subparser_map.get(args.command, parser)
     try:
         cfg: Config = apply_config_overrides(
-            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+            args, subparser, args.config, mapping={"timeout": "api.timeout_read"}
         )
         if args.print_config:
             print_config(cfg)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -1,4 +1,11 @@
-"""Command line interface for retrieving target data from external sources."""
+"""Command line interface for retrieving target data from external sources.
+
+Example
+-------
+Fetch ChEMBL target information for identifiers in ``targets.csv``::
+
+    python get_target_data.py chembl --config config.yaml --input targets.csv
+"""
 
 from __future__ import annotations
 
@@ -20,6 +27,7 @@ from library import uniprot_library as uu
 
 from library.cli import (
     apply_config_overrides,
+    build_root_parser,
     configure_logging,
 )
 
@@ -61,36 +69,25 @@ def _first_token(value: str | None) -> str:
 def build_parser() -> argparse.ArgumentParser:
     """Create and return the top-level CLI argument parser.
 
-    The command line interface is organised into sub-commands for
-    retrieving data from individual sources (UniProt, ChEMBL and IUPHAR)
-    as well as a convenience ``all`` command that runs all pipelines and
-    merges their outputs.
+    The command line interface is organised into sub-commands for retrieving
+    data from individual sources (UniProt, ChEMBL and IUPHAR) as well as a
+    convenience ``all`` command that runs all pipelines and merges their
+    outputs.
     """
 
-    parser = argparse.ArgumentParser(description="Target data utilities")
-    parser.add_argument(
-        "--config", default="config.yaml", help="Path to YAML configuration file"
+    root = build_root_parser()
+    parser = argparse.ArgumentParser(
+        description="Target data utilities", parents=[root]
     )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        help="Logging level (DEBUG, INFO, WARNING)",
-    )
-    parser.add_argument(
-        "--print-config",
-        action="store_true",
-        help="Print effective configuration and exit",
-    )
-
-    #   parser = base_parser("Target data utilities", column="chembl_id", chunk_size=5)
-
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # ----------------------------
     # UniProt sub-command
     # ----------------------------
     uniprot = subparsers.add_parser(
-        "uniprot", help="Extract information for UniProt accessions"
+        "uniprot",
+        parents=[root],
+        help="Extract information for UniProt accessions",
     )
     uniprot.add_argument(
         "--input",
@@ -133,7 +130,9 @@ def build_parser() -> argparse.ArgumentParser:
     # ChEMBL sub-command
     # ----------------------------
     chembl = subparsers.add_parser(
-        "chembl", help="Retrieve target information from ChEMBL"
+        "chembl",
+        parents=[root],
+        help="Retrieve target information from ChEMBL",
     )
     chembl.add_argument(
         "--input",
@@ -172,7 +171,9 @@ def build_parser() -> argparse.ArgumentParser:
     # IUPHAR sub-command
     # ----------------------------
     iuphar = subparsers.add_parser(
-        "iuphar", help="Map UniProt accessions to IUPHAR classifications"
+        "iuphar",
+        parents=[root],
+        help="Map UniProt accessions to IUPHAR classifications",
     )
     iuphar.add_argument(
         "--input",
@@ -213,6 +214,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ----------------------------
     all_cmd = subparsers.add_parser(
         "all",
+        parents=[root],
         help="Run ChEMBL, UniProt and IUPHAR pipelines and merge results",
     )
     all_cmd.add_argument(
@@ -289,6 +291,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="File encoding for input and output CSV files",
     )
     all_cmd.set_defaults(func=run_all)
+
+    setattr(
+        parser,
+        "subparsers_map",
+        {
+            "uniprot": uniprot,
+            "chembl": chembl,
+            "iuphar": iuphar,
+            "all": all_cmd,
+        },
+    )
 
     return parser
 
@@ -632,9 +645,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    subparser_map = getattr(parser, "subparsers_map", {})
+    subparser = subparser_map.get(args.command, parser)
     try:
         cfg: Config = apply_config_overrides(
-            args, parser, args.config, mapping={"timeout": "api.timeout_read"}
+            args, subparser, args.config, mapping={"timeout": "api.timeout_read"}
         )
         if args.print_config:
             print_config(cfg)

--- a/library/cli.py
+++ b/library/cli.py
@@ -101,6 +101,32 @@ def build_parser(
     return parser
 
 
+def build_root_parser() -> argparse.ArgumentParser:
+    """Return a parser containing root-level options.
+
+    The parser is created with ``add_help=False`` so it can be used as a parent
+    for both the top-level parser and sub-commands, allowing shared options such
+    as ``--config`` and ``--log-level`` to be supplied before or after the
+    chosen sub-command.
+    """
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="YAML configuration file",
+    )
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
+    return parser
+
+
 def configure_logging(
     level: str, *, fmt: str | None = None, datefmt: str | None = None
 ) -> None:
@@ -214,4 +240,9 @@ def apply_config_overrides(
     return cfg
 
 
-__all__ = ["build_parser", "configure_logging", "apply_config_overrides"]
+__all__ = [
+    "build_parser",
+    "build_root_parser",
+    "configure_logging",
+    "apply_config_overrides",
+]

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -74,9 +74,9 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
     rc = gdd.main(
         [
+            "chembl",
             "--config",
             str(config_path),
-            "chembl",
             "--input",
             str(input_csv),
             "--timeout",
@@ -138,9 +138,9 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
     rc = gtd.main(
         [
+            "chembl",
             "--config",
             str(config_path),
-            "chembl",
             "--input",
             str(input_csv),
             "--timeout",


### PR DESCRIPTION
## Summary
- allow reusing config/logging flags after subcommands via new `build_root_parser`
- refactor document and target utilities to inherit shared root options
- exercise subcommand overrides in timeout tests

## Testing
- `black get_target_data.py get_document_data.py library/cli.py tests/test_cli_timeout_override.py`
- `ruff check get_target_data.py get_document_data.py library/cli.py tests/test_cli_timeout_override.py`
- `mypy get_target_data.py get_document_data.py library/cli.py tests/test_cli_timeout_override.py`
- `pytest` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e63dd2488324b93c2c96b3c359e9