### PR TITLE
Handle unexpected errors in CLI run functions

### DIFF
--- a/chunk_io_main.py
+++ b/chunk_io_main.py
@@ -42,25 +42,29 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the chunked copy operation."""
-    if args.chunk_size <= 0:
-        raise SystemExit("--chunk-size must be a positive integer")
-    if args.limit is not None and args.limit <= 0:
-        raise SystemExit("--limit must be a positive integer")
+    try:
+        if args.chunk_size <= 0:
+            raise SystemExit("--chunk-size must be a positive integer")
+        if args.limit is not None and args.limit <= 0:
+            raise SystemExit("--limit must be a positive integer")
 
-    output = args.output_csv or default_output_path(args.input_csv, cfg.io)
-    ensure_dirs(cfg)
-    rows = process_csv_chunks(
-        args.input_csv,
-        output,
-        cfg=cfg.io,
-        chunk_size=args.chunk_size,
-        limit=args.limit,
-        checkpoint_path=args.checkpoint,
-        sep=args.sep,
-        encoding=args.encoding,
-    )
-    logger.info("rows_processed", extra={"rows": rows})
-    return 0
+        output = args.output_csv or default_output_path(args.input_csv, cfg.io)
+        ensure_dirs(cfg)
+        rows = process_csv_chunks(
+            args.input_csv,
+            output,
+            cfg=cfg.io,
+            chunk_size=args.chunk_size,
+            limit=args.limit,
+            checkpoint_path=args.checkpoint,
+            sep=args.sep,
+            encoding=args.encoding,
+        )
+        logger.info("rows_processed", extra={"rows": rows})
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("run_fail", exc=exc)
+        return 1
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -39,55 +39,59 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     try:
-        df = io.read_csv(
-            args.input_csv,
-            cfg=cfg.io,
-            sep=args.sep,
-            encoding=args.encoding,
-            dtype=str,
-            na_values=["#N/A", ""],
-        )
-    except (FileNotFoundError, OSError) as exc:
-        logger.error("%s", exc)
-        return 1
-    if args.column not in df.columns:
-        logger.error("column '%s' not found in %s", args.column, args.input_csv)
-        return 1
-
-    uniprot_ids: list[str | None] = []
-    for chembl_id in df[args.column]:
-        if pd.isna(chembl_id) or not str(chembl_id).strip():
-            uniprot_ids.append(None)
-            continue
         try:
-            uniprot_id = map_chembl_to_uniprot(str(chembl_id), cfg.uniprot_mapping)
-            uniprot_ids.append(uniprot_id)
-            if uniprot_id:
-                logger.info(
-                    "mapped",
-                    extra={"chembl_id": str(chembl_id), "uniprot_id": uniprot_id},
-                )
-            else:
-                logger.warning("no UniProt ID for %s", chembl_id)
-        except (ValueError, TimeoutError, URLError) as exc:
-            logger.warning("failed to map %s: %s", chembl_id, exc)
-            uniprot_ids.append(None)
-    df["mapping_uniprot_id"] = uniprot_ids
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    try:
-        io.write_csv(
-            df,
-            output,
-            cfg=cfg,
-            sep=args.sep,
-            encoding=args.encoding,
-            key_cols=args.key_cols,
-        )
-        logger.info("write_done", extra={"path": str(output)})
-    except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
+            df = io.read_csv(
+                args.input_csv,
+                cfg=cfg.io,
+                sep=args.sep,
+                encoding=args.encoding,
+                dtype=str,
+                na_values=["#N/A", ""],
+            )
+        except (FileNotFoundError, OSError) as exc:
+            logger.error("%s", exc)
+            return 1
+        if args.column not in df.columns:
+            logger.error("column '%s' not found in %s", args.column, args.input_csv)
+            return 1
+
+        uniprot_ids: list[str | None] = []
+        for chembl_id in df[args.column]:
+            if pd.isna(chembl_id) or not str(chembl_id).strip():
+                uniprot_ids.append(None)
+                continue
+            try:
+                uniprot_id = map_chembl_to_uniprot(str(chembl_id), cfg.uniprot_mapping)
+                uniprot_ids.append(uniprot_id)
+                if uniprot_id:
+                    logger.info(
+                        "mapped",
+                        extra={"chembl_id": str(chembl_id), "uniprot_id": uniprot_id},
+                    )
+                else:
+                    logger.warning("no UniProt ID for %s", chembl_id)
+            except (ValueError, TimeoutError, URLError) as exc:
+                logger.warning("failed to map %s: %s", chembl_id, exc)
+                uniprot_ids.append(None)
+        df["mapping_uniprot_id"] = uniprot_ids
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        try:
+            io.write_csv(
+                df,
+                output,
+                cfg=cfg,
+                sep=args.sep,
+                encoding=args.encoding,
+                key_cols=args.key_cols,
+            )
+            logger.info("write_done", extra={"path": str(output)})
+        except OSError as exc:
+            logger.error("failed to write output CSV: %s", exc)
+            return 1
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("run_fail", exc=exc)
         return 1
-    return 0
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/table_quality_main.py
+++ b/table_quality_main.py
@@ -39,19 +39,23 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     try:
-        df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
-    except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
-        logger.error("%s", exc)
-        return 1
+        try:
+            df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+        except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
+            logger.error("%s", exc)
+            return 1
 
-    original_cwd = Path.cwd()
-    try:
-        args.output_csv.mkdir(parents=True, exist_ok=True)
-        os.chdir(args.output_csv)
-        analyze_table_quality(df, table_name=args.table_name)
-    finally:
-        os.chdir(original_cwd)
-    return 0
+        original_cwd = Path.cwd()
+        try:
+            args.output_csv.mkdir(parents=True, exist_ok=True)
+            os.chdir(args.output_csv)
+            analyze_table_quality(df, table_name=args.table_name)
+        finally:
+            os.chdir(original_cwd)
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("run_fail", exc=exc)
+        return 1
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/tests/test_mapper_run_exception.py
+++ b/tests/test_mapper_run_exception.py
@@ -1,0 +1,38 @@
+import argparse
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mapper_main
+from library.cli import LoggerConfig, configure_logger
+from library.config import Config
+
+
+def test_run_logs_exception(monkeypatch, tmp_path: Path) -> None:
+    """Uncaught exceptions in run are logged and return non-zero."""
+
+    def bad_read(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(mapper_main.io, "read_csv", bad_read)
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(stream=buffer, level="INFO"))
+    base_cfg = Config()
+    cfg = SimpleNamespace(
+        io=base_cfg.io, uniprot_mapping=base_cfg.uniprot_mapping, to_dict=lambda: {}
+    )
+    args = argparse.Namespace(
+        input_csv=tmp_path / "in.csv",
+        output_csv=tmp_path / "out.csv",
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+        key_cols=None,
+    )
+    exit_code = mapper_main.run(cfg, args)
+    assert exit_code == 1
+    records = [json.loads(line) for line in buffer.getvalue().splitlines()]
+    assert any(
+        r["event"] == "run_fail" and r["exc_type"] == "RuntimeError" for r in records
+    )


### PR DESCRIPTION
## Summary
- ensure run functions in CLI modules return non-zero on unexpected exceptions
- log exceptions with `logger.exception` for chunked IO, mapper, and table quality commands
- add regression test verifying exception handling in mapper run

## Testing
- `python -m black chunk_io_main.py mapper_main.py table_quality_main.py tests/test_mapper_run_exception.py`
- `ruff check chunk_io_main.py mapper_main.py table_quality_main.py tests/test_mapper_run_exception.py`
- `python -m mypy library`
- `pytest tests/test_mapper_run_exception.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2f3ae78cc8324bce0e98ccf09d48a