### PR TITLE
chore: format codebase with ruff

### DIFF
--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -60,7 +60,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     write_csv_chunks_deterministic(
         reader,
         output,
-
         col_order=args.col_order or None,
         key_cols=args.key_cols or None,
         chunksize=args.chunk_size,

--- a/library/cli.py
+++ b/library/cli.py
@@ -169,9 +169,9 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> (
-    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
-):
+def build_root_parser() -> tuple[
+    argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig
+]:
     """Return parsers containing root-level options and logging config.
 
     Two parsers are produced:

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1821,7 +1821,7 @@ def aggregate_activity(
         target_status,
     ]:
         for m in metrics:
-            df[m] = (df[m] ).astype("float64") #corrected
+            df[m] = (df[m]).astype("float64")  # corrected
 
     return {
         "activity": activity_status,

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -18,7 +18,6 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
         called["encoding"] = encoding
         called["chunksize"] = chunksize
 
-
         def gen():
             yield pd.DataFrame({"a": [1], "b": [2]})
 
@@ -31,7 +30,6 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
         key_cols=None,
         chunksize=None,
         drop_unexpected_cols=False,
-
     ):  # type: ignore[override]
         called["output"] = output
         called["write_chunksize"] = chunksize
@@ -66,7 +64,6 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
     assert called["write_chunksize"] == 2
 
 
-
 def test_cli_generates_output_path(monkeypatch, tmp_path: Path) -> None:
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("a,b\n1,2\n", encoding="utf8")
@@ -97,4 +94,3 @@ def test_cli_generates_output_path(monkeypatch, tmp_path: Path) -> None:
     assert rc == 0
     expected = input_csv.with_name("output_input_20240102.csv")
     assert called["output"] == expected
-


### PR DESCRIPTION
## Summary
- run `ruff format` to reformat Python sources
- keep repository compliant with project style conventions

## Testing
- `ruff format --check .`
- `pytest -q` *(fails: pydantic-core ValidationError, SystemExit; see logs for details)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a5809b88324843e17714997ca78