### PR TITLE
Handle missing git executable in metadata

### DIFF
--- a/library/metadata.py
+++ b/library/metadata.py
@@ -74,6 +74,19 @@ def _git_sha() -> str:
     if env_sha:
         logger.info("Using git SHA from GIT_SHA: %s", env_sha)
         return env_sha
+    # ``shutil.which`` returns the path to the git executable or ``None`` if it
+    # cannot be located on the current ``PATH``.
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        logger.warning("Git executable not found")
+        return "UNKNOWN"
+
+    # The repository may be installed without its ``.git`` directory (e.g. when
+    # distributed as a source archive). In such cases the commit hash cannot be
+    # determined.
+    if not (repo_root / ".git").exists():
+        logger.warning("No .git directory found at %s", repo_root)
+        return "UNKNOWN"
 
     try:
         result = subprocess.check_output(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,10 +7,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-
+import library.metadata as metadata
 from library.metadata import Stats, _git_sha, write_meta_yaml
-
-
 
 
 def test_write_meta_yaml_creates_file(tmp_path: Path) -> None:
@@ -59,7 +57,6 @@ def test_write_meta_yaml_creates_file(tmp_path: Path) -> None:
     assert required_keys <= data.keys()
 
 
-
 def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     """_git_sha uses the ``GIT_SHA`` environment variable when available."""
 
@@ -67,6 +64,7 @@ def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     with patch("library.metadata.subprocess.check_output") as mock:
         assert _git_sha() == "envsha"
         mock.assert_not_called()
+
 
 def test_git_sha_missing_git_executable(monkeypatch: pytest.MonkeyPatch) -> None:
     """_git_sha returns UNKNOWN and warns when git is absent."""


### PR DESCRIPTION
## Summary
- avoid NameError when git is unavailable by locating git executable
- warn and return UNKNOWN when git or .git directory is absent
- fix metadata tests to import module explicitly

## Testing
- `black library/metadata.py tests/test_metadata.py`
- `ruff check library/metadata.py tests/test_metadata.py`
- `mypy library/metadata.py`
- `pytest -q` *(fails: api.user_agent must be provided)*
- `python scripts/get_assay_data.py --config config.yaml --input data/input-smoke/assay.csv` *(fails: failed to generate quality report)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c0fb45948324ac9ff03442e7813b