### PR TITLE
ci: upload outputs as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,10 @@ jobs:
         uses: pre-commit/action@v3
       - name: Smoke test cache
         run: pytest -q tests/test_chembl_client.py::test_request_json_cache
+      - name: Upload output data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-output
+          path: data/output
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ data/output/ChEMBL/processed/pairs_same_document.csv
 *.env
 .cache/
 data/output/
-/uniprot
-1
+uniprot/
 **/__pycache__/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ tokens should be stored in a local ``.env`` file – see
    The suite exercises the library modules using fixtures from
    ``tests/data``.
 
+
+## Генерация данных
+
+Скрипты из каталога `scripts/` создают CSV-файлы и сохраняют их в `data/output/`. Пример:
+
+```bash
+python scripts/get_activity_data.py --input tests/data/activity_ids_small.csv --output data/output/activities.csv --limit 10 --log-level INFO
+```
+
+Результирующие файлы располагаются в `data/output/`. Каталог игнорируется Git и автоматически публикуется как артефакт CI.
+
 ## Usage
 
 The examples below illustrate how to run the main CLI tools with common


### PR DESCRIPTION
## Summary
- collect pipeline outputs as CI artifacts
- ensure data/output is ignored
- document how to generate and retrieve data outputs

## Testing
- `pre-commit run --files .github/workflows/ci.yml .gitignore README.md`
- `pytest -q` *(fails: multiple import/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f3a2b6f08324aa41de40c374363b