### PR TITLE
refactor: replace urllib with requests

### DIFF
--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -2,23 +2,39 @@
 
 from __future__ import annotations
 
-import json
 import time
-import urllib.parse
-import urllib.request
 from collections.abc import Callable
 from typing import Any
-from urllib.error import HTTPError
+
+import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError
+from urllib3.util.retry import Retry
 
 from .config import UniprotMappingCfg
 from .log import logger
 from .rate_limiter import get_limiter
 
+# Default session with basic retry logic and placeholder user agent.
+_session: Session = Session()
+_adapter = HTTPAdapter(
+    max_retries=Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=None,
+        raise_on_status=False,
+    )
+)
+_session.mount("http://", _adapter)
+_session.mount("https://", _adapter)
+
 
 def map_chembl_to_uniprot(
     chembl_target_id: str,
     cfg: UniprotMappingCfg,
-    opener: Callable[..., Any] | None = None,
+    session: Session | None = None,
 ) -> str | None:
     """Map a ChEMBL target identifier to a UniProt accession.
 
@@ -29,9 +45,10 @@ def map_chembl_to_uniprot(
     cfg:
         Configuration for the UniProt ID Mapping API including base URL,
         poll interval and timeout settings.
-    opener:
-        Optional callable with the same signature as :func:`urllib.request.urlopen`
-        used to perform HTTP requests. Primarily intended for testing.
+    session:
+        Optional :class:`requests.Session` instance used for HTTP requests.
+        Defaults to a module-level session with retry logic applied. Primarily
+        intended for testing.
 
     Returns
     -------
@@ -45,43 +62,44 @@ def map_chembl_to_uniprot(
         If the API reports failure or returns an unexpected response format.
     TimeoutError
         If the mapping job does not complete within ``cfg.timeout`` seconds.
-    URLError
+    requests.RequestException
         If a network-related error occurs.
-
     """
-    if opener is None:
-        opener = urllib.request.urlopen
+
+    sess = session or _session
 
     def _open_json(
-        url: str, data: bytes | None = None, timeout: float | None = None
+        method: Callable[..., requests.Response],
+        url: str,
+        *,
+        data: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ) -> Any:
-        """Open ``url`` and parse the JSON response."""
+        """Execute an HTTP request and return the decoded JSON body."""
+
         try:
-            # Use the configured timeout for network requests to avoid hangs.
-            if opener is urllib.request.urlopen:
-                with opener(url, data=data, timeout=timeout) as response:
-                    return json.load(response)
-            else:  # For mock openers used in tests
-                with opener(url, data=data) as response:
-                    return json.load(response)
+            kwargs: dict[str, Any] = {"timeout": timeout}
+            if data is not None:
+                kwargs["data"] = data
+            with method(url, **kwargs) as response:
+                response.raise_for_status()
+                return response.json()
         except HTTPError as exc:  # pragma: no cover - network failure simulation
             body = ""
-            if exc.fp is not None:
+            if exc.response is not None:
                 try:
-                    body = exc.fp.read().decode()
+                    body = exc.response.text
                 except Exception:  # pragma: no cover - fallback if decode fails
                     body = ""
             raise ValueError(
-                f"UniProt API request to {url} failed with status {exc.code}: {body or exc.reason}"
+                f"UniProt API request to {url} failed with status {exc.response.status_code}: {body or exc.response.reason}"
             ) from exc
 
     # Submit the mapping job
