### PR TITLE
test: use config fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,22 @@
-"""Test configuration."""
+"""Test configuration fixtures.
+
+This module provides common pytest fixtures used across the test suite.
+"""
 
 from __future__ import annotations
+
+import pytest
+
+from library.config import ApiCfg, Config
+
+
+@pytest.fixture()
+def cfg() -> Config:
+    """Return a baseline :class:`~library.config.Config` instance for tests.
+
+    The configuration requires a valid ``api.user_agent`` value; the fixture
+    supplies a deterministic placeholder address so that individual tests do
+    not need to construct :class:`Config` instances manually.
+    """
+
+    return Config(api=ApiCfg(user_agent="test@example.org"))

--- a/tests/test_activity_cli_dry_run_no_input.py
+++ b/tests/test_activity_cli_dry_run_no_input.py
@@ -10,14 +10,13 @@ from library.config import Config
 from scripts import get_activity_data as gad
 
 
-def test_dry_run_no_input(tmp_path: Path) -> None:
+def test_dry_run_no_input(tmp_path: Path, cfg: Config) -> None:
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
     args = argparse.Namespace(
         input_csv=Path("missing.csv"),
         output_csv=None,
     )
-    cfg = Config()
     cfg.activity.limit = 5
     cfg.activity.dry_run = True
     rc = gad.run_chembl(cfg, args)

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -12,7 +12,7 @@ from library.config import Config
 from scripts import get_activity_data as gad
 
 
-def test_run_chembl_handles_request_error(monkeypatch) -> None:
+def test_run_chembl_handles_request_error(monkeypatch, cfg: Config) -> None:
     args = argparse.Namespace(
         input_csv=Path("dummy.csv"),
         output_csv=None,
@@ -32,7 +32,7 @@ def test_run_chembl_handles_request_error(monkeypatch) -> None:
     monkeypatch.setattr(cl, "get_activities", _raise)
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
-    result = gad.run_chembl(Config(), args)
+    result = gad.run_chembl(cfg, args)
     assert result == 1
     lines = buf.getvalue().splitlines()
     assert lines

--- a/tests/test_cli_option_order.py
+++ b/tests/test_cli_option_order.py
@@ -13,7 +13,7 @@ from scripts import get_target_data as gtd
 
 
 def test_target_input_before_subcommand(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     """Options provided before the sub-command should be honoured."""
     input_csv = tmp_path / "targets.csv"
@@ -30,7 +30,7 @@ def test_target_input_before_subcommand(
         *,
         base_parser: argparse.ArgumentParser | None = None,
     ) -> Config:
-        return Config()
+        return cfg
 
     def fake_run_all(cfg: Config, args: argparse.Namespace) -> int:
         captured["input_csv"] = Path(args.input_csv)
@@ -45,7 +45,7 @@ def test_target_input_before_subcommand(
 
 
 def test_document_input_before_subcommand(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     """Global options before the sub-command work for document CLI."""
     input_csv = tmp_path / "docs.csv"
@@ -62,7 +62,7 @@ def test_document_input_before_subcommand(
         *,
         base_parser: argparse.ArgumentParser | None = None,
     ) -> Config:
-        return Config()
+        return cfg
 
     def fake_run(cfg: Config, args: argparse.Namespace) -> int:
         captured["input_csv"] = Path(args.input_csv)

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -32,7 +32,7 @@ def _create_config(tmp_path: Path) -> Path:
     return cfg
 
 
-def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
+def test_assay_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
     input_csv = tmp_path / "assay.csv"
     input_csv.write_text("assay_chembl_id\na1\n")
     config_path = _create_config(tmp_path)
@@ -40,7 +40,6 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["a1"])
 
     def fake_apply(a, p, c, mapping=None):
-        cfg = Config()
         cfg.assay.timeout = float(a.timeout)
         return cfg
 
@@ -69,7 +68,7 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch) -> None:
     assert called["timeout"] == 5
 
 
-def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
+def test_document_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
     input_csv = tmp_path / "doc.csv"
     input_csv.write_text("document_chembl_id\nd1\n")
     config_path = _create_config(tmp_path)
@@ -78,7 +77,6 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["d1"])
 
     def fake_apply_doc(a, p, c, mapping=None, **kwargs):
-        cfg = Config()
         cfg.document.chembl.timeout = float(a.timeout)
         cfg.api.user_agent = "test/0.1 (mailto:test@example.com)"
         return cfg
@@ -108,7 +106,7 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch) -> None:
     assert called["timeout"] == 7
 
 
