### PR TITLE
refactor: use collections.abc for generic types

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 import pandas as pd
 

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from itertools import islice
 
 
@@ -70,7 +70,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-
     # Apply the ``limit`` without materialising the entire iterator first.
     # ``itertools.islice`` allows lazy slicing; converting to ``list`` enables
     # length calculation for logging purposes.
@@ -79,7 +78,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         limited = list(islice(ids_iter, limit))
         ids = limited
         logger.info("processing at most %d identifiers", len(limited))
-
 
     try:
         df = cl.get_activities(

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 import requests
 from library.config import Config, ensure_dirs, print_config, _serialize_paths

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 import pandas as pd
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -7,7 +7,7 @@ scoring logic.
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 import pandas as pd
 from library.config import Config, ensure_dirs, print_config

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 from library.config import Config, ensure_dirs, print_config
 from library.cli import (

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -13,7 +13,7 @@ import argparse
 import csv
 import sys
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 import pandas as pd
 import requests

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 import pandas as pd
 import requests

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 import pandas as pd
 

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Iterator, cast
+from collections.abc import Iterable
+from typing import Any, Iterator, cast
 
 import random
 import threading

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from .log import logger
 

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 import pandas as pd
 import yaml

--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -8,7 +8,7 @@ translation of a Power Query script into ``pandas`` operations.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 import pandas as pd
 

--- a/library/document_type_classifier.py
+++ b/library/document_type_classifier.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Dict
 
 from .document_type_terms import REVIEW_TERMS, EXPERIMENTAL_TERMS, UNKNOWN_TERMS
 

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Literal, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Any, Dict, Literal
 from .log import logger
 
 import pandas as pd

--- a/library/io.py
+++ b/library/io.py
@@ -11,7 +11,8 @@ import csv
 from datetime import datetime
 from pathlib import Path
 
-from typing import Any, Hashable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Hashable, Iterator
 import subprocess
 import sys
 import yaml

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
+from typing import List, Optional
 
 import io
 from .log import logger

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -14,7 +14,8 @@ import platform
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Mapping, TypedDict
+from collections.abc import Mapping
+from typing import Any, Dict, TypedDict
 
 import yaml
 

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -13,14 +13,13 @@ import logging
 import sys
 from datetime import date
 from pathlib import Path
+from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     Callable,
     Dict,
-    Iterable,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
     TYPE_CHECKING,

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -7,7 +7,7 @@ merged target information produced by :mod:`get_target_data`.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 import pandas as pd
 

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -38,7 +38,8 @@ import csv
 import json
 from .log import logger
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Set
+from collections.abc import Iterable
+from typing import Any, Dict, List, Set
 
 import requests
 from requests import Session

--- a/library/validation.py
+++ b/library/validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 import pandas as pd
 import pandas.api.types as ptypes

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from typing import Sequence
+from collections.abc import Sequence
 from urllib.error import URLError
 
 import pandas as pd

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 import pandas as pd
 from library.config import Config, ensure_dirs, print_config


### PR DESCRIPTION
## Summary
- import `Sequence`, `Iterable`, and `Mapping` from `collections.abc` instead of `typing`
- keep other typing imports unchanged

## Testing
- `ruff format csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/chembl_assay.py library/chembl_client.py library/chembl_target.py library/csv_utils.py library/document_postprocessing.py library/document_type_classifier.py library/input_initialisation_library.py library/io.py library/iuphar_library.py library/metadata.py library/pubmed_library.py library/target_postprocessing.py library/uniprot_library.py library/validation.py mapper_main.py table_quality_main.py`
- `ruff check csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/chembl_assay.py library/chembl_client.py library/chembl_target.py library/csv_utils.py library/document_postprocessing.py library/document_type_classifier.py library/input_initialisation_library.py library/io.py library/iuphar_library.py library/metadata.py library/pubmed_library.py library/target_postprocessing.py library/uniprot_library.py library/validation.py mapper_main.py table_quality_main.py | tail -n 20`
- `mypy csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/chembl_assay.py library/chembl_client.py library/chembl_target.py library/csv_utils.py library/document_postprocessing.py library/document_type_classifier.py library/input_initialisation_library.py library/io.py library/iuphar_library.py library/metadata.py library/pubmed_library.py library/target_postprocessing.py library/uniprot_library.py library/validation.py mapper_main.py table_quality_main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2d220f4dc832494f74e2233670695