### PR TITLE
Ensure init pipeline writes to configured output directory

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -49,7 +49,8 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             raise FileNotFoundError(f"{args.same_doc} does not exist")
         if not args.all_doc.exists():
             raise FileNotFoundError(f"{args.all_doc} does not exist")
-        args.out_dir.mkdir(parents=True, exist_ok=True)
+        out_dir = Path(args.out_dir or cfg.init.output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
 
         logger.info("Loading source workbooks")
         same = lib.load_same_doc(args.same_doc)
@@ -70,22 +71,20 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             tables[key] = lib.compute_status_statistics(df, entity)
 
         logger.info("Saving output")
-        paths = lib.save_tables(tables, args.out_dir, fmt=args.format)
+        paths = lib.save_tables(tables, out_dir, cfg, fmt=args.format)
         # Ensure that files were actually written to disk
         missing = [str(p) for p in paths.values() if not p.exists()]
         if missing:
             raise RuntimeError("failed to write output files: " + ", ".join(missing))
 
         logger.info("Generating data quality reports")
-        report_dir = args.out_dir / "data_validity_report"
+        report_dir = out_dir / "data_validity_report"
         report_dir.mkdir(parents=True, exist_ok=True)
         for entity, path in paths.items():
             logger.info("Profiling %s", entity)
             analyze_table_quality(path, table_name=str(report_dir / path.stem))
 
-        logger.info(
-            "Saved %d tables and quality reports to %s", len(paths), args.out_dir
-        )
+        logger.info("Saved %d tables and quality reports to %s", len(paths), out_dir)
         return 0
     except KeyError as exc:
         logger.error("required table '%s' missing", exc.args[0])

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -13,6 +13,9 @@ import logging
 
 import pandas as pd
 
+from .config import Config
+from .io import write_csv
+
 logger = logging.getLogger(__name__)
 
 
@@ -939,6 +942,7 @@ def build_combined_tables(
 def save_tables(
     tables: TableDict,
     out_dir: Path,
+    cfg: Config,
     fmt: str = "csv",
 ) -> Dict[str, Path]:
     """Persist combined tables to ``out_dir``.
@@ -946,9 +950,11 @@ def save_tables(
     Parameters
     ----------
     tables:
-        Mapping of entity names to DataFrames.
+        Mapping of entity names to :class:`pandas.DataFrame` instances.
     out_dir:
         Destination directory. Created if missing.
+    cfg:
+        Global configuration providing I/O settings used when writing files.
     fmt:
         Output format. Only ``"csv"`` is supported.
 
@@ -956,14 +962,13 @@ def save_tables(
     -------
     dict
         Mapping of entity names to written file paths.
-
     """
     if fmt != "csv":
         raise ValueError("only csv output is supported")
-    out_dir.mkdir(parents=True, exist_ok=True)
+
     paths: Dict[str, Path] = {}
     for entity, df in tables.items():
-
+        # Determine subdirectory based on table type.
         if entity.endswith("_non_independent_status"):
             sub_dir = out_dir / "status" / "non-independent"
         elif entity.endswith("_independent_status"):
@@ -975,9 +980,10 @@ def save_tables(
         else:
             sub_dir = out_dir
 
-        sub_dir.mkdir(parents=True, exist_ok=True)
         path = sub_dir / f"{entity}.csv"
-        df.to_csv(path, index=False, encoding="utf-8", na_rep="")
+        # Delegate writing to the shared I/O helper to ensure consistent
+        # encoding and creation of metadata sidecars.
+        write_csv(df, path, cfg=cfg)
         logger.info("Wrote %d rows to %s", len(df), path)
         paths[entity] = path
     return paths

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -95,3 +95,30 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch, caplog) ->
         result = cli.run(Config(), args)
     assert result == 1
     assert "required table 'activity' missing" in caplog.text
+
+
+def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+
+    cfg = Config()
+    cfg.init.output_dir = tmp_path / "default"
+
+    tables = {"assay": pd.DataFrame({"id": [1]})}
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "load_all_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "build_combined_tables", lambda *_a, **_k: tables)
+
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=None,
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+
+    assert cli.run(cfg, args) == 0
+    assert (cfg.init.output_dir / "assay.csv").exists()

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -16,6 +16,7 @@ from library.input_initialisation_library import (
     process_activity_table,
 )
 import library.input_initialisation_library as lib
+from library.config import Config
 
 
 def test_unify_dtypes_basic() -> None:
@@ -247,9 +248,7 @@ def test_build_combined_tables_initializes_pair_segments(
     }
 
     (tmp_path / "status.csv").write_text(
-
         "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
-
     )
 
     monkeypatch.setattr(lib, "process_activity_table", lambda df, _dir: df)
@@ -268,36 +267,30 @@ def test_build_combined_tables_initializes_pair_segments(
         assert {"Filtered1", "Filtered2", "Filtered"}.issubset(combined[key].columns)
 
 
-
 def test_build_combined_tables_aggregates_all_pair_segments(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Status aggregation should run for all pair tables."""
-
 
     same: TableDict = {
         "assay": pd.DataFrame(),
         "document": pd.DataFrame(),
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
-
         "activity": pd.DataFrame({"activity_id": [1, 2]}),
         "pairs_same_document": pd.DataFrame({"activity_id1": [1], "activity_id2": [2]}),
-
     }
     all_: TableDict = {
         "assay": pd.DataFrame(),
         "document": pd.DataFrame(),
         "target": pd.DataFrame(),
         "testitem": pd.DataFrame(),
-
         "activity": pd.DataFrame({"activity_id": [3]}),
         "pairs": pd.DataFrame(
             {
                 "INDEPENDENT": [True, False],
                 "activity_id1": [1, 2],
                 "activity_id2": [2, 1],
-
             }
         ),
     }
@@ -313,7 +306,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         lambda df, _api: df.assign(**{"Filtered.init": "good"}),
     )
 
-
     def fake_init_pairs(pair_df: pd.DataFrame, *_args, **_kwargs) -> pd.DataFrame:
         return pair_df.assign(Filtered1="good", Filtered2="good", Filtered="good")
 
@@ -325,7 +317,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         captured.append(pair_df)
         return {"activity": pd.DataFrame({"id": [1]})}
 
-
     monkeypatch.setattr(lib, "aggregate_activity", fake_aggregate)
 
     combined = build_combined_tables(same, all_, dictionary_dir=tmp_path)
@@ -336,7 +327,6 @@ def test_build_combined_tables_aggregates_all_pair_segments(
     assert "activity_independent_status" in combined
     assert "activity_non_independent_status" in combined
     assert "activity_same_document_status" in combined
-
 
 
 def test_build_combined_tables_normalizes_pair_column_names(
@@ -397,17 +387,18 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         "pairs_same_document": pd.DataFrame({"id": [1]}),
         "pairs_independent": pd.DataFrame({"id": [1]}),
         "pairs_non_independent": pd.DataFrame({"id": [2]}),
-
         "activity_independent_status": pd.DataFrame({"id": [1]}),
         "activity_non_independent_status": pd.DataFrame({"id": [1]}),
         "activity_same_document_status": pd.DataFrame({"id": [1]}),
-
     }
-    paths = save_tables(tables, tmp_path)
+    paths = save_tables(tables, tmp_path, Config())
     for entity, path in paths.items():
         assert path.exists(), f"missing {entity} file"
         df = pd.read_csv(path)
         assert not df.empty
+        # Metadata sidecar should be produced alongside each output file.
+        meta = path.with_suffix(path.suffix + ".meta.yaml")
+        assert meta.exists(), f"missing metadata for {entity}"
     assert (
         paths["activity_independent_status"].parent
         == tmp_path / "status" / "independent"
@@ -420,7 +411,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         paths["activity_same_document_status"].parent
         == tmp_path / "status" / "same_document"
     )
-
 
 
 def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- respect `init.output_dir` when `--out-dir` is omitted
- use shared IO helper to write init tables and metadata
- add regression tests for default output directory and metadata sidecar

## Testing
- `python -m black get_input_initialisation.py library/input_initialisation_library.py tests/test_input_initialisation_library.py tests/test_get_input_initialisation.py`
- `python -m ruff check get_input_initialisation.py library/input_initialisation_library.py tests/test_input_initialisation_library.py tests/test_get_input_initialisation.py`
- `python -m mypy get_input_initialisation.py library/input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_save_tables_writes_files -q`
- `pytest tests/test_get_input_initialisation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c28574f0348324b8f269b8d4c55b57