### PR TITLE
Refactor PubMed request handling

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -83,6 +83,135 @@ def read_pmids(path: str | Path, cfg: PubMedCfg | None = None) -> pd.DataFrame:
     )
 
 
+def _make_request(
+    session: requests.Session,
+    url: str,
+    expect_json: bool,
+    method: str,
+    timeout: float | tuple[float, float],
+    **kwargs: Any,
+) -> tuple[int, str, dict[str, Any] | str | None, str]:
+    """Issue a single HTTP request and parse its body.
+
+    Parameters
+    ----------
+    session:
+        Active :class:`requests.Session`.
+    url:
+        Endpoint to query.
+    expect_json:
+        Whether the response should be parsed as JSON.
+    method:
+        HTTP method to use.
+    timeout:
+        Maximum seconds to wait for the request.
+    **kwargs:
+        Extra parameters forwarded to :mod:`requests`.
+
+    Returns
+    -------
+    tuple
+        ``(status_code, text, content, parse_error)``. ``content`` contains the
+        parsed JSON or raw text and ``parse_error`` is non-empty if JSON
+        decoding failed.
+    """
+
+    if method.upper() == "POST":
+        request: Callable[..., requests.Response] = session.post
+    else:
+        request = session.get
+    with request(url, timeout=timeout, **kwargs) as resp:
+        status_code = resp.status_code
+        text = resp.text
+        if expect_json:
+            try:
+                content = resp.json()
+            except ValueError as exc:
+                return status_code, text, None, str(exc)
+            return status_code, text, content, ""
+        return status_code, text, text or "", ""
+
+
+def _handle_response(
+    url: str,
+    status_code: int,
+    text: str,
+    content: dict[str, Any] | str | None,
+    parse_error: str,
+    expect_json: bool,
+    attempt: int,
+    retries: int,
+) -> tuple[dict[str, Any] | str | None, str, bool]:
+    """Process an HTTP response and decide whether to retry.
+
+    Parameters
+    ----------
+    url:
+        URL that was requested.
+    status_code:
+        HTTP status code returned by the server.
+    text:
+        Raw response body.
+    content:
+        Parsed body when no error occurred.
+    parse_error:
+        Error message from JSON decoding.
+    expect_json:
+        Whether a JSON response was expected.
+    attempt:
+        Zero-based attempt index.
+    retries:
+        Maximum number of retries.
+
+    Returns
+    -------
+    tuple
+        ``(data, error, retry)`` where ``retry`` indicates if another attempt
+        should be performed.
+    """
+
+    if status_code in (429, 500, 502, 503, 504):
+        if attempt >= retries:
+            logger.info(
+                "request_fail",
+                extra={"stage": "request_fail", "url": url, "status": status_code},
+            )
+            return None, f"HTTP {status_code}: {text[:100]}", False
+        return None, "", True
+    if status_code == 404:
+        logger.info(
+            "request_fail",
+            extra={"stage": "request_fail", "url": url, "status": status_code},
+        )
+        return None, "PMID not found", False
+    if status_code == 400:
+        logger.info(
+            "request_fail",
+            extra={"stage": "request_fail", "url": url, "status": status_code},
+        )
+        return None, f"Bad request: {text[:100]}", False
+    if status_code != 200:
+        logger.info(
+            "request_fail",
+            extra={"stage": "request_fail", "url": url, "status": status_code},
+        )
+        return None, f"HTTP {status_code}: {text[:100]}", False
+    if expect_json:
+        if parse_error:
+            logger.info("request_fail", extra={"stage": "request_fail", "url": url})
+            return None, f"Invalid JSON: {parse_error}", False
+        logger.info(
+            "request_ok",
+            extra={"stage": "request_ok", "url": url, "status": status_code},
+        )
+        return content, "", False
+    logger.info(
+        "request_ok",
+        extra={"stage": "request_ok", "url": url, "status": status_code},
+    )
+    return content or "", "", False
+
+
 def _do_request(
     session: requests.Session,
     url: str,
@@ -93,37 +222,34 @@ def _do_request(
     timeout: float | tuple[float, float] = 10,
     **kwargs: Any,
 ) -> tuple[dict[str, Any] | str | None, str]:
-    """Perform an HTTP request with retry and error handling.
+    """Perform an HTTP request with retry logic.
 
     Parameters
     ----------
     session:
-        Requests session used to perform the call.
+        Active :class:`requests.Session`.
     url:
         Endpoint to query.
     delay:
-        Base number of seconds to wait between attempts.
+        Base seconds to wait between attempts.
     expect_json:
-        Whether to parse the response as JSON.
+        Whether the response should be parsed as JSON.
     retries:
-        Number of additional attempts after the initial one.
+        Number of additional attempts after the first one.
     method:
-        HTTP method to use, either "GET" or "POST".
+        HTTP method to use.
     timeout:
-
-        Maximum seconds to wait for each HTTP request. May be a single float
-        or a ``(connect, read)`` tuple.
-
+        Maximum seconds to wait for each attempt.
     **kwargs:
-        Additional parameters passed to ``session.get`` or ``session.post``.
+        Extra parameters forwarded to :mod:`requests`.
 
     Returns
     -------
     tuple
-        Pair of parsed data (dict/str/``None``) and an error message. The error
-        string is empty on success.
-
+        Parsed content and an error message. The error string is empty on
+        success.
     """
+
     for attempt in range(retries + 1):
         event = "request_start" if attempt == 0 else "request_retry"
         logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
@@ -131,20 +257,9 @@ def _do_request(
             sleep(delay * attempt)
 
         try:
-            if method.upper() == "POST":
-                request: Callable[..., requests.Response] = session.post
-            else:
-                request = session.get
-            with request(url, timeout=timeout, **kwargs) as resp:
-                status_code = resp.status_code
-                text = resp.text
-                try:
-                    content = resp.json() if expect_json else text
-                except ValueError as exc:
-                    content = None
-                    parse_error = str(exc)
-                else:
-                    parse_error = ""
+            status_code, text, content, parse_error = _make_request(
+                session, url, expect_json, method, timeout, **kwargs
+            )
         except requests.RequestException as exc:
             if attempt >= retries:  # pragma: no cover - network errors
                 logger.exception(
@@ -152,50 +267,14 @@ def _do_request(
                 )
                 return None, str(exc)
             continue
-        if status_code in (429, 500, 502, 503, 504):
-            if attempt >= retries:
-                logger.info(
-                    "request_fail",
-                    extra={
-                        "stage": "request_fail",
-                        "url": url,
-                        "status": status_code,
-                    },
-                )
-                return None, f"HTTP {status_code}: {text[:100]}"
-            continue
-        if status_code == 404:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, "PMID not found"
-        if status_code == 400:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, f"Bad request: {text[:100]}"
-        if status_code != 200:
-            logger.info(
-                "request_fail",
-                extra={"stage": "request_fail", "url": url, "status": status_code},
-            )
-            return None, f"HTTP {status_code}: {text[:100]}"
-        if expect_json:
-            if parse_error:
-                logger.info("request_fail", extra={"stage": "request_fail", "url": url})
-                return None, f"Invalid JSON: {parse_error}"
-            logger.info(
-                "request_ok",
-                extra={"stage": "request_ok", "url": url, "status": status_code},
-            )
-            return content, ""
-        logger.info(
-            "request_ok",
-            extra={"stage": "request_ok", "url": url, "status": status_code},
+
+        data, error, retry = _handle_response(
+            url, status_code, text, content, parse_error, expect_json, attempt, retries
         )
-        return content or "", ""
+        if retry:
+            continue
+        return data, error
+
     logger.info("request_fail", extra={"stage": "request_fail", "url": url})
     return None, "Request failed"
 

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -3,7 +3,7 @@ import requests
 
 from library import openalex_crossref_library as ocl
 from library import rate_limiter as rl
-from library.config import Config, CrossRefCfg, OpenAlexCfg
+from library.config import ApiCfg, Config, CrossRefCfg, OpenAlexCfg
 
 
 def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
@@ -19,6 +19,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
     monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
 
     cfg = Config(
+        api=ApiCfg(user_agent="test@example.com"),
         openalex=OpenAlexCfg(
             base="https://example.org",
             timeout_connect=1,
@@ -26,7 +27,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
             rps=2,
             burst=5,
             mailto="x@y.com",
-        )
+        ),
     )
     limiter = rl.RateLimiter(2)
     ocl.fetch_openalex(requests.Session(), "123", cfg.openalex, limiter)
@@ -48,6 +49,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
     monkeypatch.setattr("library.pubmed_library._do_request", fake_do_request)
 
     cfg = Config(
+        api=ApiCfg(user_agent="test@example.com"),
         crossref=CrossRefCfg(
             base="https://cr.example.org",
             timeout_connect=1,
@@ -55,7 +57,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
             rps=4,
             burst=5,
             mailto="z@e.com",
-        )
+        ),
     )
     limiter = rl.RateLimiter(4)
     ocl.fetch_crossref(requests.Session(), "10.1/abc", cfg.crossref, limiter)
@@ -74,7 +76,10 @@ def test_rate_limiter_shared(monkeypatch) -> None:
     monkeypatch.setattr(rl, "sleep", fake_sleep)
     monkeypatch.setattr("library.pubmed_library._do_request", lambda *a, **k: ({}, ""))
 
-    cfg = Config(openalex=OpenAlexCfg(rps=1, mailto="x@y.com"))
+    cfg = Config(
+        api=ApiCfg(user_agent="test@example.com"),
+        openalex=OpenAlexCfg(rps=1, mailto="x@y.com"),
+    )
     limiter = rl.RateLimiter(1)
     session = requests.Session()
     ocl.fetch_openalex(session, "1", cfg.openalex, limiter)

--- a/tests/test_pubmed_library.py
+++ b/tests/test_pubmed_library.py
@@ -12,6 +12,7 @@ import requests
 from library import pubmed_library as pl
 from library import rate_limiter as rl
 from library.config import (
+    ApiCfg,
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -98,6 +99,76 @@ def test_do_request_404() -> None:
     assert err == "PMID not found"
 
 
+def test_handle_response_retryable() -> None:
+    """500 response triggers a retry on non-final attempts."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 500, "error", None, "", True, 0, 1
+    )
+    assert data is None
+    assert err == ""
+    assert retry is True
+
+
+def test_handle_response_retryable_last_attempt() -> None:
+    """Retryable error returns a message on the last attempt."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 500, "error", None, "", True, 1, 1
+    )
+    assert data is None
+    assert retry is False
+    assert err.startswith("HTTP 500")
+
+
+def test_handle_response_parse_error() -> None:
+    """Invalid JSON is reported as a failure."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 200, "", None, "boom", True, 0, 0
+    )
+    assert data is None
+    assert retry is False
+    assert err.startswith("Invalid JSON")
+
+
+def test_handle_response_success_text() -> None:
+    """Text responses are returned when JSON is not expected."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 200, "hi", "hi", "", False, 0, 0
+    )
+    assert data == "hi"
+    assert err == ""
+    assert retry is False
+
+
+def test_handle_response_404() -> None:
+    """404 error returns a specific message."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 404, "not found", None, "", True, 0, 0
+    )
+    assert data is None
+    assert err == "PMID not found"
+    assert retry is False
+
+
+def test_handle_response_400() -> None:
+    """400 error is reported as a bad request."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 400, "bad", None, "", True, 0, 0
+    )
+    assert data is None
+    assert retry is False
+    assert err.startswith("Bad request")
+
+
+def test_handle_response_generic_error() -> None:
+    """Unexpected status codes return a generic HTTP error."""
+    data, err, retry = pl._handle_response(
+        "http://example.org", 418, "teapot", None, "", True, 0, 0
+    )
+    assert data is None
+    assert retry is False
+    assert err.startswith("HTTP 418")
+
+
 def test_fetch_pubmed_uses_cfg(monkeypatch) -> None:
     cfg = PubMedCfg(
         base="https://example.org/eutils",
@@ -142,6 +213,7 @@ def test_fetch_pubmed_uses_cfg(monkeypatch) -> None:
 
 def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
     cfg = Config(
+        api=ApiCfg(user_agent="test@example.com"),
         openalex=OpenAlexCfg(
             base="https://example.org",
             timeout_connect=1,
@@ -149,7 +221,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
             retries=4,
             rps=10,
             mailto="info@example.org",
-        )
+        ),
     )
 
     captured: dict[str, Any] = {}
@@ -201,6 +273,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch) -> None:
 
 def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
     cfg = Config(
+        api=ApiCfg(user_agent="test@example.com"),
         crossref=CrossRefCfg(
             base="https://api.example.org",
             timeout_connect=2,
@@ -208,7 +281,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch) -> None:
             retries=5,
             rps=8,
             mailto="info@example.org",
-        )
+        ),
     )
 
     captured: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- factor out `_make_request` and `_handle_response` helpers
- streamline `_do_request` retry loop
- expand tests to cover response branches and config requirements

## Testing
- `ruff check library/pubmed_library.py tests/test_pubmed_library.py tests/test_openalex_crossref_library.py`
- `mypy library/pubmed_library.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_pubmed_library.py tests/test_openalex_crossref_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c42727c12883249bc8e83932bb4094