### PR TITLE
docs: add module docstrings for CLI utilities

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -1,7 +1,8 @@
-"""Shared command-line helpers.
+"""Utilities for constructing command-line interfaces.
 
-Configuration loading errors are converted to user-facing messages using
-``argparse.ArgumentParser.error``.
+This module centralises shared CLI behaviour such as common argument
+definitions, configuration loading and logging setup. Configuration errors are
+presented to users via :meth:`argparse.ArgumentParser.error`.
 """
 
 from __future__ import annotations

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -1,4 +1,8 @@
-"""Argument parser helpers for lightweight command-line interfaces."""
+"""Helpers for building lightweight CLIs with shared arguments.
+
+The utilities here assemble an ``argparse`` parser using the common options
+from :mod:`library.cli` for scripts that expose deterministic CSV operations.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify purpose of core CLI utilities and parser builder

## Testing
- `black library/cli.py library/cli_utils.py`
- `ruff check library/cli.py library/cli_utils.py`
- `mypy library/cli.py library/cli_utils.py` *(fails: Missing named arguments and stubs in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c4070e430c832488bc1aa2ddf04880