### PR TITLE
Add organism CSV configuration and unify usage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,7 @@ resources:
   dictionary_dir: "dictionary"  # Directory with supplementary lookup tables
   iuphar_target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
   iuphar_family_csv: "dictionary/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
+  organism_csv: "dictionary/organism.csv"  # Organism taxonomy mapping file
  
 
 io:

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -287,8 +287,11 @@ def build_parser() -> argparse.ArgumentParser:
     all_cmd.add_argument(
         "--organism-csv",
         type=Path,
-        default=Path("dictionary/organism.csv"),
-        help="CSV mapping 'genus' to organism 'type' for finalisation",
+        default=None,
+        help=(
+            "CSV mapping 'genus' to organism 'type' for finalisation "
+            "(default: config resources.organism_csv)"
+        ),
     )
     all_cmd.add_argument(
         "--uniprot-column",
@@ -670,6 +673,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "timeout": "api.timeout_read",
                 "target_csv": "resources.iuphar_target_csv",
                 "family_csv": "resources.iuphar_family_csv",
+                "organism_csv": "resources.organism_csv",
             },
         )
         if args.print_config:

--- a/library/config.py
+++ b/library/config.py
@@ -211,6 +211,7 @@ class ResourcesCfg:
     dictionary_dir: Path = Path("dictionary")
     iuphar_target_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_target.csv")
     iuphar_family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
+    organism_csv: Path = Path("dictionary/organism.csv")
 
 
 @dataclass
@@ -346,7 +347,6 @@ class Config:
     semantic_scholar: SemanticScholarCfg = field(default_factory=SemanticScholarCfg)
 
     doc_type: DocTypeCfg = field(default_factory=DocTypeCfg)
-
 
     resources: ResourcesCfg = field(default_factory=ResourcesCfg)
 
@@ -534,6 +534,7 @@ _ALIAS_MAP: Dict[str, List[str]] = {
     "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],
     "CHEMBL_DA_IUPHAR_TARGET_CSV": ["resources", "iuphar_target_csv"],
     "CHEMBL_DA_IUPHAR_FAMILY_CSV": ["resources", "iuphar_family_csv"],
+    "CHEMBL_DA_ORGANISM_CSV": ["resources", "organism_csv"],
     "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
     "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],
     "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
@@ -817,7 +818,6 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             ],
             "additionalProperties": False,
         },
-
         "doc_type": {
             "type": "object",
             "properties": {
@@ -845,19 +845,19 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             "required": ["weights", "thresholds"],
             "additionalProperties": False,
         },
-
-
         "resources": {
             "type": "object",
             "properties": {
                 "dictionary_dir": {"type": "string", "minLength": 1},
                 "iuphar_target_csv": {"type": "string", "minLength": 1},
                 "iuphar_family_csv": {"type": "string", "minLength": 1},
+                "organism_csv": {"type": "string", "minLength": 1},
             },
             "required": [
                 "dictionary_dir",
                 "iuphar_target_csv",
                 "iuphar_family_csv",
+                "organism_csv",
             ],
             "additionalProperties": False,
         },
@@ -1218,7 +1218,6 @@ __all__ = [
     "PubMedCfg",
     "SemanticScholarCfg",
     "DocTypeCfg",
-
     "ResourcesCfg",
     "IoCfg",
     "JobsCfg",

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -12,7 +12,7 @@ import logging
 
 import pandas as pd
 
-from .config import IoCfg
+from .config import Config, IoCfg
 
 logger = logging.getLogger(__name__)
 
@@ -400,11 +400,12 @@ def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
 
 def finalise_file(
     input_path: Path | str,
-    organism_path: Path | str,
     output_path: Path | str,
     *,
-    sep: str = ",",
-    encoding: str = "utf8",
+    cfg: Config,
+    organism_path: Path | str | None = None,
+    sep: str | None = None,
+    encoding: str | None = None,
 ) -> None:
     """Read CSV files, finalise the target table and write the result.
 
@@ -412,16 +413,22 @@ def finalise_file(
     ----------
     input_path:
         Path to the CSV file produced by :func:`postprocess_file`.
-    organism_path:
-        Path to a CSV containing organism ``genus`` and ``type`` columns.
     output_path:
         Destination path for the cleaned CSV file.
+    cfg:
+        Application configuration providing CSV defaults and resource paths.
+    organism_path:
+        Optional path to a CSV containing organism ``genus`` and ``type`` columns.
+        Defaults to ``cfg.resources.organism_csv``.
     sep:
-        Field delimiter of the CSV files.
+        Field delimiter of the CSV files. Defaults to ``cfg.io.csv_sep``.
     encoding:
-        Text encoding of the CSV files.
+        Text encoding of the CSV files. Defaults to ``cfg.io.csv_encoding``.
 
     """
+    sep = sep or cfg.io.csv_sep
+    encoding = encoding or cfg.io.csv_encoding
+    organism_path = organism_path or cfg.resources.organism_csv
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     organism = pd.read_csv(organism_path, sep=sep, encoding=encoding, dtype=str)
     processed = finalise_targets(df, organism)

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -18,6 +18,7 @@ def _create_config(tmp_path: Path) -> Path:
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
+        "  organism_csv: dictionary/organism.csv\n"
     )
     return cfg
 

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -23,6 +23,7 @@ def _create_config(tmp_path: Path) -> Path:
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
+        "  organism_csv: dictionary/organism.csv\n"
     )
     return cfg
 

