### PR TITLE
Add metadata writer utility

### DIFF
--- a/library/metadata.py
+++ b/library/metadata.py
@@ -1,0 +1,100 @@
+"""Helpers for writing metadata sidecar files.
+
+This module provides :func:`write_meta_yaml` which records execution context
+and output statistics in a YAML file alongside a generated CSV.  The metadata
+captures information such as the Git commit, Python version, and dataset
+summary statistics.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping, TypedDict
+
+import yaml
+
+from .config import _mask_secrets
+
+logger = logging.getLogger(__name__)
+
+
+class Stats(TypedDict):
+    """Execution statistics written to the metadata file."""
+
+    rows_total: int
+    rows_kept: int
+    rows_dropped: int
+    output_sha256: str
+
+
+def _git_sha() -> str:
+    """Return the current Git commit hash.
+
+    If Git is unavailable, ``"UNKNOWN"`` is returned and a warning is logged.
+    """
+
+    repo_root = Path(__file__).resolve().parent.parent
+    try:
+        result = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root)
+        return result.decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.warning("Unable to determine git SHA: %s", exc)
+        return "UNKNOWN"
+
+
+def write_meta_yaml(
+    csv_path: Path | str,
+    command: str,
+    config_subset: Mapping[str, Any],
+    inputs: Mapping[str, Any],
+    stats: Stats,
+    schema: str,
+) -> Path:
+    """Write metadata for ``csv_path`` to ``<csv_path>.meta.yaml``.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the generated CSV file.
+    command:
+        Command used to invoke the pipeline or script.
+    config_subset:
+        Relevant configuration values. Secret keys are masked before
+        serialisation.
+    inputs:
+        Description of the inputs that produced the output.
+    stats:
+        Summary statistics about the output table.
+    schema:
+        Name of the schema applied to the output data.
+
+    Returns
+    -------
+    Path
+        Path to the written metadata YAML file.
+    """
+
+    path = Path(csv_path)
+    meta_path = path.with_name(path.name + ".meta.yaml")
+
+    metadata: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "git_sha": _git_sha(),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "command": command,
+        "config": _mask_secrets(dict(config_subset)),
+        "inputs": dict(inputs),
+        "stats": stats,
+        "schema": schema,
+    }
+
+    with meta_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(metadata, fh, sort_keys=False)
+        logger.info("Metadata written to %s", meta_path)
+
+    return meta_path

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+from library.metadata import write_meta_yaml, Stats
+
+
+def test_write_meta_yaml_creates_file(tmp_path: Path) -> None:
+    csv_path = tmp_path / "output.csv"
+    csv_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    stats: Stats = {
+        "rows_total": 2,
+        "rows_kept": 2,
+        "rows_dropped": 0,
+        "output_sha256": "deadbeef",
+    }
+
+    meta_path = write_meta_yaml(
+        csv_path=csv_path,
+        command="unit-test",
+        config_subset={"api_key": "secret"},
+        inputs={"source": "dummy"},
+        stats=stats,
+        schema="TestSchema",
+    )
+
+    assert meta_path.exists()
+    with meta_path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    assert data["command"] == "unit-test"
+    assert data["config"]["api_key"] == "***"
+    assert data["inputs"]["source"] == "dummy"
+    assert data["stats"] == stats
+    assert data["schema"] == "TestSchema"
+    assert "generated_at" in data
+    assert "git_sha" in data


### PR DESCRIPTION
## Summary
- add `write_meta_yaml` to save run metadata alongside CSV outputs
- cover metadata writer with unit tests

## Testing
- `ruff check library/metadata.py tests/test_metadata.py`
- `python -m black library/metadata.py tests/test_metadata.py`
- `mypy --ignore-missing-imports --follow-imports=skip library/metadata.py tests/test_metadata.py`
- `pytest tests/test_metadata.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c27f49272483249170272838f41c23