### PR TITLE
Ensure same-document pair entity tables are exported

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -828,6 +828,12 @@ def generate_pair_entity_tables(
             logger.warning("pair table '%s' missing", pair_key)
             continue
 
+        # Harmonise activity identifier column names to ensure downstream
+        # processing can rely on a consistent schema regardless of the source
+        # workbook's naming conventions.
+        pairs_df = normalize_pair_columns(pairs_df)
+        result[pair_key] = pairs_df
+
         required = {"activity_chembl_id1", "activity_chembl_id2"}
         missing = required - set(pairs_df.columns)
         if missing:
@@ -1019,8 +1025,12 @@ def build_combined_tables(
     combined["activity"] = df_activity
 
     # --- pairs ------------------------------------------------------------
-    df_pairs_same = add_pair_metric_columns(unify_dtypes(same["pairs_same_document"]))
-    df_pairs = add_pair_metric_columns(unify_dtypes(all_["pairs"]))
+    df_pairs_same = normalize_pair_columns(
+        add_pair_metric_columns(unify_dtypes(same["pairs_same_document"]))
+    )
+    df_pairs = normalize_pair_columns(
+        add_pair_metric_columns(unify_dtypes(all_["pairs"]))
+    )
     logger.info("Entity pairs_same_document: rows=%d", len(df_pairs_same))
     logger.info("Entity pairs: rows=%d", len(df_pairs))
     combined["pairs_same_document"] = df_pairs_same
@@ -1029,14 +1039,12 @@ def build_combined_tables(
         indep_series = _safe_to_bool(df_pairs["INDEPENDENT"], "INDEPENDENT").fillna(
             False
         )
-        df_pairs_independent = normalize_pair_columns(df_pairs[indep_series].copy())
-        df_pairs_non_independent = normalize_pair_columns(
-            df_pairs[~indep_series].copy()
-        )
+        df_pairs_independent = df_pairs[indep_series].copy()
+        df_pairs_non_independent = df_pairs[~indep_series].copy()
     else:
         logger.warning("INDEPENDENT column missing; creating empty pair segments")
-        df_pairs_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
-        df_pairs_non_independent = normalize_pair_columns(df_pairs.iloc[0:0].copy())
+        df_pairs_independent = df_pairs.iloc[0:0].copy()
+        df_pairs_non_independent = df_pairs.iloc[0:0].copy()
 
     combined["pairs_independent"] = df_pairs_independent
     combined["pairs_non_independent"] = df_pairs_non_independent

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -73,6 +73,29 @@ def test_generate_pair_entity_tables_basic() -> None:
     assert set(res["testitem_ind"]["molecule_chembl_id"]) == {"m1", "m2", "m3"}
 
 
+def test_generate_pair_entity_tables_normalizes_columns() -> None:
+    """Pair tables with variant column names should be handled."""
+    tables: TableDict = {
+        "activity": pd.DataFrame(
+            {
+                "activity_chembl_id": [1, 2],
+                "assay_chembl_id": ["a1", "a2"],
+                "document_chembl_id": ["d1", "d2"],
+                "target_chembl_id": ["t1", "t2"],
+                "molecule_chembl_id": ["m1", "m2"],
+            }
+        ),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1", "d2"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1", "t2"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1", "m2"]}),
+        # Use non-standard column names as found in some Excel sources
+        "pairs_same_document": pd.DataFrame({"Activity_ID1": [1], "Activity_ID2": [2]}),
+    }
+    res = generate_pair_entity_tables(tables, {"pairs_same_document": "same"})
+    assert set(res["activity_same"]["activity_chembl_id"]) == {1, 2}
+
+
 def test_generate_pair_entity_tables_missing_columns(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary
- normalize pair table columns during combination to keep activity ID fields consistent
- harmonize pair columns in `generate_pair_entity_tables` so entity tables for each pair type are produced
- add regression test for pair column normalization

## Testing
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `black --check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py tests/test_input_initialisation_library.py --ignore-missing-imports` *(fails: Missing named argument "concurrency" for "BatchCfg" and similar)*
- `pytest tests/test_input_initialisation_library.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2efaca58c83248950f99540aaf95a