### PR TITLE
Handle missing column errors in input initialisation

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -116,7 +116,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("save_done", extra={"tables": len(paths), "path": str(out_dir)})
         return 0
     except KeyError as exc:
-        logger.error("required table '%s' missing", exc.args[0])
+        err_msg = str(exc)
+        if "not in index" in err_msg:
+            # Pandas uses this phrasing when column selection fails.
+            logger.error("required column(s) missing: %s", err_msg)
+        else:
+            logger.error("required table '%s' missing", exc.args[0])
         return 1
 
 

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -53,7 +53,8 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch) -> None:
         format="csv",
         dictionary_dir=tmp_path,
     )
-    result = cli.run(Config(), args)
+    cfg = Config(api={"user_agent": "test/1.0 (mailto:test@example.org)"})
+    result = cli.run(cfg, args)
     assert result == 0
 
     assert (
@@ -102,12 +103,53 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch) -> None:
     )
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
-    result = cli.run(Config(), args)
+    cfg = Config(api={"user_agent": "test/1.0 (mailto:test@example.org)"})
+    result = cli.run(cfg, args)
     assert result == 1
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
     assert "required table 'activity' missing" in record.get("msg", "")
+
+
+def test_run_missing_columns_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """``run`` should report missing required columns."""
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+
+    def fake_load_same_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_load_all_doc(path: Path):  # pragma: no cover - simple stub
+        return {}
+
+    def fake_build_combined_tables(*_args, **_kwargs):
+        raise KeyError("['target_chembl_id', 'gene_index'] not in index")
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", fake_load_same_doc)
+    monkeypatch.setattr(cli.lib, "load_all_doc", fake_load_all_doc)
+    monkeypatch.setattr(cli.lib, "build_combined_tables", fake_build_combined_tables)
+
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=tmp_path / "out",
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+    buf = io.StringIO()
+    configure_logger(LoggerConfig(stream=buf))
+    cfg = Config(api={"user_agent": "test/1.0 (mailto:test@example.org)"})
+    result = cli.run(cfg, args)
+    assert result == 1
+    lines = buf.getvalue().splitlines()
+    assert lines
+    record = json.loads(lines[-1])
+    msg = record.get("msg", "")
+    assert "required column(s) missing" in msg
+    assert "target_chembl_id" in msg
 
 
 def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:
@@ -116,7 +158,7 @@ def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:
     same_doc.write_text("dummy")
     all_doc.write_text("dummy")
 
-    cfg = Config()
+    cfg = Config(api={"user_agent": "test/1.0 (mailto:test@example.org)"})
     cfg.init.output_dir = tmp_path / "default"
 
     tables = {"assay": pd.DataFrame({"id": [1]})}


### PR DESCRIPTION
## Summary
- detect and log missing column errors separately from missing tables
- cover missing column scenario with dedicated test

## Testing
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `black scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `mypy scripts/get_input_initialisation.py --follow-imports=skip --ignore-missing-imports`
- `pytest tests/test_get_input_initialisation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c305b7eb7c83249fe7eef1b279cf4c