### PR TITLE
Handle tolerant JSON decoding

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -85,6 +85,14 @@ replaces `io.csv_sep` and `io.csv_encoding` respectively. Likewise
 `--chunk-size` maps to `jobs.chunk_size`, `--timeout` to `api.timeout_read` and
 `--log-level` to `log.level`.
 
+### Robust API decoding
+
+Network requests performed through :class:`library.chembl_client.ChemblClient`
+decode response bodies using the charset declared by the server or UTF-8.
+Undecodable bytes are replaced with the Unicode replacement character
+(``\ufffd``) before JSON parsing. This behaviour is automatic and requires no
+additional configuration.
+
 ## Table quality profiler
 
 ```bash

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import random
 import threading
 from collections.abc import Iterable, Iterator
@@ -102,6 +103,11 @@ class ChemblClient:
         timeout:
             Optional override for the read timeout in seconds.
 
+        Notes
+        -----
+        The response body is decoded using the declared encoding or UTF-8,
+        replacing undecodable bytes with ``\ufffd`` before JSON parsing.
+
         Returns
         -------
         dict[str, Any]
@@ -112,7 +118,7 @@ class ChemblClient:
         requests.RequestException
             If the HTTP request fails.
         ValueError
-            If the response body is not valid JSON.
+            If the response body is not valid JSON or cannot be decoded.
         """
 
         limiter = get_limiter("chembl", cfg.rps, cfg.burst)
@@ -140,7 +146,22 @@ class ChemblClient:
                     url, timeout=(cfg.timeout_connect, read_timeout)
                 ) as response:
                     response.raise_for_status()
-                    data: dict[str, Any] = cast(dict[str, Any], response.json())
+                    try:
+                        text = response.content.decode(
+                            response.encoding or "utf-8", errors="replace"
+                        )
+                    except UnicodeDecodeError as exc:  # pragma: no cover - rare
+                        logger.exception("decode_error", extra={"url": url})
+                        raise ValueError(
+                            f"failed to decode response from {url}"
+                        ) from exc
+                    try:
+                        data: dict[str, Any] = cast(dict[str, Any], json.loads(text))
+                    except json.JSONDecodeError as exc:
+                        logger.exception("json_error", extra={"url": url})
+                        raise ValueError(
+                            f"invalid JSON in response from {url}"
+                        ) from exc
                     logger.info(
                         "request_ok",
                         extra={

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import random
 import time
 from typing import Any
@@ -27,6 +28,11 @@ def api_cfg(**kwargs: Any) -> ApiCfg:
 
 
 class DummyResponse:
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.encoding = "utf-8"
+        self._data = data or {"ok": True}
+        self.content = json.dumps(self._data).encode(self.encoding)
+
     def __enter__(self) -> DummyResponse:  # pragma: no cover - trivial
         return self
 
@@ -36,8 +42,8 @@ class DummyResponse:
     def raise_for_status(self) -> None:  # pragma: no cover - no error
         pass
 
-    def json(self) -> dict[str, Any]:
-        return {"ok": True}
+    def json(self) -> dict[str, Any]:  # pragma: no cover - compatibility
+        return self._data
 
 
 class DummySession:
@@ -206,6 +212,25 @@ def test_request_json_preserves_original_error_message(monkeypatch) -> None:
     message = str(exc_info.value)
     assert "404" in message
     assert url in message
+
+
+@responses.activate
+def test_request_json_replaces_invalid_bytes() -> None:
+    """Misencoded responses should substitute undecodable bytes."""
+
+    client = ChemblClient(api_cfg(), RetryCfg())
+    client.clear_cache()
+    url = "http://example.com/latin1"
+    body = json.dumps({"name": "±"}, ensure_ascii=False).encode("latin-1")
+    responses.add(
+        responses.GET,
+        url,
+        body=body,
+        status=200,
+        content_type="application/json; charset=utf-8",
+    )
+    result = client.request_json(url, cfg=api_cfg())
+    assert result["name"] == "\ufffd"
 
 
 def test_clear_cache() -> None:


### PR DESCRIPTION
## Summary
- decode responses manually with a unicode-replacement fallback
- test misencoded JSON responses
- document tolerant decoding behavior

## Testing
- `ruff check library/chembl_client.py tests/test_chembl_client.py mapper_main.py table_quality_main.py scripts`
- `mypy library`
- `pytest tests/test_chembl_client.py`
- `pytest` *(fails: 14 tests, e.g., tests/test_activity_schema_sidecar.py::test_activity_validation_failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c455edabdc8324b3c7767250004812