### PR TITLE
refactor: introduce ChemblClient class

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import argparse
 import sys
 from typing import Sequence
-from itertools import islice
 
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -60,7 +59,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.activity.column, cfg=cfg.io)
@@ -68,16 +67,15 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-
     if limit is not None:
         ids = ids[:limit]
         logger.info("processing at most %d identifiers", len(ids))
-
 
     try:
         df = cl.get_activities(
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=cfg.activity.chunk_size,
             timeout=cfg.activity.timeout,
         )

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -8,7 +8,7 @@ from typing import Sequence
 
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
@@ -46,7 +46,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare HTTP session for ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
@@ -58,6 +58,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = cl.get_assays(
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=cfg.assay.chunk_size,
             timeout=cfg.assay.timeout,
         )

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -38,7 +38,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session, _chunked
+from library.chembl_client import ChemblClient, _chunked
 
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -277,7 +277,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Configure session for ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io)
@@ -289,6 +289,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=cfg.document.chembl.chunk_size,
             timeout=cfg.document.chembl.timeout,
         )
@@ -381,7 +382,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare shared session before performing any API calls
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.document.all.column, cfg=cfg.io)
@@ -393,6 +394,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         doc_df = cl.get_documents(  # type: ignore[attr-defined]
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=cfg.document.all.chunk_size,
             timeout=cfg.document.all.timeout,
         )
@@ -723,7 +725,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     try:
         cfg: Config = apply_config_overrides(
-
             args,
             subparser,
             args.config,
@@ -732,7 +733,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "openalex_rps": "openalex.rps",
                 "crossref_rps": "crossref.rps",
             },
-
         )
         if args.print_config:
             print_config(cfg)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -23,7 +23,7 @@ from library.config import (
     print_config,
     _serialize_paths,
 )
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import io
@@ -357,7 +357,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Set up HTTP session with proper headers and retry behaviour
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io)
@@ -369,6 +369,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = cl.get_targets(
             ids,
             cfg=cfg.api,
+            client=client,
             mapping_cfg=cfg.uniprot_mapping,
             timeout=cfg.target.chembl.timeout,
         )

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -9,7 +9,7 @@ from typing import Sequence
 import pandas as pd
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths
-from library.chembl_client import init_session
+from library.chembl_client import ChemblClient
 
 from library import chembl_library as cl
 from library import pubchem_library as pl
@@ -124,14 +124,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Initialise HTTP session for subsequent ChEMBL requests
-    init_session(cfg.api, cfg.retry)
+    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
         ids = io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io)
     except (FileNotFoundError, ValueError) as exc:
         logger.error("%s", exc)
         return 1
-
 
     logger.info("Retrieved %d identifiers", len(ids))
     logger.info("Fetching ChEMBL data in chunks of %d", cfg.testitem.chunk_size)
@@ -140,6 +139,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = cl.get_testitem(
             ids,
             cfg=cfg.api,
+            client=client,
             chunk_size=cfg.testitem.chunk_size,
             timeout=cfg.testitem.timeout,
         )

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg
 from .log import logger
 
