### PR TITLE
feat: build config aliases dynamically

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -709,64 +709,68 @@ def print_config(cfg: Config) -> None:
     print(yaml.safe_dump(masked, sort_keys=False))
 
 
-_ALIAS_MAP: dict[str, list[str]] = {
-    "CHEMBL_DA_RPS": ["api", "rps"],
-    "CHEMBL_DA_BURST": ["api", "burst"],
+def build_alias_map(
+    model: type[BaseModel], prefix: str = "CHEMBL_DA"
+) -> dict[str, list[str]]:
+    """Generate environment variable aliases for a Pydantic model.
+
+    Parameters
+    ----------
+    model:
+        Root Pydantic model to inspect.
+    prefix:
+        Alias prefix, defaults to ``"CHEMBL_DA"``.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Mapping of alias names to configuration paths.
+    """
+
+    mapping: dict[str, list[str]] = {}
+
+    def _walk(cls: type[BaseModel], path: list[str]) -> None:
+        for name, field in cls.model_fields.items():
+            sub_path = path + [name]
+            annotation = field.annotation
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                _walk(annotation, sub_path)
+            else:
+                alias = prefix + "_" + "_".join(p.upper() for p in sub_path)
+                mapping[alias] = sub_path
+
+    _walk(model, [])
+    return mapping
+
+
+_ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_BASE": ["api", "chembl_base"],
-    "CHEMBL_DA_TIMEOUT_CONNECT": ["api", "timeout_connect"],
-    "CHEMBL_DA_TIMEOUT_READ": ["api", "timeout_read"],
-    "CHEMBL_DA_OPENALEX_BASE": ["openalex", "base"],
-    "CHEMBL_DA_OPENALEX_TIMEOUT_CONNECT": ["openalex", "timeout_connect"],
-    "CHEMBL_DA_OPENALEX_TIMEOUT_READ": ["openalex", "timeout_read"],
-    "CHEMBL_DA_OPENALEX_RPS": ["openalex", "rps"],
-    "CHEMBL_DA_OPENALEX_BURST": ["openalex", "burst"],
-    "CHEMBL_DA_OPENALEX_MAILTO": ["openalex", "mailto"],
-    "CHEMBL_DA_CROSSREF_BASE": ["crossref", "base"],
-    "CHEMBL_DA_CROSSREF_TIMEOUT_CONNECT": ["crossref", "timeout_connect"],
-    "CHEMBL_DA_CROSSREF_TIMEOUT_READ": ["crossref", "timeout_read"],
-    "CHEMBL_DA_CROSSREF_RPS": ["crossref", "rps"],
-    "CHEMBL_DA_CROSSREF_BURST": ["crossref", "burst"],
-    "CHEMBL_DA_CROSSREF_MAILTO": ["crossref", "mailto"],
-    "CHEMBL_DA_UNIPROT_BASE": ["uniprot", "base"],
-    "CHEMBL_DA_UNIPROT_TIMEOUT_CONNECT": ["uniprot", "timeout_connect"],
-    "CHEMBL_DA_UNIPROT_TIMEOUT_READ": ["uniprot", "timeout_read"],
-    "CHEMBL_DA_UNIPROT_RPS": ["uniprot", "rps"],
-    "CHEMBL_DA_UNIPROT_BURST": ["uniprot", "burst"],
-    "CHEMBL_DA_UNIPROT_MAPPING_BASE": ["uniprot_mapping", "base"],
-    "CHEMBL_DA_UNIPROT_MAPPING_POLL_INTERVAL": ["uniprot_mapping", "poll_interval"],
-    "CHEMBL_DA_UNIPROT_MAPPING_TIMEOUT": ["uniprot_mapping", "timeout"],
-    "CHEMBL_DA_IUPHAR_BASE": ["iuphar", "base"],
-    "CHEMBL_DA_IUPHAR_TIMEOUT_CONNECT": ["iuphar", "timeout_connect"],
-    "CHEMBL_DA_IUPHAR_TIMEOUT_READ": ["iuphar", "timeout_read"],
-    "CHEMBL_DA_IUPHAR_RPS": ["iuphar", "rps"],
-    "CHEMBL_DA_IUPHAR_BURST": ["iuphar", "burst"],
-    "CHEMBL_DA_PUBCHEM_BASE": ["pubchem", "base"],
-    "CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT": ["pubchem", "timeout_connect"],
-    "CHEMBL_DA_PUBCHEM_TIMEOUT_READ": ["pubchem", "timeout_read"],
-    "CHEMBL_DA_PUBCHEM_RPS": ["pubchem", "rps"],
-    "CHEMBL_DA_PUBCHEM_BURST": ["pubchem", "burst"],
-    "CHEMBL_DA_CACHE_TTL": ["chembl", "cache_ttl"],
-    "CHEMBL_DA_CACHE_MAXSIZE": ["chembl", "cache_maxsize"],
-    "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
+    "CHEMBL_DA_BURST": ["api", "burst"],
     "CHEMBL_DA_CACHE_DIR": ["io", "cache_dir"],
-    "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],
-    "CHEMBL_DA_IUPHAR_TARGET_CSV": ["resources", "iuphar_target_csv"],
-    "CHEMBL_DA_IUPHAR_FAMILY_CSV": ["resources", "iuphar_family_csv"],
-    "CHEMBL_DA_UNIPROT_DATA_DIR": ["resources", "uniprot_data_dir"],
-    "CHEMBL_DA_ORGANISM_CSV": ["resources", "organism_csv"],
-    "CHEMBL_DA_STATUS_CSV": ["resources", "status_csv"],
-    "CHEMBL_DA_TARGETS_TYPE_CSV": ["resources", "targets_type_csv"],
-    "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
+    "CHEMBL_DA_CACHE_MAXSIZE": ["chembl", "cache_maxsize"],
+    "CHEMBL_DA_CACHE_TTL": ["chembl", "cache_ttl"],
     "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],
-    "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
+    "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
+    "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],
     "CHEMBL_DA_GLOBAL_BURST": ["rate", "global_burst"],
+    "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
+    "CHEMBL_DA_IUPHAR_FAMILY_CSV": ["resources", "iuphar_family_csv"],
+    "CHEMBL_DA_IUPHAR_TARGET_CSV": ["resources", "iuphar_target_csv"],
     "CHEMBL_DA_LIMITER_CACHE_MAXSIZE": ["rate", "limiter_cache_maxsize"],
     "CHEMBL_DA_LIMITER_CACHE_TTL": ["rate", "limiter_cache_ttl"],
-    "CHEMBL_DA_LOG_LEVEL": ["log", "level"],
-    "CHEMBL_DA_LOG_FORMAT": ["log", "format"],
-    "CHEMBL_DA_LOG_DATEFMT": ["log", "datefmt"],
-    "CHEMBL_DA_RETRY_MAX_ATTEMPTS": ["retry", "max_attempts"],
-    "CHEMBL_DA_RETRY_BACKOFF_FACTOR": ["retry", "backoff_factor"],
+    "CHEMBL_DA_ORGANISM_CSV": ["resources", "organism_csv"],
+    "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
+    "CHEMBL_DA_RPS": ["api", "rps"],
+    "CHEMBL_DA_STATUS_CSV": ["resources", "status_csv"],
+    "CHEMBL_DA_TARGETS_TYPE_CSV": ["resources", "targets_type_csv"],
+    "CHEMBL_DA_TIMEOUT_CONNECT": ["api", "timeout_connect"],
+    "CHEMBL_DA_TIMEOUT_READ": ["api", "timeout_read"],
+    "CHEMBL_DA_UNIPROT_DATA_DIR": ["resources", "uniprot_data_dir"],
+}
+
+_ALIAS_MAP: dict[str, list[str]] = {
+    **build_alias_map(Config),
+    **_ALIAS_OVERRIDES,
 }
 
 
