### PR TITLE
Log failing document IDs

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -405,17 +405,19 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("%s", exc)
         return 1
 
+    chunk_ids: list[str] = []
     try:
         with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+            chunk_ids = list(ids)  # capture IDs for logging on failure
             doc_df = cl.get_documents(
-                ids,
+                chunk_ids,
                 cfg=cfg.api,
                 client=client,
                 chunk_size=cfg.document.all.chunk_size,
                 timeout=cfg.document.all.timeout,
             )
     except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve documents: %s", exc)
+        logger.error("failed to retrieve documents for %s: %s", chunk_ids, exc)
         return 1
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     if doc_df.empty or "pubmed_id" not in doc_df:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+import argparse
+import io
+import sys
 
 import pandas as pd
 import pytest
 
 from library import chembl_library as cl
-from library import io
+from library import io as lib_io
+from library.config import Config
+from library.cli import LoggerConfig, configure_logger
 from scripts import get_document_data as gdd
 
 
@@ -20,7 +25,7 @@ def test_cli_uses_custom_column(
     input_csv.write_text("document_chembl_id\nCHEMBL1\n")
 
     captured: dict[str, str] = {}
-    orig_read_ids = io.read_ids
+    orig_read_ids = lib_io.read_ids
 
     def fake_read_ids(
         path: str | Path,
@@ -33,7 +38,7 @@ def test_cli_uses_custom_column(
         captured["column"] = column
         return orig_read_ids(path, column=column, cfg=cfg, sep=sep, encoding=encoding)
 
-    monkeypatch.setattr(io, "read_ids", fake_read_ids)
+    monkeypatch.setattr(lib_io, "read_ids", fake_read_ids)
 
     class DummyClient:
         def __enter__(self) -> DummyClient:
@@ -69,7 +74,7 @@ def test_cli_uses_custom_column(
     ) -> Path:
         return path
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
@@ -88,3 +93,44 @@ def test_cli_uses_custom_column(
     )
     assert rc == 0
     assert captured["column"] == "document_chembl_id"
+
+
+def test_run_all_logs_failing_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Log message should include IDs when document retrieval fails."""
+    input_csv = tmp_path / "docs.csv"
+    input_csv.write_text("document_chembl_id\nCHEMBL1\nCHEMBL2\n")
+
+    class DummyClient:
+        def __enter__(self) -> DummyClient:
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - no cleanup
+            return None
+
+    monkeypatch.setattr(gdd, "ChemblClient", lambda *_, **__: DummyClient())
+
+    def fake_get_documents(
+        ids: Iterable[str],
+        cfg: Any,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(cl, "get_documents", fake_get_documents)
+
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(level="ERROR", stream=buffer))
+    cfg = Config()
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "out.csv",
+    )
+    rc = gdd.run_all(cfg, args)
+    assert rc == 1
+    log_output = buffer.getvalue()
+    configure_logger(LoggerConfig(stream=sys.stdout))
+    assert "CHEMBL1" in log_output and "CHEMBL2" in log_output


### PR DESCRIPTION
## Summary
- log the ChEMBL document IDs involved when `cl.get_documents` raises an error
- add regression test verifying IDs appear in log output on failure

## Testing
- `black scripts/get_document_data.py tests/test_get_document_data.py`
- `ruff check scripts/get_document_data.py tests/test_get_document_data.py`
- `mypy scripts/get_document_data.py tests/test_get_document_data.py`
- `pytest tests/test_get_document_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68c455f649448324a84037a0194f7213