### PR TITLE
Integrate schema validation with error sidecar logging

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Sequence
 
 import requests
+from pandera.errors import SchemaErrors
+from schemas.activities import ActivitiesSchema
+from library.normalization import normalize_activities
+from library.sidecar_errors import SidecarErrors
 
 from library import chembl_library as cl
 from library import io
@@ -50,6 +54,17 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("failed to retrieve activities: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
+    df = normalize_activities(df)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        df = ActivitiesSchema.validate(df, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        df = df.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -72,9 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=float,
-
         default=DEFAULT_CONFIG.timeouts.read,
-
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Sequence
 
 import requests
+from pandera.errors import SchemaErrors
+from schemas.assays import AssaysSchema
+from library.normalization import normalize_assays
+from library.sidecar_errors import SidecarErrors
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -49,8 +53,19 @@ def run_chembl(args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)
         return 1
-    df = ap.postprocess_assays(df)
     output = args.output_csv or io.default_output_path(args.input_csv)
+    df = ap.postprocess_assays(df)
+    df = normalize_assays(df)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        df = AssaysSchema.validate(df, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        df = df.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -31,6 +31,10 @@ from typing import Sequence
 
 import pandas as pd
 import requests
+from pandera.errors import SchemaErrors
+from schemas.documents import DocumentsSchema
+from library.normalization import normalize_documents
+from library.sidecar_errors import SidecarErrors
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from library import chembl_library as cl
@@ -145,6 +149,17 @@ def run_pubmed(args: argparse.Namespace) -> int:
         )
         df = fetch_pubmed_records(pmids, args.sleep, args.workers, args.batch_size)
         output = args.output_csv or io.default_output_path(args.input_csv)
+        df = normalize_documents(df)
+        sidecar = SidecarErrors(output.with_suffix(".errors"))
+        try:
+            df = DocumentsSchema.validate(df, lazy=True)
+        except SchemaErrors as err:
+            err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+            sidecar.add(str(err))
+            bad_idx = err.failure_cases["index"].dropna().unique()
+            logger.warning("schema validation failed for %d rows", len(bad_idx))
+            df = df.drop(index=bad_idx)
+        sidecar.write()
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
     except (FileNotFoundError, ValueError, OSError) as exc:
@@ -174,6 +189,17 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
+    df = normalize_documents(df)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        df = DocumentsSchema.validate(df, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        df = df.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -215,6 +241,17 @@ def run_all(args: argparse.Namespace) -> int:
                 on="document_chembl_id",
                 how="left",
             )
+        processed = normalize_documents(processed)
+        sidecar = SidecarErrors(output.with_suffix(".errors"))
+        try:
+            processed = DocumentsSchema.validate(processed, lazy=True)
+        except SchemaErrors as err:
+            err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+            sidecar.add(str(err))
+            bad_idx = err.failure_cases["index"].dropna().unique()
+            logger.warning("schema validation failed for %d rows", len(bad_idx))
+            processed = processed.drop(index=bad_idx)
+        sidecar.write()
         try:
             io.write_csv(processed, output, sep=args.sep, encoding=args.encoding)
             logger.info("Wrote %d rows to %s", len(processed), output)
@@ -227,7 +264,6 @@ def run_all(args: argparse.Namespace) -> int:
             logger.error("failed to generate quality report: %s", exc)
             return 1
         return 0
-
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
     pubmed_ids = pd.to_numeric(doc_df["pubmed_id"], errors="coerce").astype("Int64")
     pmids = pubmed_ids.dropna().astype(str).tolist()
@@ -254,6 +290,17 @@ def run_all(args: argparse.Namespace) -> int:
             on="document_chembl_id",
             how="left",
         )
+    processed = normalize_documents(processed)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        processed = DocumentsSchema.validate(processed, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        processed = processed.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(processed, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(processed), output)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -10,6 +10,10 @@ from typing import Sequence
 
 import pandas as pd
 import requests
+from pandera.errors import SchemaErrors
+from schemas.targets import TargetsSchema
+from library.normalization import normalize_targets
+from library.sidecar_errors import SidecarErrors
 
 from library import chembl_library as cl
 from library import io
@@ -356,6 +360,17 @@ def run_chembl(args: argparse.Namespace) -> int:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv)
+    df = normalize_targets(df)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        df = TargetsSchema.validate(df, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        df = df.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -9,6 +9,10 @@ from typing import Sequence
 
 import pandas as pd
 import requests
+from pandera.errors import SchemaErrors
+from schemas.testitems import TestitemsSchema
+from library.normalization import normalize_testitems
+from library.sidecar_errors import SidecarErrors
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -132,6 +136,17 @@ def run_chembl(args: argparse.Namespace) -> int:
     df = add_pubchem_data(df)
     logger.info("PubChem augmentation completed")
     output = args.output_csv or io.default_output_path(args.input_csv)
+    df = normalize_testitems(df)
+    sidecar = SidecarErrors(output.with_suffix(".errors"))
+    try:
+        df = TestitemsSchema.validate(df, lazy=True)
+    except SchemaErrors as err:
+        err.failure_cases.to_csv(output.with_name("failure_cases.csv"), index=False)
+        sidecar.add(str(err))
+        bad_idx = err.failure_cases["index"].dropna().unique()
+        logger.warning("schema validation failed for %d rows", len(bad_idx))
+        df = df.drop(index=bad_idx)
+    sidecar.write()
     try:
         io.write_csv(df, output, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -16,6 +16,7 @@ from .document_type_terms import (
     parse_terms,
 )
 from .document_type_classifier import compute_scores, decide_label
+from .sidecar_errors import SidecarErrors
 
 __all__ = [
     "parse_terms",
@@ -28,4 +29,5 @@ __all__ = [
     "validation",
     "Config",
     "load_config",
+    "SidecarErrors",
 ]

--- a/library/normalization.py
+++ b/library/normalization.py
@@ -1,0 +1,41 @@
+"""Simple DataFrame normalisation helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def normalize_activities(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise ChEMBL activity records.
+
+    Parameters
+    ----------
+    df:
+        Raw activity DataFrame.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with standardised dtypes.
+    """
+    return df.convert_dtypes()
+
+
+def normalize_assays(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise assay records returned by the ChEMBL API."""
+    return df.convert_dtypes()
+
+
+def normalize_documents(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise document metadata."""
+    return df.convert_dtypes()
+
+
+def normalize_targets(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise target information."""
+    return df.convert_dtypes()
+
+
+def normalize_testitems(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise test item (compound) information."""
+    return df.convert_dtypes()

--- a/library/sidecar_errors.py
+++ b/library/sidecar_errors.py
@@ -1,0 +1,34 @@
+"""Utilities for writing validation errors to sidecar files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+class SidecarErrors:
+    """Collect and persist error messages to a sidecar file.
+
+    Parameters
+    ----------
+    path:
+        Location of the sidecar file where error messages will be written.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._errors: List[str] = []
+
+    def add(self, message: str) -> None:
+        """Record an error ``message`` for later persistence."""
+        self._errors.append(message)
+
+    def write(self) -> None:
+        """Write collected error messages to ``self.path``.
+
+        The file is created only if at least one message was recorded.
+        """
+        if not self._errors:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text("\n".join(self._errors) + "\n", encoding="utf8")

--- a/tests/test_sidecar_errors.py
+++ b/tests/test_sidecar_errors.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from library.sidecar_errors import SidecarErrors
+
+
+def test_sidecar_writes_messages(tmp_path: Path) -> None:
+    path = tmp_path / "errors.txt"
+    sc = SidecarErrors(path)
+    sc.add("first")
+    sc.add("second")
+    sc.write()
+    assert path.read_text(encoding="utf8") == "first\nsecond\n"
+
+
+def test_sidecar_skips_empty(tmp_path: Path) -> None:
+    path = tmp_path / "empty.txt"
+    sc = SidecarErrors(path)
+    sc.write()
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- add a reusable SidecarErrors helper to capture schema validation issues
- normalise and validate ChEMBL data in CLI scripts, persisting failures and dropping invalid rows
- cover sidecar error handling with unit tests

## Testing
- `python -m black get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py library/normalization.py library/sidecar_errors.py library/__init__.py tests/test_sidecar_errors.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py library/normalization.py library/sidecar_errors.py library/__init__.py tests/test_sidecar_errors.py`
- `mypy get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py library/normalization.py library/sidecar_errors.py library/__init__.py tests/test_sidecar_errors.py` *(fails: Library stubs not installed for `pandas`, `pandera`, and `requests`)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2754b28f48324a9ed024e2f2bbfa7