### PR TITLE
fix script import

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -15,8 +15,16 @@ suffixes, for example ``activity_independent.csv`` or
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_input_initialisation.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package.  This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from library import input_initialisation_library as lib
 from library.cli import (

--- a/tests/test_get_input_initialisation_script.py
+++ b/tests/test_get_input_initialisation_script.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_executes() -> None:
+    """The script should be executable directly via Python."""
+    result = subprocess.run(
+        [sys.executable, "scripts/get_input_initialisation.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Path to same document workbook" in result.stdout


### PR DESCRIPTION
## Summary
- allow running get_input_initialisation.py directly by adding repository root to sys.path
- cover script execution via a smoke test

## Testing
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py`
- `black --check scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py`
- `mypy scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py` *(fails: Missing named argument "concurrency" for "BatchCfg" and others)*
- `pytest tests/test_get_input_initialisation_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f91c3b848324a3ad1a6ddca849d0