### PR TITLE
feat: configure UniProt mapping

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,11 @@ uniprot:
   rps: 4  # (env: CHEMBL_DA_UNIPROT_RPS)
   burst: 5  # (env: CHEMBL_DA_UNIPROT_BURST)
 
+uniprot_mapping:
+  base: "https://rest.uniprot.org/idmapping"  # UniProt ID mapping API (env: CHEMBL_DA__UNIPROT_MAPPING__BASE / CHEMBL_DA_UNIPROT_MAPPING_BASE)
+  poll_interval: 0.5  # Seconds between polling attempts (env: CHEMBL_DA_UNIPROT_MAPPING_POLL_INTERVAL)
+  timeout: 300  # Maximum time in seconds to wait for a mapping job (env: CHEMBL_DA_UNIPROT_MAPPING_TIMEOUT)
+
 iuphar:
   base: "https://www.guidetopharmacology.org/services"  # IUPHAR API base (env: CHEMBL_DA__IUPHAR__BASE / CHEMBL_DA_IUPHAR_BASE)
   timeout_connect: 5  # (env: CHEMBL_DA_IUPHAR_TIMEOUT_CONNECT)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -407,7 +407,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_targets(ids, cfg=cfg.api, timeout=args.timeout)
+        df = cl.get_targets(
+            ids, cfg=cfg.api, mapping_cfg=cfg.uniprot_mapping, timeout=args.timeout
+        )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)
         return 1

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -9,7 +9,7 @@ import logging
 import pandas as pd
 
 from .chembl_client import _chunked, request_json
-from .config import ApiCfg
+from .config import ApiCfg, UniprotMappingCfg
 from .mapper_library import map_chembl_to_uniprot
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,9 @@ def _parse_alt_names(synonyms: list[dict[str, str]]) -> str:
     return "|".join(sorted(names))
 
 
-def _parse_uniprot_id(xrefs: list[dict[str, str]], chembl_id: str) -> tuple[str, str]:
+def _parse_uniprot_id(
+    xrefs: list[dict[str, str]], chembl_id: str, mapping_cfg: UniprotMappingCfg
+) -> tuple[str, str]:
     """Return UniProt IDs from cross references and mapping."""
     uniprot_id = ""
     for x in xrefs:
