### PR TITLE
feat: support configurable NA markers

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -422,6 +422,23 @@
           "title": "Csv Encoding",
           "type": "string"
         },
+        "na_markers": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [
+            "#N/A"
+          ],
+          "title": "Na Markers"
+        },
         "csv_index": {
           "default": false,
           "title": "Csv Index",

--- a/library/config.py
+++ b/library/config.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -287,6 +288,7 @@ class IoCfg(_BoolModel):
     cache_dir: Path = Path(".cache")
     csv_sep: str = ","
     csv_encoding: str = "utf-8-sig"
+    na_markers: Sequence[str] | None = ("#N/A",)
     csv_index: bool = False
     exist_ok: bool = True
 

--- a/library/io.py
+++ b/library/io.py
@@ -56,6 +56,7 @@ def read_ids(
     cfg: IoCfg,
     sep: str | None = None,
     encoding: str | None = None,
+    na_markers: Sequence[str] | None = None,
 ) -> Iterator[str]:
     """Yield identifier values from ``column`` in ``path``.
 
@@ -71,12 +72,14 @@ def read_ids(
         Field delimiter used in the CSV file. Defaults to ``cfg.csv_sep``.
     encoding:
         Character encoding of the CSV file. Defaults to ``cfg.csv_encoding``.
+    na_markers:
+        Strings indicating missing values. Defaults to ``cfg.na_markers``.
 
     Yields
     ------
     str
-        Identifier values in the order they appear. Empty strings and
-        ``"#N/A"`` markers are discarded.
+        Identifier values in the order they appear. Empty strings and values
+        present in ``na_markers`` are discarded.
 
     Raises
     ------
@@ -88,6 +91,7 @@ def read_ids(
     """
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
+    marker_set = set(na_markers or cfg.na_markers or ())
     try:
         with Path(path).open("r", encoding=encoding, newline="") as fh:
             reader = csv.DictReader(fh, delimiter=sep)
@@ -97,7 +101,7 @@ def read_ids(
                 )
             for row in reader:
                 value = (row.get(column) or "").strip()
-                if value and value != "#N/A":
+                if value and value not in marker_set:
                     yield value
     except FileNotFoundError:
         raise

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -123,6 +123,21 @@ def test_write_csv_with_key_cols(tmp_path: Path) -> None:
     assert first_hash == second_hash
 
 
+def test_read_ids_custom_na_marker(tmp_path: Path) -> None:
+    """``read_ids`` honours custom NA markers."""
+
+    path = tmp_path / "ids.csv"
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["id"])
+        writer.writerow(["1"])
+        writer.writerow(["NA"])
+        writer.writerow(["2"])
+
+    ids = list(io.read_ids(path, column="id", cfg=IoCfg(), na_markers=["NA"]))
+    assert ids == ["1", "2"]
+
+
 def test_write_csv_missing_key_column(tmp_path: Path) -> None:
     df = pd.DataFrame({"a": [1], "b": [2]})
     path = tmp_path / "out.csv"


### PR DESCRIPTION
## Summary
- add `na_markers` option to `IoCfg` and `read_ids`
- treat values in `na_markers` as missing instead of only `#N/A`
- test alternative NA marker handling

## Testing
- `pre-commit run --files library/config.py library/io.py tests/test_io.py config.schema.json` *(fails: missing configuration, 66 tests failing)*


------
https://chatgpt.com/codex/tasks/task_e_68c4271e1c0c832490d65e9c6e5f79bd