### PR TITLE
fix: support dataclass slots on older Python

### DIFF
--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -42,7 +42,14 @@ def _level_no(name: str) -> int:
     return _LEVELS.get(name.upper(), logging.INFO)
 
 
-@dataclass(slots=True)
+# ``slots`` is available from Python 3.10 onwards.  Supplying it on older
+# versions raises ``TypeError``, so the argument is added conditionally.
+_DATACLASS_KWARGS: dict[str, bool] = (
+    {"slots": True} if sys.version_info >= (3, 10) else {}
+)
+
+
+@dataclass(**_DATACLASS_KWARGS)
 class LoggerConfig:
     """Configuration for :class:`Logger`.
 


### PR DESCRIPTION
## Summary
- avoid TypeError on Python <3.10 by conditionally passing `slots` to dataclasses

## Testing
- `black library/logging_setup.py`
- `ruff check library/logging_setup.py`
- `mypy library/logging_setup.py`
- `pytest tests/test_logging_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2a641857883248fd0056bfeb1a7e0