### PR TITLE
Gracefully handle missing pandas in determinism check

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The function ``library.csv_utils.write_csv_deterministic`` normalises column
 order, row sorting and value serialisation so repeated runs produce identical
 files. The helper script ``scripts/check_determinism.py`` writes a sample CSV
 twice and compares SHA-256 hashes to catch nondeterministic behaviour.
+The script requires the ``pandas`` package; install it with ``pip install pandas``
+if it is not already available in your environment.
 
 All commands emit the structured JSON logs described above. Adjust verbosity
 with ``--log-level`` or ``CHEMBL_DA_LOG_LEVEL``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.3.3
-pandas==2.3.2
+pandas==2.3.2  # Required for scripts/check_determinism.py
 requests==2.32.5
 PyYAML==6.0.2
 openpyxl==3.1.5

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -15,7 +15,13 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError as exc:  # pragma: no cover - import-time check
+    raise SystemExit(
+        "pandas is required to run scripts/check_determinism.py."
+        " Install it with 'pip install pandas'."
+    ) from exc
 
 # Ensure the repository root is on ``sys.path`` when executed as a script.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- handle ImportError for pandas in `check_determinism.py` and provide install hint
- note pandas requirement in README
- document pandas usage for determinism script in requirements

## Testing
- `pre-commit run --files scripts/check_determinism.py README.md requirements.txt` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_68c29adaf14483248c7bee5f06ef318e