### PR TITLE
refactor: remove sys path hacks

### DIFF
--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -10,13 +10,8 @@ hashes differ.
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 try:
     import pandas as pd
@@ -26,11 +21,9 @@ except ImportError as exc:  # pragma: no cover - import-time check
         " Install it with 'pip install pandas'."
     ) from exc
 
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-from library.cli import LoggerConfig, configure_logger  # noqa: E402
-from library.csv_utils import sha256_file, write_csv_deterministic  # noqa: E402
-from library.log import logger  # noqa: E402
+from library.cli import LoggerConfig, configure_logger
+from library.csv_utils import sha256_file, write_csv_deterministic
+from library.log import logger
 
 
 def run_check(tmp_dir: Path) -> bool:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -6,37 +6,32 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from itertools import islice
-from pathlib import Path
 
 import requests
 from pandera.errors import SchemaErrors
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import chembl_library as cl  # noqa: E402
-from library import io  # noqa: E402
-from library.chembl_client import ChemblClient  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import chembl_library as cl
+from library import io
+from library.chembl_client import ChemblClient
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (  # noqa: E402
+from library.cli import (
     build_parser as base_parser,
 )
-from library.config import (  # noqa: E402
+from library.config import (
     Config,
     _serialize_paths,
     ensure_dirs,
     print_config,
 )
-from library.log import logger  # noqa: E402
-from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
-from library.sidecar import SidecarErrors  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
-from schemas import ActivitiesSchema, normalize_activities  # noqa: E402
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import ActivitiesSchema, normalize_activities
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -5,38 +5,33 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
-from pathlib import Path
 
 import requests
 from pandera.errors import SchemaErrors
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import assay_postprocessing as ap  # noqa: E402
-from library import chembl_library as cl  # noqa: E402
-from library import io  # noqa: E402
-from library.chembl_client import ChemblClient  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import assay_postprocessing as ap
+from library import chembl_library as cl
+from library import io
+from library.chembl_client import ChemblClient
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (  # noqa: E402
+from library.cli import (
     build_parser as base_parser,
 )
-from library.config import (  # noqa: E402
+from library.config import (
     Config,
     _serialize_paths,
     ensure_dirs,
     print_config,
 )
-from library.log import logger  # noqa: E402
-from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
-from library.sidecar import SidecarErrors  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
-from schemas import AssaysSchema, normalize_assays  # noqa: E402
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import AssaysSchema, normalize_assays
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -28,30 +28,25 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import chembl_library as cl  # noqa: E402
-from library import document_postprocessing as dp  # noqa: E402
-from library import io  # noqa: E402
-from library import openalex_crossref_library as ocl  # noqa: E402
-from library import pubmed_library as pl  # noqa: E402
-from library import semantic_scholar_library as ssl  # noqa: E402
-from library.chembl_client import ChemblClient, _chunked  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import chembl_library as cl
+from library import document_postprocessing as dp
+from library import io
+from library import openalex_crossref_library as ocl
+from library import pubmed_library as pl
+from library import semantic_scholar_library as ssl
+from library.chembl_client import ChemblClient, _chunked
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     build_root_parser,
     configure_logger,
 )
-from library.config import (  # noqa: E402
+from library.config import (
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -59,12 +54,12 @@ from library.config import (  # noqa: E402
     ensure_dirs,
     print_config,
 )
-from library.log import logger  # noqa: E402
-from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
-from library.rate_limiter import get_limiter  # noqa: E402
-from library.sidecar import SidecarErrors  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
-from schemas import DocumentsSchema, normalize_documents  # noqa: E402
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.rate_limiter import get_limiter
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import DocumentsSchema, normalize_documents
 
 
 def fetch_pubmed_records(

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -7,27 +7,21 @@ scoring logic.
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
 
 import pandas as pd
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import io  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import io
+from library.cli import (
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (  # noqa: E402
+from library.cli import (
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config  # noqa: E402
-from library.document_type_classifier import compute_scores, decide_label  # noqa: E402
-from library.log import logger  # noqa: E402
+from library.config import Config, ensure_dirs, print_config
+from library.document_type_classifier import compute_scores, decide_label
+from library.log import logger
 
 
 def _split_terms(value: object) -> Iterable[str]:

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -15,26 +15,21 @@ suffixes, for example ``activity_independent.csv`` or
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import input_initialisation_library as lib  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import input_initialisation_library as lib
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (  # noqa: E402
+from library.cli import (
     build_parser as base_parser,
 )
-from library.config import Config, ensure_dirs, print_config  # noqa: E402
-from library.log import logger  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
+from library.config import Config, ensure_dirs, print_config
+from library.log import logger
+from library.table_quality import analyze_table_quality
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -19,33 +19,29 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import chembl_library as cl  # noqa: E402
-from library import io  # noqa: E402
-from library import iuphar_library as ii  # noqa: E402
-from library import target_postprocessing as tp  # noqa: E402
-from library import uniprot_library as uu  # noqa: E402
-from library.chembl_client import ChemblClient  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import chembl_library as cl
+from library import io
+from library import iuphar_library as ii
+from library import target_postprocessing as tp
+from library import uniprot_library as uu
+from library.chembl_client import ChemblClient
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     build_root_parser,
     configure_logger,
 )
-from library.config import (  # noqa: E402
+from library.config import (
     Config,
     _serialize_paths,
     ensure_dirs,
     print_config,
 )
-from library.log import logger  # noqa: E402
-from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
-from library.sidecar import SidecarErrors  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
-from schemas import TargetsSchema, normalize_targets  # noqa: E402
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import TargetsSchema, normalize_targets
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -5,39 +5,34 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
-from pathlib import Path
 
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from library import chembl_library as cl  # noqa: E402
-from library import io  # noqa: E402
-from library import pubchem_library as pl  # noqa: E402
-from library.chembl_client import ChemblClient  # noqa: E402
-from library.cli import (  # noqa: E402
+from library import chembl_library as cl
+from library import io
+from library import pubchem_library as pl
+from library.chembl_client import ChemblClient
+from library.cli import (
     LoggerConfig,
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (  # noqa: E402
+from library.cli import (
     build_parser as base_parser,
 )
-from library.config import (  # noqa: E402
+from library.config import (
     Config,
     _serialize_paths,
     ensure_dirs,
     print_config,
 )
-from library.log import logger  # noqa: E402
-from library.metadata import Stats, file_sha256, write_meta_yaml  # noqa: E402
-from library.sidecar import SidecarErrors  # noqa: E402
-from library.table_quality import analyze_table_quality  # noqa: E402
-from schemas import TestitemsSchema, normalize_testitems  # noqa: E402
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import TestitemsSchema, normalize_testitems
 
 
 def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,3 @@
 """Test configuration."""
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-# Ensure project root is on sys.path for ``import library``
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -9,7 +9,7 @@ import requests
 import responses
 from cachetools import TTLCache  # type: ignore[import-untyped]
 
-import library.rate_limiter as rl
+from library import rate_limiter as rl
 from library.chembl_client import ChemblClient
 from library.config import ApiCfg, RetryCfg
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-import library.input_initialisation_library as lib
+from library import input_initialisation_library as lib
 from library.config import Config
 from library.input_initialisation_library import (
     TableDict,

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pandas as pd
 import pytest
 
-import library.iuphar_library as ii
+from library import iuphar_library as ii
 from library.config import IupharCfg
 
 

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -1,8 +1,8 @@
 import pytest
 import requests
 
-import library.rate_limiter as rl
 from library import openalex_crossref_library as ocl
+from library import rate_limiter as rl
 from library.config import Config, CrossRefCfg, OpenAlexCfg
 
 

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import responses
 
-import library.rate_limiter as rl
 from library import pubchem_library as pl
+from library import rate_limiter as rl
 
 
 @responses.activate

--- a/tests/test_pubmed_library.py
+++ b/tests/test_pubmed_library.py
@@ -8,8 +8,8 @@ from typing import Any, cast
 import pytest
 import requests
 
-import library.rate_limiter as rl
 from library import pubmed_library as pl
+from library import rate_limiter as rl
 from library.config import (
     Config,
     CrossRefCfg,

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,4 +1,4 @@
-import library.rate_limiter as rl
+from library import rate_limiter as rl
 
 
 class FakeTime:

--- a/tests/test_rate_limiter_cache.py
+++ b/tests/test_rate_limiter_cache.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import library.rate_limiter as rl
+from library import rate_limiter as rl
 
 
 def test_limiter_cache_respects_maxsize() -> None:

--- a/tests/test_rate_limiter_threadsafe.py
+++ b/tests/test_rate_limiter_threadsafe.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 
-import library.rate_limiter as rl
+from library import rate_limiter as rl
 
 
 def test_get_limiter_thread_safe() -> None:


### PR DESCRIPTION
## Summary
- drop ROOT/sys.path hacks and rely on package imports
- clean up tests to import modules directly from `library`

## Testing
- `pip install -e .`
- `black scripts/check_determinism.py scripts/get_activity_data.py scripts/get_assay_data.py scripts/get_document_data.py scripts/get_document_type.py scripts/get_input_initialisation.py scripts/get_target_data.py scripts/get_testitem_data.py tests/conftest.py tests/test_chembl_client.py tests/test_input_initialisation_library.py tests/test_iuphar_threadsafe.py tests/test_openalex_crossref_library.py tests/test_pubchem_library.py tests/test_pubmed_library.py tests/test_rate_limiter.py tests/test_rate_limiter_cache.py tests/test_rate_limiter_threadsafe.py`
- `ruff check scripts/check_determinism.py scripts/get_activity_data.py scripts/get_assay_data.py scripts/get_document_data.py scripts/get_document_type.py scripts/get_input_initialisation.py scripts/get_target_data.py scripts/get_testitem_data.py tests/conftest.py tests/test_chembl_client.py tests/test_input_initialisation_library.py tests/test_iuphar_threadsafe.py tests/test_openalex_crossref_library.py tests/test_pubchem_library.py tests/test_pubmed_library.py tests/test_rate_limiter.py tests/test_rate_limiter_cache.py tests/test_rate_limiter_threadsafe.py`
- `mypy library` (fails: Library stubs not installed for "tabulate" [import-untyped]; Library stubs not installed for "pandas" [import-untyped]; Unused "type: ignore" comment [unused-ignore]; Redundant cast to "Path" [redundant-cast]; Library stubs not installed for "requests" [import-untyped]; Library stubs not installed for "openpyxl" [import-untyped])
- `pytest` (fails: TypeError: _run.<locals>.fake_write() got an unexpected keyword argument 'inputs' ; AssertionError: assert {'call': 1} == {'ok': 1} ; TypeError: argument should be a str or an os.PathLike object, not 'dict'; assert (None); TypeError: test_cli_arguments_passed.<locals>.fake_write() got an unexpected keyword argument 'inputs'; AssertionError: assert 'completed' in ''; assert 244916224 >= 245702656; AttributeError: <module 'scripts.get_activity_data' from '/workspace/ChEMBL_data_acquisition/scripts/get_activity_data.py'> does not have the attribute 'run_chembl'; FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pytest-of-root/pytest-1/test_init_session_uses_cfg_retry0/resources/input_assay.csv'; AttributeError: <module 'scripts.get_document_data' from '/workspace/ChEMBL_data_acquisition/scripts/get_document_data.py'> does not have the attribute 'run_chembl'; AttributeError: <module 'scripts.get_document_data' from '/workspace/ChEMBL_data_acquisition/scripts/get_document_data.py'> does not have the attribute 'run_all'; TypeError: argument should be a str or an os.PathLike object, not 'dict'; ValidationError: 1 validation error for Retrying.<locals>.WrappedFn; pydantic_core._pydantic_core.ValidationError: 1 validation error for Request; 21 failed, 213 passed, 4 warnings in 27.94s)

------
https://chatgpt.com/codex/tasks/task_e_68c2f3a158408324add3ec248b4b427b