### PR TITLE
docs: clarify CLI options and deterministic CSV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,19 @@ config.yaml       Global configuration defaults
 
 Individual scripts provide specialised data retrieval utilities:
 
-* ``get_activity_data.py`` – fetch ChEMBL activity information. Supports
-  ``--limit`` to process only the first *N* identifiers and ``--dry-run`` to
-  skip API calls and file output.
+* ``get_activity_data.py`` – fetch ChEMBL activity information.
 * ``get_assay_data.py`` – retrieve assay descriptions from ChEMBL.
 * ``get_document_data.py`` – gather publication metadata.
 * ``get_target_data.py`` – combine ChEMBL, UniProt and IUPHAR target data.
 * ``get_testitem_data.py`` – download compound data and enrich with PubChem.
 * ``get_input_initialisation.py`` – merge ChEMBL initialisation workbooks.
-* ``scripts/check_determinism.py`` – ensure deterministic CSV output.
+
+### Deterministic CSV output
+
+The function ``library.csv_utils.write_csv_deterministic`` normalises column
+order, row sorting and value serialisation so repeated runs produce identical
+files. The helper script ``scripts/check_determinism.py`` writes a sample CSV
+twice and compares SHA-256 hashes to catch nondeterministic behaviour.
 
 All commands emit the structured JSON logs described above. Adjust verbosity
 with ``--log-level`` or ``CHEMBL_DA_LOG_LEVEL``.
@@ -397,17 +401,23 @@ in ``--out-dir``.
 
 ## Development
 
-Install the optional developer tools and then run formatting, linting and type
-checking via *black*, *ruff* and *mypy* respectively:
+Install the optional developer tools and run the standard quality checks:
 
-```bash
-black get_*.py library mapper_main.py table_quality_main.py scripts
-ruff check get_*.py library mapper_main.py table_quality_main.py scripts
-mypy get_*.py library mapper_main.py table_quality_main.py scripts
-python scripts/check_determinism.py
+* ``black`` – auto-format the code::
 
-pytest
-```
+      black get_*.py library mapper_main.py table_quality_main.py scripts
 
-Test data live in ``tests/data`` and provide coverage for utility
-functions in the library modules.
+* ``ruff`` – lint the project::
+
+      ruff check get_*.py library mapper_main.py table_quality_main.py scripts
+
+* ``mypy`` – perform static type checks::
+
+      mypy get_*.py library mapper_main.py table_quality_main.py scripts
+
+* ``python scripts/check_determinism.py`` – verify deterministic CSV output.
+
+* ``pytest`` – run the unit tests.
+
+Test data live in ``tests/data`` and provide coverage for utility functions in
+the library modules.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,13 +16,6 @@ python get_activity_data.py \
     --column activity_id
 ```
 
-Limit processing and skip network requests during development::
-
-    python get_activity_data.py \
-        --input data/input-smoke/activity.csv \
-        --column activity_id \
-        --limit 5 --dry-run
-
 ## Assay descriptions
 
 ```bash
@@ -89,6 +82,13 @@ python table_quality_main.py \
 The profiler writes `<table-name>_quality_report_table.csv` and
 `<table-name>_data_correlation_report_table.csv` in the current directory.
 
+## Deterministic CSV output
+
+``library.csv_utils.write_csv_deterministic`` serialises DataFrames with a
+stable column order, row sorting and value formatting so repeated runs produce
+identical files. The ``scripts/check_determinism.py`` utility writes a sample
+dataset twice and compares SHA-256 hashes to verify reproducibility.
+
 ## Running the tests
 
 The repository contains a small regression suite using `pytest`:
@@ -107,7 +107,8 @@ changes. Install the developer extras first:
 
 ```bash
 pip install -r requirements-dev.txt
-black get_*.py library mapper_main.py table_quality_main.py
-ruff check get_*.py library mapper_main.py table_quality_main.py
-mypy get_*.py library mapper_main.py table_quality_main.py
+black get_*.py library mapper_main.py table_quality_main.py scripts
+ruff check get_*.py library mapper_main.py table_quality_main.py scripts
+mypy get_*.py library mapper_main.py table_quality_main.py scripts
+python scripts/check_determinism.py
 ```


### PR DESCRIPTION
## Summary
- drop outdated `--limit` and `--dry-run` flags from CLI docs
- document deterministic CSV writing via `write_csv_deterministic` and `scripts/check_determinism.py`
- list `black`, `ruff`, and `mypy` commands for formatting, linting, and type checking

## Testing
- `pre-commit run --files README.md docs/USAGE.md` *(failed: 39 errors during collection)*
- `pytest` *(failed: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2945eca888324b6785fcdac826236