### PR TITLE
Handle dry-run before reading IDs and cover CLI

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -49,6 +49,15 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    if args.limit is not None and args.limit < 0:
+        logger.error("--limit must be non-negative")
+        return 1
+
+    if args.dry_run:
+        expected = args.limit if args.limit is not None else 0
+        logger.info("dry run selected; would process at most %d identifiers", expected)
+        return 0
+
     try:
         ids = io.read_ids(
             args.input_csv,
@@ -62,15 +71,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     if args.limit is not None:
-        if args.limit < 0:
-            logger.error("--limit must be non-negative")
-            return 1
         ids = ids[: args.limit]
         logger.info("processing at most %d identifiers", len(ids))
-
-    if args.dry_run:
-        logger.info("dry run selected; skipping data retrieval")
-        return 0
 
     try:
         df = cl.get_activities(

--- a/tests/test_activity_cli_dry_run_no_input.py
+++ b/tests/test_activity_cli_dry_run_no_input.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import get_activity_data as gad
+
+
+def _create_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "jobs:\n  chunk_size: 10\n"
+        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
+        "log:\n  level: INFO\n"
+        "api:\n  timeout_read: 30\n"
+        "resources:\n"
+        "  dictionary_dir: dictionary\n"
+        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
+        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
+        "  uniprot_data_dir: uniprot\n"
+        "  organism_csv: dictionary/organism.csv\n"
+    )
+    return cfg
+
+
+def test_dry_run_no_input(tmp_path: Path, capfd) -> None:
+    config_path = _create_config(tmp_path)
+    rc = gad.main(["--config", str(config_path), "--dry-run", "--limit", "5"])
+    assert rc == 0
+    stderr = capfd.readouterr().err
+    assert "dry run selected" in stderr
+    assert "5 identifiers" in stderr


### PR DESCRIPTION
## Summary
- skip reading IDs during dry run and report expected count from `--limit`
- add a test ensuring the CLI dry run works without an input file

## Testing
- `black get_activity_data.py tests/test_activity_cli_dry_run_no_input.py`
- `ruff check get_activity_data.py tests/test_activity_cli_dry_run_no_input.py`
- `mypy get_activity_data.py tests/test_activity_cli_dry_run_no_input.py`
- `pytest tests/test_activity_cli_limit.py tests/test_activity_cli_dry_run_no_input.py`


------
https://chatgpt.com/codex/tasks/task_e_68c29c9621c4832483b2517d85d4a6e9