### PR TITLE
Optimize deterministic CSV sorting

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -104,9 +104,9 @@ def write_csv_deterministic(
     else:
         work = work[sorted(work.columns)]
 
-    # Sort rows deterministically
+    # Sort rows deterministically without creating a new DataFrame
     sort_cols = list(key_cols) if key_cols is not None else list(work.columns)
-    work = work.sort_values(by=sort_cols, kind="mergesort")
+    work.sort_values(by=sort_cols, kind="mergesort", inplace=True)
 
     # Normalise bool and date columns
     for col in work.columns:

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -31,6 +31,28 @@ def test_write_csv_deterministic(tmp_path: Path) -> None:
     )
 
 
+def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
+    """Generated CSV has stable SHA-256 hash."""
+
+    df = pd.DataFrame(
+        {
+            "b": [True, False],
+            "a": [2, 1],
+            "d": [pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-01")],
+            "f": [1.23456789, 2.3456789],
+        }
+    )
+    path = tmp_path / "out.csv"
+    write_csv_deterministic(df, path, col_order=["a", "b", "d", "f"], key_cols=["a"])
+
+    expected_bytes = (
+        "a,b,d,f\n" "1,false,2020-01-01,2.34568\n" "2,true,2020-01-02,1.23457\n"
+    ).encode("utf-8-sig")
+    expected_hash = hashlib.sha256(expected_bytes).hexdigest()
+
+    assert sha256_file(path) == expected_hash
+
+
 def test_default_sorting_and_order(tmp_path: Path) -> None:
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- use in-place sorting in `write_csv_deterministic` to avoid extra DataFrame copies
- add regression test that checks stable SHA-256 hash output

## Testing
- `black library/csv_utils.py tests/test_csv_utils.py`
- `ruff check library/csv_utils.py tests/test_csv_utils.py`
- `mypy library/csv_utils.py tests/test_csv_utils.py` *(fails: Library stubs not installed for "pandas", "yaml", "jsonschema", "requests", `hypothesis`)*
- `python scripts/check_determinism.py`
- `pytest tests/test_csv_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2c15dda508324b29500eff47c33d3