### PR TITLE
fix: handle missing dictionary dir

### DIFF
--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -171,10 +171,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         ensure_dirs(cfg)
 
-        args.same_doc = Path(args.same_doc)
-        args.all_doc = Path(args.all_doc)
+        # ``dictionary_dir`` is optional and may be undefined in the
+        # configuration.  Convert provided paths to :class:`Path` objects only
+        # when values are available to avoid ``TypeError`` on ``None``.
+        args.same_doc = Path(args.same_doc) if args.same_doc is not None else None
+        args.all_doc = Path(args.all_doc) if args.all_doc is not None else None
         args.out_dir = Path(args.out_dir)
-        args.dictionary_dir = Path(args.dictionary_dir)
+        args.dictionary_dir = (
+            Path(args.dictionary_dir) if args.dictionary_dir is not None else None
+        )
+        if args.same_doc is None or args.all_doc is None:
+            raise ValueError("same_doc and all_doc paths must be provided")
 
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -135,3 +135,32 @@ def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:
 
     assert cli.run(cfg, args) == 0
     assert (cfg.init.output_dir / "assay.csv").exists()
+
+
+def test_main_missing_dictionary_dir(tmp_path: Path, monkeypatch) -> None:
+    """``main`` should handle absent dictionary directory gracefully."""
+
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text('log:\n  level: "ERROR"\n')
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+    out_dir = tmp_path / "out"
+
+    # Skip heavy processing by stubbing ``run``
+    monkeypatch.setattr(cli, "run", lambda _cfg, _args: 0)
+
+    result = cli.main(
+        [
+            "--config",
+            str(cfg_path),
+            "--same-doc",
+            str(same_doc),
+            "--all-doc",
+            str(all_doc),
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+    assert result == 0


### PR DESCRIPTION
## Summary
- avoid TypeError when `dictionary_dir` is absent in config
- add regression test for missing dictionary dir

## Testing
- `ruff check get_input_initialisation.py tests/test_get_input_initialisation.py`
- `mypy get_input_initialisation.py` *(fails: Library stubs not installed for "requests")*
- `pytest tests/test_get_input_initialisation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2de50096c83248fb14996f16c45fd