@@ -90,7 +90,11 @@ TESTITEM_COLUMNS = [
 
 
 def get_assay(
-    chembl_assay_id: str, *, cfg: ApiCfg, timeout: float | None = None
+    chembl_assay_id: str,
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    timeout: float | None = None,
 ) -> pd.DataFrame:
     """Retrieve assay information as a DataFrame.
 
@@ -100,6 +104,8 @@ def get_assay(
         Identifier of the assay to fetch.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     timeout:
         Optional override for the read timeout in seconds.
 
@@ -114,7 +120,7 @@ def get_assay(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/assay/{chembl_assay_id}?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
@@ -128,6 +134,7 @@ def get_assays(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
     require_variant_sequence: bool = False,
@@ -140,6 +147,8 @@ def get_assays(
         Assay identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -168,7 +177,7 @@ def get_assays(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&assay_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
             df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
@@ -192,6 +201,7 @@ def get_activities(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
@@ -203,6 +213,8 @@ def get_activities(
         Activity identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -226,7 +238,7 @@ def get_activities(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&activity_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
@@ -247,6 +259,7 @@ def get_testitem(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
 ) -> pd.DataFrame:
@@ -258,6 +271,8 @@ def get_testitem(
         Molecule identifiers to retrieve.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     chunk_size:
         Maximum number of IDs per HTTP request.
     timeout:
@@ -281,7 +296,7 @@ def get_testitem(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&molecule_chembl_id__in={chunk_key}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
             records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-
+from dataclasses import dataclass, field
 from typing import Any, Iterable, Iterator, cast
-
 
 import random
 import threading
@@ -18,23 +17,9 @@ from .rate_limiter import get_limiter, sleep
 from .log import logger
 
 
-# Cache entries expire after one hour to avoid serving stale data. The TTL can
-# be adjusted in the future via configuration if required.
-_CACHE: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=1024, ttl=3600)
-_CACHE_LOCK = threading.Lock()
-
-
-_session: Session | None = None
-_session_lock = threading.Lock()
-
-
-def init_session(api: ApiCfg, retry: RetryCfg, chembl: ChemblCfg | None = None) -> None:
-    """Initialise the shared HTTP session and cache.
-
-    The provided ``api`` and ``retry`` configurations are forwarded to
-    :func:`session_with_retry`, ensuring that subsequent requests use the
-    correct ``User-Agent`` and retry policy. When ``chembl`` is supplied the
-    cache TTL is taken from ``chembl.cache_ttl``.
+@dataclass
+class ChemblClient:
+    """HTTP client for the ChEMBL API with a TTL cache.
 
     Parameters
     ----------
@@ -43,111 +28,116 @@ def init_session(api: ApiCfg, retry: RetryCfg, chembl: ChemblCfg | None = None) 
     retry:
         Retry configuration applied to all requests.
     chembl:
-        Optional ChEMBL-specific settings controlling cache TTL.
+        Optional ChEMBL-specific configuration controlling cache TTL.
+    session:
+        Optional pre-configured :class:`requests.Session` instance; primarily
+        intended for tests.
     """
 
-    global _session, _CACHE
-    _session = session_with_retry(api, retry)
-    ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
-    _CACHE = TTLCache(maxsize=1024, ttl=ttl)
+    session: Session = field(init=False)
+    cache: TTLCache[str, dict[str, Any]] = field(init=False)
+    _cache_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
+    def __init__(
+        self,
+        api: ApiCfg | None = None,
+        retry: RetryCfg | None = None,
+        chembl: ChemblCfg | None = None,
+        *,
+        session: Session | None = None,
+    ) -> None:
+        api = api or ApiCfg()
+        retry = retry or RetryCfg()
+        self.session = session or session_with_retry(api, retry)
+        ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
+        self.cache = TTLCache(maxsize=1024, ttl=ttl)
+        self._cache_lock = threading.Lock()
 
-def request_json(
-    url: str, *, cfg: ApiCfg, timeout: float | None = None
-) -> dict[str, Any]:
-    """Return JSON content from *url*.
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, Any]:
+        """Return JSON content from ``url``.
 
-    Parameters
-    ----------
-    url:
-        API endpoint to query.
-    cfg:
-        Configuration providing timeout and retry settings.
-    timeout:
-        Optional override for the read timeout in seconds.
+        Parameters
+        ----------
+        url:
+            API endpoint to query.
+        cfg:
+            Configuration providing timeout and retry settings.
+        timeout:
+            Optional override for the read timeout in seconds.
 
-    Returns
-    -------
-    dict[str, Any]
-        Parsed JSON document.
+        Returns
+        -------
+        dict[str, Any]
+            Parsed JSON document.
 
-    Raises
-    ------
-    requests.RequestException
-        If the HTTP request fails.
-    ValueError
-        If the response body is not valid JSON.
+        Raises
+        ------
+        requests.RequestException
+            If the HTTP request fails.
+        ValueError
+            If the response body is not valid JSON.
+        """
 
-    """
-    limiter = get_limiter("chembl", cfg.rps, cfg.burst)
-    read_timeout = timeout if timeout is not None else cfg.timeout_read
-    cache_key = url
-    with _CACHE_LOCK:
-        cached = _CACHE.get(cache_key)
-        if cached is not None:
-            logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
-            return cached
-        logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
+        limiter = get_limiter("chembl", cfg.rps, cfg.burst)
+        read_timeout = timeout if timeout is not None else cfg.timeout_read
+        cache_key = url
+        with self._cache_lock:
+            cached = self.cache.get(cache_key)
+            if cached is not None:
+                logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
+                return cached
+            logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
-    global _session
-    if _session is None:
-        with _session_lock:
-            if _session is None:
-                _session = session_with_retry(ApiCfg(), RetryCfg())
-    session = _session
-    assert session is not None  # noqa: S101 - ensure session exists
+        last_exc: requests.RequestException | ValueError | None = None
 
-    last_exc: requests.RequestException | ValueError | None = None
+        for attempt in range(1, cfg.retries + 1):
+            limiter.acquire()
+            event = "request_start" if attempt == 1 else "request_retry"
+            logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
+            try:
+                with self.session.get(
+                    url, timeout=(cfg.timeout_connect, read_timeout)
+                ) as response:
+                    response.raise_for_status()
+                    data: dict[str, Any] = cast(dict[str, Any], response.json())
+                    logger.info(
+                        "request_ok",
+                        extra={
+                            "stage": "request_ok",
+                            "url": url,
+                            "status": getattr(response, "status_code", None),
+                        },
+                    )
+                    with self._cache_lock:
+                        cached = self.cache.get(cache_key)
+                        if cached is not None:
+                            return cached
+                        self.cache[cache_key] = data
+                        logger.info(
+                            "cache_set", extra={"stage": "cache_set", "url": url}
+                        )
+                        return data
+            except (requests.RequestException, ValueError) as exc:
+                last_exc = exc
+                if attempt >= cfg.retries:
+                    logger.exception(
+                        "request_fail", extra={"stage": "request_fail", "url": url}
+                    )
+                    break
+                delay = cfg.backoff_factor * (2 ** (attempt - 1))
+                delay += random.uniform(0, cfg.backoff_factor)
+                sleep(delay)
 
-    for attempt in range(1, cfg.retries + 1):
-        limiter.acquire()
-        event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt})
-        try:
-            with session.get(
-                url, timeout=(cfg.timeout_connect, read_timeout)
-            ) as response:
-                response.raise_for_status()
-                data: dict[str, Any] = cast(dict[str, Any], response.json())
-                logger.info(
-                    "request_ok",
-                    extra={
-                        "stage": "request_ok",
-                        "url": url,
-                        "status": getattr(response, "status_code", None),
-                    },
-                )
-                with _CACHE_LOCK:
-                    cached = _CACHE.get(cache_key)
-                    if cached is not None:
-                        return cached
-                    _CACHE[cache_key] = data
-                    logger.info("cache_set", extra={"stage": "cache_set", "url": url})
-                    return data
-        except (requests.RequestException, ValueError) as exc:
-            last_exc = exc
-            if attempt >= cfg.retries:
-                logger.exception(
-                    "request_fail", extra={"stage": "request_fail", "url": url}
-                )
-                break
-            # Exponential backoff with jitter to avoid thundering herd problems
-            delay = cfg.backoff_factor * (2 ** (attempt - 1))
-            delay += random.uniform(0, cfg.backoff_factor)
-            sleep(delay)
+        assert last_exc is not None
+        raise last_exc
 
