### PR TITLE
Add pandera data schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.xlsx
+__pycache__/
 data/input/pairs.csv
 data/input/pairs_independent.csv
 data/input/pairs_non_independent.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ black>=23.0
 ruff>=0.0.290
 mypy>=1.8
 PyYAML>=6.0
+pandera>=0.17
 
 openpyxl>=3.1
 pyarrow>=12.0

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Convenient exports for schema definitions."""
+
+from .activities import ActivitiesSchema
+from .assays import AssaysSchema
+from .documents import DocumentsSchema
+from .targets import TargetsSchema
+from .testitems import TestitemsSchema
+
+__all__ = [
+    "ActivitiesSchema",
+    "AssaysSchema",
+    "DocumentsSchema",
+    "TargetsSchema",
+    "TestitemsSchema",
+]

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -1,0 +1,28 @@
+"""Schema definitions for activity data.
+
+This module provides the :data:`ActivitiesSchema` object describing
+expected structure of activity dataframes.
+"""
+
+from __future__ import annotations
+
+from pandera import Check, Column, DataFrameSchema
+
+
+# Definition of the schema describing the activities table.
+ActivitiesSchema: DataFrameSchema = DataFrameSchema(
+    {
+        "activity_id": Column(int, Check.ge(0), required=True),
+        "testitem_id": Column(str, required=True),
+        "target_id": Column(str, required=False),
+        "standard_type": Column(
+            str,
+            Check.isin(["IC50", "EC50", "Ki", "Kd"]),
+            required=False,
+        ),
+        "standard_value": Column(float, Check.ge(0), required=True),
+        "pA_value": Column(float, Check.in_range(0, 14), required=False),
+    }
+)
+
+"""pandera.DataFrameSchema: Validation schema for activities."""

--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -1,0 +1,18 @@
+"""Schema definitions for assay data."""
+
+from __future__ import annotations
+
+from pandera import Check, Column, DataFrameSchema
+
+
+AssaysSchema: DataFrameSchema = DataFrameSchema(
+    {
+        "assay_chembl_id": Column(str, required=True),
+        "document_chembl_id": Column(str, required=True),
+        "target_chembl_id": Column(str, required=False),
+        "year": Column(int, Check.in_range(1900, 2100), required=True),
+        "month": Column(int, Check.in_range(1, 12), required=True),
+    }
+)
+
+"""pandera.DataFrameSchema: Validation schema for assays."""

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -1,0 +1,20 @@
+"""Schema definitions for document data."""
+
+from __future__ import annotations
+
+from pandera import Check, Column, DataFrameSchema
+
+
+DocumentsSchema: DataFrameSchema = DataFrameSchema(
+    {
+        "document_chembl_id": Column(str, required=True),
+        "doi": Column(str, required=False),
+        "title": Column(str, required=True),
+        "year": Column(int, Check.in_range(1900, 2100), required=True),
+        "month": Column(int, Check.in_range(1, 12), required=True),
+        "day": Column(int, Check.in_range(1, 31), required=False),
+        "citation": Column(int, Check.ge(0), required=False),
+    }
+)
+
+"""pandera.DataFrameSchema: Validation schema for documents."""

--- a/schemas/targets.py
+++ b/schemas/targets.py
@@ -1,0 +1,18 @@
+"""Schema definitions for target data."""
+
+from __future__ import annotations
+
+from pandera import Check, Column, DataFrameSchema
+
+
+TargetsSchema: DataFrameSchema = DataFrameSchema(
+    {
+        "target_chembl_id": Column(str, required=True),
+        "organism": Column(str, required=True),
+        "target_uniprot_id": Column(str, required=False),
+        "pH_dependence": Column(float, Check.in_range(0, 14), required=False),
+        "isoforms": Column(float, Check.ge(0), required=False),
+    }
+)
+
+"""pandera.DataFrameSchema: Validation schema for targets."""

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -1,0 +1,24 @@
+"""Schema definitions for test item data."""
+
+from __future__ import annotations
+
+from pandera import Check, Column, DataFrameSchema
+
+
+TestitemsSchema: DataFrameSchema = DataFrameSchema(
+    {
+        "salt_chembl_id": Column(str, required=True),
+        "molecule_chembl_id": Column(str, required=True),
+        "molecule_type": Column(
+            str,
+            Check.isin(["Small molecule", "Biopolymer", "Oligosaccharide", "Unknown"]),
+            required=True,
+        ),
+        "chirality": Column(int, Check.isin([-1, 0, 1, 2]), required=False),
+        "mw_freebase": Column(float, Check.in_range(0, 2000), required=True),
+        "num_ro5_violations": Column(float, Check.in_range(0, 5), required=False),
+        "is_radical": Column(bool, required=False),
+    }
+)
+
+"""pandera.DataFrameSchema: Validation schema for test items."""

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,115 @@
+"""Unit tests for pandera DataFrame schemas."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from pandera.errors import SchemaError
+
+from schemas import (
+    ActivitiesSchema,
+    AssaysSchema,
+    DocumentsSchema,
+    TargetsSchema,
+    TestitemsSchema,
+)
+
+
+def test_activities_schema_validation() -> None:
+    """Ensure :data:`ActivitiesSchema` validates expected data."""
+    valid = pd.DataFrame(
+        {
+            "activity_id": [1],
+            "testitem_id": ["CHEMBL1"],
+            "target_id": ["CHEMBL2"],
+            "standard_type": ["IC50"],
+            "standard_value": [10.0],
+            "pA_value": [5.0],
+        }
+    )
+    ActivitiesSchema.validate(valid)
+
+    invalid = valid.copy()
+    invalid.loc[0, "standard_type"] = "Unknown"
+    with pytest.raises(SchemaError):
+        ActivitiesSchema.validate(invalid)
+
+
+def test_assays_schema_validation() -> None:
+    """Ensure :data:`AssaysSchema` validates expected data."""
+    valid = pd.DataFrame(
+        {
+            "assay_chembl_id": ["CHEMBL1"],
+            "document_chembl_id": ["CHEMBL2"],
+            "target_chembl_id": ["CHEMBL3"],
+            "year": [2020],
+            "month": [6],
+        }
+    )
+    AssaysSchema.validate(valid)
+
+    invalid = valid.copy()
+    invalid.loc[0, "month"] = 13
+    with pytest.raises(SchemaError):
+        AssaysSchema.validate(invalid)
+
+
+def test_documents_schema_validation() -> None:
+    """Ensure :data:`DocumentsSchema` validates expected data."""
+    valid = pd.DataFrame(
+        {
+            "document_chembl_id": ["CHEMBL1"],
+            "doi": ["10.1000/xyz123"],
+            "title": ["Example"],
+            "year": [2020],
+            "month": [1],
+            "day": [15],
+            "citation": [0],
+        }
+    )
+    DocumentsSchema.validate(valid)
+
+    invalid = valid.copy()
+    invalid.loc[0, "citation"] = -1
+    with pytest.raises(SchemaError):
+        DocumentsSchema.validate(invalid)
+
+
+def test_targets_schema_validation() -> None:
+    """Ensure :data:`TargetsSchema` validates expected data."""
+    valid = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "organism": ["Homo sapiens"],
+            "target_uniprot_id": ["P12345"],
+            "pH_dependence": [7.0],
+            "isoforms": [2.0],
+        }
+    )
+    TargetsSchema.validate(valid)
+
+    invalid = valid.copy()
+    invalid.loc[0, "pH_dependence"] = 20.0
+    with pytest.raises(SchemaError):
+        TargetsSchema.validate(invalid)
+
+
+def test_testitems_schema_validation() -> None:
+    """Ensure :data:`TestitemsSchema` validates expected data."""
+    valid = pd.DataFrame(
+        {
+            "salt_chembl_id": ["CHEMBL1"],
+            "molecule_chembl_id": ["CHEMBL1"],
+            "molecule_type": ["Small molecule"],
+            "chirality": [1],
+            "mw_freebase": [100.0],
+            "num_ro5_violations": [0.0],
+            "is_radical": [False],
+        }
+    )
+    TestitemsSchema.validate(valid)
+
+    invalid = valid.copy()
+    invalid.loc[0, "molecule_type"] = "Peptide"
+    with pytest.raises(SchemaError):
+        TestitemsSchema.validate(invalid)


### PR DESCRIPTION
## Summary
- add DataFrameSchema definitions for activities, assays, documents, targets and test items
- export schemas via `schemas` package
- validate schemas with new unit tests

## Testing
- `black schemas tests/test_schemas.py`
- `ruff check schemas tests/test_schemas.py`
- `mypy schemas tests/test_schemas.py`
- `pytest tests/test_schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68c273f985c48324a4b8d7d5157a06c8