### PR TITLE
Protect rate limiter registry with lock

### DIFF
--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -51,6 +51,7 @@ class RateLimiter:
 
 
 _limiters: Dict[str, RateLimiter] = {}
+_limiters_lock = threading.Lock()
 
 
 def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
@@ -66,15 +67,16 @@ def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
     burst:
         Maximum burst size.  Defaults to ``ceil(rps)``.
     """
-    limiter = _limiters.get(name)
-    if (
-        limiter is None
-        or limiter.rps != rps
-        or (burst is not None and limiter.burst != burst)
-    ):
-        limiter = RateLimiter(rps, burst)
-        _limiters[name] = limiter
-    return limiter
+    with _limiters_lock:
+        limiter = _limiters.get(name)
+        if (
+            limiter is None
+            or limiter.rps != rps
+            or (burst is not None and limiter.burst != burst)
+        ):
+            limiter = RateLimiter(rps, burst)
+            _limiters[name] = limiter
+        return limiter
 
 
 def sleep(delay: float) -> None:

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`library.pubchem_library`."""
 
- 
 from __future__ import annotations
 
 from typing import Dict, Tuple
@@ -8,16 +7,15 @@ from typing import Dict, Tuple
 import responses
 
 import library.rate_limiter as rl
- 
+
 from library import pubchem_library as pl
 
 
 @responses.activate
 def test_get_cid_from_smiles_uses_base() -> None:
- 
     """Ensure the configured base URL is used for PubChem requests."""
     cfg = pl.PubChemCfg(base="https://example.org/api", delay=0)
- 
+
     url = "https://example.org/api/compound/smiles/C/cids/JSON"
     responses.add(
         responses.GET,
@@ -34,12 +32,7 @@ def test_get_cid_from_smiles_uses_base() -> None:
 
 @responses.activate
 def test_make_request_uses_timeout(monkeypatch) -> None:
- 
     """`make_request` passes configured timeouts to the session."""
-    called: dict[str, tuple[int, int]] = {}
-
- 
-    """Requests should apply configured timeouts."""
     called: Dict[str, Tuple[int, int]] = {}
 
     class Resp:
@@ -56,6 +49,7 @@ def test_make_request_uses_timeout(monkeypatch) -> None:
         return Resp()
 
     monkeypatch.setattr(pl._session, "get", capture)
+    pl._CACHE.clear()
 
     cfg = pl.PubChemCfg(timeout_connect=1, timeout_read=2, retries=1, rps=0)
     responses.add(responses.GET, "https://example.org", json={}, status=200)
@@ -80,8 +74,9 @@ def test_make_request_rate_limited(monkeypatch) -> None:
 
     fake_time = FakeTime()
     monkeypatch.setattr(rl, "time", fake_time)
-    rl._limiters.clear()
- 
+    with rl._limiters_lock:
+        rl._limiters.clear()
+
     class Resp:
         status_code = 200
 
@@ -97,13 +92,18 @@ def test_make_request_rate_limited(monkeypatch) -> None:
     cfg = pl.PubChemCfg(rps=1, burst=1, retries=1)
     pl.make_request("https://example.org/a", cfg)
     pl.make_request("https://example.org/b", cfg)
- 
+
+    called: dict[str, tuple[int, int]] = {}
+
+    def capture(url: str, timeout: tuple[int, int]) -> Resp:
+        called["timeout"] = timeout
+        return Resp()
+
     monkeypatch.setattr(pl._session, "get", capture)
     cfg = pl.PubChemCfg(timeout_connect=1, timeout_read=2, delay=0, retries=1)
 
     pl.make_request("https://example.org", cfg)
 
     assert called["timeout"] == (1, 2)
- 
+
     assert fake_time.sleeps == [1.0]
- 

--- a/tests/test_rate_limiter_threadsafe.py
+++ b/tests/test_rate_limiter_threadsafe.py
@@ -1,0 +1,30 @@
+"""Thread-safety tests for :mod:`library.rate_limiter`."""
+
+from __future__ import annotations
+
+import threading
+
+import library.rate_limiter as rl
+
+
+def test_get_limiter_thread_safe() -> None:
+    """Concurrent calls to :func:`get_limiter` should return the same instance."""
+    results: list[rl.RateLimiter] = []
+
+    with rl._limiters_lock:
+        rl._limiters.clear()
+
+    def target() -> None:
+        results.append(rl.get_limiter("shared", rps=1))
+
+    threads = [threading.Thread(target=target) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len({id(limiter) for limiter in results}) == 1
+
+    with rl._limiters_lock:
+        assert len(rl._limiters) == 1
+        rl._limiters.clear()


### PR DESCRIPTION
## Summary
- guard shared `_limiters` registry with a module-level `threading.Lock`
- update PubChem tests to clear registry via the lock
- add concurrent test confirming `get_limiter` is thread-safe

## Testing
- `SKIP=pytest pre-commit run --files library/rate_limiter.py tests/test_pubchem_library.py tests/test_rate_limiter_threadsafe.py`
- `pytest tests/test_rate_limiter_threadsafe.py tests/test_pubchem_library.py::test_make_request_rate_limited tests/test_pubchem_library.py::test_make_request_uses_timeout`
- `pytest` *(fails: AssertionError and AttributeError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c29f07d6048324b79e4635a36d4fc2