### PR TITLE
Document configuration URL validation and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ parsing, validation, aggregation and export of tabular data.
    The suite exercises the library modules using fixtures from
    ``tests/data``.
 
+## Валидация конфигурации
+
+`library.config.load_config` проверяет корректность значений в `config.yaml`.
+Некорректный URL приводит к `ValueError` при загрузке:
+
+```yaml
+api:
+  chembl_base: https://
+```
+
+```
+ValueError: api.chembl_base must be a valid URL
+```
+
+Исправленный вариант задаёт полный адрес службы:
+
+```yaml
+api:
+  chembl_base: https://www.ebi.ac.uk/chembl/api/data
+```
+
 ## Logging
 
 All command-line tools emit structured logs as one JSON object per line

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,3 +49,28 @@ All defaults are chosen to match the existing behaviour of the scripts. If
 `config.yaml` is missing or a field is undefined, the corresponding fallback is
 used. On multi-user systems, consider customising the output directories to
 avoid race conditions.
+
+## Environment variables
+
+Every configuration setting can be overridden via environment variables that
+follow the pattern `CHEMBL_DA__SECTION__KEY`. Sections and keys are separated
+by double underscores. For example, to increase the global request rate:
+
+```bash
+export CHEMBL_DA__API__RPS=10
+```
+
+Common options offer shorter aliases. The following environment variables map
+to the same configuration keys as their longer forms:
+
+| Alias | Equivalent key |
+|-------|----------------|
+| `CHEMBL_DA_BASE` | `CHEMBL_DA__API__CHEMBL_BASE` |
+| `CHEMBL_DA_TIMEOUT_CONNECT` | `CHEMBL_DA__API__TIMEOUT_CONNECT` |
+| `CHEMBL_DA_TIMEOUT_READ` | `CHEMBL_DA__API__TIMEOUT_READ` |
+| `CHEMBL_DA_OUTDIR` | `CHEMBL_DA__IO__OUTPUT_DIR` |
+| `CHEMBL_DA_CACHE_DIR` | `CHEMBL_DA__IO__CACHE_DIR` |
+| `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__LOG__LEVEL` |
+
+The loader warns about unknown variables and ignores them. All overrides are
+applied after reading `config.yaml` and before command line options.

--- a/tests/test_config_invalid_url.py
+++ b/tests/test_config_invalid_url.py
@@ -1,0 +1,17 @@
+"""Test configuration validation for malformed URLs."""
+
+from pathlib import Path
+
+import pytest
+
+from library.config import load_config
+
+
+def test_env_alias_invalid_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid base URL supplied via env alias should raise ``ValueError``."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    monkeypatch.setenv("CHEMBL_DA_BASE", "https://")
+    with pytest.raises(ValueError, match="api.chembl_base"):
+        load_config(path)


### PR DESCRIPTION
## Summary
- explain configuration validation with bad/valid URL examples
- document `CHEMBL_DA__SECTION__KEY` environment variables and aliases
- add unit test for invalid URL via env alias

## Testing
- `black tests/test_config_invalid_url.py`
- `ruff check tests/test_config_invalid_url.py`
- `mypy tests/test_config_invalid_url.py`
- `pytest tests/test_config_invalid_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68c29c90a97483248f029a6ca593407e