### PR TITLE
feat: add http clients for metadata services

### DIFF
--- a/library/http_clients.py
+++ b/library/http_clients.py
@@ -1,0 +1,277 @@
+"""HTTP clients for external metadata services.
+
+This module contains low-level helpers that query the OpenAlex and CrossRef
+APIs.  Higher level modules such as :mod:`library.pubmed_library` and
+:mod:`library.openalex_crossref_library` import these functions to avoid a
+circular dependency between them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+from .config import CrossRefCfg, OpenAlexCfg
+from .log import logger
+from .rate_limiter import RateLimiter, get_limiter, sleep
+
+
+def _do_request(
+    session: requests.Session,
+    url: str,
+    delay: float,
+    expect_json: bool = True,
+    retries: int = 2,
+    method: str = "GET",
+    timeout: float | tuple[float, float] = 10,
+    **kwargs: Any,
+) -> tuple[dict[str, Any] | str | None, str]:
+    """Perform an HTTP request with retry and error handling.
+
+    Parameters
+    ----------
+    session:
+        Active :class:`requests.Session` used to issue the call.
+    url:
+        Endpoint to query.
+    delay:
+        Base number of seconds to wait between attempts.
+    expect_json:
+        Whether to parse the response as JSON.
+    retries:
+        Number of additional attempts after the initial one.
+    method:
+        HTTP method to use, either ``"GET"`` or ``"POST"``.
+    timeout:
+        Maximum seconds to wait for each HTTP request. May be a single float or
+        a ``(connect, read)`` tuple.
+    **kwargs:
+        Additional parameters passed to ``session.get`` or ``session.post``.
+
+    Returns
+    -------
+    tuple
+        Pair of parsed data (``dict``/``str``/``None``) and an error message.
+        The error string is empty on success.
+    """
+
+    for attempt in range(retries + 1):
+        event = "request_start" if attempt == 0 else "request_retry"
+        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
+        if attempt:
+            sleep(delay * attempt)
+
+        try:
+            if method.upper() == "POST":
+                request: Callable[..., requests.Response] = session.post
+            else:
+                request = session.get
+            with request(url, timeout=timeout, **kwargs) as resp:
+                status_code = resp.status_code
+                text = resp.text
+                try:
+                    content = resp.json() if expect_json else text
+                except ValueError as exc:
+                    content = None
+                    parse_error = str(exc)
+                else:
+                    parse_error = ""
+        except requests.RequestException as exc:
+            if attempt >= retries:  # pragma: no cover - network errors
+                logger.exception(
+                    "request_fail", extra={"stage": "request_fail", "url": url}
+                )
+                return None, str(exc)
+            continue
+
+        if status_code in (429, 500, 502, 503, 504):
+            if attempt >= retries:
+                logger.info(
+                    "request_fail",
+                    extra={
+                        "stage": "request_fail",
+                        "url": url,
+                        "status": status_code,
+                    },
+                )
+                return None, f"HTTP {status_code}: {text[:100]}"
+            continue
+        if status_code == 404:
+            logger.info(
+                "request_fail",
+                extra={"stage": "request_fail", "url": url, "status": status_code},
+            )
+            return None, "PMID not found"
+        if status_code == 400:
+            logger.info(
+                "request_fail",
+                extra={"stage": "request_fail", "url": url, "status": status_code},
+            )
+            return None, f"Bad request: {text[:100]}"
+        if status_code != 200:
+            logger.info(
+                "request_fail",
+                extra={"stage": "request_fail", "url": url, "status": status_code},
+            )
+            return None, f"HTTP {status_code}: {text[:100]}"
+        if expect_json:
+            if parse_error:
+                logger.info("request_fail", extra={"stage": "request_fail", "url": url})
+                return None, f"Invalid JSON: {parse_error}"
+            logger.info(
+                "request_ok",
+                extra={"stage": "request_ok", "url": url, "status": status_code},
+            )
+            return content, ""
+        logger.info(
+            "request_ok",
+            extra={"stage": "request_ok", "url": url, "status": status_code},
+        )
+        return content or "", ""
+    logger.info("request_fail", extra={"stage": "request_fail", "url": url})
+    return None, "Request failed"
+
+
+def fetch_openalex(
+    session: requests.Session,
+    pmid: str,
+    cfg: OpenAlexCfg,
+    limiter: RateLimiter | None = None,
+) -> dict[str, str]:
+    """Retrieve OpenAlex metadata for ``pmid``.
+
+    Parameters
+    ----------
+    session:
+        Active :class:`requests.Session`.
+    pmid:
+        PubMed identifier to query.
+    cfg:
+        OpenAlex configuration providing base URL, timeouts and rate limits.
+    limiter:
+        Shared :class:`RateLimiter` instance. If ``None``, a limiter is
+        retrieved via :func:`get_limiter` using the configuration values.
+
+    Returns
+    -------
+    dict
+        Mapping of OpenAlex fields and any error encountered.
+    """
+
+    if limiter is None:
+        limiter = get_limiter("openalex", cfg.rps, cfg.burst)
+    limiter.acquire()
+    delay = 1 / cfg.rps if cfg.rps else 0
+    base = cfg.base.rstrip("/")
+    url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(session, url, delay, retries=cfg.retries, timeout=timeout)
+
+    if error or not isinstance(data, dict):
+        return {
+            "OpenAlex.PublicationTypes": "",
+            "OpenAlex.TypeCrossref": "",
+            "OpenAlex.Genre": "",
+            "OpenAlex.Id": "",
+            "OpenAlex.Venue": "",
+            "OpenAlex.MeshDescriptors": "",
+            "OpenAlex.MeshQualifiers": "",
+            "OpenAlex.Error": error or "Invalid response",
+        }
+    mesh_entries = data.get("mesh") or []
+    descriptors: list[str] = []
+    qualifiers: list[str] = []
+    for entry in mesh_entries:
+        d = entry.get("descriptor_name")
+        if d:
+            descriptors.append(d)
+        for q in entry.get("qualifiers") or []:
+            qn = q.get("qualifier_name")
+            if qn:
+                qualifiers.append(qn)
+    combine = "|".join
+    return {
+        "OpenAlex.PublicationTypes": data.get("type", ""),
+        "OpenAlex.TypeCrossref": data.get("type_crossref", ""),
+        "OpenAlex.Genre": data.get("genre", ""),
+        "OpenAlex.Id": data.get("id", ""),
+        "OpenAlex.Venue": data.get("host_venue", {}).get("display_name", ""),
+        "OpenAlex.MeshDescriptors": combine(descriptors),
+        "OpenAlex.MeshQualifiers": combine(qualifiers),
+        "OpenAlex.Error": "",
+    }
+
+
+def fetch_crossref(
+    session: requests.Session,
+    doi: str,
+    *,
+    cfg: CrossRefCfg,
+    limiter: RateLimiter | None = None,
+) -> dict[str, str]:
+    """Retrieve Crossref metadata for a given DOI.
+
+    Parameters
+    ----------
+    session:
+        Active :class:`requests.Session`.
+    doi:
+        Digital Object Identifier to query.
+    cfg:
+        CrossRef configuration providing base URL, timeouts and rate limits.
+    limiter:
+        Shared :class:`RateLimiter` instance. If ``None``, a limiter is
+        retrieved via :func:`get_limiter` using the configuration values.
+
+    Returns
+    -------
+    dict
+        Mapping of CrossRef fields and any error encountered.
+    """
+
+    if not doi:
+        return {
+            "crossref.Type": "",
+            "crossref.Subtype": "",
+            "crossref.Title": "",
+            "crossref.Subtitle": "",
+            "crossref.Subject": "",
+            "crossref.Error": "Missing DOI",
+        }
+
+    if limiter is None:
+        limiter = get_limiter("crossref", cfg.rps, cfg.burst)
+    limiter.acquire()
+    delay = 1 / cfg.rps if cfg.rps else 0
+    base = cfg.base.rstrip("/")
+    url = f"{base}/works/{quote(doi, safe='')}?mailto={quote(cfg.mailto)}"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(session, url, delay, retries=cfg.retries, timeout=timeout)
+
+    if error or not isinstance(data, dict):
+        return {
+            "crossref.Type": "",
+            "crossref.Subtype": "",
+            "crossref.Title": "",
+            "crossref.Subtitle": "",
+            "crossref.Subject": "",
+            "crossref.Error": error or "Invalid response",
+        }
+    message = data.get("message", {})
+    title = message.get("title") or [""]
+    subtitle = message.get("subtitle") or [""]
+    subject = "; ".join(message.get("subject") or [])
+    return {
+        "crossref.Type": message.get("type", ""),
+        "crossref.Subtype": message.get("subtype", ""),
+        "crossref.Title": title[0] if title else "",
+        "crossref.Subtitle": subtitle[0] if subtitle else "",
+        "crossref.Subject": subject,
+        "crossref.Error": "",
+    }
+
+
+__all__ = ["fetch_openalex", "fetch_crossref", "_do_request"]

--- a/library/openalex_crossref_library.py
+++ b/library/openalex_crossref_library.py
@@ -1,6 +1,6 @@
 """OpenAlex and CrossRef query helpers.
 
