### PR TITLE
Handle pandera import errors

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -30,7 +30,14 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
-import pandera.pandas as pa
+
+try:
+    import pandera.pandas as pa
+except (ImportError, TypeError) as exc:
+    raise RuntimeError(
+        "pandera is required for schema validation; install a compatible "
+        "version of pandera for your Python interpreter."
+    ) from exc
 import yaml
 
 from . import validation

--- a/tests/test_io_pandera_import.py
+++ b/tests/test_io_pandera_import.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_pandera_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise a helpful error when pandera import fails."""
+    module_name = "library.io"
+    orig_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "pandera.pandas":
+            raise TypeError("boom")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop(module_name, None)
+
+    with pytest.raises(RuntimeError, match="pandera is required"):
+        importlib.import_module(module_name)
+
+    # restore real module for other tests
+    monkeypatch.setattr(builtins, "__import__", orig_import, raising=False)
+    sys.modules.pop(module_name, None)
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- raise clear RuntimeError when pandera fails to import
- test pandera import failure handling

## Testing
- `black library/io.py tests/test_io_pandera_import.py`
- `ruff check library/io.py tests/test_io_pandera_import.py`
- `mypy library/io.py tests/test_io_pandera_import.py` *(fails: Returning Any from function declared to return "RateLimiter")*
- `pytest tests/test_io_pandera_import.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2e04d4e1c8324843cd8dbb389da80