### PR TITLE
Explicitly re-export ChEMBL helper functions

### DIFF
--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -1,11 +1,33 @@
-"""Compatibility layer aggregating ChEMBL helpers."""
+"""Compatibility layer aggregating ChEMBL helpers.
+
+This module re-exports selected public functions from :mod:`chembl_assay` and
+:mod:`chembl_target` as a convenient façade.  The functions are imported
+explicitly rather than via ``import *`` to make the exported API clear and to
+keep linters happy.
+"""
 
 from __future__ import annotations
 
-from . import chembl_assay as _chembl_assay
-from . import chembl_target as _chembl_target
-from .chembl_assay import *  # noqa: F401,F403
+from .chembl_assay import (
+    get_activities,
+    get_assay,
+    get_assays,
+    get_testitem,
+)
 from .chembl_client import _chunked
-from .chembl_target import *  # noqa: F401,F403
+from .chembl_target import (
+    extend_target,
+    get_target,
+    get_targets,
+)
 
-__all__ = [*_chembl_target.__all__, *_chembl_assay.__all__, "_chunked"]
+__all__ = [
+    "get_assay",
+    "get_assays",
+    "get_activities",
+    "get_testitem",
+    "get_target",
+    "get_targets",
+    "extend_target",
+    "_chunked",
+]


### PR DESCRIPTION
## Summary
- re-export public helpers from `chembl_assay` and `chembl_target` using explicit imports
- list those helpers and `_chunked` in `chembl_library.__all__`

## Testing
- `black library/chembl_library.py`
- `ruff check library/chembl_library.py`
- `mypy library/chembl_library.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_chembl_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f3a1fcec832484e13b0ea52f40cb