-    assert last_exc is not None
-    raise last_exc
+    def clear_cache(self) -> None:
+        """Remove all entries from the in-memory cache."""
 
-
-def clear_cache() -> None:
-    """Remove all entries from the in-memory cache.
-
-    This helper is primarily intended for tests to avoid interference
-    from previously cached responses.
-    """
-    with _CACHE_LOCK:
-        _CACHE.clear()
+        with self._cache_lock:
+            self.cache.clear()
 
 
 def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
@@ -169,8 +159,8 @@ def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
     ------
     ValueError
         If ``size`` is not a positive integer.
-
     """
+
     if size <= 0:
         raise ValueError("size must be a positive integer")
 
@@ -182,3 +172,6 @@ def _chunked(items: Iterable[str], size: int) -> Iterator[list[str]]:
             chunk = []
     if chunk:
         yield chunk
+
+
+__all__ = ["ChemblClient", "_chunked"]

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -8,7 +8,7 @@ from .log import logger
 
 import pandas as pd
 
-from .chembl_client import _chunked, request_json
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg, UniprotMappingCfg
 from .mapper_library import map_chembl_to_uniprot
 
@@ -146,6 +146,7 @@ def get_target(
     chembl_target_id: str,
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     mapping_cfg: UniprotMappingCfg,
     timeout: float | None = None,
 ) -> dict[str, str]:
@@ -157,6 +158,8 @@ def get_target(
         ChEMBL target identifier (e.g., ``"CHEMBL203"``).
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     mapping_cfg:
         Configuration for the UniProt mapping service.
     timeout:
@@ -167,7 +170,7 @@ def get_target(
     base = cfg.chembl_base.rstrip("/")
     url = f"{base}/target/{chembl_target_id}.json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    data = request_json(url, cfg=cfg, timeout=effective_timeout)
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     target_list = _get_items(data, "target")
     if not target_list:
         return dict(EMPTY_TARGET)
@@ -178,6 +181,7 @@ def get_targets(
     ids: Iterable[str],
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     mapping_cfg: UniprotMappingCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
@@ -190,6 +194,8 @@ def get_targets(
         ChEMBL target identifiers to retrieve.
     cfg:
         API configuration with base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     mapping_cfg:
         Settings for the UniProt mapping service.
     chunk_size:
@@ -206,7 +212,7 @@ def get_targets(
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = request_json(url, cfg=cfg, timeout=effective_timeout)
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("targets") or data.get("target") or []
         records.extend(_parse_target_record(item, mapping_cfg) for item in items)
     if not records:
@@ -219,6 +225,7 @@ def extend_target(
     df: pd.DataFrame,
     *,
     cfg: ApiCfg,
+    client: ChemblClient,
     mapping_cfg: UniprotMappingCfg,
     id_column: str = "target_chembl_id",
 ) -> pd.DataFrame:
@@ -230,6 +237,8 @@ def extend_target(
         DataFrame containing a column with ChEMBL target identifiers.
     cfg:
         API configuration providing base URL and timeouts.
+    client:
+        ChemblClient used for HTTP requests and caching.
     mapping_cfg:
         Settings for the UniProt mapping service.
     id_column:
@@ -239,7 +248,7 @@ def extend_target(
     if id_column not in df.columns:
         raise ValueError(f"missing required column: {id_column}")
     targets = [
-        get_target(i, cfg=cfg, mapping_cfg=mapping_cfg)
+        get_target(i, cfg=cfg, client=client, mapping_cfg=mapping_cfg)
         for i in df[id_column].fillna("")
     ]
     extra = pd.DataFrame(targets)

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -1,34 +1,24 @@
-"""Tests for :mod:`library.chembl_client`."""
-
 from __future__ import annotations
 
+import random
+import time
 from typing import Any
 
-import random
-import requests
-import responses  # type: ignore[import-not-found]
-import time
-
-
 import pytest
-
-
+import requests
+import responses
 from cachetools import TTLCache  # type: ignore[import-untyped]
 
-
-from library import chembl_client
-
-
-from library.chembl_client import clear_cache, init_session, request_json
-from library.config import ApiCfg, ChemblCfg, RetryCfg, session_with_retry
+from library.chembl_client import ChemblClient
+from library.config import ApiCfg, RetryCfg, session_with_retry
 import library.rate_limiter as rl
 
 
 class DummyResponse:
-    def __enter__(self) -> "DummyResponse":
+    def __enter__(self) -> "DummyResponse":  # pragma: no cover - trivial
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no-op
         pass
 
     def raise_for_status(self) -> None:  # pragma: no cover - no error
@@ -52,14 +42,12 @@ class DummySession:
         return DummyResponse()
 
 
-def test_init_session_sets_user_agent(monkeypatch) -> None:
+def test_client_sets_user_agent() -> None:
     """Session should include the configured ``User-Agent`` header."""
-    monkeypatch.setattr("library.chembl_client._session", None)
+
     cfg = ApiCfg(user_agent="test-agent/1.0 (mailto:test@example.org)")
-    init_session(cfg, RetryCfg())
-    session = chembl_client._session
-    assert session is not None
-    assert session.headers.get("User-Agent") == cfg.user_agent
+    client = ChemblClient(cfg, RetryCfg())
+    assert client.session.headers.get("User-Agent") == cfg.user_agent
 
 
 class FakeTime:
@@ -78,20 +66,15 @@ class FakeTime:
 @responses.activate
 def test_request_json_uses_cfg(monkeypatch) -> None:
     session = DummySession(failures=1)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(ApiCfg(), RetryCfg(), session=session)
+    client.clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=2, backoff_factor=0.5)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert session.timeout == (1, 2)
     assert len(session.calls) == 2
@@ -100,15 +83,15 @@ def test_request_json_uses_cfg(monkeypatch) -> None:
 
 def test_request_json_backoff_grows(monkeypatch) -> None:
     session = DummySession(failures=2)
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(ApiCfg(), RetryCfg(), session=session)
+    client.clear_cache()
 
     sleep_times: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda t: sleep_times.append(t))
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
 
     cfg = ApiCfg(timeout_connect=1, timeout_read=2, retries=3, backoff_factor=1)
-    request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     assert sleep_times == [1.0, 2.0]
 
@@ -122,34 +105,28 @@ def test_request_json_reuses_session(monkeypatch) -> None:
     monkeypatch.setattr(
         "library.chembl_client.session_with_retry", fake_session_with_retry
     )
-    init_session(ApiCfg(), RetryCfg())
+    client = ChemblClient(ApiCfg(), RetryCfg())
+    client.clear_cache()
 
-    def fail_session(*args, **kwargs):  # pragma: no cover - ensure no new session
-        raise AssertionError("requests.Session should not be called")
-
-    monkeypatch.setattr(requests, "Session", fail_session)
-    clear_cache()
-
-    request_json("http://example.com/1", cfg=ApiCfg())
-    request_json("http://example.com/2", cfg=ApiCfg())
+    client.request_json("http://example.com/1", cfg=ApiCfg())
+    client.request_json("http://example.com/2", cfg=ApiCfg())
 
     assert dummy.calls == [id(dummy), id(dummy)]
 
 
 @responses.activate
 def test_request_json_cache(monkeypatch) -> None:
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+    client = ChemblClient(ApiCfg(), RetryCfg())
+    client.clear_cache()
     url = "http://example.com/cache"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    request_json(url, cfg=ApiCfg())
-    assert url in chembl_client._CACHE
+    client.request_json(url, cfg=ApiCfg())
+    assert url in client.cache
 
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
-    assert url in chembl_client._CACHE
-
+    assert url in client.cache
     assert len(responses.calls) == 1
 
 
@@ -161,56 +138,46 @@ def test_request_json_cache_ttl_expiration(monkeypatch) -> None:
         maxsize=2, ttl=1, timer=lambda: timer[0]
     )
 
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
+    client = ChemblClient(ApiCfg(), RetryCfg())
+    client.cache = cache
+    client.clear_cache()
+    assert client.cache.ttl == 1
 
-    monkeypatch.setattr("library.chembl_client._session", None)
-    chembl_cfg = ChemblCfg(cache_ttl=1)
-    init_session(ApiCfg(), RetryCfg(), chembl_cfg)
-    assert chembl_client._CACHE.ttl == chembl_cfg.cache_ttl
-    chembl_client._CACHE = TTLCache(
-        maxsize=1024, ttl=chembl_cfg.cache_ttl, timer=lambda: timer[0]
-    )
-    clear_cache()
     url = "http://example.com/ttl"
     responses.add(responses.GET, url, json={"ok": True}, status=200)
 
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
-    # Advance time beyond the TTL to force expiration of the cached entry.
     timer[0] = 2.0
     responses.add(responses.GET, url, json={"ok": True}, status=200)
-    request_json(url, cfg=ApiCfg())
+    client.request_json(url, cfg=ApiCfg())
 
-    # Two HTTP calls should have occurred because the cache entry expired.
     assert len(responses.calls) == 2
 
 
 @responses.activate
 def test_request_json_preserves_original_error_message(monkeypatch) -> None:
-    """Ensure the raised error retains status code and URL."""
-
-    clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
+    client = ChemblClient(ApiCfg(), RetryCfg())
+    client.clear_cache()
     url = "http://example.com/notfound"
     responses.add(responses.GET, url, status=404)
 
     cfg = ApiCfg(retries=1)
     with pytest.raises(requests.HTTPError) as exc_info:
-        request_json(url, cfg=cfg)
+        client.request_json(url, cfg=cfg)
 
     message = str(exc_info.value)
     assert "404" in message
     assert url in message
 
 
-def test_clear_cache(monkeypatch) -> None:
-
+def test_clear_cache() -> None:
     cache: TTLCache[str, dict[str, Any]] = TTLCache(maxsize=2, ttl=100)
-
-    monkeypatch.setattr(chembl_client, "_CACHE", cache)
-    chembl_client._CACHE["x"] = {"ok": True}
-    clear_cache()
-    assert len(chembl_client._CACHE) == 0
+    client = ChemblClient(ApiCfg(), RetryCfg())
+    client.cache = cache
+    client.cache["x"] = {"ok": True}
+    client.clear_cache()
+    assert len(client.cache) == 0
 
 
 def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
@@ -220,14 +187,26 @@ def test_request_json_rate_limiter_blocks(monkeypatch) -> None:
     with rl._limiters_lock:
         rl._limiters.clear()
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    clear_cache()
+    client = ChemblClient(ApiCfg(), RetryCfg(), session=session)
+    client.clear_cache()
     cfg = ApiCfg(rps=1, burst=1)
-    request_json("http://example.com/1", cfg=cfg)
-    request_json("http://example.com/2", cfg=cfg)
+    client.request_json("http://example.com/1", cfg=cfg)
+    client.request_json("http://example.com/2", cfg=cfg)
     assert fake_time.sleeps == [1.0]
     with rl._limiters_lock:
         rl._limiters.clear()
+
+
+@responses.activate
+def test_clients_do_not_share_cache() -> None:
+    url = "http://example.com/data"
+    responses.add(responses.GET, url, json={"ok": 1}, status=200)
+    client1 = ChemblClient(ApiCfg(), RetryCfg())
+    client1.request_json(url, cfg=ApiCfg())
+    responses.add(responses.GET, url, json={"ok": 2}, status=200)
+    client2 = ChemblClient(ApiCfg(), RetryCfg())
+    client2.request_json(url, cfg=ApiCfg())
+    assert len(responses.calls) == 2
 
 
 @responses.activate

--- a/tests/test_chembl_client_threadsafe.py
+++ b/tests/test_chembl_client_threadsafe.py
@@ -7,8 +7,8 @@ from typing import Any
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-from library import chembl_client
-from library.config import ApiCfg
+from library.chembl_client import ChemblClient
+from library.config import ApiCfg, RetryCfg
 
 
 class DummyResponse:
@@ -72,17 +72,17 @@ def test_request_json_threadsafe(monkeypatch) -> None:
     """Concurrent calls should yield the same result as sequential ones."""
 
     session = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", session)
-    chembl_client.clear_cache()
+    client = ChemblClient(ApiCfg(), RetryCfg(), session=session)
+    client.clear_cache()
 
     url = "http://example.com/threadsafe"
     cfg = ApiCfg()
 
     # Sequential calls: only the first should trigger a real request.
-    sequential = [chembl_client.request_json(url, cfg=cfg) for _ in range(5)]
+    sequential = [client.request_json(url, cfg=cfg) for _ in range(5)]
     assert session.calls == 1
 
-    chembl_client.clear_cache()
+    client.clear_cache()
     session.calls = 0
 
     # Parallel calls starting at the same time.
@@ -91,7 +91,7 @@ def test_request_json_threadsafe(monkeypatch) -> None:
 
     def worker() -> None:
         start.wait()
-        results.append(chembl_client.request_json(url, cfg=cfg))
+        results.append(client.request_json(url, cfg=cfg))
 
     threads = [threading.Thread(target=worker) for _ in range(5)]
     for t in threads:
@@ -106,11 +106,8 @@ def test_request_json_threadsafe(monkeypatch) -> None:
 def test_single_session_created(monkeypatch) -> None:
     """Ensure only one HTTP session is initialised across threads."""
 
-    chembl_client.clear_cache()
-    monkeypatch.setattr("library.chembl_client._session", None)
-
-    dummy = ThreadTrackingSession()
     create_calls = 0
+    dummy = ThreadTrackingSession()
 
     def fake_session_with_retry(api: ApiCfg, retry: Any) -> ThreadTrackingSession:
         nonlocal create_calls
@@ -120,9 +117,10 @@ def test_single_session_created(monkeypatch) -> None:
     monkeypatch.setattr(
         "library.chembl_client.session_with_retry", fake_session_with_retry
     )
+    client = ChemblClient(ApiCfg(), RetryCfg())
 
     def worker() -> dict[str, Any]:
-        return chembl_client.request_json("http://example.com", cfg=ApiCfg())
+        return client.request_json("http://example.com", cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
@@ -133,20 +131,19 @@ def test_single_session_created(monkeypatch) -> None:
 
 
 def test_cache_shared_across_threads(monkeypatch) -> None:
-    clear_cache()
-    dummy = DummySession()
-    monkeypatch.setattr("library.chembl_client._session", dummy)
+    client = ChemblClient(ApiCfg(), RetryCfg(), session=DummySession())
+    client.clear_cache()
 
     url = "http://example.com/data"
-    assert request_json(url, cfg=ApiCfg()) == {"ok": True}
-    assert len(dummy.calls) == 1
+    assert client.request_json(url, cfg=ApiCfg()) == {"ok": True}
+    assert len(client.session.calls) == 1  # type: ignore[attr-defined]
 
     def worker() -> dict[str, Any]:
-        return request_json(url, cfg=ApiCfg())
+        return client.request_json(url, cfg=ApiCfg())
 
     with ThreadPoolExecutor(max_workers=5) as pool:
         futures = [pool.submit(worker) for _ in range(5)]
         results = [f.result() for f in futures]
 
     assert all(r == {"ok": True} for r in results)
-    assert len(dummy.calls) == 1
+    assert len(client.session.calls) == 1  # type: ignore[attr-defined]

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -45,8 +45,7 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(gas, "apply_config_overrides", fake_apply)
 
-
-    def fake_get_assays(ids, cfg, chunk_size, timeout):
+    def fake_get_assays(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"assay_chembl_id": data})
@@ -84,8 +83,7 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply_doc)
 
-
-    def fake_get_documents(ids, cfg, chunk_size, timeout):
+    def fake_get_documents(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"document_chembl_id": data})
@@ -123,8 +121,7 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(gtdt, "apply_config_overrides", fake_apply_test)
 
-
-    def fake_get_testitem(ids, cfg, chunk_size, timeout):
+    def fake_get_testitem(ids, cfg, client, chunk_size, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"molecule_chembl_id": data})
@@ -162,7 +159,7 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply_target)
 
-    def fake_get_targets(ids, cfg, mapping_cfg, timeout):
+    def fake_get_targets(ids, cfg, client, mapping_cfg, timeout):
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"target_chembl_id": data})

--- a/tests/test_init_session_retry.py
+++ b/tests/test_init_session_retry.py
@@ -24,31 +24,22 @@ def test_init_session_uses_cfg_retry(
     """Ensure CLI scripts use retry settings from :class:`Config`.
 
     The test verifies that each script passes ``cfg.retry`` to
