### PR TITLE
Ensure ChEMBL IDs lead saved tables

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1233,6 +1233,7 @@ def save_tables(
             sub_dir = out_dir
 
         path = sub_dir / f"{entity}.csv"
+        chembl_id_col = f"{entity}_chembl_id"
         # Drop duplicated columns before writing to avoid ambiguous headers.
         duplicate_cols = df.columns[df.columns.duplicated()].tolist()
         if duplicate_cols:
@@ -1242,7 +1243,7 @@ def save_tables(
             df = df.loc[:, ~df.columns.duplicated()]
         # Delegate writing to the shared I/O helper to ensure consistent
         # encoding and creation of metadata sidecars.
-        write_csv(df, path, cfg=cfg)
+        write_csv(df, path, cfg=cfg, col_order=[chembl_id_col])
         logger.info("file_written", rows=len(df), path=str(path))
         paths[entity] = path
     return paths

--- a/library/io.py
+++ b/library/io.py
@@ -184,6 +184,7 @@ def write_csv(
     sep: str | None = None,
     encoding: str | None = None,
     key_cols: Iterable[str] | None = None,
+    col_order: Iterable[str] | None = None,
     chunksize: int | None = None,
 ) -> Path:
     """Write ``df`` to ``path`` as CSV and store metadata.
@@ -208,6 +209,9 @@ def write_csv(
     key_cols:
         Columns used to determine row order. Defaults to all columns if
         omitted.
+    col_order:
+        Optional preferred column ordering. Columns not listed here are
+        appended in lexicographical order.
     chunksize:
         Optional number of rows per chunk to stream when writing the CSV.
         Passed through to :meth:`pandas.DataFrame.to_csv` and
@@ -229,12 +233,14 @@ def write_csv(
     sep = sep or cfg.io.csv_sep
     encoding = encoding or cfg.io.csv_encoding
     key_cols_list = list(key_cols) if key_cols is not None else sorted(df.columns)
+    col_order_list = list(col_order) if col_order is not None else None
     from .csv_utils import write_csv_deterministic
 
     return write_csv_deterministic(
         df,
         path,
         key_cols=key_cols_list,
+        col_order=col_order_list,
         chunksize=chunksize,
         sep=sep,
         encoding=encoding,

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -645,6 +645,21 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
 
 
+def test_save_tables_orders_key_column_first(tmp_path: Path, cfg: Config) -> None:
+    """Ensure the ChEMBL identifier column is the first in saved CSV files."""
+    tables: TableDict = {
+        "target": pd.DataFrame(
+            {
+                "target_chembl_id": ["T1"],
+                "name": ["example"],
+            }
+        )
+    }
+    paths = save_tables(tables, tmp_path, cfg)
+    result = pd.read_csv(paths["target"])
+    assert result.columns[0] == "target_chembl_id"
+
+
 def test_save_tables_drops_duplicate_columns_and_warns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- allow specifying column order when writing CSVs via `write_csv`
- force `<entity>_chembl_id` to be the first column in `save_tables`
- test that `target_chembl_id` is written as the leading column

## Testing
- `pre-commit run --files library/io.py library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_save_tables_orders_key_column_first`


------
https://chatgpt.com/codex/tasks/task_e_68c441c3f72c832483cb370f32fb0e0e