### PR TITLE
chore: clean imports and format

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -53,7 +53,6 @@ class _BaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     def to_dict(self) -> dict[str, Any]:
- 
         """Return the model as a plain dictionary.
 
         Uses :meth:`pydantic.BaseModel.model_dump` to obtain a standard
@@ -63,8 +62,8 @@ class _BaseModel(BaseModel):
         -------
         dict[str, Any]
             Dictionary representation of the model.
- 
- 
+
+
         """
 
         return self.model_dump()

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -146,11 +146,9 @@ def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> str | None:
 def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     """Make an HTTP GET request and return parsed JSON."""
     if url in _CACHE:
-
         logger.info("cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"})
         return cast(dict[str, Any], _CACHE[url])
     logger.info("cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"})
-
 
     for attempt in range(1, cfg.retries + 1):
         event = "request_start" if attempt == 1 else "request_retry"

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -12,10 +12,7 @@ from __future__ import annotations
 import threading
 import time
 
-from typing import cast
-
 from cachetools import TTLCache  # type: ignore[import-untyped]
-
 
 
 class RateLimiter:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402
     LoggerConfig,

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
 
 from library import assay_postprocessing as ap  # noqa: E402
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402
     LoggerConfig,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -40,7 +40,7 @@ if str(ROOT) not in sys.path:
 
 from library import chembl_library as cl  # noqa: E402
 from library import document_postprocessing as dp  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library import openalex_crossref_library as ocl  # noqa: E402
 from library import pubmed_library as pl  # noqa: E402
 from library import semantic_scholar_library as ssl  # noqa: E402

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library import pubchem_library as pl  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402


### PR DESCRIPTION
## Summary
- remove unused `cast` and tidy imports in rate limiter
- drop unused `write_csv_deterministic` imports from data retrieval scripts
- format config and PubChem modules so ruff formatting passes

## Testing
- `ruff check .`
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2efdc8e788324a562720e82cc0325