### PR TITLE
Handle missing PubMed IDs in document merge

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -510,12 +510,13 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         cfg.document.all.workers,
         cfg.document.all.batch_size,
     )
-    doc_df["pubmed_id"] = pubmed_ids.astype(str)
+    doc_df["pubmed_id"] = pubmed_ids.astype("Int64").astype("string").fillna("")
     if not pub_df.empty and "PubMed.PMID" in pub_df.columns:
         pub_df["PubMed.PMID"] = (
             pd.to_numeric(pub_df["PubMed.PMID"], errors="coerce")
             .astype("Int64")
-            .astype(str)
+            .astype("string")
+            .fillna("")
         )
         merged = doc_df.merge(
             pub_df, how="left", left_on="pubmed_id", right_on="PubMed.PMID"


### PR DESCRIPTION
## Summary
- handle missing PubMed IDs as empty strings before merging with PubMed records

## Testing
- `ruff check scripts/get_document_data.py`
- `mypy library`
- `pytest tests/test_get_document_data.py -q`
- `pytest tests/test_pubmed_aggregation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45145b7ac8324894db7d589f61ce6