-    data = urllib.parse.urlencode(
-        {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
-    ).encode()
+    data = {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
     logger.debug("Submitting ID mapping job for %s", chembl_target_id)
     base = cfg.base.rstrip("/")
-    run_data = _open_json(f"{base}/run", data=data, timeout=cfg.timeout)
+    run_data = _open_json(sess.post, f"{base}/run", data=data, timeout=cfg.timeout)
     job_id = run_data.get("jobId")
     if not job_id:
         raise ValueError("UniProt ID Mapping API did not return a job ID")
@@ -89,13 +107,13 @@ def map_chembl_to_uniprot(
     # Poll the job status until it finishes
     status_url = f"{base}/status/{job_id}"
     start = time.time()
-    result_data = {}  # Initialize result_data
+    result_data: dict[str, Any] = {}
     limiter = get_limiter(
         "uniprot_mapping", 1 / cfg.poll_interval if cfg.poll_interval else 0
     )
     while True:
         limiter.acquire()
-        status_data = _open_json(status_url, timeout=cfg.timeout)
+        status_data = _open_json(sess.get, status_url, timeout=cfg.timeout)
 
         # Check for results in the response, which indicates a redirect has occurred
         if "results" in status_data:
@@ -116,7 +134,7 @@ def map_chembl_to_uniprot(
     # If the last status check was a redirect, status_data already contains the results
     if not result_data:
         result_url = f"{base}/uniprotkb/results/{job_id}?format=json"
-        result_data = _open_json(result_url, timeout=cfg.timeout)
+        result_data = _open_json(sess.get, result_url, timeout=cfg.timeout)
 
     results = result_data.get("results", [])
     if not results:

--- a/mapper_main.py
+++ b/mapper_main.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
-from urllib.error import URLError
 
 import pandas as pd
+import requests
 
 from library import io
 from library.cli import (
@@ -70,7 +70,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                     )
                 else:
                     logger.warning("no UniProt ID for %s", chembl_id)
-            except (ValueError, TimeoutError, URLError) as exc:
+            except (ValueError, TimeoutError, requests.RequestException) as exc:
                 logger.warning("failed to map %s: %s", chembl_id, exc)
                 uniprot_ids.append(None)
         df["mapping_uniprot_id"] = uniprot_ids

--- a/tests/test_mapper_library.py
+++ b/tests/test_mapper_library.py
@@ -2,57 +2,96 @@
 
 from __future__ import annotations
 
-import io
-import json
-import urllib.request
-from typing import Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
 
 import pytest
+import requests
 
 from library.config import UniprotMappingCfg
 from library.mapper_library import map_chembl_to_uniprot
 
 
-class _BytesIOContext:
-    """Context manager returning a :class:`io.BytesIO` object."""
+@dataclass
+class DummyResponse:
+    """Minimal stand-in for :class:`requests.Response`."""
 
-    def __init__(self, data: bytes) -> None:
-        self._bio = io.BytesIO(data)
+    status_code: int
+    json_data: dict[str, Any]
+    reason: str = "OK"
 
-    def __enter__(self) -> io.BytesIO:
-        return self._bio
+    def json(self) -> dict[str, Any]:
+        return self.json_data
 
-    def __exit__(self, *args: object) -> None:
-        self._bio.close()
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+    def __enter__(self) -> DummyResponse:
+        return self
+
+    def __exit__(self, *exc: object) -> None:  # pragma: no cover - context cleanup
+        return None
 
 
-def test_map_chembl_to_uniprot_uses_config_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+class DummySession:
+    """Session returning predefined responses and recording timeouts."""
+
+    def __init__(self, responders: list[Callable[[], DummyResponse]]) -> None:
+        self._responders = responders
+        self.timeouts: list[float | tuple[float, float] | None] = []
+
+    def post(
+        self, url: str, data: Any | None = None, timeout: float | None = None
+    ) -> DummyResponse:
+        self.timeouts.append(timeout)
+        return self._responders.pop(0)()
+
+    def get(self, url: str, timeout: float | None = None) -> DummyResponse:
+        self.timeouts.append(timeout)
+        return self._responders.pop(0)()
+
+
+def test_map_chembl_to_uniprot_uses_config_timeout() -> None:
     """Ensure network requests use ``cfg.timeout`` instead of a hard-coded value."""
 
-    timeouts: list[float | None] = []
+    def _run_response() -> DummyResponse:
+        return DummyResponse(200, {"jobId": "1"})
 
-    def fake_urlopen(
-        url: str, data: bytes | None = None, timeout: float | None = None
-    ) -> _BytesIOContext:
-        timeouts.append(timeout)
-        if url.endswith("/run"):
-            content: dict[str, Any] = {"jobId": "1"}
-        elif "/status/" in url:
-            if fake_urlopen.calls == 0:
-                fake_urlopen.calls += 1
-                content = {"jobStatus": "RUNNING"}
-            else:
-                content = {"jobStatus": "FINISHED"}
-        else:
-            content = {"results": [{"to": {"primaryAccession": "P12345"}}]}
-        return _BytesIOContext(json.dumps(content).encode())
+    def _status_run() -> DummyResponse:
+        return DummyResponse(200, {"jobStatus": "RUNNING"})
 
-    fake_urlopen.calls = 0  # type: ignore[attr-defined]
+    def _status_finish() -> DummyResponse:
+        return DummyResponse(200, {"jobStatus": "FINISHED"})
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    def _result_response() -> DummyResponse:
+        return DummyResponse(200, {"results": [{"to": {"primaryAccession": "P12345"}}]})
+
+    session = DummySession(
+        [
+            _run_response,
+            _status_run,
+            _status_finish,
+            _result_response,
+        ]
+    )
 
     cfg = UniprotMappingCfg(poll_interval=0.1, timeout=5.0)
-    assert map_chembl_to_uniprot("CHEMBL1", cfg) == "P12345"
-    assert timeouts and all(t == cfg.timeout for t in timeouts)
+    assert (
+        map_chembl_to_uniprot("CHEMBL1", cfg, cast(requests.Session, session))
+        == "P12345"
+    )
+    assert session.timeouts and all(t == cfg.timeout for t in session.timeouts)
+
+
+def test_map_chembl_to_uniprot_handles_server_error() -> None:
+    """5xx responses are reported as :class:`ValueError`."""
+
+    def _run_error() -> DummyResponse:
+        return DummyResponse(500, {})
+
+    session = DummySession([_run_error])
+    cfg = UniprotMappingCfg(poll_interval=0.1, timeout=5.0)
+    with pytest.raises(ValueError):
+        map_chembl_to_uniprot("CHEMBL1", cfg, cast(requests.Session, session))


### PR DESCRIPTION
## Summary
- replace `urllib` calls with `requests.Session` using retry/backoff logic
- handle server errors in UniProt mapping and update CLI to catch `RequestException`
- add tests covering timeout propagation and server error handling

## Testing
- `pre-commit run --files library/mapper_library.py tests/test_mapper_library.py mapper_main.py` *(failed: ImportError: cannot import name '_save_snapshot' from 'scripts.get_target_data')*
- `pytest tests/test_mapper_library.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c471ba56fc83248a43313a8256e93f