### PR TITLE
Add Config.to_dict compatibility shim

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -52,6 +52,15 @@ class _BaseModel(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return model data as a plain ``dict``.
+
+        This is a small compatibility shim around :meth:`model_dump` for code
+        that still expects a ``to_dict`` method as provided by Pydantic v1.
+        """
+
+        return self.model_dump()
+
 
 class _BoolModel(_BaseModel):
     """Model base that parses boolean values from strings."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,15 @@ from library.cli import LoggerConfig, configure_logger
 from library.config import ConfigError, ensure_dirs, load_config
 
 
+def test_config_to_dict(tmp_path: Path) -> None:
+    """``Config.to_dict`` should mirror :meth:`model_dump`."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    cfg = load_config(path)
+    assert cfg.to_dict() == cfg.model_dump()
+
+
 def test_load_minimal_config(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("")


### PR DESCRIPTION
## Summary
- provide `Config.to_dict` method to preserve compatibility with older pydantic usage
- add regression test for `Config.to_dict`

## Testing
- `python -m black library/config.py tests/test_config.py`
- `python -m ruff check library/config.py tests/test_config.py`
- `python -m mypy library/config.py --ignore-missing-imports --follow-imports=skip` (fails: missing stubs & untyped decorators)
- `pytest` (23 failures, 205 passed)


------
https://chatgpt.com/codex/tasks/task_e_68c2ea3b1f708324b923a446f365f75f