### PR TITLE
Improve input initialisation error reporting

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -116,7 +116,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("save_done", extra={"tables": len(paths), "path": str(out_dir)})
         return 0
     except KeyError as exc:
-        logger.error("required table '%s' missing", exc.args[0])
+        msg = exc.args[0]
+        if " " in msg:
+            logger.error(msg)
+        else:
+            logger.error("required table '%s' missing", msg)
         return 1
 
 

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -110,6 +110,45 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch) -> None:
     assert "required table 'activity' missing" in record.get("msg", "")
 
 
+def test_run_missing_activity_column_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """``run`` should report missing columns without prefixing table message."""
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+
+    def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_load_all_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_build_combined_tables(*_args, **_kwargs):
+        raise KeyError("activity table missing expected columns: activity_id")
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", fake_load_same_doc)
+    monkeypatch.setattr(cli.lib, "load_all_doc", fake_load_all_doc)
+    monkeypatch.setattr(cli.lib, "build_combined_tables", fake_build_combined_tables)
+
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=tmp_path / "out",
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+    buf = io.StringIO()
+    configure_logger(LoggerConfig(stream=buf))
+    result = cli.run(Config(), args)
+    assert result == 1
+    lines = buf.getvalue().splitlines()
+    assert lines
+    record = json.loads(lines[-1])
+    assert "activity table missing expected columns: activity_id" in record.get(
+        "msg", ""
+    )
+
+
 def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:
     same_doc = tmp_path / "same.xlsx"
     all_doc = tmp_path / "all.xlsx"


### PR DESCRIPTION
## Summary
- report missing column details without incorrectly labelling them as missing tables
- add regression test for missing-column logging

## Testing
- `black scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `mypy library` *(fails: Incompatible types in assignment, missing named arguments)*
- `pytest` *(fails: pydantic_core.ValidationError, KeyError, SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fdaac6488324b1ee8bff9775fb01