### PR TITLE
Ensure thread-safe ChEMBL client session

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, Iterator
 
 import random
+import threading
 import requests
 from requests import Session
 
@@ -14,7 +15,8 @@ from .log import logger
 
 _CACHE: Dict[str, dict[str, Any]] = {}
 
-_session: Session = session_with_retry(ApiCfg(), RetryCfg())
+_session: Session | None = None
+_session_lock = threading.Lock()
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
@@ -66,11 +68,19 @@ def request_json(
         return _CACHE[cache_key]
     logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
+    global _session
+    if _session is None:
+        with _session_lock:
+            if _session is None:
+                _session = session_with_retry(ApiCfg(), RetryCfg())
+    session = _session
+    assert session is not None  # noqa: S101 - ensure session exists
+
     for attempt in range(1, cfg.retries + 1):
         event = "request_start" if attempt == 1 else "request_retry"
         logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
         try:
-            with _session.get(
+            with session.get(
                 url, timeout=(cfg.timeout_connect, read_timeout)
             ) as response:
                 response.raise_for_status()
@@ -97,6 +107,16 @@ def request_json(
             delay += random.uniform(0, cfg.backoff_factor)
             sleep(delay)
     raise requests.RequestException(f"request_json failed for url: {url}")
+
+
+def clear_cache() -> None:
+    """Remove all entries from the in-memory cache.
+
+    This helper is primarily intended for tests to avoid interference
+    from previously cached responses.
+    """
+
+    _CACHE.clear()
 
 
 def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -8,7 +8,7 @@ import random
 import requests
 import responses
 import time
-from library.chembl_client import init_session, request_json
+from library.chembl_client import clear_cache, init_session, request_json
 from library.config import ApiCfg, RetryCfg
 
 
@@ -44,7 +44,7 @@ class DummySession:
 def test_request_json_uses_cfg(monkeypatch) -> None:
     session = DummySession(failures=1)
     monkeypatch.setattr("library.chembl_client._session", session)
-    monkeypatch.setattr("library.chembl_client._CACHE", {})
+    clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
@@ -66,7 +66,7 @@ def test_request_json_uses_cfg(monkeypatch) -> None:
 def test_request_json_backoff_grows(monkeypatch) -> None:
     session = DummySession(failures=2)
     monkeypatch.setattr("library.chembl_client._session", session)
-    monkeypatch.setattr("library.chembl_client._CACHE", {})
+    clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
@@ -93,7 +93,7 @@ def test_request_json_reuses_session(monkeypatch) -> None:
         raise AssertionError("requests.Session should not be called")
 
     monkeypatch.setattr(requests, "Session", fail_session)
-    monkeypatch.setattr("library.chembl_client._CACHE", {})
+    clear_cache()
 
     request_json("http://example.com/1", cfg=ApiCfg())
     request_json("http://example.com/2", cfg=ApiCfg())

--- a/tests/test_chembl_client_threadsafe.py
+++ b/tests/test_chembl_client_threadsafe.py
@@ -1,0 +1,61 @@
+"""Thread-safety tests for :mod:`library.chembl_client`."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import threading
+
+from library.chembl_client import clear_cache, request_json
+from library.config import ApiCfg
+
+
+class DummyResponse:
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return {"ok": True}
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def get(self, url: str, timeout: Any) -> DummyResponse:
+        self.calls.append(threading.get_ident())
+        return DummyResponse()
+
+
+def test_single_session_created(monkeypatch) -> None:
+    clear_cache()
+    monkeypatch.setattr("library.chembl_client._session", None)
+
+    dummy = DummySession()
+    create_calls = 0
+
+    def fake_session_with_retry(api: ApiCfg, retry: Any) -> DummySession:
+        nonlocal create_calls
+        create_calls += 1
+        return dummy
+
+    monkeypatch.setattr(
+        "library.chembl_client.session_with_retry", fake_session_with_retry
+    )
+
+    def worker() -> dict[str, Any]:
+        return request_json("http://example.com", cfg=ApiCfg())
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        futures = [pool.submit(worker) for _ in range(5)]
+        results = [f.result() for f in futures]
+
+    assert create_calls == 1
+    assert all(r == {"ok": True} for r in results)


### PR DESCRIPTION
## Summary
- add thread-safe session creation and cache clearing helper in `chembl_client`
- expand unit tests to reset cache
- introduce concurrency test verifying session initialization is performed once

## Testing
- `pre-commit run --files library/chembl_client.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py` *(fails: tests/test_chembl_client.py ... tests/test_uniprot_library.py; 6 errors during collection)*
- `black library/chembl_client.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py`
- `ruff check library/chembl_client.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py`
- `mypy library/chembl_client.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py`
- `pytest tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68c29cbca53083249ba97db94f6bed08