### PR TITLE
Ensure final activity table uses unique column set

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -540,12 +540,15 @@ def process_activity_table(
         "IUPHAR_subclass",
         "unicellular_organism",
         "multifunctional_enzyme",
-        "IUPHAR_class",
-        "IUPHAR_subclass",
         "gene_index",
         "taxon_index",
         "target_sort_order",
     ]
+
+    # Remove any accidental duplicates while preserving the declared order. This
+    # guards against repeated column names that would otherwise lead to
+    # duplicated output columns downstream.
+    final_cols = list(dict.fromkeys(final_cols))
 
     missing_final = set(final_cols) - set(df.columns)
     if missing_final:

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -642,13 +642,13 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
         "IUPHAR_subclass",
         "unicellular_organism",
         "multifunctional_enzyme",
-        "IUPHAR_class",
-        "IUPHAR_subclass",
         "gene_index",
         "taxon_index",
         "target_sort_order",
     ]
     assert list(res.columns) == expected_cols
+    # ensure no duplicate columns
+    assert len(res.columns) == len(set(res.columns))
     assert bool(res.loc[0, "is_citation"])
     assert not bool(res.loc[1, "is_citation"])
     assert res["high_citation_rate"].all()


### PR DESCRIPTION
## Summary
- deduplicate `final_cols` in activity table to avoid repeated column names
- update tests to reflect the unique column ordering and assert column uniqueness

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py tests/test_input_initialisation_library.py` *(fails: missing stubs and configuration errors)*
- `pytest` *(fails: missing optional dependencies such as responses and hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e8c9aa188324836498194f93ceae