### PR TITLE
feat: require user agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ python -m dotenv run -- python scripts/get_assay_data.py --input tests/data/assa
 Утилиты читают переменные окружения автоматически, поэтому значения из
 `.env` доступны всем CLI без дополнительных аргументов.
 
+## Обязательное поле `api.user_agent`
+
+Для доступа к API необходимо заполнить параметр `api.user_agent` в
+`config.yaml`. Значение должно идентифицировать ваше приложение и содержать
+контактную информацию.
+
+```yaml
+api:
+  user_agent: "my-app/1.0 (mailto:me@example.org)"
+```
+
+Скрипты завершаются с `ConfigError`, если поле не задано. Параметр можно
+передать через переменную окружения `CHEMBL_DA__API__USER_AGENT` или флаг
+CLI `--api.user_agent`.
+
 ## Валидация конфигурации
 
 `library.config.load_config` проверяет корректность значений в `config.yaml`.

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ api:
   backoff_factor: 0.5  # Exponential backoff multiplier
   rps: 5  # Requests per second limit (env: CHEMBL_DA__API__RPS / CHEMBL_DA_RPS)
   burst: 5  # Burst size for token bucket limiter
-  # user_agent: "my-app/1.0 (mailto:me@example.org)"  # Example User-Agent header; must include contact info
+  user_agent: "your-app/1.0 (mailto:you@example.org)"  # Required User-Agent header; replace with your contact info
 
 chembl:
   cache_ttl: 3600  # Seconds to cache ChEMBL API responses (env: CHEMBL_DA__CHEMBL__CACHE_TTL / CHEMBL_DA_CACHE_TTL)

--- a/library/config.py
+++ b/library/config.py
@@ -626,7 +626,9 @@ def load_config(
     if "api" not in data or "user_agent" not in data.get("api", {}):
         raise ConfigError(
             "api.user_agent must be provided via environment variable "
-            "CHEMBL_DA__API__USER_AGENT or CLI option --api.user_agent"
+            "CHEMBL_DA__API__USER_AGENT or CLI option --api.user_agent. "
+            "See README.md for details and example: "
+            "'my-app/1.0 (mailto:me@example.org)'."
         )
 
     cfg = Config.model_validate(data)


### PR DESCRIPTION
## Summary
- expose `api.user_agent` in default config with placeholder
- link README and example format when `api.user_agent` is missing
- document required `api.user_agent` field in README

## Testing
- `pre-commit run --files README.md config.yaml library/config.py` *(fails: ValidationError for Config in multiple tests)*
- `pytest tests/test_config.py::test_user_agent_required_env_or_cli -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2fa1a33a88324b0588d35a18b23d3