### PR TITLE
Use shared logger in utility scripts

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -1,46 +1,21 @@
 """CLI wrapper for :func:`write_csv_deterministic`.
 
-This script reads an input CSV file and re-serialises it deterministically using
-:func:`library.csv_utils.write_csv_deterministic`.
+This script reads an input CSV file and re-serialises it deterministically
+using :func:`library.csv_utils.write_csv_deterministic`.
 """
 
 from __future__ import annotations
 
-
-import logging
- 
-import argparse
- 
 import time
 from pathlib import Path
 from typing import Sequence
 
 import pandas as pd
 
-
 from library.csv_utils import write_csv_deterministic
 from library.cli_utils import build_parser
-
-
- 
 from library.log import logger
 from library.logging_setup import LoggerConfig, configure_logger
-
-from library.cli import add_common_arguments
-
-logger = logging.getLogger(__name__)
-
-
-
-
-def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    """Parse command-line arguments."""
-
-    parser = argparse.ArgumentParser(description=__doc__)
-    add_common_arguments(parser)
-    parser.add_argument("--col-order", nargs="*", help="Preferred column order")
-    parser.add_argument("--key-cols", nargs="*", help="Columns used for sorting")
-    return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -59,7 +34,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = build_parser()
     args = parser.parse_args(argv)
-    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    configure_logger(LoggerConfig(level=args.log_level))
 
     start = time.perf_counter()
     df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import argparse
-import logging
 from tempfile import TemporaryDirectory
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -30,6 +29,8 @@ except ImportError as exc:  # pragma: no cover - import-time check
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from library.csv_utils import sha256_file, write_csv_deterministic  # noqa: E402
+from library.log import logger  # noqa: E402
+from library.logging_setup import LoggerConfig, configure_logger  # noqa: E402
 
 
 def run_check(tmp_dir: Path) -> bool:
@@ -58,8 +59,8 @@ def run_check(tmp_dir: Path) -> bool:
     write_csv_deterministic(df, second)
     hash2 = sha256_file(second)
 
-    logging.debug("First hash: %s", hash1)
-    logging.debug("Second hash: %s", hash2)
+    logger.debug("First hash: %s", hash1)
+    logger.debug("Second hash: %s", hash2)
 
     return hash1 == hash2
 
@@ -79,18 +80,16 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=args.log_level.upper(), format="%(levelname)s: %(message)s"
-    )
+    configure_logger(LoggerConfig(level=args.log_level))
 
     with TemporaryDirectory() as tmp:
         ok = run_check(Path(tmp))
 
     if ok:
-        logging.info("Hashes match; output is deterministic")
+        logger.info("Hashes match; output is deterministic")
         return 0
 
-    logging.error("Hashes differ; output is not deterministic")
+    logger.error("Hashes differ; output is not deterministic")
     return 1
 
 

--- a/tests/test_log_timestamp_format.py
+++ b/tests/test_log_timestamp_format.py
@@ -1,0 +1,24 @@
+"""Regex-based tests for log timestamp format."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import sys
+
+from library import log
+from library.cli import LoggerConfig, configure_logger
+
+
+def test_timestamp_has_iso_format() -> None:
+    """Logger emits ISO 8601 timestamps with timezone."""
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(level="INFO", run_id="rid", stream=buffer))
+    log.logger.info("sample_event")
+    record = json.loads(buffer.getvalue().splitlines()[0])
+    configure_logger(LoggerConfig(stream=sys.stdout))
+    assert re.match(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00",
+        record["ts"],
+    )


### PR DESCRIPTION
## Summary
- refactor csv_utils_main and check_determinism scripts to use shared structured logger
- add regex-based test verifying log timestamp format

## Testing
- `pre-commit run --files csv_utils_main.py scripts/check_determinism.py tests/test_log_timestamp_format.py` *(fails: 8 errors during collection)*
- `pytest tests/test_log_timestamp_format.py tests/test_csv_utils_main_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2bf690a0083248f79338694c8156e