### PR TITLE
Fix status statistics handling

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1144,6 +1144,8 @@ def save_tables(
     - ``*_non_independent`` → ``non_independent/``
     - ``*_status`` tables are placed under ``status/`` with the above
       variants nested within it.
+    - ``*_status_statistics`` tables follow the same pattern and are also
+      stored beneath ``status/``.
 
     Parameters
     ----------
@@ -1167,7 +1169,15 @@ def save_tables(
     paths: dict[str, Path] = {}
     for entity, df in tables.items():
         # Determine subdirectory based on table type.
-        if entity.endswith("_non_independent_status"):
+        if entity.endswith("_non_independent_status_statistics"):
+            sub_dir = out_dir / "status" / "non-independent"
+        elif entity.endswith("_independent_status_statistics"):
+            sub_dir = out_dir / "status" / "independent"
+        elif entity.endswith("_same_document_status_statistics"):
+            sub_dir = out_dir / "status" / "same_document"
+        elif entity.endswith("_status_statistics"):
+            sub_dir = out_dir / "status"
+        elif entity.endswith("_non_independent_status"):
             sub_dir = out_dir / "status" / "non-independent"
         elif entity.endswith("_independent_status"):
             sub_dir = out_dir / "status" / "independent"

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -132,9 +132,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                     )
                 tables[base_name] = renamed
 
-            tables[f"{key}_statistics"] = lib.compute_status_statistics(
-                renamed, base_name
-            )
+            tables[f"{key}_statistics"] = lib.compute_status_statistics(df, base_name)
             del tables[key]
 
         logger.info("save_output")

--- a/tests/test_percentages.py
+++ b/tests/test_percentages.py
@@ -24,7 +24,7 @@ def test_add_percentage_and_compute_statistics() -> None:
     df = pd.DataFrame(
         {
             "activity_id": [1, 2, 3],
-            "Filtered": ["good", "bad", "good"],
+            "Filtered.new": ["good", "bad", "good"],
             "independent_IC50": [1, 0, 1],
             "non_independent_IC50": [0, 1, 0],
             "independent_Ki": [0, 0, 0],


### PR DESCRIPTION
## Summary
- compute status statistics from original status tables instead of renamed copies
- place *_status_statistics outputs in the status subdirectories
- align percentage tests with Filtered.new column

## Testing
- `black scripts/get_input_initialisation.py tests/test_percentages.py library/input_initialisation_library.py`
- `ruff check scripts/get_input_initialisation.py tests/test_percentages.py library/input_initialisation_library.py`
- `mypy --follow-imports=skip --ignore-missing-imports scripts/get_input_initialisation.py library/input_initialisation_library.py`
- `pytest tests/test_get_input_initialisation.py tests/test_percentages.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3dc0895b88324b755abe73d785418