### PR TITLE
refactor: simplify CSV writing across CLI tools

### DIFF
--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -11,7 +11,7 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
-from library import io, write_csv_deterministic
+from library import io
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -27,8 +27,6 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from schemas import ActivitiesSchema, normalize_activities
-
-ORIG_WRITE_CSV = io.write_csv
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -120,27 +118,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["activity_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "activity_id",
-                "testitem_id",
-                "target_id",
-                "standard_type",
-                "standard_value",
-                "pA_value",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
-        if io.write_csv is not ORIG_WRITE_CSV:
-            io.write_csv(
-                df,
-                output,
-                cfg=cfg,
-                sep=cfg.io.csv_sep,
-                encoding=cfg.io.csv_encoding,
-            )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -11,7 +11,7 @@ from pandera.errors import SchemaErrors
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
-from library import io, write_csv_deterministic
+from library import io
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -94,16 +94,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["assay_chembl_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "assay_chembl_id",
-                "document_chembl_id",
-                "target_chembl_id",
-                "year",
-                "month",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -35,7 +35,7 @@ from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
 from library import document_postprocessing as dp
-from library import io, write_csv_deterministic
+from library import io
 from library import openalex_crossref_library as ocl
 from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
@@ -215,18 +215,10 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
         key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "document_chembl_id",
-                "doi",
-                "title",
-                "year",
-                "month",
-                "day",
-                "citation",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)
@@ -320,18 +312,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "document_chembl_id",
-                "doi",
-                "title",
-                "year",
-                "month",
-                "day",
-                "citation",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)
@@ -431,18 +415,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         rows_dropped = rows_total - rows_kept
         try:
             key_cols = [c for c in ["document_chembl_id"] if c in processed.columns]
-            csv_path = write_csv_deterministic(
+            csv_path = io.write_csv(
                 processed,
                 output,
-                col_order=[
-                    "document_chembl_id",
-                    "doi",
-                    "title",
-                    "year",
-                    "month",
-                    "day",
-                    "citation",
-                ],
+                cfg=cfg,
                 key_cols=key_cols or None,
             )
             logger.info("Wrote %d rows to %s", rows_kept, csv_path)
@@ -526,18 +502,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["document_chembl_id"] if c in processed.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             processed,
             output,
-            col_order=[
-                "document_chembl_id",
-                "doi",
-                "title",
-                "year",
-                "month",
-                "day",
-                "citation",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -20,7 +20,7 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
-from library import io, write_csv_deterministic
+from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
@@ -397,16 +397,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["target_chembl_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "target_chembl_id",
-                "organism",
-                "target_uniprot_id",
-                "pH_dependence",
-                "isoforms",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -11,7 +11,7 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
-from library import io, write_csv_deterministic
+from library import io
 from library import pubchem_library as pl
 from library.chembl_client import ChemblClient
 from library.cli import (
@@ -178,18 +178,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["salt_chembl_id"] if c in df.columns]
-        csv_path = write_csv_deterministic(
+        csv_path = io.write_csv(
             df,
             output,
-            col_order=[
-                "salt_chembl_id",
-                "molecule_chembl_id",
-                "molecule_type",
-                "chirality",
-                "mw_freebase",
-                "num_ro5_violations",
-                "is_radical",
-            ],
+            cfg=cfg,
             key_cols=key_cols or None,
         )
         logger.info("Wrote %d rows to %s", rows_kept, csv_path)


### PR DESCRIPTION
## Summary
- remove now unnecessary ORIG_WRITE_CSV constant
- call `io.write_csv` directly in all CLI pipelines

## Testing
- `ruff check get_activity_data.py get_target_data.py get_document_data.py get_testitem_data.py get_assay_data.py`
- `black --check get_activity_data.py get_target_data.py get_document_data.py get_testitem_data.py get_assay_data.py`
- `mypy get_activity_data.py get_target_data.py get_document_data.py get_testitem_data.py get_assay_data.py` *(fails: missing type stubs and other typing issues)*
- `pytest -k write_csv`


------
https://chatgpt.com/codex/tasks/task_e_68c2e0c315808324967c9b522cbf013d