### PR TITLE
Expand mypy coverage for scripts and schemas

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -92,7 +92,7 @@ class ChemblClient:
                 logger.info(
                     "cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"}
                 )
-                return cast(dict[str, Any], cached)
+                return cached
             logger.info(
                 "cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"}
             )

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from .config import _mask_secrets
 from .git_utils import _git_sha

--- a/library/pandas_utils.py
+++ b/library/pandas_utils.py
@@ -6,10 +6,10 @@ newer versions of pandas (>=2.0), such as the ``dtype_backend`` argument.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 
 def json_normalize_pyarrow(
@@ -42,19 +42,20 @@ def json_normalize_pyarrow(
         Normalized data.
     """
 
+    json_normalize: Callable[..., Any] = pd.json_normalize
     try:
         # pandas >= 2.0 supports ``dtype_backend``
         return cast(
             pd.DataFrame,
-            pd.json_normalize(
+            json_normalize(
                 data,
                 dtype_backend=dtype_backend,
                 **kwargs,
             ),
-        )  # type: ignore[arg-type, unused-ignore]
+        )
     except TypeError:
         # For pandas < 2.0, fall back to the default behaviour
-        return cast(pd.DataFrame, pd.json_normalize(data, **kwargs))
+        return cast(pd.DataFrame, json_normalize(data, **kwargs))
 
 
 def read_csv_pyarrow(
@@ -80,17 +81,18 @@ def read_csv_pyarrow(
         Parsed CSV data.
     """
 
+    read_csv: Callable[..., Any] = pd.read_csv
     try:
         return cast(
             pd.DataFrame,
-            pd.read_csv(
+            read_csv(
                 *args,
                 dtype_backend=dtype_backend,
                 **kwargs,
             ),
-        )  # type: ignore[arg-type, unused-ignore]
+        )
     except (TypeError, ImportError):
-        return cast(pd.DataFrame, pd.read_csv(*args, **kwargs))
+        return cast(pd.DataFrame, read_csv(*args, **kwargs))
 
 
 __all__ = ["json_normalize_pyarrow", "read_csv_pyarrow"]

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -167,7 +167,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     """
     if url in _CACHE:
         logger.info("cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"})
-        return cast(dict[str, Any], _CACHE[url])
+        return _CACHE[url]
     logger.info("cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"})
 
     for attempt in range(1, cfg.retries + 1):

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -25,6 +25,7 @@ import requests
 from .cli import LoggerConfig, configure_logger
 from .cli import build_parser as base_parser
 from .config import (
+    ApiCfg,
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -862,15 +863,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     log_cfg.level = args.log_level
     configure_logger(log_cfg)
 
-    cfg = Config()
+    cfg = Config(api=ApiCfg(user_agent="chembl-da/0.1 (mailto:info@example.org)"))
     pubmed_cfg = cfg.pubmed
     semsch_cfg = cfg.semantic_scholar
     limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
     delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
 
-    cfg = Config()
-    pubmed_cfg = cfg.pubmed
-    semsch_cfg = cfg.semantic_scholar
     pmid_df = read_pmids(args.input_csv, cfg=pubmed_cfg)
     pmids = pmid_df["PMID"].tolist()
     openalex_limiter = get_limiter("openalex", cfg.openalex.rps, cfg.openalex.burst)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ ignore = ["E501"]
 python_version = "3.12"
 strict = true
 warn_unused_configs = true
-exclude = "^(?!library/).*"
+exclude = "^(?!(library/|schemas/|scripts/)).*"
 plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]

--- a/schemas/normalize.py
+++ b/schemas/normalize.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 _RELATION_MAP: dict[str, str] = {"<": "<=", ">": ">=", "=": "=", "<=": "<=", ">=": ">="}
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 # Allow running the script directly via ``python scripts/get_assay_data.py``
 # by ensuring the repository root is on ``sys.path`` when the module is executed
@@ -198,7 +199,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code = cast(int, args.func(cfg, args))
     if exit_code == 0:
         logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 # Allow running the script directly via ``python scripts/get_testitem_data.py``
 # by ensuring the repository root is on ``sys.path`` when the module is executed
@@ -32,6 +33,7 @@ from library.cli import (
 )
 from library.config import (
     Config,
+    PubChemCfg,
     _serialize_paths,
     ensure_dirs,
     print_config,
@@ -43,7 +45,7 @@ from library.table_quality import analyze_table_quality
 from schemas import TestitemsSchema, normalize_testitems
 
 
-def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
+def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -288,7 +290,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code = cast(int, args.func(cfg, args))
     if exit_code == 0:
         logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
     else:


### PR DESCRIPTION
## Summary
- include `schemas/` and `scripts/` in mypy analysis
- clean up redundant casts and type ignores across library modules
- fix CLI scripts to use explicit types and configuration

## Testing
- `pre-commit run --files pyproject.toml library/pubchem_library.py library/metadata.py library/chembl_client.py library/pandas_utils.py library/pubmed_library.py schemas/normalize.py scripts/get_testitem_data.py scripts/get_assay_data.py` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c4228661e48324a1ca6948a3935238