### PR TITLE
feat: validate CLI args with pydantic

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -16,6 +16,7 @@ from library.cli import LoggerConfig, configure_logger
 from library.cli_utils import build_parser
 from library.csv_utils import write_csv_deterministic
 from library.log import logger
+from library.parser_schema import CSVExportArgs
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -33,7 +34,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
 
     parser = build_parser()
-    args = parser.parse_args(argv)
+    ns = parser.parse_args(argv)
+    args = CSVExportArgs.model_validate(vars(ns))
     configure_logger(LoggerConfig(level=args.log_level))
 
     start = time.perf_counter()
@@ -46,6 +48,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         output,
         col_order=args.col_order or None,
         key_cols=args.key_cols or None,
+        drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start
     logger.info("written %s", output)

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -18,6 +18,7 @@ from .document_type_terms import (
     parse_terms,
 )
 from .logging_setup import Logger, LoggerConfig, configure_logger
+from .parser_schema import CSVExportArgs
 from .sidecar import SidecarErrors
 
 __all__ = [
@@ -37,4 +38,5 @@ __all__ = [
     "Logger",
     "LoggerConfig",
     "configure_logger",
+    "CSVExportArgs",
 ]

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -86,9 +86,10 @@ def _normalise_dates(series: pd.Series) -> pd.Series:
 
     if (
         ptypes.is_object_dtype(series)
-        and series.dropna().map(lambda x: isinstance(x, (date, datetime))).all()
+        and series.dropna().map(lambda x: isinstance(x, date | datetime)).all()
     ):
-        return pd.to_datetime(series).dt.strftime("%Y-%m-%d")
+        result: pd.Series = pd.to_datetime(series).dt.strftime("%Y-%m-%d")
+        return result
 
     return series
 
@@ -103,6 +104,7 @@ def write_csv_deterministic(
     sep: str = ",",
     encoding: str = "utf-8-sig",
     cfg: Config | None = None,
+    drop_unexpected_cols: bool = False,
 ) -> Path:
     """Serialise ``df`` to ``path`` as a deterministic CSV file.
 
@@ -114,7 +116,8 @@ def write_csv_deterministic(
         Destination file path.
     col_order:
         Optional preferred column ordering. Columns not listed here are
-        appended in lexicographical order.
+        appended in lexicographical order unless ``drop_unexpected_cols`` is
+        ``True``, in which case they are omitted with a warning.
     key_cols:
         Optional sequence of column names defining row ordering.  If omitted
         all columns are used as sort keys.
@@ -123,6 +126,9 @@ def write_csv_deterministic(
         streaming output via :meth:`pandas.DataFrame.to_csv`, reducing peak
         memory usage for large tables. ``None`` (the default) writes the
         dataframe in a single call.
+    drop_unexpected_cols:
+        When ``True`` and ``col_order`` is provided, columns not present in
+        ``col_order`` are dropped from the output with a log warning.
 
     Notes
     -----
@@ -155,7 +161,11 @@ def write_csv_deterministic(
     if col_order is not None:
         head = [c for c in col_order if c in work.columns]
         tail = sorted(c for c in work.columns if c not in head)
-        work = work.reindex(columns=head + tail, copy=False)
+        if drop_unexpected_cols and tail:
+            logger.warning("Dropping unexpected columns: %s", tail)
+            work = work.reindex(columns=head, copy=False)
+        else:
+            work = work.reindex(columns=head + tail, copy=False)
     else:
         work = work.reindex(columns=sorted(work.columns), copy=False)
 

--- a/library/parser_schema.py
+++ b/library/parser_schema.py
@@ -1,0 +1,49 @@
+"""Pydantic models for CSV export CLI arguments.
+
+This module defines :class:`CSVExportArgs`, a Pydantic model that validates
+and normalises arguments used by :mod:`csv_utils_main`. Using a data model
+ensures consistent handling of command-line parameters across scripts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CSVExportArgs(BaseModel):  # type: ignore[misc]
+    """Validated parameters for CSV export operations.
+
+    Attributes
+    ----------
+    input_csv:
+        Path to the source CSV file.
+    output_csv:
+        Optional destination path. When ``None`` an automatic name based on
+        ``input_csv`` is used.
+    sep:
+        Field delimiter for the CSV file.
+    encoding:
+        Character encoding of the CSV file.
+    col_order:
+        Optional list specifying the expected column order. Columns not listed
+        here are dropped during export.
+    key_cols:
+        Optional list of columns used to determine row ordering.
+    log_level:
+        Logging verbosity passed through to the application logger.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_csv: Path = Field(default=Path("input.csv"))
+    output_csv: Path | None = None
+    sep: str = ","
+    encoding: str = "utf8"
+    col_order: list[str] | None = None
+    key_cols: list[str] | None = None
+    log_level: str = "INFO"
+
+
+__all__ = ["CSVExportArgs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "jsonschema>=4.25.1",
   "pandera>=0.26.1",
   "cachetools>=5.3.2",
+  "pydantic>=2.10.7",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_csv_utils_drop_unexpected.py
+++ b/tests/test_csv_utils_drop_unexpected.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.csv_utils import write_csv_deterministic
+
+
+def test_drop_unexpected_columns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+    out = tmp_path / "out.csv"
+    with caplog.at_level("WARNING"):
+        write_csv_deterministic(
+            df,
+            out,
+            col_order=["a", "b"],
+            drop_unexpected_cols=True,
+        )
+    result = pd.read_csv(out)
+    assert list(result.columns) == ["a", "b"]
+    assert "Dropping unexpected columns" in caplog.text

--- a/tests/test_parser_schema.py
+++ b/tests/test_parser_schema.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from library.parser_schema import CSVExportArgs
+
+
+def test_extra_fields_forbidden() -> None:
+    """Extra fields should raise a validation error."""
+    with pytest.raises(ValidationError):
+        CSVExportArgs.model_validate({"input_csv": "in.csv", "extra": 1})


### PR DESCRIPTION
## Summary
- validate csv utils CLI arguments with a pydantic model
- drop unexpected columns during deterministic CSV export
- expose CSVExportArgs and add pydantic dependency

## Testing
- `ruff check library/__init__.py library/parser_schema.py library/csv_utils.py csv_utils_main.py tests/test_parser_schema.py tests/test_csv_utils_drop_unexpected.py`
- `python -m mypy library/__init__.py library/parser_schema.py library/csv_utils.py csv_utils_main.py tests/test_parser_schema.py tests/test_csv_utils_drop_unexpected.py --follow-imports=skip --ignore-missing-imports`
- `pytest tests/test_parser_schema.py tests/test_csv_utils_drop_unexpected.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2d9e656dc832491ec9f2df38b63b8