### PR TITLE
feat: add dtype handling to CSV reader

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import csv
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Any
 import subprocess
 import sys
 
 import pandas as pd
+import pandera as pa
 import yaml
 
 
@@ -84,7 +85,11 @@ def read_csv(
     cfg: IoCfg,
     sep: str | None = None,
     encoding: str | None = None,
+    dtype: Any = None,
+    na_values: Any = None,
+    parse_dates: Any = None,
     required_columns: Iterable[str] | None = None,
+    schema: pa.DataFrameSchema | None = None,
 ) -> pd.DataFrame:
     """Load a CSV file into a :class:`pandas.DataFrame` with optional schema validation.
 
@@ -98,9 +103,19 @@ def read_csv(
         Field delimiter used in the CSV file. Defaults to ``cfg.csv_sep``.
     encoding:
         Character encoding of the CSV file. Defaults to ``cfg.csv_encoding``.
+    dtype:
+        Optional mapping of column names to data types forwarded to
+        :func:`pandas.read_csv`.
+        na_values:
+            Additional strings to recognise as ``NA``/missing values.
+        parse_dates:
+            Column names to parse as dates via :func:`pandas.read_csv`.
     required_columns:
         Optional list of column names that must be present in the loaded
         DataFrame. A :class:`ValueError` is raised if any are missing.
+    schema:
+        Optional :class:`pandera.DataFrameSchema` used for advanced
+        validation and type coercion.
 
     Returns
     -------
@@ -110,7 +125,16 @@ def read_csv(
     """
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
-    df = pd.read_csv(path, sep=sep, encoding=encoding)
+    df = pd.read_csv(
+        path,
+        sep=sep,
+        encoding=encoding,
+        dtype=dtype,
+        na_values=na_values,
+        parse_dates=parse_dates,
+    )
+    if schema is not None:
+        df = schema.validate(df)
     if required_columns is not None:
         validation.validate_columns(df, required_columns)
     return df

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -38,7 +38,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     """
     try:
         df = io.read_csv(
-            args.input_csv, cfg=cfg.io, sep=args.sep, encoding=args.encoding
+            args.input_csv,
+            cfg=cfg.io,
+            sep=args.sep,
+            encoding=args.encoding,
+            dtype={args.column: str},
         )
     except (FileNotFoundError, OSError) as exc:
         logger.error("%s", exc)

--- a/tests/data/io_types.csv
+++ b/tests/data/io_types.csv
@@ -1,0 +1,4 @@
+flag,date
+True,2021-01-01
+False,2021-01-02
+#N/A,#N/A

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import pandera as pa
 import yaml
 
 from library import io
@@ -30,6 +31,27 @@ def test_read_csv_missing_column(tmp_path: Path) -> None:
         writer.writerow(["1"])
     with pytest.raises(ValueError):
         io.read_csv(path, cfg=IoCfg(), required_columns=["a", "b"])
+
+
+def test_read_csv_handles_dtype_and_na() -> None:
+    path = Path("tests/data/io_types.csv")
+    schema = pa.DataFrameSchema(
+        {
+            "date": pa.Column(pa.DateTime, nullable=True),
+        }
+    )
+    df = io.read_csv(
+        path,
+        cfg=IoCfg(),
+        dtype={"flag": "boolean"},
+        na_values=["#N/A"],
+        parse_dates=["date"],
+        schema=schema,
+    )
+    assert df["flag"].tolist() == [True, False, pd.NA]
+    assert df["flag"].dtype == "boolean"
+    assert str(df["date"].dtype).startswith("datetime64")
+    assert pd.isna(df.loc[2, "date"])
 
 
 def test_write_csv_creates_single_metadata_file(


### PR DESCRIPTION
## Summary
- extend io.read_csv with dtype, na_values, parse_dates, and optional pandera schema validation
- ensure mapper_main passes column dtype when reading input
- test boolean, date and NA parsing with pandera validation

## Testing
- `black --check library/io.py tests/test_io.py mapper_main.py`
- `ruff check library/io.py mapper_main.py tests/test_io.py`
- `mypy --ignore-missing-imports library/io.py mapper_main.py tests/test_io.py`
- `pytest tests/test_io.py`
- `pytest` *(fails: missing dependencies responses, hypothesis, plus syntax errors in some tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c147346883248cae29e03baa12f6