### PR TITLE
Use safe boolean conversion for activity tables

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -364,7 +364,7 @@ def process_activity_table(
     df["multimol_assay_same"] = df["assay_chembl_id"].isin(assays)
 
     df["multmol_assay"] = (
-        df["multmol_assay"].astype("boolean").fillna(False).astype(bool)
+        _safe_to_bool(df["multmol_assay"], "multmol_assay").fillna(False)
         | df["multimol_assay_same"]
     )
     df.drop(columns=["multimol_assay_same", "Count"], inplace=True)
@@ -420,7 +420,7 @@ def process_activity_table(
     ]
     for col in bool_cols:
         if col in df.columns:
-            df[col] = df[col].astype("boolean").fillna(False).astype(bool)
+            df[col] = _safe_to_bool(df[col], col).fillna(False)
 
     df["is_citation"] = df[bool_cols].any(axis=1)
 
@@ -448,9 +448,9 @@ def process_activity_table(
         on="document_chembl_id",
         how="left",
     )
-    df["high_citation_rate"] = (
-        df["high_citation_rate"].astype("boolean").fillna(False).astype(bool)
-    )
+    df["high_citation_rate"] = _safe_to_bool(
+        df["high_citation_rate"], "high_citation_rate"
+    ).fillna(False)
 
     # --- target types ------------------------------------------------------
     if targets_csv is not None:
@@ -484,7 +484,11 @@ def process_activity_table(
     df = df.merge(
         targets[
             [
-                "target_chembl_id",              
+                "target_chembl_id",
+                "IUPHAR_class",
+                "IUPHAR_subclass",
+                "gene_index",
+                "taxon_index",
                 "target_sort_order",
                 "multifunctional_enzyme",
                 "organism_type",
@@ -493,16 +497,18 @@ def process_activity_table(
         how="left",
         on="target_chembl_id",
     )
+
+    df["multifunctional_enzyme"] = _safe_to_bool(
+        df["multifunctional_enzyme"], "multifunctional_enzyme"
+    )
     mapping = {
         "Multicellular organism": False,
         "Viruses": True,
         "Unicellular organism": True,
     }
-    df["unicellular_organism"] = (
-        df["organism_type"].map(mapping).astype("boolean").fillna(False).astype(bool)
-    )
-
-  #  df["multifunctional_enzyme"] = df["multifunctional_enzyme"].eq(True)
+    df["unicellular_organism"] = _safe_to_bool(
+        df["organism_type"].map(mapping), "unicellular_organism"
+    ).fillna(False)
 
     df.drop(columns=["organism_type"], inplace=True)
 
@@ -535,7 +541,9 @@ def process_activity_table(
         "IUPHAR_class",
         "IUPHAR_subclass",
         "unicellular_organism",
-        "multifunctional_enzyme",      
+        "multifunctional_enzyme",
+        "gene_index",
+        "taxon_index",
         "target_sort_order",
     ]
 
@@ -567,7 +575,7 @@ def process_activity_table(
         "multifunctional_enzyme",
     ]
     for col in bool_cols_final:
-        df[col] = df[col].astype("boolean")
+        df[col] = _safe_to_bool(df[col], col)
 
     return df
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -713,7 +713,8 @@ def test_process_activity_table_without_nstereo(tmp_path: Path) -> None:
     assert "unknown_chirality" in res.columns
     assert res.loc[0, "unknown_chirality"]
 
-    assert pd.isna(res.loc[0, "multifunctional_enzyme"])
+    assert res["multifunctional_enzyme"].dtype == "string"
+    assert res.loc[0, "multifunctional_enzyme"] == " "
 
 
 def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- use `_safe_to_bool` instead of `astype('boolean')` throughout `process_activity_table`
- coerce `multifunctional_enzyme` via `_safe_to_bool` after merging target metadata and keep invalid values as strings
- extend activity table output ordering with gene and taxon indexes

## Testing
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `python -m mypy library/input_initialisation_library.py tests/test_input_initialisation_library.py` (fails: Library stubs not installed for "pandas", "yaml", "requests", etc.)
- `pytest tests/test_input_initialisation_library.py::test_process_activity_table_basic tests/test_input_initialisation_library.py::test_process_activity_table_without_nstereo tests/test_input_initialisation_library.py::test_process_activity_table_targets_in_subdir -q`
- `pytest -q` (fails: ModuleNotFoundError: No module named 'responses', 'hypothesis', 'psutil')

------
https://chatgpt.com/codex/tasks/task_e_68c3f21cb3448324b0f1b34217c4ab47