-def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
+def test_testitem_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
     input_csv = tmp_path / "testitem.csv"
     input_csv.write_text("molecule_chembl_id\nt1\n")
     config_path = _create_config(tmp_path)
@@ -117,7 +115,6 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
 
     def fake_apply_test(a, p, c, mapping=None):
-        cfg = Config()
         cfg.testitem.timeout = float(a.timeout)
         return cfg
 
@@ -146,7 +143,7 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
     assert called["timeout"] == 9
 
 
-def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
+def test_target_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
     input_csv = tmp_path / "target.csv"
     input_csv.write_text("chembl_id\nt1\n")
     config_path = _create_config(tmp_path)
@@ -155,7 +152,6 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
 
     def fake_apply_target(a, p, c, mapping=None):
-        cfg = Config()
         cfg.target.chembl.timeout = float(a.timeout)
         return cfg
 

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -19,12 +19,11 @@ def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:
 
 
 def test_mapper_run_defaults_to_io_output_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     input_path = tmp_path / "data.csv"
     input_path.write_text("chembl_id\nCHEMBL1\n")
 
-    cfg = Config()
     cfg.io.output_dir = tmp_path / "results"
 
     args = argparse.Namespace(

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -13,12 +13,11 @@ from scripts import get_activity_data as gad
 
 
 def test_run_chembl_respects_limit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     input_csv = tmp_path / "activity.csv"
     input_csv.write_text("activity_id\n1\n2\n3\n")
 
-    cfg = Config()
     cfg.activity.limit = 2
     args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
 
@@ -57,12 +56,11 @@ def test_run_chembl_respects_limit(
 
 
 def test_run_chembl_limit_dry_run(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     input_csv = tmp_path / "activity.csv"
     input_csv.write_text("activity_id\n1\n2\n3\n")
 
-    cfg = Config()
     cfg.activity.limit = 2
     cfg.activity.dry_run = True
     args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")

--- a/tests/test_init_session_retry.py
+++ b/tests/test_init_session_retry.py
@@ -19,7 +19,7 @@ from library.config import Config
     ],
 )
 def test_init_session_uses_cfg_retry(
-    module_name: str, func_name: str, monkeypatch: pytest.MonkeyPatch
+    module_name: str, func_name: str, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     """Ensure CLI scripts use retry settings from :class:`Config`.
 
@@ -29,7 +29,6 @@ def test_init_session_uses_cfg_retry(
     """
 
     module = import_module(module_name)
-    cfg = Config()
     captured: dict[str, object] = {}
 
     class FakeClient:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -76,10 +76,9 @@ def test_read_csv_types_and_na_values() -> None:
     assert pd.isna(df.loc[2, "count"])  # custom NA token
 
 
-def test_write_csv_creates_metadata_file(tmp_path: Path) -> None:
+def test_write_csv_creates_metadata_file(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1]})
     path = tmp_path / "out.csv"
-    cfg = Config()
     io.write_csv(df, path, cfg=cfg)
     meta_files = list(tmp_path.glob("*.meta.yaml"))
     assert path.exists()
@@ -87,10 +86,9 @@ def test_write_csv_creates_metadata_file(tmp_path: Path) -> None:
     assert meta_files[0].exists()
 
 
