### PR TITLE
feat: update activity pair column mapping

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -385,9 +385,7 @@ def process_activity_table(
             "activity_chembl_id": "activity_chembl_id",
             "salt_chembl_id": "saltform_id",
             "molecule_chembl_id": "testitem_id",
-            "target_chembl_id": "target_id",
-            "assay_chembl_id": "assay_id",
-            "document_chembl_id": "document_id",
+            # keep CHEMBL identifiers for related entities
             "standard_type": "standard_type",
             "log_value": "pA_value",
         }
@@ -429,7 +427,7 @@ def process_activity_table(
 
     # --- documents with significant citations ------------------------------
     counts_doc = (
-        df.groupby("document_id")["is_citation"]
+        df.groupby("document_chembl_id")["is_citation"]
         .agg(n_citation="sum", n_non_citation=lambda s: (~s).sum())
         .reset_index()
     )
@@ -447,8 +445,8 @@ def process_activity_table(
     )
 
     df = df.merge(
-        counts_doc[["document_id", "high_citation_rate"]],
-        on="document_id",
+        counts_doc[["document_chembl_id", "high_citation_rate"]],
+        on="document_chembl_id",
         how="left",
     )
     df["high_citation_rate"] = (
@@ -498,8 +496,7 @@ def process_activity_table(
             ]
         ],
         how="left",
-        left_on="target_id",
-        right_on="target_chembl_id",
+        on="target_chembl_id",
     )
     mapping = {
         "Multicellular organism": False,
@@ -512,16 +509,16 @@ def process_activity_table(
 
     df["multifunctional_enzyme"] = df["multifunctional_enzyme"].eq(True)
 
-    df.drop(columns=["target_chembl_id", "organism_type"], inplace=True)
+    df.drop(columns=["organism_type"], inplace=True)
 
     # --- final ordering ----------------------------------------------------
     final_cols = [
         "activity_chembl_id",
         "saltform_id",
         "testitem_id",
-        "target_id",
-        "assay_id",
-        "document_id",
+        "target_chembl_id",
+        "assay_chembl_id",
+        "document_chembl_id",
         "bao_endpoint",
         "standard_type",
         "standard_value",
@@ -835,14 +832,13 @@ def generate_pair_entity_tables(
         logger.warning("'activity' table missing column 'activity_chembl_id'")
         return result
 
-    # Columns linking activities to related entities have been renamed during
-    # preprocessing (e.g. ``assay_chembl_id`` -> ``assay_id``).  The mapping
-    # below reflects the new schema so that pair table generation can correctly
-    # retrieve the associated entity rows.
+    # Columns linking activities to related entities use CHEMBL identifiers.
+    # This mapping specifies the identifier column for each entity so that pair
+    # table generation can correctly retrieve the associated rows.
     entity_cols: dict[str, str] = {
-        "assay": "assay_id",
-        "document": "document_id",
-        "target": "target_id",
+        "assay": "assay_chembl_id",
+        "document": "document_chembl_id",
+        "target": "target_chembl_id",
         "testitem": "testitem_id",
     }
 
@@ -1708,10 +1704,10 @@ def aggregate_activity(
     for m in metrics:
         merged[m] = merged[m].fillna(0)
 
-    assay_status = _aggregate_entity(merged, "assay_id", status_api)
-    document_status = _aggregate_entity(merged, "document_id", status_api)
+    assay_status = _aggregate_entity(merged, "assay_chembl_id", status_api)
+    document_status = _aggregate_entity(merged, "document_chembl_id", status_api)
 
-    system_cols = ["testitem_id", "target_id", "standard_type"]
+    system_cols = ["testitem_id", "target_chembl_id", "standard_type"]
 
     missing_sys = [c for c in system_cols if c not in merged.columns]
     if missing_sys:
@@ -1726,14 +1722,14 @@ def aggregate_activity(
         system_src["system_id"] = (
             system_src["testitem_id"].astype("string")
             + "_"
-            + system_src["target_id"].astype("string")
+            + system_src["target_chembl_id"].astype("string")
             + "_"
             + system_src["standard_type"].astype("string")
         )
         system_status = _aggregate_entity(system_src, "system_id", status_api)
         split = system_status["system_id"].str.split("_", n=2, expand=True)
         system_status["testitem_id"] = split[0]
-        system_status["target_id"] = split[1]
+        system_status["target_chembl_id"] = split[1]
         system_status["standard_type"] = split[2]
 
     if "testitem_id" in merged.columns:
@@ -1751,13 +1747,15 @@ def aggregate_activity(
             columns=["testitem_id", "Filtered.new", *metrics]
         )
 
-    if "target_id" in merged.columns:
-        target_status = _aggregate_entity(merged, "target_id", status_api)
+    if "target_chembl_id" in merged.columns:
+        target_status = _aggregate_entity(merged, "target_chembl_id", status_api)
     else:
         logger.warning(
-            "activity table missing column target_id; skipping target aggregation"
+            "activity table missing column target_chembl_id; skipping target aggregation"
         )
-        target_status = pd.DataFrame(columns=["target_id", "Filtered.new", *metrics])
+        target_status = pd.DataFrame(
+            columns=["target_chembl_id", "Filtered.new", *metrics]
+        )
 
     # metrics are counted per activity; divide by 2 for higher-level aggregations
     for df in [

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -51,15 +51,15 @@ def test_generate_pair_entity_tables_basic() -> None:
         "activity": pd.DataFrame(
             {
                 "activity_chembl_id": [1, 2, 3, 4],
-                "assay_id": ["a1", "a2", "a3", "a4"],
-                "document_id": ["d1", "d2", "d3", "d4"],
-                "target_id": ["t1", "t2", "t3", "t4"],
+                "assay_chembl_id": ["a1", "a2", "a3", "a4"],
+                "document_chembl_id": ["d1", "d2", "d3", "d4"],
+                "target_chembl_id": ["t1", "t2", "t3", "t4"],
                 "testitem_id": ["m1", "m2", "m3", "m4"],
             }
         ),
-        "assay": pd.DataFrame({"assay_id": ["a1", "a2", "a3", "a4"]}),
-        "document": pd.DataFrame({"document_id": ["d1", "d2", "d3", "d4"]}),
-        "target": pd.DataFrame({"target_id": ["t1", "t2", "t3", "t4"]}),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2", "a3", "a4"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1", "d2", "d3", "d4"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1", "t2", "t3", "t4"]}),
         "testitem": pd.DataFrame({"testitem_id": ["m1", "m2", "m3", "m4"]}),
         "pairs_independent": pd.DataFrame(
             {"activity_chembl_id1": [1, 2], "activity_chembl_id2": [3, None]}
@@ -67,9 +67,9 @@ def test_generate_pair_entity_tables_basic() -> None:
     }
     res = generate_pair_entity_tables(tables, {"pairs_independent": "ind"})
     assert set(res["activity_ind"]["activity_chembl_id"]) == {1, 2, 3}
-    assert set(res["assay_ind"]["assay_id"]) == {"a1", "a2", "a3"}
-    assert set(res["document_ind"]["document_id"]) == {"d1", "d2", "d3"}
-    assert set(res["target_ind"]["target_id"]) == {"t1", "t2", "t3"}
+    assert set(res["assay_ind"]["assay_chembl_id"]) == {"a1", "a2", "a3"}
+    assert set(res["document_ind"]["document_chembl_id"]) == {"d1", "d2", "d3"}
+    assert set(res["target_ind"]["target_chembl_id"]) == {"t1", "t2", "t3"}
     assert set(res["testitem_ind"]["testitem_id"]) == {"m1", "m2", "m3"}
 
 
@@ -79,15 +79,15 @@ def test_generate_pair_entity_tables_normalizes_columns() -> None:
         "activity": pd.DataFrame(
             {
                 "activity_chembl_id": [1, 2],
-                "assay_id": ["a1", "a2"],
-                "document_id": ["d1", "d2"],
-                "target_id": ["t1", "t2"],
+                "assay_chembl_id": ["a1", "a2"],
+                "document_chembl_id": ["d1", "d2"],
+                "target_chembl_id": ["t1", "t2"],
                 "testitem_id": ["m1", "m2"],
             }
         ),
-        "assay": pd.DataFrame({"assay_id": ["a1", "a2"]}),
-        "document": pd.DataFrame({"document_id": ["d1", "d2"]}),
-        "target": pd.DataFrame({"target_id": ["t1", "t2"]}),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1", "d2"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1", "t2"]}),
         "testitem": pd.DataFrame({"testitem_id": ["m1", "m2"]}),
         # Use non-standard column names as found in some Excel sources
         "pairs_same_document": pd.DataFrame({"Activity_ID1": [1], "Activity_ID2": [2]}),
@@ -104,15 +104,15 @@ def test_generate_pair_entity_tables_missing_columns(
         "activity": pd.DataFrame(
             {
                 "activity_chembl_id": [1],
-                "assay_id": ["a1"],
-                "document_id": ["d1"],
-                "target_id": ["t1"],
+                "assay_chembl_id": ["a1"],
+                "document_chembl_id": ["d1"],
+                "target_chembl_id": ["t1"],
                 "testitem_id": ["m1"],
             }
         ),
-        "assay": pd.DataFrame({"assay_id": ["a1"]}),
-        "document": pd.DataFrame({"document_id": ["d1"]}),
-        "target": pd.DataFrame({"target_id": ["t1"]}),
+        "assay": pd.DataFrame({"assay_chembl_id": ["a1"]}),
+        "document": pd.DataFrame({"document_chembl_id": ["d1"]}),
+        "target": pd.DataFrame({"target_chembl_id": ["t1"]}),
         "testitem": pd.DataFrame({"testitem_id": ["m1"]}),
         "pairs_bad": pd.DataFrame({"foo": [1]}),
     }
@@ -617,9 +617,9 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
         "activity_chembl_id",
         "saltform_id",
         "testitem_id",
-        "target_id",
-        "assay_id",
-        "document_id",
+        "target_chembl_id",
+        "assay_chembl_id",
+        "document_chembl_id",
         "bao_endpoint",
         "standard_type",
         "standard_value",

--- a/tests/test_status_processing.py
+++ b/tests/test_status_processing.py
@@ -36,11 +36,11 @@ def test_status_pipeline(tmp_path) -> None:
 
     activity = pd.DataFrame(
         {
-            "activity_id": [1, 2],
-            "assay_id": ["A1", "A1"],
-            "document_id": ["D1", "D1"],
+            "activity_chembl_id": [1, 2],
+            "assay_chembl_id": ["A1", "A1"],
+            "document_chembl_id": ["D1", "D1"],
             "testitem_id": ["T1", "T2"],
-            "target_id": ["TG1", "TG1"],
+            "target_chembl_id": ["TG1", "TG1"],
             "mesurement_type": ["IC50", "IC50"],
             "high_citation_rate": [False, False],
             "unicellular_organism": [False, False],
@@ -62,7 +62,7 @@ def test_status_pipeline(tmp_path) -> None:
             "activity_chembl_id1": [1],
             "activity_chembl_id2": [2],
             "testitem_id": ["T1"],
-            "target_id": ["TG1"],
+            "target_chembl_id": ["TG1"],
             "mesurement_type": ["IC50"],
             "independent_IC50": [1],
             "non_independent_IC50": [0],
@@ -73,7 +73,9 @@ def test_status_pipeline(tmp_path) -> None:
     pair_df = initialize_pairs(pair_df, activity, api)
     assert pair_df.loc[0, "Filtered"] == "warning"
     agg = aggregate_activity(pair_df, activity, api)
-    assert agg["activity"].set_index("activity_id").loc[1, "Filtered.new"] == "bad"
+    assert (
+        agg["activity"].set_index("activity_chembl_id").loc[1, "Filtered.new"] == "bad"
+    )
     assert agg["assay"].loc[0, "independent_IC50"] == 1
 
 
@@ -98,11 +100,11 @@ def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
     api = build_status_helpers(status_df)
     activity = pd.DataFrame(
         {
-            "activity_id": [1, 2],
-            "assay_id": ["A1", "A1"],
-            "document_id": ["D1", "D1"],
+            "activity_chembl_id": [1, 2],
+            "assay_chembl_id": ["A1", "A1"],
+            "document_chembl_id": ["D1", "D1"],
             "testitem_id": ["T1", "T2"],
-            "target_id": ["TG1", "TG1"],
+            "target_chembl_id": ["TG1", "TG1"],
             "mesurement_type": ["IC50", "IC50"],
             "high_citation_rate": [False, False],
             "unicellular_organism": [False, False],
@@ -114,13 +116,13 @@ def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
             "activity_chembl_id1": [1],
             "activity_chembl_id2": [2],
             "testitem_id": ["T1"],
-            "target_id": ["TG1"],
+            "target_chembl_id": ["TG1"],
             "mesurement_type": ["IC50"],
         }
     )
     pair_df = initialize_pairs(pair_df, activity, api)
     agg = aggregate_activity(pair_df, activity, api)
-    activity_status = agg["activity"].set_index("activity_id")
+    activity_status = agg["activity"].set_index("activity_chembl_id")
     for col in [
         "independent_IC50",
         "non_independent_IC50",
@@ -141,10 +143,10 @@ def test_aggregate_activity_handles_missing_testitem_id(tmp_path: Path) -> None:
     # activity table deliberately lacks ``testitem_id``
     activity = pd.DataFrame(
         {
-            "activity_id": [1, 2],
-            "assay_id": ["A1", "A1"],
-            "document_id": ["D1", "D1"],
-            "target_id": ["TG1", "TG1"],
+            "activity_chembl_id": [1, 2],
+            "assay_chembl_id": ["A1", "A1"],
+            "document_chembl_id": ["D1", "D1"],
+            "target_chembl_id": ["TG1", "TG1"],
             "mesurement_type": ["IC50", "IC50"],
             "high_citation_rate": [False, False],
             "unicellular_organism": [False, False],
@@ -165,4 +167,6 @@ def test_aggregate_activity_handles_missing_testitem_id(tmp_path: Path) -> None:
     agg = aggregate_activity(pair_df, activity, api)
     assert agg["system"].empty
     assert agg["testitem"].empty
-    assert agg["target"].set_index("target_id").loc["TG1", "independent_IC50"] == 1
+    assert (
+        agg["target"].set_index("target_chembl_id").loc["TG1", "independent_IC50"] == 1
+    )


### PR DESCRIPTION
## Summary
- align pair table generation with renamed activity ID columns
- update tests for new entity ID schema and activity processing

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check .`
- `mypy .` *(fails: Library stubs not installed for "pandas", and other configuration errors)*
- `pytest` *(fails: api.user_agent must be provided and multiple CLI/config tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c82352048324b5dc52ac7f55aa76