### PR TITLE
refactor: adopt cli-based logging

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import logging
 import sys
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date
@@ -24,6 +23,8 @@ from xml.etree import ElementTree as ET
 import pandas as pd
 import requests
 
+from .cli import LoggerConfig, configure_logger
+from .cli import build_parser as base_parser
 from .config import (
     Config,
     CrossRefCfg,
@@ -791,7 +792,7 @@ def print_results(records: list[dict[str, str]]) -> None:
     records:
         Sequence of result dictionaries produced by ``main``.
     """
-    log = logging.getLogger(__name__)
+    log = logger
     try:
         from tabulate import tabulate
 
@@ -823,23 +824,18 @@ def print_results(records: list[dict[str, str]]) -> None:
         sys.stdout.buffer.write(encoded + b"\n")
 
 
-def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+def parse_args(
+    argv: Sequence[str] | None = None,
+) -> tuple[argparse.Namespace, LoggerConfig]:
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description="Fetch publication metadata by PMID")
-    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser, log_cfg = base_parser("Fetch publication metadata by PMID", column="PMID")
     parser.add_argument(
         "--input-csv",
         dest="input_csv",
-        default="input.csv",
         help="Input CSV path with PMID column",
     )
-    parser.add_argument(
-        "--output",
-        dest="output_csv",
-        default=None,
-        help="Output CSV path (default: auto-generated)",
-    )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    return args, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -855,9 +851,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     int
         Zero on success.
     """
-    args = parse_args(argv)
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
-    log = logging.getLogger(__name__)
+    args, log_cfg = parse_args(argv)
+    log_cfg.level = args.log_level
+    configure_logger(log_cfg)
 
     cfg = Config()
     pubmed_cfg = cfg.pubmed
@@ -915,7 +911,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         else Path(f"output_{Path(args.input_csv).stem}_{date.today():%Y%m%d}.csv")
     )
     write_csv_deterministic(df, output_path)
-    log.info("written %s", output_path)
+    logger.info("written %s", output_path)
     return 0
 
 

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import argparse
-import logging
 from collections.abc import Sequence
 
+from library import cli
 from library.activities import get_activities
+from library.log import logger
 
-logger = logging.getLogger(__name__)
 
-
-def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+def parse_args(
+    argv: Sequence[str] | None = None,
+) -> tuple[argparse.Namespace, cli.LoggerConfig]:
     """Parse command-line arguments.
 
     Parameters
@@ -21,10 +22,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
     Returns
     -------
-    argparse.Namespace
-        Parsed arguments containing ``limit`` and ``dry_run``.
+    tuple[argparse.Namespace, cli.LoggerConfig]
+        Parsed arguments and logging configuration.
     """
-    parser = argparse.ArgumentParser(description="Generate dummy activity data")
+    parser, log_cfg = cli.build_parser("Generate dummy activity data", column="id")
     parser.add_argument(
         "--limit",
         type=int,
@@ -36,7 +37,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Log actions without generating data",
     )
-    return parser.parse_args(argv)
+    return parser.parse_args(argv), log_cfg
 
 
 def run(limit: int, dry_run: bool) -> int:
@@ -65,8 +66,9 @@ def run(limit: int, dry_run: bool) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command-line entry point."""
-    args = parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+    args, log_cfg = parse_args(argv)
+    log_cfg.level = args.log_level
+    cli.configure_logger(log_cfg)
     return run(limit=args.limit, dry_run=args.dry_run)
 
 


### PR DESCRIPTION
## Summary
- replace direct logging calls with `library.cli`
- configure logger via `build_parser` and `configure_logger`

## Testing
- `black scripts/get_activities.py library/pubmed_library.py`
- `ruff check scripts/get_activities.py library/pubmed_library.py`
- `mypy library/pubmed_library.py` *(fails: Library stubs not installed for pandas, requests, etc.)*
- `pytest tests/test_pubmed_library_main_smoke.py tests/test_pubmed_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f3a1729c83248d55b1eb009457d4