### PR TITLE
refactor: update pandera import paths

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -27,11 +27,11 @@ import sys
 from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
+import pandera.pandas as pa
 import yaml
-from pandera import DataFrameModel, DataFrameSchema
 
 from . import validation
 from .config import Config, IoCfg, _serialize_paths
@@ -103,7 +103,7 @@ def read_csv(
     dtype: Mapping[Hashable, Any] | type | None = None,
     na_values: Sequence[str] | str | None = None,
     parse_dates: Sequence[str] | None = None,
-    schema: DataFrameSchema | type[DataFrameModel] | None = None,
+    schema: pa.DataFrameSchema | type[pa.DataFrameModel] | None = None,
 ) -> pd.DataFrame:
     """Load a CSV file into a :class:`pandas.DataFrame` with optional schema validation.
 
@@ -130,8 +130,8 @@ def read_csv(
     parse_dates:
         Column names to parse as dates using :func:`pandas.read_csv`.
     schema:
-        Optional :class:`pandera.DataFrameSchema` or
-        :class:`pandera.DataFrameModel` used for advanced validation and
+        Optional :class:`pa.DataFrameSchema` or
+        :class:`pa.DataFrameModel` used for advanced validation and
         dtype coercion.
 
     Returns
@@ -151,7 +151,7 @@ def read_csv(
         parse_dates=list(parse_dates) if parse_dates is not None else None,
     )
     if schema is not None:
-        if isinstance(schema, DataFrameSchema):
+        if isinstance(schema, pa.DataFrameSchema):
             df = schema.validate(df)
         else:
             df = schema.to_schema().validate(df)
@@ -212,14 +212,17 @@ def write_csv(
     """
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
-    return write_csv_deterministic(
-        df,
-        path,
-        key_cols=list(key_cols) if key_cols is not None else None,
-        chunksize=chunksize,
-        sep=sep,
-        encoding=encoding,
-        cfg=cfg,
+    return cast(
+        Path,
+        write_csv_deterministic(
+            df,
+            path,
+            key_cols=list(key_cols) if key_cols is not None else None,
+            chunksize=chunksize,
+            sep=sep,
+            encoding=encoding,
+            cfg=cfg,
+        ),
     )
 
 

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -6,22 +6,22 @@ expected structure of activity dataframes.
 
 from __future__ import annotations
 
-from pandera import Check, Column, DataFrameSchema
+import pandera.pandas as pa
 
 # Definition of the schema describing the activities table.
-ActivitiesSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
+ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "activity_id": Column(int, Check.ge(0), required=True),
-        "testitem_id": Column(str, required=True),
-        "target_id": Column(str, required=False),
-        "standard_type": Column(
+        "activity_id": pa.Column(int, pa.Check.ge(0), required=True),
+        "testitem_id": pa.Column(str, required=True),
+        "target_id": pa.Column(str, required=False),
+        "standard_type": pa.Column(
             str,
-            Check.isin(["IC50", "EC50", "Ki", "Kd"]),
+            pa.Check.isin(["IC50", "EC50", "Ki", "Kd"]),
             required=False,
         ),
-        "standard_value": Column(float, Check.ge(0), required=True),
-        "pA_value": Column(float, Check.in_range(0, 14), required=False),
+        "standard_value": pa.Column(float, pa.Check.ge(0), required=True),
+        "pA_value": pa.Column(float, pa.Check.in_range(0, 14), required=False),
     }
 )
 
-"""pandera.DataFrameSchema: Validation schema for activities."""
+"""pa.DataFrameSchema: Validation schema for activities."""

--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from pandera import Check, Column, DataFrameSchema
+import pandera.pandas as pa
 
-AssaysSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
+AssaysSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "assay_chembl_id": Column(str, required=True),
-        "document_chembl_id": Column(str, required=True),
-        "target_chembl_id": Column(str, required=False),
-        "year": Column(int, Check.in_range(1900, 2100), required=True),
-        "month": Column(int, Check.in_range(1, 12), required=True),
+        "assay_chembl_id": pa.Column(str, required=True),
+        "document_chembl_id": pa.Column(str, required=True),
+        "target_chembl_id": pa.Column(str, required=False),
+        "year": pa.Column(int, pa.Check.in_range(1900, 2100), required=True),
+        "month": pa.Column(int, pa.Check.in_range(1, 12), required=True),
     }
 )
 
-"""pandera.DataFrameSchema: Validation schema for assays."""
+"""pa.DataFrameSchema: Validation schema for assays."""

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from pandera import Check, Column, DataFrameSchema
+import pandera.pandas as pa
 
-DocumentsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
+DocumentsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "document_chembl_id": Column(str, required=True),
-        "doi": Column(str, required=False),
-        "title": Column(str, required=True),
-        "year": Column(int, Check.in_range(1900, 2100), required=True),
-        "month": Column(int, Check.in_range(1, 12), required=True),
-        "day": Column(int, Check.in_range(1, 31), required=False),
-        "citation": Column(int, Check.ge(0), required=False),
+        "document_chembl_id": pa.Column(str, required=True),
+        "doi": pa.Column(str, required=False),
+        "title": pa.Column(str, required=True),
+        "year": pa.Column(int, pa.Check.in_range(1900, 2100), required=True),
+        "month": pa.Column(int, pa.Check.in_range(1, 12), required=True),
+        "day": pa.Column(int, pa.Check.in_range(1, 31), required=False),
+        "citation": pa.Column(int, pa.Check.ge(0), required=False),
     }
 )
 
-"""pandera.DataFrameSchema: Validation schema for documents."""
+"""pa.DataFrameSchema: Validation schema for documents."""

--- a/schemas/targets.py
+++ b/schemas/targets.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from pandera import Check, Column, DataFrameSchema
+import pandera.pandas as pa
 
-TargetsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
+TargetsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "target_chembl_id": Column(str, required=True),
-        "organism": Column(str, required=True),
-        "target_uniprot_id": Column(str, required=False),
-        "pH_dependence": Column(float, Check.in_range(0, 14), required=False),
-        "isoforms": Column(float, Check.ge(0), required=False),
+        "target_chembl_id": pa.Column(str, required=True),
+        "organism": pa.Column(str, required=True),
+        "target_uniprot_id": pa.Column(str, required=False),
+        "pH_dependence": pa.Column(float, pa.Check.in_range(0, 14), required=False),
+        "isoforms": pa.Column(float, pa.Check.ge(0), required=False),
     }
 )
 
-"""pandera.DataFrameSchema: Validation schema for targets."""
+"""pa.DataFrameSchema: Validation schema for targets."""

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -2,22 +2,24 @@
 
 from __future__ import annotations
 
-from pandera import Check, Column, DataFrameSchema
+import pandera.pandas as pa
 
-TestitemsSchema: DataFrameSchema = DataFrameSchema(  # type: ignore[no-untyped-call]
+TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "salt_chembl_id": Column(str, required=True),
-        "molecule_chembl_id": Column(str, required=True),
-        "molecule_type": Column(
+        "salt_chembl_id": pa.Column(str, required=True),
+        "molecule_chembl_id": pa.Column(str, required=True),
+        "molecule_type": pa.Column(
             str,
-            Check.isin(["Small molecule", "Biopolymer", "Oligosaccharide", "Unknown"]),
+            pa.Check.isin(
+                ["Small molecule", "Biopolymer", "Oligosaccharide", "Unknown"]
+            ),
             required=True,
         ),
-        "chirality": Column(int, Check.isin([-1, 0, 1, 2]), required=False),
-        "mw_freebase": Column(float, Check.in_range(0, 2000), required=True),
-        "num_ro5_violations": Column(float, Check.in_range(0, 5), required=False),
-        "is_radical": Column(bool, required=False),
+        "chirality": pa.Column(int, pa.Check.isin([-1, 0, 1, 2]), required=False),
+        "mw_freebase": pa.Column(float, pa.Check.in_range(0, 2000), required=True),
+        "num_ro5_violations": pa.Column(float, pa.Check.in_range(0, 5), required=False),
+        "is_radical": pa.Column(bool, required=False),
     }
 )
 
-"""pandera.DataFrameSchema: Validation schema for test items."""
+"""pa.DataFrameSchema: Validation schema for test items."""


### PR DESCRIPTION
## Summary
- import Pandera through the `pandera.pandas` namespace and reference classes via the `pa` alias
- adjust schema definitions and I/O utilities to use `pa.Check`, `pa.Column`, `pa.DataFrameSchema`
- ensure `write_csv` returns a typed `Path`

## Testing
- `ruff check library/io.py schemas/documents.py schemas/testitems.py schemas/targets.py schemas/activities.py schemas/assays.py`
- `pytest tests/test_schemas.py`
- `mypy --follow-imports=skip library/io.py schemas/documents.py schemas/testitems.py schemas/targets.py schemas/activities.py schemas/assays.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2da5c82dc8324841c29b15dceb95e