### PR TITLE
Add PyYAML dependency and document dev tooling commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ parsing, validation, aggregation and export of tabular data.
 
 ## Installation
 
-Clone the repository and install the runtime and development dependencies:
+Clone the repository and install the runtime dependencies. Optional tooling for
+formatting, linting and type checking lives in ``requirements-dev.txt``:
 
 ```bash
 git clone https://example.com/ChEMBL_data_acquisition.git
 cd ChEMBL_data_acquisition
 pip install -r requirements.txt
+# Development extras
+pip install -r requirements-dev.txt
 ```
 
 ## Project structure
@@ -326,10 +329,11 @@ in ``--out-dir``.
 
 ## Development
 
-Formatting, linting and type checking are handled by *black*, *ruff* and
-*mypy* respectively. Run the following before committing changes:
+Install the optional developer tools and then run formatting, linting and type
+checking via *black*, *ruff* and *mypy* respectively:
 
 ```bash
+pip install -r requirements-dev.txt
 black get_*.py library mapper_main.py table_quality_main.py
 ruff check get_*.py library mapper_main.py table_quality_main.py
 mypy get_*.py library mapper_main.py table_quality_main.py

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -92,3 +92,15 @@ pytest
 
 Test data resides in `tests/data` and offers realistic examples of the CSV
 structures expected by the command line tools.
+
+## Code style checks
+
+Run the standard formatting, linting and type checking tools before submitting
+changes. Install the developer extras first:
+
+```bash
+pip install -r requirements-dev.txt
+black get_*.py library mapper_main.py table_quality_main.py
+ruff check get_*.py library mapper_main.py table_quality_main.py
+mypy get_*.py library mapper_main.py table_quality_main.py
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ pytest>=7.0
 black>=23.0
 ruff>=0.0.290
 mypy>=1.8
+PyYAML>=6.0
 jsonschema>=4.0
 pandera>=0.26
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pandas>=2.0
 numpy>=1.21
 requests>=2.31
+PyYAML>=6.0  # YAML configuration parsing
 pytest>=7.0
 black>=23.0
 ruff>=0.0.290


### PR DESCRIPTION
## Summary
- include PyYAML for configuration parsing
- document installing developer extras and running black, ruff, mypy
- add code style commands to usage guide

## Testing
- `black get_*.py library mapper_main.py table_quality_main.py`
- `ruff check get_*.py library mapper_main.py table_quality_main.py` *(fails: F811 redefinition of CrossRefCfg/OpenAlexCfg)*
- `mypy get_*.py library mapper_main.py table_quality_main.py` *(fails: missing pandas/requests stubs)*
- `pytest` *(fails: 9 failed, 141 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2894369088324b200dc9608aa659b