-def test_write_meta_serialises_paths(tmp_path: Path) -> None:
+def test_write_meta_serialises_paths(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1]})
     path = tmp_path / "out.csv"
-    cfg = Config()
     io.write_csv(df, path, cfg=cfg)
 
     meta_path = Path(f"{path}.meta.yaml")
@@ -99,10 +97,9 @@ def test_write_meta_serialises_paths(tmp_path: Path) -> None:
     assert meta["config"]["io"]["output_dir"] == str(cfg.io.output_dir)
 
 
-def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
+def test_write_csv_deterministic_hash(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"b": [3, 1], "a": [4.0, 2.0]})
     path = tmp_path / "out.csv"
-    cfg = Config()
     io.write_csv(df, path, cfg=cfg)
     first_hash = hashlib.sha256(path.read_bytes()).hexdigest()
     shuffled = df.sample(frac=1).reset_index(drop=True)[["b", "a"]]
@@ -111,10 +108,9 @@ def test_write_csv_deterministic_hash(tmp_path: Path) -> None:
     assert first_hash == second_hash
 
 
-def test_write_csv_with_key_cols(tmp_path: Path) -> None:
+def test_write_csv_with_key_cols(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [2, 1], "b": ["x", "y"]})
     path = tmp_path / "out.csv"
-    cfg = Config()
     io.write_csv(df, path, cfg=cfg, key_cols=["a"])
     first_hash = hashlib.sha256(path.read_bytes()).hexdigest()
     shuffled = df.sample(frac=1).reset_index(drop=True)
@@ -138,15 +134,14 @@ def test_read_ids_custom_na_marker(tmp_path: Path) -> None:
     assert ids == ["1", "2"]
 
 
-def test_write_csv_missing_key_column(tmp_path: Path) -> None:
+def test_write_csv_missing_key_column(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1], "b": [2]})
     path = tmp_path / "out.csv"
-    cfg = Config()
     with pytest.raises(ValueError, match="Missing key columns: \['c'\]"):
         io.write_csv(df, path, cfg=cfg, key_cols=["c"])
 
 
-def test_write_csv_normalises_types(tmp_path: Path) -> None:
+def test_write_csv_normalises_types(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame(
         {
             "b": [True, False],
@@ -154,13 +149,12 @@ def test_write_csv_normalises_types(tmp_path: Path) -> None:
         }
     )
     path = tmp_path / "out.csv"
-    cfg = Config()
     io.write_csv(df, path, cfg=cfg, key_cols=["d"])
     text = path.read_text(encoding="utf-8-sig")
     assert text == ("b,d\nfalse,2020-01-01\ntrue,2020-01-02\n")
 
 
-def test_write_csv_chunksize(tmp_path: Path) -> None:
+def test_write_csv_chunksize(tmp_path: Path, cfg: Config) -> None:
     """Chunked writes yield the same output as unchunked writes."""
 
     rows = 1500
@@ -172,7 +166,6 @@ def test_write_csv_chunksize(tmp_path: Path) -> None:
             "f": [i / 3 for i in range(rows)],
         }
     )
-    cfg = Config()
     path1 = tmp_path / "plain.csv"
     path2 = tmp_path / "chunked.csv"
     io.write_csv(df, path1, cfg=cfg)

--- a/tests/test_mapper_logging.py
+++ b/tests/test_mapper_logging.py
@@ -27,7 +27,9 @@ def test_mapper_library_has_no_logging_side_effect() -> None:
     assert not root.handlers
 
 
-def test_mapper_main_logs_mapping(tmp_path: Path, monkeypatch: Any) -> None:
+def test_mapper_main_logs_mapping(
+    tmp_path: Path, monkeypatch: Any, cfg: Config
+) -> None:
     """Mapper CLI emits structured mapping log records."""
 
     def fake_map(cid: str, cfg: object) -> str | None:
@@ -48,11 +50,12 @@ def test_mapper_main_logs_mapping(tmp_path: Path, monkeypatch: Any) -> None:
     buffer = io.StringIO()
     configure_logger(LoggerConfig(stream=buffer, level="INFO"))
 