-These functions proxy to implementations in :mod:`library.pubmed_library` but
+These functions proxy to implementations in :mod:`library.http_clients` but
 are exposed in a separate module to provide a clear separation of concerns.
 """
 
@@ -10,9 +10,10 @@ from urllib.parse import quote
 
 import requests
 
-from . import pubmed_library as _pl
+from .config import CrossRefCfg, OpenAlexCfg
+from .http_clients import fetch_crossref as _fetch_crossref
+from .http_clients import fetch_openalex as _fetch_openalex
 from .log import logger
-from .pubmed_library import CrossRefCfg, OpenAlexCfg  # type: ignore[attr-defined]
 from .rate_limiter import RateLimiter
 
 
@@ -52,7 +53,7 @@ def fetch_openalex(
     url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
     logger.info("request_start", extra={"stage": "request_start", "url": url})
     try:
-        data = _pl.fetch_openalex(session, pmid, cfg=cfg, limiter=limiter)
+        data = _fetch_openalex(session, pmid, cfg=cfg, limiter=limiter)
     except requests.RequestException:
         logger.exception("request_fail", extra={"stage": "request_fail", "url": url})
         raise
@@ -93,10 +94,10 @@ def fetch_crossref(
     """
 
     base = cfg.base.rstrip("/")
-    url = f"{base}/works/{quote(doi)}"
+    url = f"{base}/works/{quote(doi, safe='')}"
     logger.info("request_start", extra={"stage": "request_start", "url": url})
     try:
