### PR TITLE
Log and re-raise unexpected git SHA errors

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -28,7 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 def _git_sha() -> str:
-    """Return the current Git commit hash or ``"unknown"`` if unavailable."""
+    """Return the current Git commit hash.
+
+    If ``git`` exits with a non-zero status or times out, ``"unknown"`` is
+    returned and a warning is logged. Unexpected exceptions are logged and
+    re-raised.
+    """
 
     try:
         result = subprocess.run(
@@ -39,11 +44,15 @@ def _git_sha() -> str:
             timeout=5,
         )
         return result.stdout.strip()
-    except subprocess.TimeoutExpired:
-        logger.warning("git rev-parse timed out")
+    except subprocess.CalledProcessError as exc:
+        logger.warning("git rev-parse failed: %s", exc)
         return "unknown"
-    except Exception:  # pragma: no cover - git may be unavailable
+    except subprocess.TimeoutExpired as exc:
+        logger.warning("git rev-parse timed out: %s", exc)
         return "unknown"
+    except Exception:  # pragma: no cover - unexpected
+        logger.exception("unexpected error while determining git SHA")
+        raise
 
 
 def _write_meta(path: Path, cfg: Config | None) -> Path:

--- a/library/io.py
+++ b/library/io.py
@@ -264,8 +264,9 @@ def _git_sha() -> str:
     """Return the current Git commit hash.
 
     The command is limited to a short timeout to avoid hanging when ``git``
-    is unavailable. If the call times out or fails, ``"unknown"`` is
-    returned and a warning is logged.
+    is unavailable.  If the call fails with :class:`subprocess.CalledProcessError`
+    or :class:`subprocess.TimeoutExpired`, ``"unknown"`` is returned and a
+    warning is logged.  Unexpected exceptions are logged and re-raised.
     """
 
     try:
@@ -277,11 +278,15 @@ def _git_sha() -> str:
             timeout=5,
         )
         return result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        logger.warning("git command failed: %s", exc)
+        return "unknown"
     except subprocess.TimeoutExpired as exc:
         logger.warning("git command timed out: %s", exc)
-    except Exception as exc:  # pragma: no cover - git may be unavailable
-        logger.warning("unable to determine git SHA: %s", exc)
-    return "unknown"
+        return "unknown"
+    except Exception:  # pragma: no cover - unexpected
+        logger.exception("unexpected error while determining git SHA")
+        raise
 
 
 def _write_meta(path: Path, cfg: Config) -> None:

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -59,16 +59,26 @@ def file_sha256(path: Path | str) -> str:
 def _git_sha() -> str:
     """Return the current Git commit hash.
 
-    If Git is unavailable, ``"UNKNOWN"`` is returned and a warning is logged.
+    The command runs with a short timeout. If ``git`` exits with a non-zero
+    status or times out, ``"UNKNOWN"`` is returned and a warning is logged.
+    Unexpected exceptions are logged and re-raised.
     """
 
     repo_root = Path(__file__).resolve().parent.parent
     try:
-        result = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root)
+        result = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repo_root, timeout=5
+        )
         return result.decode().strip()
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+    except subprocess.CalledProcessError as exc:
         logger.warning("Unable to determine git SHA: %s", exc)
         return "UNKNOWN"
+    except subprocess.TimeoutExpired as exc:
+        logger.warning("git command timed out: %s", exc)
+        return "UNKNOWN"
+    except Exception:  # pragma: no cover - unexpected
+        logger.exception("unexpected error while determining git SHA")
+        raise
 
 
 def write_meta_yaml(

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -210,3 +210,13 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
             result = _git_sha()
     assert result == "unknown"
     assert "timed out" in caplog.text
+
+
+def test_git_sha_unexpected_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Unexpected errors are logged and propagated."""
+
+    with patch("library.csv_utils.subprocess.run", side_effect=ValueError("boom")):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ValueError, match="boom"):
+                _git_sha()
+    assert "unexpected error" in caplog.text

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -164,3 +164,23 @@ def test_git_sha_timeout_returns_unknown(
 
     assert io._git_sha() == "unknown"
     assert "timed out" in stream.getvalue()
+
+
+def test_git_sha_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unexpected errors in ``git`` invocation are logged and re-raised."""
+
+    stream = StringIO()
+    monkeypatch.setattr(
+        io,
+        "logger",
+        configure_logger(LoggerConfig(level="ERROR", stream=stream)),
+    )
+
+    def boom(*args: Any, **kwargs: Any) -> NoReturn:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(io.subprocess, "run", boom)
+
+    with pytest.raises(ValueError, match="boom"):
+        io._git_sha()
+    assert "unexpected error" in stream.getvalue()


### PR DESCRIPTION
## Summary
- log unexpected subprocess errors when fetching git SHA
- handle TimeoutExpired and CalledProcessError specifically
- test unexpected git failures in io and csv utils

## Testing
- `black library/io.py library/metadata.py library/csv_utils.py tests/test_io.py tests/test_csv_utils.py`
- `ruff check library/io.py library/metadata.py library/csv_utils.py tests/test_io.py tests/test_csv_utils.py`
- `mypy --ignore-missing-imports --follow-imports=skip library/io.py library/metadata.py library/csv_utils.py` *(fails: missing stubs and redefinition warnings)*
- `pytest tests/test_io.py::test_git_sha_unexpected_error tests/test_csv_utils.py::test_git_sha_unexpected_error`

------
https://chatgpt.com/codex/tasks/task_e_68c2fcc344f883248e8d0eddde856a6d