### PR TITLE
refactor: remove redundant config import

### DIFF
--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -11,7 +11,6 @@ from urllib.parse import quote
 
 import requests
 
-from .config import CrossRefCfg, OpenAlexCfg
 from . import pubmed_library as _pl
 from .log import logger
 
@@ -19,7 +18,7 @@ from .log import logger
 def fetch_openalex(
     session: requests.Session,
     pmid: str,
-    cfg: OpenAlexCfg,
+    cfg: _pl.OpenAlexCfg,
 ) -> Dict[str, str]:
     """Return OpenAlex metadata for ``pmid``.
 
@@ -61,7 +60,7 @@ def fetch_openalex(
 def fetch_crossref(
     session: requests.Session,
     doi: str,
-    cfg: CrossRefCfg,
+    cfg: _pl.CrossRefCfg,
 ) -> Dict[str, str]:
     """Return CrossRef metadata for ``doi``.
 


### PR DESCRIPTION
## Summary
- avoid duplicating config imports in OpenAlex/CrossRef helper module
- reference configuration types via `pubmed_library`

## Testing
- `black get_*.py library mapper_main.py table_quality_main.py`
- `ruff check get_*.py library mapper_main.py table_quality_main.py`
- `mypy get_*.py library mapper_main.py table_quality_main.py`
- `pytest` *(fails: tests/test_input_initialisation_library.py, tests/test_io.py, tests/test_iuphar_library.py, tests/test_metadata.py, tests/test_normalize.py, tests/test_openalex_crossref_library.py, tests/test_percentages.py, tests/test_print_config.py, tests/test_pubchem_library.py, tests/test_pubmed_library.py, tests/test_schemas.py, tests/test_sidecar.py, tests/test_status_processing.py, tests/test_table_quality.py, tests/test_target_cli_organism_csv.py, tests/test_target_postprocessing.py, tests/test_uniprot_library.py, tests/test_validation.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c28a739ea88324b9430f42f17d6f1a