-        data = _pl.fetch_crossref(session, doi, cfg=cfg, limiter=limiter)
+        data = _fetch_crossref(session, doi, cfg=cfg, limiter=limiter)
     except requests.RequestException:
         logger.exception("request_fail", extra={"stage": "request_fail", "url": url})
         raise

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from datetime import date
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
 )
-from urllib.parse import quote
 from xml.etree import ElementTree as ET
 
 import pandas as pd
@@ -24,20 +23,14 @@ import requests
 
 from .cli import LoggerConfig, configure_logger
 from .cli import build_parser as base_parser
-from .config import (
-    Config,
-    CrossRefCfg,
-    OpenAlexCfg,
-    PubMedCfg,
-    SemanticScholarCfg,
-    session_with_retry,
-)
+from .config import Config, PubMedCfg, SemanticScholarCfg, session_with_retry
 from .csv_utils import write_csv_deterministic
+from .http_clients import _do_request, fetch_crossref, fetch_openalex
 from .log import logger
-from .rate_limiter import get_limiter, sleep
+from .rate_limiter import get_limiter
 
 if TYPE_CHECKING:
-    from .rate_limiter import RateLimiter
+    pass
 
 
 def read_pmids(path: str | Path, cfg: PubMedCfg | None = None) -> pd.DataFrame:
@@ -80,123 +73,6 @@ def read_pmids(path: str | Path, cfg: PubMedCfg | None = None) -> pd.DataFrame:
     raise ValueError(
         f"Could not decode {path} with encodings {encodings}. Last error: {last_exc}"
     )