@@ -810,4 +814,5 @@ __all__ = [
     "ensure_dirs",
     "load_config",
     "print_config",
+    "build_alias_map",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,16 @@ import logging
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from library.cli import LoggerConfig, configure_logger
-from library.config import ConfigError, ensure_dirs, load_config
+from library.config import (
+    Config,
+    ConfigError,
+    build_alias_map,
+    ensure_dirs,
+    load_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -396,6 +402,19 @@ def test_unknown_env_var_warning(
     record = json.loads(lines[-1])
     msg = record.get("msg", "") or record.get("event", "")
     assert "Environment variable CHEMBL_DA__FOO__BAR ignored" in msg
+
+
+def test_new_field_auto_alias() -> None:
+    """Adding a field to the config should expose an alias automatically."""
+
+    class Extra(BaseModel):
+        foo: int = 1
+
+    class ExtendedConfig(Config):
+        extra: Extra = Field(default_factory=Extra)
+
+    aliases = build_alias_map(ExtendedConfig)
+    assert aliases["CHEMBL_DA_EXTRA_FOO"] == ["extra", "foo"]
 
 
 def test_log_level_valid(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- generate alias mappings from the Config model
- retain manual overrides for non-standard environment variables
- test that new model fields automatically expose aliases

## Testing
- `SKIP=pytest pre-commit run --files library/config.py tests/test_config.py`
- `pytest tests/test_config.py::test_alias_env_overrides tests/test_config.py::test_new_field_auto_alias`


------
https://chatgpt.com/codex/tasks/task_e_68c42b048da48324a33443b37dd70ff6