### PR TITLE
Ensure batch pause is float

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,7 +180,7 @@ jobs:
 
 batch:
   size: 1000  # Number of rows per batch (env: CHEMBL_DA__BATCH__SIZE)
-  pause: 0  # Delay between batches in seconds (env: CHEMBL_DA__BATCH__PAUSE)
+  pause: 0.0  # Delay between batches in seconds (env: CHEMBL_DA__BATCH__PAUSE)
   concurrency: 2  # Number of concurrent batch workers (env: CHEMBL_DA__BATCH__CONCURRENCY)
   fail_fast: true  # Abort on first error (env: CHEMBL_DA__BATCH__FAIL_FAST)
   retry_failed: true  # Retry failed batches (env: CHEMBL_DA__BATCH__RETRY_FAILED)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -248,6 +248,14 @@ def test_config_type_coercion() -> None:
     path = Path(__file__).resolve().parents[1] / "config.yaml"
     cfg = load_config(path, strict=True)
     assert isinstance(cfg.pubchem.delay, float)
+    assert isinstance(cfg.batch.pause, float)
+
+
+def test_batch_pause_negative_value(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("batch:\n  pause: -1.0\n")
+    with pytest.raises(ValidationError):
+        load_config(path)
 
 
 def test_yaml_error_includes_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure batch pause configuration uses floating point
- test config loader for float type and negative value rejection

## Testing
- `SKIP=pytest pre-commit run --files config.yaml tests/test_config.py` *(mypy: Cannot assign to a type [misc])* 
- `pytest tests/test_config.py::test_config_type_coercion tests/test_config.py::test_batch_pause_negative_value -q -vv`
- `python get_activity_data.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68c2da524e6c8324a7e585a7e0342206