### PR TITLE
refactor(pubmed): streamline cfg usage

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -85,12 +85,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     configure_logger(log_cfg)
 
     cfg = Config(api=ApiCfg(user_agent="chembl-da/0.1 (mailto:info@example.org)"))
-    pubmed_cfg = cfg.pubmed
-    semsch_cfg = cfg.semantic_scholar
     limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
     delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
 
-    pmid_df = read_pmids(args.input_csv, cfg=pubmed_cfg)
+    pmid_df = read_pmids(args.input_csv, cfg=cfg.pubmed)
     pmids = pmid_df["PMID"].tolist()
     openalex_limiter = get_limiter("openalex", cfg.openalex.rps, cfg.openalex.burst)
     crossref_limiter = get_limiter("crossref", cfg.crossref.rps, cfg.crossref.burst)
@@ -102,11 +100,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             batch_pmids = pmids[i : i + batch_size]
             limiter.acquire()
             pubmed_list = fetch_pubmed_batch(
-                session, batch_pmids, delay, cfg=pubmed_cfg
+                session, batch_pmids, delay, cfg=cfg.pubmed
             )
             limiter.acquire()
             semsch_list = fetch_semantic_scholar_batch(
-                session, batch_pmids, delay, cfg=semsch_cfg
+                session, batch_pmids, delay, cfg=cfg.semantic_scholar
             )
             semsch_map = {s.get("scholar.PMID"): s for s in semsch_list}
             for pubmed in pubmed_list:

--- a/tests/test_pubmed_library_config_single.py
+++ b/tests/test_pubmed_library_config_single.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library import pubmed_library as pl
+
+
+class DummyLimiter:
+    def acquire(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+def _stub_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None):
+        return [
+            {
+                "PubMed.PMID": pid,
+                "PubMed.DOI": "10.1000/example",
+                "PubMed.ArticleTitle": "Example",
+            }
+            for pid in pmids
+        ]
+
+    def fake_fetch_semantic_scholar_batch(session, pmids, delay, cfg=None):
+        return [
+            {
+                "scholar.PMID": pid,
+                "scholar.DOI": "10.1000/example",
+                "scholar.Error": "",
+            }
+            for pid in pmids
+        ]
+
+    monkeypatch.setattr(pl, "fetch_pubmed_batch", fake_fetch_pubmed_batch)
+    monkeypatch.setattr(
+        pl, "fetch_semantic_scholar_batch", fake_fetch_semantic_scholar_batch
+    )
+    monkeypatch.setattr(pl, "fetch_openalex", lambda *a, **k: {"OpenAlex.Error": ""})
+    monkeypatch.setattr(pl, "fetch_crossref", lambda *a, **k: {"crossref.Error": ""})
+    monkeypatch.setattr(pl, "get_limiter", lambda *a, **k: DummyLimiter())
+
+
+def test_pubmed_library_single_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure :func:`pubmed_library.main` creates ``Config`` only once."""
+    _stub_network(monkeypatch)
+    input_csv = Path("tests/data/pmids.csv")
+    output_csv = tmp_path / "out.csv"
+
+    calls: dict[str, int] = {"cfg": 0}
+    OriginalConfig = pl.Config
+
+    class CountingConfig(OriginalConfig):
+        def __init__(self, *args, **kwargs):
+            calls["cfg"] += 1
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(pl, "Config", CountingConfig)
+
+    exit_code = pl.main(
+        [
+            "--input-csv",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "ERROR",
+        ]
+    )
+    assert exit_code == 0
+    assert output_csv.exists()
+    df = pd.read_csv(output_csv)
+    assert not df.empty
+    assert calls["cfg"] == 1


### PR DESCRIPTION
## Summary
- use original config in pubmed CLI instead of temporary copies
- add regression test to ensure config object is created once

## Testing
- `black library/pubmed_library.py tests/test_pubmed_library_config_single.py`
- `ruff check library/pubmed_library.py tests/test_pubmed_library_config_single.py`
- `mypy library/pubmed_library.py tests/test_pubmed_library_config_single.py` *(fails: Library stubs not installed for "cachetools", "tabulate", "pandas", "yaml", "requests")*
- `pytest tests/test_pubmed_library_config_single.py tests/test_pubmed_library_main_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68c44247b4348324b9d7209f4ccf308a