### PR TITLE
feat: allow key-based ordering in write_csv

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -123,6 +123,7 @@ def write_csv(
     cfg: Config,
     sep: str | None = None,
     encoding: str | None = None,
+    key_cols: Iterable[str] | None = None,
 ) -> None:
     """Write ``df`` to ``path`` as CSV and store metadata.
 
@@ -142,13 +143,22 @@ def write_csv(
         Field delimiter used in the CSV file. Defaults to ``cfg.io.csv_sep``.
     encoding:
         Character encoding of the CSV file. Defaults to ``cfg.io.csv_encoding``.
+    key_cols:
+        Optional columns to determine row order. When provided, rows are
+        sorted by these columns. Otherwise all columns are used, preserving
+        the previous deterministic behaviour.
 
     """
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     sorted_df = df.sort_index(axis=1)
-    sorted_df = sorted_df.sort_values(by=list(sorted_df.columns))
+    if key_cols is not None:
+        # Only sort by the specified key columns for determinism.
+        sorted_df = sorted_df.sort_values(by=list(key_cols))
+    else:
+        # Fall back to the original behaviour of sorting by all columns.
+        sorted_df = sorted_df.sort_values(by=list(sorted_df.columns))
     sorted_df.to_csv(
         path,
         index=False,

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -67,7 +67,14 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     df["mapping_uniprot_id"] = uniprot_ids
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     try:
-        io.write_csv(df, output, cfg=cfg, sep=args.sep, encoding=args.encoding)
+        io.write_csv(
+            df,
+            output,
+            cfg=cfg,
+            sep=args.sep,
+            encoding=args.encoding,
+            key_cols=args.key_cols,
+        )
         logger.info("wrote %s", output)
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
@@ -81,6 +88,11 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "Map ChEMBL target IDs to UniProt accessions",
         column="chembl_id",
         chunk_size=1,
+    )
+    parser.add_argument(
+        "--key-cols",
+        nargs="*",
+        help="Columns used to sort the output CSV deterministically",
     )
     parser.set_defaults(func=run)
     return parser, log_cfg

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -33,6 +33,7 @@ def test_mapper_run_defaults_to_io_output_dir(
         column="chembl_id",
         sep=",",
         encoding="utf8",
+        key_cols=None,
     )
 
     monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _i, _cfg: "P12345")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -77,3 +77,15 @@ def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
     io.write_csv(shuffled, path, cfg=cfg)
     second_hash = hashlib.sha256(path.read_bytes()).hexdigest()
     assert first_hash == second_hash
+
+
+def test_write_csv_with_key_cols(tmp_path: Path) -> None:
+    df = pd.DataFrame({"a": [2, 1], "b": ["x", "y"]})
+    path = tmp_path / "out.csv"
+    cfg = Config()
+    io.write_csv(df, path, cfg=cfg, key_cols=["a"])
+    first_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    shuffled = df.sample(frac=1).reset_index(drop=True)
+    io.write_csv(shuffled, path, cfg=cfg, key_cols=["a"])
+    second_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert first_hash == second_hash


### PR DESCRIPTION
## Summary
- add optional `key_cols` to `io.write_csv` for custom row sorting
- expose `--key-cols` in `mapper_main` CLI
- test deterministic output when sort keys provided

## Testing
- `ruff check library/io.py mapper_main.py tests/test_default_output_dir.py tests/test_io.py`
- `mypy library/io.py mapper_main.py tests/test_default_output_dir.py tests/test_io.py`
- `pytest tests/test_io.py::test_write_csv_with_key_cols tests/test_default_output_dir.py::test_mapper_run_defaults_to_io_output_dir -q`
- `pytest` *(fails: NameError: TTLCache is not defined; AssertionError in test_cli_bad_config)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a88a3dc883249c5e5bc0ee453c7b