### PR TITLE
Add configurable PubMed settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,11 @@ pubchem:
   rps: 3  # (env: CHEMBL_DA_PUBCHEM_RPS)
   burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
 
+pubmed:
+  sleep: 5.0  # Seconds to pause between PubMed requests
+  workers: 1  # Number of concurrent PubMed workers
+  batch_size: 100  # PMIDs per PubMed API request
+
 io:
   output_dir: "data/output"  # Directory for generated datasets
   cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA__IO__CACHE_DIR)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -31,7 +31,14 @@ from typing import Sequence
 
 import pandas as pd
 
-from library.config import Config, ensure_dirs, OpenAlexCfg, CrossRefCfg, print_config
+from library.config import (
+    Config,
+    ensure_dirs,
+    OpenAlexCfg,
+    CrossRefCfg,
+    PubMedCfg,
+    print_config,
+)
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -54,11 +61,9 @@ logger = logging.getLogger(__name__)
 
 def fetch_pubmed_records(
     pmids: list[str],
-    sleep: float,
+    cfg: PubMedCfg,
     openalex_cfg: OpenAlexCfg,
     crossref_cfg: CrossRefCfg,
-    max_workers: int = 1,
-    batch_size: int = 100,
 ) -> pd.DataFrame:
     """Retrieve metadata for a list of PubMed identifiers.
 
@@ -66,18 +71,12 @@ def fetch_pubmed_records(
     ----------
     pmids:
         Identifiers to query.
-    sleep:
-
-        Seconds to pause between PubMed and Semantic Scholar requests.
+    cfg:
+        PubMed-specific configuration.
     openalex_cfg:
         Configuration for OpenAlex API access.
     crossref_cfg:
         Configuration for CrossRef API access.
-
-    max_workers:
-        Maximum number of concurrent threads.
-    batch_size:
-        Maximum number of PMIDs per PubMed request.
 
     Returns
     -------
@@ -97,12 +96,12 @@ def fetch_pubmed_records(
         """
         try:
             with requests.Session() as session:
-                pubmed_list = pl.fetch_pubmed_batch(session, batch, sleep)
+                pubmed_list = pl.fetch_pubmed_batch(session, batch, cfg.sleep)
                 pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
 
                 # Fetch Semantic Scholar data in a single batch
                 semsch_list = ssl.fetch_semantic_scholar_batch(
-                    session, pmids_in_batch, sleep
+                    session, pmids_in_batch, cfg.sleep
                 )
 
                 # Create a map for easy lookup
@@ -134,10 +133,12 @@ def fetch_pubmed_records(
         return pd.DataFrame()
 
     records: list[dict[str, str]] = []
-    batches = [pmids[i : i + batch_size] for i in range(0, len(pmids), batch_size)]
+    batches = [
+        pmids[i : i + cfg.batch_size] for i in range(0, len(pmids), cfg.batch_size)
+    ]
     total = len(pmids)
     processed = 0
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+    with ThreadPoolExecutor(max_workers=cfg.workers) as ex:
         futures = {ex.submit(_fetch_batch, batch): len(batch) for batch in batches}
         for future in as_completed(futures):
             batch_len = futures[future]
@@ -176,11 +177,9 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         )
         df = fetch_pubmed_records(
             pmids,
-            args.sleep,
+            cfg.pubmed,
             cfg.openalex,
             cfg.crossref,
-            args.workers,
-            args.batch_size,
         )
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
@@ -319,11 +318,9 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
-        args.sleep,
+        cfg.pubmed,
         cfg.openalex,
         cfg.crossref,
-        args.workers,
-        args.batch_size,
     )
     doc_df["pubmed_id"] = pubmed_ids.astype(str)
     if not pub_df.empty and "PubMed.PMID" in pub_df.columns:
@@ -399,15 +396,15 @@ def build_parser() -> argparse.ArgumentParser:
     pubmed.add_argument("--sep", default=",", help="CSV delimiter")
     pubmed.add_argument("--encoding", default="utf8", help="File encoding")
     pubmed.add_argument(
-        "--sleep", type=float, default=5.0, help="Seconds to sleep between requests"
+        "--sleep", type=float, default=None, help="Seconds to sleep between requests"
     )
     pubmed.add_argument(
-        "--workers", type=int, default=1, help="Number of concurrent requests"
+        "--workers", type=int, default=None, help="Number of concurrent requests"
     )
     pubmed.add_argument(
         "--batch-size",
         type=int,
-        default=100,
+        default=None,
         help="Maximum PMIDs per PubMed request",
     )
     pubmed.set_defaults(func=run_pubmed)