--- a/tests/test_target_cli_organism_csv.py
+++ b/tests/test_target_cli_organism_csv.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import get_target_data as gtd
+
+
+def test_organism_csv_default_from_config(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+        "resources:\n"
+        "  dictionary_dir: dictionary\n"
+        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
+        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
+        "  organism_csv: dictionary/organism.csv\n"
+    )
+    captured: dict[str, Path] = {}
+
+    def fake_run_all(cfg, args):  # type: ignore[unused-argument]
+        captured["organism_csv"] = args.organism_csv
+        return 0
+
+    monkeypatch.setattr(gtd, "run_all", fake_run_all)
+    rc = gtd.main(["all", "--config", str(cfg_path)])
+    assert rc == 0
+    assert captured["organism_csv"] == Path("dictionary/organism.csv")

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -12,7 +12,7 @@ import pandas as pd
 import warnings
 
 from library import target_postprocessing as tp
-from library.config import IoCfg
+from library.config import Config, IoCfg
 
 
 def test_postprocess_targets_merges_and_normalises() -> None:
@@ -135,7 +135,9 @@ def test_finalise_file_roundtrip(tmp_path: Path) -> None:
     organism.to_csv(organism_path, index=False)
     output_path = tmp_path / "out.csv"
 
-    tp.finalise_file(input_path, organism_path, output_path)
+    cfg = Config()
+    cfg.resources.organism_csv = organism_path
+    tp.finalise_file(input_path, output_path, cfg=cfg)
 
     expected = tp.finalise_targets(df, organism).astype(str)
     result = pd.read_csv(output_path, dtype=str)


### PR DESCRIPTION
## Summary
- add `resources.organism_csv` to global configuration and schema
- use config-driven default for `--organism-csv` in `get_target_data`
- allow `target_postprocessing.finalise_file` to pull organism data path from config
- cover organism CSV defaults with tests

## Testing
- `black library/config.py get_target_data.py library/target_postprocessing.py tests/test_target_postprocessing.py tests/test_cli_timeout_override.py tests/test_activity_cli_overrides.py tests/test_target_cli_organism_csv.py`
- `ruff check library/config.py get_target_data.py library/target_postprocessing.py tests/test_target_postprocessing.py tests/test_cli_timeout_override.py tests/test_activity_cli_overrides.py tests/test_target_cli_organism_csv.py`
- `mypy library/config.py get_target_data.py library/target_postprocessing.py tests/test_target_postprocessing.py tests/test_cli_timeout_override.py tests/test_activity_cli_overrides.py tests/test_target_cli_organism_csv.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c27209a7c08324a465290e029c303b