### PR TITLE
Wrap normalization helpers around schemas.normalize

### DIFF
--- a/library/normalization.py
+++ b/library/normalization.py
@@ -1,12 +1,21 @@
-"""Simple DataFrame normalisation helpers."""
+"""Wrappers around :mod:`schemas.normalize` helpers."""
 
 from __future__ import annotations
 
 import pandas as pd
+from schemas.normalize import (
+    normalize_activities as _normalize_activities,
+    normalize_assays as _normalize_assays,
+    normalize_documents as _normalize_documents,
+    normalize_targets as _normalize_targets,
+    normalize_testitems as _normalize_testitems,
+)
 
 
 def normalize_activities(df: pd.DataFrame) -> pd.DataFrame:
     """Normalise ChEMBL activity records.
+
+    This is a thin wrapper around :func:`schemas.normalize.normalize_activities`.
 
     Parameters
     ----------
@@ -16,26 +25,52 @@ def normalize_activities(df: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     pandas.DataFrame
-        DataFrame with standardised dtypes.
+        Normalised copy of ``df``.
     """
-    return df.convert_dtypes()
+
+    return _normalize_activities(df)
 
 
 def normalize_assays(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalise assay records returned by the ChEMBL API."""
-    return df.convert_dtypes()
+    """Normalise assay records returned by the ChEMBL API.
+
+    This delegates to :func:`schemas.normalize.normalize_assays`.
+    """
+
+    return _normalize_assays(df)
 
 
 def normalize_documents(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalise document metadata."""
-    return df.convert_dtypes()
+    """Normalise document metadata.
+
+    This delegates to :func:`schemas.normalize.normalize_documents`.
+    """
+
+    return _normalize_documents(df)
 
 
 def normalize_targets(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalise target information."""
-    return df.convert_dtypes()
+    """Normalise target information.
+
+    This delegates to :func:`schemas.normalize.normalize_targets`.
+    """
+
+    return _normalize_targets(df)
 
 
 def normalize_testitems(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalise test item (compound) information."""
-    return df.convert_dtypes()
+    """Normalise test item (compound) information.
+
+    This delegates to :func:`schemas.normalize.normalize_testitems`.
+    """
+
+    return _normalize_testitems(df)
+
+
+__all__ = [
+    "normalize_activities",
+    "normalize_assays",
+    "normalize_documents",
+    "normalize_targets",
+    "normalize_testitems",
+]

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,11 +1,11 @@
-"""Tests for :mod:`schemas.normalize`."""
+"""Tests for :mod:`library.normalization`."""
 
 from __future__ import annotations
 
 import pandas as pd
 import pytest
 
-from schemas import (
+from library.normalization import (
     normalize_activities,
     normalize_assays,
     normalize_documents,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,8 +14,8 @@ from schemas import (
     DocumentsSchema,
     TargetsSchema,
     TestitemsSchema,
-    normalize_activities,
 )
+from library.normalization import normalize_activities
 
 
 def test_activities_schema_validation() -> None:


### PR DESCRIPTION
## Summary
- delegate library `normalize_*` helpers to `schemas.normalize`
- switch test suite to import unified normalization functions

## Testing
- `black --check library/normalization.py tests/test_normalize.py tests/test_schemas.py`
- `ruff check library/normalization.py tests/test_normalize.py tests/test_schemas.py`
- `mypy --ignore-missing-imports library/normalization.py tests/test_normalize.py tests/test_schemas.py`
- `pytest tests/test_normalize.py tests/test_schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68c27d0c015c83248b6862bab9272e93