### PR TITLE
Deduplicate columns before writing tables

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1164,6 +1164,10 @@ def save_tables(
     - ``*_status_statistics`` tables follow the same pattern and are also
       stored beneath ``status/``.
 
+    Duplicate column names are removed prior to writing to avoid ambiguous
+    headers. The dropped columns are listed in a warning message to aid
+    debugging.
+
     Parameters
     ----------
     tables:
@@ -1212,6 +1216,13 @@ def save_tables(
             sub_dir = out_dir
 
         path = sub_dir / f"{entity}.csv"
+        # Drop duplicated columns before writing to avoid ambiguous headers.
+        duplicate_cols = df.columns[df.columns.duplicated()].tolist()
+        if duplicate_cols:
+            logger.warning(
+                "Duplicate columns removed from %s: %s", entity, duplicate_cols
+            )
+            df = df.loc[:, ~df.columns.duplicated()]
         # Delegate writing to the shared I/O helper to ensure consistent
         # encoding and creation of metadata sidecars.
         write_csv(df, path, cfg=cfg)

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from library import input_initialisation_library as lib
-from library.config import Config
+from library.config import ApiCfg, Config
 from library.input_initialisation_library import (
     TableDict,
     _ensure_openpyxl,
@@ -489,6 +489,9 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         "pairs_same_document": pd.DataFrame({"id": [1]}),
         "pairs_independent": pd.DataFrame({"id": [1]}),
         "pairs_non_independent": pd.DataFrame({"id": [2]}),
+        "activity_independent": pd.DataFrame({"id": [1]}),
+        "activity_non_independent": pd.DataFrame({"id": [2]}),
+        "activity_same_document": pd.DataFrame({"id": [3]}),
         "activity_independent_status": pd.DataFrame({"id": [1]}),
         "activity_non_independent_status": pd.DataFrame({"id": [1]}),
         "activity_same_document_status": pd.DataFrame({"id": [1]}),
@@ -502,7 +505,8 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
             {"Filtered": ["good"], "Count": [1]}
         ),
     }
-    paths = save_tables(tables, tmp_path, Config())
+    cfg = Config(api=ApiCfg(user_agent="test@example.com"))
+    paths = save_tables(tables, tmp_path, cfg)
     for entity, path in paths.items():
         assert path.exists(), f"missing {entity} file"
         df = pd.read_csv(path)
@@ -540,6 +544,29 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_same_document"].parent == tmp_path / "same_document"
     assert paths["pairs_independent"].parent == tmp_path / "independent"
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
+
+
+def test_save_tables_drops_duplicate_columns_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Capture warning messages emitted by the logger
+    messages: list[str] = []
+
+    def fake_warn(msg: str, *args: object) -> None:
+        messages.append(msg % args)
+
+    monkeypatch.setattr(lib.logger, "warning", fake_warn)
+
+    # Create a table with duplicated column names
+    df = pd.DataFrame([[1, "a", "b"]], columns=["id", "dup", "dup"])
+    tables: TableDict = {"activity": df}
+    cfg = Config(api=ApiCfg(user_agent="test@example.com"))
+    paths = save_tables(tables, tmp_path, cfg)
+    # Written table should contain only unique columns
+    result = pd.read_csv(paths["activity"])
+    assert set(result.columns) == {"id", "dup"}
+    # Warning should list removed duplicates
+    assert "Duplicate columns removed from activity: ['dup']" in messages[0]
 
 
 def test_ensure_openpyxl_version(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- drop duplicate DataFrame columns in `save_tables` before writing
- warn with the removed column names
- test that duplicate columns are removed and warning emitted

## Testing
- `python -m black tests/test_input_initialisation_library.py library/input_initialisation_library.py`
- `python -m ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `python -m mypy library/input_initialisation_library.py --follow-imports=skip` *(fails: Returning Any from function, Series not callable, Unsupported operand type)*
- `pytest tests/test_input_initialisation_library.py::test_save_tables_writes_files tests/test_input_initialisation_library.py::test_save_tables_drops_duplicate_columns_and_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f465daf8832489528d7765a4b8fd