### PR TITLE
Handle git command timeouts in _git_sha

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 import hashlib
+import logging
 import os
 import subprocess
 import sys
@@ -24,6 +25,9 @@ from pandas.api import types as ptypes
 from .config import Config, _serialize_paths
 
 
+logger = logging.getLogger(__name__)
+
+
 def _git_sha() -> str:
     """Return the current Git commit hash or ``"unknown"`` if unavailable."""
 
@@ -33,8 +37,12 @@ def _git_sha() -> str:
             check=True,
             capture_output=True,
             text=True,
+            timeout=5,
         )
         return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        logger.warning("git rev-parse timed out")
+        return "unknown"
     except Exception:  # pragma: no cover - git may be unavailable
         return "unknown"
 

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 import hashlib
+import logging
+import subprocess
 
 import pandas as pd
 import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 from hypothesis.extra.pandas import column, data_frames, range_indexes
+from unittest.mock import patch
 
-from library.csv_utils import sha256_file, write_csv_deterministic
+from library.csv_utils import _git_sha, sha256_file, write_csv_deterministic
 from library.config import Config
 
 
@@ -129,3 +132,20 @@ def test_sha256_file_missing(tmp_path: Path) -> None:
     missing = tmp_path / "missing.csv"
     with pytest.raises(FileNotFoundError, match=str(missing)):
         sha256_file(missing)
+
+
+def test_git_sha_timeout_returns_unknown_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_git_sha returns 'unknown' and logs a warning on timeout."""
+
+    with patch(
+        "library.csv_utils.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(
+            cmd=["git", "rev-parse", "HEAD"], timeout=5
+        ),
+    ):
+        with caplog.at_level(logging.WARNING):
+            result = _git_sha()
+    assert result == "unknown"
+    assert "timed out" in caplog.text


### PR DESCRIPTION
## Summary
- log and return unknown when `git rev-parse` times out
- test `_git_sha` timeout handling with mocked subprocess

## Testing
- `black library/csv_utils.py tests/test_csv_utils.py`
- `ruff check library/csv_utils.py tests/test_csv_utils.py`
- `mypy library/csv_utils.py tests/test_csv_utils.py`
- `pytest tests/test_csv_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c77e6b608324979a7cc57ab7ed72