### PR TITLE
Add pair entity table generator

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Literal
+from typing import Any, Dict, Iterable, Literal, Mapping
 from .log import logger
 
 import pandas as pd
@@ -772,6 +772,99 @@ def append_entities(df_a: pd.DataFrame, df_b: pd.DataFrame) -> pd.DataFrame:
     """Vertically concatenate ``df_a`` and ``df_b`` and remove duplicates."""
     combined = pd.concat([df_a, df_b], ignore_index=True, sort=False)
     return combined.drop_duplicates(keep="first")
+
+
+def generate_pair_entity_tables(
+    tables: TableDict, pair_keys: Mapping[str, str]
+) -> TableDict:
+    """Generate entity subtables for each pair type.
+
+    For every pair table listed in ``pair_keys`` the function extracts unique
+    activity identifiers, filters the ``activity`` table accordingly and
+    produces corresponding ``assay``, ``document``, ``target`` and ``testitem``
+    subtables. New tables are appended to a copy of ``tables`` using the
+    provided suffixes.
+
+    Args:
+        tables: Mapping of entity names to their dataframes. Must include the
+            ``activity`` table and the pair tables referenced in ``pair_keys``.
+        pair_keys: Mapping of pair table keys to suffixes used for naming the
+            resulting subtables. For example ``{"pairs_independent": "ind"}``
+            would create tables named ``activity_ind``, ``assay_ind`` etc.
+
+    Returns:
+        TableDict: Copy of ``tables`` extended with newly generated entity
+        tables.
+
+    Warns:
+        logger.warning: If required tables or columns are missing. In such
+        cases the corresponding subtables are skipped.
+    """
+
+    result: TableDict = {**tables}
+
+    activity_df = tables.get("activity")
+    if activity_df is None:
+        logger.warning("'activity' table missing; cannot generate pair tables")
+        return result
+    if "activity_chembl_id" not in activity_df.columns:
+        logger.warning("'activity' table missing column 'activity_chembl_id'")
+        return result
+
+    entity_cols: Dict[str, str] = {
+        "assay": "assay_chembl_id",
+        "document": "document_chembl_id",
+        "target": "target_chembl_id",
+        "testitem": "molecule_chembl_id",
+    }
+
+    for pair_key, suffix in pair_keys.items():
+        pairs_df = tables.get(pair_key)
+        if pairs_df is None:
+            logger.warning("pair table '%s' missing", pair_key)
+            continue
+
+        required = {"activity_chembl_id1", "activity_chembl_id2"}
+        missing = required - set(pairs_df.columns)
+        if missing:
+            logger.warning(
+                "pair table '%s' missing columns %s", pair_key, sorted(missing)
+            )
+            continue
+
+        activity_ids = pd.unique(
+            pd.concat(
+                [pairs_df["activity_chembl_id1"], pairs_df["activity_chembl_id2"]],
+                ignore_index=True,
+            ).dropna()
+        )
+
+        filtered_activity = activity_df[
+            activity_df["activity_chembl_id"].isin(activity_ids)
+        ].copy()
+        result[f"activity_{suffix}"] = filtered_activity
+
+        for entity, id_col in entity_cols.items():
+            if id_col not in filtered_activity.columns:
+                logger.warning(
+                    "activity table missing column '%s'; skipping %s_%s",
+                    id_col,
+                    entity,
+                    suffix,
+                )
+                continue
+
+            ids = pd.unique(filtered_activity[id_col].dropna())
+            entity_df = tables.get(entity)
+            if entity_df is None:
+                logger.warning("entity table '%s' missing", entity)
+                continue
+            if id_col not in entity_df.columns:
+                logger.warning("entity table '%s' missing column '%s'", entity, id_col)
+                continue
+            result[f"{entity}_{suffix}"] = entity_df[entity_df[id_col].isin(ids)].copy()
+
+    return result
 
 
 def add_pair_metric_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -10,6 +10,7 @@ from library.input_initialisation_library import (
     _ensure_openpyxl,
     TableDict,
     append_entities,
+    generate_pair_entity_tables,
     build_combined_tables,
     unify_dtypes,
     save_tables,
@@ -43,6 +44,57 @@ def test_append_entities_deduplication() -> None:
     res = append_entities(df_a, df_b)
     assert len(res) == 3
     assert sorted(res["id"].tolist()) == [1, 2, 3]
+
+
+def test_generate_pair_entity_tables_basic() -> None:
+    tables: TableDict = {
+        "activity": pd.DataFrame(
+            {
+                "activity_chembl_id": [1, 2, 3, 4],
+                "assay_chembl_id": ["a1", "a2", "a3", "a4"],
+                "document_chembl_id": ["d1", "d2", "d3", "d4"],
+                "target_chembl_id": ["t1", "t2", "t3", "t4"],
+                "molecule_chembl_id": ["m1", "m2", "m3", "m4"],
+            }
+        ),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2", "a3", "a4"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1", "d2", "d3", "d4"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1", "t2", "t3", "t4"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1", "m2", "m3", "m4"]}),
+        "pairs_independent": pd.DataFrame(
+            {"activity_chembl_id1": [1, 2], "activity_chembl_id2": [3, None]}
+        ),
+    }
+    res = generate_pair_entity_tables(tables, {"pairs_independent": "ind"})
+    assert set(res["activity_ind"]["activity_chembl_id"]) == {1, 2, 3}
+    assert set(res["assay_ind"]["assay_chembl_id"]) == {"a1", "a2", "a3"}
+    assert set(res["document_ind"]["document_chembl_id"]) == {"d1", "d2", "d3"}
+    assert set(res["target_ind"]["target_chembl_id"]) == {"t1", "t2", "t3"}
+    assert set(res["testitem_ind"]["molecule_chembl_id"]) == {"m1", "m2", "m3"}
+
+
+def test_generate_pair_entity_tables_missing_columns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("WARNING")
+    tables: TableDict = {
+        "activity": pd.DataFrame(
+            {
+                "activity_chembl_id": [1],
+                "assay_chembl_id": ["a1"],
+                "document_chembl_id": ["d1"],
+                "target_chembl_id": ["t1"],
+                "molecule_chembl_id": ["m1"],
+            }
+        ),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1"]}),
+        "pairs_bad": pd.DataFrame({"foo": [1]}),
+    }
+    res = generate_pair_entity_tables(tables, {"pairs_bad": "bad"})
+    assert "activity_bad" not in res
 
 
 def test_build_combined_tables_drops_activity_cols() -> None:
