### PR TITLE
Use TTL cache for ChEMBL client responses

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from typing import Any, Dict, Iterable, Iterator, cast
+from typing import Any, Iterable, Iterator, cast
 
 
 import random
@@ -11,13 +11,15 @@ import threading
 import requests
 from requests import Session
 
-from cachetools import LRUCache
+from cachetools import TTLCache  # type: ignore[import-untyped]
 
 from .config import ApiCfg, RetryCfg, session_with_retry
 from .rate_limiter import sleep
 from .log import logger
 
-_CACHE: LRUCache[str, dict[str, Any]] = LRUCache(maxsize=1024)
+# Cache entries expire after one hour to avoid serving stale data. The TTL can
+# be adjusted in the future via configuration if required.
+_CACHE: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=1024, ttl=3600)
 
 _session: Session | None = None
 _session_lock = threading.Lock()

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -9,9 +9,7 @@ import requests
 import responses
 import time
 
-import library.chembl_client as chembl_client
-
-from cachetools import LRUCache
+from cachetools import TTLCache  # type: ignore[import-untyped]
 from library import chembl_client
 
 from library.chembl_client import clear_cache, init_session, request_json
@@ -125,14 +123,29 @@ def test_request_json_cache(monkeypatch) -> None:
 
 
 @responses.activate
-def test_request_json_cache_eviction(monkeypatch) -> None:
-    monkeypatch.setattr(chembl_client, "_CACHE", LRUCache(maxsize=2))
+def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
+    timer = [0.0]
+    cache = TTLCache(maxsize=2, ttl=1, timer=lambda: timer[0])
+    monkeypatch.setattr(chembl_client, "_CACHE", cache)
+    monkeypatch.setattr("library.chembl_client._session", None)
     clear_cache()
-    urls = [f"http://example.com/{i}" for i in range(3)]
-    for i, url in enumerate(urls, start=1):
-        responses.add(responses.GET, url, json={"ok": i}, status=200)
-        request_json(url, cfg=ApiCfg())
+    url = "http://example.com/ttl"
+    responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    assert urls[0] not in chembl_client._CACHE
-    assert len(chembl_client._CACHE) == 2
+    request_json(url, cfg=ApiCfg())
 
+    # Advance time beyond the TTL to force expiration of the cached entry.
+    timer[0] = 2.0
+    responses.add(responses.GET, url, json={"ok": True}, status=200)
+    request_json(url, cfg=ApiCfg())
+
+    # Two HTTP calls should have occurred because the cache entry expired.
+    assert len(responses.calls) == 2
+
+
+def test_clear_cache(monkeypatch) -> None:
+    cache = TTLCache(maxsize=2, ttl=100)
+    monkeypatch.setattr(chembl_client, "_CACHE", cache)
+    chembl_client._CACHE["x"] = {"ok": True}
+    clear_cache()
+    assert len(chembl_client._CACHE) == 0


### PR DESCRIPTION
## Summary
- replace LRUCache with TTLCache expiring entries after one hour
- add tests for cache clearing and TTL expiration

## Testing
- `ruff check library/chembl_client.py tests/test_chembl_client.py`
- `mypy library/chembl_client.py tests/test_chembl_client.py`
- `pytest tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2a655673883248a84f695a3d67c8b