### PR TITLE
feat: make ChEMBL cache size configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,1431 @@
+{
+  "$defs": {
+    "ActivityCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "activity_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        },
+        "dry_run": {
+          "default": false,
+          "title": "Dry Run",
+          "type": "boolean"
+        }
+      },
+      "title": "ActivityCfg",
+      "type": "object"
+    },
+    "ApiCfg": {
+      "additionalProperties": false,
+      "description": "Settings for ChEMBL API access.",
+      "properties": {
+        "chembl_base": {
+          "default": "https://www.ebi.ac.uk/chembl/api/data",
+          "title": "Chembl Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 30,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "backoff_factor": {
+          "default": 0.5,
+          "minimum": 0,
+          "title": "Backoff Factor",
+          "type": "number"
+        },
+        "rps": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        },
+        "user_agent": {
+          "default": "chembl-da/0.1 (mailto:info@example.org)",
+          "title": "User Agent",
+          "type": "string"
+        }
+      },
+      "title": "ApiCfg",
+      "type": "object"
+    },
+    "AssayCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "assay_chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "chunk_size": {
+          "default": 10,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "AssayCfg",
+      "type": "object"
+    },
+    "BatchCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "size": {
+          "default": 1000,
+          "minimum": 1,
+          "title": "Size",
+          "type": "integer"
+        },
+        "pause": {
+          "default": 0.0,
+          "minimum": 0,
+          "title": "Pause",
+          "type": "number"
+        },
+        "concurrency": {
+          "default": 2,
+          "minimum": 1,
+          "title": "Concurrency",
+          "type": "integer"
+        },
+        "fail_fast": {
+          "default": true,
+          "title": "Fail Fast",
+          "type": "boolean"
+        },
+        "retry_failed": {
+          "default": true,
+          "title": "Retry Failed",
+          "type": "boolean"
+        }
+      },
+      "title": "BatchCfg",
+      "type": "object"
+    },
+    "ChemblCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "cache_ttl": {
+          "default": 3600,
+          "minimum": 1,
+          "title": "Cache Ttl",
+          "type": "integer"
+        },
+        "cache_maxsize": {
+          "default": 1024,
+          "minimum": 1,
+          "title": "Cache Maxsize",
+          "type": "integer"
+        }
+      },
+      "title": "ChemblCfg",
+      "type": "object"
+    },
+    "CrossRefCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://api.crossref.org",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 30,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "rps": {
+          "default": 4,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        },
+        "mailto": {
+          "default": "info@example.org",
+          "title": "Mailto",
+          "type": "string"
+        }
+      },
+      "title": "CrossRefCfg",
+      "type": "object"
+    },
+    "DocTypeCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "weights": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Weights",
+          "type": "object"
+        },
+        "thresholds": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Thresholds",
+          "type": "object"
+        }
+      },
+      "title": "DocTypeCfg",
+      "type": "object"
+    },
+    "DocumentAllCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "sleep": {
+          "default": 5.0,
+          "minimum": 0,
+          "title": "Sleep",
+          "type": "number"
+        },
+        "workers": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Workers",
+          "type": "integer"
+        },
+        "batch_size": {
+          "default": 50,
+          "minimum": 1,
+          "title": "Batch Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "DocumentAllCfg",
+      "type": "object"
+    },
+    "DocumentCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "pubmed": {
+          "$ref": "#/$defs/DocumentPubmedCfg",
+          "default": {
+            "column": "PMID",
+            "sleep": 5.0,
+            "workers": 1,
+            "batch_size": 100
+          }
+        },
+        "chembl": {
+          "$ref": "#/$defs/DocumentChemblCfg",
+          "default": {
+            "column": "chembl_id",
+            "chunk_size": 5,
+            "timeout": 30.0
+          }
+        },
+        "all": {
+          "$ref": "#/$defs/DocumentAllCfg",
+          "default": {
+            "column": "chembl_id",
+            "chunk_size": 5,
+            "sleep": 5.0,
+            "workers": 1,
+            "batch_size": 50,
+            "timeout": 30.0
+          }
+        }
+      },
+      "title": "DocumentCfg",
+      "type": "object"
+    },
+    "DocumentChemblCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "DocumentChemblCfg",
+      "type": "object"
+    },
+    "DocumentPubmedCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "PMID",
+          "title": "Column",
+          "type": "string"
+        },
+        "sleep": {
+          "default": 5.0,
+          "minimum": 0,
+          "title": "Sleep",
+          "type": "number"
+        },
+        "workers": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Workers",
+          "type": "integer"
+        },
+        "batch_size": {
+          "default": 100,
+          "minimum": 1,
+          "title": "Batch Size",
+          "type": "integer"
+        }
+      },
+      "title": "DocumentPubmedCfg",
+      "type": "object"
+    },
+    "InitCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "same_doc": {
+          "default": "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx",
+          "format": "path",
+          "title": "Same Doc",
+          "type": "string"
+        },
+        "all_doc": {
+          "default": "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx",
+          "format": "path",
+          "title": "All Doc",
+          "type": "string"
+        },
+        "output_dir": {
+          "default": "data/output/ChEMBL/processed",
+          "format": "path",
+          "title": "Output Dir",
+          "type": "string"
+        }
+      },
+      "title": "InitCfg",
+      "type": "object"
+    },
+    "IoCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "output_dir": {
+          "default": "data/output",
+          "format": "path",
+          "title": "Output Dir",
+          "type": "string"
+        },
+        "cache_dir": {
+          "default": ".cache",
+          "format": "path",
+          "title": "Cache Dir",
+          "type": "string"
+        },
+        "csv_sep": {
+          "default": ",",
+          "title": "Csv Sep",
+          "type": "string"
+        },
+        "csv_encoding": {
+          "default": "utf-8-sig",
+          "title": "Csv Encoding",
+          "type": "string"
+        },
+        "csv_index": {
+          "default": false,
+          "title": "Csv Index",
+          "type": "boolean"
+        },
+        "exist_ok": {
+          "default": true,
+          "title": "Exist Ok",
+          "type": "boolean"
+        }
+      },
+      "title": "IoCfg",
+      "type": "object"
+    },
+    "IupharCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://www.guidetopharmacology.org/services",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 30,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "rps": {
+          "default": 4,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        }
+      },
+      "title": "IupharCfg",
+      "type": "object"
+    },
+    "JobsCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "concurrency": {
+          "default": 8,
+          "minimum": 1,
+          "title": "Concurrency",
+          "type": "integer"
+        },
+        "chunk_size": {
+          "default": 500,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        }
+      },
+      "title": "JobsCfg",
+      "type": "object"
+    },
+    "LogCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "default": "INFO",
+          "title": "Level",
+          "type": "string"
+        },
+        "format": {
+          "default": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+          "title": "Format",
+          "type": "string"
+        },
+        "datefmt": {
+          "default": "%Y-%m-%d %H:%M:%S",
+          "title": "Datefmt",
+          "type": "string"
+        }
+      },
+      "title": "LogCfg",
+      "type": "object"
+    },
+    "MapperCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enable_cache": {
+          "default": true,
+          "title": "Enable Cache",
+          "type": "boolean"
+        },
+        "strict_schema": {
+          "default": true,
+          "title": "Strict Schema",
+          "type": "boolean"
+        },
+        "warn_on_cast": {
+          "default": true,
+          "title": "Warn On Cast",
+          "type": "boolean"
+        }
+      },
+      "title": "MapperCfg",
+      "type": "object"
+    },
+    "OpenAlexCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://api.openalex.org",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 30,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "rps": {
+          "default": 4,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        },
+        "mailto": {
+          "default": "info@example.org",
+          "title": "Mailto",
+          "type": "string"
+        }
+      },
+      "title": "OpenAlexCfg",
+      "type": "object"
+    },
+    "PubChemCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://pubchem.ncbi.nlm.nih.gov/rest/pug",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 60,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "rps": {
+          "default": 3,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        },
+        "delay": {
+          "default": 3.0,
+          "minimum": 0,
+          "title": "Delay",
+          "type": "number"
+        }
+      },
+      "title": "PubChemCfg",
+      "type": "object"
+    },
+    "PubMedCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 10,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 2,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "encodings": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Encodings",
+          "type": "array"
+        }
+      },
+      "title": "PubMedCfg",
+      "type": "object"
+    },
+    "QualityCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "sample_rows": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Sample Rows",
+          "type": "integer"
+        },
+        "corr_method": {
+          "default": "pearson",
+          "title": "Corr Method",
+          "type": "string"
+        },
+        "max_unique_preview": {
+          "default": 50,
+          "minimum": 1,
+          "title": "Max Unique Preview",
+          "type": "integer"
+        },
+        "bin_count": {
+          "default": 20,
+          "minimum": 1,
+          "title": "Bin Count",
+          "type": "integer"
+        }
+      },
+      "title": "QualityCfg",
+      "type": "object"
+    },
+    "RateCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "global_rps": {
+          "default": 8,
+          "minimum": 1,
+          "title": "Global Rps",
+          "type": "integer"
+        },
+        "global_burst": {
+          "default": 8,
+          "minimum": 1,
+          "title": "Global Burst",
+          "type": "integer"
+        },
+        "limiter_cache_maxsize": {
+          "default": 128,
+          "minimum": 1,
+          "title": "Limiter Cache Maxsize",
+          "type": "integer"
+        },
+        "limiter_cache_ttl": {
+          "default": 600,
+          "minimum": 1,
+          "title": "Limiter Cache Ttl",
+          "type": "integer"
+        }
+      },
+      "title": "RateCfg",
+      "type": "object"
+    },
+    "ResourcesCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "dictionary_dir": {
+          "default": "dictionary",
+          "format": "path",
+          "title": "Dictionary Dir",
+          "type": "string"
+        },
+        "iuphar_target_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+          "format": "path",
+          "title": "Iuphar Target Csv",
+          "type": "string"
+        },
+        "iuphar_family_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+          "format": "path",
+          "title": "Iuphar Family Csv",
+          "type": "string"
+        },
+        "uniprot_data_dir": {
+          "default": "uniprot",
+          "format": "path",
+          "title": "Uniprot Data Dir",
+          "type": "string"
+        },
+        "organism_csv": {
+          "default": "dictionary/organism.csv",
+          "format": "path",
+          "title": "Organism Csv",
+          "type": "string"
+        },
+        "status_csv": {
+          "default": "dictionary/status.csv",
+          "format": "path",
+          "title": "Status Csv",
+          "type": "string"
+        },
+        "targets_type_csv": {
+          "default": "dictionary/targets_type.csv",
+          "format": "path",
+          "title": "Targets Type Csv",
+          "type": "string"
+        }
+      },
+      "title": "ResourcesCfg",
+      "type": "object"
+    },
+    "RetryCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "max_attempts": {
+          "default": 3,
+          "minimum": 1,
+          "title": "Max Attempts",
+          "type": "integer"
+        },
+        "backoff_factor": {
+          "default": 0.5,
+          "minimum": 0,
+          "title": "Backoff Factor",
+          "type": "number"
+        },
+        "status_forcelist": {
+          "items": {
+            "type": "integer"
+          },
+          "title": "Status Forcelist",
+          "type": "array"
+        }
+      },
+      "title": "RetryCfg",
+      "type": "object"
+    },
+    "SemanticScholarCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://api.semanticscholar.org/graph/v1",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 10,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 2,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "encodings": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Encodings",
+          "type": "array"
+        }
+      },
+      "title": "SemanticScholarCfg",
+      "type": "object"
+    },
+    "TargetAllCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "data_dir": {
+          "default": "dictionary/uniprot",
+          "format": "path",
+          "title": "Data Dir",
+          "type": "string"
+        },
+        "target_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+          "format": "path",
+          "title": "Target Csv",
+          "type": "string"
+        },
+        "family_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+          "format": "path",
+          "title": "Family Csv",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        },
+        "organism_csv": {
+          "default": "dictionary/_Target/organism.csv",
+          "format": "path",
+          "title": "Organism Csv",
+          "type": "string"
+        },
+        "uniprot_column": {
+          "default": "uniprot_id",
+          "title": "Uniprot Column",
+          "type": "string"
+        },
+        "chembl_out": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Chembl Out"
+        },
+        "uniprot_out": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uniprot Out"
+        },
+        "iuphar_out": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Iuphar Out"
+        }
+      },
+      "title": "TargetAllCfg",
+      "type": "object"
+    },
+    "TargetCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "uniprot": {
+          "$ref": "#/$defs/TargetUniprotCfg",
+          "default": {
+            "column": "uniprot_id",
+            "data_dir": "dictionary/uniprot"
+          }
+        },
+        "chembl": {
+          "$ref": "#/$defs/TargetChemblCfg",
+          "default": {
+            "column": "chembl_id",
+            "timeout": 30.0
+          }
+        },
+        "iuphar": {
+          "$ref": "#/$defs/TargetIupharCfg",
+          "default": {
+            "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+            "family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv"
+          }
+        },
+        "all": {
+          "$ref": "#/$defs/TargetAllCfg",
+          "default": {
+            "data_dir": "dictionary/uniprot",
+            "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+            "family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+            "timeout": 30.0,
+            "organism_csv": "dictionary/_Target/organism.csv",
+            "uniprot_column": "uniprot_id",
+            "chembl_out": null,
+            "uniprot_out": null,
+            "iuphar_out": null
+          }
+        }
+      },
+      "title": "TargetCfg",
+      "type": "object"
+    },
+    "TargetChemblCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "TargetChemblCfg",
+      "type": "object"
+    },
+    "TargetIupharCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "target_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+          "format": "path",
+          "title": "Target Csv",
+          "type": "string"
+        },
+        "family_csv": {
+          "default": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+          "format": "path",
+          "title": "Family Csv",
+          "type": "string"
+        }
+      },
+      "title": "TargetIupharCfg",
+      "type": "object"
+    },
+    "TargetUniprotCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "uniprot_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "data_dir": {
+          "default": "dictionary/uniprot",
+          "format": "path",
+          "title": "Data Dir",
+          "type": "string"
+        }
+      },
+      "title": "TargetUniprotCfg",
+      "type": "object"
+    },
+    "TestitemCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "molecule_chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "TestitemCfg",
+      "type": "object"
+    },
+    "UniprotCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://rest.uniprot.org",
+          "title": "Base",
+          "type": "string"
+        },
+        "timeout_connect": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Timeout Connect",
+          "type": "integer"
+        },
+        "timeout_read": {
+          "default": 30,
+          "minimum": 1,
+          "title": "Timeout Read",
+          "type": "integer"
+        },
+        "retries": {
+          "default": 3,
+          "minimum": 0,
+          "title": "Retries",
+          "type": "integer"
+        },
+        "rps": {
+          "default": 4,
+          "minimum": 1,
+          "title": "Rps",
+          "type": "integer"
+        },
+        "burst": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Burst",
+          "type": "integer"
+        },
+        "delay": {
+          "default": 0.25,
+          "minimum": 0,
+          "title": "Delay",
+          "type": "number"
+        }
+      },
+      "title": "UniprotCfg",
+      "type": "object"
+    },
+    "UniprotMappingCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "default": "https://rest.uniprot.org/idmapping",
+          "title": "Base",
+          "type": "string"
+        },
+        "poll_interval": {
+          "default": 0.5,
+          "exclusiveMinimum": 0,
+          "title": "Poll Interval",
+          "type": "number"
+        },
+        "timeout": {
+          "default": 300.0,
+          "minimum": 1,
+          "title": "Timeout",
+          "type": "number"
+        }
+      },
+      "title": "UniprotMappingCfg",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "api": {
+      "$ref": "#/$defs/ApiCfg",
+      "default": {
+        "chembl_base": "https://www.ebi.ac.uk/chembl/api/data",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "retries": 3,
+        "backoff_factor": 0.5,
+        "rps": 5,
+        "burst": 5,
+        "user_agent": "chembl-da/0.1 (mailto:info@example.org)"
+      }
+    },
+    "chembl": {
+      "$ref": "#/$defs/ChemblCfg",
+      "default": {
+        "cache_ttl": 3600,
+        "cache_maxsize": 1024
+      }
+    },
+    "openalex": {
+      "$ref": "#/$defs/OpenAlexCfg",
+      "default": {
+        "base": "https://api.openalex.org",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "retries": 3,
+        "rps": 4,
+        "burst": 5,
+        "mailto": "info@example.org"
+      }
+    },
+    "crossref": {
+      "$ref": "#/$defs/CrossRefCfg",
+      "default": {
+        "base": "https://api.crossref.org",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "retries": 3,
+        "rps": 4,
+        "burst": 5,
+        "mailto": "info@example.org"
+      }
+    },
+    "uniprot": {
+      "$ref": "#/$defs/UniprotCfg",
+      "default": {
+        "base": "https://rest.uniprot.org",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "retries": 3,
+        "rps": 4,
+        "burst": 5,
+        "delay": 0.25
+      }
+    },
+    "uniprot_mapping": {
+      "$ref": "#/$defs/UniprotMappingCfg",
+      "default": {
+        "base": "https://rest.uniprot.org/idmapping",
+        "poll_interval": 0.5,
+        "timeout": 300.0
+      }
+    },
+    "iuphar": {
+      "$ref": "#/$defs/IupharCfg",
+      "default": {
+        "base": "https://www.guidetopharmacology.org/services",
+        "timeout_connect": 5,
+        "timeout_read": 30,
+        "retries": 3,
+        "rps": 4,
+        "burst": 5
+      }
+    },
+    "pubchem": {
+      "$ref": "#/$defs/PubChemCfg",
+      "default": {
+        "base": "https://pubchem.ncbi.nlm.nih.gov/rest/pug",
+        "timeout_connect": 5,
+        "timeout_read": 60,
+        "retries": 3,
+        "rps": 3,
+        "burst": 5,
+        "delay": 3.0
+      }
+    },
+    "pubmed": {
+      "$ref": "#/$defs/PubMedCfg",
+      "default": {
+        "base": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+        "timeout_connect": 5,
+        "timeout_read": 10,
+        "retries": 2,
+        "encodings": [
+          "utf-8-sig",
+          "cp1251",
+          "latin1"
+        ]
+      }
+    },
+    "semantic_scholar": {
+      "$ref": "#/$defs/SemanticScholarCfg",
+      "default": {
+        "base": "https://api.semanticscholar.org/graph/v1",
+        "timeout_connect": 5,
+        "timeout_read": 10,
+        "retries": 2,
+        "encodings": [
+          "utf-8-sig"
+        ]
+      }
+    },
+    "doc_type": {
+      "$ref": "#/$defs/DocTypeCfg",
+      "default": {
+        "weights": {
+          "openalex": 3,
+          "pubmed": 4,
+          "scholar": 2
+        },
+        "thresholds": {
+          "experimental": 1,
+          "review": 1,
+          "unknown": 2
+        }
+      }
+    },
+    "resources": {
+      "$ref": "#/$defs/ResourcesCfg",
+      "default": {
+        "dictionary_dir": "dictionary",
+        "iuphar_target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+        "iuphar_family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+        "uniprot_data_dir": "uniprot",
+        "organism_csv": "dictionary/organism.csv",
+        "status_csv": "dictionary/status.csv",
+        "targets_type_csv": "dictionary/targets_type.csv"
+      }
+    },
+    "io": {
+      "$ref": "#/$defs/IoCfg",
+      "default": {
+        "output_dir": "data/output",
+        "cache_dir": ".cache",
+        "csv_sep": ",",
+        "csv_encoding": "utf-8-sig",
+        "csv_index": false,
+        "exist_ok": true
+      }
+    },
+    "jobs": {
+      "$ref": "#/$defs/JobsCfg",
+      "default": {
+        "concurrency": 8,
+        "chunk_size": 500
+      }
+    },
+    "log": {
+      "$ref": "#/$defs/LogCfg",
+      "default": {
+        "level": "INFO",
+        "format": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+        "datefmt": "%Y-%m-%d %H:%M:%S"
+      }
+    },
+    "init": {
+      "$ref": "#/$defs/InitCfg",
+      "default": {
+        "same_doc": "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx",
+        "all_doc": "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx",
+        "output_dir": "data/output/ChEMBL/processed"
+      }
+    },
+    "batch": {
+      "$ref": "#/$defs/BatchCfg",
+      "default": {
+        "size": 1000,
+        "pause": 0.0,
+        "concurrency": 2,
+        "fail_fast": true,
+        "retry_failed": true
+      }
+    },
+    "quality": {
+      "$ref": "#/$defs/QualityCfg",
+      "default": {
+        "sample_rows": 0,
+        "corr_method": "pearson",
+        "max_unique_preview": 50,
+        "bin_count": 20
+      }
+    },
+    "mapper": {
+      "$ref": "#/$defs/MapperCfg",
+      "default": {
+        "enable_cache": true,
+        "strict_schema": true,
+        "warn_on_cast": true
+      }
+    },
+    "rate": {
+      "$ref": "#/$defs/RateCfg",
+      "default": {
+        "global_rps": 8,
+        "global_burst": 8,
+        "limiter_cache_maxsize": 128,
+        "limiter_cache_ttl": 600
+      }
+    },
+    "retry": {
+      "$ref": "#/$defs/RetryCfg",
+      "default": {
+        "max_attempts": 3,
+        "backoff_factor": 0.5,
+        "status_forcelist": [
+          429,
+          500,
+          502,
+          503,
+          504
+        ]
+      }
+    },
+    "activity": {
+      "$ref": "#/$defs/ActivityCfg",
+      "default": {
+        "column": "activity_id",
+        "chunk_size": 5,
+        "timeout": 30.0,
+        "limit": null,
+        "dry_run": false
+      }
+    },
+    "assay": {
+      "$ref": "#/$defs/AssayCfg",
+      "default": {
+        "column": "assay_chembl_id",
+        "chunk_size": 10,
+        "timeout": 30.0
+      }
+    },
+    "testitem": {
+      "$ref": "#/$defs/TestitemCfg",
+      "default": {
+        "column": "molecule_chembl_id",
+        "chunk_size": 5,
+        "timeout": 30.0
+      }
+    },
+    "document": {
+      "$ref": "#/$defs/DocumentCfg",
+      "default": {
+        "pubmed": {
+          "batch_size": 100,
+          "column": "PMID",
+          "sleep": 5.0,
+          "workers": 1
+        },
+        "chembl": {
+          "chunk_size": 5,
+          "column": "chembl_id",
+          "timeout": 30.0
+        },
+        "all": {
+          "batch_size": 50,
+          "chunk_size": 5,
+          "column": "chembl_id",
+          "sleep": 5.0,
+          "timeout": 30.0,
+          "workers": 1
+        }
+      }
+    },
+    "target": {
+      "$ref": "#/$defs/TargetCfg",
+      "default": {
+        "uniprot": {
+          "column": "uniprot_id",
+          "data_dir": "dictionary/uniprot"
+        },
+        "chembl": {
+          "column": "chembl_id",
+          "timeout": 30.0
+        },
+        "iuphar": {
+          "family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+          "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv"
+        },
+        "all": {
+          "chembl_out": null,
+          "data_dir": "dictionary/uniprot",
+          "family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
+          "iuphar_out": null,
+          "organism_csv": "dictionary/_Target/organism.csv",
+          "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+          "timeout": 30.0,
+          "uniprot_column": "uniprot_id",
+          "uniprot_out": null
+        }
+      }
+    }
+  },
+  "title": "Config",
+  "type": "object"
+}

