### PR TITLE
Use configured retry settings for session initialisation

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -7,7 +7,7 @@ import sys
 from typing import Sequence
 
 import requests
-from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
+from library.config import Config, ensure_dirs, print_config, _serialize_paths
 from library.chembl_client import init_session
 
 from library import chembl_library as cl
@@ -58,7 +58,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -7,7 +7,7 @@ import sys
 from typing import Sequence
 
 import requests
-from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
+from library.config import Config, ensure_dirs, print_config, _serialize_paths
 from library.chembl_client import init_session
 
 from library import assay_postprocessing as ap
@@ -46,7 +46,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare HTTP session for ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -34,7 +34,6 @@ from library.config import (
     Config,
     OpenAlexCfg,
     CrossRefCfg,
-    RetryCfg,
     ensure_dirs,
     print_config,
     _serialize_paths,
@@ -276,7 +275,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Configure session for ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(
@@ -386,7 +385,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare shared session before performing any API calls
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -19,7 +19,6 @@ import pandas as pd
 import requests
 from library.config import (
     Config,
-    RetryCfg,
     ensure_dirs,
     print_config,
     _serialize_paths,
@@ -347,7 +346,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Set up HTTP session with proper headers and retry behaviour
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import pandas as pd
 import requests
-from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
+from library.config import Config, ensure_dirs, print_config, _serialize_paths
 from library.chembl_client import init_session
 
 from library import chembl_library as cl
@@ -124,7 +124,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Initialise HTTP session for subsequent ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    init_session(cfg.api, cfg.retry)
 
     try:
         ids = io.read_ids(

--- a/tests/test_init_session_retry.py
+++ b/tests/test_init_session_retry.py
@@ -1,0 +1,69 @@
+import argparse
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+from library.config import Config
+
+
+@pytest.mark.parametrize(
+    ("module_name", "func_name"),
+    [
+        ("get_activity_data", "run_chembl"),
+        ("get_assay_data", "run_chembl"),
+        ("get_document_data", "run_chembl"),
+        ("get_document_data", "run_all"),
+        ("get_target_data", "run_chembl"),
+        ("get_testitem_data", "run_chembl"),
+    ],
+)
+def test_init_session_uses_cfg_retry(
+    module_name: str, func_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure CLI scripts use retry settings from :class:`Config`.
+
+    The test verifies that each script passes ``cfg.retry`` to
+    :func:`library.chembl_client.init_session` by monkeypatching the
+    function and capturing the supplied arguments.
+    """
+
+    module = import_module(module_name)
+    cfg = Config()
+    captured: dict[str, object] = {}
+
+    def fake_init(api: object, retry: object, *_args: object) -> None:
+        """Record parameters supplied to :func:`init_session`.
+
+        Parameters
+        ----------
+        api : object
+            API configuration object.
+        retry : object
+            Retry configuration to apply.
+        *_args : object
+            Additional positional arguments, ignored.
+        """
+
+        captured["api"] = api
+        captured["retry"] = retry
+
+    monkeypatch.setattr(module, "init_session", fake_init)
+
+    args = argparse.Namespace(
+        input_csv=Path("missing.csv"),
+        output_csv=None,
+        column="id",
+        sep=",",
+        encoding="utf8",
+        chunk_size=1,
+        timeout=1.0,
+        limit=None,
+        dry_run=False,
+    )
+
+    result = getattr(module, func_name)(cfg, args)
+
+    assert result == 1
+    assert captured["api"] is cfg.api
+    assert captured["retry"] is cfg.retry


### PR DESCRIPTION
## Summary
- pass Config.retry to init_session across all data retrieval scripts
- add tests ensuring CLI scripts use configured retry settings

## Testing
- `ruff check get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py tests/test_init_session_retry.py`
- `mypy get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py tests/test_init_session_retry.py`
- `pytest tests/test_init_session_retry.py`
- `pytest` *(fails: errors during collection in unrelated tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c2c130094483249d148862e1d335a2