### PR TITLE
feat: add column name parameters for target postprocessing

### DIFF
--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -128,7 +128,9 @@ def _validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
         raise ValueError(f"missing required columns: {', '.join(sorted(missing))}")
 
 
-def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
+def postprocess_targets(
+    df: pd.DataFrame, *, chembl_col: str = "target_chembl_id"
+) -> pd.DataFrame:
     """Clean and reshape merged target information.
 
     The function normalises UniProt identifiers, resolves gene names and
@@ -140,6 +142,10 @@ def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
     df:
         DataFrame produced by the ``all`` pipeline in
         :mod:`get_target_data`.
+    chembl_col:
+        Name of the column containing ChEMBL target identifiers. The input
+        column will be preserved in the returned DataFrame. Defaults to
+        ``"target_chembl_id"``.
 
     Returns
     -------
@@ -153,6 +159,9 @@ def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
 
     """
     df = df.copy()
+    internal_id = "target_chembl_id"
+    if chembl_col in df.columns and chembl_col != internal_id:
+        df = df.rename(columns={chembl_col: internal_id})
 
     # --- normalise identifiers -------------------------------------------------
     df["uniprotkb_Id"] = (
@@ -235,7 +244,7 @@ def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- final column ordering --------------------------------------------------
     columns = [
-        "target_chembl_id",
+        internal_id,
         "uniprotkb_Id",
         "uniprot_id",
         "secondary_uniprot_id",
@@ -287,7 +296,7 @@ def postprocess_targets(df: pd.DataFrame) -> pd.DataFrame:
     for col in columns:
         if col not in df.columns:
             df[col] = "-"
-    return df[columns]
+    return df[columns].rename(columns={internal_id: chembl_col})
 
 
 def postprocess_file(
@@ -295,6 +304,7 @@ def postprocess_file(
     output_path: Path | str,
     *,
     cfg: IoCfg,
+    chembl_col: str = "target_chembl_id",
     sep: str | None = None,
     encoding: str | None = None,
 ) -> None:
@@ -308,6 +318,9 @@ def postprocess_file(
         Destination path for the cleaned CSV file.
     cfg:
         I/O configuration providing default CSV parameters.
+    chembl_col:
+        Name of the column containing ChEMBL target identifiers. Passed to
+        :func:`postprocess_targets`.
     sep:
         Field delimiter of the CSV files. Defaults to ``cfg.csv_sep``.
     encoding:
@@ -322,11 +335,18 @@ def postprocess_file(
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
-    processed = postprocess_targets(df)
+    processed = postprocess_targets(df, chembl_col=chembl_col)
     processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)
 
 
-def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
+def finalise_targets(
+    df: pd.DataFrame,
+    organism: pd.DataFrame,
+    *,
+    chembl_col: str = "target_chembl_id",
+    uniprot_col: str = "uniprotkb_Id",
+    genus_col: str = "genus",
+) -> pd.DataFrame:
     """Apply final cleaning steps and organism merge.
 
     This function mirrors a Power Query script that was previously used to
@@ -340,6 +360,13 @@ def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
         DataFrame produced by :func:`postprocess_targets`.
     organism:
         Lookup table with at least ``genus`` and ``type`` columns.
+    chembl_col:
+        Column containing ChEMBL target identifiers.
+    uniprot_col:
+        Column containing UniProt identifiers.
+    genus_col:
+        Column containing the organism genus used for merging with
+        ``organism``.
 
     Returns
     -------
@@ -347,10 +374,21 @@ def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
         Cleaned table ready for export.
 
     """
+    df = df.copy()
+    organism = organism.copy()
+
+    internal_mapping = {
+        chembl_col: "target_chembl_id",
+        uniprot_col: "uniprotkb_Id",
+        genus_col: "genus",
+    }
+    df = df.rename(columns={k: v for k, v in internal_mapping.items() if k != v})
+    organism = organism.rename(
+        columns={genus_col: "genus"} if genus_col != "genus" else {}
+    )
+
     _validate_columns(df, ["target_chembl_id", "uniprotkb_Id", "genus"])
     _validate_columns(organism, ["genus", "type"])
-
-    df = df.copy()
 
     # Drop rows where uniprotkb_Id is the string "nan"
     mask_nan = df["uniprotkb_Id"].astype(str) == "nan"
@@ -361,7 +399,7 @@ def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
     # Remove duplicate chembl_id entries
     before = len(df)
     df = df.drop_duplicates(subset="target_chembl_id", keep="first")
-    logger.debug("Removed %d duplicate target_chembl_id rows", before - len(df))
+    logger.debug("Removed %d duplicate %s rows", before - len(df), chembl_col)
 
     # Enforce column types
     for col in TEXT_COLUMNS:
@@ -392,7 +430,13 @@ def finalise_targets(df: pd.DataFrame, organism: pd.DataFrame) -> pd.DataFrame:
         if col in df.columns:
             df[col] = df[col].astype("string").str.lower()
 
-    return df
+    return df.rename(
+        columns={
+            "target_chembl_id": chembl_col,
+            "uniprotkb_Id": uniprot_col,
+            "genus": genus_col,
+        }
+    )
 
 
 def finalise_file(
@@ -400,6 +444,9 @@ def finalise_file(
     output_path: Path | str,
     *,
     cfg: Config,
+    chembl_col: str = "target_chembl_id",
+    uniprot_col: str = "uniprotkb_Id",
+    genus_col: str = "genus",
     organism_path: Path | str | None = None,
     sep: str | None = None,
     encoding: str | None = None,
@@ -414,6 +461,12 @@ def finalise_file(
         Destination path for the cleaned CSV file.
     cfg:
         Application configuration providing CSV defaults and resource paths.
+    chembl_col:
+        Column containing ChEMBL target identifiers.
+    uniprot_col:
+        Column containing UniProt identifiers.
+    genus_col:
+        Column containing the organism genus used for merging.
     organism_path:
         Optional path to a CSV containing organism ``genus`` and ``type`` columns.
         Defaults to ``cfg.resources.organism_csv``.
@@ -428,5 +481,11 @@ def finalise_file(
     organism_path = organism_path or cfg.resources.organism_csv
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     organism = pd.read_csv(organism_path, sep=sep, encoding=encoding, dtype=str)
-    processed = finalise_targets(df, organism)
+    processed = finalise_targets(
+        df,
+        organism,
+        chembl_col=chembl_col,
+        uniprot_col=uniprot_col,
+        genus_col=genus_col,
+    )
     processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -39,7 +39,7 @@ def test_postprocess_targets_merges_and_normalises() -> None:
             "ec_code": ["2.2.2.2"],
         }
     )
-    out = tp.postprocess_targets(df)
+    out = tp.postprocess_targets(df, chembl_col="chembl_id")
 
     row = out.iloc[0]
     assert row["uniprotkb_Id"] == "P12345"
@@ -81,9 +81,9 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
     df.to_csv(input_path, index=False, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
     output_path = tmp_path / "out.csv"
 
-    tp.postprocess_file(input_path, output_path, cfg=cfg)
+    tp.postprocess_file(input_path, output_path, cfg=cfg, chembl_col="chembl_id")
 
-    expected = tp.postprocess_targets(df).astype(str)
+    expected = tp.postprocess_targets(df, chembl_col="chembl_id").astype(str)
     result = pd.read_csv(
         output_path, dtype=str, sep=cfg.csv_sep, encoding=cfg.csv_encoding
     )
@@ -96,22 +96,29 @@ def test_finalise_targets_filters_duplicates_and_merges() -> None:
     df = pd.DataFrame(
         {
             "chembl_id": ["CHEMBL1", "CHEMBL1", "CHEMBL2"],
-            "uniprotkb_Id": ["P12345", "P12345", "nan"],
-            "genus": ["Homo", "Homo", "Mus"],
+            "uniprot": ["P12345", "P12345", "nan"],
+            "organism": ["Homo", "Homo", "Mus"],
             "isoform_names": ["IsoA", "IsoB", "IsoC"],
             "synonyms": ["SynA", "SynB", "SynC"],
             "SUPFAM": ["s1", "s2", "s3"],
             "transmembrane": ["True", "True", "False"],
         }
     )
-    organism = pd.DataFrame({"genus": ["Homo"], "type": ["Mammal"]})
+    organism = pd.DataFrame({"organism": ["Homo"], "type": ["Mammal"]})
 
-    out = tp.finalise_targets(df, organism)
+    out = tp.finalise_targets(
+        df,
+        organism,
+        chembl_col="chembl_id",
+        uniprot_col="uniprot",
+        genus_col="organism",
+    )
 
     assert list(out["chembl_id"]) == ["CHEMBL1"]
     assert "SUPFAM" not in out.columns
     assert out.loc[0, "isoform_names"] == "isoa"
     assert out.loc[0, "type"] == "Mammal"
+    assert out.loc[0, "organism"] == "Homo"
     assert out["transmembrane"].dtype == "boolean"
 
 
@@ -121,13 +128,13 @@ def test_finalise_file_roundtrip(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame(
         {
             "chembl_id": ["CHEMBL1", "CHEMBL1", "CHEMBL2"],
-            "uniprotkb_Id": ["P12345", "P12345", "nan"],
-            "genus": ["Homo", "Homo", "Mus"],
+            "uniprot": ["P12345", "P12345", "nan"],
+            "organism": ["Homo", "Homo", "Mus"],
             "synonyms": ["SynA", "SynB", "SynC"],
             "SUPFAM": ["s1", "s2", "s3"],
         }
     )
-    organism = pd.DataFrame({"genus": ["Homo"], "type": ["Mammal"]})
+    organism = pd.DataFrame({"organism": ["Homo"], "type": ["Mammal"]})
 
     input_path = tmp_path / "in.csv"
     df.to_csv(input_path, index=False)
@@ -136,9 +143,22 @@ def test_finalise_file_roundtrip(tmp_path: Path, cfg: Config) -> None:
     output_path = tmp_path / "out.csv"
 
     cfg.resources.organism_csv = organism_path
-    tp.finalise_file(input_path, output_path, cfg=cfg)
+    tp.finalise_file(
+        input_path,
+        output_path,
+        cfg=cfg,
+        chembl_col="chembl_id",
+        uniprot_col="uniprot",
+        genus_col="organism",
+    )
 
-    expected = tp.finalise_targets(df, organism).astype(str)
+    expected = tp.finalise_targets(
+        df,
+        organism,
+        chembl_col="chembl_id",
+        uniprot_col="uniprot",
+        genus_col="organism",
+    ).astype(str)
     result = pd.read_csv(output_path, dtype=str)
     pd.testing.assert_frame_equal(result, expected)
 
@@ -149,13 +169,19 @@ def test_finalise_targets_no_downcast_warning() -> None:
     df = pd.DataFrame(
         {
             "chembl_id": ["CHEMBL1"],
-            "uniprotkb_Id": ["P12345"],
-            "genus": ["Homo"],
+            "uniprot": ["P12345"],
+            "organism": ["Homo"],
             "transmembrane": ["True"],
         }
     )
-    organism = pd.DataFrame({"genus": ["Homo"], "type": ["Mammal"]})
+    organism = pd.DataFrame({"organism": ["Homo"], "type": ["Mammal"]})
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
-        tp.finalise_targets(df, organism)
+        tp.finalise_targets(
+            df,
+            organism,
+            chembl_col="chembl_id",
+            uniprot_col="uniprot",
+            genus_col="organism",
+        )


### PR DESCRIPTION
## Summary
- allow `postprocess_targets` and `postprocess_file` to accept a customizable ChEMBL ID column
- extend `finalise_targets` and `finalise_file` with column parameters for ChEMBL, UniProt and genus fields
- update target post-processing tests to cover non-standard schemas

## Testing
- `python -m black library/target_postprocessing.py tests/test_target_postprocessing.py`
- `python -m ruff check library/target_postprocessing.py tests/test_target_postprocessing.py`
- `python -m mypy library/target_postprocessing.py tests/test_target_postprocessing.py`
- `pytest tests/test_target_postprocessing.py`

------
https://chatgpt.com/codex/tasks/task_e_68c434e20a048324bb3440ebdbc20262