-    :func:`library.chembl_client.init_session` by monkeypatching the
-    function and capturing the supplied arguments.
+    :class:`library.chembl_client.ChemblClient` by monkeypatching the
+    class and capturing the supplied arguments.
     """
 
     module = import_module(module_name)
     cfg = Config()
     captured: dict[str, object] = {}
 
-    def fake_init(api: object, retry: object, *_args: object) -> None:
-        """Record parameters supplied to :func:`init_session`.
+    class FakeClient:
+        def __init__(
+            self, api: object, retry: object, *_args: object, **_kwargs: object
+        ) -> None:
+            captured["api"] = api
+            captured["retry"] = retry
 
-        Parameters
-        ----------
-        api : object
-            API configuration object.
-        retry : object
-            Retry configuration to apply.
-        *_args : object
-            Additional positional arguments, ignored.
-        """
-
-        captured["api"] = api
-        captured["retry"] = retry
-
-    monkeypatch.setattr(module, "init_session", fake_init)
+    monkeypatch.setattr(module, "ChemblClient", FakeClient)
 
     args = argparse.Namespace(
         input_csv=Path("missing.csv"),


### PR DESCRIPTION
## Summary
- encapsulate session and cache handling in new `ChemblClient` class
- refactor ChEMBL helpers and CLI scripts to use explicit `ChemblClient`
- update tests to use isolated clients and validate caching behaviour

## Testing
- `ruff check library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_testitem_data.py get_target_data.py get_document_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_init_session_retry.py tests/test_cli_timeout_override.py`
- `mypy --ignore-missing-imports library/chembl_client.py library/chembl_assay.py library/chembl_target.py get_activity_data.py get_assay_data.py get_testitem_data.py get_target_data.py get_document_data.py tests/test_chembl_client.py tests/test_chembl_client_threadsafe.py tests/test_init_session_retry.py tests/test_cli_timeout_override.py` *(fails: Library stubs not installed for "requests", "yaml", and others)*
- `pytest` *(fails: multiple test failures including missing fixtures and assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c83930ec8324ab9f4242ba2d65f6