### PR TITLE
Log execution duration in determinism check

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -26,6 +26,7 @@ from .document_type_terms import (
 from .logging_setup import Logger, LoggerConfig, configure_logger
 from .parser_schema import CSVExportArgs
 from .sidecar import SidecarErrors
+from .timing import log_duration
 
 __all__ = [
     "parse_terms",
@@ -46,4 +47,5 @@ __all__ = [
     "LoggerConfig",
     "configure_logger",
     "CSVExportArgs",
+    "log_duration",
 ]

--- a/library/timing.py
+++ b/library/timing.py
@@ -1,0 +1,28 @@
+"""Utility functions for measuring and logging execution durations."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .log import logger
+
+
+def log_duration(start: float) -> float:
+    """Log the elapsed time since ``start``.
+
+    Parameters
+    ----------
+    start : float
+        Start time as returned by :func:`time.perf_counter`.
+
+    Returns
+    -------
+    float
+        The elapsed duration in seconds.
+    """
+    duration = perf_counter() - start
+    logger.info("duration_sec", extra={"value": duration})
+    return duration
+
+
+__all__ = ["log_duration"]

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -13,6 +13,7 @@ import argparse
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from time import perf_counter
 
 # Allow running the script directly via ``python scripts/check_determinism.py``
 # by ensuring the repository root is on ``sys.path`` when the module is executed
@@ -32,6 +33,7 @@ except ImportError as exc:  # pragma: no cover - import-time check
 from library.cli import LoggerConfig, configure_logger
 from library.csv_utils import sha256_file, write_csv_deterministic
 from library.log import logger
+from library.timing import log_duration
 
 
 def run_check(tmp_dir: Path) -> bool:
@@ -75,23 +77,31 @@ def main() -> int:
         ``0`` on success, ``1`` when hashes differ.
     """
 
-    parser = argparse.ArgumentParser(description="Check deterministic CSV writing")
-    parser.add_argument(
-        "--log-level", default="INFO", help="Logging level (default: INFO)."
-    )
-    args = parser.parse_args()
+    start = perf_counter()
+    try:
+        parser = argparse.ArgumentParser(
+            description="Check deterministic CSV writing",
+        )
+        parser.add_argument(
+            "--log-level",
+            default="INFO",
+            help="Logging level (default: INFO).",
+        )
+        args = parser.parse_args()
 
-    configure_logger(LoggerConfig(level=args.log_level))
+        configure_logger(LoggerConfig(level=args.log_level))
 
-    with TemporaryDirectory() as tmp:
-        ok = run_check(Path(tmp))
+        with TemporaryDirectory() as tmp:
+            ok = run_check(Path(tmp))
 
-    if ok:
-        logger.info("Hashes match; output is deterministic")
-        return 0
+        if ok:
+            logger.info("Hashes match; output is deterministic")
+            return 0
 
-    logger.error("Hashes differ; output is not deterministic")
-    return 1
+        logger.error("Hashes differ; output is not deterministic")
+        return 1
+    finally:
+        log_duration(start)
 
 
 if __name__ == "__main__":

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from io import StringIO
+from time import perf_counter
+
+from library.cli import LoggerConfig, configure_logger
+from library.timing import log_duration
+
+
+def test_log_duration_logs_and_returns_value() -> None:
+    """Ensure ``log_duration`` logs the elapsed time in seconds."""
+    stream = StringIO()
+    configure_logger(LoggerConfig(stream=stream))
+    start = perf_counter()
+    duration = log_duration(start)
+    assert duration >= 0
+    assert "duration_sec" in stream.getvalue()


### PR DESCRIPTION
## Summary
- add reusable `log_duration` helper
- log execution time in `check_determinism` script
- cover timing helper with unit test

## Testing
- `pre-commit run --files library/timing.py library/__init__.py scripts/check_determinism.py tests/test_timing.py` *(fails: pydantic_core.ValidationError in many tests)*
- `pytest tests/test_timing.py tests/test_determinism_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68c41716c7248324b147c90a98558b20