### PR TITLE
Include dataset sections in config schema

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -991,6 +991,168 @@ CONFIG_SCHEMA: Dict[str, Any] = {
             "required": ["weights", "thresholds"],
             "additionalProperties": False,
         },
+        "activity": {
+            "type": "object",
+            "properties": {
+                "column": {"type": "string", "minLength": 1},
+                "chunk_size": {"type": "integer", "minimum": 1},
+                "timeout": {"type": "number", "minimum": 1},
+                "limit": {
+                    "anyOf": [
+                        {"type": "integer", "minimum": 1},
+                        {"type": "null"},
+                    ]
+                },
+                "dry_run": {"type": "boolean"},
+            },
+            "required": ["column", "chunk_size", "timeout", "dry_run"],
+            "additionalProperties": False,
+        },
+        "assay": {
+            "type": "object",
+            "properties": {
+                "column": {"type": "string", "minLength": 1},
+                "chunk_size": {"type": "integer", "minimum": 1},
+                "timeout": {"type": "number", "minimum": 1},
+            },
+            "required": ["column", "chunk_size", "timeout"],
+            "additionalProperties": False,
+        },
+        "testitem": {
+            "type": "object",
+            "properties": {
+                "column": {"type": "string", "minLength": 1},
+                "chunk_size": {"type": "integer", "minimum": 1},
+                "timeout": {"type": "number", "minimum": 1},
+            },
+            "required": ["column", "chunk_size", "timeout"],
+            "additionalProperties": False,
+        },
+        "document": {
+            "type": "object",
+            "properties": {
+                "pubmed": {
+                    "type": "object",
+                    "properties": {
+                        "column": {"type": "string", "minLength": 1},
+                        "sleep": {"type": "number", "minimum": 0},
+                        "workers": {"type": "integer", "minimum": 1},
+                        "batch_size": {"type": "integer", "minimum": 1},
+                    },
+                    "required": [
+                        "column",
+                        "sleep",
+                        "workers",
+                        "batch_size",
+                    ],
+                    "additionalProperties": False,
+                },
+                "chembl": {
+                    "type": "object",
+                    "properties": {
+                        "column": {"type": "string", "minLength": 1},
+                        "chunk_size": {"type": "integer", "minimum": 1},
+                        "timeout": {"type": "number", "minimum": 1},
+                    },
+                    "required": ["column", "chunk_size", "timeout"],
+                    "additionalProperties": False,
+                },
+                "all": {
+                    "type": "object",
+                    "properties": {
+                        "column": {"type": "string", "minLength": 1},
+                        "chunk_size": {"type": "integer", "minimum": 1},
+                        "sleep": {"type": "number", "minimum": 0},
+                        "workers": {"type": "integer", "minimum": 1},
+                        "batch_size": {"type": "integer", "minimum": 1},
+                        "timeout": {"type": "number", "minimum": 1},
+                    },
+                    "required": [
+                        "column",
+                        "chunk_size",
+                        "sleep",
+                        "workers",
+                        "batch_size",
+                        "timeout",
+                    ],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["pubmed", "chembl", "all"],
+            "additionalProperties": False,
+        },
+        "target": {
+            "type": "object",
+            "properties": {
+                "uniprot": {
+                    "type": "object",
+                    "properties": {
+                        "column": {"type": "string", "minLength": 1},
+                        "data_dir": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["column", "data_dir"],
+                    "additionalProperties": False,
+                },
+                "chembl": {
+                    "type": "object",
+                    "properties": {
+                        "column": {"type": "string", "minLength": 1},
+                        "timeout": {"type": "number", "minimum": 1},
+                    },
+                    "required": ["column", "timeout"],
+                    "additionalProperties": False,
+                },
+                "iuphar": {
+                    "type": "object",
+                    "properties": {
+                        "target_csv": {"type": "string", "minLength": 1},
+                        "family_csv": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["target_csv", "family_csv"],
+                    "additionalProperties": False,
+                },
+                "all": {
+                    "type": "object",
+                    "properties": {
+                        "data_dir": {"type": "string", "minLength": 1},
+                        "target_csv": {"type": "string", "minLength": 1},
+                        "family_csv": {"type": "string", "minLength": 1},
+                        "timeout": {"type": "number", "minimum": 1},
+                        "organism_csv": {"type": "string", "minLength": 1},
+                        "uniprot_column": {"type": "string", "minLength": 1},
+                        "chembl_out": {
+                            "anyOf": [
+                                {"type": "string", "minLength": 1},
+                                {"type": "null"},
+                            ]
+                        },
+                        "uniprot_out": {
+                            "anyOf": [
+                                {"type": "string", "minLength": 1},
+                                {"type": "null"},
+                            ]
+                        },
+                        "iuphar_out": {
+                            "anyOf": [
+                                {"type": "string", "minLength": 1},
+                                {"type": "null"},
+                            ]
+                        },
+                    },
+                    "required": [
+                        "data_dir",
+                        "target_csv",
+                        "family_csv",
+                        "timeout",
+                        "organism_csv",
+                        "uniprot_column",
+                    ],
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["uniprot", "chembl", "iuphar", "all"],
+            "additionalProperties": False,
+        },
         "resources": {
             "type": "object",
             "properties": {
@@ -1141,6 +1303,11 @@ CONFIG_SCHEMA: Dict[str, Any] = {
         "pubmed",
         "semantic_scholar",
         "doc_type",
+        "activity",
+        "assay",
+        "testitem",
+        "document",
+        "target",
         "resources",
         "io",
         "jobs",

--- a/library/io.py
+++ b/library/io.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Iterable, Iterator
 import subprocess
 import sys
+import yaml
 
 
 import pandas as pd
@@ -24,7 +25,6 @@ from .config import Config, IoCfg, _serialize_paths
 from .csv_utils import write_csv_deterministic
 
 from .log import logger
-
 
 
 def read_ids(
@@ -187,7 +187,6 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
 
 
-
 def _git_sha() -> str:
     """Return the current Git commit hash.
 
@@ -227,4 +226,3 @@ def _write_meta(path: Path, cfg: Config) -> None:
     meta_path = Path(f"{path}.meta.yaml")
     with meta_path.open("w", encoding="utf8") as fh:
         yaml.safe_dump(meta, fh, sort_keys=False)
-

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -1,12 +1,13 @@
- 
 """Thread-safety tests for :mod:`library.iuphar_library`."""
 
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 import threading
+import time
 
 import pandas as pd
+import pytest
 
 import library.iuphar_library as ii
 from library.config import IupharCfg
@@ -56,19 +57,9 @@ def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
 
     assert all(r == {"id": 1} for r in results)
     assert len(dummy.calls) == 10
- 
+
+
 """Thread-safety tests for IUPHAR session handling."""
-
-from __future__ import annotations
-
-import threading
-import time
-
-import pandas as pd
-import pytest
-
-from library import iuphar_library as ii
-from library.config import IupharCfg
 
 
 def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- extend configuration schema with dataset sections (activity, assay, test item, document, target)
- add missing `yaml` import in I/O utilities
- tidy thread-safety test imports

## Testing
- `pre-commit run --files library/config.py library/io.py tests/test_iuphar_threadsafe.py` (failed: mypy missing import, pytest collection errors)
- `SKIP=pytest pre-commit run --files library/config.py library/io.py tests/test_iuphar_threadsafe.py`
- `python get_input_initialisation.py --config config.yaml` (fails: FileNotFoundError: data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx)


------
https://chatgpt.com/codex/tasks/task_e_68c2c618fb888324815dc45a04e7d3ab