### PR TITLE
Add runtime Python version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Utilities for downloading and processing biological data from public APIs.
 The project demonstrates a typical Python 3.12 data pipeline including
 parsing, validation, aggregation and export of tabular data.
 
+## Requirements
+
+- Python 3.12 or later. Older interpreters abort with an informative message.
+
 ## Установка
 
 ```bash

--- a/library/cli.py
+++ b/library/cli.py
@@ -15,6 +15,9 @@ from . import log
 from .config import Config, ConfigError, load_config
 from .logging_setup import Logger, LoggerConfig
 from .logging_setup import configure_logger as _configure_logger
+from .version import require_python_version
+
+require_python_version()
 
 
 def create_logger_config(level: str) -> LoggerConfig:

--- a/library/version.py
+++ b/library/version.py
@@ -1,0 +1,35 @@
+"""Runtime checks for interpreter compatibility.
+
+This module provides a helper ensuring the running Python interpreter meets
+project requirements. The package targets Python 3.12+, so running the tools on
+an older version should fail fast with a clear error message.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from .log import logger
+
+
+def require_python_version(min_version: tuple[int, int] = (3, 12)) -> None:
+    """Validate that the interpreter meets ``min_version``.
+
+    Parameters
+    ----------
+    min_version:
+        Required ``(major, minor)`` Python version. Defaults to ``(3, 12)``.
+
+    Raises
+    ------
+    RuntimeError
+        If the current interpreter is older than ``min_version``.
+    """
+    current_info = sys.version_info
+    current = (current_info.major, current_info.minor, current_info.micro)
+    required = min_version + (0,)
+    if current < required:
+        current_str = f"{current_info.major}.{current_info.minor}"
+        needed = f"{min_version[0]}.{min_version[1]}"
+        logger.error("Python %s or later is required (found %s)", needed, current_str)
+        raise RuntimeError(f"Python {needed} or later is required; found {current_str}")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,28 @@
+"""Tests for the Python version check utility."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from library.version import require_python_version
+
+
+def _mock_version(major: int, minor: int) -> object:
+    """Return a minimal ``sys.version_info`` mock."""
+    return SimpleNamespace(
+        major=major, minor=minor, micro=0, releaselevel="final", serial=0
+    )
+
+
+def test_require_python_version_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "version_info", _mock_version(3, 12))
+    require_python_version((3, 12))
+
+
+def test_require_python_version_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "version_info", _mock_version(3, 11))
+    with pytest.raises(RuntimeError):
+        require_python_version((3, 12))


### PR DESCRIPTION
## Summary
- add `require_python_version` helper to fail fast on unsupported interpreters
- invoke version check from shared CLI utilities so every command validates Python at startup
- document Python 3.12+ requirement and add unit test for the helper

## Testing
- `ruff check library/version.py library/cli.py tests/test_version.py`
- `black --check library/version.py library/cli.py tests/test_version.py`
- `mypy library/version.py library/cli.py` *(fails: Unused "type: ignore" comment in rate_limiter.py; Redundant cast in io.py)*
- `pytest tests/test_version.py`
- `pre-commit run --files library/version.py library/cli.py README.md tests/test_version.py` *(fails: 14 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e03f19108324bc62774a93175e18