### PR TITLE
Use public logging API for log level validation

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -788,8 +788,10 @@ def _validate(cfg: Config) -> None:
     validator.validate(_serialize_paths(cfg.to_dict()))
 
     # Validate logging level (case-insensitive)
-    if cfg.log.level.upper() not in logging._nameToLevel:
-        valid = ", ".join(sorted(logging._nameToLevel))
+    # Use public API introduced in Python 3.11 to map names to levels
+    level_names = logging.getLevelNamesMapping()
+    if cfg.log.level.upper() not in level_names:
+        valid = ", ".join(sorted(level_names))
         raise ValueError(f"log.level must be one of {valid}, got {cfg.log.level!r}")
 
     """Basic sanity checks for configuration values."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -276,5 +276,7 @@ def test_log_level_valid(tmp_path: Path) -> None:
 def test_log_level_invalid(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("log:\n  level: verbose\n")
-    with pytest.raises(ValueError, match="log.level"):
+    with pytest.raises(ValueError) as exc:
         load_config(path)
+    valid = ", ".join(sorted(logging.getLevelNamesMapping()))
+    assert str(exc.value) == f"log.level must be one of {valid}, got 'verbose'"


### PR DESCRIPTION
## Summary
- replace deprecated `logging._nameToLevel` with `logging.getLevelNamesMapping()` for log level validation
- expand config tests to assert full error message for invalid log level

## Testing
- `black library/config.py tests/test_config.py`
- `ruff check library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1e66eb08083249ee156631e0ab74d