### PR TITLE
Handle optional schema columns in validation

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -103,8 +103,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = normalize_activities(df)
     rows_total = len(df)
     exit_code = 0
-    required_cols = set(ActivitiesSchema.columns.keys())
-    if required_cols.issubset(df.columns):
+    required_cols = {
+        name for name, col in ActivitiesSchema.columns.items() if col.required
+    }
+    optional_cols = set(ActivitiesSchema.columns) - required_cols
+    missing_required = required_cols - set(df.columns)
+    missing_optional = optional_cols - set(df.columns)
+    if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
         try:
             df = ActivitiesSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -121,8 +130,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
-        missing = required_cols.difference(df.columns)
-        logger.warning("Skipping validation due to missing columns: %s", missing)
+        logger.warning(
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
+        )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -83,8 +83,15 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = normalize_assays(df)
     rows_total = len(df)
     exit_code = 0
-    required_cols = set(AssaysSchema.columns.keys())
-    if required_cols.issubset(df.columns):
+    required_cols = {name for name, col in AssaysSchema.columns.items() if col.required}
+    optional_cols = set(AssaysSchema.columns) - required_cols
+    missing_required = required_cols - set(df.columns)
+    missing_optional = optional_cols - set(df.columns)
+    if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
         try:
             df = AssaysSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -101,8 +108,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
-        missing = required_cols.difference(df.columns)
-        logger.warning("Skipping validation due to missing columns: %s", missing)
+        logger.warning(
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
+        )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -206,21 +206,37 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         df = normalize_documents(df)
         rows_total = len(df)
         exit_code = 0
