### PR TITLE
feat: externalize resource paths to configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,11 @@ pubchem:
   rps: 3  # (env: CHEMBL_DA_PUBCHEM_RPS)
   burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
 
+resources:
+  dictionary_dir: "dictionary"  # Directory with supplementary lookup tables
+  iuphar_target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
+  iuphar_family_csv: "dictionary/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
+
 io:
   output_dir: "data/output"  # Directory for generated datasets
   cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA__IO__CACHE_DIR)

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -107,8 +107,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dictionary-dir",
         type=Path,
-        default=Path("dictionary"),
-        help="Directory with targets_type.csv, citation_fraction.csv and status.csv",
+        default=None,
+        help=(
+            "Directory with targets_type.csv, citation_fraction.csv and status.csv "
+            "(default: config resources.dictionary_dir)"
+        ),
     )
     parser.add_argument(
         "--out-dir",
@@ -136,6 +139,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "same_doc": "init.same_doc",
                 "all_doc": "init.all_doc",
                 "out_dir": "init.output_dir",
+                "dictionary_dir": "resources.dictionary_dir",
             },
         )
         if args.print_config:
@@ -146,6 +150,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.same_doc = Path(args.same_doc)
         args.all_doc = Path(args.all_doc)
         args.out_dir = Path(args.out_dir)
+        args.dictionary_dir = Path(args.dictionary_dir)
 
         configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -192,14 +192,20 @@ def build_parser() -> argparse.ArgumentParser:
     iuphar.add_argument(
         "--target-csv",
         type=Path,
-        default=Path("dictionary/_IUPHAR/_IUPHAR_target.csv"),
-        help="Path to the _IUPHAR_target.csv file",
+        default=None,
+        help=(
+            "Path to the _IUPHAR_target.csv file "
+            "(default: config resources.iuphar_target_csv)"
+        ),
     )
     iuphar.add_argument(
         "--family-csv",
         type=Path,
-        default=Path("dictionary/_IUPHAR/_IUPHAR_family.csv"),
-        help="Path to the _IUPHAR_family.csv file",
+        default=None,
+        help=(
+            "Path to the _IUPHAR_family.csv file "
+            "(default: config resources.iuphar_family_csv)"
+        ),
     )
     iuphar.add_argument("--sep", default=",", help="CSV delimiter for I/O")
     iuphar.add_argument(
@@ -257,14 +263,20 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.add_argument(
         "--target-csv",
         type=Path,
-        default=Path("dictionary/_IUPHAR/_IUPHAR_target.csv"),
-        help="Path to the _IUPHAR_target.csv file",
+        default=None,
+        help=(
+            "Path to the _IUPHAR_target.csv file "
+            "(default: config resources.iuphar_target_csv)"
+        ),
     )
     all_cmd.add_argument(
         "--family-csv",
         type=Path,
-        default=Path("dictionary/_IUPHAR/_IUPHAR_family.csv"),
-        help="Path to the _IUPHAR_family.csv file",
+        default=None,
+        help=(
+            "Path to the _IUPHAR_family.csv file "
+            "(default: config resources.iuphar_family_csv)"
+        ),
     )
     all_cmd.add_argument(
         "--timeout",
@@ -649,7 +661,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     subparser = subparser_map.get(args.command, parser)
     try:
         cfg: Config = apply_config_overrides(
-            args, subparser, args.config, mapping={"timeout": "api.timeout_read"}
+            args,
+            subparser,
+            args.config,
+            mapping={
+                "timeout": "api.timeout_read",
+                "target_csv": "resources.iuphar_target_csv",
+                "family_csv": "resources.iuphar_family_csv",
+            },
         )
         if args.print_config:
             print_config(cfg)

--- a/library/config.py
+++ b/library/config.py
@@ -155,6 +155,15 @@ class PubChemCfg:
 
 
 @dataclass
+class ResourcesCfg:
+    """Paths to static resource files used by the application."""
+
+    dictionary_dir: Path = Path("dictionary")
+    iuphar_target_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_target.csv")
+    iuphar_family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
+
+
+@dataclass
 class IoCfg:
     """Input/output defaults."""
 
@@ -251,6 +260,7 @@ class Config:
     uniprot: UniprotCfg = field(default_factory=UniprotCfg)
     iuphar: IupharCfg = field(default_factory=IupharCfg)
     pubchem: PubChemCfg = field(default_factory=PubChemCfg)
+    resources: ResourcesCfg = field(default_factory=ResourcesCfg)
     io: IoCfg = field(default_factory=IoCfg)
     jobs: JobsCfg = field(default_factory=JobsCfg)
     batch: BatchCfg = field(default_factory=BatchCfg)
@@ -416,6 +426,9 @@ _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_PUBCHEM_BURST": ["pubchem", "burst"],
     "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
     "CHEMBL_DA_CACHE_DIR": ["io", "cache_dir"],
+    "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],
+    "CHEMBL_DA_IUPHAR_TARGET_CSV": ["resources", "iuphar_target_csv"],
+    "CHEMBL_DA_IUPHAR_FAMILY_CSV": ["resources", "iuphar_family_csv"],
     "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
     "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],
     "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
@@ -643,6 +656,20 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             ],
             "additionalProperties": False,
         },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "dictionary_dir": {"type": "string", "minLength": 1},
