### PR TITLE
Add chunked CSV writing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ commit, command line invocation and relevant configuration values so results can
 be reproduced. The script requires the ``pandas`` package; install it with
 ``pip install pandas`` if it is not already available in your environment.
 
+For very large tables, ``write_csv_deterministic`` accepts a ``chunksize``
+argument which streams the CSV in smaller pieces to reduce memory usage:
+
+```python
+from library.csv_utils import write_csv_deterministic
+import pandas as pd
+
+df = pd.read_csv("large.csv")
+write_csv_deterministic(df, "out.csv", chunksize=1000)
+```
+
+Rows are still sorted deterministically before writing; ``chunksize`` only
+affects how data is flushed to disk.
+
 Each command-line tool emits a ``<output>.meta.yaml`` sidecar file alongside
 every CSV. The YAML document records the SHA-256 checksum, command-line
 arguments and timestamps to make results reproducible. The determinism check is

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -58,6 +58,7 @@ def write_csv_deterministic(
     *,
     col_order: Sequence[str] | None = None,
     key_cols: Sequence[str] | None = None,
+    chunksize: int | None = None,
 ) -> Path:
     """Serialise ``df`` to ``path`` as a deterministic CSV file.
 
@@ -73,6 +74,11 @@ def write_csv_deterministic(
     key_cols:
         Optional sequence of column names defining row ordering.  If omitted
         all columns are used as sort keys.
+    chunksize:
+        Optional number of rows to write per chunk. Passing a value enables
+        streaming output via :meth:`pandas.DataFrame.to_csv`, reducing peak
+        memory usage for large tables. ``None`` (the default) writes the
+        dataframe in a single call.
 
     Returns
     -------
@@ -82,6 +88,11 @@ def write_csv_deterministic(
 
     out_path = Path(path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Validate optional chunksize to avoid infinite loops or crashes
+    if chunksize is not None and chunksize <= 0:
+        msg = f"chunksize must be a positive integer, got {chunksize}"
+        raise ValueError(msg)
 
     work = df.copy()
 
@@ -110,7 +121,13 @@ def write_csv_deterministic(
         "w", encoding="utf-8-sig", newline="\n", delete=False, dir=str(out_path.parent)
     ) as fh:
         tmp_path = Path(fh.name)
-        work.to_csv(fh, index=False, float_format="%.6g", na_rep="")
+        work.to_csv(
+            fh,
+            index=False,
+            float_format="%.6g",
+            na_rep="",
+            chunksize=chunksize,
+        )
     os.replace(tmp_path, out_path)
     return out_path
 

--- a/tests/test_csv_chunks.py
+++ b/tests/test_csv_chunks.py
@@ -1,0 +1,40 @@
+"""Tests for chunked deterministic CSV writing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.csv_utils import write_csv_deterministic
+
+
+def test_write_csv_deterministic_chunks(tmp_path: Path) -> None:
+    """Chunked and unchunked writes must yield identical files."""
+
+    rows = 5000
+    df = pd.DataFrame(
+        {
+            "a": range(rows),
+            "b": [i % 2 == 0 for i in range(rows)],
+            "d": pd.date_range("2020-01-01", periods=rows, freq="D"),
+            "f": [i / 3 for i in range(rows)],
+        }
+    )
+    shuffled = df.sample(frac=1, random_state=1).reset_index(drop=True)
+    path1 = tmp_path / "unchunked.csv"
+    path2 = tmp_path / "chunked.csv"
+    write_csv_deterministic(
+        shuffled,
+        path1,
+        col_order=["a", "b", "d", "f"],
+        key_cols=["a"],
+    )
+    write_csv_deterministic(
+        shuffled,
+        path2,
+        col_order=["a", "b", "d", "f"],
+        key_cols=["a"],
+        chunksize=1000,
+    )
+    assert path1.read_bytes() == path2.read_bytes()


### PR DESCRIPTION
## Summary
- allow `write_csv_deterministic` to write CSV files in configurable row chunks
- document `chunksize` usage in README
- test chunked writes produce identical output

## Testing
- `black library/csv_utils.py tests/test_csv_chunks.py`
- `ruff check library/csv_utils.py tests/test_csv_chunks.py`
- `mypy library/csv_utils.py tests/test_csv_chunks.py`
- `pytest tests/test_csv_chunks.py tests/test_csv_utils.py tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ab0e59648324aeac9b9a009ea15a