### PR TITLE
Add SHA-256 hashing utility

### DIFF
--- a/chembl_da/__init__.py
+++ b/chembl_da/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for ChEMBL data acquisition helpers."""

--- a/chembl_da/library/__init__.py
+++ b/chembl_da/library/__init__.py
@@ -1,0 +1,5 @@
+"""General utility functions for the :mod:`chembl_da` package."""
+
+from .csv_utils import sha256_file
+
+__all__ = ["sha256_file"]

--- a/chembl_da/library/csv_utils.py
+++ b/chembl_da/library/csv_utils.py
@@ -1,0 +1,45 @@
+"""Utility helpers for CSV-related workflows.
+
+Currently only provides a convenience function to compute SHA-256 hashes
+for files which is useful when verifying downloaded resources.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+__all__ = ["sha256_file"]
+
+_CHUNK_SIZE = 1 << 20  # Read files in 1 MiB blocks
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 checksum of ``path``.
+
+    The file is processed incrementally in fixed-size blocks to keep the
+    memory footprint low even for very large files.
+
+    Parameters
+    ----------
+    path:
+        Location of the file to hash.
+
+    Returns
+    -------
+    str
+        Hexadecimal representation of the SHA-256 digest.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    """
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for block in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+                digest.update(block)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"file not found: {path}") from exc
+    return digest.hexdigest()

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from chembl_da.library.csv_utils import sha256_file
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    data = b"hello world"
+    file_path = tmp_path / "sample.txt"
+    file_path.write_bytes(data)
+    expected = hashlib.sha256(data).hexdigest()
+    assert sha256_file(file_path) == expected
+
+
+def test_sha256_file_missing(tmp_path: Path) -> None:
+    path = tmp_path / "missing.txt"
+    with pytest.raises(FileNotFoundError) as excinfo:
+        sha256_file(path)
+    assert "file not found" in str(excinfo.value)
+    assert str(path) in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add `sha256_file` helper to compute SHA-256 digests for files
- expose helper from `chembl_da.library`
- test hashing and missing-file handling

## Testing
- `black chembl_da tests/test_csv_utils.py`
- `ruff check chembl_da tests/test_csv_utils.py`
- `mypy chembl_da tests/test_csv_utils.py`
- `pytest` *(fails: SchemaErrors object has no attribute 'validated_data')*

------
https://chatgpt.com/codex/tasks/task_e_68c27f42e63083249901daece21044a7