### PR TITLE
Log CSV utility runtime with logging

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import time
 from pathlib import Path
 from typing import Sequence
 
@@ -16,7 +17,12 @@ import pandas as pd
 from library.csv_utils import write_csv_deterministic
 
 
+logger = logging.getLogger(__name__)
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", default="input.csv", help="Input CSV path")
     parser.add_argument(
@@ -41,8 +47,22 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Zero on success.
+    """
+
     args = parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    start = time.perf_counter()
     df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
     output = args.output or Path(args.input).with_name(
         f"output_{Path(args.input).stem}.csv"
@@ -53,7 +73,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         col_order=args.col_order or None,
         key_cols=args.key_cols or None,
     )
-    logging.info("written %s", output)
+    elapsed = time.perf_counter() - start
+    logger.info("written %s", output)
+    logger.info("completed in %.3f seconds", elapsed)
     return 0
 
 

--- a/tests/test_csv_utils_main_smoke.py
+++ b/tests/test_csv_utils_main_smoke.py
@@ -1,0 +1,31 @@
+"""Smoke test for csv_utils_main runtime logging."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_csv_utils_main_logs_runtime(tmp_path: Path) -> None:
+    """The CLI should log its execution duration."""
+    root = Path(__file__).resolve().parents[1]
+    input_csv = Path(__file__).parent / "data" / "csv_utils_input.csv"
+    output_csv = tmp_path / "out.csv"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(root / "csv_utils_main.py"),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "INFO",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "completed in" in proc.stderr
+    assert output_csv.exists()


### PR DESCRIPTION
## Summary
- measure execution time in `csv_utils_main.py` using `time.perf_counter`
- log runtime and add docstrings for CLI entry points
- add smoke test verifying runtime is reported

## Testing
- `pre-commit run --files csv_utils_main.py tests/test_csv_utils_main_smoke.py` *(fails: tests/test_chembl_client.py::test_request_json_cache - assert 0 == 1, tests/test_iuphar_library.py::test_websearch_gene_to_id_uses_cfg2 - AttributeError: module 'library.iuphar_library' has no attribute 'time', tests/test_iuphar_library.py::test_iuphar_upload_uses_cfg - AttributeError: module 'library.iuphar_library' has no attribute 'time', tests/test_iuphar_library.py::test_query_gene_symbol_backoff - AttributeError: module 'library.iuphar_library' has no attribute 'time')*
- `pytest tests/test_csv_utils_main_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2a1c7dd848324b21212cdad2f9c63