### PR TITLE
Use shallow copy in document postprocessing

### DIFF
--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -180,7 +180,10 @@ def postprocess_documents(
     """
     if required_columns is not None:
         validation.validate_columns(df, required_columns)
-    result = df.copy()
+    # Create a view to avoid an expensive deep copy. Subsequent operations
+    # either replace columns or return new DataFrames, so the original
+    # ``df`` remains unchanged while minimising memory usage.
+    result = df.copy(deep=False)
     if result.empty:
         return result
 


### PR DESCRIPTION
## Summary
- avoid expensive deep copy in `postprocess_documents` by using a shallow DataFrame copy

## Testing
- `python -m black library/document_postprocessing.py tests/test_document_postprocessing.py`
- `python -m ruff check library/document_postprocessing.py tests/test_document_postprocessing.py`
- `python -m mypy library/document_postprocessing.py tests/test_document_postprocessing.py` *(fails: returning Any, missing type stubs and call-arg issues)*
- `pytest tests/test_document_postprocessing.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4057828bc8324a24201b0b4002301