### PR TITLE
Include additional target metadata and handle duplicates

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -484,15 +484,31 @@ def process_activity_table(
     df = df.merge(
         targets[
             [
-                "target_chembl_id",              
+                "target_chembl_id",
                 "target_sort_order",
                 "multifunctional_enzyme",
                 "organism_type",
+                "IUPHAR_class",
+                "IUPHAR_subclass",
+                "gene_index",
+                "taxon_index",
             ]
         ],
         how="left",
         on="target_chembl_id",
     )
+    # Drop any duplicated columns to avoid unexpected suffixed names when the
+    # input dataframe already contains some of these fields.
+    df = df.loc[:, ~df.columns.duplicated()]
+
+    df["multifunctional_enzyme"] = (
+        df["multifunctional_enzyme"]
+        .astype("string")
+        .str.lower()
+        .map({"true": True, "false": False})
+        .astype("boolean")
+    )
+
     mapping = {
         "Multicellular organism": False,
         "Viruses": True,
@@ -501,8 +517,6 @@ def process_activity_table(
     df["unicellular_organism"] = (
         df["organism_type"].map(mapping).astype("boolean").fillna(False).astype(bool)
     )
-
-  #  df["multifunctional_enzyme"] = df["multifunctional_enzyme"].eq(True)
 
     df.drop(columns=["organism_type"], inplace=True)
 
@@ -535,7 +549,9 @@ def process_activity_table(
         "IUPHAR_class",
         "IUPHAR_subclass",
         "unicellular_organism",
-        "multifunctional_enzyme",      
+        "multifunctional_enzyme",
+        "gene_index",
+        "taxon_index",
         "target_sort_order",
     ]
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -715,6 +715,9 @@ def test_process_activity_table_without_nstereo(tmp_path: Path) -> None:
 
     assert pd.isna(res.loc[0, "multifunctional_enzyme"])
 
+    for col in ["IUPHAR_class", "IUPHAR_subclass", "gene_index", "taxon_index"]:
+        assert col in res.columns
+
 
 def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
     """Load targets from a nested ``_Target`` subdirectory."""
@@ -772,3 +775,6 @@ def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
     res = process_activity_table(df, tmp_path)
     assert "unicellular_organism" in res.columns
     assert res.loc[0, "unicellular_organism"]
+
+    for col in ["IUPHAR_class", "IUPHAR_subclass", "gene_index", "taxon_index"]:
+        assert col in res.columns


### PR DESCRIPTION
## Summary
- include IUPHAR and index columns when merging targets into activity table
- drop duplicate columns post-merge and expose new fields in final ordering
- extend tests for process_activity_table to check new metadata columns

## Testing
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_input_initialisation_library.py::test_process_activity_table_basic -q`
- `pytest tests/test_input_initialisation_library.py::test_process_activity_table_without_nstereo -q`
- `pytest tests/test_input_initialisation_library.py::test_process_activity_table_targets_in_subdir -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f20b13d88324a4c4cc13d0cb9aac