### PR TITLE
Add minimal get_activities CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ python scripts/get_target_data.py chembl \
 Replace ``path/to/targets.csv`` with a CSV containing a ``chembl_id``
 column.
 
+### scripts/get_activities.py
+
+Generate dummy activity entries without contacting external services:
+
+```bash
+python scripts/get_activities.py --limit 500 --dry-run
+```
+
+The command logs that it would generate 500 activity rows and exits without
+creating any files.
+
 ## Updating Dependencies
 
 To keep the environment current, periodically refresh the pinned

--- a/library/activities.py
+++ b/library/activities.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def get_activities(limit: int) -> list[dict[str, int]]:
+    """Return dummy activity identifiers.
+
+    Parameters
+    ----------
+    limit
+        Number of activity rows to generate. Must be non-negative.
+
+    Returns
+    -------
+    list of dict
+        Sequence of dictionaries with an ``activity_id`` field.
+
+    Raises
+    ------
+    ValueError
+        If ``limit`` is negative.
+    """
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return [{"activity_id": i} for i in range(limit)]

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -1,0 +1,74 @@
+"""Minimal CLI for generating dummy activity data."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Sequence
+
+from library.activities import get_activities
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Parameters
+    ----------
+    argv
+        Optional sequence of arguments for unit testing.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments containing ``limit`` and ``dry_run``.
+    """
+    parser = argparse.ArgumentParser(description="Generate dummy activity data")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of activity rows to emit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log actions without generating data",
+    )
+    return parser.parse_args(argv)
+
+
+def run(limit: int, dry_run: bool) -> int:
+    """Execute the activity generation pipeline.
+
+    Parameters
+    ----------
+    limit
+        Number of activities to generate.
+    dry_run
+        If ``True``, only log the intention without generating data.
+
+    Returns
+    -------
+    int
+        Zero on success, non-zero on failure.
+    """
+    if dry_run:
+        logger.info("dry run: would generate %d activities", limit)
+        return 0
+
+    activities = get_activities(limit)
+    logger.info("generated %d activities", len(activities))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command-line entry point."""
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    return run(limit=args.limit, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,8 @@
+from library.activities import get_activities
+
+
+def test_get_activities_limit() -> None:
+    activities = get_activities(3)
+    assert len(activities) == 3
+    assert activities[0]["activity_id"] == 0
+    assert activities[-1]["activity_id"] == 2


### PR DESCRIPTION
## Summary
- add library utility to generate dummy activity IDs
- expose a simple `get_activities.py` script with `--limit` and `--dry-run` flags
- document the new command in README and add a unit test

## Testing
- `ruff check scripts/get_activities.py library/activities.py tests/test_activities.py`
- `ruff format scripts/get_activities.py library/activities.py tests/test_activities.py`
- `black scripts/get_activities.py library/activities.py tests/test_activities.py`
- `mypy scripts/get_activities.py library/activities.py tests/test_activities.py` *(fails: Missing named argument "sleep" for "DocumentPubmedCfg"  [call-arg])* 
- `pytest tests/test_activities.py`
- `pre-commit run --files README.md library/activities.py scripts/get_activities.py tests/test_activities.py` *(fails: 24 failed, 209 passed, 3 warnings in 37.23s)*
- `PYTHONHASHSEED=0 bash -lc 'time python scripts/get_activities.py --limit 500 --dry-run'`


------
https://chatgpt.com/codex/tasks/task_e_68c2efd9c5008324a29ffadd983a39d4