-    base_cfg = Config()
-    cfg = SimpleNamespace(
-        io=base_cfg.io, uniprot_mapping=base_cfg.uniprot_mapping, to_dict=lambda: {}
+    cfg_ns = SimpleNamespace(
+        io=cfg.io,
+        uniprot_mapping=cfg.uniprot_mapping,
+        to_dict=lambda: {},
     )
-    exit_code = mapper_main.run(cfg, args)
+    exit_code = mapper_main.run(cfg_ns, args)
     assert exit_code == 0
     records = [json.loads(line) for line in buffer.getvalue().splitlines()]
     mapped = [r for r in records if r["event"] == "mapped"]

--- a/tests/test_mapper_run_exception.py
+++ b/tests/test_mapper_run_exception.py
@@ -9,7 +9,7 @@ from library.cli import LoggerConfig, configure_logger
 from library.config import Config
 
 
-def test_run_logs_exception(monkeypatch, tmp_path: Path) -> None:
+def test_run_logs_exception(monkeypatch, tmp_path: Path, cfg: Config) -> None:
     """Uncaught exceptions in run are logged and return non-zero."""
 
     def bad_read(*args, **kwargs):
@@ -18,9 +18,10 @@ def test_run_logs_exception(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(mapper_main.io, "read_csv", bad_read)
     buffer = io.StringIO()
     configure_logger(LoggerConfig(stream=buffer, level="INFO"))
-    base_cfg = Config()
-    cfg = SimpleNamespace(
-        io=base_cfg.io, uniprot_mapping=base_cfg.uniprot_mapping, to_dict=lambda: {}
+    cfg_ns = SimpleNamespace(
+        io=cfg.io,
+        uniprot_mapping=cfg.uniprot_mapping,
+        to_dict=lambda: {},
     )
     args = argparse.Namespace(
         input_csv=tmp_path / "in.csv",
@@ -30,7 +31,7 @@ def test_run_logs_exception(monkeypatch, tmp_path: Path) -> None:
         encoding="utf8",
         key_cols=None,
     )
-    exit_code = mapper_main.run(cfg, args)
+    exit_code = mapper_main.run(cfg_ns, args)
     assert exit_code == 1
     records = [json.loads(line) for line in buffer.getvalue().splitlines()]
     assert any(

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -115,7 +115,7 @@ def test_finalise_targets_filters_duplicates_and_merges() -> None:
     assert out["transmembrane"].dtype == "boolean"
 
 
-def test_finalise_file_roundtrip(tmp_path: Path) -> None:
+def test_finalise_file_roundtrip(tmp_path: Path, cfg: Config) -> None:
     """``finalise_file`` reads, processes and writes the expected table."""
 
     df = pd.DataFrame(
@@ -135,7 +135,6 @@ def test_finalise_file_roundtrip(tmp_path: Path) -> None:
     organism.to_csv(organism_path, index=False)
     output_path = tmp_path / "out.csv"
 
-    cfg = Config()
     cfg.resources.organism_csv = organism_path
     tp.finalise_file(input_path, output_path, cfg=cfg)
 


### PR DESCRIPTION
## Summary
- add cfg fixture providing default Config with user-agent
- use cfg fixture instead of Config() across tests

## Testing
- `pre-commit run --files tests/conftest.py tests/test_activity_cli_dry_run_no_input.py tests/test_activity_cli_error.py tests/test_cli_option_order.py tests/test_cli_timeout_override.py tests/test_default_output_dir.py tests/test_get_activity_data.py tests/test_init_session_retry.py tests/test_io.py tests/test_mapper_logging.py tests/test_mapper_run_exception.py tests/test_target_postprocessing.py`
- `pytest --maxfail=1` *(fails: test_dry_run_no_input - AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68c4300622ec832498bbbf4c86e8e369