### PR TITLE
feat: make UniProt mapping timeout configurable

### DIFF
--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -52,13 +52,14 @@ def map_chembl_to_uniprot(
     if opener is None:
         opener = urllib.request.urlopen
 
-    def _open_json(url: str, data: bytes | None = None) -> Any:
+    def _open_json(
+        url: str, data: bytes | None = None, timeout: float | None = None
+    ) -> Any:
         """Open ``url`` and parse the JSON response."""
         try:
-            # Add a 30-second timeout to the underlying urlopen call
-            # to prevent hangs on network requests.
+            # Use the configured timeout for network requests to avoid hangs.
             if opener is urllib.request.urlopen:
-                with opener(url, data=data, timeout=30) as response:
+                with opener(url, data=data, timeout=timeout) as response:
                     return json.load(response)
             else:  # For mock openers used in tests
                 with opener(url, data=data) as response:
@@ -80,7 +81,7 @@ def map_chembl_to_uniprot(
     ).encode()
     logger.debug("Submitting ID mapping job for %s", chembl_target_id)
     base = cfg.base.rstrip("/")
-    run_data = _open_json(f"{base}/run", data=data)
+    run_data = _open_json(f"{base}/run", data=data, timeout=cfg.timeout)
     job_id = run_data.get("jobId")
     if not job_id:
         raise ValueError("UniProt ID Mapping API did not return a job ID")
@@ -94,7 +95,7 @@ def map_chembl_to_uniprot(
     )
     while True:
         limiter.acquire()
-        status_data = _open_json(status_url)
+        status_data = _open_json(status_url, timeout=cfg.timeout)
 
         # Check for results in the response, which indicates a redirect has occurred
         if "results" in status_data:
@@ -115,7 +116,7 @@ def map_chembl_to_uniprot(
     # If the last status check was a redirect, status_data already contains the results
     if not result_data:
         result_url = f"{base}/uniprotkb/results/{job_id}?format=json"
-        result_data = _open_json(result_url)
+        result_data = _open_json(result_url, timeout=cfg.timeout)
 
     results = result_data.get("results", [])
     if not results:

--- a/tests/test_mapper_library.py
+++ b/tests/test_mapper_library.py
@@ -1,0 +1,58 @@
+"""Tests for :mod:`library.mapper_library`."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.request
+from typing import Any
+
+import pytest
+
+from library.config import UniprotMappingCfg
+from library.mapper_library import map_chembl_to_uniprot
+
+
+class _BytesIOContext:
+    """Context manager returning a :class:`io.BytesIO` object."""
+
+    def __init__(self, data: bytes) -> None:
+        self._bio = io.BytesIO(data)
+
+    def __enter__(self) -> io.BytesIO:
+        return self._bio
+
+    def __exit__(self, *args: object) -> None:
+        self._bio.close()
+
+
+def test_map_chembl_to_uniprot_uses_config_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure network requests use ``cfg.timeout`` instead of a hard-coded value."""
+
+    timeouts: list[float | None] = []
+
+    def fake_urlopen(
+        url: str, data: bytes | None = None, timeout: float | None = None
+    ) -> _BytesIOContext:
+        timeouts.append(timeout)
+        if url.endswith("/run"):
+            content: dict[str, Any] = {"jobId": "1"}
+        elif "/status/" in url:
+            if fake_urlopen.calls == 0:
+                fake_urlopen.calls += 1
+                content = {"jobStatus": "RUNNING"}
+            else:
+                content = {"jobStatus": "FINISHED"}
+        else:
+            content = {"results": [{"to": {"primaryAccession": "P12345"}}]}
+        return _BytesIOContext(json.dumps(content).encode())
+
+    fake_urlopen.calls = 0  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    cfg = UniprotMappingCfg(poll_interval=0.1, timeout=5.0)
+    assert map_chembl_to_uniprot("CHEMBL1", cfg) == "P12345"
+    assert timeouts and all(t == cfg.timeout for t in timeouts)


### PR DESCRIPTION
## Summary
- respect configurable timeout for UniProt ID mapping requests
- test mapping uses provided timeout

## Testing
- `SKIP=pytest pre-commit run --files library/mapper_library.py`
- `SKIP=pytest,mypy pre-commit run --files tests/test_mapper_library.py`
- `pytest tests/test_mapper_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c41cad82ec83249681ec886fe4662f