### PR TITLE
Relax dependency pinning and document upgrade process

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,23 @@ parsing, validation, aggregation and export of tabular data.
    pytest
     ```
 
-    The suite exercises the library modules using fixtures from
-    ``tests/data``.
+   The suite exercises the library modules using fixtures from
+   ``tests/data``.
+
+## Updating Dependencies
+
+To keep the environment current, periodically refresh the pinned
+libraries and verify that the project remains compatible:
+
+```bash
+pip install -U -r requirements.txt -r requirements-dev.txt
+pre-commit run --all-files
+```
+
+The first command upgrades both runtime and development requirements to
+the newest minor releases permitted by the version ranges. The second
+command formats code, lints, runs static type checks and executes the
+test suite to confirm nothing broke during the upgrade.
 
 ## Конфигурация через `.env`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy==2.3.3
-pandas==2.3.2  # Required for scripts/check_determinism.py
-requests==2.32.5
-PyYAML==6.0.2
-openpyxl==3.1.5
-pyarrow==21.0.0
-jsonschema==4.25.1  # Required for configuration validation
-pandera==0.26.1  # Dataframe validation
-cachetools==5.3.2
+numpy~=2.3.3
+pandas~=2.3.2  # Required for scripts/check_determinism.py
+requests~=2.32.5
+PyYAML~=6.0.2
+openpyxl~=3.1.5
+pyarrow~=21.0.0
+jsonschema~=4.25.1  # Required for configuration validation
+pandera~=0.26.1  # Dataframe validation
+cachetools~=5.3.2


### PR DESCRIPTION
## Summary
- Switch runtime dependencies to compatible `~=` ranges
- Document how to upgrade requirements and run checks

## Testing
- `pip install -r requirements.txt`
- `pre-commit run --files requirements.txt README.md` *(fails: SyntaxError in tests/test_iuphar_threadsafe.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c77790788324acdc71f0be4a940c