### PR TITLE
Fix batch pause type and enable future annotations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,7 +180,7 @@ jobs:
 
 batch:
   size: 1000  # Number of rows per batch (env: CHEMBL_DA__BATCH__SIZE)
-  pause: 0  # Delay between batches in seconds (env: CHEMBL_DA__BATCH__PAUSE)
+  pause: 0.0  # Delay between batches in seconds (env: CHEMBL_DA__BATCH__PAUSE)
   concurrency: 2  # Number of concurrent batch workers (env: CHEMBL_DA__BATCH__CONCURRENCY)
   fail_fast: true  # Abort on first error (env: CHEMBL_DA__BATCH__FAIL_FAST)
   retry_failed: true  # Retry failed batches (env: CHEMBL_DA__BATCH__RETRY_FAILED)

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -7,6 +7,8 @@ so that ``python`` can resolve them correctly regardless of the working
 directory.
 """
 
+from __future__ import annotations
+
 from . import io, validation
 from .config import Config, load_config
 from .csv_utils import sha256_file, write_csv_deterministic

--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -1,5 +1,7 @@
 """Compatibility layer aggregating ChEMBL helpers."""
 
+from __future__ import annotations
+
 from . import chembl_assay as _chembl_assay
 from . import chembl_target as _chembl_target
 from .chembl_assay import *  # noqa: F401,F403

--- a/library/config.py
+++ b/library/config.py
@@ -274,7 +274,7 @@ class BatchCfg:
     """Batch processing parameters."""
 
     size: int = 1000
-    pause: float = 0
+    pause: float = 0.0
     concurrency: int = 2
     fail_fast: bool = True
     retry_failed: bool = True


### PR DESCRIPTION
## Summary
- ensure `batch.pause` is treated as float in config and defaults
- postpone annotation evaluation in library modules to avoid runtime errors

## Testing
- `black library/config.py library/__init__.py library/chembl_library.py`
- `ruff check library/config.py library/__init__.py library/chembl_library.py`
- `mypy library/config.py library/__init__.py library/chembl_library.py` *(fails: Library stubs not installed for "requests"; Returning Any from function declared to return "str"; Library stubs not installed for "requests.adapters"; Library stubs not installed for "pandas"; Library stubs not installed for "yaml"; Library stubs not installed for "pandas.api"; Library stubs not installed for "pandas"; Unused "type: ignore" comment; Library stubs not installed for "pandas"; Library stubs not installed for "yaml"; Found 21 errors in 7 files (checked 3 source files))*

------
https://chatgpt.com/codex/tasks/task_e_68c2d9d35c9c8324b77340926fd8ec6f