### PR TITLE
Fix document timeout override

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -766,12 +766,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.config,
             mapping=mapping
             | {
-                "timeout": "api.timeout_read",
                 "openalex_rps": "openalex.rps",
                 "crossref_rps": "crossref.rps",
             },
             base_parser=parser,
         )
+        cfg.api.timeout_read = getattr(args, "timeout", cfg.api.timeout_read)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -120,6 +120,8 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> 
     )
     assert rc == 0
     assert called["timeout"] == 7
+    assert cfg.document.chembl.timeout == 7
+    assert cfg.api.timeout_read == 7
 
 
 def test_testitem_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:


### PR DESCRIPTION
## Summary
- ensure document timeout CLI flag also overrides API read timeout
- test document CLI timeout affects document and API configs

## Testing
- `pre-commit run --files scripts/get_document_data.py tests/test_cli_timeout_override.py`
- `pytest tests/test_cli_timeout_override.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4537e4098832496931f34581a2773