### PR TITLE
Add guard for config schema misuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,10 @@ All scripts share a common set of flags:
 Default settings live in ``config.yaml`` and are split into sections for each
 API (``api``, ``openalex``, ``crossref``, ``uniprot``, ``iuphar``, ``pubchem``),
 I/O and processing (``io``, ``jobs``, ``batch``, ``quality``, ``mapper``) and
-general infrastructure (``init``, ``rate``, ``retry``, ``log``). A minimal
-configuration looks like::
+general infrastructure (``init``, ``rate``, ``retry``, ``log``). The companion
+``config.schema.json`` file documents these fields and is useful for editor
+validation, but it must **not** be passed to ``--config`` because it lacks
+runtime values such as ``api.user_agent``. A minimal configuration looks like::
 
 
     api:

--- a/library/config.py
+++ b/library/config.py
@@ -612,6 +612,15 @@ def load_config(
     if not isinstance(data, dict):
         raise TypeError("top-level structure in config file must be a mapping")
 
+    # Guard against accidentally passing the JSON schema instead of a runtime
+    # configuration file. The schema contains the ``$defs`` key at the top
+    # level which is not present in actual application settings.
+    if "$defs" in data:
+        raise ConfigError(
+            f"{path} appears to be a configuration schema; "
+            "provide an application config file such as config.yaml."
+        )
+
     _apply_env_overrides(data)
 
     if cli_overrides:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,15 @@ def test_missing_config_raises(tmp_path: Path) -> None:
         load_config(tmp_path / "missing.yaml")
 
 
+def test_schema_file_rejected(tmp_path: Path) -> None:
+    """Passing the JSON schema instead of a config file should fail."""
+
+    path = tmp_path / "schema.json"
+    path.write_text('{"$defs": {}}')
+    with pytest.raises(ConfigError, match="configuration schema"):
+        load_config(path)
+
+
 def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api:\n  rps: 1\nopenalex:\n  rps: 1\n")


### PR DESCRIPTION
## Summary
- reject `config.schema.json` if passed as runtime config
- document that schema file can't be used with `--config`
- cover this case with a unit test

## Testing
- `pre-commit run --files README.md library/config.py tests/test_config.py` *(fails: mypy reports missing typed dependencies)*
- `pytest tests/test_config.py::test_schema_file_rejected -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3bd2f76c083249376c3f4a5a498f4