### PR TITLE
Add chunksize parameter to CSV writing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ write_csv_deterministic(df, "out.csv", chunksize=1000)
 Rows are still sorted deterministically before writing; ``chunksize`` only
 affects how data is flushed to disk.
 
+The higher-level wrapper ``library.io.write_csv`` exposes the same
+``chunksize`` argument and additionally writes a metadata sidecar alongside
+the CSV:
+
+```python
+from library import io, Config
+import pandas as pd
+
+cfg = Config()
+df = pd.read_csv("large.csv")
+io.write_csv(df, "out.csv", cfg=cfg, chunksize=1000)
+```
+
+The YAML sidecar records the Git commit and command-line parameters to aid
+reproducibility.
+
 Each command-line tool emits a ``<output>.meta.yaml`` sidecar file alongside
 every CSV. The YAML document records the SHA-256 checksum, command-line
 arguments and timestamps to make results reproducible. The determinism check is

--- a/library/io.py
+++ b/library/io.py
@@ -18,7 +18,6 @@ import yaml
 
 
 import pandas as pd
-import yaml
 from pandera import DataFrameModel, DataFrameSchema
 
 from . import validation
@@ -158,6 +157,7 @@ def write_csv(
     sep: str | None = None,
     encoding: str | None = None,
     key_cols: Iterable[str] | None = None,
+    chunksize: int | None = None,
 ) -> Path:
     """Write ``df`` to ``path`` as CSV and store metadata.
 
@@ -179,6 +179,10 @@ def write_csv(
     key_cols:
         Optional columns to determine row order. When provided, rows are
         sorted by these columns. Otherwise all columns are used.
+    chunksize:
+        Optional number of rows per chunk to stream when writing the CSV.
+        Passed through to :meth:`pandas.DataFrame.to_csv` and
+        :func:`library.csv_utils.write_csv_deterministic`.
 
     Returns
     -------
@@ -191,6 +195,7 @@ def write_csv(
         df,
         path,
         key_cols=list(key_cols) if key_cols is not None else None,
+        chunksize=chunksize,
         sep=sep,
         encoding=encoding,
         cfg=cfg,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -122,7 +122,27 @@ def test_write_csv_normalises_types(tmp_path: Path) -> None:
     cfg = Config()
     io.write_csv(df, path, cfg=cfg, key_cols=["d"])
     text = path.read_text(encoding="utf-8-sig")
-    assert text == ("b,d\n" "false,2020-01-01\n" "true,2020-01-02\n")
+    assert text == ("b,d\nfalse,2020-01-01\ntrue,2020-01-02\n")
+
+
+def test_write_csv_chunksize(tmp_path: Path) -> None:
+    """Chunked writes yield the same output as unchunked writes."""
+
+    rows = 1500
+    df = pd.DataFrame(
+        {
+            "a": range(rows),
+            "b": [i % 2 == 0 for i in range(rows)],
+            "d": pd.date_range("2020-01-01", periods=rows, freq="D"),
+            "f": [i / 3 for i in range(rows)],
+        }
+    )
+    cfg = Config()
+    path1 = tmp_path / "plain.csv"
+    path2 = tmp_path / "chunked.csv"
+    io.write_csv(df, path1, cfg=cfg)
+    io.write_csv(df, path2, cfg=cfg, chunksize=500)
+    assert path1.read_bytes() == path2.read_bytes()
 
 
 def test_git_sha_timeout_returns_unknown(


### PR DESCRIPTION
## Summary
- allow `library.io.write_csv` to stream large outputs via optional `chunksize`
- document `chunksize` usage in README
- test chunked writing produces same output as unchunked

## Testing
- `ruff format --check library/io.py tests/test_io.py`
- `ruff check library/io.py tests/test_io.py`
- `pre-commit run --hook-stage manual mypy --files library/io.py tests/test_io.py`
- `pytest tests/test_io.py -q`
- `pre-commit run --files library/io.py README.md tests/test_io.py` *(fails: FileNotFoundError in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cbc208548324bf0cd7a8ec94a859