### PR TITLE
feat: centralize CLI IO arguments

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -15,6 +15,7 @@ from typing import Sequence
 import pandas as pd
 
 from library.csv_utils import write_csv_deterministic
+from library.cli import add_common_arguments
 
 
 logger = logging.getLogger(__name__)
@@ -24,25 +25,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", default="input.csv", help="Input CSV path")
-    parser.add_argument(
-        "--output",
-        default=None,
-        help="Output CSV path (default: derive from input name)",
-    )
+    add_common_arguments(parser)
     parser.add_argument("--col-order", nargs="*", help="Preferred column order")
     parser.add_argument("--key-cols", nargs="*", help="Columns used for sorting")
-    parser.add_argument("--sep", default=",", help="Input CSV delimiter")
-    parser.add_argument(
-        "--encoding",
-        default="utf8",
-        help="Input CSV encoding",
-    )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        help="Logging level",
-    )
     return parser.parse_args(argv)
 
 
@@ -63,9 +48,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
     start = time.perf_counter()
-    df = pd.read_csv(args.input, sep=args.sep, encoding=args.encoding)
-    output = args.output or Path(args.input).with_name(
-        f"output_{Path(args.input).stem}.csv"
+    df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+    output = args.output_csv or Path(args.input_csv).with_name(
+        f"output_{Path(args.input_csv).stem}.csv"
     )
     write_csv_deterministic(
         df,

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
@@ -594,24 +593,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "pubmed", parents=[root], help="Fetch data from PubMed and related APIs"
     )
     pubmed.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV with a PMID column",
-    )
-    pubmed.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file (default: auto-generate)",
-    )
-    pubmed.add_argument(
         "--column", default="PMID", help="Column name containing identifiers"
     )
-    pubmed.add_argument("--sep", default=",", help="CSV delimiter")
-    pubmed.add_argument("--encoding", default="utf8", help="File encoding")
     pubmed.add_argument(
         "--sleep", type=float, default=5.0, help="Seconds to sleep between requests"
     )
@@ -630,24 +613,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "chembl", parents=[root], help="Fetch document information from ChEMBL"
     )
     chembl.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV with document_chembl_id column",
-    )
-    chembl.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file (default: auto-generate)",
-    )
-    chembl.add_argument(
         "--column", default="chembl_id", help="Column name containing identifiers"
     )
-    chembl.add_argument("--sep", default=",", help="CSV delimiter")
-    chembl.add_argument("--encoding", default="utf8", help="File encoding")
     chembl.add_argument(
         "--chunk-size", type=int, default=5, help="Maximum number of IDs per request"
     )
@@ -663,24 +630,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "all", parents=[root], help="Run both ChEMBL and PubMed pipelines"
     )
     all_cmd.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV with document_chembl_id column",
-    )
-    all_cmd.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file (default: auto-generate)",
-    )
-    all_cmd.add_argument(
         "--column", default="chembl_id", help="Column in the input CSV"
     )
-    all_cmd.add_argument("--sep", default=",", help="CSV delimiter")
-    all_cmd.add_argument("--encoding", default="utf8", help="File encoding")
     all_cmd.add_argument(
         "--chunk-size", type=int, default=5, help="Maximum IDs per request"
     )

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -97,34 +97,10 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Extract information for UniProt accessions",
     )
     uniprot.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV file containing a 'uniprot_id' column",
-    )
-    uniprot.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file for the extracted information (default: auto-generate)",
-    )
-    uniprot.add_argument(
         "--column",
         default="uniprot_id",
         choices=["uniprot_id", "mapping_uniprot_id"],
         help="Column in the input CSV containing UniProt accessions",
-    )
-    uniprot.add_argument(
-        "--sep",
-        default=",",
-        help="CSV delimiter used for input and output files",
-    )
-    uniprot.add_argument(
-        "--encoding",
-        default="utf8",
-        help="File encoding for input and output CSV files",
     )
     uniprot.add_argument(
         "--data-dir",
@@ -146,29 +122,9 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Retrieve target information from ChEMBL",
     )
     chembl.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV file containing ChEMBL target identifiers",
