### PR TITLE
Clarify PubChem delay type

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ pubchem:
   retries: 3
   rps: 3  # (env: CHEMBL_DA_PUBCHEM_RPS)
   burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
-  delay: 3  # Delay between requests in seconds
+  delay: 3.0  # Delay between requests in seconds; must be a float for strict type validation
 
 
 pubmed:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -235,6 +235,14 @@ def test_unknown_key_error(tmp_path: Path) -> None:
         load_config(path, strict=True)
 
 
+def test_config_type_coercion() -> None:
+    """The default configuration should load without type errors in strict mode."""
+
+    path = Path(__file__).resolve().parents[1] / "config.yaml"
+    cfg = load_config(path, strict=True)
+    assert isinstance(cfg.pubchem.delay, float)
+
+
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api: [\n")  # malformed YAML


### PR DESCRIPTION
## Summary
- fix PubChem delay configuration to use a float value and clarify requirement in comments
- ensure config loads without type errors when strict mode is enabled

## Testing
- `black tests/test_config.py`
- `ruff check tests/test_config.py`
- `mypy tests/test_config.py`
- `pytest tests/test_config.py::test_config_type_coercion -q`


------
https://chatgpt.com/codex/tasks/task_e_68c28a301a48832487aa4bee4004306a