### PR TITLE
Organize CLI scripts in dedicated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tokens should be stored in a local ``.env`` file – see
 3. **Run a sample script**
 
    ```bash
-   python get_activity_data.py --input tests/data/activity_ids_small.csv \
+   python scripts/get_activity_data.py --input tests/data/activity_ids_small.csv \
        --output out/activities.csv --limit 10 --log-level INFO
    ```
 
@@ -55,9 +55,9 @@ tokens should be stored in a local ``.env`` file – see
    ``--encoding`` for file encoding. Additional examples:
 
    ```bash
-   python mapper_main.py --input tests/data/assays.csv \
+   python scripts/mapper_main.py --input tests/data/assays.csv \
        --output out/mapped.csv --log-level DEBUG
-   python table_quality_main.py --input tests/data/assays.csv \
+   python scripts/table_quality_main.py --input tests/data/assays.csv \
        --output out/report.csv --log-level INFO
    ```
 
@@ -83,7 +83,7 @@ Retrieve document metadata for a list of PubMed IDs using the bundled
 sample file:
 
 ```bash
-python get_document_data.py pubmed \
+python scripts/get_document_data.py pubmed \
     --input tests/data/pmids.csv \
     --output out/documents.csv \
     --limit 5 \
@@ -98,7 +98,7 @@ experimentation.
 Fetch basic target information from ChEMBL:
 
 ```bash
-python get_target_data.py chembl \
+python scripts/get_target_data.py chembl \
     --input path/to/targets.csv \
     --output out/targets.csv \
     --limit 5 \
@@ -140,7 +140,7 @@ CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
 Запустить скрипт с автоматической подгрузкой настроек можно так:
 
 ```bash
-python -m dotenv run -- python get_assay_data.py --input tests/data/assays.csv \\
+python -m dotenv run -- python scripts/get_assay_data.py --input tests/data/assays.csv \\
     --output out/assays.csv
 ```
 
@@ -173,7 +173,7 @@ api:
 Пример включения JSON‑формата через переменную окружения:
 
 ```bash
-LOG_FORMAT=json python get_assay_data.py --input tests/data/assays.csv \
+LOG_FORMAT=json python scripts/get_assay_data.py --input tests/data/assays.csv \
     --output out/assays.csv --log-level INFO
 ```
 
@@ -181,7 +181,7 @@ LOG_FORMAT=json python get_assay_data.py --input tests/data/assays.csv \
 `CHEMBL_DA_LOG_LEVEL`:
 
 ```bash
-CHEMBL_DA_LOG_LEVEL=DEBUG python get_assay_data.py --input tests/data/assays.csv \
+CHEMBL_DA_LOG_LEVEL=DEBUG python scripts/get_assay_data.py --input tests/data/assays.csv \
     --output out/assays.csv
 ```
 
@@ -258,11 +258,8 @@ Continuous integration executes the same checks.
 data/             Example input and output files
 dictionary/       Lookup tables used during processing
 library/          Reusable data-processing modules
+scripts/          CLI entry points and development helpers
 tests/            Pytest suite and sample datasets
-get_*.py          Command-line utilities for specific tasks
-mapper_main.py    Mapping CLI
-table_quality_main.py  CSV profiling CLI
-scripts/          Development helpers
 config.yaml       Global configuration defaults
 ```
 
@@ -281,7 +278,7 @@ For a quick connectivity check without writing any files, limit the number of
 records and enable dry-run mode:
 
 ```bash
