### PR TITLE
Introduce shared rate limiter and tests

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, Iterator
 
-import time
-
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .config import ApiCfg
+from .rate_limiter import rate_limiter
 from .log import logger
 
 _CACHE: Dict[str, dict[str, Any]] = {}
@@ -86,7 +85,7 @@ def request_json(
                         "request_fail", extra={"stage": "request_fail", "url": url}
                     )
                     raise
-                time.sleep(cfg.backoff_factor * attempt)
+                rate_limiter.wait(cfg.backoff_factor * attempt)
     raise requests.RequestException(f"request_json failed for url: {url}")
 
 

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -20,7 +20,6 @@ from typing import Iterable, List, Optional
 import io
 import logging
 import random
-import time
 from urllib.parse import quote
 
 import pandas as pd
@@ -28,6 +27,7 @@ import requests
 from requests import Session
 
 from .config import ApiCfg, IupharCfg, RetryCfg, session_with_retry
+from .rate_limiter import rate_limiter
 
 
 logger = logging.getLogger(__name__)
@@ -174,7 +174,7 @@ def _query_gene_symbol(gene_name: str, cfg: IupharCfg, retry: RetryCfg) -> dict:
 
     for attempt in range(1, retry.max_attempts + 1):
         if rate_delay:
-            time.sleep(rate_delay)
+            rate_limiter.wait(rate_delay)
         try:
             with _session.get(url, timeout=timeout) as response:
                 response.raise_for_status()
@@ -186,7 +186,7 @@ def _query_gene_symbol(gene_name: str, cfg: IupharCfg, retry: RetryCfg) -> dict:
                 break
             backoff = retry.backoff_factor * (2 ** (attempt - 1))
             jitter = random.uniform(0, backoff)
-            time.sleep(backoff + jitter)
+            rate_limiter.wait(backoff + jitter)
     return {}
 
 
@@ -653,7 +653,7 @@ class IUPHARData:
         def _download(url: str) -> pd.DataFrame:
             for attempt in range(1, retry_cfg.max_attempts + 1):
                 if rate_delay:
-                    time.sleep(rate_delay)
+                    rate_limiter.wait(rate_delay)
                 try:
                     with _session.get(url, timeout=timeout) as resp:
                         resp.raise_for_status()
@@ -664,7 +664,7 @@ class IUPHARData:
                         raise
                     backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
                     jitter = random.uniform(0, backoff)
-                    time.sleep(backoff + jitter)
+                    rate_limiter.wait(backoff + jitter)
             raise RuntimeError("Failed to download mapping")
 
         uni_df = _download(f"{data_base}/GtP_to_UniProt_mapping.csv")

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Optional
 from urllib.error import HTTPError
 
 from .config import UniprotMappingCfg
