### PR TITLE
Ensure deterministic CSV output

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -126,6 +126,10 @@ def write_csv(
 ) -> None:
     """Write ``df`` to ``path`` as CSV and store metadata.
 
+    Columns are sorted alphabetically and rows lexicographically to ensure
+    deterministic output. Values are written using Unix line endings and a
+    consistent floating-point representation.
+
     Parameters
     ----------
     df:
@@ -143,7 +147,16 @@ def write_csv(
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
     Path(path).parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(path, index=False, sep=sep, encoding=encoding)
+    sorted_df = df.sort_index(axis=1)
+    sorted_df = sorted_df.sort_values(by=list(sorted_df.columns))
+    sorted_df.to_csv(
+        path,
+        index=False,
+        sep=sep,
+        encoding=encoding,
+        lineterminator="\n",
+        float_format="%.6g",
+    )
     _write_meta(Path(path), cfg)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 from pathlib import Path
 
 import pandas as pd
@@ -64,3 +65,15 @@ def test_write_meta_serialises_paths(tmp_path: Path) -> None:
     meta = yaml.safe_load(meta_path.read_text())
     assert isinstance(meta["config"]["io"]["output_dir"], str)
     assert meta["config"]["io"]["output_dir"] == str(cfg.io.output_dir)
+
+
+def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
+    df = pd.DataFrame({"b": [3, 1], "a": [4.0, 2.0]})
+    path = tmp_path / "out.csv"
+    cfg = Config()
+    io.write_csv(df, path, cfg=cfg)
+    first_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    shuffled = df.sample(frac=1).reset_index(drop=True)[["b", "a"]]
+    io.write_csv(shuffled, path, cfg=cfg)
+    second_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert first_hash == second_hash


### PR DESCRIPTION
## Summary
- sort CSV columns and rows before serialization
- standardize line endings and float formatting for CSVs
- verify that repeated writes produce identical hashes

## Testing
- `black library/io.py tests/test_io.py`
- `ruff check library/io.py tests/test_io.py`
- `mypy library/io.py tests/test_io.py`
- `pytest tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c29adf519083249db8cd2786d32fc5