### PR TITLE
ci: include tests in pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
-        exclude: ^tests/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.1
     hooks:
@@ -12,7 +11,6 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        exclude: ^tests/
         additional_dependencies:
           - pandas
           - pandas-stubs


### PR DESCRIPTION
## Summary
- include tests in black and mypy pre-commit hooks

## Testing
- `pre-commit run --files tests/test_chembl_client.py` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_68c297eade708324b561d04c8093b516