@@ -306,14 +358,18 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         lambda df, _api: df.assign(**{"Filtered.init": "good"}),
     )
 
-    def fake_init_pairs(pair_df: pd.DataFrame, *_args, **_kwargs) -> pd.DataFrame:
+    def fake_init_pairs(
+        pair_df: pd.DataFrame, *_args: object, **_kwargs: object
+    ) -> pd.DataFrame:
         return pair_df.assign(Filtered1="good", Filtered2="good", Filtered="good")
 
     monkeypatch.setattr(lib, "initialize_pairs", fake_init_pairs)
 
     captured: list[pd.DataFrame] = []
 
-    def fake_aggregate(pair_df: pd.DataFrame, *_args, **_kwargs):
+    def fake_aggregate(
+        pair_df: pd.DataFrame, *_args: object, **_kwargs: object
+    ) -> dict[str, pd.DataFrame]:
         captured.append(pair_df)
         return {"activity": pd.DataFrame({"id": [1]})}
 


### PR DESCRIPTION
## Summary
- implement `generate_pair_entity_tables` to derive entity tables per pair type with logging
- cover new utility with tests for normal operation and missing columns

## Testing
- `pre-commit run --files library/input_initialisation_library.py tests/test_input_initialisation_library.py` (ruff, pytest skipped)
- `pytest tests/test_input_initialisation_library.py::test_generate_pair_entity_tables_basic tests/test_input_initialisation_library.py::test_generate_pair_entity_tables_missing_columns -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2cf5586348324964a173415c1b3f1