### PR TITLE
fix: allow running scripts without installation

### DIFF
--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -10,8 +10,16 @@ hashes differ.
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+# Allow running the script directly via ``python scripts/check_determinism.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 try:
     import pandas as pd

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -3,7 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_activities.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from library import cli
 from library.activities import get_activities

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -6,6 +6,14 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from itertools import islice
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_activity_data.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import requests
 from pandera.errors import SchemaErrors

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_assay_data.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import requests
 from pandera.errors import SchemaErrors

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -28,6 +28,14 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_document_data.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -7,7 +7,16 @@ scoring logic.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_document_type.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -15,6 +15,13 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+# Allow running the script directly via ``python scripts/get_target_data.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
+from pathlib import Path
+
+# Allow running the script directly via ``python scripts/get_testitem_data.py``
+# by ensuring the repository root is on ``sys.path`` when the module is executed
+# outside of the ``scripts`` package. This mirrors the behaviour of installing
+# the project in editable mode.
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests


### PR DESCRIPTION
## Summary
- allow running CLI scripts directly by appending the project root to `sys.path` when executed outside the `scripts` package

## Testing
- `black scripts mapper_main.py table_quality_main.py`
- `ruff check scripts library mapper_main.py table_quality_main.py`
- `mypy scripts library mapper_main.py table_quality_main.py`
- `python scripts/check_determinism.py`
- `pytest` *(fails: pydantic validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ad4a85a083248b6764fea6233310