### PR TITLE
refactor: simplify rate limiter cache access

### DIFF
--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import cast
 
 from cachetools import TTLCache
 
@@ -87,8 +86,7 @@ def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
         Maximum burst size.  Defaults to ``ceil(rps)``.
     """
     with _limiters_lock:
-
-        limiter = cast(RateLimiter | None, _limiters.get(name))  # type: ignore[redundant-cast]
+        limiter: RateLimiter | None = _limiters.get(name)
 
         if (
             limiter is None


### PR DESCRIPTION
## Summary
- drop redundant cast and ignore when retrieving rate limiter from cache
- tidy rate_limiter imports

## Testing
- `ruff check library/rate_limiter.py`
- `mypy library/rate_limiter.py`
- `pytest tests/test_rate_limiter.py tests/test_rate_limiter_threadsafe.py tests/test_rate_limiter_cache.py`
- `pytest` *(fails: pydantic validation errors & CLI configuration; 66 failed, 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c42558a89c832491f8d37a6030857f