### PR TITLE
feat: add run-scoped logger helpers

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -16,7 +16,8 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -136,9 +137,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     return exit_code
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser = base_parser(
+    parser, log_cfg = base_parser(
         "ChEMBL activity data utilities", column="activity_id", chunk_size=5
     )
     parser.add_argument(
@@ -148,13 +149,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -164,16 +168,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -17,7 +17,8 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -133,9 +134,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     return exit_code
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser = base_parser(
+    parser, log_cfg = base_parser(
         "ChEMBL assay data utilities", column="assay_chembl_id", chunk_size=10
     )
     parser.add_argument(
@@ -145,29 +146,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
             args, parser, args.config, mapping={"timeout": "api.timeout_read"}
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -56,7 +56,8 @@ from library.table_quality import analyze_table_quality
 from library.cli import (
     apply_config_overrides,
     build_root_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from pandera.errors import SchemaErrors
 from schemas import DocumentsSchema, normalize_documents
@@ -574,16 +575,16 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     return exit_code
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the argument parser for document utilities.
 
     Returns
     -------
-    argparse.ArgumentParser
-        Parser populated with all sub-commands.
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        Parser populated with all sub-commands and logging configuration.
 
     """
-    root = build_root_parser()
+    root, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
         description="Document data utilities", parents=[root]
     )
@@ -712,13 +713,16 @@ def build_parser() -> argparse.ArgumentParser:
         {"pubmed": pubmed, "chembl": chembl, "all": all_cmd},
     )
 
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     try:
@@ -727,16 +731,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -16,7 +16,7 @@ from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
 )
 from library import io
 
@@ -81,7 +81,9 @@ def classify_dataframe(
 def main(argv: Sequence[str] | None = None) -> int:
     """Command-line entry point for document type classification."""
 
-    parser = base_parser(__doc__ or "Document type classification", column="chembl_id")
+    parser, log_cfg = base_parser(
+        __doc__ or "Document type classification", column="chembl_id"
+    )
     parser.add_argument(
         "--weight-pubmed",
         dest="weight_pubmed",
@@ -125,6 +127,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Minimum score for unknown label",
     )
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger_inst = configure_logger(log_cfg)
+    logger_inst.info(
+        "pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"}
+    )
 
     try:
         cfg: Config = apply_config_overrides(
@@ -142,14 +149,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger_inst.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger_inst = configure_logger(
+            log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt
+        )
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger_inst.info(
+            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
+        )
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger_inst.info(
+            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
+        )
         return 1
 
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
@@ -160,6 +179,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
+    logger_inst.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
     return 0
 
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -18,12 +18,12 @@ from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
-from library.config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +92,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create argument parser."""
-    parser = base_parser(__doc__ or "Input initialisation", column="chembl_id")
+    parser, log_cfg = base_parser(__doc__ or "Input initialisation", column="chembl_id")
     parser.add_argument(
         "--same-doc",
         type=Path,
@@ -123,14 +123,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--format", choices=["csv"], default="csv", help="Output format"
     )
     parser.set_defaults(func=run)
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
 
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -145,6 +148,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
 
@@ -153,14 +160,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.out_dir = Path(args.out_dir)
         args.dictionary_dir = Path(args.dictionary_dir)
 
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -30,7 +30,8 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.cli import (
     apply_config_overrides,
     build_root_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -72,7 +73,7 @@ def _first_token(value: str | None) -> str:
     return ""
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create and return the top-level CLI argument parser.
 
     The command line interface is organised into sub-commands for retrieving
@@ -81,7 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
     outputs.
     """
 
-    root = build_root_parser()
+    root, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
         description="Target data utilities", parents=[root]
     )
@@ -332,7 +333,7 @@ def build_parser() -> argparse.ArgumentParser:
         },
     )
 
-    return parser
+    return parser, log_cfg
 
 
 def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
@@ -742,8 +743,11 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     try:
@@ -761,18 +765,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     if hasattr(args, "func"):
-        return args.func(cfg, args)
+        exit_code = args.func(cfg, args)
+        if exit_code == 0:
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
+        else:
+            logger.info(
+                "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
+            )
+        return exit_code
     parser.print_help()
+    logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
     return 1
 
 

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -18,7 +18,8 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -217,9 +218,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     return exit_code
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser = base_parser(
+    parser, log_cfg = base_parser(
         "ChEMBL and PubChem compound data utilities",
         column="molecule_chembl_id",
         chunk_size=5,
@@ -231,29 +232,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Timeout in seconds for each HTTP request",
     )
     parser.set_defaults(func=run_chembl)
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
             args, parser, args.config, mapping={"timeout": "api.timeout_read"}
         )
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/library/cli.py
+++ b/library/cli.py
@@ -8,10 +8,45 @@ from __future__ import annotations
 
 import argparse
 import logging
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict
 
 from .config import Config, ConfigError, load_config
+
+
+@dataclass
+class LoggerConfig:
+    """Configuration for pipeline logging.
+
+    Parameters
+    ----------
+    run_id:
+        Unique identifier for the current run.
+    level:
+        Textual logging level such as ``"INFO"`` or ``"DEBUG"``.
+    """
+
+    run_id: str
+    level: str
+
+
+def create_logger_config(level: str) -> LoggerConfig:
+    """Return :class:`LoggerConfig` with a random ``run_id``.
+
+    Parameters
+    ----------
+    level:
+        Desired logging level.
+
+    Returns
+    -------
+    LoggerConfig
+        Configuration containing ``run_id`` and ``level``.
+    """
+
+    return LoggerConfig(run_id=uuid.uuid4().hex, level=level)
 
 
 def _positive_int(value: str) -> int:
@@ -44,8 +79,8 @@ def _positive_int(value: str) -> int:
 
 def build_parser(
     description: str, *, column: str, chunk_size: int = 10
-) -> argparse.ArgumentParser:
-    """Return an argument parser with shared options.
+) -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Return a parser with shared options and logging configuration.
 
     Parameters
     ----------
@@ -56,6 +91,10 @@ def build_parser(
     chunk_size:
         Default chunk size for API requests.
 
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        The parser and associated :class:`LoggerConfig`.
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--log-level", default="INFO", help="Logging level")
@@ -98,11 +137,12 @@ def build_parser(
         action="store_true",
         help="Print effective configuration and exit",
     )
-    return parser
+    log_cfg = create_logger_config(parser.get_default("log_level"))
+    return parser, log_cfg
 
 
-def build_root_parser() -> argparse.ArgumentParser:
-    """Return a parser containing root-level options.
+def build_root_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Return a parser containing root-level options and logging config.
 
     The parser is created with ``add_help=False`` so it can be used as a parent
     for both the top-level parser and sub-commands, allowing shared options such
@@ -124,7 +164,8 @@ def build_root_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print effective configuration and exit",
     )
-    return parser
+    log_cfg = create_logger_config(parser.get_default("log_level"))
+    return parser, log_cfg
 
 
 def configure_logging(
@@ -145,6 +186,36 @@ def configure_logging(
         datefmt=datefmt,
         force=True,
     )
+
+
+def configure_logger(
+    cfg: LoggerConfig, *, fmt: str | None = None, datefmt: str | None = None
+) -> logging.Logger:
+    """Configure and return a logger based on ``cfg``.
+
+    Parameters
+    ----------
+    cfg:
+        Logging configuration containing ``run_id`` and ``level``.
+    fmt:
+        Optional message format.
+    datefmt:
+        Optional date format.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger instance.
+    """
+
+    numeric = getattr(logging, cfg.level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=numeric,
+        format=fmt or "%(levelname)s: %(message)s",
+        datefmt=datefmt,
+        force=True,
+    )
+    return logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -241,8 +312,11 @@ def apply_config_overrides(
 
 
 __all__ = [
+    "LoggerConfig",
+    "create_logger_config",
     "build_parser",
     "build_root_parser",
     "configure_logging",
+    "configure_logger",
     "apply_config_overrides",
 ]

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -14,7 +14,8 @@ from library import io
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 from library.mapper_library import map_chembl_to_uniprot
 
@@ -74,36 +75,50 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser = base_parser(
+    parser, log_cfg = base_parser(
         "Map ChEMBL target IDs to UniProt accessions",
         column="chembl_id",
         chunk_size=1,
     )
     parser.set_defaults(func=run)
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
 
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -13,7 +13,8 @@ from library.config import Config, ensure_dirs, print_config
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
-    configure_logging,
+    configure_logger,
+    LoggerConfig,
 )
 
 from library.table_quality import analyze_table_quality
@@ -54,36 +55,50 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser = base_parser("Table quality analysis", column="chembl_id")
+    parser, log_cfg = base_parser("Table quality analysis", column="chembl_id")
     parser.add_argument(
         "--table-name",
         required=True,
         help="Base name used for output report files",
     )
     parser.set_defaults(func=run, output_csv=Path("."), encoding="utf-8-sig")
-    return parser
+    return parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
-    parser = build_parser()
+    parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info(
+                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
+            )
             return 0
         ensure_dirs(cfg)
-        configure_logging(args.log_level, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    return args.func(cfg, args)
+    exit_code = args.func(cfg, args)
+    if exit_code == 0:
+        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    else:
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -4,12 +4,12 @@ from library.cli import build_parser
 
 
 def test_chunk_size_positive() -> None:
-    parser = build_parser("desc", column="id")
+    parser, _ = build_parser("desc", column="id")
     args = parser.parse_args(["--chunk-size", "3"])
     assert args.chunk_size == 3
 
 
 def test_chunk_size_non_positive() -> None:
-    parser = build_parser("desc", column="id")
+    parser, _ = build_parser("desc", column="id")
     with pytest.raises(SystemExit):
         parser.parse_args(["--chunk-size", "0"])


### PR DESCRIPTION
## Summary
- add `LoggerConfig` with UUID run identifiers
- expose `configure_logger` for pipeline logging
- emit pipeline start/done/fail events with consistent run IDs

## Testing
- `black get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py get_input_initialisation.py mapper_main.py table_quality_main.py get_document_type.py library/cli.py tests/test_cli_validation.py`
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py get_input_initialisation.py mapper_main.py table_quality_main.py get_document_type.py library/cli.py tests/test_cli_validation.py`
- `mypy get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py get_input_initialisation.py mapper_main.py table_quality_main.py get_document_type.py library/cli.py tests/test_cli_validation.py`
- `pytest` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2862818c483248cf9097530d0d002