### PR TITLE
fix: ensure retry supports all methods on py312

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 import logging
 import os
 import re
-from collections.abc import Collection
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml
@@ -519,7 +518,10 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
         total=retry.max_attempts,
         backoff_factor=retry.backoff_factor,
         status_forcelist=retry.status_forcelist,
-        allowed_methods=cast(Collection[str] | None, False),
+        # ``None`` disables method filtering and retries all HTTP methods.
+        # Using ``None`` directly avoids ``Collection`` union type evaluation
+        # issues under Python 3.12.
+        allowed_methods=None,
         raise_on_status=False,
     )
     adapter = HTTPAdapter(max_retries=retry_cfg)


### PR DESCRIPTION
## Summary
- avoid runtime error on Python 3.12 by setting `allowed_methods=None` when building HTTP retry sessions

## Testing
- `black library/config.py`
- `ruff check library/config.py`
- `mypy library/config.py --follow-imports=skip` *(fails: Missing named argument "timeout" for "TargetChemblCfg" and other errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'responses')*


------
https://chatgpt.com/codex/tasks/task_e_68c3b91fa6088324b5033e5fcd09bf56