### PR TITLE
feat: use structured logging in CLI scripts

### DIFF
--- a/chunk_io_main.py
+++ b/chunk_io_main.py
@@ -59,7 +59,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         sep=args.sep,
         encoding=args.encoding,
     )
-    logger.info("processed %d rows", rows)
+    logger.info("rows_processed", extra={"rows": rows})
     return 0
 
 

--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -51,8 +51,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start
-    logger.info("written %s", output)
-    logger.info("completed in %.3f seconds", elapsed)
+    logger.info("write_done", extra={"path": str(output)})
+    logger.info("run_completed", extra={"elapsed": elapsed})
     return 0
 
 

--- a/get_activity_data.py
+++ b/get_activity_data.py
@@ -54,11 +54,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     if cfg.activity.dry_run:
         expected = limit if limit is not None else 0
-        logger.info(
-            "dry run selected; would process at most %d identifiers",
-            expected,
-            extra={"event": "dry_run"},
-        )
+        logger.info("dry_run", extra={"limit": expected})
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
@@ -77,7 +73,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if limit is not None:
         limited = list(islice(ids_iter, limit))
         ids = limited
-        logger.info("processing at most %d identifiers", len(limited))
+        logger.info("process_limit", extra={"limit": len(limited)})
 
     try:
         df = cl.get_activities(
@@ -124,7 +120,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -187,7 +183,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -204,25 +200,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code: int = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/get_assay_data.py
+++ b/get_assay_data.py
@@ -100,7 +100,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -149,7 +149,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -164,25 +164,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/get_document_data.py
+++ b/get_document_data.py
@@ -159,7 +159,7 @@ def fetch_pubmed_records(
             batch_len = futures[future]
             records.extend(future.result())
             processed += batch_len
-            logger.info("Processed %d documents", processed)
+            logger.info("documents_processed", extra={"count": processed})
     if not records:
         return pd.DataFrame()
     return pd.DataFrame(records)
@@ -221,7 +221,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
 
         stats: Stats = {
             "rows_total": rows_total,
@@ -318,7 +318,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -421,7 +421,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 key_cols=key_cols or None,
             )
-            logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
             return 1
@@ -508,7 +508,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -654,7 +654,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     mapping = {"column": f"document.{args.command}.column"}
@@ -697,25 +697,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/get_document_type.py
+++ b/get_document_type.py
@@ -128,9 +128,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger_inst = configure_logger(log_cfg)
-    logger_inst.info(
-        "pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"}
-    )
+    logger_inst.info("pipeline_start", extra={"run_id": log_cfg.run_id})
 
     try:
         cfg: Config = apply_config_overrides(
@@ -149,9 +147,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger_inst.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger_inst.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger_inst = configure_logger(
@@ -159,15 +155,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger_inst.info(
-            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
-        )
+        logger_inst.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger_inst.info(
-            "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
-        )
+        logger_inst.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
 
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
@@ -178,7 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
-    logger_inst.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+    logger_inst.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     return 0
 
 

--- a/get_input_initialisation.py
+++ b/get_input_initialisation.py
@@ -60,11 +60,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         out_dir = Path(args.out_dir or cfg.init.output_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info("Loading source workbooks")
+        logger.info("load_workbooks")
         same = lib.load_same_doc(args.same_doc)
         all_ = lib.load_all_doc(args.all_doc)
 
-        logger.info("Combining tables")
+        logger.info("combine_tables")
         tables = lib.build_combined_tables(
             same,
             all_,
@@ -72,7 +72,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             status_csv=cfg.resources.status_csv,
             targets_type_csv=cfg.resources.targets_type_csv,
         )
-        logger.info("Generating entity tables for pair segments")
+        logger.info("generate_pair_tables")
         tables = lib.generate_pair_entity_tables(
             tables,
             {
@@ -81,7 +81,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 "pairs_same_document": "same_document",
             },
         )
-        logger.info("Computing status percentages")
+        logger.info("compute_status_percentages")
         for key, df in list(tables.items()):
             if not key.endswith("_status"):
                 continue
@@ -91,21 +91,21 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             entity = key.split("_")[0]
             tables[key] = lib.compute_status_statistics(df, entity)
 
-        logger.info("Saving output")
+        logger.info("save_output")
         paths = lib.save_tables(tables, out_dir, cfg, fmt=args.format)
         # Ensure that files were actually written to disk
         missing = [str(p) for p in paths.values() if not p.exists()]
         if missing:
             raise RuntimeError("failed to write output files: " + ", ".join(missing))
 
-        logger.info("Generating data quality reports")
+        logger.info("generate_quality_reports")
         report_dir = out_dir / "data_validity_report"
         report_dir.mkdir(parents=True, exist_ok=True)
         for entity, path in paths.items():
-            logger.info("Profiling %s", entity)
+            logger.info("profiling", extra={"entity": entity})
             analyze_table_quality(path, table_name=str(report_dir / path.stem))
 
-        logger.info("Saved %d tables and quality reports to %s", len(paths), out_dir)
+        logger.info("save_done", extra={"tables": len(paths), "path": str(out_dir)})
         return 0
     except KeyError as exc:
         logger.error("required table '%s' missing", exc.args[0])
@@ -153,7 +153,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -169,9 +169,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
 
@@ -197,17 +195,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = int(args.func(cfg, args))
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/get_target_data.py
+++ b/get_target_data.py
@@ -403,7 +403,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -693,7 +693,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     try:
@@ -731,33 +731,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     if hasattr(args, "func"):
         exit_code = args.func(cfg, args)
         if exit_code == 0:
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
         else:
-            logger.info(
-                "pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"}
-            )
+            logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return exit_code
     parser.print_help()
-    logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+    logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return 1
 
 

--- a/get_testitem_data.py
+++ b/get_testitem_data.py
@@ -62,13 +62,13 @@ def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
 
     total = len(unique_smiles)
     if total:
-        logger.info("Fetching PubChem data for %d unique SMILES", total)
+        logger.info("pubchem_start", extra={"total": total})
     else:
-        logger.info("No SMILES strings available for PubChem lookup")
+        logger.info("pubchem_no_smiles")
 
     records: dict[str, dict[str, str]] = {}
     for idx, smi in enumerate(unique_smiles, start=1):
-        logger.info("PubChem lookup %d/%d", idx, total)
+        logger.info("pubchem_progress", extra={"current": idx, "total": total})
         cid = pl.get_cid_from_smiles(smi, cfg) or ""
         first_cid = cid.split("|")[0] if cid else ""
         if first_cid:
@@ -132,8 +132,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
-    logger.info("Retrieved %d identifiers", len(ids))
-    logger.info("Fetching ChEMBL data in chunks of %d", cfg.testitem.chunk_size)
+    logger.info("identifiers_retrieved", extra={"count": len(ids)})
+    logger.info("chembl_fetch_start", extra={"chunk_size": cfg.testitem.chunk_size})
 
     try:
         df = cl.get_testitem(
@@ -146,10 +146,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error("failed to retrieve compounds: %s", exc)
         return 1
-    logger.info("Retrieved %d rows from ChEMBL", len(df))
-    logger.info("Augmenting results with PubChem data")
+    logger.info("chembl_fetch_done", extra={"rows": len(df)})
+    logger.info("pubchem_augment_start")
     df = add_pubchem_data(df, cfg.pubchem)
-    logger.info("PubChem augmentation completed")
+    logger.info("pubchem_augment_done")
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df = normalize_testitems(df)
     rows_total = len(df)
@@ -184,7 +184,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("Wrote %d rows to %s", rows_kept, csv_path)
+        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -234,7 +234,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -249,25 +249,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -36,6 +36,10 @@ _LEVELS = {
 # Global lock ensuring thread-safe writes to the log stream.
 _EMIT_LOCK = threading.Lock()
 
+# Default attributes present on :class:`logging.LogRecord` instances.  Used to
+# extract ``extra`` fields supplied via the standard :mod:`logging` API.
+_LOG_RECORD_DEFAULT_KEYS = set(logging.LogRecord("", 0, "", 0, "", (), None).__dict__)
+
 
 def _level_no(name: str) -> int:
     """Return numeric value for ``name``.
@@ -315,9 +319,13 @@ def configure_logger(cfg: LoggerConfig) -> Logger:
         """Forward ``logging`` records to :class:`Logger` as JSON lines."""
 
         def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - thin
-            # ``record.name`` acts as the event identifier while the formatted
-            # message is stored in ``msg`` for human readability.
-            logger.log(record.levelname, record.name, msg=record.getMessage())
+            extras = {
+                k: v
+                for k, v in record.__dict__.items()
+                if k not in _LOG_RECORD_DEFAULT_KEYS
+            }
+            extras["logger"] = record.name
+            logger.log(record.levelname, record.getMessage(), extra=extras)
 
     root_logger = logging.getLogger()
     handler = _ForwardHandler()

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -63,7 +63,10 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             uniprot_id = map_chembl_to_uniprot(str(chembl_id), cfg.uniprot_mapping)
             uniprot_ids.append(uniprot_id)
             if uniprot_id:
-                logger.info("mapped %s -> %s", chembl_id, uniprot_id)
+                logger.info(
+                    "mapped",
+                    extra={"chembl_id": str(chembl_id), "uniprot_id": uniprot_id},
+                )
             else:
                 logger.warning("no UniProt ID for %s", chembl_id)
         except (ValueError, TimeoutError, URLError) as exc:
@@ -80,7 +83,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             encoding=args.encoding,
             key_cols=args.key_cols,
         )
-        logger.info("wrote %s", output)
+        logger.info("write_done", extra={"path": str(output)})
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -110,31 +113,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -72,31 +72,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline start run_id=%s", log_cfg.run_id, extra={"event": "start"})
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info(
-                "pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"}
-            )
+            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline done run_id=%s", log_cfg.run_id, extra={"event": "done"})
+        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:
-        logger.info("pipeline fail run_id=%s", log_cfg.run_id, extra={"event": "fail"})
+        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
     return exit_code
 
 

--- a/tests/test_log_json_format.py
+++ b/tests/test_log_json_format.py
@@ -23,3 +23,18 @@ def test_logger_emits_required_fields() -> None:
     assert record["status"] == "ok"
     assert record["rps"] == 1.5
     assert "ts" in record
+
+
+def test_standard_logging_forwards_extra() -> None:
+    """Standard :mod:`logging` calls are forwarded with extras."""
+
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(level="INFO", stream=buffer))
+    import logging
+
+    logging.getLogger("std").info("std_event", extra={"foo": 1})
+    record = json.loads(buffer.getvalue().splitlines()[0])
+    configure_logger(LoggerConfig(stream=sys.stdout))
+    assert record["event"] == "std_event"
+    assert record["foo"] == 1
+    assert record["logger"] == "std"

--- a/tests/test_mapper_logging.py
+++ b/tests/test_mapper_logging.py
@@ -1,6 +1,18 @@
+import argparse
 import importlib
+import io
+import json
 import logging
 import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+
+import mapper_main
+from library.cli import LoggerConfig, configure_logger
+from library.config import Config
 
 
 def test_mapper_library_has_no_logging_side_effect() -> None:
@@ -13,3 +25,38 @@ def test_mapper_library_has_no_logging_side_effect() -> None:
         del sys.modules[module_name]
     importlib.import_module(module_name)
     assert not root.handlers
+
+
+def test_mapper_main_logs_mapping(tmp_path: Path, monkeypatch: Any) -> None:
+    """Mapper CLI emits structured mapping log records."""
+
+    def fake_map(cid: str, cfg: object) -> str | None:
+        return "P12345"
+
+    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", fake_map)
+    df = pd.DataFrame({"chembl_id": ["CHEMBL1"]})
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False)
+    args = argparse.Namespace(
+        input_csv=input_path,
+        output_csv=tmp_path / "out.csv",
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+        key_cols=None,
+    )
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(stream=buffer, level="INFO"))
+
+    base_cfg = Config()
+    cfg = SimpleNamespace(
+        io=base_cfg.io, uniprot_mapping=base_cfg.uniprot_mapping, to_dict=lambda: {}
+    )
+    exit_code = mapper_main.run(cfg, args)
+    assert exit_code == 0
+    records = [json.loads(line) for line in buffer.getvalue().splitlines()]
+    mapped = [r for r in records if r["event"] == "mapped"]
+    assert mapped
+    rec = mapped[0]
+    assert rec["chembl_id"] == "CHEMBL1"
+    assert rec["uniprot_id"] == "P12345"


### PR DESCRIPTION
## Summary
- switch CLI scripts to structured `logger.info("event", extra={...})` calls
- forward standard `logging` extra fields in JSON logger
- test logging JSON formatting and mapper logs

## Testing
- `ruff check chunk_io_main.py csv_utils_main.py get_activity_data.py get_assay_data.py get_document_data.py get_document_type.py get_input_initialisation.py get_target_data.py get_testitem_data.py library/logging_setup.py mapper_main.py table_quality_main.py tests/test_log_json_format.py tests/test_mapper_logging.py`
- `mypy tests/test_log_json_format.py tests/test_mapper_logging.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_log_json_format.py tests/test_mapper_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2e5c3c53c8324aa8a3787cff3b57d