### PR TITLE
Handle git SHA timeout in IO helpers

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -20,6 +20,7 @@ import yaml
 
 from . import validation
 from .config import Config, IoCfg, _serialize_paths
+from .log import logger
 
 
 def read_ids(
@@ -192,16 +193,27 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
 
 
 def _git_sha() -> str:
+    """Return the current Git commit hash.
+
+    The command is limited to a short timeout to avoid hanging when ``git``
+    is unavailable. If the call times out or fails, ``"unknown"`` is
+    returned and a warning is logged.
+    """
+
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
         )
         return result.stdout.strip()
-    except Exception:  # pragma: no cover - git may be unavailable
-        return "unknown"
+    except subprocess.TimeoutExpired as exc:
+        logger.warning("git command timed out: %s", exc)
+    except Exception as exc:  # pragma: no cover - git may be unavailable
+        logger.warning("unable to determine git SHA: %s", exc)
+    return "unknown"
 
 
 def _write_meta(path: Path, cfg: Config) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,12 +4,18 @@ import csv
 import hashlib
 from pathlib import Path
 
+import subprocess
+import time
+from io import StringIO
+from typing import Any, NoReturn
+
 import pandas as pd
 import pytest
 import yaml
 
 from library import io
 from library.config import Config, IoCfg
+from library.logging_setup import LoggerConfig, configure_logger
 
 
 def test_read_csv_validates_columns(tmp_path: Path) -> None:
@@ -89,3 +95,25 @@ def test_write_csv_with_key_cols(tmp_path: Path) -> None:
     io.write_csv(shuffled, path, cfg=cfg, key_cols=["a"])
     second_hash = hashlib.sha256(path.read_bytes()).hexdigest()
     assert first_hash == second_hash
+
+
+def test_git_sha_timeout_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_git_sha returns ``"unknown"`` when the git command exceeds timeout."""
+
+    stream = StringIO()
+    monkeypatch.setattr(
+        io,
+        "logger",
+        configure_logger(LoggerConfig(level="WARNING", stream=stream)),
+    )
+
+    def slow_run(*args: Any, **kwargs: Any) -> NoReturn:
+        time.sleep(0.1)  # Simulate a hanging git command
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+
+    monkeypatch.setattr(io.subprocess, "run", slow_run)
+
+    assert io._git_sha() == "unknown"
+    assert "timed out" in stream.getvalue()


### PR DESCRIPTION
## Summary
- add timeout and warning handling when resolving git SHA
- test that hanging git commands return "unknown"

## Testing
- `black library/io.py tests/test_io.py`
- `ruff check library/io.py tests/test_io.py`
- `mypy --ignore-missing-imports library/io.py tests/test_io.py`
- `pytest tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c141a0288324ac9f8ab59e8c3f56