-
-
-def _do_request(
-    session: requests.Session,
-    url: str,
-    delay: float,
-    expect_json: bool = True,
-    retries: int = 2,
-    method: str = "GET",
-    timeout: float | tuple[float, float] = 10,
-    **kwargs: Any,
-) -> tuple[dict[str, Any] | str | None, str]:
-    """Perform an HTTP request with retry and error handling.
-
-    Parameters
-    ----------
-    session:
-        Requests session used to perform the call.
-    url:
-        Endpoint to query.
-    delay:
-        Base number of seconds to wait between attempts.
-    expect_json:
-        Whether to parse the response as JSON.
-    retries:
-        Number of additional attempts after the initial one.
-    method:
-        HTTP method to use, either "GET" or "POST".
-    timeout:
-
-        Maximum seconds to wait for each HTTP request. May be a single float
-        or a ``(connect, read)`` tuple.
-
-    **kwargs:
-        Additional parameters passed to ``session.get`` or ``session.post``.
-
-    Returns
-    -------
-    tuple
-        Pair of parsed data (dict/str/``None``) and an error message. The error
-        string is empty on success.
-
-    """
-    for attempt in range(retries + 1):
-        event = "request_start" if attempt == 0 else "request_retry"
-        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
-        if attempt:
-            sleep(delay * attempt)
-
-        try:
-            if method.upper() == "POST":
-                request: Callable[..., requests.Response] = session.post
-            else:
-                request = session.get
-            with request(url, timeout=timeout, **kwargs) as resp:
-                status_code = resp.status_code
-                text = resp.text
-                try:
-                    content = resp.json() if expect_json else text
-                except ValueError as exc:
-                    content = None
-                    parse_error = str(exc)
-                else:
-                    parse_error = ""
-        except requests.RequestException as exc:
-            if attempt >= retries:  # pragma: no cover - network errors
-                logger.exception(
-                    "request_fail", extra={"stage": "request_fail", "url": url}
-                )
-                return None, str(exc)
-            continue
-        if status_code in (429, 500, 502, 503, 504):
-            if attempt >= retries:
-                logger.info(
-                    "request_fail",
-                    extra={
-                        "stage": "request_fail",
-                        "url": url,
-                        "status": status_code,
-                    },
-                )
-                return None, f"HTTP {status_code}: {text[:100]}"
-            continue
-        if status_code == 404:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, "PMID not found"
-        if status_code == 400:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, f"Bad request: {text[:100]}"
-        if status_code != 200:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, f"HTTP {status_code}: {text[:100]}"
-        if expect_json:
-            if parse_error:
-                logger.info("request_fail", extra={"stage": "request_fail", "url": url})
-                return None, f"Invalid JSON: {parse_error}"
-            logger.info(
-                "request_ok",
-                extra={"stage": "request_ok", "url": url, "status": status_code},
-            )
-            return content, ""
-        logger.info(
-            "request_ok",
-            extra={"stage": "request_ok", "url": url, "status": status_code},
-        )
-        return content or "", ""
-    logger.info("request_fail", extra={"stage": "request_fail", "url": url})
-    return None, "Request failed"
 
 
 def fetch_pubmed_batch(
@@ -647,148 +523,6 @@ def fetch_semantic_scholar_batch(
         ]
 
     return results
-
-
-def fetch_openalex(
-    session: requests.Session,
-    pmid: str,
-    *,
-    cfg: OpenAlexCfg,
-    limiter: RateLimiter | None = None,
-) -> dict[str, str]:
-    """Retrieve OpenAlex metadata for ``pmid``.
-
-    Parameters
-    ----------
-    session:
-        Active :class:`requests.Session`.
-    pmid:
-        PubMed identifier to query.
-    cfg:
-        OpenAlex configuration providing base URL, timeouts and rate limits.
-    limiter:
-        Shared :class:`RateLimiter` instance. If ``None``, a limiter is
-        retrieved via :func:`get_limiter` using the configuration values.
-
-
-    Returns
-    -------
-    dict
-        Mapping of OpenAlex fields and any error encountered.
-
-    """
-
-    if limiter is None:
-        limiter = get_limiter("openalex", cfg.rps, cfg.burst)
-    limiter.acquire()
-    delay = 1 / cfg.rps if cfg.rps else 0
-    base = cfg.base.rstrip("/")
-    url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
-    timeout = (cfg.timeout_connect, cfg.timeout_read)
-    data, error = _do_request(session, url, delay, retries=cfg.retries, timeout=timeout)
-
-    if error or not isinstance(data, dict):
-        return {
-            "OpenAlex.PublicationTypes": "",
-            "OpenAlex.TypeCrossref": "",
-            "OpenAlex.Genre": "",
-            "OpenAlex.Id": "",
-            "OpenAlex.Venue": "",
-            "OpenAlex.MeshDescriptors": "",
-            "OpenAlex.MeshQualifiers": "",
-            "OpenAlex.Error": error or "Invalid response",
-        }
-    mesh_entries = data.get("mesh") or []
-    descriptors: list[str] = []
-    qualifiers: list[str] = []
-    for entry in mesh_entries:
-        d = entry.get("descriptor_name")
-        if d:
-            descriptors.append(d)
-        for q in entry.get("qualifiers") or []:
-            qn = q.get("qualifier_name")
-            if qn:
-                qualifiers.append(qn)
-    return {
-        "OpenAlex.PublicationTypes": data.get("type", ""),
-        "OpenAlex.TypeCrossref": data.get("type_crossref", ""),
-        "OpenAlex.Genre": data.get("genre", ""),
-        "OpenAlex.Id": data.get("id", ""),
-        "OpenAlex.Venue": data.get("host_venue", {}).get("display_name", ""),
-        "OpenAlex.MeshDescriptors": combine(descriptors),
-        "OpenAlex.MeshQualifiers": combine(qualifiers),
-        "OpenAlex.Error": "",
-    }
-
-
-def fetch_crossref(
-    session: requests.Session,
-    doi: str,
-    *,
-    cfg: CrossRefCfg,
-    limiter: RateLimiter | None = None,
-) -> dict[str, str]:
-    """Retrieve Crossref metadata for a given DOI.
-
-    Parameters
-    ----------
-    session:
-        Active :class:`requests.Session`.
-    doi:
-        Digital Object Identifier to query.
-    cfg:
-        CrossRef configuration providing base URL, timeouts and rate limits.
-    limiter:
-        Shared :class:`RateLimiter` instance. If ``None``, a limiter is
-        retrieved via :func:`get_limiter` using the configuration values.
-
-
-    Returns
-    -------
-    dict
-        Mapping of Crossref fields and any error encountered.
-
-    """
-    if not doi:
-        return {
-            "crossref.Type": "",
-            "crossref.Subtype": "",
-            "crossref.Title": "",
-            "crossref.Subtitle": "",
-            "crossref.Subject": "",
-            "crossref.Error": "Missing DOI",
-        }
-
-    if limiter is None:
-        limiter = get_limiter("crossref", cfg.rps, cfg.burst)
-    limiter.acquire()
-    delay = 1 / cfg.rps if cfg.rps else 0
-    base = cfg.base.rstrip("/")
-    url = f"{base}/works/{quote(doi, safe='')}?mailto={quote(cfg.mailto)}"
-    timeout = (cfg.timeout_connect, cfg.timeout_read)
-    data, error = _do_request(session, url, delay, retries=cfg.retries, timeout=timeout)
-
-    if error or not isinstance(data, dict):
-        return {
-            "crossref.Type": "",
-            "crossref.Subtype": "",
-            "crossref.Title": "",
-            "crossref.Subtitle": "",
-            "crossref.Subject": "",
-            "crossref.Error": error or "Invalid response",
-        }
-    message = data.get("message", {})
-    title = message.get("title") or [""]
-    subtitle = message.get("subtitle") or [""]
-    subject = "; ".join(message.get("subject") or [])
-    return {
-        "crossref.Type": message.get("type", ""),
-        "crossref.Subtype": message.get("subtype", ""),
-        "crossref.Title": title[0] if title else "",
-        "crossref.Subtitle": subtitle[0] if subtitle else "",
-        "crossref.Subject": subject,
-        "crossref.Error": "",
-    }
 
 
 def print_results(records: list[dict[str, str]]) -> None:

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -3,7 +3,7 @@ import requests
 
 from library import openalex_crossref_library as ocl
 from library import rate_limiter as rl
-from library.config import Config, CrossRefCfg, OpenAlexCfg
+from library.config import ApiCfg, Config, CrossRefCfg, OpenAlexCfg
 
 
 def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
@@ -16,9 +16,10 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
         called["timeout"] = timeout
         return {}, ""
 
-    monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
+    monkeypatch.setattr("library.http_clients._do_request", fake_do_request)
 
     cfg = Config(
+        api=ApiCfg(user_agent="ua (test@example.org)"),
         openalex=OpenAlexCfg(
             base="https://example.org",
             timeout_connect=1,
@@ -26,7 +27,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
             rps=2,
             burst=5,
             mailto="x@y.com",
-        )
+        ),
     )
     limiter = rl.RateLimiter(2)
     ocl.fetch_openalex(requests.Session(), "123", cfg.openalex, limiter)
