### PR TITLE
Generate pair entity tables

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -58,6 +58,13 @@ python get_input_initialisation.py \
     --out-dir data/output-smoke
 ```
 
+The command writes the merged entity tables along with pair tables
+(`pairs_same_document.csv`, `pairs_independent.csv` and
+`pairs_non_independent.csv`). For each pair segment (``independent``,
+``non_independent`` and ``same_document``) additional status summaries are
+produced for the activity, assay, document, system, testitem and target
+entities, e.g. ``activity_independent_status.csv``.
+
 Each command supports the common flags `--sep`, `--encoding` and
 `--log-level`. The default output path mirrors the input location and can be
 manually overridden with `--output` where available.

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -5,24 +5,31 @@ Exports pair tables without merging:
 - ``pairs_same_document.csv`` from sheet ``pairs_same_doc`` in ``--same-doc``
 - ``pairs_independent.csv`` and ``pairs_non_independent.csv`` derived from
   ``step5_pairs`` in ``--all-doc`` based on the ``INDEPENDENT`` flag
+
+Additionally, the CLI derives per-entity status summaries from the pair tables
+and writes them as ``<entity>_<segment>_status.csv`` where ``<entity>`` is one
+of ``activity``, ``assay``, ``document``, ``system``, ``testitem`` or
+``target`` and ``<segment>`` is ``independent``, ``non_independent`` or
+``same_document``.
 """
 
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
-
-from library.config import Config, ensure_dirs, print_config
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logger,
-    LoggerConfig,
-)
-from library.log import logger
 
 from library import input_initialisation_library as lib
+from library.cli import (
+    LoggerConfig,
+    apply_config_overrides,
+    configure_logger,
+)
+from library.cli import (
+    build_parser as base_parser,
+)
+from library.config import Config, ensure_dirs, print_config
+from library.log import logger
 from library.table_quality import analyze_table_quality
 
 
@@ -61,6 +68,10 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             dictionary_dir=args.dictionary_dir,
             status_csv=cfg.resources.status_csv,
             targets_type_csv=cfg.resources.targets_type_csv,
+        )
+        logger.info("Generating pair entity tables")
+        tables.update(
+            lib.generate_pair_entity_tables(tables, status_csv=cfg.resources.status_csv)
         )
         logger.info("Computing status percentages")
         for key, df in list(tables.items()):
@@ -170,7 +181,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code: int = args.func(cfg, args)
     if exit_code == 0:
         logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
     else:

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -6,16 +6,16 @@ common column types, merge entity tables and persist the final CSV files.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Literal
-from .log import logger
+from typing import Any, Literal
 
 import pandas as pd
 
 from .config import Config
 from .io import write_csv
-
+from .log import logger
 
 EntityName = Literal[
     "activity",
@@ -30,7 +30,7 @@ EntityName = Literal[
 # Mapping of entity names to their corresponding dataframes.  The dictionary
 # may contain additional keys such as ``"activity_status"`` produced during
 # processing, hence the generic ``str`` key type.
-TableDict = Dict[str, pd.DataFrame]
+TableDict = dict[str, pd.DataFrame]
 
 
 # Mapping of sheet names to entity identifiers
@@ -187,8 +187,9 @@ def get_percentage(df: pd.DataFrame, table_name: str) -> pd.DataFrame:
     """
 
     if "Filtered" not in df.columns:
+        cols = ", ".join(df.columns)
         raise KeyError(
-            f"table '{table_name}' missing column 'Filtered'; available: {', '.join(df.columns)}"
+            f"table '{table_name}' missing column 'Filtered'; available: {cols}"
         )
 
     counts = df.groupby("Filtered", dropna=False).size().rename("Count").reset_index()
@@ -267,8 +268,9 @@ def compute_status_statistics(df: pd.DataFrame, table_name: str) -> pd.DataFrame
     """
 
     if "Filtered.new" not in df.columns:
+        cols = ", ".join(df.columns)
         raise KeyError(
-            f"table '{table_name}' missing column 'Filtered.new'; available: {', '.join(df.columns)}"
+            f"table '{table_name}' missing column 'Filtered.new'; available: {cols}"
         )
 
     df_tmp = df.rename(columns={"Filtered.new": "Filtered"}).copy()
@@ -735,9 +737,9 @@ def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
             return pd.NA
         if isinstance(value, str):
             value = value.strip().lower()
-        if value in {True, 1, "1", "true", "t"}:
+        if value in {True, "1", "true", "t"}:
             return True
-        if value in {False, 0, "0", "false", "f"}:
+        if value in {False, "0", "false", "f"}:
             return False
         raise ValueError(f"invalid boolean value: {value}")
 
@@ -971,7 +973,8 @@ def build_combined_tables(
                 combined[pair_key] = df_pair
 
                 logger.warning(
-                    "skip initialize_pairs: table '%s' missing or has no activity_chembl_id1/activity_chembl_id2",
+                    "skip initialize_pairs: table '%s' missing or has no "
+                    "activity_chembl_id1/activity_chembl_id2",
                     pair_key,
                 )
 
@@ -992,7 +995,8 @@ def build_combined_tables(
                 )
             else:
                 logger.warning(
-                    "%s table missing or lacks Filtered columns; skipping status aggregation",
+                    "%s table missing or lacks Filtered columns; "
+                    "skipping status aggregation",
                     pair_key,
                 )
 
@@ -1004,7 +1008,7 @@ def save_tables(
     out_dir: Path,
     cfg: Config,
     fmt: str = "csv",
-) -> Dict[str, Path]:
+) -> dict[str, Path]:
     """Persist combined tables to ``out_dir``.
 
     Parameters
@@ -1026,7 +1030,7 @@ def save_tables(
     if fmt != "csv":
         raise ValueError("only csv output is supported")
 
-    paths: Dict[str, Path] = {}
+    paths: dict[str, Path] = {}
     for entity, df in tables.items():
         # Determine subdirectory based on table type.
         if entity.endswith("_non_independent_status"):
@@ -1074,8 +1078,8 @@ class StatusAPI:
     table: pd.DataFrame
     status_list: list[str]
     conditions: list[str]
-    order_map: Dict[str, int]
-    score_map: Dict[str, int]
+    order_map: dict[str, int]
+    score_map: dict[str, int]
 
     def pair(self, s1: str, s2: str) -> str:
         """Return the lower-ranked status between ``s1`` and ``s2``.
@@ -1360,8 +1364,8 @@ def build_status_helpers(status_df: pd.DataFrame) -> StatusAPI:
         .unique()
         .tolist()
     )
-    order_map = dict(zip(status_df["status"], status_df["order"]))
-    score_map = dict(zip(status_df["status"], status_df["score"]))
+    order_map = dict(zip(status_df["status"], status_df["order"], strict=False))
+    score_map = dict(zip(status_df["status"], status_df["score"], strict=False))
     return StatusAPI(status_df, status_list, conditions, order_map, score_map)
 
 
@@ -1390,7 +1394,13 @@ def initialize_activity_status(
 
     # Map condition fields to their corresponding status and order
     cond_rows = status_api.table[status_api.table["condition_value"] != "null"]
-    field_to_status = dict(zip(cond_rows["condition_field"], cond_rows["status"]))
+    field_to_status = dict(
+        zip(
+            cond_rows["condition_field"],
+            cond_rows["status"],
+            strict=False,
+        )
+    )
     order_to_status = {v: k for k, v in status_api.order_map.items()}
     default_order = status_api.order_map[status_api.status_list[-1]]
 
@@ -1417,8 +1427,9 @@ def normalize_pair_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Standardize activity ID column names in pair tables.
 
     The Excel sources occasionally vary in the casing or use of underscores
-    for ``activity_chembl_id1`` and ``activity_chembl_id2``.  This helper normalises these
-    column names so downstream processing can rely on a consistent schema.
+    for ``activity_chembl_id1`` and ``activity_chembl_id2``. This helper
+    normalises these column names so downstream processing can rely on a
+    consistent schema.
 
     Parameters
     ----------
@@ -1491,7 +1502,7 @@ def _aggregate_entity(
 
 def aggregate_activity(
     pair_df: pd.DataFrame, activity_df: pd.DataFrame, status_api: StatusAPI
-) -> Dict[str, pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """Aggregate status metrics across entities.
 
     The function combines activity pair information with per-activity
@@ -1604,3 +1615,57 @@ def aggregate_activity(
         "testitem": testitem_status,
         "target": target_status,
     }
+
+
+def generate_pair_entity_tables(
+    tables: TableDict, *, status_csv: Path | None = None
+) -> TableDict:
+    """Create entity-level summaries from pair tables.
+
+    Parameters
+    ----------
+    tables:
+        Mapping containing at least the activity table and pair variants.
+    status_csv:
+        Optional path to ``status.csv`` describing status ordering. If missing
+        or the file does not exist, no tables are generated.
+
+    Returns
+    -------
+    TableDict
+        New entity status tables keyed as ``<entity>_<segment>_status`` where
+        ``<segment>`` is one of ``independent``, ``non_independent`` or
+        ``same_document``.
+    """
+
+    if status_csv is None or not Path(status_csv).exists():
+        logger.warning("status CSV %s missing; skipping pair entity tables", status_csv)
+        return {}
+
+    activity = tables.get("activity")
+    if activity is None:
+        logger.warning("activity table missing; skipping pair entity tables")
+        return {}
+
+    status_df = load_status_table(status_csv)
+    status_api = build_status_helpers(status_df)
+
+    result: TableDict = {}
+    for suffix, pair_key in [
+        ("independent", "pairs_independent"),
+        ("non_independent", "pairs_non_independent"),
+        ("same_document", "pairs_same_document"),
+    ]:
+        pair_table = tables.get(pair_key)
+        if pair_table is None or not {"Filtered1", "Filtered2"}.issubset(
+            pair_table.columns
+        ):
+            logger.warning(
+                "pair table '%s' missing or lacks Filtered columns; skipping",
+                pair_key,
+            )
+            continue
+        aggregates = aggregate_activity(pair_table, activity, status_api)
+        result.update({f"{k}_{suffix}_status": v for k, v in aggregates.items()})
+
+    return result

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
-import pandas as pd
 import sys
 from pathlib import Path
+from typing import Any
 
+import pandas as pd
 import pytest
 
-from library.input_initialisation_library import (
-    _ensure_openpyxl,
-    TableDict,
-    append_entities,
-    build_combined_tables,
-    unify_dtypes,
-    save_tables,
-    process_activity_table,
-)
 import library.input_initialisation_library as lib
 from library.config import Config
+from library.input_initialisation_library import (
+    TableDict,
+    _ensure_openpyxl,
+    append_entities,
+    build_combined_tables,
+    process_activity_table,
+    save_tables,
+    unify_dtypes,
+)
 
 
 def test_unify_dtypes_basic() -> None:
@@ -306,14 +307,18 @@ def test_build_combined_tables_aggregates_all_pair_segments(
         lambda df, _api: df.assign(**{"Filtered.init": "good"}),
     )
 
-    def fake_init_pairs(pair_df: pd.DataFrame, *_args, **_kwargs) -> pd.DataFrame:
+    def fake_init_pairs(
+        pair_df: pd.DataFrame, *_args: Any, **_kwargs: Any
+    ) -> pd.DataFrame:
         return pair_df.assign(Filtered1="good", Filtered2="good", Filtered="good")
 
     monkeypatch.setattr(lib, "initialize_pairs", fake_init_pairs)
 
     captured: list[pd.DataFrame] = []
 
-    def fake_aggregate(pair_df: pd.DataFrame, *_args, **_kwargs):
+    def fake_aggregate(
+        pair_df: pd.DataFrame, *_args: Any, **_kwargs: Any
+    ) -> dict[str, pd.DataFrame]:
         captured.append(pair_df)
         return {"activity": pd.DataFrame({"id": [1]})}
 
@@ -453,7 +458,8 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
         "N,K_min_significant,test_used_at_threshold,p_value_at_threshold\n2,1,x,0.05\n"
     )
     (tmp_path / "targets_type.csv").write_text(
-        "chembl_id,type,IUPHAR_class,IUPHAR_subclass\nT1,Unicellular organism,ClassA,Multifunctional\n"
+        "chembl_id,type,IUPHAR_class,IUPHAR_subclass\n"
+        "T1,Unicellular organism,ClassA,Multifunctional\n"
     )
 
     res = process_activity_table(df, tmp_path)
@@ -580,3 +586,44 @@ def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
     res = process_activity_table(df, tmp_path)
     assert "unicellular_organism" in res.columns
     assert res.loc[0, "unicellular_organism"]
+
+
+def test_generate_pair_entity_tables_basic(tmp_path: Path) -> None:
+    status_csv = tmp_path / "status.csv"
+    status_csv.write_text(
+        "status,condition_field,condition_value,order,score\nok,null,null,0,0\n"
+    )
+
+    activity = pd.DataFrame(
+        {
+            "activity_id": [1, 2],
+            "assay_id": [10, 20],
+            "document_id": [100, 200],
+            "testitem_id": [1000, 2000],
+            "target_id": [10000, 20000],
+            "standard_type": ["IC50", "IC50"],
+            "Filtered.init": ["ok", "ok"],
+        }
+    )
+    pair_df = pd.DataFrame(
+        {
+            "activity_chembl_id1": [1],
+            "activity_chembl_id2": [2],
+            "Filtered1": ["ok"],
+            "Filtered2": ["ok"],
+            "independent_IC50": [1],
+            "non_independent_IC50": [0],
+            "independent_Ki": [0],
+            "non_independent_Ki": [0],
+        }
+    )
+    tables: TableDict = {
+        "activity": activity,
+        "pairs_independent": pair_df,
+        "pairs_non_independent": pair_df.iloc[0:0],
+        "pairs_same_document": pair_df.iloc[0:0],
+    }
+
+    res = lib.generate_pair_entity_tables(tables, status_csv=status_csv)
+    assert "activity_independent_status" in res
+    assert res["activity_independent_status"].loc[0, "Filtered.new"] == "ok"


### PR DESCRIPTION
## Summary
- derive per-entity status tables from pair data with new `generate_pair_entity_tables`
- invoke pair table generation in `get_input_initialisation.py` and document new outputs
- describe additional outputs in the CLI usage docs and test pair table generation

## Testing
- `black get_input_initialisation.py library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check get_input_initialisation.py library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy get_input_initialisation.py library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `pytest` *(fails: NameError: name 'caplog' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cf657a6083248efa07b4eecd262b