### PR TITLE
style: format codebase with ruff

### DIFF
--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -87,7 +87,6 @@ def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
         Maximum burst size.  Defaults to ``ceil(rps)``.
     """
     with _limiters_lock:
-
         limiter = cast(RateLimiter | None, _limiters.get(name))  # type: ignore[redundant-cast]
 
         if (


### PR DESCRIPTION
## Summary
- run `ruff format .` to harmonize code style

## Testing
- `pytest` *(fails: ConfigError: api.user_agent must be provided ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c41edda11c8324a33b4d89d26d7502