### PR TITLE
Fix duplicate config option and add missing dependency

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -60,12 +60,6 @@ def build_parser(
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
-        "--config",
-        type=Path,
-        default=Path("config.yaml"),
-        help="Path to YAML configuration file",
-    )
-    parser.add_argument(
         "--input",
         dest="input_csv",
         type=Path,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ black>=23.0
 ruff>=0.0.290
 mypy>=1.8
 jsonschema>=4.0
+pandera>=0.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mypy>=1.8
 openpyxl>=3.1
 pyarrow>=12.0
 jsonschema>=4.0  # Required for configuration validation
+pandera>=0.26  # Dataframe validation

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -18,8 +18,6 @@ from library.cli import (
 
 from library.table_quality import analyze_table_quality
 
-from library.config import DEFAULT_CONFIG, load_config
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove redundant --config argument from CLI parser to avoid conflicts
- drop unused DEFAULT_CONFIG import from table_quality entrypoint
- include pandera as dependency for schema validation

## Testing
- `ruff check table_quality_main.py library/config.py`
- `ruff check library/cli.py`
- `black table_quality_main.py library/config.py`
- `black library/cli.py`
- `mypy table_quality_main.py` *(fails: Library stubs not installed for "pandas", "yaml", "jsonschema", "requests" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c27c0f719883248961f8ec210a58a2