### PR TITLE
Handle missing logging.getLevelNamesMapping on older Python

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -790,8 +790,14 @@ def _validate(cfg: Config) -> None:
     validator.validate(_serialize_paths(cfg.to_dict()))
 
     # Validate logging level (case-insensitive)
-    # Use public API introduced in Python 3.11 to map names to levels
-    level_names = logging.getLevelNamesMapping()
+    # ``logging.getLevelNamesMapping`` was added in Python 3.11. Fallback to the
+    # private ``logging._nameToLevel`` mapping for older versions.
+    try:
+        level_names = logging.getLevelNamesMapping()
+    except AttributeError:  # pragma: no cover - python <3.11 only
+        level_names = {
+            name.upper(): level for name, level in logging._nameToLevel.items()
+        }
     if cfg.log.level.upper() not in level_names:
         valid = ", ".join(sorted(level_names))
         raise ValueError(f"log.level must be one of {valid}, got {cfg.log.level!r}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,3 +295,30 @@ def test_log_level_invalid(tmp_path: Path) -> None:
         load_config(path)
     valid = ", ".join(sorted(logging.getLevelNamesMapping()))
     assert str(exc.value) == f"log.level must be one of {valid}, got 'verbose'"
+
+
+def test_log_level_valid_no_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fallback mapping should validate known log levels."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("log:\n  level: warn\n")
+    monkeypatch.delattr(logging, "getLevelNamesMapping", raising=False)
+    cfg = load_config(path)
+    assert cfg.log.level == "warn"
+
+
+def test_log_level_invalid_no_mapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fallback mapping should reject unknown levels."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("log:\n  level: verbose\n")
+    monkeypatch.delattr(logging, "getLevelNamesMapping", raising=False)
+    with pytest.raises(ValueError) as exc:
+        load_config(path)
+    level_names = {name.upper(): level for name, level in logging._nameToLevel.items()}
+    valid = ", ".join(sorted(level_names))
+    assert str(exc.value) == f"log.level must be one of {valid}, got 'verbose'"


### PR DESCRIPTION
## Summary
- support Python <3.11 by falling back to `logging._nameToLevel`
- add regression tests for log-level validation without `getLevelNamesMapping`

## Testing
- `ruff check library/config.py tests/test_config.py`
- `black library/config.py tests/test_config.py`
- `mypy library/config.py tests/test_config.py`
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2697c05d08324ae83abebbf8eeeee