### PR TITLE
refactor: simplify document CLI packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,33 +49,27 @@ dev = [
 ]
 
 [project.scripts]
-get-activity-data = "get_activity_data:main"
-get-assay-data = "get_assay_data:main"
-get-target-data = "get_target_data:main"
-get-document-data = "get_document_data:main"
-get-document-type = "get_document_type:main"
-get-input-initialisation = "get_input_initialisation:main"
-get-testitem-data = "get_testitem_data:main"
+get-activity-data = "scripts.get_activity_data:main"
+get-assay-data = "scripts.get_assay_data:main"
+get-target-data = "scripts.get_target_data:main"
+get-document-data = "scripts.get_document_data:main"
+get-document-type = "scripts.get_document_type:main"
+get-input-initialisation = "scripts.get_input_initialisation:main"
+get-testitem-data = "scripts.get_testitem_data:main"
 csv-utils = "csv_utils_main:main"
 mapper = "mapper_main:main"
 table-quality = "table_quality_main:main"
 
 [tool.setuptools]
 py-modules = [
-  "get_activity_data",
-  "get_assay_data",
-  "get_target_data",
-  "get_document_data",
-  "get_document_type",
-  "get_input_initialisation",
-  "get_testitem_data",
+  "chunk_io_main",
   "csv_utils_main",
   "mapper_main",
   "table_quality_main",
 ]
 
 [tool.setuptools.packages.find]
-include = ["library", "schemas"]
+include = ["library", "schemas", "scripts"]
 
 [tool.black]
 line-length = 88

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -16,9 +16,10 @@ Example
 -------
 Fetch PubMed metadata for identifiers listed in ``pmids.csv``::
 
-    python scripts/get_document_data.py pubmed --config config.yaml --input pmids.csv --output output.csv
+    python -m scripts.get_document_data pubmed --config config.yaml --input pmids.csv --output output.csv
 
-The input file must contain a ``PMID`` column.
+The input file must contain a ``PMID`` column. Alternatively, use the
+``get-document-data`` console script installed with the package.
 
 """
 
@@ -28,15 +29,7 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 from typing import cast
-
-# Allow running the script directly via ``python scripts/get_document_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests


### PR DESCRIPTION
## Summary
- drop custom `sys.path` handling in document metadata CLI
- support execution as `python -m scripts.get_document_data` and via `get-document-data` entry point
- package `scripts` modules for console entry points

## Testing
- `python -m scripts.get_document_data -h`
- `ruff check scripts/get_document_data.py pyproject.toml`
- `black --check scripts/get_document_data.py`
- `mypy scripts/get_document_data.py` *(fails: Missing named argument "sleep" for "DocumentPubmedCfg" ...)*
- `pytest` *(fails: pydantic_core._pydantic_core.ValidationError: 1 validation error for Config)*

------
https://chatgpt.com/codex/tasks/task_e_68c413bec8ec8324a4e115c2a305a2a3