### PR TITLE
Add structured JSON logger with context management

### DIFF
--- a/chembl_da/library/__init__.py
+++ b/chembl_da/library/__init__.py
@@ -1,5 +1,11 @@
-"""Utility helpers for deterministic CSV writing."""
+"""Utility helpers for deterministic CSV writing and logging."""
 
 from .csv_utils import write_csv_deterministic
+from .logging_setup import Logger, LoggerConfig, configure_logger
 
-__all__ = ["write_csv_deterministic"]
+__all__ = [
+    "write_csv_deterministic",
+    "Logger",
+    "LoggerConfig",
+    "configure_logger",
+]

--- a/chembl_da/library/logging_setup.py
+++ b/chembl_da/library/logging_setup.py
@@ -1,0 +1,223 @@
+"""Structured JSON logging utilities.
+
+This module provides :class:`Logger` which emits structured log records as
+JSON objects. Each log entry consists of a single line with a set of standard
+fields and arbitrary key/value pairs supplied by the caller. Secrets contained
+in the data are automatically redacted before output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import logging
+import sys
+import time
+import traceback
+from contextlib import contextmanager
+from typing import Any, IO, Iterator, Optional
+
+
+_SECRET_SUFFIXES: tuple[str, ...] = ("token", "key", "secret", "password")
+_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+}
+
+
+def _level_no(name: str) -> int:
+    """Return numeric value for ``name``.
+
+    Parameters
+    ----------
+    name:
+        Level name such as ``"INFO"`` or ``"ERROR"``.  Unknown names default to
+        ``logging.INFO``.
+    """
+
+    return _LEVELS.get(name.upper(), logging.INFO)
+
+
+@dataclass(slots=True)
+class LoggerConfig:
+    """Configuration for :class:`Logger`.
+
+    Parameters
+    ----------
+    level:
+        Minimum severity of emitted log records. Defaults to ``"INFO"``.
+    run_id:
+        Identifier for the current run or process. This value is included with
+        every log record unless overridden via :meth:`Logger.bind`.
+    redact_secrets:
+        If ``True`` (default), values associated with keys ending in
+        ``token``, ``key``, ``secret`` or ``password`` are replaced with
+        ``"***"``.
+    stream:
+        Target text stream. Defaults to :data:`sys.stdout`.
+    """
+
+    level: str = "INFO"
+    run_id: str = ""
+    redact_secrets: bool = True
+    stream: IO[str] = sys.stdout
+
+
+class Logger:
+    """Minimal structured logger writing JSON to a stream.
+
+    Notes
+    -----
+    Instances are immutable. Methods that alter context such as
+    :meth:`bind` return new logger objects.
+    """
+
+    def __init__(
+        self, cfg: LoggerConfig, context: Optional[dict[str, Any]] = None
+    ) -> None:
+        self._cfg = cfg
+        self._context: dict[str, Any] = context or {}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _should_log(self, level: str) -> bool:
+        return _level_no(level) >= _level_no(self._cfg.level)
+
+    def _redact(self, data: dict[str, Any]) -> dict[str, Any]:
+        if not self._cfg.redact_secrets:
+            return data
+        redacted = {}
+        for k, v in data.items():
+            if any(k.lower().endswith(s) for s in _SECRET_SUFFIXES):
+                redacted[k] = "***"
+            else:
+                redacted[k] = v
+        return redacted
+
+    def _emit(self, record: dict[str, Any]) -> None:
+        json.dump(record, self._cfg.stream)
+        self._cfg.stream.write("\n")
+        self._cfg.stream.flush()
+
+    # ------------------------------------------------------------------
+    # Public API
+    def bind(self, **ctx: Any) -> "Logger":
+        """Return a new logger with ``ctx`` merged into the context."""
+
+        new_ctx = {**self._context, **ctx}
+        return Logger(self._cfg, new_ctx)
+
+    def log(
+        self,
+        level: str,
+        event: str,
+        *,
+        stage: Optional[str] = None,
+        msg: Optional[str] = None,
+        **kv: Any,
+    ) -> None:
+        """Emit a log record.
+
+        Parameters
+        ----------
+        level:
+            Severity of the event (e.g. ``"INFO"``).
+        event:
+            Short event name.
+        stage:
+            Optional stage name for pipelines. Overrides any bound ``stage``.
+        msg:
+            Optional human readable message.
+        **kv:
+            Additional key/value pairs added to the log record.
+        """
+
+        if not self._should_log(level):
+            return
+
+        record: dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": level.upper(),
+            "event": event,
+        }
+
+        merged: dict[str, Any] = {**self._context, **kv}
+
+        run_id = merged.pop("run_id", self._cfg.run_id)
+        stage = stage if stage is not None else merged.pop("stage", None)
+
+        record["run_id"] = run_id
+        if stage is not None:
+            record["stage"] = stage
+        if msg is not None:
+            record["msg"] = msg
+
+        record.update(self._redact(merged))
+        self._emit(record)
+
+    # Convenience wrappers ------------------------------------------------
+    def debug(self, event: str, **kv: Any) -> None:
+        self.log("DEBUG", event, **kv)
+
+    def info(self, event: str, **kv: Any) -> None:
+        self.log("INFO", event, **kv)
+
+    def warn(self, event: str, **kv: Any) -> None:
+        self.log("WARN", event, **kv)
+
+    def error(self, event: str, **kv: Any) -> None:
+        self.log("ERROR", event, **kv)
+
+    def exception(self, event: str, exc: BaseException, **kv: Any) -> None:
+        """Log ``exc`` at ``ERROR`` level."""
+
+        tb = "".join(
+            traceback.format_exception(exc.__class__, exc, exc.__traceback__, limit=3)
+        ).strip()
+        self.log(
+            "ERROR",
+            event,
+            msg=str(exc),
+            exc_type=exc.__class__.__name__,
+            exc_message=str(exc),
+            traceback=tb,
+            **kv,
+        )
+
+    @contextmanager
+    def stage(self, name: str, **kv: Any) -> Iterator["Logger"]:
+        """Context manager logging stage start/done/fail events.
+
+        Parameters
+        ----------
+        name:
+            Stage identifier used in event names and bound context.
+        **kv:
+            Extra context added for the duration of the stage.
+        """
+
+        bound = self.bind(stage=name, **kv)
+        start = time.perf_counter()
+        bound.info(f"{name}_start")
+        try:
+            yield bound
+        except Exception as exc:  # pragma: no cover - branch exercised in tests
+            bound.exception(f"{name}_fail", exc)
+            raise
+        else:
+            elapsed = time.perf_counter() - start
+            bound.info(f"{name}_done", elapsed=elapsed)
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+
+
+def configure_logger(cfg: LoggerConfig) -> Logger:
+    """Return a :class:`Logger` instance configured with ``cfg``."""
+
+    return Logger(cfg)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,75 @@
+"""Tests for :mod:`chembl_da.library.logging_setup`."""
+
+from __future__ import annotations
+
+from io import StringIO
+import json
+import pytest
+
+from chembl_da.library.logging_setup import LoggerConfig, configure_logger
+
+
+def parse_lines(buffer: StringIO) -> list[dict[str, object]]:
+    buffer.seek(0)
+    return [json.loads(line) for line in buffer.getvalue().splitlines() if line]
+
+
+def test_basic_logging_and_redaction() -> None:
+    stream = StringIO()
+    cfg = LoggerConfig(level="INFO", run_id="r1", stream=stream)
+    logger = configure_logger(cfg)
+    logger.info("test_event", api_token="secret", value=1)
+    lines = parse_lines(stream)
+    assert lines[0]["event"] == "test_event"
+    assert lines[0]["api_token"] == "***"
+    assert lines[0]["value"] == 1
+    assert lines[0]["run_id"] == "r1"
+
+
+def test_level_filtering() -> None:
+    stream = StringIO()
+    cfg = LoggerConfig(level="ERROR", run_id="r2", stream=stream)
+    logger = configure_logger(cfg)
+    logger.info("will_skip")
+    logger.error("will_log")
+    lines = parse_lines(stream)
+    assert len(lines) == 1
+    assert lines[0]["event"] == "will_log"
+
+
+def test_exception_logging() -> None:
+    stream = StringIO()
+    cfg = LoggerConfig(level="INFO", run_id="r3", stream=stream)
+    logger = configure_logger(cfg)
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        logger.exception("error_event", exc)
+    rec = parse_lines(stream)[0]
+    assert rec["event"] == "error_event"
+    assert rec["exc_type"] == "ValueError"
+    assert rec["exc_message"] == "boom"
+    assert "ValueError" in str(rec["traceback"])
+
+
+def test_stage_context_manager_success() -> None:
+    stream = StringIO()
+    cfg = LoggerConfig(level="INFO", run_id="r4", stream=stream)
+    logger = configure_logger(cfg)
+    with logger.stage("stage1") as staged:
+        staged.info("inside")
+    lines = parse_lines(stream)
+    events = [line["event"] for line in lines]
+    assert events == ["stage1_start", "inside", "stage1_done"]
+    assert "elapsed" in lines[-1]
+
+
+def test_stage_context_manager_failure() -> None:
+    stream = StringIO()
+    cfg = LoggerConfig(level="INFO", run_id="r5", stream=stream)
+    logger = configure_logger(cfg)
+    with pytest.raises(RuntimeError):
+        with logger.stage("stage2"):
+            raise RuntimeError("fail")
+    events = [line["event"] for line in parse_lines(stream)]
+    assert events == ["stage2_start", "stage2_fail"]


### PR DESCRIPTION
## Summary
- implement structured JSON logger with configurable levels, context binding, and secret redaction
- expose logger utilities in library API
- test logging features including stage context manager and redaction

## Testing
- `ruff check chembl_da/library/logging_setup.py chembl_da/library/__init__.py tests/test_logging_setup.py`
- `black chembl_da/library/logging_setup.py chembl_da/library/__init__.py tests/test_logging_setup.py`
- `mypy --ignore-missing-imports chembl_da/library/logging_setup.py chembl_da/library/__init__.py tests/test_logging_setup.py`
- `pytest tests/test_logging_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2857c75bc83249964407e246532d4