### PR TITLE
refactor: centralize logging and add format test

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -7,18 +7,16 @@ This script reads an input CSV file and re-serialises it deterministically using
 from __future__ import annotations
 
 import argparse
-import logging
 import time
 from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
 
+import logging
 from library.csv_utils import write_csv_deterministic
 from library.cli import add_common_arguments
-
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from typing import Sequence
 
@@ -14,6 +13,7 @@ from library.chembl_client import init_session
 from library import chembl_library as cl
 from library import io
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.log import logger
 from library.cli import (
     apply_config_overrides,
     build_parser as base_parser,
@@ -28,8 +28,6 @@ from schemas import ActivitiesSchema, normalize_activities
 from library import write_csv_deterministic
 
 ORIG_WRITE_CSV = io.write_csv
-
-logger = logging.getLogger(__name__)
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -187,7 +185,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
@@ -204,7 +202,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from typing import Sequence
 
@@ -27,8 +26,7 @@ from pandera.errors import SchemaErrors
 from schemas import AssaysSchema, normalize_assays
 
 from library import write_csv_deterministic
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -158,7 +156,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
@@ -172,7 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -25,7 +25,6 @@ The input file must contain a ``PMID`` column.
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from typing import Sequence
 
@@ -64,8 +63,7 @@ from pandera.errors import SchemaErrors
 from schemas import DocumentsSchema, normalize_documents
 
 from library import write_csv_deterministic
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def fetch_pubmed_records(
@@ -680,7 +678,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
@@ -696,7 +694,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping, Sequence
 
-import logging
-
 import pandas as pd
 from library.config import Config, ensure_dirs, print_config
 from library.cli import (
@@ -19,10 +17,9 @@ from library.cli import (
     configure_logger,
 )
 from library import io
+from library.log import logger
 
 from library.document_type_classifier import compute_scores, decide_label
-
-logger = logging.getLogger(__name__)
 
 
 def _split_terms(value: object) -> Iterable[str]:
@@ -128,10 +125,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger_inst = configure_logger(log_cfg)
-    logger_inst.info(
-        "pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"}
-    )
+    configure_logger(log_cfg)
+    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
 
     try:
         cfg: Config = apply_config_overrides(
@@ -150,25 +145,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger_inst.info(
+            logger.info(
                 "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
             )
             return 0
         ensure_dirs(cfg)
-        logger_inst = configure_logger(
-            log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt
-        )
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger_inst.info(
-            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
-        )
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger_inst.info(
-            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
-        )
+        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
 
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
@@ -179,7 +168,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
-    logger_inst.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
     return 0
 
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -10,7 +10,6 @@ Exports pair tables without merging:
 from __future__ import annotations
 
 import argparse
-import logging
 from pathlib import Path
 from typing import Sequence
 
@@ -24,8 +23,7 @@ from library.cli import (
 
 from library import input_initialisation_library as lib
 from library.table_quality import analyze_table_quality
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -135,7 +133,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
@@ -163,7 +161,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.out_dir = Path(args.out_dir)
         args.dictionary_dir = Path(args.dictionary_dir)
 
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import logging
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -46,8 +45,7 @@ from pandera.errors import SchemaErrors
 from schemas import TargetsSchema, normalize_targets
 
 from library import write_csv_deterministic
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:
@@ -673,7 +671,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
@@ -698,7 +696,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from typing import Sequence
 
@@ -28,8 +27,7 @@ from pandera.errors import SchemaErrors
 from schemas import TestitemsSchema, normalize_testitems
 
 from library import write_csv_deterministic
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
@@ -244,7 +242,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(
@@ -258,7 +256,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -9,15 +9,13 @@ Power Query script used in the original workflow.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 import pandas as pd
 
 from .config import IoCfg
 from .validation import validate_schema
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-import logging
-
 import pandas as pd
 
 from .chembl_client import _chunked, request_json
 from .config import ApiCfg, UniprotMappingCfg
 from .mapper_library import map_chembl_to_uniprot
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 TARGET_FIELDS = [
     "pref_name",

--- a/library/cli.py
+++ b/library/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .config import Config, ConfigError, load_config
+from .log import logger as shared_logger
 
 
 @dataclass
@@ -233,7 +234,7 @@ def configure_logger(
         datefmt=datefmt,
         force=True,
     )
-    return logging.getLogger(__name__)
+    return shared_logger
 
 
 # ---------------------------------------------------------------------------

--- a/library/config.py
+++ b/library/config.py
@@ -24,7 +24,6 @@ appropriate built-in exceptions during validation.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, is_dataclass
-import logging
 import os
 import re
 from pathlib import Path
@@ -35,10 +34,10 @@ import yaml
 import jsonschema
 from requests import Session
 from requests.adapters import HTTPAdapter
+import logging
 from urllib3.util.retry import Retry
 
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")

--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -7,7 +7,6 @@ translation of a Power Query script into ``pandas`` operations.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Iterable
 
@@ -15,8 +14,6 @@ import pandas as pd
 
 from . import validation
 from .config import IoCfg
-
-logger = logging.getLogger(__name__)
 
 # Columns that should be treated as text
 TEXT_COLUMNS: list[str] = [

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Literal
-import logging
 
 import pandas as pd
 
 from .config import Config
 from .io import write_csv
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 EntityName = Literal[

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 import io
-import logging
 import random
 import time
 from urllib.parse import quote
@@ -30,9 +29,7 @@ import requests
 from requests import Session
 
 from .config import ApiCfg, IupharCfg, RetryCfg, session_with_retry
-
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 _session: Session = session_with_retry(ApiCfg(), RetryCfg())

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 import urllib.parse
 import urllib.request
@@ -12,8 +11,7 @@ from urllib.error import HTTPError
 
 from .config import UniprotMappingCfg
 from .rate_limiter import get_limiter
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 def map_chembl_to_uniprot(
@@ -79,7 +77,7 @@ def map_chembl_to_uniprot(
     data = urllib.parse.urlencode(
         {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
     ).encode()
-    logging.debug("Submitting ID mapping job for %s", chembl_target_id)
+    logger.debug("Submitting ID mapping job for %s", chembl_target_id)
     base = cfg.base.rstrip("/")
     run_data = _open_json(f"{base}/run", data=data)
     job_id = run_data.get("jobId")
@@ -104,7 +102,7 @@ def map_chembl_to_uniprot(
         else:
             status = status_data.get("jobStatus") or status_data.get("status")
 
-        logging.debug("Job %s status: %s", job_id, status)
+        logger.debug("Job %s status: %s", job_id, status)
         if status == "FINISHED":
             break
         if status == "FAILED":

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -9,7 +9,6 @@ summary statistics.
 from __future__ import annotations
 
 import hashlib
-import logging
 import platform
 import subprocess
 from datetime import datetime, timezone
@@ -19,8 +18,7 @@ from typing import Any, Dict, Mapping, TypedDict
 import yaml
 
 from .config import _mask_secrets
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 class Stats(TypedDict):

--- a/library/semantic_scholar_library.py
+++ b/library/semantic_scholar_library.py
@@ -9,13 +9,10 @@ request retries.
 from __future__ import annotations
 
 from typing import Dict, List
-import logging
 
 import requests
 
 from . import pubmed_library as _pl
-
-logger = logging.getLogger(__name__)
 
 
 def fetch_semantic_scholar(

--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -8,7 +8,6 @@ use without external dependencies beyond :mod:`pandas` and :mod:`numpy`.
 
 from __future__ import annotations
 
-import logging
 import re
 import warnings
 from pathlib import Path
@@ -19,7 +18,7 @@ import numpy as np
 import pandas as pd
 from pandas.errors import DtypeWarning
 
-logger = logging.getLogger(__name__)
+from .log import logger
 
 # Precompiled regular expressions for pattern coverage
 _DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
-import logging
 
 import pandas as pd
 
 from .config import Config, IoCfg
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 # Columns removed in the final export

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import csv
 import json
-import logging
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Set
 
@@ -45,8 +44,7 @@ from requests import Session
 
 from .config import ApiCfg, RetryCfg, UniprotCfg, session_with_retry
 from .rate_limiter import get_limiter, sleep
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 _DEFAULT_UNIPROT_DATA_DIR = Path("uniprot")

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 from typing import Sequence
 from urllib.error import URLError
 
@@ -18,8 +17,7 @@ from library.cli import (
     LoggerConfig,
 )
 from library.mapper_library import map_chembl_to_uniprot
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -104,7 +102,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
@@ -116,7 +114,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import os
 from pathlib import Path
 from typing import Sequence
@@ -18,9 +17,7 @@ from library.cli import (
 )
 
 from library.table_quality import analyze_table_quality
-
-
-logger = logging.getLogger(__name__)
+from library.log import logger
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -72,7 +69,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
-    logger = configure_logger(log_cfg)
+    configure_logger(log_cfg)
     logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
@@ -84,7 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,7 +223,7 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 def test_unknown_key_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\napi:\n  rps: 1\n")
-    with caplog.at_level(logging.WARNING, logger="library.config"):
+    with caplog.at_level(logging.WARNING, logger="chembl_da"):
         load_config(path)
     assert "Unknown configuration key" in caplog.text
 
@@ -308,7 +308,7 @@ def test_unknown_env_var_warning(
     path = tmp_path / "cfg.yaml"
     path.write_text("")
     monkeypatch.setenv("CHEMBL_DA__FOO__BAR", "1")
-    with caplog.at_level(logging.WARNING, logger="library.config"):
+    with caplog.at_level(logging.WARNING, logger="chembl_da"):
         load_config(path)
     assert "Environment variable CHEMBL_DA__FOO__BAR ignored" in caplog.text
 

--- a/tests/test_logger_format.py
+++ b/tests/test_logger_format.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from library.cli import LoggerConfig, configure_logger
+from library.log import logger
+
+
+def test_shared_logger_format(capfd: pytest.CaptureFixture[str]) -> None:
+    """Shared logger uses configured format."""
+    cfg = LoggerConfig(run_id="test", level="INFO")
+    configure_logger(cfg, fmt="%(levelname)s|%(message)s")
+    logger.info("hello")
+    captured = capfd.readouterr()
+    assert captured.err.strip() == "INFO|hello"


### PR DESCRIPTION
## Summary
- use shared logger from `library.log` across scripts and libraries
- configure shared logger via `configure_logger`
- add test covering log format

## Testing
- `python -m ruff check csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/assay_postprocessing.py library/chembl_target.py library/cli.py library/config.py library/document_postprocessing.py library/input_initialisation_library.py library/iuphar_library.py library/mapper_library.py library/metadata.py library/semantic_scholar_library.py library/table_quality.py library/target_postprocessing.py library/uniprot_library.py mapper_main.py table_quality_main.py tests/test_config.py tests/test_logger_format.py`
- `python -m mypy --ignore-missing-imports csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/assay_postprocessing.py library/chembl_target.py library/cli.py library/config.py library/document_postprocessing.py library/input_initialisation_library.py library/iuphar_library.py library/mapper_library.py library/metadata.py library/semantic_scholar_library.py library/table_quality.py library/target_postprocessing.py library/uniprot_library.py mapper_main.py table_quality_main.py tests/test_config.py tests/test_logger_format.py`
- `pytest tests/test_logger_format.py tests/test_config.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c2ac27de148324b6df7365648ff1cc