### PR TITLE
fix: handle generator length for testitem ids

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -140,7 +140,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
 
     try:
-        ids = io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io)
+        # ``read_ids`` returns a generator to minimise memory use.  Convert to a
+        # list so we can log the total number of identifiers and iterate over the
+        # values multiple times if needed.
+        ids = list(io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io))
     except (FileNotFoundError, ValueError) as exc:
         logger.error("%s", exc)
         return 1


### PR DESCRIPTION
## Summary
- materialise input ID generator to list before logging its length in `get_testitem_data`

## Testing
- `black scripts/get_testitem_data.py`
- `ruff check scripts/get_testitem_data.py`
- `mypy library` *(fails: Missing named argument "retries" for "PubMedCfg", etc.)*
- `pytest` *(fails: pydantic_core._pydantic_core.ValidationError: 1 validation error for Config, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b06817f48324a4183ffa47065b73