### PR TITLE
Improve missing column logging for input initialisation

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -162,12 +162,20 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("save_done", extra={"tables": len(paths), "path": str(out_dir)})
         return 0
     except KeyError as exc:
-        err_msg = str(exc)
-        if "not in index" in err_msg:
-            # Pandas uses this phrasing when column selection fails.
-            logger.error("required column(s) missing: %s", err_msg)
+        msg = exc.args[0] if exc.args else str(exc)
+        if any(
+            indicator in msg
+            for indicator in (
+                "not in index",
+                "table missing expected columns",
+                "required column",
+            )
+        ):
+            # Log a column-specific message when the error clearly refers to
+            # missing columns rather than an absent table.
+            logger.error("required column(s) missing: %s", msg)
         else:
-            logger.error("required table '%s' missing", exc.args[0])
+            logger.error("required table '%s' missing", msg)
         return 1
 
 

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from library.cli import LoggerConfig, configure_logger
 from library.config import Config
@@ -121,6 +122,53 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch) -> None:
     assert lines
     record = json.loads(lines[-1])
     assert "required table 'activity' missing" in record.get("msg", "")
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        "activity table missing expected columns: foo, bar",
+        "required column(s) baz missing",
+    ],
+)
+def test_run_missing_columns_logs_specific_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error_msg: str
+) -> None:
+    """``run`` should report missing required columns with a specific message."""
+    same_doc = tmp_path / "same.xlsx"
+    all_doc = tmp_path / "all.xlsx"
+    same_doc.write_text("dummy")
+    all_doc.write_text("dummy")
+
+    def fake_load_same_doc(path: Path) -> dict[str, object]:  # pragma: no cover
+        return {}
+
+    def fake_load_all_doc(path: Path) -> dict[str, object]:  # pragma: no cover
+        return {}
+
+    def fake_build_combined_tables(*_args, **_kwargs):
+        raise KeyError(error_msg)
+
+    monkeypatch.setattr(cli.lib, "load_same_doc", fake_load_same_doc)
+    monkeypatch.setattr(cli.lib, "load_all_doc", fake_load_all_doc)
+    monkeypatch.setattr(cli.lib, "build_combined_tables", fake_build_combined_tables)
+
+    args = argparse.Namespace(
+        same_doc=same_doc,
+        all_doc=all_doc,
+        out_dir=tmp_path / "out",
+        format="csv",
+        dictionary_dir=tmp_path,
+    )
+    buf = io.StringIO()
+    configure_logger(LoggerConfig(stream=buf))
+    cfg = Config.model_validate({"api": {"user_agent": "test@example.org"}})
+    result = cli.run(cfg, args)
+    assert result == 1
+    lines = buf.getvalue().splitlines()
+    assert lines
+    record = json.loads(lines[-1])
+    assert f"required column(s) missing: {error_msg}" in record.get("msg", "")
 
 
 def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- enhance `get_input_initialisation` CLI to log missing column errors specifically
- add regression tests for missing column scenarios

## Testing
- `python -m black scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `mypy .` *(fails: Missing named argument ... in library/pubmed_library.py)*
- `pytest tests/test_get_input_initialisation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e8c003e08324b2b824a7ecbe180d