### PR TITLE
Add cache smoke test to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -r requirements.txt
-      - run: pip install -r requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
       - run: python scripts/check_determinism.py
       - run: pre-commit run --all-files
+      - name: Smoke test cache
+        run: pytest -q tests/test_chembl_client.py::test_request_json_cache

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -99,3 +99,16 @@ def test_request_json_reuses_session(monkeypatch) -> None:
     request_json("http://example.com/2", cfg=ApiCfg())
 
     assert dummy.calls == [id(dummy), id(dummy)]
+
+
+@responses.activate
+def test_request_json_cache(monkeypatch) -> None:
+    monkeypatch.setattr("library.chembl_client._CACHE", {})
+    url = "http://example.com/cache"
+    responses.add(responses.GET, url, json={"ok": True}, status=200)
+
+    request_json(url, cfg=ApiCfg())
+    assert len(responses.calls) == 1
+
+    request_json(url, cfg=ApiCfg())
+    assert len(responses.calls) == 1


### PR DESCRIPTION
## Summary
- verify ChEMBL client uses cache with new unit test
- ensure CI installs dev dependencies and runs smoke test

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml tests/test_chembl_client.py`
- `pytest -q tests/test_chembl_client.py::test_request_json_cache`


------
https://chatgpt.com/codex/tasks/task_e_68c29ca9dc4c8324ae192e1f26e0495c