### PR TITLE
Allow retrying POST requests

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -330,7 +330,7 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
         total=retry.max_attempts,
         backoff_factor=retry.backoff_factor,
         status_forcelist=retry.status_forcelist,
-        allowed_methods=["GET"],
+        allowed_methods=["GET", "POST"],  # allow retries for POST requests
     )
     adapter = HTTPAdapter(max_retries=retry_cfg)
     session = Session()

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -13,19 +13,14 @@ import time
 import pytest
 
 
-
-
 from cachetools import TTLCache  # type: ignore[import-untyped]
-
-
 
 
 from library import chembl_client
 
 
-
 from library.chembl_client import clear_cache, init_session, request_json
-from library.config import ApiCfg, ChemblCfg, RetryCfg
+from library.config import ApiCfg, ChemblCfg, RetryCfg, session_with_retry
 import library.rate_limiter as rl
 
 
@@ -162,11 +157,9 @@ def test_request_json_cache(monkeypatch) -> None:
 def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
     timer = [0.0]
 
-
     cache: TTLCache[str, dict[str, Any]] = TTLCache(
         maxsize=2, ttl=1, timer=lambda: timer[0]
     )
-
 
     monkeypatch.setattr(chembl_client, "_CACHE", cache)
 
@@ -212,9 +205,7 @@ def test_request_json_preserves_original_error_message(monkeypatch) -> None:
 
 def test_clear_cache(monkeypatch) -> None:
 
-
     cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=2, ttl=100)
-
 
     monkeypatch.setattr(chembl_client, "_CACHE", cache)
     chembl_client._CACHE["x"] = {"ok": True}
@@ -238,3 +229,17 @@ def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
     with rl._limiters_lock:
         rl._limiters.clear()
 
+
+@responses.activate
+def test_session_with_retry_retries_post() -> None:
+    """Ensure POST requests are retried when configured."""
+
+    url = "http://example.com/post"
+    responses.add(responses.POST, url, status=500)
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+
+    session = session_with_retry(ApiCfg(), RetryCfg(max_attempts=2, backoff_factor=0))
+    response = session.post(url)
+
+    assert response.status_code == 200
+    assert len(responses.calls) == 2


### PR DESCRIPTION
## Summary
- allow HTTP session to retry POST requests
- add regression test for POST retry behavior

## Testing
- `ruff check library/config.py tests/test_chembl_client.py`
- `black library/config.py tests/test_chembl_client.py`
- `mypy library/config.py tests/test_chembl_client.py`
- `pytest tests/test_chembl_client.py`
- ⚠️ `pytest` (fails: SyntaxError in tests/test_activity_cli_dry_run_no_input.py)


------
https://chatgpt.com/codex/tasks/task_e_68c2c135fab88324bc9de23602b3edfa