### PR TITLE
chore: tighten typings for API utilities

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -87,7 +87,7 @@ class ChemblClient:
             cached = self.cache.get(cache_key)
             if cached is not None:
                 logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
-                return cached
+                return cast(dict[str, Any], cached)
             logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
         last_exc: requests.RequestException | ValueError | None = None
@@ -113,7 +113,7 @@ class ChemblClient:
                     with self._cache_lock:
                         cached = self.cache.get(cache_key)
                         if cached is not None:
-                            return cached
+                            return cast(dict[str, Any], cached)
                         self.cache[cache_key] = data
                         logger.info(
                             "cache_set", extra={"stage": "cache_set", "url": url}

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -20,6 +20,7 @@ import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 from urllib.parse import quote
 
 import pandas as pd
@@ -148,7 +149,9 @@ def load_families(path: str | Path, *, encoding: str = "utf-8") -> pd.DataFrame:
     return df
 
 
-def _query_gene_symbol(gene_name: str, cfg: IupharCfg, retry: RetryCfg) -> dict:
+def _query_gene_symbol(
+    gene_name: str, cfg: IupharCfg, retry: RetryCfg
+) -> dict[str, Any]:
     """Return the first IUPHAR result for *gene_name*.
 
     Parameters
@@ -177,7 +180,7 @@ def _query_gene_symbol(gene_name: str, cfg: IupharCfg, retry: RetryCfg) -> dict:
             with _session_lock:
                 with _session.get(url, timeout=timeout) as response:
                     response.raise_for_status()
-                    data = response.json()
+                    data = cast(list[dict[str, Any]], response.json())
                     return data[0] if data else {}
         except requests.RequestException as exc:  # pragma: no cover - network errors
             if attempt >= retry.max_attempts:
@@ -596,7 +599,7 @@ class IUPHARData:
 
     def websearch_gene_to_id(
         self, gene_name: str, cfg: IupharCfg, retry: RetryCfg | None = None
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Query the IUPHAR web API for ``gene_name``.
 
         Parameters

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -127,4 +127,4 @@ def map_chembl_to_uniprot(
     if not accession:
         raise ValueError("Unexpected response format from UniProt ID mapping API")
 
-    return accession
+    return str(accession)

--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -12,13 +12,14 @@ import requests
 
 from . import pubmed_library as _pl
 from .log import logger
+from .pubmed_library import CrossRefCfg, OpenAlexCfg  # type: ignore[attr-defined]
 from .rate_limiter import RateLimiter
 
 
 def fetch_openalex(
     session: requests.Session,
     pmid: str,
-    cfg: _pl.OpenAlexCfg,
+    cfg: OpenAlexCfg,
     limiter: RateLimiter | None = None,
 ) -> dict[str, str]:
     """Return OpenAlex metadata for ``pmid``.
@@ -62,7 +63,7 @@ def fetch_openalex(
 def fetch_crossref(
     session: requests.Session,
     doi: str,
-    cfg: _pl.CrossRefCfg,
+    cfg: CrossRefCfg,
     limiter: RateLimiter | None = None,
 ) -> dict[str, str]:
     """Return CrossRef metadata for ``doi``.

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -7,7 +7,7 @@ The implementation is a Python translation of a PowerQuery script.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 import requests
@@ -147,7 +147,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     """Make an HTTP GET request and return parsed JSON."""
     if url in _CACHE:
         logger.info("cache_hit", extra={"stage": "cache_hit", "url": url})
-        return _CACHE[url]
+        return cast(dict[str, Any], _CACHE[url])
     logger.info("cache_miss", extra={"stage": "cache_miss", "url": url})
 
     for attempt in range(1, cfg.retries + 1):
@@ -178,7 +178,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             return None
         try:
             response.raise_for_status()
-            data = response.json()
+            data = cast(dict[str, Any], response.json())
         except requests.RequestException as exc:  # pragma: no cover - network
             if attempt >= cfg.retries:
                 logger.error("HTTP request failed for url %s: %s", url, exc)
@@ -325,7 +325,7 @@ def get_standard_name(cid: str, cfg: PubChemCfg) -> str | None:
     info = response.get("InformationList", {}).get("Information", [])
     if not info:
         return None
-    return info[0].get("Title")
+    return cast(str | None, info[0].get("Title"))
 
 
 @dataclass

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -38,7 +38,7 @@ import csv
 import json
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import requests
 from requests import Session
@@ -116,7 +116,7 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
         with _session.get(url, timeout=timeout) as resp:
             resp.raise_for_status()
             try:
-                return resp.json()
+                return cast(dict[str, Any], resp.json())
             except json.JSONDecodeError as exc:  # pragma: no cover - malformed JSON
                 raise UniProtFetchError(
                     f"Failed to decode JSON for UniProt {uniprot_id}: {exc}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
   "pre-commit==4.3.0",
   "pandas-stubs==2.3.2.250827",
   "types-requests==2.32.4.20250809",
+  "types-python-dateutil",
   "types-PyYAML==6.0.12.20250822",
   "types-jsonschema==4.25.1.20250822",
   "pytest==8.4.2",

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pandera import Check, Column, DataFrameSchema
 
 # Definition of the schema describing the activities table.
-ActivitiesSchema: DataFrameSchema = DataFrameSchema(
+ActivitiesSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
     {
         "activity_id": Column(int, Check.ge(0), required=True),
         "testitem_id": Column(str, required=True),

--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pandera import Check, Column, DataFrameSchema
 
-AssaysSchema: DataFrameSchema = DataFrameSchema(
+AssaysSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
     {
         "assay_chembl_id": Column(str, required=True),
         "document_chembl_id": Column(str, required=True),

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pandera import Check, Column, DataFrameSchema
 
-DocumentsSchema: DataFrameSchema = DataFrameSchema(
+DocumentsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
     {
         "document_chembl_id": Column(str, required=True),
         "doi": Column(str, required=False),

--- a/schemas/targets.py
+++ b/schemas/targets.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pandera import Check, Column, DataFrameSchema
 
-TargetsSchema: DataFrameSchema = DataFrameSchema(
+TargetsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
     {
         "target_chembl_id": Column(str, required=True),
         "organism": Column(str, required=True),

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pandera import Check, Column, DataFrameSchema
 
-TestitemsSchema: DataFrameSchema = DataFrameSchema(
+TestitemsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
     {
         "salt_chembl_id": Column(str, required=True),
         "molecule_chembl_id": Column(str, required=True),


### PR DESCRIPTION
## Summary
- add `types-python-dateutil` dev dependency
- cast JSON responses and dictionaries to satisfy strict mypy
- annotate IUPHAR helpers and support OpenAlex/CrossRef configs

## Testing
- `ruff check library/uniprot_library.py library/pubchem_library.py library/mapper_library.py library/chembl_client.py library/iuphar_library.py library/openalex_crossref_library.py schemas/testitems.py schemas/targets.py schemas/documents.py schemas/assays.py schemas/activities.py`
- `mypy --strict library`
- `pytest -q` *(fails: TypeError: _run.<locals>.fake_get() got an unexpected keyword argument 'client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d67137bc8324920fb5b826054b10