### PR TITLE
refactor: clean pubmed imports and add tests

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -11,25 +11,28 @@ import csv
 import json
 import logging
 import sys
-
-from .rate_limiter import RateLimiter, get_limiter, sleep
-
 from datetime import date
-
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
-
-import pandas as pd
-from .rate_limiter import get_limiter, sleep
-
-import requests
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+)
 from xml.etree import ElementTree as ET
 from urllib.parse import quote
 
+import pandas as pd
+import requests
+
 from .log import logger
-
-
-
+from .rate_limiter import get_limiter, sleep
 from .config import (
     Config,
     CrossRefCfg,
@@ -40,6 +43,8 @@ from .config import (
 )
 from .csv_utils import write_csv_deterministic
 
+if TYPE_CHECKING:
+    from .rate_limiter import RateLimiter
 
 
 def read_pmids(path: Union[str, Path], cfg: PubMedCfg | None = None) -> List[str]:
@@ -867,7 +872,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
     delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
 
-
     cfg = Config()
     pubmed_cfg = cfg.pubmed
     semsch_cfg = cfg.semantic_scholar
@@ -893,7 +897,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pmid = pubmed.get("PubMed.PMID", "")
                 semsch = semsch_map.get(pmid, {})
 
-
                 # Still fetching these individually
 
                 openalex = fetch_openalex(
@@ -903,7 +906,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 crossref = fetch_crossref(
                     session, doi, cfg=cfg.crossref, limiter=crossref_limiter
                 )
-
 
                 combined: Dict[str, str] = {}
                 combined.update(pubmed)

--- a/tests/test_pubmed_library.py
+++ b/tests/test_pubmed_library.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import requests
 import pytest
@@ -26,6 +26,75 @@ def test_read_pmids() -> None:
     path = DATA_DIR / "pmids.csv"
     pmids = pl.read_pmids(path)
     assert pmids == ["1", "2"]
+
+
+def test_read_pmids_missing_column(tmp_path: Path) -> None:
+    """Ensure ``read_pmids`` validates presence of the PMID column."""
+    path = tmp_path / "bad.csv"
+    path.write_text("ID\n1\n")
+    with pytest.raises(ValueError, match="PMID"):
+        pl.read_pmids(path)
+
+
+class DummyResponse:
+    def __init__(
+        self, status: int, text: str = "", json_data: Dict[str, Any] | None = None
+    ) -> None:
+        self.status_code = status
+        self._text = text
+        self._json = json_data
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(
+        self, exc_type, exc, tb
+    ) -> None:  # pragma: no cover - no cleanup needed
+        return None
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def json(self) -> Dict[str, Any]:
+        if self._json is None:
+            raise ValueError("no json")
+        return self._json
+
+
+class DummySession:
+    def __init__(self, response: DummyResponse) -> None:
+        self._response = response
+
+    def get(
+        self, url: str, timeout: float | tuple[float, float], **kwargs: Any
+    ) -> DummyResponse:
+        return self._response
+
+    def post(
+        self, url: str, timeout: float | tuple[float, float], **kwargs: Any
+    ) -> DummyResponse:
+        return self._response
+
+
+def test_do_request_success() -> None:
+    """Successful call returns parsed JSON and empty error string."""
+    session = DummySession(DummyResponse(200, text="{}", json_data={"a": 1}))
+    data, err = pl._do_request(
+        cast(requests.Session, session), "http://example.org", delay=0
+    )
+    assert data == {"a": 1}
+    assert err == ""
+
+
+def test_do_request_404() -> None:
+    """404 response is reported as 'PMID not found'."""
+    session = DummySession(DummyResponse(404, text="not found", json_data={}))
+    data, err = pl._do_request(
+        cast(requests.Session, session), "http://example.org", delay=0
+    )
+    assert data is None
+    assert err == "PMID not found"
 
 
 def test_fetch_pubmed_uses_cfg(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- tidy `pubmed_library` imports by removing duplicates and moving `RateLimiter` into a `TYPE_CHECKING` block
- test `_do_request` success and error paths
- validate missing column handling in `read_pmids`

## Testing
- `pre-commit run --files library/pubmed_library.py tests/test_pubmed_library.py` *(fails: AttributeError: 'Namespace' object has no attribute 'input')*


------
https://chatgpt.com/codex/tasks/task_e_68c2cbc1f7908324aad19c789bcc1342