### PR TITLE
Refactor check_determinism imports and add script test

### DIFF
--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -2,7 +2,7 @@
 """Verify deterministic CSV output.
 
 This script writes a small test :class:`pandas.DataFrame` twice using
-:func:`chembl_da.library.csv_utils.write_csv_deterministic` and compares the
+:func:`library.csv_utils.write_csv_deterministic` and compares the
 SHA-256 hashes of the resulting files. A non-zero exit code is returned if the
 hashes differ.
 """
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -23,15 +22,7 @@ except ImportError as exc:  # pragma: no cover - import-time check
         " Install it with 'pip install pandas'."
     ) from exc
 
-# Ensure the repository root is on ``sys.path`` when executed as a script.
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-from chembl_da.library.csv_utils import (  # noqa: E402
-    sha256_file,
-    write_csv_deterministic,
-)
+from library.csv_utils import sha256_file, write_csv_deterministic
 
 
 def run_check(tmp_dir: Path) -> bool:

--- a/tests/test_check_determinism_script.py
+++ b/tests/test_check_determinism_script.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_check_determinism_script() -> None:
+    """Ensure the check_determinism script exits successfully."""
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.check_determinism"], check=False
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- import csv utilities directly from `library` and drop manual `sys.path` handling
- add subprocess-based test for `scripts.check_determinism`

## Testing
- `ruff check scripts/check_determinism.py tests/test_check_determinism_script.py`
- `black --check scripts/check_determinism.py tests/test_check_determinism_script.py`
- `mypy scripts/check_determinism.py tests/test_check_determinism_script.py`
- `pytest tests/test_check_determinism_script.py`
- `pre-commit run --files scripts/check_determinism.py tests/test_check_determinism_script.py` *(fails: ERROR tests/test_pubchem_library.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c29c84dd348324bd2c784ddc43d1f7