### PR TITLE
refactor: import Iterable and Mapping from collections.abc

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -6,16 +6,10 @@ common column types, merge entity tables and persist the final CSV files.
 
 from __future__ import annotations
 
-
-
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-
-from typing import Any, Dict, Iterable, Literal, Mapping
-from .log import logger
-
-
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -748,7 +742,6 @@ def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
         if value in (True, 1, "1", "true", "t"):
             return True
         if value in (False, 0, "0", "false", "f"):
-
             return False
         raise ValueError(f"invalid boolean value: {value}")
 


### PR DESCRIPTION
## Summary
- replace typing imports for `Iterable` and `Mapping` with `collections.abc` in input initialisation utilities
- drop unused `Dict` typing and deduplicate logger imports

## Testing
- `ruff format library/input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest` *(fails: TypeError: _run.<locals>.fake_get() got an unexpected keyword argument 'client', AssertionError: assert {'call': 1} == {'ok': True}, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d682eb2483249dfc8baf965263ad