### PR TITLE
Handle optional target columns in validation

### DIFF
--- a/schemas/targets.py
+++ b/schemas/targets.py
@@ -7,7 +7,9 @@ import pandera.pandas as pa
 TargetsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
         "target_chembl_id": pa.Column(str, required=True),
-        "organism": pa.Column(str, required=True),
+        # ``organism`` is not present in all datasets; treat as optional to allow
+        # validation of partial records without skipping the entire step.
+        "organism": pa.Column(str, required=False),
         "target_uniprot_id": pa.Column(str, required=False),
         "pH_dependence": pa.Column(float, pa.Check.in_range(0, 14), required=False),
         "isoforms": pa.Column(float, pa.Check.ge(0), required=False),

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -24,7 +24,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library import iuphar_library as ii  # noqa: E402
 from library import target_postprocessing as tp  # noqa: E402
 from library import uniprot_library as uu  # noqa: E402
@@ -377,8 +377,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = normalize_targets(df)
     rows_total = len(df)
     exit_code = 0
-    required_cols = set(TargetsSchema.columns.keys())
-    if required_cols.issubset(df.columns):
+    # Only enforce columns marked as ``required`` in the schema. Optional columns
+    # may be absent in the input dataset without preventing validation.
+    required_cols = {
+        name for name, col in TargetsSchema.columns.items() if col.required
+    }
+    missing_required = required_cols.difference(df.columns)
+    if not missing_required:
         try:
             df = TargetsSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -395,8 +400,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
-        missing = required_cols.difference(df.columns)
-        logger.warning("Skipping validation due to missing columns: %s", missing)
+        logger.warning(
+            "Skipping validation due to missing columns: %s", missing_required
+        )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -86,8 +86,6 @@ def test_targets_schema_validation() -> None:
     valid = pd.DataFrame(
         {
             "target_chembl_id": ["CHEMBL1"],
-            "organism": ["Homo sapiens"],
-            "target_uniprot_id": ["P12345"],
             "pH_dependence": [7.0],
             "isoforms": [2.0],
         }
@@ -98,6 +96,12 @@ def test_targets_schema_validation() -> None:
     invalid.loc[0, "pH_dependence"] = 20.0
     with pytest.raises(SchemaError):
         TargetsSchema.validate(invalid)
+
+
+def test_targets_schema_allows_missing_optional_columns() -> None:
+    """Schema validation succeeds when optional columns are absent."""
+    df = pd.DataFrame({"target_chembl_id": ["CHEMBL1"]})
+    TargetsSchema.validate(df)
 
 
 def test_testitems_schema_validation() -> None:


### PR DESCRIPTION
## Summary
- allow missing `organism` and other optional fields when validating target data
- skip validation only if required target columns are absent
- test that target schema accepts missing optional columns

## Testing
- `pre-commit run --files schemas/targets.py scripts/get_target_data.py tests/test_schemas.py` *(fails: tests fail, type check errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eca592dc83248a0eab285da0a8f8