### PR TITLE
Handle zip strict incompatibility in input initialization

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1478,8 +1478,14 @@ def build_status_helpers(status_df: pd.DataFrame) -> StatusAPI:
         .unique()
         .tolist()
     )
-    order_map = dict(zip(status_df["status"], status_df["order"], strict=False))
-    score_map = dict(zip(status_df["status"], status_df["score"], strict=False))
+    if len(status_df["status"]) != len(status_df["order"]):
+        msg = "status and order columns have different lengths"
+        raise ValueError(msg)
+    order_map = dict(zip(status_df["status"], status_df["order"]))  # noqa: B905
+    if len(status_df["status"]) != len(status_df["score"]):
+        msg = "status and score columns have different lengths"
+        raise ValueError(msg)
+    score_map = dict(zip(status_df["status"], status_df["score"]))  # noqa: B905
     return StatusAPI(status_df, status_list, conditions, order_map, score_map)
 
 
@@ -1508,8 +1514,11 @@ def initialize_activity_status(
 
     # Map condition fields to their corresponding status and order
     cond_rows = status_api.table[status_api.table["condition_value"] != "null"]
+    if len(cond_rows["condition_field"]) != len(cond_rows["status"]):
+        msg = "condition_field and status columns have different lengths"
+        raise ValueError(msg)
     field_to_status = dict(
-        zip(cond_rows["condition_field"], cond_rows["status"], strict=False)
+        zip(cond_rows["condition_field"], cond_rows["status"])  # noqa: B905
     )
     order_to_status = {v: k for k, v in status_api.order_map.items()}
     default_order = status_api.order_map[status_api.status_list[-1]]


### PR DESCRIPTION
## Summary
- replace `zip(strict=...)` calls with explicit length checks and standard `zip` for broader Python compatibility
- validate column lengths before zipping condition fields and statuses

## Testing
- `black library/input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py --select B905`
- `mypy library/input_initialisation_library.py`
- `pytest` *(fails: 23 failed, 192 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d3db889c8324afab2f01fbe21e1c