-    )
-    chembl.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file for target information (default: auto-generate)",
-    )
-    chembl.add_argument(
         "--column",
         default="chembl_id",
         help="Column name in the input CSV containing identifiers",
-    )
-    chembl.add_argument("--sep", default=",", help="CSV delimiter for I/O")
-    chembl.add_argument(
-        "--encoding",
-        default="utf8",
-        help="File encoding for input and output CSV files",
     )
     chembl.add_argument(
         "--timeout",
@@ -185,20 +141,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "iuphar",
         parents=[root],
         help="Map UniProt accessions to IUPHAR classifications",
-    )
-    iuphar.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV file containing a 'uniprot_id' column",
-    )
-    iuphar.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file for the mapping results (default: auto-generate)",
     )
     iuphar.add_argument(
         "--target-csv",
@@ -218,12 +160,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
             "(default: config resources.iuphar_family_csv)"
         ),
     )
-    iuphar.add_argument("--sep", default=",", help="CSV delimiter for I/O")
-    iuphar.add_argument(
-        "--encoding",
-        default="utf8",
-        help="File encoding for input and output CSV files",
-    )
     iuphar.set_defaults(func=run_iuphar)
 
     # ----------------------------
@@ -233,20 +169,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "all",
         parents=[root],
         help="Run ChEMBL, UniProt and IUPHAR pipelines and merge results",
-    )
-    all_cmd.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="CSV with a 'chembl_id' column",
-    )
-    all_cmd.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file for the merged table (default: auto-generate)",
     )
     all_cmd.add_argument(
         "--chembl-out",
@@ -313,12 +235,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default="uniprot_id",
         choices=["uniprot_id", "mapping_uniprot_id"],
         help="Column from ChEMBL output to use for UniProt processing",
-    )
-    all_cmd.add_argument("--sep", default=",", help="CSV delimiter for I/O")
-    all_cmd.add_argument(
-        "--encoding",
-        default="utf8",
-        help="File encoding for input and output CSV files",
     )
     all_cmd.set_defaults(func=run_all)
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -77,6 +77,40 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
+def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add shared CLI arguments to ``parser``.
+
+    Parameters
+    ----------
+    parser:
+        Parser to be extended with common arguments.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The parser instance for convenience.
+    """
+
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--input",
+        dest="input_csv",
+        type=Path,
+        default=Path("input.csv"),
+        help="Input CSV file",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_csv",
+        type=Path,
+        default=None,
+        help="Destination CSV file (default: auto-generate)",
+    )
+    parser.add_argument("--sep", default=",", help="CSV delimiter")
+    parser.add_argument("--encoding", default="utf8", help="File encoding")
+    return parser
+
+
 def build_parser(
     description: str, *, column: str, chunk_size: int = 10
 ) -> tuple[argparse.ArgumentParser, LoggerConfig]:
@@ -97,28 +131,12 @@ def build_parser(
         The parser and associated :class:`LoggerConfig`.
     """
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--log-level", default="INFO", help="Logging level")
-    parser.add_argument(
-        "--input",
-        dest="input_csv",
-        type=Path,
-        default=Path("input.csv"),
-        help="Input CSV file",
-    )
-    parser.add_argument(
-        "--output",
-        dest="output_csv",
-        type=Path,
-        default=None,
-        help="Destination CSV file (default: auto-generate)",
-    )
+    add_common_arguments(parser)
     parser.add_argument(
         "--column",
         default=column,
         help="Identifier column in input CSV",
     )
