### PR TITLE
chore: enable openpyxl typing

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -465,7 +465,6 @@ def process_activity_table(
         )
         raise FileNotFoundError(msg)
 
-
     targets = pd.read_csv(
         targets_path,
         dtype={
@@ -565,7 +564,7 @@ def _ensure_openpyxl() -> None:
 
     """
     try:
-        import openpyxl  # type: ignore
+        import openpyxl
     except Exception as exc:  # pragma: no cover - import error path
         raise RuntimeError("openpyxl>=3.1 is required to read Excel files") from exc
     version = tuple(int(v) for v in openpyxl.__version__.split(".")[:3])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ pandas-stubs==2.3.2.250827
 types-requests==2.32.4.20250809
 types-PyYAML==6.0.12.20250822
 types-jsonschema==4.25.1.20250822
+types-openpyxl>=3.1.5
 hypothesis==6.138.15
 responses==0.25.8


### PR DESCRIPTION
## Summary
- remove type ignore for `openpyxl` import
- add `types-openpyxl` to development requirements

## Testing
- `ruff check library/input_initialisation_library.py`
- `black library/input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2a1678a8c8324a44ea06b06a18285