### PR TITLE
Centralise metadata sidecar generation

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -10,33 +10,17 @@ from __future__ import annotations
 
 import hashlib
 import os
-import sys
 import tempfile
 from collections.abc import Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
 
 import pandas as pd
-import yaml
 from pandas.api import types as ptypes
 
-from .config import Config, _serialize_paths
-from .git_utils import _git_sha
+from .config import Config
+from .io import write_meta_yaml
 from .log import logger
-
-
-def _write_meta(path: Path, cfg: Config | None) -> Path:
-    """Write a sidecar YAML file with basic provenance information."""
-
-    meta = {
-        "git_sha": _git_sha(),
-        "command": " ".join(sys.argv),
-        "config": _serialize_paths(cfg.to_dict()) if cfg is not None else {},
-    }
-    meta_path = Path(f"{path}.meta.yaml")
-    with meta_path.open("w", encoding="utf8") as fh:
-        yaml.safe_dump(meta, fh, sort_keys=False)
-    return meta_path
 
 
 def _normalise_bool(series: pd.Series) -> pd.Series:
@@ -200,7 +184,7 @@ def write_csv_deterministic(
             sep=sep,
         )
     os.replace(tmp_path, out_path)
-    _write_meta(out_path, cfg)
+    write_meta_yaml(out_path, cfg)
     return out_path
 
 

--- a/library/io.py
+++ b/library/io.py
@@ -34,7 +34,6 @@ import yaml
 
 from . import validation
 from .config import Config, IoCfg, _serialize_paths
-from .csv_utils import write_csv_deterministic
 from .git_utils import _git_sha
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
@@ -229,6 +228,8 @@ def write_csv(
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
     key_cols_list = list(key_cols) if key_cols is not None else sorted(df.columns)
+    from .csv_utils import write_csv_deterministic
+
     return write_csv_deterministic(
         df,
         path,
@@ -261,18 +262,31 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
 
 
-def _write_meta(path: Path, cfg: Config) -> None:
-    """Write YAML metadata alongside the output file.
+def write_meta_yaml(path: Path | str, cfg: Config | None = None) -> Path:
+    """Write minimal metadata for ``path`` to ``<path>.meta.yaml``.
 
-    Paths inside the configuration are converted to plain strings so that the
-    resulting YAML does not contain :class:`~pathlib.Path` objects.
+    Parameters
+    ----------
+    path:
+        Target file for which the sidecar should be created.
+    cfg:
+        Optional configuration instance. When provided all :class:`~pathlib.Path`
+        objects inside the configuration are serialised as plain strings to make
+        the resulting YAML portable. When ``None`` an empty mapping is written
+        under the ``config`` key.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the generated ``.meta.yaml`` file.
     """
 
     meta = {
         "git_sha": _git_sha(),
         "command": " ".join(sys.argv),
-        "config": _serialize_paths(cfg.to_dict()),
+        "config": _serialize_paths(cfg.to_dict()) if cfg is not None else {},
     }
     meta_path = Path(f"{path}.meta.yaml")
     with meta_path.open("w", encoding="utf8") as fh:
         yaml.safe_dump(meta, fh, sort_keys=False)
+    return meta_path

--- a/library/sidecar.py
+++ b/library/sidecar.py
@@ -6,6 +6,9 @@ import csv
 from pathlib import Path
 from typing import Any
 
+from .config import Config
+from .io import write_meta_yaml
+
 
 class SidecarErrors:
     """Collect tabular error records and persist them to CSV.
@@ -29,13 +32,15 @@ class SidecarErrors:
         """
         self._errors.append(row)
 
-    def save(self, path: Path) -> None:
-        """Write collected errors to ``path`` as CSV.
+    def save(self, path: Path, *, cfg: Config | None = None) -> None:
+        """Write collected errors to ``path`` as CSV and emit metadata.
 
         Parameters
         ----------
-        path: pathlib.Path
+        path:
             Destination file. Parent directories are created as needed.
+        cfg:
+            Optional configuration forwarded to :func:`write_meta_yaml`.
 
         Notes
         -----
@@ -49,3 +54,4 @@ class SidecarErrors:
             writer = csv.DictWriter(fh, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(self._errors)
+        write_meta_yaml(path, cfg)

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -37,7 +37,7 @@ def test_mapper_run_defaults_to_io_output_dir(
     )
 
     monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _i, _cfg: "P12345")
-    monkeypatch.setattr(io, "_write_meta", lambda *_a, **_k: None)
+    monkeypatch.setattr(io, "write_meta_yaml", lambda *_a, **_k: None)
 
     rc = mapper_main.run(cfg, args)
     assert rc == 0

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -10,6 +10,8 @@ def test_sidecar_writes_rows(tmp_path: Path) -> None:
     sc.add_error({"col": "second", "msg": "two"})
     sc.save(path)
     assert path.read_text(encoding="utf8") == "col,msg\nfirst,one\nsecond,two\n"
+    meta = Path(str(path) + ".meta.yaml")
+    assert meta.exists()
 
 
 def test_sidecar_skips_empty(tmp_path: Path) -> None:
@@ -17,3 +19,4 @@ def test_sidecar_skips_empty(tmp_path: Path) -> None:
     sc = SidecarErrors()
     sc.save(path)
     assert not path.exists()
+    assert not Path(str(path) + ".meta.yaml").exists()


### PR DESCRIPTION
## Summary
- expose `write_meta_yaml` in `library.io` for reusable sidecar creation
- switch CSV utilities and sidecar error writer to use `write_meta_yaml`
- adjust tests for metadata sidecar paths

## Testing
- `black library/io.py library/csv_utils.py library/sidecar.py tests/test_sidecar.py tests/test_default_output_dir.py`
- `ruff check library/io.py library/csv_utils.py library/sidecar.py tests/test_sidecar.py tests/test_default_output_dir.py`
- `mypy library/io.py library/csv_utils.py library/sidecar.py`
- `pytest tests/test_sidecar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c427049968832496d0a058e86f672c