+                "iuphar_target_csv": {"type": "string", "minLength": 1},
+                "iuphar_family_csv": {"type": "string", "minLength": 1},
+            },
+            "required": [
+                "dictionary_dir",
+                "iuphar_target_csv",
+                "iuphar_family_csv",
+            ],
+            "additionalProperties": False,
+        },
         "io": {
             "type": "object",
             "properties": {
@@ -766,6 +793,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         "uniprot",
         "iuphar",
         "pubchem",
+        "resources",
         "io",
         "jobs",
         "batch",
@@ -963,6 +991,7 @@ __all__ = [
     "UniprotCfg",
     "IupharCfg",
     "PubChemCfg",
+    "ResourcesCfg",
     "IoCfg",
     "JobsCfg",
     "BatchCfg",

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -14,6 +14,10 @@ def _create_config(tmp_path: Path) -> Path:
         "io:\n  csv_sep: '|'\n  csv_encoding: iso-8859-1\n"
         "log:\n  level: INFO\n"
         "api:\n  timeout_read: 30\n"
+        "resources:\n"
+        "  dictionary_dir: dictionary\n"
+        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
+        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
     )
     return cfg
 

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -33,7 +33,7 @@ def test_malformed_config_exits(
 ) -> None:
     cfg = tmp_path / "config.yaml"
     cfg.write_text("jobs:\n  chunk_size: bad\n")
-    argv = ["--config", str(cfg), *extra]
+    argv = [*extra, "--config", str(cfg)]
     with caplog.at_level(logging.ERROR):
         if use_sys:
             monkeypatch.setattr(sys, "argv", ["prog", *argv])

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -19,6 +19,10 @@ def _create_config(tmp_path: Path) -> Path:
         "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
         "log:\n  level: INFO\n"
         "api:\n  timeout_read: 30\n"
+        "resources:\n"
+        "  dictionary_dir: dictionary\n"
+        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
+        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
     )
     return cfg
 


### PR DESCRIPTION
## Summary
- add `resources` config section for IUPHAR mapping files and dictionaries
- use `resources.*` defaults in `get_target_data.py` and `get_input_initialisation.py`
- document new keys and adjust CLI tests for subcommand config handling

## Testing
- `black get_target_data.py get_input_initialisation.py library/config.py tests/test_activity_cli_overrides.py tests/test_cli_timeout_override.py`
- `ruff check get_target_data.py get_input_initialisation.py library/config.py tests/test_activity_cli_overrides.py tests/test_cli_timeout_override.py`
- `mypy get_target_data.py get_input_initialisation.py library/config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c26ae767648324851685ab0f992731