### PR TITLE
Add duplicate column checks to CSV utilities

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -108,6 +108,9 @@ def write_csv_deterministic(
 ) -> Path:
     """Serialise ``df`` to ``path`` as a deterministic CSV file.
 
+    Column names must be unique; duplicate labels will raise a
+    :class:`ValueError`.
+
     Parameters
     ----------
     df:
@@ -140,6 +143,12 @@ def write_csv_deterministic(
     -------
     pathlib.Path
         Path to the written CSV file.
+
+    Raises
+    ------
+    ValueError
+        If ``df`` contains duplicate column names or ``chunksize`` is not a
+        positive integer.
     """
 
     out_path = Path(path)
@@ -148,6 +157,16 @@ def write_csv_deterministic(
     # Validate optional chunksize to avoid infinite loops or crashes
     if chunksize is not None and chunksize <= 0:
         msg = f"chunksize must be a positive integer, got {chunksize}"
+        raise ValueError(msg)
+
+    # Ensure column names are unique to avoid ambiguous output
+    duplicated = df.columns[df.columns.duplicated()]
+    if not duplicated.empty:
+        dup_list = list(duplicated)
+        msg = (
+            f"Duplicate column names found: {dup_list}. "
+            "Rename or disambiguate columns before writing."
+        )
         raise ValueError(msg)
 
     # Operations below mutate ``df`` directly to avoid unnecessary copies.
@@ -213,6 +232,9 @@ def write_csv_chunks_deterministic(
 ) -> Path:
     """Write DataFrame chunks to ``path`` deterministically.
 
+    Column names in each chunk must be unique; duplicates result in a
+    :class:`ValueError`.
+
     Each ``df_chunk`` is immediately normalised and written to a temporary
     file using :func:`write_csv_deterministic` with ``chunksize`` to reduce
     peak memory usage. After all chunks are processed the temporary files are
@@ -247,11 +269,26 @@ def write_csv_chunks_deterministic(
     -------
     pathlib.Path
         Path to the written CSV file.
+
+    Raises
+    ------
+    ValueError
+        If any chunk contains duplicate column names.
     """
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_paths: list[Path] = []
         for idx, chunk in enumerate(chunks):
+            # Detect duplicate column names within each chunk
+            duplicated = chunk.columns[chunk.columns.duplicated()]
+            if not duplicated.empty:
+                dup_list = list(duplicated)
+                msg = (
+                    f"Duplicate column names found in chunk {idx}: {dup_list}. "
+                    "Rename or disambiguate columns before writing."
+                )
+                raise ValueError(msg)
+
             tmp_path = Path(tmpdir) / f"chunk_{idx}.csv"
             write_csv_deterministic(
                 chunk,

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -27,8 +27,9 @@ def test_write_csv_deterministic(tmp_path: Path) -> None:
         }
     )
     path = tmp_path / "out.csv"
+    cfg = Config(api={"user_agent": "test@example.org"})
     result = write_csv_deterministic(
-        df, path, col_order=["a", "b", "d", "f"], key_cols=["a"], cfg=Config()
+        df, path, col_order=["a", "b", "d", "f"], key_cols=["a"], cfg=cfg
     )
     assert result == path
     text = path.read_text(encoding="utf-8-sig")
@@ -56,6 +57,16 @@ def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
     expected_hash = hashlib.sha256(expected_bytes).hexdigest()
 
     assert sha256_file(path) == expected_hash
+
+
+def test_write_csv_deterministic_duplicate_columns(tmp_path: Path) -> None:
+    """Duplicate column labels raise a ValueError."""
+
+    df = pd.DataFrame([[1, 2]], columns=["a", "a"])
+    path = tmp_path / "dup.csv"
+    msg = r"Duplicate column names found: \['a'\]"
+    with pytest.raises(ValueError, match=msg):
+        write_csv_deterministic(df, path)
 
 
 def test_default_sorting_and_order(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- validate column label uniqueness before writing deterministic CSV
- note column uniqueness requirement in chunked writer
- test duplicate column detection

## Testing
- `black library/csv_utils.py tests/test_csv_utils.py tests/test_write_csv_chunks_deterministic.py`
- `ruff check library/csv_utils.py tests/test_csv_utils.py tests/test_write_csv_chunks_deterministic.py`
- `mypy library/csv_utils.py` *(fails: Missing dependencies and other type errors)*
- `pytest tests/test_csv_utils.py tests/test_write_csv_chunks_deterministic.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e1eb8fb8832490be14fe33e2e38d