### PR TITLE
Handle missing UnionType for Python <3.10

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -32,7 +32,10 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from pathlib import Path
 
 from typing import Any, Union, get_args, get_origin, get_type_hints
-from types import UnionType
+
+import types
+
+UnionType = getattr(types, "UnionType", None)
 
 from urllib.parse import urlparse
 


### PR DESCRIPTION
## Summary
- handle absence of `types.UnionType` so config loader works on Python <3.10

## Testing
- `black library/config.py`
- `ruff check library/config.py`
- `mypy library/config.py --follow-imports=skip --ignore-missing-imports`
- `pytest` *(fails: AttributeError: 'Namespace' object has no attribute 'input', TypeError: _run.<locals>.fake_get() got an unexpected keyword argument 'client', AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2deca93b48324b7a042d0ea6e3b8c