### PR TITLE
Avoid duplicating existing fields when merging IUPHAR data

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -659,10 +659,17 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         iuphar_df = pd.read_csv(
             iuphar_out, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
         )
-        existing_cols = set(chembl_df.columns) | set(uniprot_df.columns)
+        # ``combined_df`` already contains the consolidated data from
+        # ChEMBL and UniProt, including helper fields like ``synonyms``,
+        # ``ec_number`` and ``gene_name``. Build the set of existing
+        # columns from this frame to avoid reintroducing those fields
+        # when selecting IUPHAR classification columns.
+        existing_cols = set(combined_df.columns)
         classification_cols = [c for c in iuphar_df.columns if c not in existing_cols]
 
-        iuphar_df = iuphar_df[["uniprot_id", *classification_cols]]
+        # Recreate the IUPHAR frame with only the new classification
+        # columns before merging.
+        iuphar_df = iuphar_df[["uniprot_id", *classification_cols]].copy()
 
         merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
         # Apply domain-specific clean-up and finalise table before exporting

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -1,0 +1,38 @@
+"""Tests for merging IUPHAR classifications with existing target data."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def test_iuphar_merge_preserves_ec_number() -> None:
+    """Ensure merging does not duplicate the ``ec_number`` column."""
+    combined_df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P12345"],
+            "ec_number": ["1.1.1.1"],
+            "synonyms": ["foo"],
+            "gene_name": ["GN1"],
+        }
+    )
+    iuphar_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P12345"],
+            "class_a": ["Enzyme"],
+            "synonyms": ["bar"],
+            "ec_number": ["2.2.2.2"],
+            "gene_name": ["GN1"],
+        }
+    )
+
+    existing_cols = set(combined_df.columns)
+    classification_cols = [c for c in iuphar_df.columns if c not in existing_cols]
+    iuphar_df = iuphar_df[["uniprot_id", *classification_cols]].copy()
+
+    merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+
+    assert "ec_number" in merged.columns
+    assert "ec_number_x" not in merged.columns
+    assert "ec_number_y" not in merged.columns
+    assert merged.loc[0, "ec_number"] == "1.1.1.1"


### PR DESCRIPTION
## Summary
- Ensure IUPHAR classification merge filters out pre-existing columns from ChEMBL/UniProt data
- Add regression test to confirm `ec_number` column is not duplicated

## Testing
- `pre-commit run --files scripts/get_target_data.py tests/test_get_target_data_merge.py`
- `pytest tests/test_get_target_data_merge.py`


------
https://chatgpt.com/codex/tasks/task_e_68c43370d3a08324912b1719147817ce