### PR TITLE
Add thread-safe IUPHAR session

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -20,6 +20,7 @@ from typing import Iterable, List, Optional
 import io
 import logging
 import random
+import threading
 import time
 from urllib.parse import quote
 
@@ -36,13 +37,15 @@ logger = logging.getLogger(__name__)
 
 
 _session: Session = session_with_retry(ApiCfg(), RetryCfg())
+_session_lock = threading.Lock()
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session."""
 
     global _session
-    _session = session_with_retry(api, retry)
+    with _session_lock:
+        _session = session_with_retry(api, retry)
 
 
 EXPECTED_TARGET_COLUMNS: tuple[str, ...] = (
@@ -177,10 +180,11 @@ def _query_gene_symbol(gene_name: str, cfg: IupharCfg, retry: RetryCfg) -> dict:
     for attempt in range(1, retry.max_attempts + 1):
         limiter.acquire()
         try:
-            with _session.get(url, timeout=timeout) as response:
-                response.raise_for_status()
-                data = response.json()
-                return data[0] if data else {}
+            with _session_lock:
+                with _session.get(url, timeout=timeout) as response:
+                    response.raise_for_status()
+                    data = response.json()
+                    return data[0] if data else {}
         except requests.RequestException as exc:  # pragma: no cover - network errors
             if attempt >= retry.max_attempts:
                 logger.error("IUPHAR web request failed: %s", exc)
@@ -655,9 +659,10 @@ class IUPHARData:
             for attempt in range(1, retry_cfg.max_attempts + 1):
                 limiter.acquire()
                 try:
-                    with _session.get(url, timeout=timeout) as resp:
-                        resp.raise_for_status()
-                        return pd.read_csv(io.StringIO(resp.text))
+                    with _session_lock:
+                        with _session.get(url, timeout=timeout) as resp:
+                            resp.raise_for_status()
+                            return pd.read_csv(io.StringIO(resp.text))
                 except requests.RequestException as exc:  # pragma: no cover - network
                     if attempt >= retry_cfg.max_attempts:
                         logger.error("IUPHAR mapping request failed: %s", exc)

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -1,0 +1,69 @@
+"""Thread-safety tests for IUPHAR session handling."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pandas as pd
+import pytest
+
+from library import iuphar_library as ii
+from library.config import IupharCfg
+
+
+def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure concurrent calls to the shared session are serialised."""
+    data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
+    cfg = IupharCfg(
+        base="https://example.org", timeout_connect=1, timeout_read=1, rps=0, burst=1
+    )
+
+    class DummyLimiter:
+        def acquire(self) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(ii, "get_limiter", lambda *a, **k: DummyLimiter())
+
+    order: list[str] = []
+    in_use = False
+    lock = threading.Lock()
+
+    def fake_get(url: str, timeout: tuple[int, int]):
+        nonlocal in_use
+        with lock:
+            assert not in_use, "Concurrent session usage detected"
+            in_use = True
+            order.append("start")
+        time.sleep(0.05)
+        with lock:
+            in_use = False
+            order.append("end")
+
+        class Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self):  # pragma: no cover - unused
+                return []
+
+        return Resp()
+
+    monkeypatch.setattr(ii._session, "get", fake_get)
+
+    threads = [
+        threading.Thread(target=data.websearch_gene_to_id, args=("GENE", cfg))
+        for _ in range(2)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert order == ["start", "end", "start", "end"]


### PR DESCRIPTION
## Summary
- protect shared IUPHAR session with a threading lock
- guard HTTP requests and session initialization with the lock
- add concurrency test for thread-safe session usage

## Testing
- `black library/iuphar_library.py tests/test_iuphar_threadsafe.py`
- `ruff check library/iuphar_library.py tests/test_iuphar_threadsafe.py`
- `mypy library/iuphar_library.py tests/test_iuphar_threadsafe.py`
- `pytest tests/test_iuphar_library.py tests/test_iuphar_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ab0728a883249063e2959063cf61