### PR TITLE
feat: add dry-run and limit options to activity CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ config.yaml       Global configuration defaults
 
 Individual scripts provide specialised data retrieval utilities:
 
-* ``get_activity_data.py`` – fetch ChEMBL activity information.
+* ``get_activity_data.py`` – fetch ChEMBL activity information. Supports
+  ``--limit`` to process only the first *N* identifiers and ``--dry-run`` to
+  skip API calls and file output.
 * ``get_assay_data.py`` – retrieve assay descriptions from ChEMBL.
 * ``get_document_data.py`` – gather publication metadata.
 * ``get_target_data.py`` – combine ChEMBL, UniProt and IUPHAR target data.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,6 +16,13 @@ python get_activity_data.py \
     --column activity_id
 ```
 
+Limit processing and skip network requests during development::
+
+    python get_activity_data.py \
+        --input data/input-smoke/activity.csv \
+        --column activity_id \
+        --limit 5 --dry-run
+
 ## Assay descriptions
 
 ```bash

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -39,7 +39,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     cfg : Config
         Application configuration.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments. ``args.limit`` constrains the number of
+        identifiers processed, while ``args.dry_run`` skips network calls and
+        file generation.
 
     Returns
     -------
@@ -58,6 +60,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError) as exc:
         logger.error("%s", exc)
         return 1
+
+    if args.limit is not None:
+        if args.limit < 0:
+            logger.error("--limit must be non-negative")
+            return 1
+        ids = ids[: args.limit]
+        logger.info("processing at most %d identifiers", len(ids))
+
+    if args.dry_run:
+        logger.info("dry run selected; skipping data retrieval")
+        return 0
 
     try:
         df = cl.get_activities(
@@ -147,6 +160,17 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=30.0,
         help="Timeout in seconds for each HTTP request",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read input and exit without contacting the API or writing files",
     )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -18,6 +18,8 @@ def test_run_chembl_handles_request_error(monkeypatch, caplog) -> None:
         encoding="utf8",
         chunk_size=5,
         timeout=30.0,
+        limit=None,
+        dry_run=False,
     )
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["1"])
 

--- a/tests/test_activity_cli_limit.py
+++ b/tests/test_activity_cli_limit.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+import get_activity_data as gad
+from library import chembl_library as cl, io
+
+
+def _create_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+        "resources:\n"
+        "  dictionary_dir: dictionary\n"
+        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
+        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
+        "  uniprot_data_dir: uniprot\n"
+        "  organism_csv: dictionary/organism.csv\n"
+    )
+    return cfg
+
+
+def test_activity_cli_limit(tmp_path: Path, monkeypatch) -> None:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\n1\n2\n3\n")
+    config_path = _create_config(tmp_path)
+
+    called: dict[str, object] = {"ids": None, "written": False}
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["1", "2", "3"])
+
+    def fake_get(ids, cfg, chunk_size, timeout):
+        called["ids"] = ids
+        return pd.DataFrame({"activity_id": ids})
+
+    def fake_write(df, output, cfg, sep, encoding):
+        called["written"] = True
+
+    monkeypatch.setattr(cl, "get_activities", fake_get)
+    monkeypatch.setattr(io, "write_csv", fake_write)
+    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+
+    rc = gad.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--limit",
+            "2",
+        ]
+    )
+    assert rc == 0
+    assert called["ids"] == ["1", "2"]
+
+    called["ids"] = None
+    called["written"] = False
+    rc = gad.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--limit",
+            "2",
+            "--dry-run",
+        ]
+    )
+    assert rc == 0
+    assert called["ids"] is None
+    assert called["written"] is False


### PR DESCRIPTION
## Summary
- support `--limit` and `--dry-run` in the activity data CLI
- document new options in README and usage guide
- test limiting behavior and dry runs

## Testing
- `black get_*.py library mapper_main.py table_quality_main.py tests/test_activity_cli_limit.py`
- `ruff check get_*.py library mapper_main.py table_quality_main.py tests/test_activity_cli_limit.py`
- `mypy get_*.py library mapper_main.py table_quality_main.py`
- `pytest tests/test_activity_cli_limit.py tests/test_activity_cli_overrides.py tests/test_activity_cli_error.py`

------
https://chatgpt.com/codex/tasks/task_e_68c290c9d28c832493576797adbb0679