### PR TITLE
Improve git SHA detection

### DIFF
--- a/library/metadata.py
+++ b/library/metadata.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import platform
+import shutil
 import subprocess
 from collections.abc import Mapping
 from datetime import datetime, timezone
@@ -59,14 +60,27 @@ def file_sha256(path: Path | str) -> str:
 def _git_sha() -> str:
     """Return the current Git commit hash.
 
-    If Git is unavailable, ``"UNKNOWN"`` is returned and a warning is logged.
+    If Git is unavailable or the repository lacks a ``.git`` directory,
+    ``"UNKNOWN"`` is returned and a warning is logged.
     """
 
     repo_root = Path(__file__).resolve().parent.parent
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        logger.warning("Git executable not found; install Git or add it to PATH")
+        return "UNKNOWN"
+
+    git_dir = repo_root / ".git"
+    if not git_dir.exists():
+        logger.warning("No .git directory found at %s", repo_root)
+        return "UNKNOWN"
+
     try:
-        result = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root)
+        result = subprocess.check_output(
+            [git_executable, "rev-parse", "HEAD"], cwd=repo_root
+        )
         return result.decode().strip()
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+    except subprocess.CalledProcessError as exc:
         logger.warning("Unable to determine git SHA: %s", exc)
         return "UNKNOWN"
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+import pytest
 import yaml
 
+from library import metadata
 from library.metadata import Stats, write_meta_yaml
 
 
@@ -52,3 +54,37 @@ def test_write_meta_yaml_creates_file(tmp_path: Path) -> None:
         "schema",
     }
     assert required_keys <= data.keys()
+
+
+def test_git_sha_missing_git_executable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_git_sha returns UNKNOWN and warns when git is absent."""
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    messages: list[str] = []
+    monkeypatch.setattr(
+        metadata.logger, "warning", lambda msg, *args: messages.append(msg % args)
+    )
+
+    assert metadata._git_sha() == "UNKNOWN"
+    assert "Git executable not found" in messages[0]
+
+
+def test_git_sha_missing_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_git_sha returns UNKNOWN and warns when .git directory is missing."""
+
+    repo_root = Path(metadata.__file__).resolve().parent.parent
+    original_exists = metadata.Path.exists
+
+    def mock_exists(self: Path) -> bool:  # type: ignore[override]
+        if self == repo_root / ".git":
+            return False
+        return original_exists(self)
+
+    monkeypatch.setattr(metadata.Path, "exists", mock_exists)
+    messages: list[str] = []
+    monkeypatch.setattr(
+        metadata.logger, "warning", lambda msg, *args: messages.append(msg % args)
+    )
+
+    assert metadata._git_sha() == "UNKNOWN"
+    assert f"No .git directory found at {repo_root}" in messages[0]


### PR DESCRIPTION
## Summary
- warn when git is absent or repository has no .git directory
- test git SHA behavior when git or repo metadata are missing

## Testing
- `black library/metadata.py tests/test_metadata.py`
- `ruff check library/metadata.py tests/test_metadata.py`
- `mypy library/metadata.py --follow-imports=skip`
- `pytest tests/test_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3be8641248324a800c291a995fd55