### PR TITLE
Handle system status tables

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,6 +65,11 @@ The command emits three pair tables:
 written with matching suffixes, for example
 `activity_independent.csv` or `assay_same_document.csv`.
 
+Status tables for recognised entities (``activity``, ``assay``, ``document``,
+``target``, ``testitem`` and ``system``) are merged into the corresponding
+outputs. Status tables for unrecognised entities are skipped with an
+informational log message.
+
 Each command supports the common flags `--sep`, `--encoding` and
 `--log-level`. The default output path mirrors the input location and can be
 manually overridden with `--output` where available.

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -7,9 +7,11 @@ Exports pair tables without merging:
   ``step5_pairs`` in ``--all-doc`` based on the ``INDEPENDENT`` flag.
 
 Additionally, for each pair table the corresponding ``activity``, ``assay``,
-``document``, ``target`` and ``testitem`` entries are exported with matching
-suffixes, for example ``activity_independent.csv`` or
-``assay_same_document.csv``.
+``document``, ``target``, ``testitem`` and ``system`` entries are exported with
+matching suffixes, for example ``activity_independent.csv`` or
+``assay_same_document.csv``. Status tables for these entities are merged into
+the outputs; tables for unknown entities are skipped with an informational log
+message.
 """
 
 from __future__ import annotations
@@ -97,6 +99,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             "target": "target_chembl_id",
             "testitem": "molecule_chembl_id",
             "molecule": "molecule_chembl_id",
+            "system": "system_id",
         }
         for key, df in list(tables.items()):
             if not key.endswith("_status"):
@@ -108,6 +111,13 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             base_name = key.removesuffix("_status")
             entity = base_name.split("_")[0]
             id_col = id_cols.get(entity)
+            if entity == "system" and id_col is None:
+                logger.info("dropping unsupported system status table '%s'", key)
+                del tables[key]
+                continue
+            if entity == "system":
+                logger.info("processing system status table '%s'", key)
+
             renamed = df.rename(columns={"Filtered.new": "Filtered"})
 
             if id_col and base_name in tables and id_col in tables[base_name].columns:

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -225,3 +225,52 @@ def test_status_merge_preserves_columns(tmp_path: Path, monkeypatch) -> None:
         df = pd.read_csv(out_dir / "independent" / f"{entity}_independent.csv")
         assert id_col in df.columns
         assert "orig" in df.columns
+
+
+def test_run_handles_system_status_table(tmp_path: Path, monkeypatch) -> None:
+    """System status tables should be merged or emitted with logging."""
+
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+    out_dir = tmp_path / "out"
+
+    tables = {
+        "system_independent_status": pd.DataFrame(
+            {
+                "system_id": ["T1_TG1_IC50"],
+                "Filtered.new": ["good"],
+                "independent_IC50": [1],
+            }
+        )
+    }
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "load_all_doc", lambda _p: {})
+    monkeypatch.setattr(cli.lib, "build_combined_tables", lambda *_a, **_k: tables)
+    monkeypatch.setattr(cli.lib, "generate_pair_entity_tables", lambda t, _m: t)
+    monkeypatch.setattr(cli, "analyze_table_quality", lambda *_a, **_k: None)
+
+    buf = io.StringIO()
+    configure_logger(LoggerConfig(stream=buf))
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=out_dir,
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+    cfg = Config.model_validate({"api": {"user_agent": "test@example.org"}})
+    assert cli.run(cfg, args) == 0
+
+    out_file = out_dir / "independent" / "system_independent.csv"
+    assert out_file.exists()
+    df = pd.read_csv(out_file)
+    assert "system_id" in df.columns
+    assert "Filtered" in df.columns
+
+    logs = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    assert any(
+        "base table 'system_independent' missing" in rec.get("msg", "") for rec in logs
+    )


### PR DESCRIPTION
## Summary
- support `system` status tables with `system_id` mapping and clear logging
- document handling of unknown status entities
- add regression test for system status table processing

## Testing
- `black scripts library mapper_main.py table_quality_main.py tests/test_get_input_initialisation.py`
- `ruff check scripts library mapper_main.py table_quality_main.py tests/test_get_input_initialisation.py`
- `mypy scripts library mapper_main.py table_quality_main.py` *(fails: There are no .py[i] files in directory 'scripts')*
- `pytest` *(fails: missing configuration, 69 failed)*
- `pytest tests/test_get_input_initialisation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e243c3088324a0161e90dffa230b