### PR TITLE
Use --input-csv flag for PubMed library

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ python scripts/get_document_data.py pubmed \
 The ``tests/data/pmids.csv`` file contains a small set of PMIDs for
 experimentation.
 
+You can also run the PubMed pipeline directly using the library module:
+
+```bash
+python -m library.pubmed_library \
+    --input-csv tests/data/pmids.csv \
+    --output out/documents.csv \
+    --log-level INFO
+```
+
 ### scripts/get_target_data.py
 
 Fetch basic target information from ChEMBL:

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -828,7 +828,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Fetch publication metadata by PMID")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument(
-        "--input",
+        "--input-csv",
         dest="input_csv",
         default="input.csv",
         help="Input CSV path with PMID column",
@@ -868,7 +868,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     cfg = Config()
     pubmed_cfg = cfg.pubmed
     semsch_cfg = cfg.semantic_scholar
-    pmids = read_pmids(args.input, cfg=pubmed_cfg)
+    pmids = read_pmids(args.input_csv, cfg=pubmed_cfg)
     openalex_limiter = get_limiter("openalex", cfg.openalex.rps, cfg.openalex.burst)
     crossref_limiter = get_limiter("crossref", cfg.crossref.rps, cfg.crossref.burst)
 

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -35,10 +35,10 @@ def test_pubmed_library_main_smoke(
             for pid in pmids
         ]
 
-    def fake_fetch_openalex(session, pmid, cfg=None):
+    def fake_fetch_openalex(session, pmid, cfg=None, limiter=None):
         return {"OpenAlex.Error": ""}
 
-    def fake_fetch_crossref(session, doi, cfg=None):
+    def fake_fetch_crossref(session, doi, cfg=None, limiter=None):
         return {"crossref.Error": ""}
 
     class DummyLimiter:
@@ -54,7 +54,14 @@ def test_pubmed_library_main_smoke(
     monkeypatch.setattr(pl, "get_limiter", lambda *args, **kwargs: DummyLimiter())
 
     exit_code = pl.main(
-        ["--input", str(input_csv), "--output", str(output_csv), "--log-level", "ERROR"]
+        [
+            "--input-csv",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "ERROR",
+        ]
     )
     assert exit_code == 0
     assert output_csv.exists()


### PR DESCRIPTION
## Summary
- switch PubMed library CLI to `--input-csv` flag
- adjust smoke test and documentation for new argument

## Testing
- `ruff check .` *(fails: Import block is un-sorted or un-formatted; unused imports)*
- `mypy library` *(fails: Library stubs not installed for "pandas" and other modules; missing named arguments for configs)*
- `pytest tests/test_pubmed_library.py`
- `pytest tests/test_pubmed_library_main_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2efcbc57883248bf60a2b5e8fb110