### PR TITLE
Add test verifying run_id consistency in CLI logs

### DIFF
--- a/tests/test_cli_run_id.py
+++ b/tests/test_cli_run_id.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+import csv_utils_main
+from chembl_da.library.logging_setup import LoggerConfig, configure_logger
+
+
+def test_cli_run_id(capfd: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    """CLI emits consistent run_id across run_start and run_done events."""
+    input_csv = Path("tests/data/csv_utils_input.csv")
+    output_csv = tmp_path / "out.csv"
+    logger = configure_logger(LoggerConfig(run_id="test-run", stream=sys.stdout))
+    with logger.stage("run"):
+        exit_code = csv_utils_main.main(
+            ["--input", str(input_csv), "--output", str(output_csv)]
+        )
+    assert exit_code == 0
+    captured = capfd.readouterr().out.splitlines()
+    events = [json.loads(line) for line in captured if line.strip()]
+    assert events[0]["event"] == "run_start"
+    assert events[-1]["event"] == "run_done"
+    assert events[0]["run_id"] == events[-1]["run_id"] == "test-run"


### PR DESCRIPTION
## Summary
- Add test that runs a lightweight CLI and captures structured log output
- Confirm `run_id` is emitted and identical for `run_start` and `run_done`

## Testing
- `python -m black tests/test_cli_run_id.py`
- `python -m ruff check tests/test_cli_run_id.py`
- `python -m mypy tests/test_cli_run_id.py`
- `pytest tests/test_cli_run_id.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c287ef7b088324bea0412c332f562f