-python get_activity_data.py --limit 10 --dry-run
+python scripts/get_activity_data.py --limit 10 --dry-run
 ```
 
 ## Reproducibility
@@ -365,7 +362,7 @@ quality, corr = analyze_table_quality(df, table_name="data")
 Running the CLI saves ``data_quality_report_table.csv`` and
 ``data_data_correlation_report_table.csv`` in the current working directory::
 
-    python table_quality_main.py --input data.csv --table-name data
+    python scripts/table_quality_main.py --input data.csv --table-name data
 
 All scripts share a common set of flags:
 
@@ -455,7 +452,7 @@ Common flags shared by scripts include:
 
 Example fetching assay data::
 
-    python get_assay_data.py --input assays.csv --output assays_out.csv \
+    python scripts/get_assay_data.py --input assays.csv --output assays_out.csv \
         --column assay_chembl_id
 
 Each command validates required columns before querying external APIs and
@@ -617,12 +614,12 @@ available options.
 
 Example merging initialisation tables::
 
-    python get_input_initialisation.py --config config.yaml
+    python scripts/get_input_initialisation.py --config config.yaml
 
 The ``same_doc`` and ``all_doc`` workbook paths default to values from
 ``config.yaml`` but can be overridden on the command line::
 
-    python get_input_initialisation.py \
+    python scripts/get_input_initialisation.py \
       --same-doc path/to/ChEMBL_same_document_20_05.xlsx \
       --all-doc  path/to/ChEMBL_all_10_05_step5.xlsx \
       --out-dir  ./out
@@ -638,15 +635,15 @@ Install the optional developer tools and run the standard quality checks:
 
 * ``black`` – auto-format the code::
 
-      black get_*.py library mapper_main.py table_quality_main.py scripts
+      black library scripts
 
 * ``ruff`` – lint the project::
 
-      ruff check get_*.py library mapper_main.py table_quality_main.py scripts
+      ruff check library scripts
 
 * ``mypy`` – perform static type checks::
 
-      mypy get_*.py library mapper_main.py table_quality_main.py scripts
+      mypy library scripts
 
 * ``python scripts/check_determinism.py`` – verify deterministic CSV output.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,7 +11,7 @@ processing begins.
 ## Activity data
 
 ```bash
-python get_activity_data.py \
+python scripts/get_activity_data.py \
     --input data/input-smoke/activity.csv \
     --column activity_id
 ```
@@ -19,7 +19,7 @@ python get_activity_data.py \
 ## Assay descriptions
 
 ```bash
-python get_assay_data.py \
+python scripts/get_assay_data.py \
     --input data/input-smoke/assay.csv \
     --column assay_chembl_id
 ```
@@ -27,7 +27,7 @@ python get_assay_data.py \
 ## Document metadata
 
 ```bash
-python get_document_data.py \
+python scripts/get_document_data.py \
     --input data/input-smoke/documents.csv \
     --column document_chembl_id
 ```
@@ -36,7 +36,7 @@ python get_document_data.py \
 ## Target data aggregation
 
 ```bash
-python get_target_data.py \
+python scripts/get_target_data.py \
     --input data/input-smoke/targets.csv \
     --column target_chembl_id
 ```
@@ -44,7 +44,7 @@ python get_target_data.py \
 ## Test item data enrichment
 
 ```bash
-python get_testitem_data.py \
+python scripts/get_testitem_data.py \
     --input data/input-smoke/testitem.csv \
     --column compound_chembl_id
 ```
@@ -52,7 +52,7 @@ python get_testitem_data.py \
 ## Input initialisation merging
 
 ```bash
-python get_input_initialisation.py \
+python scripts/get_input_initialisation.py \
     --same-doc dictionary/classifications/assay_classification.csv \
     --all-doc dictionary/classifications/target_classification.csv \
     --out-dir data/output-smoke
@@ -81,7 +81,7 @@ replaces `io.csv_sep` and `io.csv_encoding` respectively. Likewise
 ## Table quality profiler
 
 ```bash
-python table_quality_main.py \
+python scripts/table_quality_main.py \
     --input data/input-smoke/activity.csv \
     --table-name activity
 ```
