### PR TITLE
feat: make pandera optional for CSV schema validation

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -27,23 +27,25 @@ import sys
 from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
 
 import pandas as pd
-
-try:
-    import pandera.pandas as pa
-except (ImportError, TypeError) as exc:
-    raise RuntimeError(
-        "pandera is required for schema validation; install a compatible "
-        "version of pandera for your Python interpreter."
-    ) from exc
 import yaml
 
 from . import validation
 from .config import Config, IoCfg, _serialize_paths
 from .csv_utils import write_csv_deterministic
 from .log import logger
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checking
+    import pandera.pandas as pa
+
+pa: ModuleType | None = None
+try:  # pragma: no cover - exercised in tests via monkeypatch
+    import pandera.pandas as pa
+except (ImportError, TypeError):
+    pa = None
 
 
 def read_ids(
@@ -139,7 +141,7 @@ def read_csv(
     schema:
         Optional :class:`pa.DataFrameSchema` or
         :class:`pa.DataFrameModel` used for advanced validation and
-        dtype coercion.
+        dtype coercion. Requires :mod:`pandera` when provided.
 
     Returns
     -------
@@ -158,6 +160,10 @@ def read_csv(
         parse_dates=list(parse_dates) if parse_dates is not None else None,
     )
     if schema is not None:
+        if pa is None:
+            raise RuntimeError(
+                "pandera is required for schema validation; install pandera to use the 'schema' argument"
+            )
         if isinstance(schema, pa.DataFrameSchema):
             df = schema.validate(df)
         else:

--- a/tests/test_io_pandera_import.py
+++ b/tests/test_io_pandera_import.py
@@ -3,25 +3,33 @@ from __future__ import annotations
 import builtins
 import importlib
 import sys
+from pathlib import Path
 
 import pytest
 
+from library.config import IoCfg
 
-def test_pandera_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Raise a helpful error when pandera import fails."""
+
+def test_import_without_pandera(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import :mod:`library.io` when ``pandera`` is missing and validate error on schema use."""
     module_name = "library.io"
     orig_import = builtins.__import__
 
     def fake_import(name: str, *args: object, **kwargs: object):
         if name == "pandera.pandas":
-            raise TypeError("boom")
+            raise ImportError("boom")
         return orig_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     sys.modules.pop(module_name, None)
 
+    io_mod = importlib.import_module(module_name)
+    assert io_mod.pa is None
+
+    cfg = IoCfg()
+    path = Path("tests/data/pmids.csv")
     with pytest.raises(RuntimeError, match="pandera is required"):
-        importlib.import_module(module_name)
+        io_mod.read_csv(path, cfg=cfg, schema=object())
 
     # restore real module for other tests
     monkeypatch.setattr(builtins, "__import__", orig_import, raising=False)


### PR DESCRIPTION
## Summary
- defer `pandera` import and expose optional `pa` module reference
- guard `read_csv` schema validation when `pandera` is missing
- add test ensuring `library.io` imports without `pandera`

## Testing
- `pre-commit run --files library/io.py tests/test_io_pandera_import.py` *(fails: 21 failed, 213 passed, see log)*
- `black library/io.py tests/test_io_pandera_import.py`
- `ruff check library/io.py tests/test_io_pandera_import.py`
- `mypy library/io.py tests/test_io_pandera_import.py` *(fails: numerous import and call-arg errors)*
- `pytest tests/test_io_pandera_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2f3ac83d48324ba773d6ef19e3848