### PR TITLE
Add normalization helpers for schema data

### DIFF
--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -5,6 +5,13 @@ from .assays import AssaysSchema
 from .documents import DocumentsSchema
 from .targets import TargetsSchema
 from .testitems import TestitemsSchema
+from .normalize import (
+    normalize_activities,
+    normalize_assays,
+    normalize_documents,
+    normalize_targets,
+    normalize_testitems,
+)
 
 __all__ = [
     "ActivitiesSchema",
@@ -12,4 +19,9 @@ __all__ = [
     "DocumentsSchema",
     "TargetsSchema",
     "TestitemsSchema",
+    "normalize_activities",
+    "normalize_assays",
+    "normalize_documents",
+    "normalize_targets",
+    "normalize_testitems",
 ]

--- a/schemas/normalize.py
+++ b/schemas/normalize.py
@@ -1,0 +1,132 @@
+"""Normalization helpers for schema dataframes.
+
+This module provides utility functions for cleaning raw data before
+validation against the :mod:`schemas` definitions.  The helpers ensure
+consistent relation operators, unify units and trim identifier values.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+_RELATION_MAP: dict[str, str] = {"<": "<=", ">": ">=", "=": "=", "<=": "<=", ">=": ">="}
+
+
+def _apply_if_string(series: pd.Series, func: Callable[[str], str]) -> pd.Series:
+    """Apply ``func`` to string elements of ``series``.
+
+    Non-string values are returned unchanged.
+    """
+    return series.map(lambda x: func(x) if isinstance(x, str) else x)
+
+
+def _normalize_common(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a normalised copy of ``df``.
+
+    The function standardises relation operators (``<`` → ``<=``, ``>`` → ``>=``),
+    converts the micro sign ``μM`` to ``uM`` and strips whitespace from identifier
+    columns.  Only string values are modified.
+    """
+    result = df.copy()
+    for col in result.columns:
+        series = result[col]
+        series = _apply_if_string(series, lambda s: s.replace("μM", "uM"))
+        if "relation" in col.lower():
+            series = _apply_if_string(
+                series, lambda s: _RELATION_MAP.get(s.strip(), s.strip())
+            )
+        if "id" in col.lower():
+            series = _apply_if_string(series, str.strip)
+        result[col] = series
+    return result
+
+
+def normalize_activities(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise an activities dataframe.
+
+    Parameters
+    ----------
+    df:
+        Raw activities data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised copy of ``df``.
+    """
+    return _normalize_common(df)
+
+
+def normalize_assays(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise an assays dataframe.
+
+    Parameters
+    ----------
+    df:
+        Raw assays data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised copy of ``df``.
+    """
+    return _normalize_common(df)
+
+
+def normalize_documents(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a documents dataframe.
+
+    Parameters
+    ----------
+    df:
+        Raw documents data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised copy of ``df``.
+    """
+    return _normalize_common(df)
+
+
+def normalize_targets(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a targets dataframe.
+
+    Parameters
+    ----------
+    df:
+        Raw targets data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised copy of ``df``.
+    """
+    return _normalize_common(df)
+
+
+def normalize_testitems(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a test items dataframe.
+
+    Parameters
+    ----------
+    df:
+        Raw test items data.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalised copy of ``df``.
+    """
+    return _normalize_common(df)
+
+
+__all__ = [
+    "normalize_activities",
+    "normalize_assays",
+    "normalize_documents",
+    "normalize_targets",
+    "normalize_testitems",
+]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,44 @@
+"""Tests for :mod:`schemas.normalize`."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from schemas import (
+    normalize_activities,
+    normalize_assays,
+    normalize_documents,
+    normalize_targets,
+    normalize_testitems,
+)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        normalize_activities,
+        normalize_assays,
+        normalize_documents,
+        normalize_targets,
+        normalize_testitems,
+    ],
+)
+def test_normalization_common(func) -> None:
+    """All normalisation helpers perform standard replacements."""
+    df = pd.DataFrame(
+        {
+            "any_id": [" CHEMBL1 "],
+            "any_relation": ["<"],
+            "any_units": ["5 μM"],
+        }
+    )
+    original = df.copy()
+    result = func(df)
+
+    assert result.loc[0, "any_id"] == "CHEMBL1"
+    assert result.loc[0, "any_relation"] == "<="
+    assert result.loc[0, "any_units"] == "5 uM"
+
+    # Ensure original data is not modified
+    assert original.equals(df)


### PR DESCRIPTION
## Summary
- add normalization utilities for schema dataframes
- export normalization helpers from schemas package
- cover normalization logic with parametrized tests

## Testing
- `ruff check schemas/normalize.py schemas/__init__.py tests/test_normalize.py`
- `mypy schemas/normalize.py schemas/__init__.py tests/test_normalize.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2754399608324a66fcce7bba5dcc8