### PR TITLE
Refactor ChEMBL API client into reusable class

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import requests
 from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -58,7 +58,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -78,7 +78,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_activities(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            client=client,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import requests
 from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -46,7 +46,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare HTTP session for ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -62,7 +62,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_assays(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            client=client,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -39,7 +39,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -276,7 +276,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Configure session for ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -293,6 +293,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     try:
         df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
+            client=client,
             cfg=cfg.api,
             chunk_size=args.chunk_size,
             timeout=args.timeout,
@@ -386,7 +387,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare shared session before performing any API calls
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -403,6 +404,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     try:
         doc_df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
+            client=client,
             cfg=cfg.api,
             chunk_size=args.chunk_size,
             timeout=args.timeout,

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -24,7 +24,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -347,7 +347,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Set up HTTP session with proper headers and retry behaviour
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -363,7 +363,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_targets(
-            ids, cfg=cfg.api, mapping_cfg=cfg.uniprot_mapping, timeout=args.timeout
+            ids,
+            client=client,
+            cfg=cfg.api,
+            mapping_cfg=cfg.uniprot_mapping,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -9,7 +9,7 @@ from typing import Sequence
 import pandas as pd
 import requests
 from library.config import Config, RetryCfg, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -124,7 +124,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Initialise HTTP session for subsequent ChEMBL requests
-    init_session(cfg.api, RetryCfg())
+    client = ChemblClient(cfg.api, RetryCfg())
 
     try:
         ids = io.read_ids(
@@ -142,7 +142,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
         df = cl.get_testitem(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            client=client,
+            cfg=cfg.api,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg
 from .log import logger
 
@@ -90,7 +90,11 @@ TESTITEM_COLUMNS = [
 
 
 def get_assay(
-    chembl_assay_id: str, *, cfg: ApiCfg, timeout: float | None = None
+    chembl_assay_id: str,
+    *,
+    client: ChemblClient,
+    cfg: ApiCfg,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Retrieve assay information as a DataFrame.
 
@@ -98,6 +102,8 @@ def get_assay(
     ----------
     chembl_assay_id:
         Identifier of the assay to fetch.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     timeout:
@@ -114,7 +120,7 @@ def get_assay(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/assay/{chembl_assay_id}?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
@@ -127,6 +133,7 @@ def get_assay(
 def get_assays(
     ids: Iterable[str],
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
@@ -138,6 +145,8 @@ def get_assays(
     ----------
     ids:
         Assay identifiers to retrieve.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     chunk_size:
@@ -168,7 +177,7 @@ def get_assays(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&assay_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
             df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
@@ -191,6 +200,7 @@ def get_assays(
 def get_activities(
     ids: Iterable[str],
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
@@ -201,6 +211,8 @@ def get_activities(
     ----------
     ids:
         Activity identifiers to retrieve.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     chunk_size:
@@ -226,7 +238,7 @@ def get_activities(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&activity_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
@@ -246,6 +258,7 @@ def get_activities(
 def get_testitem(
     ids: Iterable[str],
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
@@ -256,6 +269,8 @@ def get_testitem(
     ----------
     ids:
         Molecule identifiers to retrieve.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     chunk_size:
@@ -281,7 +296,7 @@ def get_testitem(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&molecule_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -18,136 +18,129 @@ from .rate_limiter import get_limiter, sleep
 from .log import logger
 
 
-# Cache entries expire after one hour to avoid serving stale data. The TTL can
-# be adjusted in the future via configuration if required.
-_CACHE: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=1024, ttl=3600)
-_CACHE_LOCK = threading.Lock()
+class ChemblClient:
+    """HTTP helper for ChEMBL API access.
 
-
-_session: Session | None = None
-_session_lock = threading.Lock()
-
-
-def init_session(api: ApiCfg, retry: RetryCfg, chembl: ChemblCfg | None = None) -> None:
-    """Initialise the shared HTTP session and cache.
-
-    The provided ``api`` and ``retry`` configurations are forwarded to
-    :func:`session_with_retry`, ensuring that subsequent requests use the
-    correct ``User-Agent`` and retry policy. When ``chembl`` is supplied the
-    cache TTL is taken from ``chembl.cache_ttl``.
+    The client encapsulates a shared :class:`requests.Session` and an
+    in-memory cache to avoid repeated network calls. The cache is
+    thread-safe and entries expire after a configurable time-to-live.
 
     Parameters
     ----------
     api:
-        Global API settings providing the ``User-Agent`` header.
+        Global API settings providing the ``User-Agent`` header. Defaults to
+        :class:`~library.config.ApiCfg`.
     retry:
-        Retry configuration applied to all requests.
+        Retry configuration applied to all requests. Defaults to
+        :class:`~library.config.RetryCfg`.
     chembl:
-        Optional ChEMBL-specific settings controlling cache TTL.
+        Optional ChEMBL-specific settings controlling the cache TTL. Defaults
+        to :class:`~library.config.ChemblCfg`.
+    session:
+        Optional pre-configured :class:`requests.Session` used for requests.
+        Primarily intended for tests.
     """
 
-    global _session, _CACHE
-    _session = session_with_retry(api, retry)
-    ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
-    _CACHE = TTLCache(maxsize=1024, ttl=ttl)
+    def __init__(
+        self,
+        api: ApiCfg | None = None,
+        retry: RetryCfg | None = None,
+        chembl: ChemblCfg | None = None,
+        session: Session | None = None,
+    ) -> None:
+        self._cache_lock = threading.Lock()
+        self.session = session or session_with_retry(
+            api or ApiCfg(), retry or RetryCfg()
+        )
+        ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
+        self.cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=1024, ttl=ttl)
 
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, Any]:
+        """Return JSON content from *url*.
 
-def request_json(
-    url: str, *, cfg: ApiCfg, timeout: float | None = None
-) -> dict[str, Any]:
-    """Return JSON content from *url*.
+        Parameters
+        ----------
+        url:
+            API endpoint to query.
+        cfg:
+            Configuration providing timeout and retry settings.
+        timeout:
+            Optional override for the read timeout in seconds.
 
-    Parameters
-    ----------
-    url:
-        API endpoint to query.
-    cfg:
-        Configuration providing timeout and retry settings.
-    timeout:
-        Optional override for the read timeout in seconds.
+        Returns
+        -------
+        dict[str, Any]
+            Parsed JSON document.
 
-    Returns
-    -------
-    dict[str, Any]
-        Parsed JSON document.
+        Raises
+        ------
+        requests.RequestException
+            If the HTTP request fails.
+        ValueError
+            If the response body is not valid JSON.
+        """
 
-    Raises
-    ------
-    requests.RequestException
-        If the HTTP request fails.
-    ValueError
-        If the response body is not valid JSON.
+        limiter = get_limiter("chembl", cfg.rps, cfg.burst)
+        read_timeout = timeout if timeout is not None else cfg.timeout_read
+        cache_key = url
+        with self._cache_lock:
+            cached = self.cache.get(cache_key)
+            if cached is not None:
+                logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
+                return cached
+            logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
-    """
-    limiter = get_limiter("chembl", cfg.rps, cfg.burst)
-    read_timeout = timeout if timeout is not None else cfg.timeout_read
-    cache_key = url
-    with _CACHE_LOCK:
-        cached = _CACHE.get(cache_key)
-        if cached is not None:
-            logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
-            return cached
-        logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
+        last_exc: requests.RequestException | ValueError | None = None
 
-    global _session
-    if _session is None:
-        with _session_lock:
-            if _session is None:
-                _session = session_with_retry(ApiCfg(), RetryCfg())
-    session = _session
-    assert session is not None  # noqa: S101 - ensure session exists
+        for attempt in range(1, cfg.retries + 1):
+            limiter.acquire()
+            event = "request_start" if attempt == 1 else "request_retry"
+            logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
+            try:
+                with self.session.get(
+                    url, timeout=(cfg.timeout_connect, read_timeout)
+                ) as response:
+                    response.raise_for_status()
+                    data: dict[str, Any] = cast(dict[str, Any], response.json())
+                    logger.info(
+                        "request_ok",
+                        extra={
+                            "stage": "request_ok",
+                            "url": url,
+                            "status": getattr(response, "status_code", None),
+                        },
+                    )
+                    with self._cache_lock:
+                        cached = self.cache.get(cache_key)
+                        if cached is not None:
+                            return cached
+                        self.cache[cache_key] = data
+                        logger.info(
+                            "cache_set", extra={"stage": "cache_set", "url": url}
+                        )
+                        return data
+            except (requests.RequestException, ValueError) as exc:
+                last_exc = exc
+                if attempt >= cfg.retries:
+                    logger.exception(
+                        "request_fail", extra={"stage": "request_fail", "url": url}
+                    )
+                    break
+                # Exponential backoff with jitter to avoid thundering herd problems
+                delay = cfg.backoff_factor * (2 ** (attempt - 1))
+                delay += random.uniform(0, cfg.backoff_factor)
+                sleep(delay)
 
-    last_exc: requests.RequestException | ValueError | None = None
+        assert last_exc is not None
+        raise last_exc
 
-    for attempt in range(1, cfg.retries + 1):
-        limiter.acquire()
-        event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
-        try:
-            with session.get(
-                url, timeout=(cfg.timeout_connect, read_timeout)
-            ) as response:
-                response.raise_for_status()
-                data: dict[str, Any] = cast(dict[str, Any], response.json())
-                logger.info(
-                    "request_ok",
-                    extra={
-                        "stage": "request_ok",
-                        "url": url,
-                        "status": getattr(response, "status_code", None),
-                    },
-                )
-                with _CACHE_LOCK:
-                    cached = _CACHE.get(cache_key)
-                    if cached is not None:
-                        return cached
-                    _CACHE[cache_key] = data
-                    logger.info("cache_set", extra={"stage": "cache_set", "url": url})
-                    return data
-        except (requests.RequestException, ValueError) as exc:
-            last_exc = exc
-            if attempt >= cfg.retries:
-                logger.exception(
-                    "request_fail", extra={"stage": "request_fail", "url": url}
-                )
-                break
-            # Exponential backoff with jitter to avoid thundering herd problems
-            delay = cfg.backoff_factor * (2 ** (attempt - 1))
-            delay += random.uniform(0, cfg.backoff_factor)
-            sleep(delay)
+    def clear_cache(self) -> None:
+        """Remove all entries from the in-memory cache."""
 
-    assert last_exc is not None
-    raise last_exc
-
-
-def clear_cache() -> None:
-    """Remove all entries from the in-memory cache.
-
-    This helper is primarily intended for tests to avoid interference
-    from previously cached responses.
-    """
-    with _CACHE_LOCK:
-        _CACHE.clear()
+        with self._cache_lock:
+            self.cache.clear()
 
 
 def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
@@ -182,3 +175,6 @@ def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
             chunk = []
     if chunk:
         yield chunk
+
+
+__all__ = ["ChemblClient", "_chunked"]

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -8,7 +8,7 @@ from .log import logger
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg, UniprotMappingCfg
 from .mapper_library import map_chembl_to_uniprot
 
@@ -145,6 +145,7 @@ def _parse_target_record(
 def get_target(
     chembl_target_id: str,
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
     timeout: float | None = None,
@@ -155,6 +156,8 @@ def get_target(
     ----------
     chembl_target_id:
         ChEMBL target identifier (e.g., ``"CHEMBL203"``).
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     mapping_cfg:
@@ -167,7 +170,7 @@ def get_target(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/target/{chembl_target_id}.json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     target_list = _get_items(data, "target")
     if not target_list:
         return dict(EMPTY_TARGET)
@@ -177,6 +180,7 @@ def get_target(
 def get_targets(
     ids: Iterable[str],
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
     chunk_size: int = 5,
@@ -188,6 +192,8 @@ def get_targets(
     ----------
     ids:
         ChEMBL target identifiers to retrieve.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration with base URL and timeouts.
     mapping_cfg:
@@ -206,7 +212,7 @@ def get_targets(
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("targets") or data.get("target") or []
         records.extend(_parse_target_record(item, mapping_cfg) for item in items)
     if not records:
@@ -218,6 +224,7 @@ def get_targets(
 def extend_target(
     df: pd.DataFrame,
     *,
+    client: ChemblClient,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
     id_column: str = "target_chembl_id",
@@ -228,6 +235,8 @@ def extend_target(
     ----------
     df:
         DataFrame containing a column with ChEMBL target identifiers.
+    client:
+        Instance used for HTTP requests and caching.
     cfg:
         API configuration providing base URL and timeouts.
     mapping_cfg:
@@ -239,7 +248,7 @@ def extend_target(
     if id_column not in df.columns:
         raise ValueError(f"missing required column: {id_column}")
     targets = [
-        get_target(i, cfg=cfg, mapping_cfg=mapping_cfg)
+        get_target(i, client=client, cfg=cfg, mapping_cfg=mapping_cfg)
         for i in df[id_column].fillna("")
     ]
     extra = pd.DataFrame(targets)

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -13,18 +13,10 @@ import time
 import pytest
 
 
-
-
 from cachetools import TTLCache  # type: ignore[import-untyped]
 
 
-
-
-from library import chembl_client
-
-
-
-from library.chembl_client import clear_cache, init_session, request_json
+from library.chembl_client import ChemblClient
 from library.config import ApiCfg, ChemblCfg, RetryCfg
 import library.rate_limiter as rl
 
@@ -57,14 +49,11 @@ class DummySession:
         return DummyResponse()
 
 
-def test_init_session_sets_user_agent(monkeypatch) -> None:
+def test_client_sets_user_agent() -> None:
     """Session should include the configured ``User-Agent`` header."""
-    monkeypatch.setattr("library.chembl_client._session", None)
     cfg = ApiCfg(user_agent="test-agent/1.0 (mailto:test@example.org)")
-    init_session(cfg, RetryCfg())
-    session = chembl_client._session
-    assert session is not None
-    assert session.headers.get("User-Agent") == cfg.user_agent
+    client = ChemblClient(cfg, RetryCfg())
+    assert client.session.headers.get("User-Agent") == cfg.user_agent
 
 
 class FakeTime:
@@ -83,20 +72,18 @@ class FakeTime:
 @responses.activate
 def test_request_json_uses_cfg(monkeypatch) -> None:
     session = DummySession(failures=1)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    monkeypatch.setattr(
+        "library.chembl_client.session_with_retry", lambda a, r: session
+    )
+    client = ChemblClient()
+    client.clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=2, backoff_factor=0.5)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert session.timeout == (1, 2)
     assert len(session.calls) == 2
@@ -105,15 +92,18 @@ def test_request_json_uses_cfg(monkeypatch) -> None:
 
 def test_request_json_backoff_grows(monkeypatch) -> None:
     session = DummySession(failures=2)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    monkeypatch.setattr(
+        "library.chembl_client.session_with_retry", lambda a, r: session
+    )
+    client = ChemblClient()
+    client.clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=3, backoff_factor=1)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert sleep_times == [1.0, 2.0]
 
@@ -127,33 +117,28 @@ def test_request_json_reuses_session(monkeypatch) -> None:
     monkeypatch.setattr(
         "library.chembl_client.session_with_retry", fake_session_with_retry
     )
-    init_session(ApiCfg(), RetryCfg())
+    client = ChemblClient()
+    client.clear_cache()
 
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-    clear_cache()
-
-    request_json("http://example.com/1", cfg=ApiCfg())
-    request_json("http://example.com/2", cfg=ApiCfg())
+    client.request_json("http://example.com/1", cfg=ApiCfg())
+    client.request_json("http://example.com/2", cfg=ApiCfg())
 
     assert dummy.calls == [id(dummy), id(dummy)]
 
 
 @responses.activate
 def test_request_json_cache(monkeypatch) -> None:
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+    client = ChemblClient()
+    client.clear_cache()
     url = "http://example.com/cache"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    request_json(url, cfg=ApiCfg())
-    assert url in chembl_client._CACHE
+    client.request_json(url, cfg=ApiCfg())
+    assert url in client.cache
 
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
-    assert url in chembl_client._CACHE
+    assert url in client.cache
 
     assert len(responses.calls) == 1
 
@@ -161,32 +146,21 @@ def test_request_json_cache(monkeypatch) -> None:
 @responses.activate
 def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
     timer = [0.0]
-
-
-    cache: TTLCache[str, dict[str, Any]] = TTLCache(
-        maxsize=2, ttl=1, timer=lambda: timer[0]
-    )
-
-
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
-
-    monkeypatch.setattr("library.chembl_client._session", None)
     chembl_cfg = ChemblCfg(cache_ttl=1)
-    init_session(ApiCfg(), RetryCfg(), chembl_cfg)
-    assert chembl_client._CACHE.ttl == chembl_cfg.cache_ttl
-    chembl_client._CACHE = TTLCache(
+    client = ChemblClient(chembl=chembl_cfg)
+    client.cache = TTLCache(
         maxsize=1024, ttl=chembl_cfg.cache_ttl, timer=lambda: timer[0]
     )
-    clear_cache()
+    client.clear_cache()
     url = "http://example.com/ttl"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
     # Advance time beyond the TTL to force expiration of the cached entry.
     timer[0] = 2.0
     responses.add(responses.GET, url, json={"ok": True}, status=200)
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
     # Two HTTP calls should have occurred because the cache entry expired.
     assert len(responses.calls) == 2
@@ -196,30 +170,27 @@ def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
 def test_request_json_preserves_original_error_message(monkeypatch) -> None:
     """Ensure the raised error retains status code and URL."""
 
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+    client = ChemblClient()
+    client.clear_cache()
     url = "http://example.com/notfound"
     responses.add(responses.GET, url, status=404)
 
     cfg = ApiCfg(retries=1)
     with pytest.raises(requests.HTTPError) as exc_info:
-        request_json(url, cfg=cfg)
+        client.request_json(url, cfg=cfg)
 
     message = str(exc_info.value)
     assert "404" in message
     assert url in message
 
 
-def test_clear_cache(monkeypatch) -> None:
-
-
+def test_clear_cache() -> None:
     cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=2, ttl=100)
-
-
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
-    chembl_client._CACHE["x"] = {"ok": True}
-    clear_cache()
-    assert len(chembl_client._CACHE) == 0
+    client = ChemblClient()
+    client.cache = cache
+    client.cache["x"] = {"ok": True}
+    client.clear_cache()
+    assert len(client.cache) == 0
 
 
 def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
@@ -229,12 +200,14 @@ def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
     with rl._limiters_lock:
         rl._limiters.clear()
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    monkeypatch.setattr(
+        "library.chembl_client.session_with_retry", lambda a, r: session
+    )
+    client = ChemblClient()
+    client.clear_cache()
     cfg = ApiCfg(rps=1, burst=1)
-    request_json("http://example.com/1", cfg=cfg)
-    request_json("http://example.com/2", cfg=cfg)
+    client.request_json("http://example.com/1", cfg=cfg)
+    client.request_json("http://example.com/2", cfg=cfg)
     assert fake_time.sleeps == [1.0]
     with rl._limiters_lock:
         rl._limiters.clear()
-

--- a/tests/test_chembl_client_threadsafe.py
+++ b/tests/test_chembl_client_threadsafe.py
@@ -7,7 +7,7 @@ from typing import Any
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-from library import chembl_client
+from library.chembl_client import ChemblClient
 from library.config import ApiCfg
 
 
@@ -70,19 +70,21 @@ class ThreadTrackingSession:
 
 def test_request_json_threadsafe(monkeypatch) -> None:
     """Concurrent calls should yield the same result as sequential ones."""
-
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    chembl_client.clear_cache()
+    monkeypatch.setattr(
+        "library.chembl_client.session_with_retry", lambda a, r: session
+    )
+    client = ChemblClient()
+    client.clear_cache()
 
     url = "http://example.com/threadsafe"
     cfg = ApiCfg()
 
     # Sequential calls: only the first should trigger a real request.
-    sequential = [chembl_client.request_json(url, cfg=cfg) for _ in range(5)]
+    sequential = [client.request_json(url, cfg=cfg) for _ in range(5)]
     assert session.calls == 1
 
-    chembl_client.clear_cache()
+    client.clear_cache()
     session.calls = 0
 
     # Parallel calls starting at the same time.
@@ -91,7 +93,7 @@ def test_request_json_threadsafe(monkeypatch) -> None:
 
     def worker() -> None:
         start.wait()
-        results.append(chembl_client.request_json(url, cfg=cfg))
+        results.append(client.request_json(url, cfg=cfg))
 
     threads = [threading.Thread(target=worker) for _ in range(5)]
     for t in threads:
@@ -106,9 +108,6 @@ def test_request_json_threadsafe(monkeypatch) -> None:
 def test_single_session_created(monkeypatch) -> None:
     """Ensure only one HTTP session is initialised across threads."""
 
-    chembl_client.clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
-
     dummy = ThreadTrackingSession()
     create_calls = 0
 
@@ -120,9 +119,10 @@ def test_single_session_created(monkeypatch) -> None:
     monkeypatch.setattr(
         "library.chembl_client.session_with_retry", fake_session_with_retry
     )
+    client = ChemblClient()
 
     def worker() -> dict[str, Any]:
-        return chembl_client.request_json("http://example.com", cfg=ApiCfg())
+        return client.request_json("http://example.com", cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
@@ -133,20 +133,19 @@ def test_single_session_created(monkeypatch) -> None:
 
 
 def test_cache_shared_across_threads(monkeypatch) -> None:
-    clear_cache()
-    dummy = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", dummy)
+    client = ChemblClient(session=DummySession())
+    client.clear_cache()
 
     url = "http://example.com/data"
-    assert request_json(url, cfg=ApiCfg()) == {"ok": True}
-    assert len(dummy.calls) == 1
+    assert client.request_json(url, cfg=ApiCfg()) == {"ok": True}
+    assert len(client.session.calls) == 1
 
     def worker() -> dict[str, Any]:
-        return request_json(url, cfg=ApiCfg())
+        return client.request_json(url, cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
         results = [f.result() for f in futures]
 
     assert all(r == {"ok": True} for r in results)
-    assert len(dummy.calls) == 1
+    assert len(client.session.calls) == 1

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -41,7 +41,7 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gas, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_assays(ids, cfg, chunk_size, timeout):
+    def fake_get_assays(ids, *, client, cfg, chunk_size, timeout):
         called["timeout"] = timeout
         return pd.DataFrame({"assay_chembl_id": ids})
 
@@ -73,7 +73,7 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gdd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_documents(ids, cfg, chunk_size, timeout):
+    def fake_get_documents(ids, *, client, cfg, chunk_size, timeout):
         called["timeout"] = timeout
         return pd.DataFrame({"document_chembl_id": ids})
 
@@ -105,7 +105,7 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gtdt, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_testitem(ids, cfg, chunk_size, timeout):
+    def fake_get_testitem(ids, *, client, cfg, chunk_size, timeout):
         called["timeout"] = timeout
         return pd.DataFrame({"molecule_chembl_id": ids})
 
@@ -137,7 +137,7 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gtd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_targets(ids, cfg, mapping_cfg, timeout):
+    def fake_get_targets(ids, *, client, cfg, mapping_cfg, timeout):
         called["timeout"] = timeout
         return pd.DataFrame({"target_chembl_id": ids})
 


### PR DESCRIPTION
## Summary
- replace global state in `chembl_client` with `ChemblClient` class managing session and cache
- pass `ChemblClient` instances through library functions and CLI entrypoints
- adjust tests to use isolated client objects

## Testing
- `black library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py`
- `ruff check library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py`
- `mypy library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_target_data.py get_document_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py` *(fails: Library stubs not installed for many modules)*
- `pytest` *(fails: collection errors in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c13ae6388324b1d26332518cb549