### PR TITLE
Validate retrieved data against schemas

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -16,7 +16,10 @@ from library.cli import (
     build_parser as base_parser,
     configure_logging,
 )
+from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from pandera.errors import SchemaErrors
+from schemas import ActivitiesSchema, normalize_activities
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +60,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("failed to retrieve activities: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    df = normalize_activities(df)
+    exit_code = 0
+    try:
+        df = ActivitiesSchema.validate(df, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        df = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -68,7 +88,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -17,7 +17,10 @@ from library.cli import (
     build_parser as base_parser,
     configure_logging,
 )
+from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from pandera.errors import SchemaErrors
+from schemas import AssaysSchema, normalize_assays
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     df = ap.postprocess_assays(df)
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    df = normalize_assays(df)
+    exit_code = 0
+    try:
+        df = AssaysSchema.validate(df, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        df = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -70,7 +90,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -42,12 +42,15 @@ from library import semantic_scholar_library as ssl
 from library import openalex_crossref_library as ocl
 from library import io
 from library import document_postprocessing as dp
+from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.cli import (
     apply_config_overrides,
     build_root_parser,
     configure_logging,
 )
+from pandera.errors import SchemaErrors
+from schemas import DocumentsSchema, normalize_documents
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +186,23 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             args.batch_size,
         )
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_documents(df)
+        exit_code = 0
+        try:
+            df = DocumentsSchema.validate(df, lazy=True)
+        except SchemaErrors as exc:
+            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+            errors = SidecarErrors()
+            for row in exc.failure_cases.to_dict("records"):
+                errors.add_error(row)
+            errors.save(failure_path)
+            logger.error(
+                "validation failed; wrote %d failure cases to %s",
+                len(exc.failure_cases),
+                failure_path,
+            )
+            df = exc.validated_data  # type: ignore[attr-defined]
+            exit_code = 1
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
     except (FileNotFoundError, ValueError, OSError) as exc:
@@ -193,7 +213,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -235,6 +255,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("failed to retrieve documents: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    df = normalize_documents(df)
+    exit_code = 0
+    try:
+        df = DocumentsSchema.validate(df, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        df = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -246,7 +283,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def run_all(cfg: Config, args: argparse.Namespace) -> int:
@@ -299,6 +336,23 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 on="document_chembl_id",
                 how="left",
             )
+        processed = normalize_documents(processed)
+        exit_code = 0
+        try:
+            processed = DocumentsSchema.validate(processed, lazy=True)
+        except SchemaErrors as exc:
+            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+            errors = SidecarErrors()
+            for row in exc.failure_cases.to_dict("records"):
+                errors.add_error(row)
+            errors.save(failure_path)
+            logger.error(
+                "validation failed; wrote %d failure cases to %s",
+                len(exc.failure_cases),
+                failure_path,
+            )
+            processed = exc.validated_data  # type: ignore[attr-defined]
+            exit_code = 1
         try:
             io.write_csv(
                 processed, output, cfg=cfg, sep=args.sep, encoding=args.encoding
@@ -312,7 +366,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         except ValueError as exc:
             logger.error("failed to generate quality report: %s", exc)
             return 1
-        return 0
+        return exit_code
 
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
     pubmed_ids = pd.to_numeric(doc_df["pubmed_id"], errors="coerce").astype("Int64")
@@ -347,6 +401,23 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             on="document_chembl_id",
             how="left",
         )
+    processed = normalize_documents(processed)
+    exit_code = 0
+    try:
+        processed = DocumentsSchema.validate(processed, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        processed = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(processed, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(processed), output)
@@ -358,7 +429,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -30,8 +30,10 @@ from library.cli import (
     build_root_parser,
     configure_logging,
 )
-
+from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from pandera.errors import SchemaErrors
+from schemas import TargetsSchema, normalize_targets
 
 logger = logging.getLogger(__name__)
 
@@ -437,6 +439,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("failed to retrieve targets: %s", exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    df = normalize_targets(df)
+    exit_code = 0
+    try:
+        df = TargetsSchema.validate(df, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        df = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -448,7 +467,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
@@ -653,7 +672,23 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             args.organism_csv, sep=args.sep, encoding=args.encoding, dtype=str
         )
         final_df = tp.finalise_targets(processed, organism_df)
-
+        final_df = normalize_targets(final_df)
+        exit_code = 0
+        try:
+            final_df = TargetsSchema.validate(final_df, lazy=True)
+        except SchemaErrors as exc:
+            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+            errors = SidecarErrors()
+            for row in exc.failure_cases.to_dict("records"):
+                errors.add_error(row)
+            errors.save(failure_path)
+            logger.error(
+                "validation failed; wrote %d failure cases to %s",
+                len(exc.failure_cases),
+                failure_path,
+            )
+            final_df = exc.validated_data  # type: ignore[attr-defined]
+            exit_code = 1
         io.write_csv(final_df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("%s", exc)
@@ -663,7 +698,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -18,7 +18,10 @@ from library.cli import (
     build_parser as base_parser,
     configure_logging,
 )
+from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from pandera.errors import SchemaErrors
+from schemas import TestitemsSchema, normalize_testitems
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +145,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = add_pubchem_data(df, cfg.pubchem)
     logger.info("PubChem augmentation completed")
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    df = normalize_testitems(df)
+    exit_code = 0
+    try:
+        df = TestitemsSchema.validate(df, lazy=True)
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path)
+        logger.error(
+            "validation failed; wrote %d failure cases to %s",
+            len(exc.failure_cases),
+            failure_path,
+        )
+        df = exc.validated_data  # type: ignore[attr-defined]
+        exit_code = 1
     try:
         io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
         logger.info("Wrote %d rows to %s", len(df), output)
@@ -153,7 +173,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except ValueError as exc:
         logger.error("failed to generate quality report: %s", exc)
         return 1
-    return 0
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- normalize and validate activity, assay, document, target, and test item outputs
- log schema validation failures via SidecarErrors and emit failure case CSVs
- propagate non-zero exit codes on validation failure

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py`
- `mypy --ignore-missing-imports --follow-imports=skip get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py`
- `pytest` *(fails: ImportError: cannot import name 'DEFAULT_CONFIG' from 'library.config')*


------
https://chatgpt.com/codex/tasks/task_e_68c27d09e16c8324b5bdaa20ffac9295