@@ -45,9 +46,10 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
         called["timeout"] = timeout
         return {}, ""
 
-    monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
+    monkeypatch.setattr("library.http_clients._do_request", fake_do_request)
 
     cfg = Config(
+        api=ApiCfg(user_agent="ua (test@example.org)"),
         crossref=CrossRefCfg(
             base="https://cr.example.org",
             timeout_connect=1,
@@ -55,7 +57,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
             rps=4,
             burst=5,
             mailto="z@e.com",
-        )
+        ),
     )
     limiter = rl.RateLimiter(4)
     ocl.fetch_crossref(requests.Session(), "10.1/abc", cfg.crossref, limiter)
@@ -72,9 +74,12 @@ def test_rate_limiter_shared(monkeypatch) -> None:
         delays.append(delay)
 
     monkeypatch.setattr(rl, "sleep", fake_sleep)
-    monkeypatch.setattr("library.pubmed_library._do_request", lambda *a, **k: ({}, ""))
+    monkeypatch.setattr("library.http_clients._do_request", lambda *a, **k: ({}, ""))
 
-    cfg = Config(openalex=OpenAlexCfg(rps=1, mailto="x@y.com"))
+    cfg = Config(
+        api=ApiCfg(user_agent="ua (test@example.org)"),
+        openalex=OpenAlexCfg(rps=1, mailto="x@y.com"),
+    )
     limiter = rl.RateLimiter(1)
     session = requests.Session()
     ocl.fetch_openalex(session, "1", cfg.openalex, limiter)