@@ -114,8 +114,8 @@ changes. Install the developer extras first:
 
 ```bash
 pip install -r requirements-dev.txt
-black get_*.py library mapper_main.py table_quality_main.py scripts
-ruff check get_*.py library mapper_main.py table_quality_main.py scripts
-mypy get_*.py library mapper_main.py table_quality_main.py scripts
+black library scripts
+ruff check library scripts
+mypy library scripts
 python scripts/check_determinism.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,33 +49,19 @@ dev = [
 ]
 
 [project.scripts]
-get-activity-data = "get_activity_data:main"
-get-assay-data = "get_assay_data:main"
-get-target-data = "get_target_data:main"
-get-document-data = "get_document_data:main"
-get-document-type = "get_document_type:main"
-get-input-initialisation = "get_input_initialisation:main"
-get-testitem-data = "get_testitem_data:main"
-csv-utils = "csv_utils_main:main"
-mapper = "mapper_main:main"
-table-quality = "table_quality_main:main"
-
-[tool.setuptools]
-py-modules = [
-  "get_activity_data",
-  "get_assay_data",
-  "get_target_data",
-  "get_document_data",
-  "get_document_type",
-  "get_input_initialisation",
-  "get_testitem_data",
-  "csv_utils_main",
-  "mapper_main",
-  "table_quality_main",
-]
+get-activity-data = "scripts.get_activity_data:main"
+get-assay-data = "scripts.get_assay_data:main"
+get-target-data = "scripts.get_target_data:main"
+get-document-data = "scripts.get_document_data:main"
+get-document-type = "scripts.get_document_type:main"
+get-input-initialisation = "scripts.get_input_initialisation:main"
+get-testitem-data = "scripts.get_testitem_data:main"
+csv-utils = "scripts.csv_utils_main:main"
+mapper = "scripts.mapper_main:main"
+table-quality = "scripts.table_quality_main:main"
 
 [tool.setuptools.packages.find]
-include = ["library", "schemas"]
+include = ["library", "schemas", "scripts"]
 
 [tool.black]
 line-length = 88

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts for ChEMBL data acquisition CLIs."""

--- a/scripts/chunk_io_main.py
+++ b/scripts/chunk_io_main.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from library.chunk_io import process_csv_chunks
-from library.cli import LoggerConfig, add_common_arguments, configure_logger
-from library.config import Config, ensure_dirs
-from library.io import default_output_path
-from library.log import logger
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.chunk_io import process_csv_chunks  # noqa: E402
+from library.cli import (  # noqa: E402
+    LoggerConfig,
+    add_common_arguments,
+    configure_logger,
+)
+from library.config import Config, ensure_dirs  # noqa: E402
+from library.io import default_output_path  # noqa: E402
+from library.log import logger  # noqa: E402
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/csv_utils_main.py
+++ b/scripts/csv_utils_main.py
@@ -6,17 +6,22 @@ using :func:`library.csv_utils.write_csv_deterministic`.
 
 from __future__ import annotations
 
+import sys
 import time
 from collections.abc import Sequence
 from pathlib import Path
 
 import pandas as pd
 
-from library.cli import LoggerConfig, configure_logger
-from library.cli_utils import build_parser
-from library.csv_utils import write_csv_deterministic
-from library.log import logger
-from library.parser_schema import CSVExportArgs
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.cli import LoggerConfig, configure_logger  # noqa: E402
+from library.cli_utils import build_parser  # noqa: E402
+from library.csv_utils import write_csv_deterministic  # noqa: E402
+from library.log import logger  # noqa: E402
+from library.parser_schema import CSVExportArgs  # noqa: E402
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -6,27 +6,37 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from itertools import islice
+from pathlib import Path
 
 import requests
 from pandera.errors import SchemaErrors
 
-from library import chembl_library as cl
-from library import io
-from library.chembl_client import ChemblClient
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import chembl_library as cl  # noqa: E402
+from library import io  # noqa: E402
+from library.chembl_client import ChemblClient  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, _serialize_paths, ensure_dirs, print_config
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
-from schemas import ActivitiesSchema, normalize_activities
+from library.config import (  # noqa: E402
+    Config,
+    _serialize_paths,
+    ensure_dirs,
+    print_config,
+)
+from library.log import logger  # noqa: E402
+from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
+from library.sidecar import SidecarErrors  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
+from schemas import ActivitiesSchema, normalize_activities  # noqa: E402
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -5,28 +5,38 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
 import requests
 from pandera.errors import SchemaErrors
 
-from library import assay_postprocessing as ap
-from library import chembl_library as cl
-from library import io
-from library.chembl_client import ChemblClient
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import assay_postprocessing as ap  # noqa: E402
+from library import chembl_library as cl  # noqa: E402
+from library import io  # noqa: E402
+from library.chembl_client import ChemblClient  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, _serialize_paths, ensure_dirs, print_config
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
-from schemas import AssaysSchema, normalize_assays
+from library.config import (  # noqa: E402
+    Config,
+    _serialize_paths,
+    ensure_dirs,
+    print_config,
+)
+from library.log import logger  # noqa: E402
+from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
+from library.sidecar import SidecarErrors  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
+from schemas import AssaysSchema, normalize_assays  # noqa: E402
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -28,25 +28,30 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-from library import chembl_library as cl
-from library import document_postprocessing as dp
-from library import io
-from library import openalex_crossref_library as ocl
-from library import pubmed_library as pl
-from library import semantic_scholar_library as ssl
-from library.chembl_client import ChemblClient, _chunked
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import chembl_library as cl  # noqa: E402
+from library import document_postprocessing as dp  # noqa: E402
+from library import io  # noqa: E402
+from library import openalex_crossref_library as ocl  # noqa: E402
+from library import pubmed_library as pl  # noqa: E402
+from library import semantic_scholar_library as ssl  # noqa: E402
+from library.chembl_client import ChemblClient, _chunked  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     build_root_parser,
     configure_logger,
 )
-from library.config import (
+from library.config import (  # noqa: E402
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -54,12 +59,12 @@ from library.config import (
     ensure_dirs,
     print_config,
 )
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.rate_limiter import get_limiter
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
-from schemas import DocumentsSchema, normalize_documents
+from library.log import logger  # noqa: E402
+from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
+from library.rate_limiter import get_limiter  # noqa: E402
+from library.sidecar import SidecarErrors  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
+from schemas import DocumentsSchema, normalize_documents  # noqa: E402
 
 
 def fetch_pubmed_records(

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -7,21 +7,27 @@ scoring logic.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
 
 import pandas as pd
 
-from library import io
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import io  # noqa: E402
+from library.cli import (  # noqa: E402
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config
-from library.document_type_classifier import compute_scores, decide_label
-from library.log import logger
+from library.config import Config, ensure_dirs, print_config  # noqa: E402
+from library.document_type_classifier import compute_scores, decide_label  # noqa: E402
+from library.log import logger  # noqa: E402
 
 
 def _split_terms(value: object) -> Iterable[str]:

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -15,21 +15,26 @@ suffixes, for example ``activity_independent.csv`` or
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from library import input_initialisation_library as lib
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import input_initialisation_library as lib  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config
-from library.log import logger
-from library.table_quality import analyze_table_quality
+from library.config import Config, ensure_dirs, print_config  # noqa: E402
+from library.log import logger  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -19,29 +19,33 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-from library import chembl_library as cl
-from library import io
-from library import iuphar_library as ii
-from library import target_postprocessing as tp
-from library import uniprot_library as uu
-from library.chembl_client import ChemblClient
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import chembl_library as cl  # noqa: E402
+from library import io  # noqa: E402
+from library import iuphar_library as ii  # noqa: E402
+from library import target_postprocessing as tp  # noqa: E402
+from library import uniprot_library as uu  # noqa: E402
+from library.chembl_client import ChemblClient  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     build_root_parser,
     configure_logger,
 )
-from library.config import (
+from library.config import (  # noqa: E402
     Config,
     _serialize_paths,
     ensure_dirs,
     print_config,
 )
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
-from schemas import TargetsSchema, normalize_targets
+from library.log import logger  # noqa: E402
+from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
+from library.sidecar import SidecarErrors  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
+from schemas import TargetsSchema, normalize_targets  # noqa: E402
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -5,29 +5,39 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-from library import chembl_library as cl
-from library import io
-from library import pubchem_library as pl
-from library.chembl_client import ChemblClient
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import chembl_library as cl  # noqa: E402
+from library import io  # noqa: E402
+from library import pubchem_library as pl  # noqa: E402
+from library.chembl_client import ChemblClient  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, _serialize_paths, ensure_dirs, print_config
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
-from schemas import TestitemsSchema, normalize_testitems
+from library.config import (  # noqa: E402
+    Config,
+    _serialize_paths,
+    ensure_dirs,
+    print_config,
+)
+from library.log import logger  # noqa: E402
+from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
+from library.sidecar import SidecarErrors  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
+from schemas import TestitemsSchema, normalize_testitems  # noqa: E402
 
 
 def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:

--- a/scripts/mapper_main.py
+++ b/scripts/mapper_main.py
@@ -3,23 +3,29 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
+from pathlib import Path
 from urllib.error import URLError
 
 import pandas as pd
 
-from library import io
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library import io  # noqa: E402
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config
-from library.log import logger
-from library.mapper_library import map_chembl_to_uniprot
+from library.config import Config, ensure_dirs, print_config  # noqa: E402
+from library.log import logger  # noqa: E402
+from library.mapper_library import map_chembl_to_uniprot  # noqa: E402
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -4,22 +4,27 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 import pandas as pd
 
-from library.cli import (
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.cli import (  # noqa: E402
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
+from library.cli import (  # noqa: E402
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config
-from library.log import logger
-from library.table_quality import analyze_table_quality
+from library.config import Config, ensure_dirs, print_config  # noqa: E402
+from library.log import logger  # noqa: E402
+from library.table_quality import analyze_table_quality  # noqa: E402
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/tests/test_activity_cli_dry_run_no_input.py
+++ b/tests/test_activity_cli_dry_run_no_input.py
@@ -5,9 +5,9 @@ import io
 import json
 from pathlib import Path
 
-import get_activity_data as gad
 from library.cli import LoggerConfig, configure_logger
 from library.config import Config
+from scripts import get_activity_data as gad
 
 
 def test_dry_run_no_input(tmp_path: Path) -> None:

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import requests
 
-import get_activity_data as gad
 from library import chembl_library as cl
 from library import io as lib_io
 from library.cli import LoggerConfig, configure_logger
 from library.config import Config
+from scripts import get_activity_data as gad
 
 
 def test_run_chembl_handles_request_error(monkeypatch) -> None:

--- a/tests/test_activity_cli_limit.py
+++ b/tests/test_activity_cli_limit.py
@@ -1,6 +1,6 @@
 import pytest
 
-import get_activity_data as gad
+from scripts import get_activity_data as gad
 
 
 def test_negative_limit_rejected(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import pandas as pd
 
-import get_activity_data as gad
 from library import chembl_library as cl
 from library import io
+from scripts import get_activity_data as gad
 
 
 def _create_config(tmp_path: Path) -> Path:

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
-import chunk_io_main as cli
+from scripts import chunk_io_main as cli
 
 
 def test_cli_limit(tmp_path: Path) -> None:

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -4,16 +4,16 @@ from pathlib import Path
 
 import pytest
 
-import get_activity_data as gad
-import get_assay_data as gas
-import get_document_data as gdd
-import get_document_type as gdoctype
-import get_input_initialisation as gii
-import get_target_data as gtd
-import get_testitem_data as gtdt
-import mapper_main as mapper
-import table_quality_main as tqm
 from library.cli import configure_logger
+from scripts import get_activity_data as gad
+from scripts import get_assay_data as gas
+from scripts import get_document_data as gdd
+from scripts import get_document_type as gdoctype
+from scripts import get_input_initialisation as gii
+from scripts import get_target_data as gtd
+from scripts import get_testitem_data as gtdt
+from scripts import mapper_main as mapper
+from scripts import table_quality_main as tqm
 
 CLIS = [
     (gad.main, [], False),

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from table_quality_main import main
+from scripts.table_quality_main import main
 
 
 def test_table_quality_cli_with_config(tmp_path: Path) -> None:

--- a/tests/test_cli_run_id.py
+++ b/tests/test_cli_run_id.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
-import csv_utils_main
 from library.logging_setup import LoggerConfig, configure_logger
+from scripts import csv_utils_main
 
 
 def test_cli_run_id(capfd: pytest.CaptureFixture[str], tmp_path: Path) -> None:

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 import pandas as pd
 
-import get_assay_data as gas
-import get_document_data as gdd
-import get_target_data as gtd
-import get_testitem_data as gtdt
 from library import chembl_library as cl
 from library import io
 from library.config import Config
+from scripts import get_assay_data as gas
+from scripts import get_document_data as gdd
+from scripts import get_target_data as gtd
+from scripts import get_testitem_data as gtdt
 
 
 def _create_config(tmp_path: Path) -> Path:

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pandas as pd
 
-import csv_utils_main as cli
+from scripts import csv_utils_main as cli
 
 
 def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_csv_utils_main_smoke.py
+++ b/tests/test_csv_utils_main_smoke.py
@@ -16,7 +16,7 @@ def test_csv_utils_main_logs_runtime(tmp_path: Path) -> None:
     proc = subprocess.run(
         [
             sys.executable,
-            str(root / "csv_utils_main.py"),
+            str(root / "scripts" / "csv_utils_main.py"),
             "--input",
             str(input_csv),
             "--output",

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -6,9 +6,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-import mapper_main
 from library import io
 from library.config import Config, IoCfg
+from scripts import mapper_main
 
 
 def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-import get_activity_data as gad
 from library import chembl_library as cl
 from library import io
 from library.config import Config
+from scripts import get_activity_data as gad
 
 
 def test_run_chembl_respects_limit(

--- a/tests/test_get_activity_data_smoke.py
+++ b/tests/test_get_activity_data_smoke.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-import get_activity_data
 from library import chembl_library as cl
+from scripts import get_activity_data
 
 
 def test_get_activity_data_smoke(

--- a/tests/test_get_document_type.py
+++ b/tests/test_get_document_type.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
-
-from get_document_type import classify_dataframe
+from scripts.get_document_type import classify_dataframe
 
 
 def test_classify_dataframe_basic() -> None:

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 import pandas as pd
 
-import get_input_initialisation as cli
 from library.cli import LoggerConfig, configure_logger
 from library.config import Config
+from scripts import get_input_initialisation as cli
 
 
 def test_run_creates_quality_reports(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_get_target_data_helpers.py
+++ b/tests/test_get_target_data_helpers.py
@@ -1,6 +1,6 @@
 """Tests for helper utilities in :mod:`get_target_data`."""
 
-from get_target_data import _first_token, _pipe_merge
+from scripts.get_target_data import _first_token, _pipe_merge
 
 
 def test_pipe_merge_deduplicates_and_sorts() -> None:

--- a/tests/test_print_config.py
+++ b/tests/test_print_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import yaml
 
-from table_quality_main import main
+from scripts.table_quality_main import main
 
 
 def test_print_config_cli(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_target_cli_organism_csv.py
+++ b/tests/test_target_cli_organism_csv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import get_target_data as gtd
+from scripts import get_target_data as gtd
 
 
 def test_organism_csv_default_from_config(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- move CLI entry points into a new `scripts` package
- update imports and pyproject entry points for the new locations
- document new script paths in README and docs

## Testing
- `black scripts tests`
- `ruff check scripts tests`
- `mypy library` (fails: Library stubs not installed for "pandas", etc.)
- `pytest` (fails: AttributeError: 'Config' object has no attribute 'to_dict', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68c2e49056d88324800acb58ee03e6a9