### PR TITLE
Fix subcommand option parsing and add tests

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -67,13 +67,21 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
-def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_common_arguments(
+    parser: argparse.ArgumentParser, *, defaults: bool = True
+) -> argparse.ArgumentParser:
     """Add shared CLI arguments to ``parser``.
 
     Parameters
     ----------
     parser:
         Parser to be extended with common arguments.
+    defaults:
+        Whether to apply default values. When ``False`` the options are added
+        with ``argparse.SUPPRESS`` so that they do not override values provided
+        on a parent parser. This is useful for sub-commands that share global
+        options while still allowing those options to be specified before the
+        sub-command name.
 
     Returns
     -------
@@ -86,23 +94,29 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
     ``output_<input-stem>_<YYYYMMDD>.csv`` is created next to the input file.
     """
 
-    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    log_level = "INFO" if defaults else argparse.SUPPRESS
+    input_default: Path | object = Path("input.csv") if defaults else argparse.SUPPRESS
+    output_default: Path | None | object = None if defaults else argparse.SUPPRESS
+    sep_default: str | object = "," if defaults else argparse.SUPPRESS
+    enc_default: str | object = "utf8" if defaults else argparse.SUPPRESS
+
+    parser.add_argument("--log-level", default=log_level, help="Logging level")
     parser.add_argument(
         "--input",
         dest="input_csv",
         type=Path,
-        default=Path("input.csv"),
+        default=input_default,
         help="Input CSV file",
     )
     parser.add_argument(
         "--output",
         dest="output_csv",
         type=Path,
-        default=None,
+        default=output_default,
         help="Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)",
     )
-    parser.add_argument("--sep", default=",", help="CSV delimiter")
-    parser.add_argument("--encoding", default="utf8", help="File encoding")
+    parser.add_argument("--sep", default=sep_default, help="CSV delimiter")
+    parser.add_argument("--encoding", default=enc_default, help="File encoding")
     return parser
 
 
@@ -154,31 +168,60 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
-    """Return a parser containing root-level options and logging config.
+def build_root_parser() -> (
+    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
+):
+    """Return parsers containing root-level options and logging config.
 
-    The parser is created with ``add_help=False`` so it can be used as a parent
-    for both the top-level parser and sub-commands, allowing shared options such
-    as ``--config`` and ``--log-level`` to be supplied before or after the
-    chosen sub-command.
+    Two parsers are produced:
+
+    ``root``
+        Includes default values and is intended as the parent for the top-level
+        parser.
+    ``shared``
+        Contains the same arguments but without defaults so that sub-commands
+        can inherit the options without overriding values supplied before the
+        sub-command name.
+
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
+        The parser with defaults, the version without defaults for sub-commands
+        and the associated :class:`LoggerConfig`.
     """
 
-    parser = argparse.ArgumentParser(add_help=False)
-    add_common_arguments(parser)
-    parser.add_argument(
+    root = argparse.ArgumentParser(add_help=False)
+    add_common_arguments(root)
+    root.add_argument(
         "--config",
         dest="config",
         type=Path,
         default=Path("config.yaml"),
         help="YAML configuration file",
     )
-    parser.add_argument(
+    root.add_argument(
         "--print-config",
         action="store_true",
         help="Print effective configuration and exit",
     )
-    log_cfg = create_logger_config(parser.get_default("log_level"))
-    return parser, log_cfg
+
+    shared = argparse.ArgumentParser(add_help=False)
+    add_common_arguments(shared, defaults=False)
+    shared.add_argument(
+        "--config",
+        dest="config",
+        type=Path,
+        default=argparse.SUPPRESS,
+        help="YAML configuration file",
+    )
+    shared.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
+
+    log_cfg = create_logger_config(root.get_default("log_level"))
+    return root, shared, log_cfg
 
 
 def configure_logger(
@@ -249,6 +292,8 @@ def apply_config_overrides(
     parser: argparse.ArgumentParser,
     config_path: str | Path,
     mapping: dict[str, str] | None = None,
+    *,
+    base_parser: argparse.ArgumentParser | None = None,
 ) -> Config:
     """Load configuration applying command line overrides.
 
