### PR TITLE
feat: require explicit key columns for deterministic CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ from library.csv_utils import write_csv_deterministic
 import pandas as pd
 
 df = pd.read_csv("large.csv")
-write_csv_deterministic(df, "out.csv", chunksize=1000)
+write_csv_deterministic(df, "out.csv", key_cols=df.columns, chunksize=1000)
 ```
 
 Rows are still sorted deterministically before writing; ``chunksize`` only

--- a/csv_utils_main.py
+++ b/csv_utils_main.py
@@ -44,6 +44,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"output_{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
         )
     args = CSVExportArgs.model_validate(vars(ns))
+    if not args.key_cols:
+        parser.error("--key-cols must be provided")
     configure_logger(LoggerConfig(level=args.log_level))
 
     start = time.perf_counter()
@@ -60,9 +62,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     write_csv_chunks_deterministic(
         reader,
         output,
-
         col_order=args.col_order or None,
-        key_cols=args.key_cols or None,
+        key_cols=args.key_cols,
         chunksize=args.chunk_size,
         drop_unexpected_cols=True,
     )

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -26,12 +26,6 @@ from .git_utils import _git_sha
 
 logger = logging.getLogger(__name__)
 
-# Default columns used for deterministic sorting when ``key_cols`` is omitted.
-# Tests and small utility scripts rely on a simple alphabetical key, hence the
-# single-column default. Larger applications should explicitly pass ``key_cols``
-# suited to their domain.
-DEFAULT_KEY_COLS: Sequence[str] = ("a",)
-
 
 def _write_meta(path: Path, cfg: Config | None) -> Path:
     """Write a sidecar YAML file with basic provenance information."""
@@ -109,8 +103,8 @@ def write_csv_deterministic(
         appended in lexicographical order unless ``drop_unexpected_cols`` is
         ``True``, in which case they are omitted with a warning.
     key_cols:
-        Optional sequence of column names defining row ordering. If omitted,
-        :data:`DEFAULT_KEY_COLS` is used and a warning is logged.
+        Sequence of column names defining row ordering. ``None`` is invalid
+        and results in a :class:`ValueError`.
     chunksize:
         Optional number of rows to write per chunk. Passing a value enables
         streaming output via :meth:`pandas.DataFrame.to_csv`, reducing peak
@@ -135,7 +129,8 @@ def write_csv_deterministic(
     ------
     ValueError
         If ``df`` contains duplicate column names, ``chunksize`` is not a
-        positive integer or required sort keys are missing.
+        positive integer, ``key_cols`` is ``None`` or required sort keys are
+        missing.
     """
 
     out_path = Path(path)
@@ -177,10 +172,8 @@ def write_csv_deterministic(
 
     # Sort rows deterministically in-place using a stable algorithm.
     if key_cols is None:
-        sort_cols = list(DEFAULT_KEY_COLS)
-        logger.warning("key_cols is None; using default keys: %s", sort_cols)
-    else:
-        sort_cols = list(key_cols)
+        raise ValueError("key_cols must be provided")
+    sort_cols = list(key_cols)
     missing = [c for c in sort_cols if c not in work.columns]
     if missing:
         msg = f"Missing key columns: {missing}"
@@ -247,8 +240,8 @@ def write_csv_chunks_deterministic(
         Optional preferred column order. Forwarded to
         :func:`write_csv_deterministic`.
     key_cols:
-        Optional columns defining row order. Forwarded to
-        :func:`write_csv_deterministic`.
+        Columns defining row order. ``None`` is invalid and results in a
+        :class:`ValueError`.
     chunksize:
         Number of rows written per chunk.
     sep:
@@ -268,8 +261,11 @@ def write_csv_chunks_deterministic(
     Raises
     ------
     ValueError
-        If any chunk contains duplicate column names.
+        If any chunk contains duplicate column names or ``key_cols`` is ``None``.
     """
+
+    if key_cols is None:
+        raise ValueError("key_cols must be provided")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_paths: list[Path] = []

--- a/library/io.py
+++ b/library/io.py
@@ -206,8 +206,8 @@ def write_csv(
     encoding:
         Character encoding of the CSV file. Defaults to ``cfg.io.csv_encoding``.
     key_cols:
-        Optional columns to determine row order. When provided, rows are
-        sorted by these columns. Otherwise all columns are used.
+        Columns used to determine row order. Defaults to all columns if
+        omitted.
     chunksize:
         Optional number of rows per chunk to stream when writing the CSV.
         Passed through to :meth:`pandas.DataFrame.to_csv` and
@@ -228,10 +228,11 @@ def write_csv(
     """
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
+    key_cols_list = list(key_cols) if key_cols is not None else sorted(df.columns)
     return write_csv_deterministic(
         df,
         path,
-        key_cols=list(key_cols) if key_cols is not None else None,
+        key_cols=key_cols_list,
         chunksize=chunksize,
         sep=sep,
         encoding=encoding,

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -918,7 +918,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.output_csv
         else Path(f"output_{Path(args.input_csv).stem}_{date.today():%Y%m%d}.csv")
     )
-    write_csv_deterministic(df, output_path)
+    write_csv_deterministic(df, output_path, key_cols=sorted(df.columns))
     logger.info("written %s", output_path)
     return 0
 

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -56,10 +56,11 @@ def run_check(tmp_dir: Path) -> bool:
     second = tmp_dir / "second.csv"
 
     # Write the DataFrame twice using the deterministic writer
-    write_csv_deterministic(df, first)
+    key_cols = list(df.columns)
+    write_csv_deterministic(df, first, key_cols=key_cols)
     hash1 = sha256_file(first)
 
-    write_csv_deterministic(df, second)
+    write_csv_deterministic(df, second, key_cols=key_cols)
     hash2 = sha256_file(second)
 
     logger.debug("First hash: %s", hash1)

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -66,7 +66,7 @@ def test_write_csv_deterministic_duplicate_columns(tmp_path: Path) -> None:
     path = tmp_path / "dup.csv"
     msg = r"Duplicate column names found: \['a'\]"
     with pytest.raises(ValueError, match=msg):
-        write_csv_deterministic(df, path)
+        write_csv_deterministic(df, path, key_cols=["a"])
 
 
 def test_default_sorting_and_order(tmp_path: Path) -> None:
@@ -77,8 +77,15 @@ def test_default_sorting_and_order(tmp_path: Path) -> None:
         }
     )
     path = tmp_path / "out.csv"
-    write_csv_deterministic(df, path)
+    write_csv_deterministic(df, path, key_cols=["a"])
     assert path.read_text(encoding="utf-8-sig") == "a,b\nx,true\ny,false\n"
+
+
+def test_write_csv_deterministic_none_key_cols(tmp_path: Path) -> None:
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    path = tmp_path / "out.csv"
+    with pytest.raises(ValueError, match="key_cols must be provided"):
+        write_csv_deterministic(df, path, key_cols=None)
 
 
 def test_deterministic_writes_identical_bytes(tmp_path: Path) -> None:
@@ -104,11 +111,11 @@ def test_write_csv_deterministic_hash_stable(tmp_path: Path) -> None:
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     path = tmp_path / "out.csv"
 
-    write_csv_deterministic(df.copy(), path)
+    write_csv_deterministic(df.copy(), path, key_cols=sorted(df.columns))
     first_hash = sha256_file(path)
     first_meta_hash = sha256_file(Path(str(path) + ".meta.yaml"))
 
-    write_csv_deterministic(df.copy(), path)
+    write_csv_deterministic(df.copy(), path, key_cols=sorted(df.columns))
     second_hash = sha256_file(path)
     second_meta_hash = sha256_file(Path(str(path) + ".meta.yaml"))
 
@@ -192,8 +199,8 @@ def test_write_csv_deterministic_random_types(
     path2 = tmp_path / "second.csv"
     df1 = df.sample(frac=1).reset_index(drop=True)
     df2 = df.sample(frac=1).reset_index(drop=True)
-    write_csv_deterministic(df1.copy(), path1)
-    write_csv_deterministic(df2.copy(), path2)
+    write_csv_deterministic(df1.copy(), path1, key_cols=["a"])
+    write_csv_deterministic(df2.copy(), path2, key_cols=["a"])
     assert path1.read_bytes() == path2.read_bytes()
 
 

--- a/tests/test_csv_utils_drop_unexpected.py
+++ b/tests/test_csv_utils_drop_unexpected.py
@@ -18,6 +18,7 @@ def test_drop_unexpected_columns(
             df,
             out,
             col_order=["a", "b"],
+            key_cols=["a"],
             drop_unexpected_cols=True,
         )
     result = pd.read_csv(out)

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -18,7 +18,6 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
         called["encoding"] = encoding
         called["chunksize"] = chunksize
 
-
         def gen():
             yield pd.DataFrame({"a": [1], "b": [2]})
 
@@ -31,7 +30,6 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
         key_cols=None,
         chunksize=None,
         drop_unexpected_cols=False,
-
     ):  # type: ignore[override]
         called["output"] = output
         called["write_chunksize"] = chunksize
@@ -50,6 +48,8 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
             "|",
             "--encoding",
             "latin1",
+            "--key-cols",
+            "a",
             "--chunk-size",
             "2",
             "--log-level",
@@ -66,35 +66,39 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
     assert called["write_chunksize"] == 2
 
 
-
 def test_cli_generates_output_path(monkeypatch, tmp_path: Path) -> None:
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("a,b\n1,2\n", encoding="utf8")
     called: dict[str, Path] = {}
 
-    def fake_read_csv(path, sep, encoding):  # type: ignore[override]
+    def fake_read_csv(path, sep, encoding, chunksize):  # type: ignore[override]
         called["path"] = path
-        return pd.DataFrame({"a": [1], "b": [2]})
+
+        def gen():
+            yield pd.DataFrame({"a": [1], "b": [2]})
+
+        return gen()
 
     def fake_write(
-        df,
+        chunks,
         output,
         col_order=None,
         key_cols=None,
+        chunksize=None,
         drop_unexpected_cols=True,
     ):  # type: ignore[override]
         called["output"] = output
+        list(chunks)
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
-    monkeypatch.setattr(cli, "write_csv_deterministic", fake_write)
+    monkeypatch.setattr(cli, "write_csv_chunks_deterministic", fake_write)
     monkeypatch.setattr(
         cli,
         "date",
         type("D", (), {"today": staticmethod(lambda: date(2024, 1, 2))}),
     )
 
-    rc = cli.main(["--input", str(input_csv)])
+    rc = cli.main(["--input", str(input_csv), "--key-cols", "a"])
     assert rc == 0
     expected = input_csv.with_name("output_input_20240102.csv")
     assert called["output"] == expected
-

--- a/tests/test_csv_utils_memory.py
+++ b/tests/test_csv_utils_memory.py
@@ -15,7 +15,7 @@ def _worker(path: str, use_copy: bool, n: int) -> None:
     df = pd.DataFrame({"a": range(n), "b": range(n)})
     if use_copy:
         df = df.copy()
-    write_csv_deterministic(df, Path(path))
+    write_csv_deterministic(df, Path(path), key_cols=["a", "b"])
 
 
 def _peak_memory(n: int, use_copy: bool, path: Path) -> int:


### PR DESCRIPTION
## Summary
- remove DEFAULT_KEY_COLS and enforce explicit key_cols in deterministic CSV utilities
- default io.write_csv to sorting by all columns when key_cols omitted
- update scripts, docs, and tests; add test for missing key_cols

## Testing
- `pre-commit run ruff-format --files README.md csv_utils_main.py library/csv_utils.py library/io.py library/pubmed_library.py scripts/check_determinism.py tests/test_csv_utils.py tests/test_csv_utils_drop_unexpected.py tests/test_csv_utils_main_args.py tests/test_csv_utils_memory.py`
- `pre-commit run ruff-check --files README.md csv_utils_main.py library/csv_utils.py library/io.py library/pubmed_library.py scripts/check_determinism.py tests/test_csv_utils.py tests/test_csv_utils_drop_unexpected.py tests/test_csv_utils_main_args.py tests/test_csv_utils_memory.py`
- `pre-commit run black --files README.md csv_utils_main.py library/csv_utils.py library/io.py library/pubmed_library.py scripts/check_determinism.py tests/test_csv_utils.py tests/test_csv_utils_drop_unexpected.py tests/test_csv_utils_main_args.py tests/test_csv_utils_memory.py`
- `pre-commit run mypy --files README.md csv_utils_main.py library/csv_utils.py library/io.py library/pubmed_library.py scripts/check_determinism.py tests/test_csv_utils.py tests/test_csv_utils_drop_unexpected.py tests/test_csv_utils_main_args.py tests/test_csv_utils_memory.py` *(fails: untyped functions and missing stubs)*
- `pytest tests/test_csv_utils.py tests/test_csv_utils_drop_unexpected.py tests/test_csv_utils_main_args.py tests/test_csv_utils_memory.py tests/test_csv_chunks.py tests/test_write_csv_chunks_deterministic.py`

------
https://chatgpt.com/codex/tasks/task_e_68c41cfa0700832491bee5d625d6d5d0