### PR TITLE
Add determinism script test

### DIFF
--- a/tests/test_determinism_script.py
+++ b/tests/test_determinism_script.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_determinism_script_returns_zero() -> None:
+    """Run determinism check script and assert a zero exit code.
+
+    The script writes a small DataFrame twice using the deterministic CSV writer
+    and compares their SHA-256 hashes. When the output is deterministic the
+    script exits with code ``0``.
+    """
+
+    result = subprocess.run(
+        [sys.executable, "scripts/check_determinism.py", "--log-level", "DEBUG"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add unit test exercising `scripts/check_determinism.py` and asserting a zero exit code

## Testing
- `ruff check tests/test_determinism_script.py`
- `ruff format tests/test_determinism_script.py`
- `mypy tests/test_determinism_script.py`
- `python scripts/check_determinism.py --log-level DEBUG`
- `pytest tests/test_determinism_script.py -q`
- `pre-commit run --files tests/test_determinism_script.py` *(fails: SyntaxError in tests/test_iuphar_threadsafe.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c7d270fc8324b74577abab7f717e