@@ -473,16 +470,16 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.add_argument(
         "--sleep",
         type=float,
-        default=5.0,
+        default=None,
         help="Seconds to sleep between PubMed requests",
     )
     all_cmd.add_argument(
-        "--workers", type=int, default=1, help="Number of concurrent PubMed requests"
+        "--workers", type=int, default=None, help="Number of concurrent PubMed requests"
     )
     all_cmd.add_argument(
         "--batch-size",
         type=int,
-        default=50,
+        default=None,
         help="Maximum PMIDs per PubMed request",
     )
     all_cmd.add_argument(
@@ -510,7 +507,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     subparser = subparser_map.get(args.command, parser)
     try:
         cfg: Config = apply_config_overrides(
-            args, subparser, args.config, mapping={"timeout": "api.timeout_read"}
+            args,
+            subparser,
+            args.config,
+            mapping={
+                "timeout": "api.timeout_read",
+                "sleep": "pubmed.sleep",
+                "workers": "pubmed.workers",
+                "batch_size": "pubmed.batch_size",
+            },
         )
         if args.print_config:
             print_config(cfg)

--- a/library/config.py
+++ b/library/config.py
@@ -155,6 +155,15 @@ class PubChemCfg:
 
 
 @dataclass
+class PubMedCfg:
+    """Settings for retrieving PubMed metadata."""
+
+    sleep: float = 5.0
+    workers: int = 1
+    batch_size: int = 100
+
+
+@dataclass
 class IoCfg:
     """Input/output defaults."""
 
@@ -251,6 +260,7 @@ class Config:
     uniprot: UniprotCfg = field(default_factory=UniprotCfg)
     iuphar: IupharCfg = field(default_factory=IupharCfg)
     pubchem: PubChemCfg = field(default_factory=PubChemCfg)
+    pubmed: PubMedCfg = field(default_factory=PubMedCfg)
     io: IoCfg = field(default_factory=IoCfg)
     jobs: JobsCfg = field(default_factory=JobsCfg)
     batch: BatchCfg = field(default_factory=BatchCfg)
@@ -414,6 +424,9 @@ _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_PUBCHEM_TIMEOUT_READ": ["pubchem", "timeout_read"],
     "CHEMBL_DA_PUBCHEM_RPS": ["pubchem", "rps"],
     "CHEMBL_DA_PUBCHEM_BURST": ["pubchem", "burst"],
+    "CHEMBL_DA_PUBMED_SLEEP": ["pubmed", "sleep"],
+    "CHEMBL_DA_PUBMED_WORKERS": ["pubmed", "workers"],
+    "CHEMBL_DA_PUBMED_BATCH_SIZE": ["pubmed", "batch_size"],
     "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
     "CHEMBL_DA_CACHE_DIR": ["io", "cache_dir"],
     "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
@@ -643,6 +656,16 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             ],
             "additionalProperties": False,
         },
+        "pubmed": {
+            "type": "object",
+            "properties": {
+                "sleep": {"type": "number", "minimum": 0},
+                "workers": {"type": "integer", "minimum": 1},
+                "batch_size": {"type": "integer", "minimum": 1},
+            },
+            "required": ["sleep", "workers", "batch_size"],
+            "additionalProperties": False,
+        },
         "io": {
             "type": "object",
             "properties": {
@@ -766,6 +789,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         "uniprot",
         "iuphar",
         "pubchem",
+        "pubmed",
         "io",
         "jobs",
         "batch",
@@ -852,6 +876,10 @@ def _validate(cfg: Config) -> None:
         raise ValueError(
             "retry.max_attempts must be positive and backoff_factor non-negative"
         )
+    if cfg.pubmed.sleep < 0:
+        raise ValueError("pubmed.sleep must be non-negative")
+    if cfg.pubmed.workers <= 0 or cfg.pubmed.batch_size <= 0:
+        raise ValueError("pubmed.workers and pubmed.batch_size must be positive")
 
     out_dir = cfg.io.output_dir
     cache_dir = cfg.io.cache_dir
@@ -969,6 +997,7 @@ __all__ = [
     "UniprotCfg",
     "IupharCfg",
     "PubChemCfg",
+    "PubMedCfg",
     "IoCfg",
     "JobsCfg",
     "BatchCfg",


### PR DESCRIPTION
## Summary
- add `pubmed` configuration section for sleep, workers, and batch size
- support `PubMedCfg` dataclass and environment aliases
- use configuration-driven PubMed parameters in `get_document_data.py`

## Testing
- `ruff check get_document_data.py library/config.py`
- `black --check get_document_data.py library/config.py`
- `mypy get_document_data.py library/config.py`
- `pytest` *(fails: assertion in `tests/test_cli_bad_config.py` expecting log message)*


------
https://chatgpt.com/codex/tasks/task_e_68c26b7735948324be3616a15de1fb61