### PR TITLE
feat: auto-generate CSV output name

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -2,12 +2,16 @@
 
 This script reads an input CSV file and re-serialises it deterministically
 using :func:`library.csv_utils.write_csv_deterministic`.
+
+If ``--output`` is omitted, a file named
+``output_<input-stem>_<YYYYMMDD>.csv`` is created next to the input.
 """
 
 from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from datetime import date
 from pathlib import Path
 
 import pandas as pd
@@ -35,23 +39,24 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = build_parser()
     ns = parser.parse_args(argv)
+    if ns.output_csv is None:
+        ns.output_csv = Path(ns.input_csv).with_name(
+            f"output_{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
+        )
     args = CSVExportArgs.model_validate(vars(ns))
     configure_logger(LoggerConfig(level=args.log_level))
 
     start = time.perf_counter()
     df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
-    output = args.output_csv or Path(args.input_csv).with_name(
-        f"output_{Path(args.input_csv).stem}.csv"
-    )
     write_csv_deterministic(
         df,
-        output,
+        args.output_csv,
         col_order=args.col_order or None,
         key_cols=args.key_cols or None,
         drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start
-    logger.info("write_done", extra={"path": str(output)})
+    logger.info("write_done", extra={"path": str(args.output_csv)})
     logger.info("run_completed", extra={"elapsed": elapsed})
     return 0
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -79,6 +79,11 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     -------
     argparse.ArgumentParser
         The parser instance for convenience.
+
+    Notes
+    -----
+    When ``--output`` is omitted, a file named
+    ``output_<input-stem>_<YYYYMMDD>.csv`` is created next to the input file.
     """
 
     parser.add_argument("--log-level", default="INFO", help="Logging level")
@@ -94,7 +99,7 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
         dest="output_csv",
         type=Path,
         default=None,
-        help="Destination CSV file (default: auto-generate)",
+        help="Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)",
     )
     parser.add_argument("--sep", default=",", help="CSV delimiter")
     parser.add_argument("--encoding", default="utf8", help="File encoding")

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -20,7 +20,10 @@ def test_cli_utils_flags_and_help() -> None:
     assert set(actions) == expected
     assert actions["--log-level"].help == "Logging level"
     assert actions["--input"].help == "Input CSV file"
-    assert actions["--output"].help == "Destination CSV file (default: auto-generate)"
+    assert (
+        actions["--output"].help
+        == "Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)"
+    )
     assert actions["--sep"].help == "CSV delimiter"
     assert actions["--encoding"].help == "File encoding"
     assert actions["--col-order"].help == "Preferred column order"

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pathlib import Path
 
 import pandas as pd
@@ -17,7 +18,13 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
         called["encoding"] = encoding
         return pd.DataFrame({"a": [1], "b": [2]})
 
-    def fake_write(df, output, col_order=None, key_cols=None):  # type: ignore[override]
+    def fake_write(
+        df,
+        output,
+        col_order=None,
+        key_cols=None,
+        drop_unexpected_cols=True,
+    ):  # type: ignore[override]
         called["output"] = output
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
@@ -42,3 +49,35 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
     assert called["output"] == output_csv
     assert called["sep"] == "|"
     assert called["encoding"] == "latin1"
+
+
+def test_cli_generates_output_path(monkeypatch, tmp_path: Path) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("a,b\n1,2\n", encoding="utf8")
+    called: dict[str, Path] = {}
+
+    def fake_read_csv(path, sep, encoding):  # type: ignore[override]
+        called["path"] = path
+        return pd.DataFrame({"a": [1], "b": [2]})
+
+    def fake_write(
+        df,
+        output,
+        col_order=None,
+        key_cols=None,
+        drop_unexpected_cols=True,
+    ):  # type: ignore[override]
+        called["output"] = output
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    monkeypatch.setattr(cli, "write_csv_deterministic", fake_write)
+    monkeypatch.setattr(
+        cli,
+        "date",
+        type("D", (), {"today": staticmethod(lambda: date(2024, 1, 2))}),
+    )
+
+    rc = cli.main(["--input", str(input_csv)])
+    assert rc == 0
+    expected = input_csv.with_name("output_input_20240102.csv")
+    assert called["output"] == expected


### PR DESCRIPTION
## Summary
- auto-generate `--output` CSV filename with `output_<stem>_<YYYYMMDD>.csv` if omitted
- document new default output format in CLI utilities
- test automatic output path generation and updated CLI help

## Testing
- `black csv_utils_main.py library/cli.py tests/test_cli_utils.py tests/test_csv_utils_main_args.py`
- `ruff check csv_utils_main.py library/cli.py tests/test_cli_utils.py tests/test_csv_utils_main_args.py`
- `mypy csv_utils_main.py library/cli.py` *(fails: Missing type stubs for pandas, yaml, requests, and other libraries)*
- `pytest tests/test_cli_utils.py tests/test_csv_utils_main_args.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2f3ab9ee483248c8de90326afb353