### PR TITLE
Fix uniprot merge key preservation

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -587,7 +587,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         # from the ChEMBL frame only when it is *not* used as the merge key.
         # When "uniprot_id" is the join column we keep it for the merge and
         # replace it afterwards with the canonical value from ``uniprot_df``.
-        if cfg.target.all.uniprot_column != "target_uniprot_id":
+        if cfg.target.all.uniprot_column != "uniprot_id":
             chembl_for_merge = chembl_df.drop(columns=["uniprot_id"], errors="ignore")
         else:
             chembl_for_merge = chembl_df.copy()


### PR DESCRIPTION
## Summary
- ensure run_all preserves `uniprot_id` when used as merge key

## Testing
- `ruff check --fix scripts/get_target_data.py`
- `black scripts/get_target_data.py`
- `mypy scripts/get_target_data.py`
- `pytest tests/test_get_target_data_merge.py tests/test_target_cli_organism_csv.py tests/test_cli_option_order.py tests/test_cli_bad_config.py tests/test_cli_timeout_override.py`


------
https://chatgpt.com/codex/tasks/task_e_68c45864da688324a9d5be669fd3a7e4