### PR TITLE
feat: add chunked csv processing with checkpoints

### DIFF
--- a/chunk_io_main.py
+++ b/chunk_io_main.py
@@ -1,0 +1,76 @@
+"""CLI for chunked CSV copying with checkpoint resume."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from pathlib import Path
+
+from library.chunk_io import process_csv_chunks
+from library.cli import LoggerConfig, add_common_arguments, configure_logger
+from library.config import Config, ensure_dirs
+from library.io import default_output_path
+from library.log import logger
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Create the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Copy CSV files in chunks with checkpointing",
+    )
+    add_common_arguments(parser)
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=1000,
+        help="Number of rows processed per chunk",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional maximum number of rows to process",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("checkpoint.json"),
+        help="Path to checkpoint file",
+    )
+    return parser, LoggerConfig(level="INFO")
+
+
+def run(cfg: Config, args: argparse.Namespace) -> int:
+    """Execute the chunked copy operation."""
+    if args.chunk_size <= 0:
+        raise SystemExit("--chunk-size must be a positive integer")
+    if args.limit is not None and args.limit <= 0:
+        raise SystemExit("--limit must be a positive integer")
+
+    output = args.output_csv or default_output_path(args.input_csv, cfg.io)
+    ensure_dirs(cfg)
+    rows = process_csv_chunks(
+        args.input_csv,
+        output,
+        cfg=cfg.io,
+        chunk_size=args.chunk_size,
+        limit=args.limit,
+        checkpoint_path=args.checkpoint,
+        sep=args.sep,
+        encoding=args.encoding,
+    )
+    logger.info("processed %d rows", rows)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser, log_cfg = build_parser()
+    args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    configure_logger(log_cfg)
+    cfg = Config()
+    return run(cfg, args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/library/chunk_io.py
+++ b/library/chunk_io.py
@@ -1,0 +1,198 @@
+"""Chunked CSV processing utilities with checkpoint support.
+
+This module provides helper functions to read and write CSV files in
+manageable chunks. A simple checkpointing mechanism records the number of
+processed rows enabling pipelines to resume from the last successful chunk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pandas as pd
+
+from .config import IoCfg
+
+logger = logging.getLogger(__name__)
+
+
+def _read_checkpoint(path: Path) -> int:
+    """Return number of rows already processed.
+
+    Parameters
+    ----------
+    path:
+        Location of the checkpoint file.
+
+    Returns
+    -------
+    int
+        Number of rows previously written. ``0`` if the checkpoint does not
+        exist or is malformed.
+    """
+    try:
+        with path.open("r", encoding="utf8") as fh:
+            data = json.load(fh)
+        rows = int(data.get("rows", 0))
+        if rows < 0:
+            raise ValueError
+        return rows
+    except FileNotFoundError:
+        return 0
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.warning("ignoring invalid checkpoint %s: %s", path, exc)
+        return 0
+
+
+def _write_checkpoint(path: Path, rows: int) -> None:
+    """Persist ``rows`` to ``path`` as JSON."""
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf8") as fh:
+        json.dump({"rows": rows}, fh)
+    tmp.replace(path)
+
+
+def read_csv_chunks(
+    path: str | Path,
+    *,
+    cfg: IoCfg,
+    chunk_size: int,
+    limit: int | None = None,
+    skiprows: int = 0,
+    sep: str | None = None,
+    encoding: str | None = None,
+) -> Iterator[pd.DataFrame]:
+    """Yield chunks from ``path``.
+
+    Parameters
+    ----------
+    path:
+        CSV input file.
+    cfg:
+        I/O defaults for CSV handling.
+    chunk_size:
+        Maximum number of rows per yielded chunk. Must be positive.
+    limit:
+        Optional global row limit across all chunks.
+    skiprows:
+        Number of data rows to skip from the start (for resume).
+    sep:
+        Field delimiter overriding ``cfg.csv_sep``.
+    encoding:
+        Character encoding overriding ``cfg.csv_encoding``.
+
+    Yields
+    ------
+    pandas.DataFrame
+        Consecutive chunks of the input table.
+    """
+    if chunk_size <= 0:
+        msg = f"chunk_size must be positive, got {chunk_size}"
+        raise ValueError(msg)
+
+    sep = sep or cfg.csv_sep
+    encoding = encoding or cfg.csv_encoding
+
+    # ``skiprows`` expects an iterable of row indices starting at 0 including
+    # the header. We skip the header plus ``skiprows`` data rows.
+    to_skip = range(1, skiprows + 1) if skiprows else None
+    reader = pd.read_csv(
+        path,
+        sep=sep,
+        encoding=encoding,
+        chunksize=chunk_size,
+        skiprows=to_skip,
+    )
+    emitted = 0
+    for chunk in reader:
+        if limit is not None and emitted >= limit:
+            break
+        if limit is not None:
+            remaining = limit - emitted
+            if len(chunk) > remaining:
+                yield chunk.iloc[:remaining]
+                break
+        emitted += len(chunk)
+        yield chunk
+
+
+def process_csv_chunks(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    cfg: IoCfg,
+    chunk_size: int,
+    limit: int | None = None,
+    checkpoint_path: Path | None = None,
+    sep: str | None = None,
+    encoding: str | None = None,
+) -> int:
+    """Copy ``input_path`` to ``output_path`` using chunked I/O.
+
+    Existing data and checkpoints allow resuming interrupted runs. The number of
+    rows written is returned.
+
+    Parameters
+    ----------
+    input_path:
+        Source CSV file.
+    output_path:
+        Destination CSV file.
+    cfg:
+        I/O configuration providing defaults.
+    chunk_size:
+        Number of rows processed per chunk.
+    limit:
+        Optional maximum number of rows to process in total. ``None`` processes
+        the entire file.
+    checkpoint_path:
+        Location of a checkpoint file storing processed row counts.
+    sep, encoding:
+        CSV formatting options overriding ``cfg`` defaults.
+
+    Returns
+    -------
+    int
+        Total number of rows written after completion.
+    """
+    sep = sep or cfg.csv_sep
+    encoding = encoding or cfg.csv_encoding
+
+    processed = 0
+    header_written = False
+    if checkpoint_path is not None:
+        processed = _read_checkpoint(checkpoint_path)
+        header_written = Path(output_path).exists() and processed > 0
+        if processed:
+            logger.info("resuming from row %d", processed)
+
+    rows_written = processed
+    for chunk in read_csv_chunks(
+        input_path,
+        cfg=cfg,
+        chunk_size=chunk_size,
+        limit=None if limit is None else max(limit - rows_written, 0),
+        skiprows=processed,
+        sep=sep,
+        encoding=encoding,
+    ):
+        mode = "a" if header_written else "w"
+        chunk.to_csv(
+            output_path,
+            mode=mode,
+            index=False,
+            header=not header_written,
+            sep=sep,
+            encoding=encoding,
+        )
+        header_written = True
+        rows_written += len(chunk)
+        if checkpoint_path is not None:
+            _write_checkpoint(checkpoint_path, rows_written)
+        if limit is not None and rows_written >= limit:
+            break
+
+    return rows_written