--- a/tests/test_pubmed_library.py
+++ b/tests/test_pubmed_library.py
@@ -12,6 +12,7 @@ import requests
 from library import pubmed_library as pl
 from library import rate_limiter as rl
 from library.config import (
+    ApiCfg,
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -142,6 +143,7 @@ def test_fetch_pubmed_uses_cfg(monkeypatch) -> None:
 
 def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
     cfg = Config(
+        api=ApiCfg(user_agent="ua (test@example.org)"),
         openalex=OpenAlexCfg(
             base="https://example.org",
             timeout_connect=1,
@@ -149,7 +151,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
             retries=4,
             rps=10,
             mailto="info@example.org",
-        )
+        ),
     )
 
     captured: dict[str, Any] = {}
@@ -176,7 +178,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
             "mesh": [],
         }, ""
 
-    monkeypatch.setattr(pl, "_do_request", fake_do_request)
+    monkeypatch.setattr("library.http_clients._do_request", fake_do_request)
 
     class DummyLimiter(rl.RateLimiter):
         def __init__(self) -> None:
@@ -201,6 +203,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
 
 def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
     cfg = Config(
+        api=ApiCfg(user_agent="ua (test@example.org)"),
         crossref=CrossRefCfg(
             base="https://api.example.org",
             timeout_connect=2,
@@ -208,7 +211,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
             retries=5,
             rps=8,
             mailto="info@example.org",
-        )
+        ),
     )
 
     captured: dict[str, Any] = {}
@@ -228,7 +231,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
         )
         return {"message": {}}, ""
 
-    monkeypatch.setattr(pl, "_do_request", fake_do_request)
+    monkeypatch.setattr("library.http_clients._do_request", fake_do_request)
 
     class DummyLimiter(rl.RateLimiter):
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- factor out OpenAlex and CrossRef HTTP requests into new `http_clients` module
- switch `openalex_crossref_library` and `pubmed_library` to use the shared clients
- adjust unit tests for the new module structure

## Testing
- `ruff check library/http_clients.py library/openalex_crossref_library.py library/pubmed_library.py tests/test_openalex_crossref_library.py tests/test_pubmed_library.py`
- `black library/http_clients.py library/openalex_crossref_library.py library/pubmed_library.py tests/test_openalex_crossref_library.py tests/test_pubmed_library.py`
- `pytest tests/test_openalex_crossref_library.py tests/test_pubmed_library.py -q`
- `mypy library/http_clients.py library/openalex_crossref_library.py library/pubmed_library.py` *(fails: Missing named argument "timeout_connect" for "PubMedCfg" and similar)*


------
https://chatgpt.com/codex/tasks/task_e_68c2fcbf063883248b456c05c7ebf468