### PR TITLE
Expand pair entity tables in input initialization CLI

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -58,6 +58,13 @@ python get_input_initialisation.py \
     --out-dir data/output-smoke
 ```
 
+The command emits three pair tables:
+`pairs_same_document.csv`, `pairs_independent.csv` and
+`pairs_non_independent.csv`.  For each of these segments filtered
+`activity`, `assay`, `document`, `target` and `testitem` tables are also
+written with matching suffixes, for example
+`activity_independent.csv` or `assay_same_document.csv`.
+
 Each command supports the common flags `--sep`, `--encoding` and
 `--log-level`. The default output path mirrors the input location and can be
 manually overridden with `--output` where available.

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -4,25 +4,31 @@ Exports pair tables without merging:
 
 - ``pairs_same_document.csv`` from sheet ``pairs_same_doc`` in ``--same-doc``
 - ``pairs_independent.csv`` and ``pairs_non_independent.csv`` derived from
-  ``step5_pairs`` in ``--all-doc`` based on the ``INDEPENDENT`` flag
+  ``step5_pairs`` in ``--all-doc`` based on the ``INDEPENDENT`` flag.
+
+Additionally, for each pair table the corresponding ``activity``, ``assay``,
+``document``, ``target`` and ``testitem`` entries are exported with matching
+suffixes, for example ``activity_independent.csv`` or
+``assay_same_document.csv``.
 """
 
 from __future__ import annotations
 
 import argparse
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
-
-from library.config import Config, ensure_dirs, print_config
-from library.cli import (
-    apply_config_overrides,
-    build_parser as base_parser,
-    configure_logger,
-    LoggerConfig,
-)
-from library.log import logger
 
 from library import input_initialisation_library as lib
+from library.cli import (
+    LoggerConfig,
+    apply_config_overrides,
+    configure_logger,
+)
+from library.cli import (
+    build_parser as base_parser,
+)
+from library.config import Config, ensure_dirs, print_config
+from library.log import logger
 from library.table_quality import analyze_table_quality
 
 
@@ -61,6 +67,15 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             dictionary_dir=args.dictionary_dir,
             status_csv=cfg.resources.status_csv,
             targets_type_csv=cfg.resources.targets_type_csv,
+        )
+        logger.info("Generating entity tables for pair segments")
+        tables = lib.generate_pair_entity_tables(
+            tables,
+            {
+                "pairs_independent": "independent",
+                "pairs_non_independent": "non_independent",
+                "pairs_same_document": "same_document",
+            },
         )
         logger.info("Computing status percentages")
         for key, df in list(tables.items()):
@@ -170,7 +185,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code = int(args.func(cfg, args))
     if exit_code == 0:
         logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
     else:


### PR DESCRIPTION
## Summary
- export filtered activity, assay, document, target and testitem tables for each pair segment
- document new pair entity outputs in CLI usage guide

## Testing
- `black get_input_initialisation.py`
- `ruff check get_input_initialisation.py`
- `mypy get_input_initialisation.py`
- `pytest tests/test_get_input_initialisation.py`
- `pytest` *(fails: missing data and configuration for broader suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d286e7388324bcae9a9c3c1e08ad