### PR TITLE
Add ChEMBL document retrieval helper

### DIFF
--- a/library/chembl_document.py
+++ b/library/chembl_document.py
@@ -1,0 +1,98 @@
+"""Document helpers for the ChEMBL API."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import pandas as pd
+
+from .chembl_client import ChemblClient, _chunked
+from .config import ApiCfg
+
+DOCUMENT_COLUMNS = [
+    "document_chembl_id",
+    "title",
+    "abstract",
+    "doi",
+    "year",
+    "journal",
+    "journal_abbrev",
+    "volume",
+    "issue",
+    "first_page",
+    "last_page",
+    "pubmed_id",
+    "authors",
+    "source",
+]
+
+
+def get_documents(
+    ids: Iterable[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    chunk_size: int = 5,
+    timeout: float | None = None,
+) -> pd.DataFrame:
+    """Fetch document records for ``ids`` from the ChEMBL API.
+
+    Parameters
+    ----------
+    ids:
+        ChEMBL document identifiers to retrieve.
+    cfg:
+        API configuration providing base URL and timeouts.
+    client:
+        :class:`ChemblClient` instance used for HTTP requests and caching.
+    chunk_size:
+        Maximum number of identifiers per HTTP request.
+    timeout:
+        Optional override for the read timeout in seconds.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data frame containing the retrieved document metadata. Missing
+        identifiers result in an empty frame.
+    """
+    valid = [i for i in ids if i not in {"", "#N/A"}]
+    if not valid:
+        return pd.DataFrame(columns=DOCUMENT_COLUMNS)
+
+    base = f"{cfg.chembl_base.rstrip('/')}/document.json?format=json"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+    records: list[dict[str, Any]] = []
+
+    for chunk in _chunked(valid, chunk_size):
+        url = f"{base}&document_chembl_id__in={','.join(chunk)}"
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
+        items = data.get("documents") or data.get("document") or []
+        for item in items:
+            record = {
+                "document_chembl_id": item.get("document_chembl_id"),
+                "title": item.get("title"),
+                "abstract": item.get("abstract"),
+                "doi": item.get("doi"),
+                "year": item.get("year"),
+                "journal": item.get("journal_full_title"),
+                "journal_abbrev": item.get("journal"),
+                "volume": item.get("volume"),
+                "issue": item.get("issue"),
+                "first_page": item.get("first_page"),
+                "last_page": item.get("last_page"),
+                "pubmed_id": item.get("pubmed_id"),
+                "authors": item.get("authors"),
+                "source": "ChEMBL",
+            }
+            records.append(record)
+
+    if not records:
+        return pd.DataFrame(columns=DOCUMENT_COLUMNS)
+
+    df = pd.DataFrame(records)
+    return df.reindex(columns=DOCUMENT_COLUMNS)
+
+
+__all__ = ["get_documents"]

--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -15,6 +15,7 @@ from .chembl_assay import (
     get_testitem,
 )
 from .chembl_client import _chunked
+from .chembl_document import get_documents
 from .chembl_target import (
     extend_target,
     get_target,
@@ -26,6 +27,7 @@ __all__ = [
     "get_assays",
     "get_activities",
     "get_testitem",
+    "get_documents",
     "get_target",
     "get_targets",
     "extend_target",

--- a/tests/test_chembl_document.py
+++ b/tests/test_chembl_document.py
@@ -1,0 +1,63 @@
+"""Tests for :mod:`library.chembl_document`."""
+
+from __future__ import annotations
+
+from library.chembl_document import get_documents
+from library.config import ApiCfg
+
+
+class FakeClient:
+    """Minimal stand-in for :class:`ChemblClient` used in tests."""
+
+    def __init__(self) -> None:
+        self.called: list[tuple[str, float | None]] = []
+
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, object]:
+        self.called.append((url, timeout))
+        ids = url.split("document_chembl_id__in=")[-1].split("&")[0].split(",")
+        docs = [
+            {
+                "document_chembl_id": i,
+                "title": f"title-{i}",
+                "abstract": "",
+                "doi": "",
+                "year": 2020,
+                "journal": "J",
+                "journal_full_title": "Journal",
+                "volume": "1",
+                "issue": "2",
+                "first_page": "3",
+                "last_page": "4",
+                "pubmed_id": 1,
+                "authors": "A",
+            }
+            for i in ids
+        ]
+        return {"documents": docs}
+
+
+def test_get_documents_returns_frame() -> None:
+    cfg = ApiCfg(
+        chembl_base="https://example.com",
+        user_agent="test/0.1 (mailto:test@example.com)",
+    )
+    client = FakeClient()
+    df = get_documents(
+        ["CHEMBL1", "CHEMBL2"], cfg=cfg, client=client, chunk_size=1, timeout=5.0
+    )
+    assert df["document_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert len(client.called) == 2
+    assert all(t == 5.0 for _, t in client.called)
+
+
+def test_get_documents_handles_invalid_ids() -> None:
+    cfg = ApiCfg(
+        chembl_base="https://example.com",
+        user_agent="test/0.1 (mailto:test@example.com)",
+    )
+    client = FakeClient()
+    df = get_documents(["", "#N/A"], cfg=cfg, client=client)
+    assert df.empty
+    assert not client.called

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -77,9 +77,10 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["d1"])
 
-    def fake_apply_doc(a, p, c, mapping=None):
+    def fake_apply_doc(a, p, c, mapping=None, **kwargs):
         cfg = Config()
         cfg.document.chembl.timeout = float(a.timeout)
+        cfg.api.user_agent = "test/0.1 (mailto:test@example.com)"
         return cfg
 
     monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply_doc)


### PR DESCRIPTION
## Summary
- fetch document metadata from ChEMBL API
- expose document retrieval via existing chembl library
- test document helper

## Testing
- `ruff check tests/test_chembl_document.py tests/test_cli_timeout_override.py library/chembl_document.py library/chembl_library.py`
- `black --check library/chembl_document.py library/chembl_library.py tests/test_chembl_document.py tests/test_cli_timeout_override.py`
- `mypy --ignore-missing-imports --follow-imports=skip library/chembl_document.py library/chembl_library.py`
- `pytest tests/test_chembl_document.py tests/test_chembl_library.py -q`
- `python scripts/get_document_data.py all --config config.yaml --input data/input-smoke/documents.csv`

------
https://chatgpt.com/codex/tasks/task_e_68c3b287f1cc8324b7a48dbde16acb46