### PR TITLE
Ensure thread-safe JSON logging

### DIFF
--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -15,6 +15,7 @@ import logging
 import sys
 import time
 import traceback
+import threading
 from contextlib import contextmanager
 from typing import Any, IO, Iterator, Optional
 
@@ -27,6 +28,9 @@ _LEVELS = {
     "WARNING": logging.WARNING,
     "ERROR": logging.ERROR,
 }
+
+# Global lock ensuring thread-safe writes to the log stream.
+_EMIT_LOCK = threading.Lock()
 
 
 def _level_no(name: str) -> int:
@@ -99,9 +103,10 @@ class Logger:
         return redacted
 
     def _emit(self, record: dict[str, Any]) -> None:
-        json.dump(record, self._cfg.stream)
-        self._cfg.stream.write("\n")
-        self._cfg.stream.flush()
+        with _EMIT_LOCK:
+            json.dump(record, self._cfg.stream)
+            self._cfg.stream.write("\n")
+            self._cfg.stream.flush()
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -17,6 +17,7 @@ import sys
 from typing import Any
 
 import pytest
+import threading
 
 from library.logging_setup import LoggerConfig, configure_logger
 
@@ -90,3 +91,27 @@ def test_stage_context_manager_failure(
     assert fail["event"] == "load_fail"
     assert start["stage"] == fail["stage"] == "load"
     assert start["run_id"] == fail["run_id"] == "rid"
+
+
+def test_multithreaded_logging_emits_valid_json(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Concurrent logging should emit one JSON object per line."""
+
+    logger = configure_logger(
+        LoggerConfig(level="INFO", run_id="rid", stream=sys.stdout)
+    )
+
+    def worker(idx: int) -> None:
+        logger.info("event", thread=idx)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = capfd.readouterr().out.strip().splitlines()
+    assert len(lines) == 10
+    for line in lines:
+        json.loads(line)


### PR DESCRIPTION
## Summary
- guard logger emission with a global lock to prevent interleaved writes
- add multi-threaded test ensuring each log line is valid JSON

## Testing
- `black library/logging_setup.py tests/test_logging_setup.py`
- `ruff check library/logging_setup.py tests/test_logging_setup.py`
- `mypy library/logging_setup.py tests/test_logging_setup.py`
- `pytest tests/test_logging_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2a65ab6bc8324afa636da8b87967d