@@ -67,7 +69,7 @@ def _parse_uniprot_id(xrefs: list[dict[str, str]], chembl_id: str) -> tuple[str,
                 uniprot_id = ident
                 break
     try:
-        mapping_uniprot_id = map_chembl_to_uniprot(chembl_id) or ""
+        mapping_uniprot_id = map_chembl_to_uniprot(chembl_id, mapping_cfg) or ""
     except Exception as exc:  # pragma: no cover - network failure paths
         logger.warning("UniProt mapping request failed for %s: %s", chembl_id, exc)
         mapping_uniprot_id = ""
@@ -98,7 +100,9 @@ def _get_items(container: Any, key: str) -> list[Any]:
     return []
 
 
-def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
+def _parse_target_record(
+    data: dict[str, Any], mapping_cfg: UniprotMappingCfg
+) -> dict[str, Any]:
     """Transform a raw target record into a flat dictionary."""
     components = _get_items(data.get("target_components"), "target_component")
     if not components:
@@ -115,7 +119,7 @@ def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
     ec_code = _parse_ec_codes(synonyms)
     alt_name = _parse_alt_names(synonyms)
     uniprot_id, mapping_uniprot_id = _parse_uniprot_id(
-        xrefs, data.get("target_chembl_id", "")
+        xrefs, data.get("target_chembl_id", ""), mapping_cfg
     )
     hgnc_name, hgnc_id = _parse_hgnc(xrefs)
 
@@ -140,9 +144,25 @@ def _parse_target_record(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def get_target(
-    chembl_target_id: str, *, cfg: ApiCfg, timeout: float | None = None
+    chembl_target_id: str,
+    *,
+    cfg: ApiCfg,
+    mapping_cfg: UniprotMappingCfg,
+    timeout: float | None = None,
 ) -> dict[str, str]:
-    """Fetch target information for a single ChEMBL identifier."""
+    """Fetch target information for a single ChEMBL identifier.
+
+    Parameters
+    ----------
+    chembl_target_id:
+        ChEMBL target identifier (e.g., ``"CHEMBL203"``).
+    cfg:
+        API configuration providing base URL and timeouts.
+    mapping_cfg:
+        Configuration for the UniProt mapping service.
+    timeout:
+        Optional override for the HTTP request timeout.
+    """
     if chembl_target_id in {"", "#N/A"}:
         return dict(EMPTY_TARGET)
     base = cfg.chembl_base.rstrip("/")
@@ -152,17 +172,32 @@ def get_target(
     target_list = _get_items(data, "target")
     if not target_list:
         return dict(EMPTY_TARGET)
-    return _parse_target_record(target_list[0])
+    return _parse_target_record(target_list[0], mapping_cfg)
 
 
 def get_targets(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    mapping_cfg: UniprotMappingCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
-    """Fetch target records for ``ids``."""
+    """Fetch target records for ``ids``.
+
+    Parameters
+    ----------
+    ids:
+        ChEMBL target identifiers to retrieve.
+    cfg:
+        API configuration with base URL and timeouts.
+    mapping_cfg:
+        Settings for the UniProt mapping service.
+    chunk_size:
+        Number of identifiers to request per HTTP call.
+    timeout:
+        Optional override for the HTTP request timeout.
+    """
     valid = [i for i in ids if i not in {"", "#N/A"}]
     if not valid:
         return pd.DataFrame(columns=TARGET_FIELDS)
@@ -174,7 +209,7 @@ def get_targets(
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"
         data = request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("targets") or data.get("target") or []
-        records.extend(_parse_target_record(item) for item in items)
+        records.extend(_parse_target_record(item, mapping_cfg) for item in items)
     if not records:
         return pd.DataFrame(columns=TARGET_FIELDS)
     df = pd.DataFrame(records)
@@ -182,7 +217,11 @@ def get_targets(
 
 
 def extend_target(
-    df: pd.DataFrame, *, cfg: ApiCfg, id_column: str = "target_chembl_id"
+    df: pd.DataFrame,
+    *,
+    cfg: ApiCfg,
+    mapping_cfg: UniprotMappingCfg,
+    id_column: str = "target_chembl_id",
 ) -> pd.DataFrame:
     """Augment ``df`` with columns returned from :func:`get_target`.
 
@@ -192,13 +231,18 @@ def extend_target(
         DataFrame containing a column with ChEMBL target identifiers.
     cfg:
         API configuration providing base URL and timeouts.
+    mapping_cfg:
+        Settings for the UniProt mapping service.
     id_column:
         Name of the column holding the identifiers.
 
     """
     if id_column not in df.columns:
         raise ValueError(f"missing required column: {id_column}")
-    targets = [get_target(i, cfg=cfg) for i in df[id_column].fillna("")]
+    targets = [
+        get_target(i, cfg=cfg, mapping_cfg=mapping_cfg)
+        for i in df[id_column].fillna("")
+    ]
     extra = pd.DataFrame(targets)
     return pd.concat([df.reset_index(drop=True), extra], axis=1)
 

--- a/library/config.py
+++ b/library/config.py
@@ -131,6 +131,15 @@ class UniprotCfg:
 
 
 @dataclass
+class UniprotMappingCfg:
+    """Settings for the UniProt ID Mapping API."""
+
+    base: str = "https://rest.uniprot.org/idmapping"
+    poll_interval: float = 0.5
+    timeout: float = 300.0
+
+
+@dataclass
 class IupharCfg:
     """Settings for the IUPHAR API."""
 
@@ -249,6 +258,7 @@ class Config:
     openalex: OpenAlexCfg = field(default_factory=OpenAlexCfg)
     crossref: CrossRefCfg = field(default_factory=CrossRefCfg)
     uniprot: UniprotCfg = field(default_factory=UniprotCfg)
+    uniprot_mapping: UniprotMappingCfg = field(default_factory=UniprotMappingCfg)
     iuphar: IupharCfg = field(default_factory=IupharCfg)
     pubchem: PubChemCfg = field(default_factory=PubChemCfg)
     io: IoCfg = field(default_factory=IoCfg)
@@ -404,6 +414,9 @@ _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_UNIPROT_TIMEOUT_READ": ["uniprot", "timeout_read"],
     "CHEMBL_DA_UNIPROT_RPS": ["uniprot", "rps"],
     "CHEMBL_DA_UNIPROT_BURST": ["uniprot", "burst"],
+    "CHEMBL_DA_UNIPROT_MAPPING_BASE": ["uniprot_mapping", "base"],
+    "CHEMBL_DA_UNIPROT_MAPPING_POLL_INTERVAL": ["uniprot_mapping", "poll_interval"],
+    "CHEMBL_DA_UNIPROT_MAPPING_TIMEOUT": ["uniprot_mapping", "timeout"],
     "CHEMBL_DA_IUPHAR_BASE": ["iuphar", "base"],
     "CHEMBL_DA_IUPHAR_TIMEOUT_CONNECT": ["iuphar", "timeout_connect"],
     "CHEMBL_DA_IUPHAR_TIMEOUT_READ": ["iuphar", "timeout_read"],
@@ -603,6 +616,16 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             ],
             "additionalProperties": False,
         },
+        "uniprot_mapping": {
+            "type": "object",
+            "properties": {
+                "base": {"type": "string", "format": "uri"},
+                "poll_interval": {"type": "number", "exclusiveMinimum": 0},
+                "timeout": {"type": "number", "minimum": 1},
+            },
+            "required": ["base", "poll_interval", "timeout"],
+            "additionalProperties": False,
+        },
         "iuphar": {
             "type": "object",
             "properties": {
@@ -764,6 +787,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         "openalex",
         "crossref",
         "uniprot",
+        "uniprot_mapping",
         "iuphar",
         "pubchem",
         "io",
@@ -828,6 +852,12 @@ def _validate(cfg: Config) -> None:
             raise ValueError(f"{name}.retries must be non-negative")
         if service.rps <= 0 or service.burst <= 0:
             raise ValueError(f"{name}.rps and {name}.burst must be positive")
+
+    mapping = cfg.uniprot_mapping
+    if not _valid_url(mapping.base):
+        raise ValueError("uniprot_mapping.base must be a valid URL")
+    if mapping.poll_interval <= 0 or mapping.timeout <= 0:
+        raise ValueError("uniprot_mapping.poll_interval and timeout must be positive")
 
     for name, mail in [
         ("openalex", cfg.openalex.mailto),
@@ -961,6 +991,7 @@ __all__ = [
     "OpenAlexCfg",
     "CrossRefCfg",
     "UniprotCfg",
+    "UniprotMappingCfg",
     "IupharCfg",
     "PubChemCfg",
     "IoCfg",

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -10,15 +10,14 @@ import urllib.request
 from typing import Any, Callable, Optional
 from urllib.error import HTTPError
 
-API_BASE = "https://rest.uniprot.org/idmapping"
+from .config import UniprotMappingCfg
 
 logger = logging.getLogger(__name__)
 
 
 def map_chembl_to_uniprot(
     chembl_target_id: str,
-    poll_interval: float = 0.5,
-    timeout: float = 300.0,  # Reduced timeout for faster failure if something is wrong
+    cfg: UniprotMappingCfg,
     opener: Optional[Callable[..., Any]] = None,
 ) -> str | None:
     """Map a ChEMBL target identifier to a UniProt accession.
@@ -27,10 +26,9 @@ def map_chembl_to_uniprot(
     ----------
     chembl_target_id:
         ChEMBL target identifier (e.g., ``"CHEMBL204"``).
-    poll_interval:
-        Seconds to wait between polling the UniProt API for job completion.
-    timeout:
-        Maximum number of seconds to wait for the mapping job to finish.
+    cfg:
+        Configuration for the UniProt ID Mapping API including base URL,
+        poll interval and timeout settings.
     opener:
         Optional callable with the same signature as :func:`urllib.request.urlopen`
         used to perform HTTP requests. Primarily intended for testing.
@@ -46,7 +44,7 @@ def map_chembl_to_uniprot(
     ValueError
         If the API reports failure or returns an unexpected response format.
     TimeoutError
-        If the mapping job does not complete within ``timeout`` seconds.
+        If the mapping job does not complete within ``cfg.timeout`` seconds.
     URLError
         If a network-related error occurs.
 
@@ -81,13 +79,14 @@ def map_chembl_to_uniprot(
         {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
     ).encode()
     logging.debug("Submitting ID mapping job for %s", chembl_target_id)
-    run_data = _open_json(f"{API_BASE}/run", data=data)
+    base = cfg.base.rstrip("/")
+    run_data = _open_json(f"{base}/run", data=data)
     job_id = run_data.get("jobId")
     if not job_id:
         raise ValueError("UniProt ID Mapping API did not return a job ID")
 
     # Poll the job status until it finishes
-    status_url = f"{API_BASE}/status/{job_id}"
+    status_url = f"{base}/status/{job_id}"
     start = time.time()
     result_data = {}  # Initialize result_data
     while True:
@@ -105,14 +104,14 @@ def map_chembl_to_uniprot(
             break
         if status == "FAILED":
             raise ValueError("UniProt ID mapping job failed")
-        if time.time() - start > timeout:
+        if time.time() - start > cfg.timeout:
             raise TimeoutError("UniProt ID mapping job timed out")
-        time.sleep(poll_interval)
+        time.sleep(cfg.poll_interval)
 
     # Retrieve the results
     # If the last status check was a redirect, status_data already contains the results
     if not result_data:
-        result_url = f"{API_BASE}/uniprotkb/results/{job_id}?format=json"
+        result_url = f"{base}/uniprotkb/results/{job_id}?format=json"
         result_data = _open_json(result_url)
 
     results = result_data.get("results", [])

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -54,7 +54,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             uniprot_ids.append(None)
             continue
         try:
-            uniprot_id = map_chembl_to_uniprot(str(chembl_id))
+            uniprot_id = map_chembl_to_uniprot(str(chembl_id), cfg.uniprot_mapping)
             uniprot_ids.append(uniprot_id)
             if uniprot_id:
                 logger.info("mapped %s -> %s", chembl_id, uniprot_id)

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -129,7 +129,7 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gtd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_targets(ids, cfg, timeout):
+    def fake_get_targets(ids, cfg, mapping_cfg, timeout):
         called["timeout"] = timeout
         return pd.DataFrame({"target_chembl_id": ids})
 

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -36,7 +36,7 @@ def test_mapper_run_defaults_to_io_output_dir(
         encoding="utf8",
     )
 
-    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _: "P12345")
+    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _i, _cfg: "P12345")
     monkeypatch.setattr(io, "_write_meta", lambda *_a, **_k: None)
 
     rc = mapper_main.run(cfg, args)


### PR DESCRIPTION
## Summary
- add `uniprot_mapping` config section for UniProt ID mapping API
- expose `UniprotMappingCfg` and wire into target mapping utilities
- make mapper use configuration instead of module constants

## Testing
- `python -m black library mapper_main.py get_target_data.py tests`
- `ruff check library/config.py library/mapper_library.py library/chembl_target.py mapper_main.py get_target_data.py tests/test_cli_timeout_override.py tests/test_default_output_dir.py`
- `python -m mypy library mapper_main.py get_target_data.py` *(fails: Library stubs not installed for "pandas" and others)*
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c26af49a888324819648bd490abc19