--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,7 @@ api:
 
 chembl:
   cache_ttl: 3600  # Seconds to cache ChEMBL API responses (env: CHEMBL_DA__CHEMBL__CACHE_TTL / CHEMBL_DA_CACHE_TTL)
+  cache_maxsize: 1024  # Max cached ChEMBL responses (env: CHEMBL_DA__CHEMBL__CACHE_MAXSIZE / CHEMBL_DA_CACHE_MAXSIZE)
 
 openalex:
   base: "https://api.openalex.org"  # OpenAlex API root URL (env: CHEMBL_DA__OPENALEX__BASE / CHEMBL_DA_OPENALEX_BASE)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,6 +35,13 @@ parameters or environment variables.
 | `max_retries` | `3` | `3` | Number of automatic retries for transient errors. |
 | `backoff_factor` | `0.3` | `0.3` | Exponential backoff multiplier between retries. |
 
+### `chembl`
+
+| Field | Default | Fallback | Description |
+|-------|---------|----------|-------------|
+| `cache_ttl` | `3600` | `3600` | Seconds to cache ChEMBL API responses. |
+| `cache_maxsize` | `1024` | `1024` | Maximum number of cached ChEMBL responses. |
+
 ### `output`
 
 | Field | Default | Fallback | Description |
@@ -70,6 +77,8 @@ to the same configuration keys as their longer forms:
 | `CHEMBL_DA_TIMEOUT_READ` | `CHEMBL_DA__API__TIMEOUT_READ` |
 | `CHEMBL_DA_OUTDIR` | `CHEMBL_DA__IO__OUTPUT_DIR` |
 | `CHEMBL_DA_CACHE_DIR` | `CHEMBL_DA__IO__CACHE_DIR` |
