### PR TITLE
Handle duplicate columns when saving tables

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -484,7 +484,7 @@ def process_activity_table(
     df = df.merge(
         targets[
             [
-                "target_chembl_id",              
+                "target_chembl_id",
                 "target_sort_order",
                 "multifunctional_enzyme",
                 "organism_type",
@@ -502,7 +502,7 @@ def process_activity_table(
         df["organism_type"].map(mapping).astype("boolean").fillna(False).astype(bool)
     )
 
-  #  df["multifunctional_enzyme"] = df["multifunctional_enzyme"].eq(True)
+    #  df["multifunctional_enzyme"] = df["multifunctional_enzyme"].eq(True)
 
     df.drop(columns=["organism_type"], inplace=True)
 
@@ -535,7 +535,7 @@ def process_activity_table(
         "IUPHAR_class",
         "IUPHAR_subclass",
         "unicellular_organism",
-        "multifunctional_enzyme",      
+        "multifunctional_enzyme",
         "target_sort_order",
     ]
 
@@ -1194,6 +1194,15 @@ def save_tables(
             sub_dir = out_dir
 
         path = sub_dir / f"{entity}.csv"
+        # Drop duplicated columns to avoid ambiguous data output
+        duplicates = df.columns[df.columns.duplicated()]
+        if len(duplicates) > 0:
+            logger.warning(
+                "Dropping duplicated columns for %s: %s",
+                entity,
+                ", ".join(map(str, duplicates)),
+            )
+            df = df.loc[:, ~df.columns.duplicated()]
         # Delegate writing to the shared I/O helper to ensure consistent
         # encoding and creation of metadata sidecars.
         write_csv(df, path, cfg=cfg)

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import sys
 from pathlib import Path
 
@@ -7,7 +8,7 @@ import pandas as pd
 import pytest
 
 from library import input_initialisation_library as lib
-from library.config import Config
+from library.config import ApiCfg, Config
 from library.input_initialisation_library import (
     TableDict,
     _ensure_openpyxl,
@@ -18,6 +19,7 @@ from library.input_initialisation_library import (
     save_tables,
     unify_dtypes,
 )
+from library.logging_setup import LoggerConfig, configure_logger
 
 
 def test_unify_dtypes_basic() -> None:
@@ -502,7 +504,8 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
             {"Filtered": ["good"], "Count": [1]}
         ),
     }
-    paths = save_tables(tables, tmp_path, Config())
+    cfg = Config(api=ApiCfg(user_agent="test@example.com"))
+    paths = save_tables(tables, tmp_path, cfg)
     for entity, path in paths.items():
         assert path.exists(), f"missing {entity} file"
         df = pd.read_csv(path)
@@ -510,21 +513,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         # Metadata sidecar should be produced alongside each output file.
         meta = path.with_suffix(path.suffix + ".meta.yaml")
         assert meta.exists(), f"missing metadata for {entity}"
-    assert paths["activity_independent"].parent == tmp_path / "independent"
-    assert (
-        paths["activity_independent_status_statistics"].parent
-        == tmp_path / "status" / "independent"
-    )
-    assert paths["activity_non_independent"].parent == tmp_path / "non_independent"
-    assert (
-        paths["activity_non_independent_status_statistics"].parent
-        == tmp_path / "status" / "non-independent"
-    )
-    assert paths["activity_same_document"].parent == tmp_path / "same_document"
-    assert (
-        paths["activity_same_document_status_statistics"].parent
-        == tmp_path / "status" / "same_document"
-    )
     assert (
         paths["activity_independent_status_statistics"].parent
         == tmp_path / "status" / "independent"
@@ -540,6 +528,24 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_same_document"].parent == tmp_path / "same_document"
     assert paths["pairs_independent"].parent == tmp_path / "independent"
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
+
+
+def test_save_tables_drops_duplicate_columns_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tables: TableDict = {"activity": pd.DataFrame([[1, 2]], columns=["a", "a"])}
+    cfg = Config(api=ApiCfg(user_agent="test@example.com"))
+    buf = io.StringIO()
+    test_logger = configure_logger(LoggerConfig(stream=buf)).bind(status=None, rps=None)
+    monkeypatch.setattr(lib, "logger", test_logger)
+    paths = save_tables(tables, tmp_path, cfg)
+    df = pd.read_csv(paths["activity"])
+    # only one column should remain after deduplication
+    assert list(df.columns) == ["a"]
+    out = buf.getvalue()
+    # warning should mention the dropped column name
+    assert "Dropping duplicated columns" in out
+    assert "a" in out
 
 
 def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- drop duplicated columns before writing CSVs in input_initialisation_library.save_tables
- log removed duplicate columns to help debugging
- test that duplicates are dropped and warning is emitted

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy --follow-imports=skip --ignore-missing-imports library/input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_save_tables_writes_files tests/test_input_initialisation_library.py::test_save_tables_drops_duplicate_columns_and_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f23e23ac8324a8c78b9356bb6f6f