### PR TITLE
Fix datetime UTC import for cross-version support

### DIFF
--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -17,8 +17,12 @@ import traceback
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import IO, Any
+
+# ``datetime.UTC`` was introduced in Python 3.11.
+# Use ``timezone.utc`` for compatibility with earlier versions.
+UTC = timezone.utc  # noqa: UP017
 
 _SECRET_SUFFIXES: tuple[str, ...] = ("token", "key", "secret", "password")
 _LEVELS = {

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -12,7 +12,7 @@ import hashlib
 import platform
 import subprocess
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -20,6 +20,10 @@ import yaml
 
 from .config import _mask_secrets
 from .log import logger
+
+# ``datetime.UTC`` is only available in Python 3.11 and later.
+# ``timezone.utc`` provides the same value and works on older versions.
+UTC = timezone.utc  # noqa: UP017
 
 
 class Stats(TypedDict):


### PR DESCRIPTION
## Summary
- replace `datetime.UTC` imports with `timezone.utc` for older Python compatibility

## Testing
- `python -m black library/logging_setup.py library/metadata.py`
- `python -m ruff check library/logging_setup.py library/metadata.py`
- `python -m mypy library/logging_setup.py library/metadata.py`
- `pytest tests/test_logging_setup.py tests/test_metadata.py`
- `pytest` *(fails: 15 failed, 203 passed, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d6fa8ab08324ba9b1d8bb9a83438