+| `CHEMBL_DA_CACHE_TTL` | `CHEMBL_DA__CHEMBL__CACHE_TTL` |
+| `CHEMBL_DA_CACHE_MAXSIZE` | `CHEMBL_DA__CHEMBL__CACHE_MAXSIZE` |
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `CHEMBL_DA__RATE__LIMITER_CACHE_MAXSIZE` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `CHEMBL_DA__RATE__LIMITER_CACHE_TTL` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__LOG__LEVEL` |

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -28,7 +28,7 @@ class ChemblClient:
     retry:
         Retry configuration applied to all requests.
     chembl:
-        Optional ChEMBL-specific configuration controlling cache TTL.
+        Optional ChEMBL-specific configuration controlling cache TTL and size.
     session:
         Optional pre-configured :class:`requests.Session` instance; primarily
         intended for tests.
@@ -50,7 +50,10 @@ class ChemblClient:
         retry = retry or RetryCfg()
         self.session = session or session_with_retry(api, retry)
         ttl = chembl.cache_ttl if chembl is not None else ChemblCfg().cache_ttl
-        self.cache = TTLCache(maxsize=1024, ttl=ttl)
+        maxsize = (
+            chembl.cache_maxsize if chembl is not None else ChemblCfg().cache_maxsize
+        )
+        self.cache = TTLCache(maxsize=maxsize, ttl=ttl)
         self._cache_lock = threading.Lock()
 
     def request_json(
@@ -86,7 +89,6 @@ class ChemblClient:
         with self._cache_lock:
             cached = self.cache.get(cache_key)
             if cached is not None:
-
                 logger.info(
                     "cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"}
                 )
@@ -94,7 +96,6 @@ class ChemblClient:
             logger.info(
                 "cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"}
             )
-
 
         last_exc: requests.RequestException | ValueError | None = None
 

--- a/library/config.py
+++ b/library/config.py
@@ -101,6 +101,7 @@ class ApiCfg(_BaseModel):
 
 class ChemblCfg(_BaseModel):
     cache_ttl: int = Field(3600, ge=1)
+    cache_maxsize: int = Field(1024, ge=1)
 
 
 class OpenAlexCfg(_BaseModel):
@@ -684,6 +685,7 @@ _ALIAS_MAP: dict[str, list[str]] = {
     "CHEMBL_DA_PUBCHEM_RPS": ["pubchem", "rps"],
     "CHEMBL_DA_PUBCHEM_BURST": ["pubchem", "burst"],
     "CHEMBL_DA_CACHE_TTL": ["chembl", "cache_ttl"],
+    "CHEMBL_DA_CACHE_MAXSIZE": ["chembl", "cache_maxsize"],
     "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
     "CHEMBL_DA_CACHE_DIR": ["io", "cache_dir"],
     "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,17 @@ def test_cache_dir_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert cfg.io.cache_dir == cache
 
 
+def test_chembl_cache_maxsize_from_yaml(tmp_path: Path) -> None:
+    """Custom ``chembl.cache_maxsize`` should override the default."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("chembl:\n  cache_maxsize: 42\n")
+
+    cfg = load_config(path)
+
+    assert cfg.chembl.cache_maxsize == 42
+
+
 def test_mailto_aliases_override_defaults(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add `cache_maxsize` option to config and schema
- use `cache_maxsize` when constructing `ChemblClient` cache
- document and test cache size setting

## Testing
- `ruff check library/chembl_client.py library/config.py tests/test_config.py`
- `ruff format library/chembl_client.py library/config.py tests/test_config.py`
- `black library/chembl_client.py library/config.py tests/test_config.py`
- `mypy library/config.py library/chembl_client.py tests/test_config.py` (fails: Untyped decorator and other existing errors)
- `pytest tests/test_config.py::test_chembl_cache_maxsize_from_yaml`


------
https://chatgpt.com/codex/tasks/task_e_68c2e5c159308324883b3dce537d839a