### PR TITLE
Cache git sha for repeated calls

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -26,24 +26,30 @@ from .config import Config, _serialize_paths
 
 logger = logging.getLogger(__name__)
 
+# Cached Git SHA for the repository, populated on first lookup.
+_GIT_SHA: str | None = None
+
 
 def _git_sha() -> str:
     """Return the current Git commit hash or ``"unknown"`` if unavailable."""
 
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout.strip()
-    except subprocess.TimeoutExpired:
-        logger.warning("git rev-parse timed out")
-        return "unknown"
-    except Exception:  # pragma: no cover - git may be unavailable
-        return "unknown"
+    global _GIT_SHA
+    if _GIT_SHA is None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            _GIT_SHA = result.stdout.strip()
+        except subprocess.TimeoutExpired:
+            logger.warning("git rev-parse timed out")
+            _GIT_SHA = "unknown"
+        except Exception:  # pragma: no cover - git may be unavailable
+            _GIT_SHA = "unknown"
+    return _GIT_SHA
 
 
 def _write_meta(path: Path, cfg: Config | None) -> Path:

--- a/library/io.py
+++ b/library/io.py
@@ -47,6 +47,9 @@ try:  # pragma: no cover - exercised in tests via monkeypatch
 except (ImportError, TypeError):
     pa = None
 
+# Cached Git SHA for the repository, populated on first lookup.
+_GIT_SHA: str | None = None
+
 
 def read_ids(
     path: str | Path,
@@ -268,20 +271,24 @@ def _git_sha() -> str:
     returned and a warning is logged.
     """
 
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        return result.stdout.strip()
-    except subprocess.TimeoutExpired as exc:
-        logger.warning("git command timed out: %s", exc)
-    except Exception as exc:  # pragma: no cover - git may be unavailable
-        logger.warning("unable to determine git SHA: %s", exc)
-    return "unknown"
+    global _GIT_SHA
+    if _GIT_SHA is None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            _GIT_SHA = result.stdout.strip()
+        except subprocess.TimeoutExpired as exc:
+            logger.warning("git command timed out: %s", exc)
+            _GIT_SHA = "unknown"
+        except Exception as exc:  # pragma: no cover - git may be unavailable
+            logger.warning("unable to determine git SHA: %s", exc)
+            _GIT_SHA = "unknown"
+    return _GIT_SHA
 
 
 def _write_meta(path: Path, cfg: Config) -> None:

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -25,6 +25,9 @@ from .log import logger
 # ``timezone.utc`` provides the same value and works on older versions.
 UTC = timezone.utc  # noqa: UP017
 
+# Cached Git SHA for the repository, populated on first lookup.
+_GIT_SHA: str | None = None
+
 
 class Stats(TypedDict):
     """Execution statistics written to the metadata file."""
@@ -62,13 +65,18 @@ def _git_sha() -> str:
     If Git is unavailable, ``"UNKNOWN"`` is returned and a warning is logged.
     """
 
-    repo_root = Path(__file__).resolve().parent.parent
-    try:
-        result = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root)
-        return result.decode().strip()
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        logger.warning("Unable to determine git SHA: %s", exc)
-        return "UNKNOWN"
+    global _GIT_SHA
+    if _GIT_SHA is None:
+        repo_root = Path(__file__).resolve().parent.parent
+        try:
+            result = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repo_root
+            )
+            _GIT_SHA = result.decode().strip()
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            logger.warning("Unable to determine git SHA: %s", exc)
+            _GIT_SHA = "UNKNOWN"
+    return _GIT_SHA
 
 
 def write_meta_yaml(

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -199,14 +199,19 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """_git_sha returns 'unknown' and logs a warning on timeout."""
+    from library import csv_utils
+
+    csv_utils._GIT_SHA = None
 
     with patch(
         "library.csv_utils.subprocess.run",
         side_effect=subprocess.TimeoutExpired(
             cmd=["git", "rev-parse", "HEAD"], timeout=5
         ),
-    ):
+    ) as mock_run:
         with caplog.at_level(logging.WARNING):
-            result = _git_sha()
-    assert result == "unknown"
+            first = _git_sha()
+            second = _git_sha()
+    assert first == second == "unknown"
     assert "timed out" in caplog.text
+    assert mock_run.call_count == 1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -148,7 +148,6 @@ def test_git_sha_timeout_returns_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_git_sha returns ``"unknown"`` when the git command exceeds timeout."""
-
     stream = StringIO()
     monkeypatch.setattr(
         io,
@@ -156,11 +155,18 @@ def test_git_sha_timeout_returns_unknown(
         configure_logger(LoggerConfig(level="WARNING", stream=stream)),
     )
 
+    calls = 0
+
     def slow_run(*args: Any, **kwargs: Any) -> NoReturn:
+        nonlocal calls
+        calls += 1
         time.sleep(0.1)  # Simulate a hanging git command
         raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
 
+    monkeypatch.setattr(io, "_GIT_SHA", None)
     monkeypatch.setattr(io.subprocess, "run", slow_run)
 
     assert io._git_sha() == "unknown"
+    assert io._git_sha() == "unknown"  # cached value
     assert "timed out" in stream.getvalue()
+    assert calls == 1


### PR DESCRIPTION
## Summary
- cache git sha in csv, IO, and metadata helpers
- test git sha caching behavior under timeout conditions

## Testing
- `ruff check --fix library tests`
- `black library/csv_utils.py library/io.py library/metadata.py tests/test_csv_utils.py tests/test_io.py`
- `mypy library` (fails: Missing named argument "retries" for "PubMedCfg", etc.)
- `pytest` (fails: ModuleNotFoundError: No module named 'responses')

------
https://chatgpt.com/codex/tasks/task_e_68c2fcc3e6788324b43f96aff0745898