-    parser.add_argument("--sep", default=",", help="CSV delimiter")
-    parser.add_argument("--encoding", default="utf8", help="File encoding")
     parser.add_argument(
         "--chunk-size",
         type=_positive_int,
@@ -151,6 +169,7 @@ def build_root_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """
 
     parser = argparse.ArgumentParser(add_help=False)
+    add_common_arguments(parser)
     parser.add_argument(
         "--config",
         dest="config",
@@ -158,7 +177,6 @@ def build_root_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=Path("config.yaml"),
         help="YAML configuration file",
     )
-    parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
         "--print-config",
         action="store_true",
@@ -314,6 +332,7 @@ def apply_config_overrides(
 __all__ = [
     "LoggerConfig",
     "create_logger_config",
+    "add_common_arguments",
     "build_parser",
     "build_root_parser",
     "configure_logging",

--- a/tests/test_cli_common_args.py
+++ b/tests/test_cli_common_args.py
@@ -1,0 +1,48 @@
+import argparse
+from pathlib import Path
+
+from library.cli import add_common_arguments, apply_config_overrides
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "io:\n  csv_sep: '|'\n  csv_encoding: latin1\n" "log:\n  level: INFO\n"
+    )
+    return cfg
+
+
+def test_config_defaults_applied(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path)
+    parser = argparse.ArgumentParser()
+    add_common_arguments(parser)
+    parser.add_argument("--config", default=cfg_path, type=Path)
+    args = parser.parse_args(["--config", str(cfg_path)])
+    cfg = apply_config_overrides(args, parser, args.config)
+    assert args.sep == "|"
+    assert args.encoding == "latin1"
+    assert cfg.io.csv_sep == "|"
+    assert cfg.io.csv_encoding == "latin1"
+
+
+def test_cli_overrides_config(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path)
+    parser = argparse.ArgumentParser()
+    add_common_arguments(parser)
+    parser.add_argument("--config", default=cfg_path, type=Path)
+    args = parser.parse_args(
+        [
+            "--config",
+            str(cfg_path),
+            "--sep",
+            ";",
+            "--encoding",
+            "utf16",
+            "--log-level",
+            "DEBUG",
+        ]
+    )
+    cfg = apply_config_overrides(args, parser, args.config)
+    assert cfg.io.csv_sep == ";"
+    assert cfg.io.csv_encoding == "utf16"
+    assert cfg.log.level == "DEBUG"

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pandas as pd
+import csv_utils_main as cli
+
+
+def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
+    input_csv = tmp_path / "in.csv"
+    input_csv.write_text("a|b\n1|2\n", encoding="latin1")
+    output_csv = tmp_path / "out.csv"
+    called: dict[str, object] = {}
+
+    def fake_read_csv(path, sep, encoding):  # type: ignore[override]
+        called["path"] = path
+        called["sep"] = sep
+        called["encoding"] = encoding
+        return pd.DataFrame({"a": [1], "b": [2]})
+
+    def fake_write(df, output, col_order=None, key_cols=None):  # type: ignore[override]
+        called["output"] = output
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    monkeypatch.setattr(cli, "write_csv_deterministic", fake_write)
+
+    rc = cli.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--sep",
+            "|",
+            "--encoding",
+            "latin1",
+            "--log-level",
+            "INFO",
+        ]
+    )
+    assert rc == 0
+    assert called["path"] == input_csv
+    assert called["output"] == output_csv
+    assert called["sep"] == "|"
+    assert called["encoding"] == "latin1"


### PR DESCRIPTION
## Summary
- centralize shared CLI flags for input/output, separators, encoding, and logging
- reuse common parser options across scripts and subcommands
- test CLI parsing and argument propagation

## Testing
- `ruff check library/cli.py csv_utils_main.py get_document_data.py get_target_data.py tests/test_cli_common_args.py tests/test_csv_utils_main_args.py`
- `mypy library/cli.py csv_utils_main.py get_document_data.py get_target_data.py tests/test_cli_common_args.py tests/test_csv_utils_main_args.py` *(fails: Library stubs not installed for "pandas", "yaml", "requests", etc.)*
- `pytest tests/test_cli_common_args.py tests/test_csv_utils_main_args.py tests/test_activity_cli_overrides.py tests/test_cli_timeout_override.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2a886beac83248bedfbb1eed86c43