### PR TITLE
Refactor Chembl client into class

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -9,7 +9,7 @@ from itertools import islice
 
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -58,8 +58,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("dry run selected; would process at most %d identifiers", expected)
         return 0
 
-    # Configure HTTP session with the supplied User-Agent and retry policy
-    init_session(cfg.api, cfg.retry)
+    # Configure HTTP client with the supplied User-Agent and retry policy
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -79,7 +79,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_activities(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            cfg=cfg.api,
+            client=client,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve activities: %s", exc)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -45,8 +45,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    # Prepare HTTP session for ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    # Prepare HTTP client for ChEMBL requests
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -62,7 +62,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_assays(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            cfg=cfg.api,
+            client=client,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve assays: %s", exc)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -38,7 +38,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session, _chunked
+from library.chembl_client import ChemblClient, _chunked
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -272,8 +272,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    # Configure session for ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    # Configure client for ChEMBL requests
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -291,6 +291,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=args.chunk_size,
             timeout=args.timeout,
         )
@@ -382,8 +383,8 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    # Prepare shared session before performing any API calls
-    init_session(cfg.api, cfg.retry)
+    # Prepare shared client before performing any API calls
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -401,6 +402,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         doc_df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=args.chunk_size,
             timeout=args.timeout,
         )

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -23,7 +23,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -345,8 +345,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    # Set up HTTP session with proper headers and retry behaviour
-    init_session(cfg.api, cfg.retry)
+    # Set up HTTP client with proper headers and retry behaviour
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -362,7 +362,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     try:
         df = cl.get_targets(
-            ids, cfg=cfg.api, mapping_cfg=cfg.uniprot_mapping, timeout=args.timeout
+            ids,
+            cfg=cfg.api,
+            mapping_cfg=cfg.uniprot_mapping,
+            client=client,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve targets: %s", exc)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -9,7 +9,7 @@ from typing import Sequence
 import pandas as pd
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -123,8 +123,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    # Initialise HTTP session for subsequent ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    # Initialise HTTP client for subsequent ChEMBL requests
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(
@@ -141,7 +141,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     logger.info("Fetching ChEMBL data in chunks of %d", args.chunk_size)
     try:
         df = cl.get_testitem(
-            ids, cfg=cfg.api, chunk_size=args.chunk_size, timeout=args.timeout
+            ids,
+            cfg=cfg.api,
+            client=client,
+            chunk_size=args.chunk_size,
+            timeout=args.timeout,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg
 from .log import logger
 
@@ -90,7 +90,11 @@ TESTITEM_COLUMNS = [
 
 
 def get_assay(
-    chembl_assay_id: str, *, cfg: ApiCfg, timeout: float | None = None
+    chembl_assay_id: str,
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Retrieve assay information as a DataFrame.
 
@@ -100,6 +104,8 @@ def get_assay(
         Identifier of the assay to fetch.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     timeout:
         Optional override for the read timeout in seconds.
 
@@ -114,7 +120,7 @@ def get_assay(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/assay/{chembl_assay_id}?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
@@ -128,6 +134,7 @@ def get_assays(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
     require_variant_sequence: bool = False,
@@ -140,6 +147,8 @@ def get_assays(
         Assay identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -168,7 +177,7 @@ def get_assays(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&assay_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
             df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
@@ -192,6 +201,7 @@ def get_activities(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
@@ -203,6 +213,8 @@ def get_activities(
         Activity identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -226,7 +238,7 @@ def get_activities(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&activity_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
@@ -247,6 +259,7 @@ def get_testitem(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
@@ -258,6 +271,8 @@ def get_testitem(
         Molecule identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -281,7 +296,7 @@ def get_testitem(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&molecule_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -1,16 +1,21 @@
-"""Shared HTTP utilities for ChEMBL API access."""
+"""Shared HTTP utilities for ChEMBL API access.
+
+This module provides :class:`ChemblClient`, a lightweight wrapper around
+:class:`requests.Session` equipped with an in-memory cache.  The previous
+implementation relied on module level globals which caused state to leak
+between tests and CLI invocations.  ``ChemblClient`` encapsulates the
+necessary state so each consumer can manage its own session and cache.
+"""
 
 from __future__ import annotations
 
-
+from dataclasses import dataclass
 from typing import Any, Iterable, Iterator, cast
-
 
 import random
 import threading
 import requests
 from requests import Session
-
 from cachetools import TTLCache  # type: ignore[import-untyped]
 
 from .config import ApiCfg, ChemblCfg, RetryCfg, session_with_retry
@@ -18,136 +23,145 @@ from .rate_limiter import get_limiter, sleep
 from .log import logger
 
 
-# Cache entries expire after one hour to avoid serving stale data. The TTL can
-# be adjusted in the future via configuration if required.
-_CACHE: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=1024, ttl=3600)
-_CACHE_LOCK = threading.Lock()
-
-
-_session: Session | None = None
-_session_lock = threading.Lock()
-
-
-def init_session(api: ApiCfg, retry: RetryCfg, chembl: ChemblCfg | None = None) -> None:
-    """Initialise the shared HTTP session and cache.
-
-    The provided ``api`` and ``retry`` configurations are forwarded to
-    :func:`session_with_retry`, ensuring that subsequent requests use the
-    correct ``User-Agent`` and retry policy. When ``chembl`` is supplied the
-    cache TTL is taken from ``chembl.cache_ttl``.
+@dataclass
+class ChemblClient:
+    """HTTP client with caching for the ChEMBL API.
 
     Parameters
     ----------
     api:
-        Global API settings providing the ``User-Agent`` header.
+        Global API settings providing headers and rate limits.  A default
+        instance is created when omitted.
     retry:
-        Retry configuration applied to all requests.
+        Retry configuration for the underlying HTTP session.  A default is
+        used when omitted.
     chembl:
-        Optional ChEMBL-specific settings controlling cache TTL.
+        Optional ChEMBL specific settings controlling cache TTL.
+    session:
+        Pre-configured :class:`requests.Session` instance.  Primarily useful
+        for tests where a dummy session should be injected.
+    cache:
+        Optional external cache.  When ``None`` a :class:`cachetools.TTLCache`
+        is created using ``chembl.cache_ttl``.
     """
 
-    global _session, _CACHE
-    _session = session_with_retry(api, retry)
-    ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
-    _CACHE = TTLCache(maxsize=1024, ttl=ttl)
+    session: Session
+    cache: TTLCache[str, dict[str, Any]]
 
+    def __init__(
+        self,
+        api: ApiCfg | None = None,
+        retry: RetryCfg | None = None,
+        chembl: ChemblCfg | None = None,
+        *,
+        session: Session | None = None,
+        cache: TTLCache[str, dict[str, Any]] | None = None,
+    ) -> None:
+        api_cfg = api or ApiCfg()
+        retry_cfg = retry or RetryCfg()
+        chembl_cfg = chembl or ChemblCfg()
+        self.session = session or session_with_retry(api_cfg, retry_cfg)
+        self.cache = cache or TTLCache(maxsize=1024, ttl=chembl_cfg.cache_ttl)
+        # Locks guard access to ``cache`` as cachetools' TTLCache is not thread
+        # safe by default.  Each instance manages its own lock to avoid shared
+        # state between clients.
+        self._cache_lock = threading.Lock()
 
-def request_json(
-    url: str, *, cfg: ApiCfg, timeout: float | None = None
-) -> dict[str, Any]:
-    """Return JSON content from *url*.
+    # ------------------------------------------------------------------
+    # Request handling
+    # ------------------------------------------------------------------
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, Any]:
+        """Return JSON content from ``url``.
 
-    Parameters
-    ----------
-    url:
-        API endpoint to query.
-    cfg:
-        Configuration providing timeout and retry settings.
-    timeout:
-        Optional override for the read timeout in seconds.
+        Parameters
+        ----------
+        url:
+            API endpoint to query.
+        cfg:
+            Configuration providing timeout and retry settings.
+        timeout:
+            Optional override for the read timeout in seconds.
 
-    Returns
-    -------
-    dict[str, Any]
-        Parsed JSON document.
+        Returns
+        -------
+        dict[str, Any]
+            Parsed JSON document.
 
-    Raises
-    ------
-    requests.RequestException
-        If the HTTP request fails.
-    ValueError
-        If the response body is not valid JSON.
+        Raises
+        ------
+        requests.RequestException
+            If the HTTP request fails after exhausting retries.
+        ValueError
+            If the response body cannot be decoded as JSON.
+        """
 
-    """
-    limiter = get_limiter("chembl", cfg.rps, cfg.burst)
-    read_timeout = timeout if timeout is not None else cfg.timeout_read
-    cache_key = url
-    with _CACHE_LOCK:
-        cached = _CACHE.get(cache_key)
-        if cached is not None:
-            logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
-            return cached
-        logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
+        limiter = get_limiter("chembl", cfg.rps, cfg.burst)
+        read_timeout = timeout if timeout is not None else cfg.timeout_read
+        cache_key = url
+        with self._cache_lock:
+            cached = self.cache.get(cache_key)
+            if cached is not None:
+                logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
+                return cached
+            logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
-    global _session
-    if _session is None:
-        with _session_lock:
-            if _session is None:
-                _session = session_with_retry(ApiCfg(), RetryCfg())
-    session = _session
-    assert session is not None  # noqa: S101 - ensure session exists
-
-    last_exc: requests.RequestException | ValueError | None = None
-
-    for attempt in range(1, cfg.retries + 1):
-        limiter.acquire()
-        event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
-        try:
-            with session.get(
-                url, timeout=(cfg.timeout_connect, read_timeout)
-            ) as response:
-                response.raise_for_status()
-                data: dict[str, Any] = cast(dict[str, Any], response.json())
-                logger.info(
-                    "request_ok",
-                    extra={
-                        "stage": "request_ok",
-                        "url": url,
-                        "status": getattr(response, "status_code", None),
-                    },
-                )
-                with _CACHE_LOCK:
-                    cached = _CACHE.get(cache_key)
-                    if cached is not None:
-                        return cached
-                    _CACHE[cache_key] = data
-                    logger.info("cache_set", extra={"stage": "cache_set", "url": url})
+        last_exc: requests.RequestException | ValueError | None = None
+        for attempt in range(1, cfg.retries + 1):
+            limiter.acquire()
+            event = "request_start" if attempt == 1 else "request_retry"
+            logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
+            try:
+                with self.session.get(
+                    url, timeout=(cfg.timeout_connect, read_timeout)
+                ) as response:
+                    response.raise_for_status()
+                    data: dict[str, Any] = cast(dict[str, Any], response.json())
+                    logger.info(
+                        "request_ok",
+                        extra={
+                            "stage": "request_ok",
+                            "url": url,
+                            "status": getattr(response, "status_code", None),
+                        },
+                    )
+                    with self._cache_lock:
+                        cached = self.cache.get(cache_key)
+                        if cached is not None:
+                            return cached
+                        self.cache[cache_key] = data
+                        logger.info(
+                            "cache_set", extra={"stage": "cache_set", "url": url}
+                        )
                     return data
-        except (requests.RequestException, ValueError) as exc:
-            last_exc = exc
-            if attempt >= cfg.retries:
-                logger.exception(
-                    "request_fail", extra={"stage": "request_fail", "url": url}
-                )
-                break
-            # Exponential backoff with jitter to avoid thundering herd problems
-            delay = cfg.backoff_factor * (2 ** (attempt - 1))
-            delay += random.uniform(0, cfg.backoff_factor)
-            sleep(delay)
+            except (
+                requests.RequestException,
+                ValueError,
+            ) as exc:  # pragma: no cover - network errors
+                last_exc = exc
+                if attempt >= cfg.retries:
+                    logger.exception(
+                        "request_fail", extra={"stage": "request_fail", "url": url}
+                    )
+                    break
+                # Exponential backoff with jitter to avoid thundering herd issues
+                delay = cfg.backoff_factor * (2 ** (attempt - 1))
+                delay += random.uniform(0, cfg.backoff_factor)
+                sleep(delay)
 
-    assert last_exc is not None
-    raise last_exc
+        assert last_exc is not None
+        raise last_exc
 
+    def clear_cache(self) -> None:
+        """Remove all entries from the in-memory cache.
 
-def clear_cache() -> None:
-    """Remove all entries from the in-memory cache.
+        This helper is primarily intended for tests to avoid interference
+        from previously cached responses.
+        """
 
-    This helper is primarily intended for tests to avoid interference
-    from previously cached responses.
-    """
-    with _CACHE_LOCK:
-        _CACHE.clear()
+        with self._cache_lock:
+            self.cache.clear()
 
 
 def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
@@ -169,8 +183,8 @@ def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
     ------
     ValueError
         If ``size`` is not a positive integer.
-
     """
+
     if size <= 0:
         raise ValueError("size must be a positive integer")
 
@@ -182,3 +196,6 @@ def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
             chunk = []
     if chunk:
         yield chunk
+
+
+__all__ = ["ChemblClient", "_chunked"]

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -8,7 +8,7 @@ from .log import logger
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg, UniprotMappingCfg
 from .mapper_library import map_chembl_to_uniprot
 
@@ -147,6 +147,7 @@ def get_target(
     *,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
+    client: ChemblClient,
     timeout: float | None = None,
 ) -> dict[str, str]:
     """Fetch target information for a single ChEMBL identifier.
@@ -159,6 +160,8 @@ def get_target(
         API configuration providing base URL and timeouts.
     mapping_cfg:
         Configuration for the UniProt mapping service.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     timeout:
         Optional override for the HTTP request timeout.
     """
@@ -167,7 +170,7 @@ def get_target(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/target/{chembl_target_id}.json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     target_list = _get_items(data, "target")
     if not target_list:
         return dict(EMPTY_TARGET)
@@ -179,6 +182,7 @@ def get_targets(
     *,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
@@ -192,6 +196,8 @@ def get_targets(
         API configuration with base URL and timeouts.
     mapping_cfg:
         Settings for the UniProt mapping service.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     chunk_size:
         Number of identifiers to request per HTTP call.
     timeout:
@@ -206,7 +212,7 @@ def get_targets(
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("targets") or data.get("target") or []
         records.extend(_parse_target_record(item, mapping_cfg) for item in items)
     if not records:
@@ -220,6 +226,7 @@ def extend_target(
     *,
     cfg: ApiCfg,
     mapping_cfg: UniprotMappingCfg,
+    client: ChemblClient,
     id_column: str = "target_chembl_id",
 ) -> pd.DataFrame:
     """Augment ``df`` with columns returned from :func:`get_target`.
@@ -232,6 +239,8 @@ def extend_target(
         API configuration providing base URL and timeouts.
     mapping_cfg:
         Settings for the UniProt mapping service.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests.
     id_column:
         Name of the column holding the identifiers.
 
@@ -239,7 +248,7 @@ def extend_target(
     if id_column not in df.columns:
         raise ValueError(f"missing required column: {id_column}")
     targets = [
-        get_target(i, cfg=cfg, mapping_cfg=mapping_cfg)
+        get_target(i, cfg=cfg, mapping_cfg=mapping_cfg, client=client)
         for i in df[id_column].fillna("")
     ]
     extra = pd.DataFrame(targets)

--- a/tests/test_activity_cli_dry_run_no_input.py
+++ b/tests/test_activity_cli_dry_run_no_input.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from pathlib import Path
+import argparse
 import io
 import json
-import argparse
+from pathlib import Path
 
-from library.cli import LoggerConfig, configure_logger
 import get_activity_data as gad
+from library.cli import LoggerConfig, configure_logger
 from library.config import Config
 
- 
+
 def test_dry_run_no_input(tmp_path: Path) -> None:
+    """Dry run should not fail when the input file is missing."""
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
     args = argparse.Namespace(
@@ -23,23 +24,6 @@ def test_dry_run_no_input(tmp_path: Path) -> None:
         timeout=30.0,
         limit=5,
         dry_run=True,
- 
-def _create_config(tmp_path: Path) -> Path:
-    cfg = tmp_path / "config.yaml"
-    cfg.write_text(
-        "jobs:\n  chunk_size: 10\n"
-        "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
-        "log:\n  level: INFO\n"
-        "api:\n  timeout_read: 30\n"
-        "resources:\n"
-        "  dictionary_dir: dictionary\n"
-        "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
-        "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
-        "  uniprot_data_dir: uniprot\n"
-        "  organism_csv: dictionary/organism.csv\n"
-        "  status_csv: dictionary/status.csv\n"
-        "  targets_type_csv: dictionary/targets_type.csv\n"
- 
     )
     rc = gad.run_chembl(Config(), args)
     assert rc == 0

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -5,30 +5,25 @@ from __future__ import annotations
 from typing import Any
 
 import random
-import requests
-import responses  # type: ignore[import-not-found]
 import time
 
-
 import pytest
-
-
+import requests
+import responses
 from cachetools import TTLCache  # type: ignore[import-untyped]
 
-
-from library import chembl_client
-
-
-from library.chembl_client import clear_cache, init_session, request_json
+from library.chembl_client import ChemblClient
 from library.config import ApiCfg, ChemblCfg, RetryCfg, session_with_retry
 import library.rate_limiter as rl
 
 
 class DummyResponse:
+    """Minimal context manager returning a fixed payload."""
+
     def __enter__(self) -> "DummyResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no-op
         pass
 
     def raise_for_status(self) -> None:  # pragma: no cover - no error
@@ -39,6 +34,8 @@ class DummyResponse:
 
 
 class DummySession:
+    """Session recording calls and allowing configured failures."""
+
     def __init__(self, *, failures: int = 0) -> None:
         self.timeout: Any = None
         self.calls: list[int] = []
@@ -52,14 +49,11 @@ class DummySession:
         return DummyResponse()
 
 
-def test_init_session_sets_user_agent(monkeypatch) -> None:
-    """Session should include the configured ``User-Agent`` header."""
-    monkeypatch.setattr("library.chembl_client._session", None)
+def test_session_sets_user_agent() -> None:
+    """Client session should include the configured ``User-Agent`` header."""
     cfg = ApiCfg(user_agent="test-agent/1.0 (mailto:test@example.org)")
-    init_session(cfg, RetryCfg())
-    session = chembl_client._session
-    assert session is not None
-    assert session.headers.get("User-Agent") == cfg.user_agent
+    client = ChemblClient(cfg, RetryCfg())
+    assert client.session.headers.get("User-Agent") == cfg.user_agent
 
 
 class FakeTime:
@@ -76,158 +70,130 @@ class FakeTime:
 
 
 @responses.activate
-def test_request_json_uses_cfg(monkeypatch) -> None:
+def test_request_json_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
     session = DummySession(failures=1)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(session=session)
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=2, backoff_factor=0.5)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert session.timeout == (1, 2)
     assert len(session.calls) == 2
     assert sleep_times == [0.5]
 
 
-def test_request_json_backoff_grows(monkeypatch) -> None:
+def test_request_json_backoff_grows(monkeypatch: pytest.MonkeyPatch) -> None:
     session = DummySession(failures=2)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(session=session)
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=3, backoff_factor=1)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert sleep_times == [1.0, 2.0]
 
 
-def test_request_json_reuses_session(monkeypatch) -> None:
+def test_request_json_reuses_session() -> None:
     dummy = DummySession()
 
-    def fake_session_with_retry(api: ApiCfg, retry: RetryCfg) -> DummySession:
-        return dummy
-
-    monkeypatch.setattr(
-        "library.chembl_client.session_with_retry", fake_session_with_retry
-    )
-    init_session(ApiCfg(), RetryCfg())
-
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-    clear_cache()
-
-    request_json("http://example.com/1", cfg=ApiCfg())
-    request_json("http://example.com/2", cfg=ApiCfg())
+    client = ChemblClient(session=dummy)
+    client.request_json("http://example.com/1", cfg=ApiCfg())
+    client.request_json("http://example.com/2", cfg=ApiCfg())
 
     assert dummy.calls == [id(dummy), id(dummy)]
 
 
 @responses.activate
-def test_request_json_cache(monkeypatch) -> None:
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+def test_request_json_cache() -> None:
+    client = ChemblClient()
     url = "http://example.com/cache"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    request_json(url, cfg=ApiCfg())
-    assert url in chembl_client._CACHE
+    client.request_json(url, cfg=ApiCfg())
+    assert url in client.cache
 
-    request_json(url, cfg=ApiCfg())
-
-    assert url in chembl_client._CACHE
-
+    client.request_json(url, cfg=ApiCfg())
+    assert url in client.cache
     assert len(responses.calls) == 1
 
 
 @responses.activate
-def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
+def test_request_json_cache_ttl_expiration() -> None:
     timer = [0.0]
-
     cache: TTLCache[str, dict[str, Any]] = TTLCache(
         maxsize=2, ttl=1, timer=lambda: timer[0]
     )
-
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
-
-    monkeypatch.setattr("library.chembl_client._session", None)
     chembl_cfg = ChemblCfg(cache_ttl=1)
-    init_session(ApiCfg(), RetryCfg(), chembl_cfg)
-    assert chembl_client._CACHE.ttl == chembl_cfg.cache_ttl
-    chembl_client._CACHE = TTLCache(
-        maxsize=1024, ttl=chembl_cfg.cache_ttl, timer=lambda: timer[0]
-    )
-    clear_cache()
+    client = ChemblClient(chembl=chembl_cfg, cache=cache)
+
     url = "http://example.com/ttl"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
+    client.request_json(url, cfg=ApiCfg())
 
-    request_json(url, cfg=ApiCfg())
-
-    # Advance time beyond the TTL to force expiration of the cached entry.
     timer[0] = 2.0
     responses.add(responses.GET, url, json={"ok": True}, status=200)
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
-    # Two HTTP calls should have occurred because the cache entry expired.
     assert len(responses.calls) == 2
 
 
 @responses.activate
-def test_request_json_preserves_original_error_message(monkeypatch) -> None:
-    """Ensure the raised error retains status code and URL."""
-
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+def test_request_json_preserves_original_error_message() -> None:
+    client = ChemblClient()
     url = "http://example.com/notfound"
     responses.add(responses.GET, url, status=404)
 
     cfg = ApiCfg(retries=1)
     with pytest.raises(requests.HTTPError) as exc_info:
-        request_json(url, cfg=cfg)
+        client.request_json(url, cfg=cfg)
 
     message = str(exc_info.value)
     assert "404" in message
     assert url in message
 
 
-def test_clear_cache(monkeypatch) -> None:
-
+def test_clear_cache() -> None:
     cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=2, ttl=100)
+    client = ChemblClient(cache=cache)
+    client.cache["x"] = {"ok": True}
+    client.clear_cache()
+    assert len(client.cache) == 0
 
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
-    chembl_client._CACHE["x"] = {"ok": True}
-    clear_cache()
-    assert len(chembl_client._CACHE) == 0
 
-
-def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
+def test_request_json_rate_limiter_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_time = FakeTime()
     monkeypatch.setattr(rl, "time", fake_time)
     monkeypatch.setattr(rl, "sleep", fake_time.sleep)
     with rl._limiters_lock:
         rl._limiters.clear()
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(session=session)
     cfg = ApiCfg(rps=1, burst=1)
-    request_json("http://example.com/1", cfg=cfg)
-    request_json("http://example.com/2", cfg=cfg)
+    client.request_json("http://example.com/1", cfg=cfg)
+    client.request_json("http://example.com/2", cfg=cfg)
     assert fake_time.sleeps == [1.0]
     with rl._limiters_lock:
         rl._limiters.clear()
+
+
+@responses.activate
+def test_clients_isolated_caches() -> None:
+    url = "http://example.com/data"
+    responses.add(responses.GET, url, json={"ok": True}, status=200)
+    client1 = ChemblClient()
+    client1.request_json(url, cfg=ApiCfg())
+    assert len(responses.calls) == 1
+    client2 = ChemblClient()
+    responses.add(responses.GET, url, json={"ok": True}, status=200)
+    client2.request_json(url, cfg=ApiCfg())
+    assert len(responses.calls) == 2
 
 
 @responses.activate

--- a/tests/test_chembl_client_threadsafe.py
+++ b/tests/test_chembl_client_threadsafe.py
@@ -1,13 +1,10 @@
-"""Thread-safety tests for :mod:`library.chembl_client`."""
-
-from __future__ import annotations
-
-from typing import Any
-
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
-from library import chembl_client
+import pytest
+
+from library.chembl_client import ChemblClient
 from library.config import ApiCfg
 
 
@@ -68,30 +65,27 @@ class ThreadTrackingSession:
         return ThreadTrackingResponse()
 
 
-def test_request_json_threadsafe(monkeypatch) -> None:
+def test_request_json_threadsafe() -> None:
     """Concurrent calls should yield the same result as sequential ones."""
 
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    chembl_client.clear_cache()
+    client = ChemblClient(session=session)
 
     url = "http://example.com/threadsafe"
     cfg = ApiCfg()
 
-    # Sequential calls: only the first should trigger a real request.
-    sequential = [chembl_client.request_json(url, cfg=cfg) for _ in range(5)]
+    sequential = [client.request_json(url, cfg=cfg) for _ in range(5)]
     assert session.calls == 1
 
-    chembl_client.clear_cache()
+    client.clear_cache()
     session.calls = 0
 
-    # Parallel calls starting at the same time.
     results: list[dict[str, Any]] = []
     start = threading.Event()
 
     def worker() -> None:
         start.wait()
-        results.append(chembl_client.request_json(url, cfg=cfg))
+        results.append(client.request_json(url, cfg=cfg))
 
     threads = [threading.Thread(target=worker) for _ in range(5)]
     for t in threads:
@@ -103,11 +97,8 @@ def test_request_json_threadsafe(monkeypatch) -> None:
     assert results == sequential
 
 
-def test_single_session_created(monkeypatch) -> None:
-    """Ensure only one HTTP session is initialised across threads."""
-
-    chembl_client.clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+def test_single_session_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure only one HTTP session is initialised when constructing a client."""
 
     dummy = ThreadTrackingSession()
     create_calls = 0
@@ -121,8 +112,10 @@ def test_single_session_created(monkeypatch) -> None:
         "library.chembl_client.session_with_retry", fake_session_with_retry
     )
 
+    client = ChemblClient()
+
     def worker() -> dict[str, Any]:
-        return chembl_client.request_json("http://example.com", cfg=ApiCfg())
+        return client.request_json("http://example.com", cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
@@ -132,21 +125,17 @@ def test_single_session_created(monkeypatch) -> None:
     assert all(r == {"ok": True} for r in results)
 
 
-def test_cache_shared_across_threads(monkeypatch) -> None:
-    clear_cache()
-    dummy = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", dummy)
-
+def test_cache_shared_across_threads() -> None:
+    client = ChemblClient(session=DummySession())
     url = "http://example.com/data"
-    assert request_json(url, cfg=ApiCfg()) == {"ok": True}
-    assert len(dummy.calls) == 1
+    assert client.request_json(url, cfg=ApiCfg()) == {"call": 1}
 
     def worker() -> dict[str, Any]:
-        return request_json(url, cfg=ApiCfg())
+        return client.request_json(url, cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
         results = [f.result() for f in futures]
 
-    assert all(r == {"ok": True} for r in results)
-    assert len(dummy.calls) == 1
+    assert all(r == {"call": 1} for r in results)
+    assert client.session.calls == 1

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -41,7 +41,7 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gas, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_assays(ids, cfg, chunk_size, timeout):
+    def fake_get_assays(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"assay_chembl_id": data})
@@ -74,7 +74,7 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gdd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_documents(ids, cfg, chunk_size, timeout):
+    def fake_get_documents(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"document_chembl_id": data})
@@ -107,7 +107,7 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gtdt, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_testitem(ids, cfg, chunk_size, timeout):
+    def fake_get_testitem(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"molecule_chembl_id": data})
@@ -140,7 +140,7 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
         gtd, "apply_config_overrides", lambda a, p, c, mapping=None: Config()
     )
 
-    def fake_get_targets(ids, cfg, mapping_cfg, timeout):
+    def fake_get_targets(ids, cfg, mapping_cfg, client, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"target_chembl_id": data})

--- a/tests/test_init_session_retry.py
+++ b/tests/test_init_session_retry.py
@@ -21,34 +21,25 @@ from library.config import Config
 def test_init_session_uses_cfg_retry(
     module_name: str, func_name: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Ensure CLI scripts use retry settings from :class:`Config`.
+    """Ensure CLI scripts pass retry settings to :class:`ChemblClient`.
 
-    The test verifies that each script passes ``cfg.retry`` to
-    :func:`library.chembl_client.init_session` by monkeypatching the
-    function and capturing the supplied arguments.
+    The test verifies that each script initialises :class:`ChemblClient`
+    with ``cfg.api`` and ``cfg.retry`` by monkeypatching the constructor and
+    capturing the supplied arguments.
     """
 
     module = import_module(module_name)
     cfg = Config()
     captured: dict[str, object] = {}
 
-    def fake_init(api: object, retry: object, *_args: object) -> None:
-        """Record parameters supplied to :func:`init_session`.
+    class DummyClient:
+        def __init__(
+            self, api: object, retry: object, chembl: object | None = None, **_: object
+        ) -> None:
+            captured["api"] = api
+            captured["retry"] = retry
 
-        Parameters
-        ----------
-        api : object
-            API configuration object.
-        retry : object
-            Retry configuration to apply.
-        *_args : object
-            Additional positional arguments, ignored.
-        """
-
-        captured["api"] = api
-        captured["retry"] = retry
-
-    monkeypatch.setattr(module, "init_session", fake_init)
+    monkeypatch.setattr(module, "ChemblClient", DummyClient)
 
     args = argparse.Namespace(
         input_csv=Path("missing.csv"),

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -1,12 +1,13 @@
- 
 """Thread-safety tests for :mod:`library.iuphar_library`."""
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
+import pytest
 
 import library.iuphar_library as ii
 from library.config import IupharCfg
@@ -40,7 +41,7 @@ class DummyLimiter:
         return None
 
 
-def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
+def test_websearch_gene_to_id_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
     data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
     dummy = DummySession()
     monkeypatch.setattr(ii, "_session", dummy)
@@ -48,7 +49,7 @@ def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
 
     cfg = IupharCfg(base="https://example.org/services", rps=10, burst=10)
 
-    def worker() -> dict:
+    def worker() -> dict[str, int]:
         return data.websearch_gene_to_id("GENE", cfg)
 
     with ThreadPoolExecutor(max_workers=10) as pool:
@@ -56,19 +57,6 @@ def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
 
     assert all(r == {"id": 1} for r in results)
     assert len(dummy.calls) == 10
- 
-"""Thread-safety tests for IUPHAR session handling."""
-
-from __future__ import annotations
-
-import threading
-import time
-
-import pandas as pd
-import pytest
-
-from library import iuphar_library as ii
-from library.config import IupharCfg
 
 
 def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -118,11 +106,11 @@ def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
 
     threads = [
         threading.Thread(target=data.websearch_gene_to_id, args=("GENE", cfg))
-        for _ in range(2)
+        for _ in range(5)
     ]
     for t in threads:
         t.start()
     for t in threads:
         t.join()
 
-    assert order == ["start", "end", "start", "end"]
+    assert order == ["start", "end"] * 5


### PR DESCRIPTION
## Summary
- encapsulate HTTP session and cache in new `ChemblClient` class
- update ChEMBL helpers and CLI scripts to use `ChemblClient`
- adjust tests to construct isolated clients

## Testing
- `black library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py tests/test_init_session_retry.py`
- `ruff check library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py tests/test_init_session_retry.py`
- `mypy library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_document_data.py get_target_data.py get_testitem_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_cli_timeout_override.py tests/test_init_session_retry.py` *(fails: Name "yaml" is not defined)*
- `pytest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c42da9188324a1af1b614af6402a