### PR TITLE
Use molecule_chembl_id for test items

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ layout. Columns must satisfy the following contracts.
 Required columns
 
 * ``activity_id`` (*int*, ``>= 0``)
-* ``testitem_id`` (*str*)
+* ``molecule_chembl_id`` (*str*)
 * ``standard_value`` (*float*, ``>= 0``)
 
 Optional columns
@@ -534,14 +534,14 @@ Optional columns
 Valid row
 
 ```csv
-activity_id,testitem_id,target_id,standard_type,standard_value,pA_value
+activity_id,molecule_chembl_id,target_id,standard_type,standard_value,pA_value
 1,TST1,TGT1,IC50,50,9
 ```
 
 Invalid row (``standard_type`` outside enum, ``pA_value`` > 14)
 
 ```csv
-activity_id,testitem_id,target_id,standard_type,standard_value,pA_value
+activity_id,molecule_chembl_id,target_id,standard_type,standard_value,pA_value
 2,TST2,TGT2,IC90,100,20
 ```
 

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -384,7 +384,6 @@ def process_activity_table(
         columns={
             "activity_chembl_id": "activity_chembl_id",
             "salt_chembl_id": "saltform_id",
-            "molecule_chembl_id": "testitem_id",
             # keep CHEMBL identifiers for related entities
             "standard_type": "standard_type",
             "log_value": "pA_value",
@@ -515,7 +514,7 @@ def process_activity_table(
     final_cols = [
         "activity_chembl_id",
         "saltform_id",
-        "testitem_id",
+        "molecule_chembl_id",
         "target_chembl_id",
         "assay_chembl_id",
         "document_chembl_id",
@@ -835,11 +834,14 @@ def generate_pair_entity_tables(
     # Columns linking activities to related entities use CHEMBL identifiers.
     # This mapping specifies the identifier column for each entity so that pair
     # table generation can correctly retrieve the associated rows.
+    # Mapping of entity names to their identifier columns. Test items now use
+    # the canonical ``molecule_chembl_id`` to ensure consistent naming across
+    # the codebase.
     entity_cols: dict[str, str] = {
         "assay": "assay_chembl_id",
         "document": "document_chembl_id",
         "target": "target_chembl_id",
-        "testitem": "testitem_id",
+        "testitem": "molecule_chembl_id",
     }
 
     for pair_key, suffix in pair_keys.items():
@@ -1717,7 +1719,7 @@ def aggregate_activity(
     assay_status = _aggregate_entity(merged, "assay_chembl_id", status_api)
     document_status = _aggregate_entity(merged, "document_chembl_id", status_api)
 
-    system_cols = ["testitem_id", "target_chembl_id", "standard_type"]
+    system_cols = ["molecule_chembl_id", "target_chembl_id", "standard_type"]
 
     missing_sys = [c for c in system_cols if c not in merged.columns]
     if missing_sys:
@@ -1730,7 +1732,7 @@ def aggregate_activity(
     else:
         system_src = merged.copy()
         system_src["system_id"] = (
-            system_src["testitem_id"].astype("string")
+            system_src["molecule_chembl_id"].astype("string")
             + "_"
             + system_src["target_chembl_id"].astype("string")
             + "_"
@@ -1738,23 +1740,23 @@ def aggregate_activity(
         )
         system_status = _aggregate_entity(system_src, "system_id", status_api)
         split = system_status["system_id"].str.split("_", n=2, expand=True)
-        system_status["testitem_id"] = split[0]
+        system_status["molecule_chembl_id"] = split[0]
         system_status["target_chembl_id"] = split[1]
         system_status["standard_type"] = split[2]
 
-    if "testitem_id" in merged.columns:
-        testitem_status = _aggregate_entity(merged, "testitem_id", status_api)
-    elif "testitem_id" not in missing_sys:
+    if "molecule_chembl_id" in merged.columns:
+        testitem_status = _aggregate_entity(merged, "molecule_chembl_id", status_api)
+    elif "molecule_chembl_id" not in missing_sys:
         logger.warning(
-            "activity table missing column testitem_id; skipping testitem aggregation"
+            "activity table missing column molecule_chembl_id; skipping testitem aggregation"
         )
         testitem_status = pd.DataFrame(
-            columns=["testitem_id", "Filtered.new", *metrics]
+            columns=["molecule_chembl_id", "Filtered.new", *metrics]
         )
 
     else:
         testitem_status = pd.DataFrame(
-            columns=["testitem_id", "Filtered.new", *metrics]
+            columns=["molecule_chembl_id", "Filtered.new", *metrics]
         )
 
     if "target_chembl_id" in merged.columns:

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -12,7 +12,7 @@ import pandera.pandas as pa
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
         "activity_id": pa.Column(int, pa.Check.ge(0), required=True),
-        "testitem_id": pa.Column(str, required=True),
+        "molecule_chembl_id": pa.Column(str, required=True),
         "target_id": pa.Column(str, required=False),
         "standard_type": pa.Column(
             str,

--- a/tests/data/activities_invalid.json
+++ b/tests/data/activities_invalid.json
@@ -1,7 +1,7 @@
 [
     {
         "activity_id": 2,
-        "testitem_id": "CHEMBL3",
+        "molecule_chembl_id": "CHEMBL3",
         "target_id": "CHEMBL4",
         "standard_type": "IC50",
         "standard_value": -1.0,

--- a/tests/data/activities_mixed.csv
+++ b/tests/data/activities_mixed.csv
@@ -1,3 +1,3 @@
-activity_id,testitem_id,target_id,standard_type,standard_value,relation,units
+activity_id,molecule_chembl_id,target_id,standard_type,standard_value,relation,units
 1,CHEMBL1,CHEMBL2,IC50,5.0,<,5 μM
 2,CHEMBL3,CHEMBL4,IC50,-1.0,>,10 μM

--- a/tests/data/activities_valid.csv
+++ b/tests/data/activities_valid.csv
@@ -1,2 +1,2 @@
-activity_id,testitem_id,target_id,standard_type,standard_value,relation,units
+activity_id,molecule_chembl_id,target_id,standard_type,standard_value,relation,units
 1,CHEMBL1,CHEMBL2,IC50,5.0,<,5 μM

--- a/tests/test_get_activity_data_smoke.py
+++ b/tests/test_get_activity_data_smoke.py
@@ -19,7 +19,7 @@ def test_get_activity_data_smoke(
         return pd.DataFrame(
             {
                 "activity_id": int_ids,
-                "testitem_id": ["CHEMBL1" for _ in int_ids],
+                "molecule_chembl_id": ["CHEMBL1" for _ in int_ids],
                 "target_id": ["CHEMBL2" for _ in int_ids],
                 "standard_type": ["IC50" for _ in int_ids],
                 "standard_value": [1.0 for _ in int_ids],

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -54,13 +54,13 @@ def test_generate_pair_entity_tables_basic() -> None:
                 "assay_chembl_id": ["a1", "a2", "a3", "a4"],
                 "document_chembl_id": ["d1", "d2", "d3", "d4"],
                 "target_chembl_id": ["t1", "t2", "t3", "t4"],
-                "testitem_id": ["m1", "m2", "m3", "m4"],
+                "molecule_chembl_id": ["m1", "m2", "m3", "m4"],
             }
         ),
         "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2", "a3", "a4"]}),
         "document": pd.DataFrame({"document_chembl_id": ["d1", "d2", "d3", "d4"]}),
         "target": pd.DataFrame({"target_chembl_id": ["t1", "t2", "t3", "t4"]}),
-        "testitem": pd.DataFrame({"testitem_id": ["m1", "m2", "m3", "m4"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1", "m2", "m3", "m4"]}),
         "pairs_independent": pd.DataFrame(
             {"activity_chembl_id1": [1, 2], "activity_chembl_id2": [3, None]}
         ),
@@ -70,7 +70,7 @@ def test_generate_pair_entity_tables_basic() -> None:
     assert set(res["assay_ind"]["assay_chembl_id"]) == {"a1", "a2", "a3"}
     assert set(res["document_ind"]["document_chembl_id"]) == {"d1", "d2", "d3"}
     assert set(res["target_ind"]["target_chembl_id"]) == {"t1", "t2", "t3"}
-    assert set(res["testitem_ind"]["testitem_id"]) == {"m1", "m2", "m3"}
+    assert set(res["testitem_ind"]["molecule_chembl_id"]) == {"m1", "m2", "m3"}
 
 
 def test_generate_pair_entity_tables_normalizes_columns() -> None:
@@ -82,13 +82,13 @@ def test_generate_pair_entity_tables_normalizes_columns() -> None:
                 "assay_chembl_id": ["a1", "a2"],
                 "document_chembl_id": ["d1", "d2"],
                 "target_chembl_id": ["t1", "t2"],
-                "testitem_id": ["m1", "m2"],
+                "molecule_chembl_id": ["m1", "m2"],
             }
         ),
         "assay": pd.DataFrame({"assay_chembl_id": ["a1", "a2"]}),
         "document": pd.DataFrame({"document_chembl_id": ["d1", "d2"]}),
         "target": pd.DataFrame({"target_chembl_id": ["t1", "t2"]}),
-        "testitem": pd.DataFrame({"testitem_id": ["m1", "m2"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1", "m2"]}),
         # Use non-standard column names as found in some Excel sources
         "pairs_same_document": pd.DataFrame({"Activity_ID1": [1], "Activity_ID2": [2]}),
     }
@@ -107,13 +107,13 @@ def test_generate_pair_entity_tables_missing_columns(
                 "assay_chembl_id": ["a1"],
                 "document_chembl_id": ["d1"],
                 "target_chembl_id": ["t1"],
-                "testitem_id": ["m1"],
+                "molecule_chembl_id": ["m1"],
             }
         ),
         "assay": pd.DataFrame({"assay_chembl_id": ["a1"]}),
         "document": pd.DataFrame({"document_chembl_id": ["d1"]}),
         "target": pd.DataFrame({"target_chembl_id": ["t1"]}),
-        "testitem": pd.DataFrame({"testitem_id": ["m1"]}),
+        "testitem": pd.DataFrame({"molecule_chembl_id": ["m1"]}),
         "pairs_bad": pd.DataFrame({"foo": [1]}),
     }
     res = generate_pair_entity_tables(tables, {"pairs_bad": "bad"})
@@ -616,7 +616,7 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
     expected_cols = [
         "activity_chembl_id",
         "saltform_id",
-        "testitem_id",
+        "molecule_chembl_id",
         "target_chembl_id",
         "assay_chembl_id",
         "document_chembl_id",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -26,7 +26,7 @@ def test_activities_schema_validation() -> None:
     valid = pd.DataFrame(
         {
             "activity_id": [1],
-            "testitem_id": ["CHEMBL1"],
+            "molecule_chembl_id": ["CHEMBL1"],
             "target_id": ["CHEMBL2"],
             "standard_type": ["IC50"],
             "standard_value": [10.0],
@@ -133,7 +133,7 @@ def test_testitems_schema_validation() -> None:
                 dtype=int,
                 elements=st.integers(min_value=0, max_value=10),
             ),
-            column("testitem_id", elements=st.text(min_size=1)),
+            column("molecule_chembl_id", elements=st.text(min_size=1)),
             column(
                 "standard_value",
                 elements=st.floats(min_value=0, allow_nan=False),
@@ -156,7 +156,7 @@ def test_activities_schema_hypothesis_valid(df: pd.DataFrame) -> None:
                 dtype=int,
                 elements=st.integers(min_value=0, max_value=10),
             ),
-            column("testitem_id", elements=st.text(min_size=1)),
+            column("molecule_chembl_id", elements=st.text(min_size=1)),
             column(
                 "standard_value",
                 elements=st.floats(max_value=-1.0, allow_nan=False),

--- a/tests/test_status_processing.py
+++ b/tests/test_status_processing.py
@@ -39,7 +39,7 @@ def test_status_pipeline(tmp_path) -> None:
             "activity_chembl_id": [1, 2],
             "assay_chembl_id": ["A1", "A1"],
             "document_chembl_id": ["D1", "D1"],
-            "testitem_id": ["T1", "T2"],
+            "molecule_chembl_id": ["T1", "T2"],
             "target_chembl_id": ["TG1", "TG1"],
             "mesurement_type": ["IC50", "IC50"],
             "high_citation_rate": [False, False],
@@ -61,7 +61,7 @@ def test_status_pipeline(tmp_path) -> None:
         {
             "activity_chembl_id1": [1],
             "activity_chembl_id2": [2],
-            "testitem_id": ["T1"],
+            "molecule_chembl_id": ["T1"],
             "target_chembl_id": ["TG1"],
             "mesurement_type": ["IC50"],
             "independent_IC50": [1],
@@ -103,7 +103,7 @@ def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
             "activity_chembl_id": [1, 2],
             "assay_chembl_id": ["A1", "A1"],
             "document_chembl_id": ["D1", "D1"],
-            "testitem_id": ["T1", "T2"],
+            "molecule_chembl_id": ["T1", "T2"],
             "target_chembl_id": ["TG1", "TG1"],
             "mesurement_type": ["IC50", "IC50"],
             "high_citation_rate": [False, False],
@@ -115,7 +115,7 @@ def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
         {
             "activity_chembl_id1": [1],
             "activity_chembl_id2": [2],
-            "testitem_id": ["T1"],
+            "molecule_chembl_id": ["T1"],
             "target_chembl_id": ["TG1"],
             "mesurement_type": ["IC50"],
         }
@@ -133,14 +133,16 @@ def test_aggregate_activity_handles_missing_metrics(tmp_path: Path) -> None:
         assert activity_status[col].eq(0).all()
 
 
-def test_aggregate_activity_handles_missing_testitem_id(tmp_path: Path) -> None:
-    """Missing ``testitem_id`` should not break aggregation."""
+def test_aggregate_activity_handles_missing_molecule_chembl_id(
+    tmp_path: Path,
+) -> None:
+    """Missing ``molecule_chembl_id`` should not break aggregation."""
     (tmp_path / "status.csv").write_text(
         "status,condition_field,condition_value,order,score\ngood,null,null,0,0\n"
     )
     status_df = load_status_table(tmp_path)
     api = build_status_helpers(status_df)
-    # activity table deliberately lacks ``testitem_id``
+    # activity table deliberately lacks ``molecule_chembl_id``
     activity = pd.DataFrame(
         {
             "activity_chembl_id": [1, 2],


### PR DESCRIPTION
## Summary
- standardize test item identifier on `molecule_chembl_id` across input initialisation and status aggregation
- update schema, documentation, and tests to reference the canonical column

## Testing
- `black library/input_initialisation_library.py schemas/activities.py tests/test_input_initialisation_library.py tests/test_status_processing.py tests/test_schemas.py tests/test_get_activity_data_smoke.py`
- `ruff check library/input_initialisation_library.py schemas/activities.py tests/test_input_initialisation_library.py tests/test_status_processing.py tests/test_schemas.py tests/test_get_activity_data_smoke.py`
- `mypy library` *(fails: Missing named argument errors in unrelated modules)*
- `pytest` *(fails: ValidationError and SystemExit in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e2141a7083248ce27e71d3553583