### PR TITLE
feat: add deterministic CSV writer

### DIFF
--- a/chembl_da/__init__.py
+++ b/chembl_da/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for ChEMBL data acquisition utilities."""

--- a/chembl_da/library/__init__.py
+++ b/chembl_da/library/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for deterministic CSV writing."""
+
+from .csv_utils import write_csv_deterministic
+
+__all__ = ["write_csv_deterministic"]

--- a/chembl_da/library/csv_utils.py
+++ b/chembl_da/library/csv_utils.py
@@ -1,0 +1,114 @@
+"""CSV utilities for deterministic output.
+
+This module provides :func:`write_csv_deterministic` which writes a
+:pandas.DataFrame to disk in a reproducible manner.  Column order, row
+sorting and value serialisation are normalised to guarantee that repeated
+runs produce identical files.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+import os
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+from pandas.api import types as ptypes
+
+
+def _normalise_bool(series: pd.Series) -> pd.Series:
+    """Return ``series`` with booleans converted to ``"true"``/``"false"``.
+
+    ``pandas`` has two boolean dtypes: the classic ``bool`` which cannot
+    represent missing values and the nullable ``boolean`` extension type. We
+    map both explicit values to lowercase strings and leave missing values as
+    ``<NA>`` which :func:`pandas.DataFrame.to_csv` will serialise using
+    ``na_rep``.
+    """
+
+    return series.map({True: "true", False: "false"}).astype("string")
+
+
+def _normalise_dates(series: pd.Series) -> pd.Series:
+    """Return ``series`` with dates formatted as ``YYYY-MM-DD``.
+
+    Both native ``datetime`` columns and object columns containing
+    :class:`datetime.date` or :class:`datetime.datetime` values are
+    supported. Non-date values are left untouched.
+    """
+
+    if ptypes.is_datetime64_any_dtype(series):
+        return series.dt.strftime("%Y-%m-%d")
+
+    if (
+        ptypes.is_object_dtype(series)
+        and series.dropna().map(lambda x: isinstance(x, (date, datetime))).all()
+    ):
+        return pd.to_datetime(series).dt.strftime("%Y-%m-%d")
+
+    return series
+
+
+def write_csv_deterministic(
+    df: pd.DataFrame,
+    path: str | Path,
+    *,
+    col_order: Sequence[str] | None = None,
+    key_cols: Sequence[str] | None = None,
+) -> Path:
+    """Serialise ``df`` to ``path`` as a deterministic CSV file.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to be written.
+    path:
+        Destination file path.
+    col_order:
+        Optional preferred column ordering. Columns not listed here are
+        appended in lexicographical order.
+    key_cols:
+        Optional sequence of column names defining row ordering.  If omitted
+        all columns are used as sort keys.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the written CSV file.
+    """
+
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    work = df.copy()
+
+    # Determine column order
+    if col_order is not None:
+        head = [c for c in col_order if c in work.columns]
+        tail = sorted(c for c in work.columns if c not in head)
+        work = work[head + tail]
+    else:
+        work = work[sorted(work.columns)]
+
+    # Sort rows deterministically
+    sort_cols = list(key_cols) if key_cols is not None else list(work.columns)
+    work = work.sort_values(by=sort_cols, kind="mergesort")
+
+    # Normalise bool and date columns
+    for col in work.columns:
+        s = work[col]
+        if ptypes.is_bool_dtype(s):
+            work[col] = _normalise_bool(s)
+        else:
+            work[col] = _normalise_dates(s)
+
+    # Write via temporary file for atomicity
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8-sig", newline="\n", delete=False, dir=str(out_path.parent)
+    ) as fh:
+        tmp_path = Path(fh.name)
+        work.to_csv(fh, index=False, float_format="%.6g", na_rep="")
+    os.replace(tmp_path, out_path)
+    return out_path

--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -1,0 +1,61 @@
+"""CLI wrapper for :func:`write_csv_deterministic`.
+
+This script reads an input CSV file and re-serialises it deterministically using
+:func:`chembl_da.library.csv_utils.write_csv_deterministic`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from chembl_da.library.csv_utils import write_csv_deterministic
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default="input.csv", help="Input CSV path")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output CSV path (default: derive from input name)",
+    )
+    parser.add_argument("--col-order", nargs="*", help="Preferred column order")
+    parser.add_argument("--key-cols", nargs="*", help="Columns used for sorting")
+    parser.add_argument("--sep", default=",", help="Input CSV delimiter")
+    parser.add_argument(
+        "--encoding",
+        default="utf8",
+        help="Input CSV encoding",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
+    output = args.output or Path(args.input).with_name(
+        f"output_{Path(args.input).stem}.csv"
+    )
+    write_csv_deterministic(
+        df,
+        output,
+        col_order=args.col_order or None,
+        key_cols=args.key_cols or None,
+    )
+    logging.info("written %s", output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from chembl_da.library.csv_utils import write_csv_deterministic
+
+
+def test_write_csv_deterministic(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "b": [True, False],
+            "a": [2, 1],
+            "d": [pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-01")],
+            "f": [1.23456789, 2.3456789],
+        }
+    )
+    path = tmp_path / "out.csv"
+    result = write_csv_deterministic(
+        df, path, col_order=["a", "b", "d", "f"], key_cols=["a"]
+    )
+    assert result == path
+    text = path.read_text(encoding="utf-8-sig")
+    assert text == (
+        "a,b,d,f\n" "1,false,2020-01-01,2.34568\n" "2,true,2020-01-02,1.23457\n"
+    )
+
+
+def test_default_sorting_and_order(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "b": [False, True],
+            "a": ["y", "x"],
+        }
+    )
+    path = tmp_path / "out.csv"
+    write_csv_deterministic(df, path)
+    assert path.read_text(encoding="utf-8-sig") == "a,b\nx,true\ny,false\n"


### PR DESCRIPTION
## Summary
- add csv utility to output dataframes with stable sorting and formatting
- expose command-line wrapper for deterministic CSV rewriting
- test deterministic writer

## Testing
- `python -m black chembl_da csv_utils_main.py tests/test_csv_utils.py`
- `ruff check chembl_da csv_utils_main.py tests/test_csv_utils.py`
- `mypy chembl_da csv_utils_main.py tests/test_csv_utils.py`
- `pytest tests/test_csv_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c27f3da1c0832498a44b6be14a8018