### PR TITLE
Provide hint when parsing tab-separated file with default comma

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -82,7 +82,8 @@ def read_ids(
     FileNotFoundError
         If ``path`` does not exist.
     ValueError
-        If the CSV file is malformed or ``column`` is missing.
+        If the CSV file is malformed, ``column`` is missing or the header
+        appears to be tab-separated while using a different delimiter.
 
     """
     sep = sep or cfg.csv_sep
@@ -91,7 +92,20 @@ def read_ids(
     try:
         with Path(path).open("r", encoding=encoding, newline="") as fh:
             reader = csv.DictReader(fh, delimiter=sep)
-            if reader.fieldnames is None or column not in reader.fieldnames:
+            if reader.fieldnames is None:
+                raise ValueError(
+                    f"column '{column}' not found in {path}; available columns: {reader.fieldnames}"
+                )
+            # Detect a single header containing tab characters which suggests
+            # that a tab-separated file is being parsed with the wrong
+            # delimiter (default comma).
+            if len(reader.fieldnames) == 1 and "\t" in reader.fieldnames[0]:
+                raise ValueError(
+                    "header contains tab characters but only a single column was detected; "
+                    "the file may be tab-separated. Specify --sep '\t' (or the correct delimiter) "
+                    "or adjust 'io.csv_sep' in the config."
+                )
+            if column not in reader.fieldnames:
                 raise ValueError(
                     f"column '{column}' not found in {path}; available columns: {reader.fieldnames}"
                 )

--- a/tests/test_cli_delimiter_hint.py
+++ b/tests/test_cli_delimiter_hint.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.config import IoCfg
+from library.io import read_ids
+
+
+def test_read_ids_tab_separated_hint(tmp_path: Path) -> None:
+    """Suggest delimiter when tab-separated file is parsed as comma-separated."""
+    path = tmp_path / "ids.tsv"
+    path.write_text("id\tname\n1\tfoo\n", encoding="utf-8")
+    with pytest.raises(ValueError) as excinfo:
+        list(read_ids(path, column="id", cfg=IoCfg()))
+    msg = str(excinfo.value)
+    assert "--sep '\t'" in msg
+    assert "io.csv_sep" in msg


### PR DESCRIPTION
## Summary
- detect when a TSV file is parsed with the default comma and raise a helpful ValueError
- add regression test ensuring hint suggests `--sep '\t'` or adjusting `io.csv_sep`

## Testing
- `pre-commit run --files library/io.py tests/test_cli_delimiter_hint.py`
- `pytest tests/test_cli_delimiter_hint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c445296a1883249cd5d1bd212a5ace