### PR TITLE
Expose CSV defaults via IoCfg in post-processing helpers

### DIFF
--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from .config import IoCfg
 from .validation import validate_schema
 
 logger = logging.getLogger(__name__)
@@ -56,8 +57,9 @@ def postprocess_file(
     input_path: Path | str,
     output_path: Path | str,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    cfg: IoCfg,
+    sep: str | None = None,
+    encoding: str | None = None,
 ) -> None:
     """Read an assay CSV, post-process and write the result.
 
@@ -67,12 +69,16 @@ def postprocess_file(
         Path to the CSV file produced by ``get_assay_data.py``.
     output_path:
         Destination path for the cleaned CSV file.
+    cfg:
+        I/O configuration providing default CSV parameters.
     sep:
-        Field delimiter of the CSV files.
+        Field delimiter of the CSV files. Defaults to ``cfg.csv_sep``.
     encoding:
-        Text encoding of the CSV files.
+        Text encoding of the CSV files. Defaults to ``cfg.csv_encoding``.
 
     """
+    sep = sep or cfg.csv_sep
+    encoding = encoding or cfg.csv_encoding
     try:
         df = pd.read_csv(
             input_path,

--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -14,6 +14,7 @@ from typing import Iterable
 import pandas as pd
 
 from . import validation
+from .config import IoCfg
 
 logger = logging.getLogger(__name__)
 
@@ -259,8 +260,9 @@ def postprocess_file(
     input_path: Path | str,
     output_path: Path | str,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    cfg: IoCfg,
+    sep: str | None = None,
+    encoding: str | None = None,
 ) -> None:
     """Read a CSV, apply :func:`postprocess_documents` and write result.
 
@@ -270,12 +272,16 @@ def postprocess_file(
         CSV file produced by ``get_document_data.py all``.
     output_path:
         Destination for the cleaned CSV file.
+    cfg:
+        I/O configuration providing default CSV parameters.
     sep:
-        Field delimiter of the CSV files.
+        Field delimiter of the CSV files. Defaults to ``cfg.csv_sep``.
     encoding:
-        Text encoding of the CSV files.
+        Text encoding of the CSV files. Defaults to ``cfg.csv_encoding``.
 
     """
+    sep = sep or cfg.csv_sep
+    encoding = encoding or cfg.csv_encoding
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_documents(df)
     processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -12,6 +12,8 @@ import logging
 
 import pandas as pd
 
+from .config import IoCfg
+
 logger = logging.getLogger(__name__)
 
 
@@ -295,8 +297,9 @@ def postprocess_file(
     input_path: Path | str,
     output_path: Path | str,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    cfg: IoCfg,
+    sep: str | None = None,
+    encoding: str | None = None,
 ) -> None:
     """Read a CSV, post-process and write the result.
 
@@ -306,10 +309,12 @@ def postprocess_file(
         Path to the CSV file produced by ``get_target_data.py all``.
     output_path:
         Destination path for the cleaned CSV file.
+    cfg:
+        I/O configuration providing default CSV parameters.
     sep:
-        Field delimiter of the CSV files.
+        Field delimiter of the CSV files. Defaults to ``cfg.csv_sep``.
     encoding:
-        Text encoding of the CSV files.
+        Text encoding of the CSV files. Defaults to ``cfg.csv_encoding``.
 
     Tests
     -----
@@ -317,6 +322,8 @@ def postprocess_file(
     :func:`tests.test_target_postprocessing.test_postprocess_file_roundtrip`.
 
     """
+    sep = sep or cfg.csv_sep
+    encoding = encoding or cfg.csv_encoding
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_targets(df)
     processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/tests/test_assay_postprocessing.py
+++ b/tests/test_assay_postprocessing.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from library import assay_postprocessing as ap
+from library.config import IoCfg
 
 
 def test_postprocess_assays_counts() -> None:
@@ -27,7 +28,7 @@ def test_postprocess_assays_counts() -> None:
 
 
 def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
-    """``postprocess_file`` reads, processes and writes data."""
+    """``postprocess_file`` honours ``IoCfg`` defaults for CSV handling."""
 
     df = pd.DataFrame(
         {
@@ -36,11 +37,12 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
             "assay_chembl_id": ["a1", "a2"],
         }
     )
+    cfg = IoCfg(csv_sep=";", csv_encoding="utf8")
     input_path = tmp_path / "in.csv"
-    df.to_csv(input_path, index=False)
+    df.to_csv(input_path, index=False, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
     output_path = tmp_path / "out.csv"
 
-    ap.postprocess_file(input_path, output_path)
+    ap.postprocess_file(input_path, output_path, cfg=cfg)
 
-    result = pd.read_csv(output_path)
+    result = pd.read_csv(output_path, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
     assert list(result["assay_with_same_target"]) == [2, 2]

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -12,6 +12,7 @@ import pandas as pd
 import warnings
 
 from library import target_postprocessing as tp
+from library.config import IoCfg
 
 
 def test_postprocess_targets_merges_and_normalises() -> None:
@@ -51,7 +52,7 @@ def test_postprocess_targets_merges_and_normalises() -> None:
 
 
 def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
-    """Ensure ``postprocess_file`` writes the same result as ``postprocess_targets``."""
+    """``postprocess_file`` respects ``IoCfg`` defaults for CSV options."""
 
     df = pd.DataFrame(
         {
@@ -75,14 +76,17 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
         }
     )
 
+    cfg = IoCfg(csv_sep=";", csv_encoding="utf8")
     input_path = tmp_path / "in.csv"
-    df.to_csv(input_path, index=False)
+    df.to_csv(input_path, index=False, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
     output_path = tmp_path / "out.csv"
 
-    tp.postprocess_file(input_path, output_path)
+    tp.postprocess_file(input_path, output_path, cfg=cfg)
 
     expected = tp.postprocess_targets(df).astype(str)
-    result = pd.read_csv(output_path, dtype=str)
+    result = pd.read_csv(
+        output_path, dtype=str, sep=cfg.csv_sep, encoding=cfg.csv_encoding
+    )
     pd.testing.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
## Summary
- allow `postprocess_file` helpers to take an `IoCfg` and derive `sep`/`encoding`
- adjust unit tests to exercise configurable CSV parameters

## Testing
- `ruff check library/assay_postprocessing.py library/document_postprocessing.py library/target_postprocessing.py tests/test_assay_postprocessing.py tests/test_target_postprocessing.py`
- `black library/assay_postprocessing.py library/document_postprocessing.py library/target_postprocessing.py tests/test_assay_postprocessing.py tests/test_target_postprocessing.py`
- `mypy library/assay_postprocessing.py library/document_postprocessing.py library/target_postprocessing.py tests/test_assay_postprocessing.py tests/test_target_postprocessing.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c26acd192c8324a2c663f42cec008f