### PR TITLE
Fix status statistics computation and add regression test

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1167,7 +1167,15 @@ def save_tables(
     paths: dict[str, Path] = {}
     for entity, df in tables.items():
         # Determine subdirectory based on table type.
-        if entity.endswith("_non_independent_status"):
+        if entity.endswith("_non_independent_status_statistics"):
+            sub_dir = out_dir / "status" / "non-independent"
+        elif entity.endswith("_independent_status_statistics"):
+            sub_dir = out_dir / "status" / "independent"
+        elif entity.endswith("_same_document_status_statistics"):
+            sub_dir = out_dir / "status" / "same_document"
+        elif entity.endswith("_status_statistics"):
+            sub_dir = out_dir / "status"
+        elif entity.endswith("_non_independent_status"):
             sub_dir = out_dir / "status" / "non-independent"
         elif entity.endswith("_independent_status"):
             sub_dir = out_dir / "status" / "independent"

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -108,6 +108,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             base_name = key.removesuffix("_status")
             entity = base_name.split("_")[0]
             id_col = id_cols.get(entity)
+            orig_df = df.copy()
             renamed = df.rename(columns={"Filtered.new": "Filtered"})
 
             if id_col and base_name in tables and id_col in tables[base_name].columns:
@@ -133,7 +134,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 tables[base_name] = renamed
 
             tables[f"{key}_statistics"] = lib.compute_status_statistics(
-                renamed, base_name
+                orig_df, base_name
             )
             del tables[key]
 

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -225,3 +225,56 @@ def test_status_merge_preserves_columns(tmp_path: Path, monkeypatch) -> None:
         df = pd.read_csv(out_dir / "independent" / f"{entity}_independent.csv")
         assert id_col in df.columns
         assert "orig" in df.columns
+
+
+def test_run_passes_original_df_to_statistics(tmp_path: Path, monkeypatch) -> None:
+    """``run`` should provide unmodified status data for statistics."""
+
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+    out_dir = tmp_path / "out"
+
+    status_df = pd.DataFrame({"Filtered.new": ["good"], "independent_IC50": [1]})
+    tables = {"activity_independent_status": status_df}
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "load_all_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "build_combined_tables", lambda *_a, **_k: tables)
+    monkeypatch.setattr(cli.lib, "generate_pair_entity_tables", lambda t, _m: t)
+    monkeypatch.setattr(cli, "analyze_table_quality", lambda *_a, **_k: None)
+
+    def fake_save_tables(data, out_dir, cfg, fmt):  # pragma: no cover - simple stub
+        paths: dict[str, Path] = {}
+        for name in data:
+            path = out_dir / f"{name}.csv"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("dummy")
+            paths[name] = path
+        return paths
+
+    monkeypatch.setattr(cli.lib, "save_tables", fake_save_tables)
+
+    captured_cols: list[str] = []
+
+    def fake_compute_status_statistics(
+        df: pd.DataFrame, table_name: str
+    ) -> pd.DataFrame:
+        captured_cols[:] = list(df.columns)
+        return pd.DataFrame({"Filtered": [], "Count": []})
+
+    monkeypatch.setattr(
+        cli.lib, "compute_status_statistics", fake_compute_status_statistics
+    )
+
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=out_dir,
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+    cfg = Config.model_validate({"api": {"user_agent": "test@example.org"}})
+    assert cli.run(cfg, args) == 0
+    assert "Filtered.new" in captured_cols


### PR DESCRIPTION
## Summary
- ensure status statistics are computed on the original DataFrame before column renaming
- route status statistics files to appropriate status directories when saving
- add regression test verifying unmodified status data is passed to statistics

## Testing
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation.py library/input_initialisation_library.py`
- `black scripts/get_input_initialisation.py tests/test_get_input_initialisation.py library/input_initialisation_library.py`
- `mypy library/input_initialisation_library.py` *(fails: Missing named arguments in config models)*
- `pytest tests/test_get_input_initialisation.py::test_run_creates_quality_reports tests/test_get_input_initialisation.py::test_run_passes_original_df_to_statistics`


------
https://chatgpt.com/codex/tasks/task_e_68c3db62206c8324822713d6181c89dd