### PR TITLE
Use typed cast when retrieving cached rate limiter

### DIFF
--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import threading
 import time
+from typing import cast
 
 from cachetools import TTLCache
 
@@ -86,7 +87,7 @@ def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
         Maximum burst size.  Defaults to ``ceil(rps)``.
     """
     with _limiters_lock:
-        limiter = _limiters.get(name)
+        limiter = cast(RateLimiter | None, _limiters.get(name))  # type: ignore[redundant-cast]
         if (
             limiter is None
             or limiter.rps != rps


### PR DESCRIPTION
## Summary
- apply explicit `cast` when fetching cached rate limiter instances

## Testing
- `ruff check library/rate_limiter.py`
- `mypy library/rate_limiter.py` *(fails: Missing named arguments in library/config.py)*
- `pytest tests/test_rate_limiter.py tests/test_rate_limiter_cache.py tests/test_rate_limiter_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4145bb58c8324be2e557f263ba7b0