### PR TITLE
feat: add dtype and NA options to read_csv

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -11,12 +11,14 @@ import csv
 from datetime import datetime
 from pathlib import Path
 
-from typing import Iterable, Iterator
+from typing import Any, Hashable, Iterable, Iterator, Mapping, Sequence
 import subprocess
 import sys
 
 
 import pandas as pd
+import yaml
+from pandera import DataFrameModel, DataFrameSchema
 
 from . import validation
 
@@ -24,7 +26,6 @@ from .config import Config, IoCfg, _serialize_paths
 from .csv_utils import write_csv_deterministic
 
 from .log import logger
-
 
 
 def read_ids(
@@ -88,6 +89,10 @@ def read_csv(
     sep: str | None = None,
     encoding: str | None = None,
     required_columns: Iterable[str] | None = None,
+    dtype: Mapping[Hashable, Any] | type | None = None,
+    na_values: Sequence[str] | str | None = None,
+    parse_dates: Sequence[str] | None = None,
+    schema: DataFrameSchema | type[DataFrameModel] | None = None,
 ) -> pd.DataFrame:
     """Load a CSV file into a :class:`pandas.DataFrame` with optional schema validation.
 
@@ -104,6 +109,19 @@ def read_csv(
     required_columns:
         Optional list of column names that must be present in the loaded
         DataFrame. A :class:`ValueError` is raised if any are missing.
+    dtype:
+        Data type specification forwarded to :func:`pandas.read_csv`.
+        Can be a single type applied to all columns or a mapping of
+        column names to types.
+    na_values:
+        Additional strings to recognize as NA/NaN. Passed to
+        :func:`pandas.read_csv`.
+    parse_dates:
+        Column names to parse as dates using :func:`pandas.read_csv`.
+    schema:
+        Optional :class:`pandera.DataFrameSchema` or
+        :class:`pandera.DataFrameModel` used for advanced validation and
+        dtype coercion.
 
     Returns
     -------
@@ -113,8 +131,20 @@ def read_csv(
     """
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
-    df = pd.read_csv(path, sep=sep, encoding=encoding)
-    if required_columns is not None:
+    df = pd.read_csv(
+        path,
+        sep=sep,
+        encoding=encoding,
+        dtype=dtype,
+        na_values=na_values,
+        parse_dates=list(parse_dates) if parse_dates is not None else None,
+    )
+    if schema is not None:
+        if isinstance(schema, DataFrameSchema):
+            df = schema.validate(df)
+        else:
+            df = schema.to_schema().validate(df)
+    elif required_columns is not None:
         validation.validate_columns(df, required_columns)
     return df
 
@@ -187,7 +217,6 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
 
 
-
 def _git_sha() -> str:
     """Return the current Git commit hash.
 
@@ -227,4 +256,3 @@ def _write_meta(path: Path, cfg: Config) -> None:
     meta_path = Path(f"{path}.meta.yaml")
     with meta_path.open("w", encoding="utf8") as fh:
         yaml.safe_dump(meta, fh, sort_keys=False)
-

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -38,7 +38,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     """
     try:
         df = io.read_csv(
-            args.input_csv, cfg=cfg.io, sep=args.sep, encoding=args.encoding
+            args.input_csv,
+            cfg=cfg.io,
+            sep=args.sep,
+            encoding=args.encoding,
+            dtype=str,
+            na_values=["#N/A", ""],
         )
     except (FileNotFoundError, OSError) as exc:
         logger.error("%s", exc)

--- a/tests/data/io_types.csv
+++ b/tests/data/io_types.csv
@@ -1,0 +1,5 @@
+flag,date,count
+true,2024-01-01,1
+false,,2
+---,2024-01-03,missing
+NA,2024-01-04,4

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,6 +12,7 @@ from typing import Any, NoReturn
 import pandas as pd
 import pytest
 import yaml
+import pandera as pa
 
 from library import io
 from library.config import Config, IoCfg
@@ -36,6 +37,31 @@ def test_read_csv_missing_column(tmp_path: Path) -> None:
         writer.writerow(["1"])
     with pytest.raises(ValueError):
         io.read_csv(path, cfg=IoCfg(), required_columns=["a", "b"])
+
+
+def test_read_csv_types_and_na_values() -> None:
+    path = Path("tests/data/io_types.csv")
+    schema = pa.DataFrameSchema(
+        {
+            "flag": pa.Column("boolean", nullable=True),
+            "date": pa.Column("datetime64[ns]", nullable=True),
+            "count": pa.Column("Int64", nullable=True),
+        },
+    )
+    df = io.read_csv(
+        path,
+        cfg=IoCfg(),
+        dtype={"flag": "boolean", "count": "Int64"},
+        na_values=["---", "missing", ""],
+        parse_dates=["date"],
+        schema=schema,
+    )
+    assert df["flag"].dtype == "boolean"
+    assert df["date"].dtype == "datetime64[ns]"
+    assert df["count"].dtype == "Int64"
+    assert pd.isna(df.loc[2, "flag"])  # custom NA token
+    assert pd.isna(df.loc[1, "date"])  # empty string -> NA
+    assert pd.isna(df.loc[2, "count"])  # custom NA token
 
 
 def test_write_csv_creates_metadata_file(tmp_path: Path) -> None:
@@ -85,7 +111,6 @@ def test_write_csv_with_key_cols(tmp_path: Path) -> None:
     assert first_hash == second_hash
 
 
-
 def test_write_csv_normalises_types(tmp_path: Path) -> None:
     df = pd.DataFrame(
         {
@@ -98,6 +123,7 @@ def test_write_csv_normalises_types(tmp_path: Path) -> None:
     io.write_csv(df, path, cfg=cfg, key_cols=["d"])
     text = path.read_text(encoding="utf-8-sig")
     assert text == ("b,d\n" "false,2020-01-01\n" "true,2020-01-02\n")
+
 
 def test_git_sha_timeout_returns_unknown(
     monkeypatch: pytest.MonkeyPatch,
@@ -119,4 +145,3 @@ def test_git_sha_timeout_returns_unknown(
 
     assert io._git_sha() == "unknown"
     assert "timed out" in stream.getvalue()
-


### PR DESCRIPTION
## Summary
- allow io.read_csv to specify `dtype`, `na_values`, and `parse_dates`, with optional Pandera schema validation
- document and exercise new parameters in mapper CLI
- test parsing of booleans, dates, and missing values via Pandera schema

## Testing
- `pre-commit run --files library/io.py mapper_main.py tests/test_io.py tests/data/io_types.csv`
- `pytest tests/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c40b7ea88324a84cbd186a10a2f1