### PR TITLE
fix: handle dataclass slots for older python

### DIFF
--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -42,7 +42,13 @@ def _level_no(name: str) -> int:
     return _LEVELS.get(name.upper(), logging.INFO)
 
 
-@dataclass(slots=True)
+if sys.version_info >= (3, 10):  # pragma: no branch
+    _dataclass = dataclass(slots=True)
+else:  # pragma: no cover - Py<3.10 compatibility
+    _dataclass = dataclass
+
+
+@_dataclass
 class LoggerConfig:
     """Configuration for :class:`Logger`.
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,7 +1,4 @@
-
-"""Tests for :mod:`library.logging_setup`."""
-
-"""Structured logging tests for :mod:`chembl_da.library.logging_setup`.
+"""Structured logging tests for :mod:`library.logging_setup`.
 
 Example
 -------
@@ -12,7 +9,6 @@ Run linters and tests on this module with::
     mypy tests/test_logging_setup.py
     pytest tests/test_logging_setup.py
 """
-
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- allow using LoggerConfig on Python <3.10 by falling back when dataclass `slots` is unsupported
- tidy logging tests and ensure tooling references are in a single docstring

## Testing
- `ruff check library/logging_setup.py tests/test_logging_setup.py`
- `black library/logging_setup.py tests/test_logging_setup.py`
- `mypy library/logging_setup.py tests/test_logging_setup.py` *(fails: missing stubs for yaml, jsonschema, requests)*
- `pytest tests/test_logging_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c28e0b1e348324862d385a44ad0df1