### PR TITLE
test: import responses after pytest

### DIFF
--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-
+import pytest
 import requests
 import responses
-
-import pytest
-
-
-responses = pytest.importorskip("responses")
 
 from library import pubchem_library as pl  # noqa: E402
 from library import rate_limiter as rl  # noqa: E402
@@ -35,7 +30,7 @@ def test_get_cid_from_smiles_uses_base() -> None:
 
 
 @responses.activate
-def test_make_request_uses_timeout(monkeypatch) -> None:
+def test_make_request_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """`make_request` passes configured timeouts to the session."""
     called: dict[str, tuple[int, int]] = {}
 
@@ -60,7 +55,6 @@ def test_make_request_uses_timeout(monkeypatch) -> None:
     )
     pl._CACHE.clear()
 
-
     cfg = pl.PubChemCfg(timeout_connect=1, timeout_read=2, retries=1, rps=1)
 
     responses.add(responses.GET, "https://example.org", json={}, status=200)
@@ -68,7 +62,7 @@ def test_make_request_uses_timeout(monkeypatch) -> None:
     assert called["timeout"] == (1, 2)
 
 
-def test_make_request_rate_limited(monkeypatch) -> None:
+def test_make_request_rate_limited(monkeypatch: pytest.MonkeyPatch) -> None:
     """``make_request`` should pause when RPS is exceeded."""
 
     class FakeTime:


### PR DESCRIPTION
## Summary
- remove pytest.importorskip for responses and place responses import after pytest
- annotate monkeypatch fixtures with pytest.MonkeyPatch

## Testing
- `ruff format tests/test_pubchem_library.py`
- `ruff check tests/test_pubchem_library.py`
- `pytest tests/test_pubchem_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c42fcecab08324bdc62f2d46f4184a