### PR TITLE
Register CLI entry points in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,35 @@ dev = [
 
 ]
 
+[project.scripts]
+get-activity-data = "get_activity_data:main"
+get-assay-data = "get_assay_data:main"
+get-target-data = "get_target_data:main"
+get-document-data = "get_document_data:main"
+get-document-type = "get_document_type:main"
+get-input-initialisation = "get_input_initialisation:main"
+get-testitem-data = "get_testitem_data:main"
+csv-utils = "csv_utils_main:main"
+mapper = "mapper_main:main"
+table-quality = "table_quality_main:main"
+
+[tool.setuptools]
+py-modules = [
+  "get_activity_data",
+  "get_assay_data",
+  "get_target_data",
+  "get_document_data",
+  "get_document_type",
+  "get_input_initialisation",
+  "get_testitem_data",
+  "csv_utils_main",
+  "mapper_main",
+  "table_quality_main",
+]
+
+[tool.setuptools.packages.find]
+include = ["library", "schemas"]
+
 [tool.black]
 line-length = 88
 target-version = ["py312"]


### PR DESCRIPTION
## Summary
- expose command line tools via `project.scripts`
- declare top-level modules and packages so the project builds cleanly

## Testing
- `pre-commit run --files pyproject.toml`
- `python -m build`
- `pytest` *(fails: _run.<locals>.fake_get() got an unexpected keyword argument 'timeout'; more details in logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e0c1a0dc8324a8714a7291a2764c