### PR TITLE
docs: add usage sections for document and target scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,44 @@ parsing, validation, aggregation and export of tabular data.
 3. **Run the tests**
 
    ```bash
-   pytest
-    ```
+    pytest
+     ```
 
    The suite exercises the library modules using fixtures from
    ``tests/data``.
+
+## Usage
+
+### scripts/get_document_data.py
+
+Retrieve document metadata for a list of PubMed IDs using the bundled
+sample file:
+
+```bash
+python get_document_data.py pubmed \
+    --input tests/data/pmids.csv \
+    --output out/documents.csv \
+    --limit 5 \
+    --log-level INFO
+```
+
+The ``tests/data/pmids.csv`` file contains a small set of PMIDs for
+experimentation.
+
+### scripts/get_target_data.py
+
+Fetch basic target information from ChEMBL:
+
+```bash
+python get_target_data.py chembl \
+    --input path/to/targets.csv \
+    --output out/targets.csv \
+    --limit 5 \
+    --log-level INFO
+```
+
+Replace ``path/to/targets.csv`` with a CSV containing a ``chembl_id``
+column.
 
 ## Updating Dependencies
 


### PR DESCRIPTION
## Summary
- document how to run `get_document_data.py` with a small PubMed ID sample
- show typical `get_target_data.py` invocation and common CLI flags

## Testing
- `pytest` *(fails: NameError: name 'caplog' is not defined, plus other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cbc44bb0832499f3721f3e1edd0c