### PR TITLE
Use target_chembl_id as default target column

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ python scripts/get_target_data.py chembl \
     --log-level INFO
 ```
 
-Replace ``path/to/targets.csv`` with a CSV containing a ``chembl_id``
+Replace ``path/to/targets.csv`` with a CSV containing a ``target_chembl_id``
 column.
- 
-The generated output will expose the same identifiers under the column
-``target_chembl_id`` to align with validation schemas.
+
+The input and output both use ``target_chembl_id`` to align with
+validation schemas.
  
 ### scripts/get_activities.py
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -957,7 +957,7 @@
         "chembl": {
           "$ref": "#/$defs/TargetChemblCfg",
           "default": {
-            "column": "chembl_id",
+            "column": "target_chembl_id",
             "timeout": 30.0
           }
         },
@@ -1421,7 +1421,7 @@
           "data_dir": "dictionary/uniprot"
         },
         "chembl": {
-          "column": "chembl_id",
+          "column": "target_chembl_id",
           "timeout": 30.0
         },
         "iuphar": {

--- a/config.yaml
+++ b/config.yaml
@@ -142,7 +142,7 @@ target:
     column: "uniprot_id"
     data_dir: "dictionary/uniprot"
   chembl:
-    column: "chembl_id"
+    column: "target_chembl_id"
     timeout: 30.0
   iuphar:
     target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"

--- a/data/input-smoke/targets.csv
+++ b/data/input-smoke/targets.csv
@@ -1,4 +1,4 @@
-chembl_id
+target_chembl_id
 CHEMBL4354
 CHEMBL247
 CHEMBL3332

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,9 +38,10 @@ The input CSV must include a ``document_chembl_id`` column.
 
 ```bash
 python scripts/get_target_data.py \
-    --input data/input-smoke/targets.csv \
-    --column target_chembl_id
+    --input data/input-smoke/targets.csv
 ```
+
+The input CSV must include a ``target_chembl_id`` column.
 
 ## Test item data enrichment
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -132,7 +132,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     chembl.add_argument(
         "--column",
-        default="chembl_id",
+        default="target_chembl_id",
         help="Column name in the input CSV containing identifiers",
     )
     chembl.add_argument(

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -148,7 +148,7 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch) -> None:
 
 def test_target_timeout_override(tmp_path: Path, monkeypatch) -> None:
     input_csv = tmp_path / "target.csv"
-    input_csv.write_text("chembl_id\nt1\n")
+    input_csv.write_text("target_chembl_id\nt1\n")
     config_path = _create_config(tmp_path)
     called: dict[str, float] = {}
 


### PR DESCRIPTION
## Summary
- expect `target_chembl_id` column when fetching target data
- update configuration, schema, docs, and sample data accordingly
- adjust tests for new default target column

## Testing
- `black scripts/get_target_data.py tests/test_cli_timeout_override.py`
- `ruff check scripts/get_target_data.py tests/test_cli_timeout_override.py`
- `mypy scripts/get_target_data.py tests/test_cli_timeout_override.py` *(fails: missing library stubs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68c43397a71483248b20af0800947c77