### PR TITLE
Document editable dev install and adjust dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ parsing, validation, aggregation and export of tabular data.
 ## Установка
 
 ```bash
-pip install .[dev]
+pip install -e .[dev]
 ```
- 
+
    ```bash
-   pip install .
+   pip install -e .
    # Development extras (black, ruff, mypy, pytest, hypothesis, responses, psutil, pre-commit, ...)
-   pip install .[dev]
+   pip install -e .[dev]
    ```
  
 The command installs the project together with development tools such as
@@ -149,7 +149,7 @@ To keep the environment current, periodically refresh the pinned
 libraries and verify that the project remains compatible:
 
 ```bash
-pip install -U .[dev]
+pip install -e -U .[dev]
 pre-commit run --all-files
 ```
 
@@ -283,10 +283,10 @@ Clone the repository and install the runtime dependencies:
 ```bash
 git clone https://example.com/ChEMBL_data_acquisition.git
 cd ChEMBL_data_acquisition
-pip install .
+pip install -e .
 
 # Development tools (black, ruff, mypy, pytest, hypothesis, responses, pre-commit)
-pip install .[dev]
+pip install -e .[dev]
 ```
 
 ### Pre-commit hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "types-jsonschema==4.25.1.20250822",
   "pytest==8.4.2",
   "types-openpyxl>=3.1.5",
-  "hypothesis==6.138.15",
+  "hypothesis>=6",
   "responses>=0.25",
   "types-cachetools==6.2.0.20250827",
   "types-urllib3==1.26.25.14",


### PR DESCRIPTION
## Summary
- Document `pip install -e .[dev]` in README for editable development installs
- Relax Hypothesis to a minimum version and ensure dev extras include responses and psutil

## Testing
- `pre-commit run --files pyproject.toml README.md`
- `pip install -e .[dev]`
- `pytest -q` *(fails: ValidationError for Config and other related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c40b4549208324ae9128fa9597c450