+from .rate_limiter import rate_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ def map_chembl_to_uniprot(
             raise ValueError("UniProt ID mapping job failed")
         if time.time() - start > cfg.timeout:
             raise TimeoutError("UniProt ID mapping job timed out")
-        time.sleep(cfg.poll_interval)
+        rate_limiter.wait(cfg.poll_interval)
 
     # Retrieve the results
     # If the last status check was a redirect, status_data already contains the results

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -7,7 +7,6 @@ The implementation is a Python translation of a PowerQuery script.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -15,6 +14,7 @@ import requests
 from requests import Session
 
 from .config import ApiCfg, PubChemCfg, RetryCfg, session_with_retry
+from .rate_limiter import rate_limiter
 from .log import logger
 
 _CACHE: Dict[str, Dict[str, Any]] = {}
@@ -152,7 +152,7 @@ def make_request(url: str, cfg: PubChemCfg) -> Optional[Dict[str, Any]]:
     for attempt in range(1, cfg.retries + 1):
         event = "request_start" if attempt == 1 else "request_retry"
         logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
-        time.sleep(cfg.delay)
+        rate_limiter.wait(cfg.delay)
         try:
             response = _session.get(
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -10,7 +10,6 @@ import argparse
 import csv
 import json
 import sys
-import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -21,6 +20,7 @@ from urllib.parse import quote
 from .log import logger
 
 from .config import CrossRefCfg, OpenAlexCfg, PubMedCfg, SemanticScholarCfg
+from .rate_limiter import rate_limiter
 
 
 def read_pmids(path: Union[str, Path], cfg: PubMedCfg | None = None) -> List[str]:
@@ -101,8 +101,7 @@ def _do_request(
     for attempt in range(retries + 1):
         event = "request_start" if attempt == 0 else "request_retry"
         logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
-        if attempt:
-            time.sleep(sleep * attempt)
+        rate_limiter.wait(sleep * (attempt or 1))
 
         try:
             if method.upper() == "POST":
@@ -651,7 +650,6 @@ def fetch_openalex(
     """
 
     delay = 1 / cfg.rps if cfg.rps else 0
-    time.sleep(delay)
     base = cfg.base.rstrip("/")
     url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
     timeout = (cfg.timeout_connect, cfg.timeout_read)
@@ -727,7 +725,6 @@ def fetch_crossref(
         }
 
     delay = 1 / cfg.rps if cfg.rps else 0
-    time.sleep(delay)
     base = cfg.base.rstrip("/")
     url = f"{base}/works/{quote(doi, safe='')}?mailto={quote(cfg.mailto)}"
     timeout = (cfg.timeout_connect, cfg.timeout_read)

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from .config import RateCfg, load_config
+
+
+class RateLimiter:
+    """Token-bucket rate limiter.
+
+    Parameters
+    ----------
+    rps:
+        Target requests per second.
+    burst:
+        Maximum burst size allowed.
+    """
+
+    def __init__(self, rps: float, burst: int) -> None:
+        self._rps = float(rps)
+        self._capacity = float(max(1, burst))
+        self._tokens = self._capacity
+        self._updated = time.monotonic()
+        self._lock = threading.Lock()
+
+    def wait(self, extra_delay: float = 0.0) -> None:
+        """Block until a token is available and sleep ``extra_delay`` seconds.
+
+        Parameters
+        ----------
+        extra_delay:
+            Additional time in seconds to wait after acquiring a token.
+        """
+        if self._rps <= 0:
+            if extra_delay > 0:
+                time.sleep(extra_delay)
+            return
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                elapsed = now - self._updated
+                self._tokens = min(self._capacity, self._tokens + elapsed * self._rps)
+                if self._tokens >= 1:
+                    self._tokens -= 1
+                    self._updated = now
+                    break
+                wait_time = (1 - self._tokens) / self._rps
+                self._updated = now
+            time.sleep(wait_time)
+        if extra_delay > 0:
+            time.sleep(extra_delay)
+
+
+try:
+    _cfg = load_config()
+    rate_limiter = RateLimiter(_cfg.rate.global_rps, _cfg.rate.global_burst)
+except Exception:
+    _defaults = RateCfg()
+    rate_limiter = RateLimiter(_defaults.global_rps, _defaults.global_burst)
+
+
+__all__ = ["RateLimiter", "rate_limiter"]

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import csv
 import json
 import logging
-import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Set
 
@@ -45,6 +44,7 @@ import requests
 from requests import Session
 
 from .config import ApiCfg, RetryCfg, UniprotCfg, load_config, session_with_retry
+from .rate_limiter import rate_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> Dict[str, Any]:
         If the request fails or the payload cannot be decoded as JSON.
 
     """
-    time.sleep(cfg.delay)
+    rate_limiter.wait(cfg.delay)
     base = cfg.base.rstrip("/")
     url = f"{base}/uniprotkb/{uniprot_id}.json"
     timeout = (cfg.timeout_connect, cfg.timeout_read)

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -16,8 +16,6 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
         return {}, ""
 
     monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
-    sleeps: list[float] = []
-    monkeypatch.setattr("library.pubmed_library.time.sleep", lambda s: sleeps.append(s))
 
     cfg = OpenAlexCfg(
         base="https://example.org",
@@ -30,7 +28,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
     ocl.fetch_openalex(requests.Session(), "123", cfg)
     assert called["url"] == "https://example.org/works/pmid:123?mailto=x%40y.com"
     assert called["timeout"] == (1, 2)
-    assert sleeps and sleeps[0] == pytest.approx(0.5)
+    assert called["sleep"] == pytest.approx(0.5)
 
 
 def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
@@ -44,8 +42,6 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
         return {}, ""
 
     monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
-    sleeps: list[float] = []
-    monkeypatch.setattr("library.pubmed_library.time.sleep", lambda s: sleeps.append(s))
 
     cfg = CrossRefCfg(
         base="https://cr.example.org",
@@ -58,4 +54,4 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
     ocl.fetch_crossref(requests.Session(), "10.1/abc", cfg)
     assert called["url"] == "https://cr.example.org/works/10.1%2Fabc?mailto=z%40e.com"
     assert called["timeout"] == (1, 2)
-    assert sleeps and sleeps[0] == pytest.approx(0.25)
+    assert called["sleep"] == pytest.approx(0.25)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,13 @@
+import time
+
+from library.rate_limiter import RateLimiter
+
+
+def test_rate_limiter_enforces_rps() -> None:
+    """Rate limiter should enforce the configured requests per second."""
+    limiter = RateLimiter(2, 1)
+    start = time.perf_counter()
+    for _ in range(3):
+        limiter.wait()
+    elapsed = time.perf_counter() - start
+    assert elapsed >= 1.0


### PR DESCRIPTION
## Summary
- add token-bucket rate limiter initialised from config
- replace `time.sleep` throttling in network clients with limiter calls
- add test to verify rate limiter respects requests-per-second

## Testing
- `ruff check library/chembl_client.py library/uniprot_library.py library/pubchem_library.py library/mapper_library.py library/iuphar_library.py library/pubmed_library.py library/rate_limiter.py tests/test_openalex_crossref_library.py tests/test_rate_limiter.py`
- `mypy library/chembl_client.py library/uniprot_library.py library/pubchem_library.py library/mapper_library.py library/iuphar_library.py library/pubmed_library.py library/rate_limiter.py tests/test_openalex_crossref_library.py tests/test_rate_limiter.py`
- `pytest tests/test_openalex_crossref_library.py tests/test_rate_limiter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c290d04df08324a07680c7bd1878c6