@@ -262,12 +307,17 @@ def apply_config_overrides(
     args:
         Parsed command line arguments.
     parser:
-        Argument parser used to determine default values.
+        Argument parser used to determine default values for command specific
+        options.
     config_path:
         Location of the YAML configuration file.
     mapping:
         Optional mapping of argument names to ``Config`` attribute paths. The
         mapping is merged with a set of common defaults.
+    base_parser:
+        Optional parser providing fallback defaults for shared arguments. This
+        is useful when ``parser`` is a sub-command parser without default values
+        for global options.
 
     Returns
     -------
@@ -288,6 +338,10 @@ def apply_config_overrides(
             continue
         value = getattr(args, arg)
         default = parser.get_default(arg)
+        if base_parser is not None and (
+            default is None or default is argparse.SUPPRESS
+        ):
+            default = base_parser.get_default(arg)
         if value != default:
             cli_overrides[key] = value
 
@@ -303,6 +357,10 @@ def apply_config_overrides(
         if not hasattr(args, arg):
             continue
         default = parser.get_default(arg)
+        if base_parser is not None and (
+            default is None or default is argparse.SUPPRESS
+        ):
+            default = base_parser.get_default(arg)
         if getattr(args, arg) == default:
             setattr(args, arg, _get_cfg_value(cfg, key))
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -29,6 +29,7 @@ import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import cast
 
 # Allow running the script directly via ``python scripts/get_document_data.py``
 # by ensuring the repository root is on ``sys.path`` when the module is executed
@@ -282,7 +283,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        df = cl.get_documents(  # type: ignore[attr-defined]
+        df = cl.get_documents(
             ids,
             cfg=cfg.api,
             client=client,
@@ -379,7 +380,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     try:
-        doc_df = cl.get_documents(  # type: ignore[attr-defined]
+        doc_df = cl.get_documents(
             ids,
             cfg=cfg.api,
             client=client,
@@ -552,14 +553,14 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         Parser populated with all sub-commands and logging configuration.
 
     """
-    root, log_cfg = build_root_parser()
+    root, shared, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
         description="Document data utilities", parents=[root]
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
     pubmed = sub.add_parser(
-        "pubmed", parents=[root], help="Fetch data from PubMed and related APIs"
+        "pubmed", parents=[shared], help="Fetch data from PubMed and related APIs"
     )
     pubmed.add_argument(
         "--column", default="PMID", help="Column name containing identifiers"
@@ -591,7 +592,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     pubmed.set_defaults(func=run_pubmed)
 
     chembl = sub.add_parser(
-        "chembl", parents=[root], help="Fetch document information from ChEMBL"
+        "chembl", parents=[shared], help="Fetch document information from ChEMBL"
     )
     chembl.add_argument(
         "--column", default="chembl_id", help="Column name containing identifiers"
@@ -608,7 +609,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     chembl.set_defaults(func=run_chembl)
 
     all_cmd = sub.add_parser(
-        "all", parents=[root], help="Run both ChEMBL and PubMed pipelines"
+        "all", parents=[shared], help="Run both ChEMBL and PubMed pipelines"
     )
     all_cmd.add_argument(
         "--column", default="chembl_id", help="Column in the input CSV"
@@ -651,7 +652,11 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     all_cmd.set_defaults(func=run_all)
 
-    parser.subparsers_map = {"pubmed": pubmed, "chembl": chembl, "all": all_cmd}
+    parser.subparsers_map = {  # type: ignore[attr-defined]
+        "pubmed": pubmed,
+        "chembl": chembl,
+        "all": all_cmd,
+    }
 
     return parser, log_cfg
 
@@ -701,6 +706,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "openalex_rps": "openalex.rps",
                 "crossref_rps": "crossref.rps",
             },
+            base_parser=parser,
         )
         if args.print_config:
             print_config(cfg)
@@ -717,7 +723,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code = cast(int, args.func(cfg, args))
     if exit_code == 0:
         logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -14,6 +14,7 @@ import csv
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 # Allow running the script directly via ``python scripts/get_target_data.py``
 # by ensuring the repository root is on ``sys.path`` when the module is executed
@@ -90,7 +91,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     outputs.
     """
 
-    root, log_cfg = build_root_parser()
+    root, shared, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
         description="Target data utilities", parents=[root]
     )
@@ -101,7 +102,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     # ----------------------------
     uniprot = subparsers.add_parser(
         "uniprot",
-        parents=[root],
+        parents=[shared],
         help="Extract information for UniProt accessions",
     )
     uniprot.add_argument(
@@ -126,7 +127,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     # ----------------------------
     chembl = subparsers.add_parser(
         "chembl",
-        parents=[root],
+        parents=[shared],
         help="Retrieve target information from ChEMBL",
     )
     chembl.add_argument(
@@ -147,7 +148,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     # ----------------------------
     iuphar = subparsers.add_parser(
         "iuphar",
-        parents=[root],
+        parents=[shared],
         help="Map UniProt accessions to IUPHAR classifications",
     )
     iuphar.add_argument(
@@ -175,7 +176,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     # ----------------------------
     all_cmd = subparsers.add_parser(
         "all",
-        parents=[root],
+        parents=[shared],
         help="Run ChEMBL, UniProt and IUPHAR pipelines and merge results",
     )
     all_cmd.add_argument(
@@ -246,7 +247,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     all_cmd.set_defaults(func=run_all)
 
-    parser.subparsers_map = {
+    parser.subparsers_map = {  # type: ignore[attr-defined]
         "uniprot": uniprot,
         "chembl": chembl,
         "iuphar": iuphar,
@@ -744,7 +745,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "iuphar_out": "target.all.iuphar_out",
             }
         cfg: Config = apply_config_overrides(
-            args, subparser, args.config, mapping=mapping
+            args, subparser, args.config, mapping=mapping, base_parser=parser
         )
         if args.print_config:
             print_config(cfg)
@@ -762,7 +763,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
     if hasattr(args, "func"):
-        exit_code = args.func(cfg, args)
+        exit_code = cast(int, args.func(cfg, args))
         if exit_code == 0:
             logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
         else:

--- a/tests/test_cli_option_order.py
+++ b/tests/test_cli_option_order.py
@@ -1,0 +1,76 @@
+"""Tests for global options specified before sub-commands."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from library.config import Config
+from scripts import get_document_data as gdd
+from scripts import get_target_data as gtd
+
+
+def test_target_input_before_subcommand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Options provided before the sub-command should be honoured."""
+    input_csv = tmp_path / "targets.csv"
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text("dummy: true\n")
+
+    captured: dict[str, Path] = {}
+
+    def fake_apply(
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+        cfg_path: str | Path,
+        mapping: dict[str, str] | None = None,
+        *,
+        base_parser: argparse.ArgumentParser | None = None,
+    ) -> Config:
+        return Config()
+
+    def fake_run_all(cfg: Config, args: argparse.Namespace) -> int:
+        captured["input_csv"] = Path(args.input_csv)
+        return 0
+
+    monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(gtd, "run_all", fake_run_all)
+
+    rc = gtd.main(["--config", str(config_yaml), "--input", str(input_csv), "all"])
+    assert rc == 0
+    assert captured["input_csv"] == input_csv
+
+
+def test_document_input_before_subcommand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Global options before the sub-command work for document CLI."""
+    input_csv = tmp_path / "docs.csv"
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text("dummy: true\n")
+
+    captured: dict[str, Path] = {}
+
+    def fake_apply(
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+        cfg_path: str | Path,
+        mapping: dict[str, str] | None = None,
+        *,
+        base_parser: argparse.ArgumentParser | None = None,
+    ) -> Config:
+        return Config()
+
+    def fake_run(cfg: Config, args: argparse.Namespace) -> int:
+        captured["input_csv"] = Path(args.input_csv)
+        return 0
+
+    monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(gdd, "run_chembl", fake_run)
+
+    rc = gdd.main(["--config", str(config_yaml), "--input", str(input_csv), "chembl"])
+    assert rc == 0
+    assert captured["input_csv"] == input_csv


### PR DESCRIPTION
## Summary
- ensure global CLI options don't override when placed before subcommands
- allow apply_config_overrides to use defaults from a base parser
- test that target and document CLIs accept options before the subcommand

## Testing
- `ruff check scripts/get_target_data.py scripts/get_document_data.py library/cli.py tests/test_cli_option_order.py`
- `mypy --ignore-missing-imports --follow-imports=skip scripts/get_target_data.py scripts/get_document_data.py library/cli.py tests/test_cli_option_order.py`
- `pytest` *(fails: pydantic validation errors and missing configuration such as api.user_agent)*

------
https://chatgpt.com/codex/tasks/task_e_68c3af56573c83248adcdf5abde05f57