### PR TITLE
Enforce strict config by default with CLI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,9 @@ types and value ranges, producing helpful error messages for nested fields.
 
 Command line flags have the highest priority. All utilities accept ``--config``
 to point at a configuration file and ``--print-config`` to show the effective
-values after all overrides have been applied. The final precedence is::
+values after all overrides have been applied. Unknown configuration keys cause
+errors by default; pass ``--no-config-strict`` to merely log a warning. The
+final precedence is::
 
     YAML < environment variables < CLI options
 
@@ -500,6 +502,7 @@ Common flags shared by scripts include:
 * ``--log-level`` – logging verbosity (default ``INFO``)
 * ``--sep`` – CSV delimiter (default taken from configuration)
 * ``--encoding`` – file encoding (default taken from configuration)
+* ``--config-strict`` – fail on unknown configuration keys (use ``--no-config-strict`` to allow them)
 * ``--column`` – column containing identifiers (script specific)
 
 Example fetching assay data::

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -83,5 +83,7 @@ to the same configuration keys as their longer forms:
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `CHEMBL_DA__RATE__LIMITER_CACHE_TTL` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__LOG__LEVEL` |
 
-The loader warns about unknown variables and ignores them. All overrides are
-applied after reading `config.yaml` and before command line options.
+By default the loader errors on unknown keys. Use ``--no-config-strict`` on the
+command line or pass ``strict=False`` to ``load_config`` to merely log a
+warning. All overrides are applied after reading ``config.yaml`` and before
+command line options.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,9 +65,10 @@ The command emits three pair tables:
 written with matching suffixes, for example
 `activity_independent.csv` or `assay_same_document.csv`.
 
-Each command supports the common flags `--sep`, `--encoding` and
-`--log-level`. The default output path mirrors the input location and can be
-manually overridden with `--output` where available.
+Each command supports the common flags `--sep`, `--encoding`, `--log-level` and
+`--config-strict`. The default output path mirrors the input location and can be
+manually overridden with `--output` where available. Use `--no-config-strict`
+to allow unknown keys in `config.yaml`.
 
 ### Configuration overrides
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -146,6 +146,12 @@ def build_parser(
         help="YAML configuration file",
     )
     parser.add_argument(
+        "--config-strict",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Fail on unknown configuration keys (use --no-config-strict to allow them)",
+    )
+    parser.add_argument(
         "--print-config",
         action="store_true",
         help="Print effective configuration and exit",
@@ -171,6 +177,12 @@ def build_root_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=Path,
         default=Path("config.yaml"),
         help="YAML configuration file",
+    )
+    parser.add_argument(
+        "--config-strict",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Fail on unknown configuration keys (use --no-config-strict to allow them)",
     )
     parser.add_argument(
         "--print-config",
@@ -292,7 +304,11 @@ def apply_config_overrides(
             cli_overrides[key] = value
 
     try:
-        cfg = load_config(config_path, cli_overrides=cli_overrides)
+        cfg = load_config(
+            config_path,
+            cli_overrides=cli_overrides,
+            strict=getattr(args, "config_strict", True),
+        )
     except ConfigError as exc:
         log.logger.error("%s", exc)
         parser.error(str(exc))

--- a/library/config.py
+++ b/library/config.py
@@ -593,9 +593,26 @@ def load_config(
     path: str | Path = "config.yaml",
     cli_overrides: dict[str, Any] | None = None,
     *,
-    strict: bool = False,
+    strict: bool = True,
 ) -> Config:
-    """Load configuration from *path* applying overrides."""
+    """Load configuration from *path* applying overrides.
+
+    Parameters
+    ----------
+    path:
+        Location of the YAML file on disk.
+    cli_overrides:
+        Mapping of dotted configuration paths to values. These are applied
+        after reading ``path`` and environment variables.
+    strict:
+        When ``True`` (default), unknown keys in the configuration result in a
+        ``ValueError``. Set to ``False`` to log a warning instead.
+
+    Returns
+    -------
+    Config
+        Fully validated configuration object.
+    """
 
     try:
         with Path(path).open("r", encoding="utf8") as fh:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,23 @@ def test_apply_config_overrides_missing_config(
         apply_config_overrides(args, parser, args.config)
     assert excinfo.value.code == 2
     assert "configuration file not found" in capsys.readouterr().err
+
+
+def test_no_config_strict_allows_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("unknown: 1\n", encoding="utf8")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default=cfg_path, type=Path)
+    parser.add_argument(
+        "--config-strict",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    monkeypatch.setenv(
+        "CHEMBL_DA__API__USER_AGENT", "test-agent/1.0 (mailto:test@example.org)"
+    )
+    args = parser.parse_args(["--config", str(cfg_path), "--no-config-strict"])
+    cfg = apply_config_overrides(args, parser, args.config)
+    assert cfg.api.rps == 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,7 +256,7 @@ def test_unknown_key_warning(tmp_path: Path) -> None:
     path.write_text("unknown: 1\napi:\n  rps: 1\n")
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
-    load_config(path)
+    load_config(path, strict=False)
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
@@ -268,14 +268,14 @@ def test_unknown_key_error(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\n")
     with pytest.raises(ValueError, match="Unknown configuration key"):
-        load_config(path, strict=True)
+        load_config(path)
 
 
 def test_config_type_coercion() -> None:
     """The default configuration should load without type errors in strict mode."""
 
     path = Path(__file__).resolve().parents[1] / "config.yaml"
-    cfg = load_config(path, strict=True)
+    cfg = load_config(path)
     assert isinstance(cfg.pubchem.delay, float)
     assert isinstance(cfg.batch.pause, float)
 


### PR DESCRIPTION
## Summary
- default `load_config` to strict mode with explicit CLI toggle
- document strict configuration loading behaviour
- add test coverage for `--no-config-strict`

## Testing
- `python -m black scripts library mapper_main.py table_quality_main.py tests/test_cli.py tests/test_config.py`
- `python -m ruff check scripts library mapper_main.py table_quality_main.py tests/test_cli.py tests/test_config.py`
- `python -m mypy library` *(fails: many missing stubs/arg mismatches)*
- `pytest tests/test_cli.py tests/test_config.py`
- `pytest` *(fails: numerous Config validation errors and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fcc068d48324af299e756581c411