-        try:
-            df = DocumentsSchema.validate(df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+        required_cols = {
+            name for name, col in DocumentsSchema.columns.items() if col.required
+        }
+        optional_cols = set(DocumentsSchema.columns) - required_cols
+        missing_required = required_cols - set(df.columns)
+        missing_optional = optional_cols - set(df.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                df = DocumentsSchema.validate(df, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                df = getattr(exc, "validated_data", df)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
             )
-            df = getattr(exc, "validated_data", df)
-            exit_code = 1
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
         key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
@@ -297,8 +313,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = normalize_documents(df)
     rows_total = len(df)
     exit_code = 0
-    required_cols = set(DocumentsSchema.columns.keys())
-    if required_cols.issubset(df.columns):
+    required_cols = {
+        name for name, col in DocumentsSchema.columns.items() if col.required
+    }
+    optional_cols = set(DocumentsSchema.columns) - required_cols
+    missing_required = required_cols - set(df.columns)
+    missing_optional = optional_cols - set(df.columns)
+    if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
         try:
             df = DocumentsSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -315,8 +340,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
-        missing = required_cols.difference(df.columns)
-        logger.warning("Skipping validation due to missing columns: %s", missing)
+        logger.warning(
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
+        )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:
@@ -405,21 +432,37 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         processed = normalize_documents(processed)
         rows_total = len(processed)
         exit_code = 0
-        try:
-            processed = DocumentsSchema.validate(processed, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+        required_cols = {
+            name for name, col in DocumentsSchema.columns.items() if col.required
+        }
+        optional_cols = set(DocumentsSchema.columns) - required_cols
+        missing_required = required_cols - set(processed.columns)
+        missing_optional = optional_cols - set(processed.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                processed = DocumentsSchema.validate(processed, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                processed = getattr(exc, "validated_data", processed)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
             )
-            processed = getattr(exc, "validated_data", processed)
-            exit_code = 1
         rows_kept = len(processed)
         rows_dropped = rows_total - rows_kept
         try:
@@ -492,21 +535,37 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     processed = normalize_documents(processed)
     rows_total = len(processed)
     exit_code = 0
-    try:
-        processed = DocumentsSchema.validate(processed, lazy=True)
-    except SchemaErrors as exc:
-        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-        errors = SidecarErrors()
-        for row in exc.failure_cases.to_dict("records"):
-            errors.add_error(row)
-        errors.save(failure_path)
-        logger.error(
-            "validation failed; wrote %d failure cases to %s",
-            len(exc.failure_cases),
-            failure_path,
+    required_cols = {
+        name for name, col in DocumentsSchema.columns.items() if col.required
+    }
+    optional_cols = set(DocumentsSchema.columns) - required_cols
+    missing_required = required_cols - set(processed.columns)
+    missing_optional = optional_cols - set(processed.columns)
+    if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
+        try:
+            processed = DocumentsSchema.validate(processed, lazy=True)
+        except SchemaErrors as exc:
+            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+            errors = SidecarErrors()
+            for row in exc.failure_cases.to_dict("records"):
+                errors.add_error(row)
+            errors.save(failure_path)
+            logger.error(
+                "validation failed; wrote %d failure cases to %s",
+                len(exc.failure_cases),
+                failure_path,
+            )
+            processed = getattr(exc, "validated_data", processed)
+            exit_code = 1
+    else:
+        logger.warning(
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
         )
-        processed = getattr(exc, "validated_data", processed)
-        exit_code = 1
     rows_kept = len(processed)
     rows_dropped = rows_total - rows_kept
     try:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -386,8 +386,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     required_cols = {
         name for name, col in TargetsSchema.columns.items() if col.required
     }
-    missing_required = required_cols.difference(df.columns)
+    optional_cols = set(TargetsSchema.columns) - required_cols
+    missing_required = required_cols - set(df.columns)
+    missing_optional = optional_cols - set(df.columns)
     if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
         try:
             df = TargetsSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -405,7 +411,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             exit_code = 1
     else:
         logger.warning(
-            "Skipping validation due to missing columns: %s", missing_required
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
         )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
@@ -673,21 +680,37 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         final_df = final_df.rename(columns={"chembl_id": "target_chembl_id"})
         final_df = normalize_targets(final_df)
         exit_code = 0
-        try:
-            final_df = TargetsSchema.validate(final_df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+        required_cols = {
+            name for name, col in TargetsSchema.columns.items() if col.required
+        }
+        optional_cols = set(TargetsSchema.columns) - required_cols
+        missing_required = required_cols - set(final_df.columns)
+        missing_optional = optional_cols - set(final_df.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                final_df = TargetsSchema.validate(final_df, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                final_df = getattr(exc, "validated_data", final_df)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
             )
-            final_df = getattr(exc, "validated_data", final_df)
-            exit_code = 1
         io.write_csv(
             final_df,
             output,

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -170,8 +170,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     df = normalize_testitems(df)
     rows_total = len(df)
     exit_code = 0
-    required_cols = set(TestitemsSchema.columns.keys())
-    if required_cols.issubset(df.columns):
+    required_cols = {
+        name for name, col in TestitemsSchema.columns.items() if col.required
+    }
+    optional_cols = set(TestitemsSchema.columns) - required_cols
+    missing_required = required_cols - set(df.columns)
+    missing_optional = optional_cols - set(df.columns)
+    if not missing_required:
+        if missing_optional:
+            logger.warning(
+                "DataFrame is missing optional columns: %s", missing_optional
+            )
         try:
             df = TestitemsSchema.validate(df, lazy=True)
         except SchemaErrors as exc:
@@ -188,8 +197,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
-        missing = required_cols.difference(df.columns)
-        logger.warning("Skipping validation due to missing columns: %s", missing)
+        logger.warning(
+            "Skipping validation due to missing required columns: %s",
+            missing_required,
+        )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:


### PR DESCRIPTION
## Summary
- Only require columns marked `required` in Pandera schemas across data retrieval scripts
- Warn about missing optional columns while continuing validation
- Apply consistent validation logic for testitem, assay, activity, document, and target data

## Testing
- `ruff check scripts/get_testitem_data.py scripts/get_assay_data.py scripts/get_activity_data.py scripts/get_document_data.py scripts/get_target_data.py`
- `black scripts/get_testitem_data.py scripts/get_assay_data.py scripts/get_activity_data.py scripts/get_document_data.py scripts/get_target_data.py`
- `mypy .` (fails: Library stubs not installed for "pandas")
- `pytest` (fails: ModuleNotFoundError: No module named 'responses')

------
https://chatgpt.com/codex/tasks/task_e_68c3d7c8f1e88324863bbd73487fedcb