### PR TITLE
Refine root parser return annotation

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -169,9 +169,9 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> (
-    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
-):
+# fmt: off
+def build_root_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]:
+# fmt: on
     """Return parsers containing root-level options and logging config.
 
     Two parsers are produced:


### PR DESCRIPTION
## Summary
- simplify `build_root_parser` signature to return concrete tuple types

## Testing
- `ruff check library/cli.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_e_68c41ca8a27c83249ef0dd23873dd047