### PR TITLE
Add SHA-256 file hashing utility

### DIFF
--- a/chembl_da/library/csv_utils.py
+++ b/chembl_da/library/csv_utils.py
@@ -9,6 +9,7 @@ runs produce identical files.
 from __future__ import annotations
 
 from datetime import date, datetime
+import hashlib
 import os
 import tempfile
 from pathlib import Path
@@ -112,3 +113,37 @@ def write_csv_deterministic(
         work.to_csv(fh, index=False, float_format="%.6g", na_rep="")
     os.replace(tmp_path, out_path)
     return out_path
+
+
+def sha256_file(path: Path, *, block_size: int = 64 * 1024) -> str:
+    """Return SHA-256 hash of ``path``.
+
+    The file is read in chunks to avoid loading large files entirely into
+    memory.
+
+    Parameters
+    ----------
+    path:
+        Path to the input file.
+    block_size:
+        Number of bytes read per iteration. Defaults to ``64 * 1024``.
+
+    Returns
+    -------
+    str
+        Hexadecimal SHA-256 digest of the file contents.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    """
+
+    if not path.is_file():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(block_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import hashlib
 
 import pandas as pd
+import pytest
 
-from chembl_da.library.csv_utils import write_csv_deterministic
+from chembl_da.library.csv_utils import sha256_file, write_csv_deterministic
 
 
 def test_write_csv_deterministic(tmp_path: Path) -> None:
@@ -54,3 +56,17 @@ def test_deterministic_writes_identical_bytes(tmp_path: Path) -> None:
     write_csv_deterministic(df2, path2, col_order=["a", "b", "d", "f"], key_cols=["a"])
 
     assert path1.read_bytes() == path2.read_bytes()
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    data = b"hello world"
+    file_path = tmp_path / "data.txt"
+    file_path.write_bytes(data)
+    expected = hashlib.sha256(data).hexdigest()
+    assert sha256_file(file_path) == expected
+
+
+def test_sha256_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.csv"
+    with pytest.raises(FileNotFoundError, match=str(missing)):
+        sha256_file(missing)


### PR DESCRIPTION
## Summary
- compute SHA-256 hash for a file in streaming fashion
- raise clear `FileNotFoundError` when file is missing
- test hash generation and missing-file error handling

## Testing
- `black chembl_da/library/csv_utils.py tests/test_csv_utils.py`
- `ruff check chembl_da/library/csv_utils.py tests/test_csv_utils.py`
- `mypy chembl_da/library/csv_utils.py tests/test_csv_utils.py`
- `pytest` *(fails: 35 errors during collection)*
- `pytest tests/test_csv_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c283d9a9208324bba71495c4091320