### PR TITLE
Add context management to ChemblClient

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -6,6 +6,7 @@ import random
 import threading
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
+from types import TracebackType
 from typing import Any, cast
 
 import requests
@@ -55,6 +56,37 @@ class ChemblClient:
         )
         self.cache = TTLCache(maxsize=maxsize, ttl=ttl)
         self._cache_lock = threading.Lock()
+
+    def close(self) -> None:
+        """Close the underlying HTTP session.
+
+        This method releases network resources held by the internal
+        :class:`requests.Session` instance. It is safe to call multiple times.
+        """
+
+        self.session.close()
+
+    def __enter__(self) -> ChemblClient:
+        """Return ``self`` when entering a context manager."""
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Close the session when leaving a context manager.
+
+        Parameters
+        ----------
+        exc_type, exc, tb:
+            Exception information supplied by the runtime; unused.
+        """
+
+        self.close()
+        return None
 
     def request_json(
         self, url: str, *, cfg: ApiCfg, timeout: float | None = None

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -71,105 +71,106 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
-    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
-
-    try:
-        ids_iter = io.read_ids(args.input_csv, column=cfg.activity.column, cfg=cfg.io)
-    except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
-        return 1
-
-    # Apply the ``limit`` without materialising the entire iterator first.
-    # ``itertools.islice`` allows lazy slicing; converting to ``list`` enables
-    # length calculation for logging purposes.
-    ids: Iterable[str] = ids_iter
-    if limit is not None:
-        limited = list(islice(ids_iter, limit))
-        ids = limited
-        logger.info("process_limit", extra={"limit": len(limited)})
-
-    try:
-        df = cl.get_activities(
-            ids,
-            cfg=cfg.api,
-            client=client,
-            chunk_size=cfg.activity.chunk_size,
-            timeout=cfg.activity.timeout,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve activities: %s", exc)
-        return 1
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    df = normalize_activities(df)
-    rows_total = len(df)
-    exit_code = 0
-    required_cols = {
-        name for name, col in ActivitiesSchema.columns.items() if col.required
-    }
-    optional_cols = set(ActivitiesSchema.columns) - required_cols
-    missing_required = required_cols - set(df.columns)
-    missing_optional = optional_cols - set(df.columns)
-    if not missing_required:
-        if missing_optional:
-            logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
-            )
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            df = ActivitiesSchema.validate(df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+            ids_iter = io.read_ids(
+                args.input_csv, column=cfg.activity.column, cfg=cfg.io
             )
-            df = getattr(exc, "validated_data", df)
-            exit_code = 1
-    else:
-        logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
-        )
-    rows_kept = len(df)
-    rows_dropped = rows_total - rows_kept
-    try:
-        key_cols = [c for c in ["activity_id"] if c in df.columns]
-        csv_path = io.write_csv(
-            df,
-            output,
-            cfg=cfg,
-            key_cols=key_cols or None,
-        )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
-    except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
-        return 1
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
 
-    stats: Stats = {
-        "rows_total": rows_total,
-        "rows_kept": rows_kept,
-        "rows_dropped": rows_dropped,
-        "output_sha256": file_sha256(csv_path),
-    }
-    write_meta_yaml(
-        csv_path=csv_path,
-        command=" ".join(sys.argv),
-        config_subset=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
-        stats=stats,
-        schema="ActivitiesSchema",
-    )
+        # Apply the ``limit`` without materialising the entire iterator first.
+        # ``itertools.islice`` allows lazy slicing; converting to ``list`` enables
+        # length calculation for logging purposes.
+        ids: Iterable[str] = ids_iter
+        if limit is not None:
+            limited = list(islice(ids_iter, limit))
+            ids = limited
+            logger.info("process_limit", extra={"limit": len(limited)})
 
-    try:
-        analyze_table_quality(df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
-        return 1
-    return exit_code
+        try:
+            df = cl.get_activities(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=cfg.activity.chunk_size,
+                timeout=cfg.activity.timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("failed to retrieve activities: %s", exc)
+            return 1
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_activities(df)
+        rows_total = len(df)
+        exit_code = 0
+        required_cols = {
+            name for name, col in ActivitiesSchema.columns.items() if col.required
+        }
+        optional_cols = set(ActivitiesSchema.columns) - required_cols
+        missing_required = required_cols - set(df.columns)
+        missing_optional = optional_cols - set(df.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                df = ActivitiesSchema.validate(df, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                df = getattr(exc, "validated_data", df)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
+            )
+        rows_kept = len(df)
+        rows_dropped = rows_total - rows_kept
+        try:
+            key_cols = [c for c in ["activity_id"] if c in df.columns]
+            csv_path = io.write_csv(
+                df,
+                output,
+                cfg=cfg,
+                key_cols=key_cols or None,
+            )
+            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        except OSError as exc:
+            logger.error("failed to write output CSV: %s", exc)
+            return 1
+
+        stats: Stats = {
+            "rows_total": rows_total,
+            "rows_kept": rows_kept,
+            "rows_dropped": rows_dropped,
+            "output_sha256": file_sha256(csv_path),
+        }
+        write_meta_yaml(
+            csv_path=csv_path,
+            command=" ".join(sys.argv),
+            config_subset=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            stats=stats,
+            schema="ActivitiesSchema",
+        )
+
+        try:
+            analyze_table_quality(df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error("failed to generate quality report: %s", exc)
+            return 1
+        return exit_code
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -59,95 +59,96 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Prepare HTTP session for ChEMBL requests
-    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
-
-    try:
-        ids = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
-    except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
-        return 1
-
-    try:
-        df = cl.get_assays(
-            ids,
-            cfg=cfg.api,
-            client=client,
-            chunk_size=cfg.assay.chunk_size,
-            timeout=cfg.assay.timeout,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve assays: %s", exc)
-        return 1
-    df = ap.postprocess_assays(df)
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    df = normalize_assays(df)
-    rows_total = len(df)
-    exit_code = 0
-    required_cols = {name for name, col in AssaysSchema.columns.items() if col.required}
-    optional_cols = set(AssaysSchema.columns) - required_cols
-    missing_required = required_cols - set(df.columns)
-    missing_optional = optional_cols - set(df.columns)
-    if not missing_required:
-        if missing_optional:
-            logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
-            )
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            df = AssaysSchema.validate(df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+            ids = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
+
+        try:
+            df = cl.get_assays(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=cfg.assay.chunk_size,
+                timeout=cfg.assay.timeout,
             )
-            df = getattr(exc, "validated_data", df)
-            exit_code = 1
-    else:
-        logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
-        )
-    rows_kept = len(df)
-    rows_dropped = rows_total - rows_kept
-    try:
-        key_cols = [c for c in ["assay_chembl_id"] if c in df.columns]
-        csv_path = io.write_csv(
-            df,
-            output,
-            cfg=cfg,
-            key_cols=key_cols or None,
-        )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
-    except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
-        return 1
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("failed to retrieve assays: %s", exc)
+            return 1
+        df = ap.postprocess_assays(df)
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_assays(df)
+        rows_total = len(df)
+        exit_code = 0
+        required_cols = {
+            name for name, col in AssaysSchema.columns.items() if col.required
+        }
+        optional_cols = set(AssaysSchema.columns) - required_cols
+        missing_required = required_cols - set(df.columns)
+        missing_optional = optional_cols - set(df.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                df = AssaysSchema.validate(df, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                df = getattr(exc, "validated_data", df)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
+            )
+        rows_kept = len(df)
+        rows_dropped = rows_total - rows_kept
+        try:
+            key_cols = [c for c in ["assay_chembl_id"] if c in df.columns]
+            csv_path = io.write_csv(
+                df,
+                output,
+                cfg=cfg,
+                key_cols=key_cols or None,
+            )
+            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        except OSError as exc:
+            logger.error("failed to write output CSV: %s", exc)
+            return 1
 
-    stats: Stats = {
-        "rows_total": rows_total,
-        "rows_kept": rows_kept,
-        "rows_dropped": rows_dropped,
-        "output_sha256": file_sha256(csv_path),
-    }
-    write_meta_yaml(
-        csv_path=csv_path,
-        command=" ".join(sys.argv),
-        config_subset=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
-        stats=stats,
-        schema="AssaysSchema",
-    )
+        stats: Stats = {
+            "rows_total": rows_total,
+            "rows_kept": rows_kept,
+            "rows_dropped": rows_dropped,
+            "output_sha256": file_sha256(csv_path),
+        }
+        write_meta_yaml(
+            csv_path=csv_path,
+            command=" ".join(sys.argv),
+            config_subset=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            stats=stats,
+            schema="AssaysSchema",
+        )
 
-    try:
-        analyze_table_quality(df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
-        return 1
-    return exit_code
+        try:
+            analyze_table_quality(df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error("failed to generate quality report: %s", exc)
+            return 1
+        return exit_code
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -290,95 +290,96 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Configure session for ChEMBL requests
-    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
-
-    try:
-        ids = io.read_ids(args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io)
-    except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
-        return 1
-
-    try:
-        df = cl.get_documents(
-            ids,
-            cfg=cfg.api,
-            client=client,
-            chunk_size=cfg.document.chembl.chunk_size,
-            timeout=cfg.document.chembl.timeout,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve documents: %s", exc)
-        return 1
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    df = normalize_documents(df)
-    rows_total = len(df)
-    exit_code = 0
-    required_cols = {
-        name for name, col in DocumentsSchema.columns.items() if col.required
-    }
-    optional_cols = set(DocumentsSchema.columns) - required_cols
-    missing_required = required_cols - set(df.columns)
-    missing_optional = optional_cols - set(df.columns)
-    if not missing_required:
-        if missing_optional:
-            logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
-            )
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            df = DocumentsSchema.validate(df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path)
-            logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+            ids = io.read_ids(
+                args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io
             )
-            df = getattr(exc, "validated_data", df)
-            exit_code = 1
-    else:
-        logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
-        )
-    rows_kept = len(df)
-    rows_dropped = rows_total - rows_kept
-    try:
-        key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
-        csv_path = io.write_csv(
-            df,
-            output,
-            cfg=cfg,
-            key_cols=key_cols or None,
-        )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
-    except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
-        return 1
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
 
-    stats_all: Stats = {
-        "rows_total": rows_total,
-        "rows_kept": rows_kept,
-        "rows_dropped": rows_dropped,
-        "output_sha256": file_sha256(csv_path),
-    }
-    write_meta_yaml(
-        csv_path=csv_path,
-        command=" ".join(sys.argv),
-        config_subset=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
-        stats=stats_all,
-        schema="DocumentsSchema",
-    )
-    try:
-        analyze_table_quality(df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
-        return 1
-    return exit_code
+        try:
+            df = cl.get_documents(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=cfg.document.chembl.chunk_size,
+                timeout=cfg.document.chembl.timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("failed to retrieve documents: %s", exc)
+            return 1
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_documents(df)
+        rows_total = len(df)
+        exit_code = 0
+        required_cols = {
+            name for name, col in DocumentsSchema.columns.items() if col.required
+        }
+        optional_cols = set(DocumentsSchema.columns) - required_cols
+        missing_required = required_cols - set(df.columns)
+        missing_optional = optional_cols - set(df.columns)
+        if not missing_required:
+            if missing_optional:
+                logger.warning(
+                    "DataFrame is missing optional columns: %s", missing_optional
+                )
+            try:
+                df = DocumentsSchema.validate(df, lazy=True)
+            except SchemaErrors as exc:
+                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                errors = SidecarErrors()
+                for row in exc.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(exc.failure_cases),
+                    failure_path,
+                )
+                df = getattr(exc, "validated_data", df)
+                exit_code = 1
+        else:
+            logger.warning(
+                "Skipping validation due to missing required columns: %s",
+                missing_required,
+            )
+        rows_kept = len(df)
+        rows_dropped = rows_total - rows_kept
+        try:
+            key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
+            csv_path = io.write_csv(
+                df,
+                output,
+                cfg=cfg,
+                key_cols=key_cols or None,
+            )
+            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        except OSError as exc:
+            logger.error("failed to write output CSV: %s", exc)
+            return 1
+
+        stats: Stats = {
+            "rows_total": rows_total,
+            "rows_kept": rows_kept,
+            "rows_dropped": rows_dropped,
+            "output_sha256": file_sha256(csv_path),
+        }
+        write_meta_yaml(
+            csv_path=csv_path,
+            command=" ".join(sys.argv),
+            config_subset=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            stats=stats,
+            schema="DocumentsSchema",
+        )
+        try:
+            analyze_table_quality(df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error("failed to generate quality report: %s", exc)
+            return 1
+        return exit_code
 
 
 def run_all(cfg: Config, args: argparse.Namespace) -> int:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -358,29 +358,30 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Set up HTTP session with proper headers and retry behaviour
-    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+        try:
+            ids = io.read_ids(
+                args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
 
-    try:
-        ids = io.read_ids(args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io)
-    except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
-        return 1
-
-    try:
-        df = cl.get_targets(
-            ids,
-            cfg=cfg.api,
-            client=client,
-            mapping_cfg=cfg.uniprot_mapping,
-            timeout=cfg.target.chembl.timeout,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve targets: %s", exc)
-        return 1
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    df = normalize_targets(df)
-    rows_total = len(df)
-    exit_code = 0
+        try:
+            df = cl.get_targets(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                mapping_cfg=cfg.uniprot_mapping,
+                timeout=cfg.target.chembl.timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("failed to retrieve targets: %s", exc)
+            return 1
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_targets(df)
+        rows_total = len(df)
+        exit_code = 0
     # Only enforce columns marked as ``required`` in the schema. Optional columns
     # may be absent in the input dataset without preventing validation.
     required_cols = {

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -137,39 +137,40 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     # Initialise HTTP session for subsequent ChEMBL requests
-    client = ChemblClient(cfg.api, cfg.retry, cfg.chembl)
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+        try:
+            # ``read_ids`` returns a generator to minimise memory use. Convert to a
+            # list so we can log the total number of identifiers and iterate over the
+            # values multiple times if needed.
+            ids = list(
+                io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io)
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
 
-    try:
-        # ``read_ids`` returns a generator to minimise memory use.  Convert to a
-        # list so we can log the total number of identifiers and iterate over the
-        # values multiple times if needed.
-        ids = list(io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io))
-    except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
-        return 1
+        logger.info("identifiers_retrieved", extra={"count": len(ids)})
+        logger.info("chembl_fetch_start", extra={"chunk_size": cfg.testitem.chunk_size})
 
-    logger.info("identifiers_retrieved", extra={"count": len(ids)})
-    logger.info("chembl_fetch_start", extra={"chunk_size": cfg.testitem.chunk_size})
-
-    try:
-        df = cl.get_testitem(
-            ids,
-            cfg=cfg.api,
-            client=client,
-            chunk_size=cfg.testitem.chunk_size,
-            timeout=cfg.testitem.timeout,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve compounds: %s", exc)
-        return 1
-    logger.info("chembl_fetch_done", extra={"rows": len(df)})
-    logger.info("pubchem_augment_start")
-    df = add_pubchem_data(df, cfg.pubchem)
-    logger.info("pubchem_augment_done")
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    df = normalize_testitems(df)
-    rows_total = len(df)
-    exit_code = 0
+        try:
+            df = cl.get_testitem(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=cfg.testitem.chunk_size,
+                timeout=cfg.testitem.timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("failed to retrieve compounds: %s", exc)
+            return 1
+        logger.info("chembl_fetch_done", extra={"rows": len(df)})
+        logger.info("pubchem_augment_start")
+        df = add_pubchem_data(df, cfg.pubchem)
+        logger.info("pubchem_augment_done")
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        df = normalize_testitems(df)
+        rows_total = len(df)
+        exit_code = 0
     required_cols = {
         name for name, col in TestitemsSchema.columns.items() if col.required
     }

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -54,6 +54,15 @@ class DummySession:
         return DummyResponse()
 
 
+def test_client_closes_session() -> None:
+    """Using the client as a context manager should close the session."""
+
+    session = MagicMock(spec=requests.Session)
+    with ChemblClient(api_cfg(), RetryCfg(), session=session):
+        pass
+    session.close.assert_called_once()
+
+
 def test_client_sets_user_agent() -> None:
     """Session should include the configured ``User-Agent`` header."""
 


### PR DESCRIPTION
## Summary
- add close, __enter__, and __exit__ methods to ChemblClient
- use ChemblClient as a context manager in data acquisition scripts
- add test ensuring ChemblClient closes its session

## Testing
- `ruff check library/chembl_client.py scripts/get_activity_data.py scripts/get_assay_data.py scripts/get_document_data.py scripts/get_target_data.py scripts/get_testitem_data.py tests/test_chembl_client.py`
- `mypy library/chembl_client.py scripts/get_activity_data.py scripts/get_assay_data.py scripts/get_document_data.py scripts/get_target_data.py scripts/get_testitem_data.py tests/test_chembl_client.py` *(fails: Library stubs not installed for "pandas", "requests", "tabulate" and other issues)*
- `pytest` *(fails: pydantic ValidationError, SystemExit, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c42ae39b8883248072966bca9916ee