### PR TITLE
chore: document env config and ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ data/input/pairs_same_document.csv
 data/output/ChEMBL/processed/pairs_independent.csv
 data/output/ChEMBL/processed/pairs_non_independent.csv
 data/output/ChEMBL/processed/pairs_same_document.csv
+.env
+*.env
+.cache/
+data/output/

--- a/README.md
+++ b/README.md
@@ -42,10 +42,34 @@ parsing, validation, aggregation and export of tabular data.
 
    ```bash
    pytest
-   ```
+    ```
 
-   The suite exercises the library modules using fixtures from
-   ``tests/data``.
+    The suite exercises the library modules using fixtures from
+    ``tests/data``.
+
+## Конфигурация через `.env`
+
+Часть параметров утилит можно задавать через переменные окружения.
+Чтобы не экспортировать их вручную при каждом запуске, поместите пары
+``NAME=value`` в файл `.env` и загрузите их с помощью пакета
+[`python-dotenv`](https://pypi.org/project/python-dotenv/).
+
+Пример файла:
+
+```dotenv
+CHEMBL_DA_LOG_LEVEL=INFO
+CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
+```
+
+Запустить скрипт с автоматической подгрузкой настроек можно так:
+
+```bash
+python -m dotenv run -- python get_assay_data.py --input tests/data/assays.csv \\
+    --output out/assays.csv
+```
+
+Утилиты читают переменные окружения автоматически, поэтому значения из
+`.env` доступны всем CLI без дополнительных аргументов.
 
 ## Валидация конфигурации
 


### PR DESCRIPTION
## Summary
- ignore `.env`, cache directories and output folder
- document configuration via `.env` in README with example

## Testing
- `pre-commit run --files .gitignore README.md` *(fails: NameError: name 'TTLCache' is not defined in tests/test_chembl_client.py)*
- `pytest` *(fails: NameError: name 'TTLCache' is not defined in tests/test_chembl_client.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ab547b048324adb9462a764ef6a5