### PR TITLE
Allow retries for POST requests in HTTP session

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Collection
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -495,13 +496,32 @@ class Config(_BaseModel):
 
 
 def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
-    """Return an HTTP session configured for retries and user agent."""
+    """Return an HTTP session configured for retries and user agent.
+
+    The returned session retries failed requests for *all* HTTP methods,
+    including ``POST``. It also avoids raising exceptions on HTTP error status
+    codes, allowing callers to handle responses manually.
+
+    Parameters
+    ----------
+    api:
+        API configuration containing the user agent string.
+    retry:
+        Retry configuration with maximum attempts and backoff strategy.
+
+    Returns
+    -------
+    Session
+        A ``requests.Session`` instance with retry logic applied.
+    """
 
     session = Session()
     retry_cfg = Retry(
         total=retry.max_attempts,
         backoff_factor=retry.backoff_factor,
         status_forcelist=retry.status_forcelist,
+        allowed_methods=cast(Collection[str] | None, False),
+        raise_on_status=False,
     )
     adapter = HTTPAdapter(max_retries=retry_cfg)
     session.mount("http://", adapter)

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -12,10 +12,7 @@ from __future__ import annotations
 import threading
 import time
 
-from typing import cast
-
 from cachetools import TTLCache  # type: ignore[import-untyped]
-
 
 
 class RateLimiter:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402
     LoggerConfig,

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
 
 from library import assay_postprocessing as ap  # noqa: E402
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402
     LoggerConfig,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -40,7 +40,7 @@ if str(ROOT) not in sys.path:
 
 from library import chembl_library as cl  # noqa: E402
 from library import document_postprocessing as dp  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library import openalex_crossref_library as ocl  # noqa: E402
 from library import pubmed_library as pl  # noqa: E402
 from library import semantic_scholar_library as ssl  # noqa: E402

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,7 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from library import chembl_library as cl  # noqa: E402
-from library import io, write_csv_deterministic  # noqa: E402
+from library import io  # noqa: E402
 from library import pubchem_library as pl  # noqa: E402
 from library.chembl_client import ChemblClient  # noqa: E402
 from library.cli import (  # noqa: E402

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -11,7 +11,7 @@ from cachetools import TTLCache  # type: ignore[import-untyped]
 
 import library.rate_limiter as rl
 from library.chembl_client import ChemblClient
-from library.config import ApiCfg, RetryCfg, session_with_retry
+from library.config import ApiCfg, RetryCfg
 
 
 class DummyResponse:
@@ -206,19 +206,4 @@ def test_clients_do_not_share_cache() -> None:
     responses.add(responses.GET, url, json={"ok": 2}, status=200)
     client2 = ChemblClient(ApiCfg(), RetryCfg())
     client2.request_json(url, cfg=ApiCfg())
-    assert len(responses.calls) == 2
-
-
-@responses.activate
-def test_session_with_retry_retries_post() -> None:
-    """Ensure POST requests are retried when configured."""
-
-    url = "http://example.com/post"
-    responses.add(responses.POST, url, status=500)
-    responses.add(responses.POST, url, json={"ok": True}, status=200)
-
-    session = session_with_retry(ApiCfg(), RetryCfg(max_attempts=2, backoff_factor=0))
-    response = session.post(url)
-
-    assert response.status_code == 200
     assert len(responses.calls) == 2

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,22 @@
+"""Tests for HTTP client session utilities."""
+
+from __future__ import annotations
+
+import responses
+
+from library.config import ApiCfg, RetryCfg, session_with_retry
+
+
+@responses.activate
+def test_session_with_retry_retries_post() -> None:
+    """Ensure POST requests are retried when configured."""
+
+    url = "http://example.com/post"
+    responses.add(responses.POST, url, status=500)
+    responses.add(responses.POST, url, json={"ok": True}, status=200)
+
+    session = session_with_retry(ApiCfg(), RetryCfg(max_attempts=2, backoff_factor=0))
+    response = session.post(url)
+
+    assert response.status_code == 200
+    assert len(responses.calls) == 2


### PR DESCRIPTION
## Summary
- allow `session_with_retry` to retry all HTTP methods without raising on status codes
- add test verifying POST retry behavior
- clean up unused imports flagged by Ruff

## Testing
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "pandas" and other modules)*
- `pytest tests/test_http_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2efd045ec8324ad2820fbbbd663bf