### PR TITLE
Apply Ruff formatting and resolve lint warnings

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -4,28 +4,23 @@ from __future__ import annotations
 
 import argparse
 import sys
-
 from collections.abc import Iterable, Sequence
 from itertools import islice
 
 import requests
-
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
 from library import io, write_csv_deterministic
-
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-
 from library.cli import (
     build_parser as base_parser,
 )
-
 from library.config import Config, _serialize_paths, ensure_dirs, print_config
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -86,7 +86,9 @@ def _normalise_dates(series: pd.Series) -> pd.Series:
 
     if (
         ptypes.is_object_dtype(series)
-        and series.dropna().map(lambda x: isinstance(x, (date, datetime))).all()
+        # Validate that all non-null entries are dates or datetimes.
+        # `isinstance(x, date | datetime)` leverages the PEP 604 union syntax.
+        and series.dropna().map(lambda x: isinstance(x, date | datetime)).all()
     ):
         return pd.to_datetime(series).dt.strftime("%Y-%m-%d")
 

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -6,16 +6,10 @@ common column types, merge entity tables and persist the final CSV files.
 
 from __future__ import annotations
 
-
-
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-
-from typing import Any, Dict, Iterable, Literal, Mapping
-from .log import logger
-
-
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -748,7 +742,6 @@ def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
         if value in (True, 1, "1", "true", "t"):
             return True
         if value in (False, 0, "0", "false", "f"):
-
             return False
         raise ValueError(f"invalid boolean value: {value}")
 

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -11,11 +11,9 @@ from __future__ import annotations
 
 import threading
 import time
-
 from typing import cast
 
 from cachetools import TTLCache  # type: ignore[import-untyped]
-
 
 
 class RateLimiter:
@@ -52,7 +50,6 @@ class RateLimiter:
                 self._tokens = min(float(self.burst), self._tokens + elapsed * self.rps)
             self._tokens -= 1
             self._updated = now
-
 
 
 _limiters: TTLCache[str, RateLimiter] = TTLCache(maxsize=128, ttl=600)

--- a/tests/test_activity_cli_limit.py
+++ b/tests/test_activity_cli_limit.py
@@ -1,5 +1,6 @@
-import get_activity_data as gad
 import pytest
+
+import get_activity_data as gad
 
 
 def test_negative_limit_rejected(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -13,9 +13,7 @@ from library.input_initialisation_library import (
     _ensure_openpyxl,
     append_entities,
     build_combined_tables,
-
     generate_pair_entity_tables,
-
     process_activity_table,
     save_tables,
     unify_dtypes,


### PR DESCRIPTION
## Summary
- Format codebase with `ruff format`
- Fix import ordering and typing warnings
- Replace tuple-based `isinstance` check with PEP 604 union syntax

## Testing
- `ruff format --check`
- `ruff check`
- `pytest` *(fails: TypeError in run_chembl tests; AttributeError in pubmed library; 12 other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d68ba55c8324b2d6335f25b59c30