--- a/tests/test_chunk_io.py
+++ b/tests/test_chunk_io.py
@@ -1,0 +1,46 @@
+"""Tests for chunked CSV processing with checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.chunk_io import process_csv_chunks
+from library.config import IoCfg
+
+
+def test_process_csv_chunks_resume(tmp_path: Path) -> None:
+    """Processing with a checkpoint should resume from last offset."""
+    cfg = IoCfg()
+    input_path = tmp_path / "input.csv"
+    df = pd.DataFrame({"a": range(200)})
+    df.to_csv(input_path, index=False)
+
+    output_path = tmp_path / "output.csv"
+    checkpoint = tmp_path / "checkpoint.json"
+
+    # First run processes only 100 rows
+    rows_written = process_csv_chunks(
+        input_path,
+        output_path,
+        cfg=cfg,
+        chunk_size=50,
+        limit=100,
+        checkpoint_path=checkpoint,
+    )
+    assert rows_written == 100
+    interim = pd.read_csv(output_path)
+    assert len(interim) == 100
+
+    # Second run resumes and completes the remaining rows
+    rows_written = process_csv_chunks(
+        input_path,
+        output_path,
+        cfg=cfg,
+        chunk_size=50,
+        checkpoint_path=checkpoint,
+    )
+    assert rows_written == 200
+    result = pd.read_csv(output_path)
+    assert result.equals(df)

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -1,0 +1,36 @@
+"""CLI smoke tests for chunk_io_main."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+import chunk_io_main as cli
+
+
+def test_cli_limit(tmp_path: Path) -> None:
+    """CLI processes only the requested number of rows."""
+    input_path = tmp_path / "input.csv"
+    df = pd.DataFrame({"a": range(200)})
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "out.csv"
+    checkpoint = tmp_path / "cp.json"
+    cli.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "50",
+            "--limit",
+            "100",
+            "--checkpoint",
+            str(checkpoint),
+            "--log-level",
+            "WARNING",
+        ]
+    )
+    result = pd.read_csv(output_path)
+    assert len(result) == 100


### PR DESCRIPTION
## Summary
- add chunked CSV reader/writer with checkpoint resume
- expose CLI utility for chunked copy with `--limit`
- cover chunked processing and CLI with tests

## Testing
- `python -m black chunk_io_main.py library/chunk_io.py tests/test_chunk_io.py tests/test_chunk_io_cli.py`
- `ruff check chunk_io_main.py library/chunk_io.py tests/test_chunk_io.py tests/test_chunk_io_cli.py`
- `mypy library/chunk_io.py` *(fails: library/rate_limiter.py:17: error: Unused "type: ignore" comment)*
- `pytest tests/test_chunk_io.py tests/test_chunk_io_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2deeac5f08324bb493fb2abe94213