### PR TITLE
Add pandas dtype backend compatibility helper

### DIFF
--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 from .config import IoCfg
 from .log import logger
+from .pandas_utils import read_csv_pyarrow
 from .validation import validate_schema
 
 
@@ -78,12 +79,11 @@ def postprocess_file(
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
     try:
-        df = pd.read_csv(
+        df = read_csv_pyarrow(
             input_path,
             sep=sep,
             encoding=encoding,
             dtype=str,
-            dtype_backend="pyarrow",
         )
     except ImportError:  # pragma: no cover - pyarrow optional
         df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -9,6 +9,7 @@ import pandas as pd
 from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg
 from .log import logger
+from .pandas_utils import json_normalize_pyarrow
 
 ASSAY_COLUMNS = [
     "aidx",
@@ -124,9 +125,7 @@ def get_assay(
     items = data.get("assays") or data.get("assay") or []
     if not items:
         return pd.DataFrame(columns=ASSAY_COLUMNS)
-    df = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
-        axis="columns", how="all"
-    )
+    df = json_normalize_pyarrow(items).dropna(axis="columns", how="all")
     return df.reindex(columns=ASSAY_COLUMNS)
 
 
@@ -180,9 +179,7 @@ def get_assays(
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("assays") or data.get("assay") or []
         if items:
-            df_chunk = pd.json_normalize(items, dtype_backend="pyarrow").dropna(  # type: ignore[call-arg]
-                axis="columns", how="all"
-            )
+            df_chunk = json_normalize_pyarrow(items).dropna(axis="columns", how="all")
             if not df_chunk.empty:
                 records.append(df_chunk)
                 logger.info(
@@ -241,7 +238,7 @@ def get_activities(
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("activities") or data.get("activity") or []
         if items:
-            records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
+            records.append(json_normalize_pyarrow(items))
             logger.info(
                 "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
             )
@@ -299,7 +296,7 @@ def get_testitem(
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("molecules") or data.get("molecule") or []
         if items:
-            records.append(pd.json_normalize(items, dtype_backend="pyarrow"))  # type: ignore[call-arg]
+            records.append(json_normalize_pyarrow(items))
             logger.info(
                 "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
             )

--- a/library/pandas_utils.py
+++ b/library/pandas_utils.py
@@ -1,0 +1,82 @@
+"""Pandas compatibility helpers.
+
+These utility functions provide fallbacks for features that are only available in
+newer versions of pandas (>=2.0), such as the ``dtype_backend`` argument.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+
+
+def json_normalize_pyarrow(
+    data: Sequence[Mapping[str, Any]] | Mapping[str, Any],
+    *,
+    dtype_backend: str = "pyarrow",
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Normalize semi-structured JSON data.
+
+    This wrapper calls :func:`pandas.json_normalize` with the ``dtype_backend``
+    parameter when supported. If running on an older pandas version that does
+    not accept ``dtype_backend``, the argument is omitted to maintain backward
+    compatibility.
+
+    Parameters
+    ----------
+    data:
+        Nested data to be normalized.
+    dtype_backend:
+        Backend to use for dtypes, passed to :func:`pandas.json_normalize` when
+        available. Defaults to ``"pyarrow"``.
+    **kwargs:
+        Additional keyword arguments forwarded to
+        :func:`pandas.json_normalize`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Normalized data.
+    """
+
+    try:
+        # pandas >= 2.0 supports ``dtype_backend``
+        return pd.json_normalize(data, dtype_backend=dtype_backend, **kwargs)
+    except TypeError:
+        # For pandas < 2.0, fall back to the default behaviour
+        return pd.json_normalize(data, **kwargs)
+
+
+def read_csv_pyarrow(
+    *args: Any,
+    dtype_backend: str = "pyarrow",
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Read a CSV file with optional ``dtype_backend`` support.
+
+    Parameters
+    ----------
+    *args:
+        Positional arguments forwarded to :func:`pandas.read_csv`.
+    dtype_backend:
+        Backend to use for dtypes, passed to :func:`pandas.read_csv` when
+        available. Defaults to ``"pyarrow"``.
+    **kwargs:
+        Additional keyword arguments forwarded to :func:`pandas.read_csv`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Parsed CSV data.
+    """
+
+    try:
+        return pd.read_csv(*args, dtype_backend=dtype_backend, **kwargs)
+    except (TypeError, ImportError):
+        return pd.read_csv(*args, **kwargs)
+
+
+__all__ = ["json_normalize_pyarrow", "read_csv_pyarrow"]


### PR DESCRIPTION
## Summary
- add `pandas_utils` with fallbacks for `dtype_backend`
- update ChemBL assay and postprocessing modules to use compatibility helpers

## Testing
- `black library/pandas_utils.py library/chembl_assay.py library/assay_postprocessing.py`
- `ruff check library/pandas_utils.py library/chembl_assay.py library/assay_postprocessing.py`
- `mypy library/chembl_assay.py library/assay_postprocessing.py library/pandas_utils.py` *(fails: multiple missing arguments and typing issues)*
- `pytest tests/test_get_activity_data_smoke.py::test_get_activity_data_smoke -q` *(fails: missing column in input data)*
- `python scripts/get_testitem_data.py --config config.yaml --input data/input-smoke/testitem.csv --log-level ERROR`


------
https://chatgpt.com/codex/tasks/task_e_68c3b1b972388324b4251c510d98b9c0