### PR TITLE
Use pandera schemas for assay validation

### DIFF
--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -13,10 +13,11 @@ from pathlib import Path
 
 import pandas as pd
 
+from schemas import AssayPostprocessSchema
+
 from .config import IoCfg
 from .log import logger
 from .pandas_utils import read_csv_pyarrow
-from .validation import validate_schema
 
 
 def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
@@ -37,13 +38,7 @@ def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
         Copy of the input with the additional ``assay_with_same_target`` column.
 
     """
-    validate_schema(
-        df,
-        {
-            "document_chembl_id": "object",
-            "target_chembl_id": "object",
-        },
-    )
+    AssayPostprocessSchema.validate(df)
     group_cols = ["document_chembl_id", "target_chembl_id"]
     groups = df.groupby(group_cols)
     logger.debug("Calculated counts for %d document/target groups", groups.ngroups)

--- a/library/validation.py
+++ b/library/validation.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 
 import pandas as pd
-import pandas.api.types as ptypes
 
 from .log import logger
 
@@ -36,46 +35,3 @@ def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
         )
         raise ValueError(f"missing columns: {', '.join(missing)}")
     logger.info("validate_done", extra={"stage": "validate_done", "columns": columns})
-
-
-def validate_schema(df: pd.DataFrame, schema: Mapping[str, str]) -> None:
-    """Validate presence and dtype of DataFrame columns.
-
-    Parameters
-    ----------
-    df:
-        DataFrame to inspect.
-    schema:
-        Mapping of column names to expected pandas dtypes (as strings).
-
-    Raises
-    ------
-    ValueError
-        If required columns are missing.
-    TypeError
-        If a column has an unexpected dtype.
-
-    """
-    schema_dict = dict(schema)
-    logger.info(
-        "validate_start", extra={"stage": "validate_start", "schema": schema_dict}
-    )
-    validate_columns(df, schema_dict.keys())
-    for column, dtype in schema_dict.items():
-        if not ptypes.is_dtype_equal(df[column].dtype, dtype):
-            logger.info(
-                "validate_done",
-                extra={
-                    "stage": "validate_done",
-                    "schema": schema_dict,
-                    "column": column,
-                    "expected": dtype,
-                    "actual": str(df[column].dtype),
-                },
-            )
-            raise TypeError(
-                f"column {column!r} has dtype {df[column].dtype}, expected {dtype}"
-            )
-    logger.info(
-        "validate_done", extra={"stage": "validate_done", "schema": schema_dict}
-    )

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,6 +1,7 @@
 """Convenient exports for schema definitions."""
 
 from .activities import ActivitiesSchema
+from .assay_postprocessing import AssayPostprocessSchema
 from .assays import AssaysSchema
 from .documents import DocumentsSchema
 from .normalize import (
@@ -16,6 +17,7 @@ from .testitems import TestitemsSchema
 __all__ = [
     "ActivitiesSchema",
     "AssaysSchema",
+    "AssayPostprocessSchema",
     "DocumentsSchema",
     "TargetsSchema",
     "TestitemsSchema",

--- a/schemas/assay_postprocessing.py
+++ b/schemas/assay_postprocessing.py
@@ -1,0 +1,13 @@
+"""Schema definitions for assay post-processing."""
+
+from __future__ import annotations
+
+import pandera.pandas as pa
+
+AssayPostprocessSchema: pa.DataFrameSchema = pa.DataFrameSchema(
+    {
+        "document_chembl_id": pa.Column(str, required=True),
+        "target_chembl_id": pa.Column(str, required=True),
+    }
+)
+"""pa.DataFrameSchema: Required columns for assay post-processing."""

--- a/tests/test_assay_postprocessing.py
+++ b/tests/test_assay_postprocessing.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+import pandera.errors as pa_errors
+import pytest
 
 from library import assay_postprocessing as ap
 from library.config import IoCfg
+from schemas import AssayPostprocessSchema
 
 
 def test_postprocess_assays_counts() -> None:
@@ -25,6 +28,14 @@ def test_postprocess_assays_counts() -> None:
     assert out.loc[0, "assay_with_same_target"] == 2
     assert out.loc[2, "assay_with_same_target"] == 1
     assert out.loc[3, "assay_with_same_target"] == 1
+
+
+def test_postprocess_assays_invalid_schema() -> None:
+    """Missing required columns trigger schema errors."""
+
+    df = pd.DataFrame({"document_chembl_id": ["doc1"], "assay_chembl_id": ["a1"]})
+    with pytest.raises(pa_errors.SchemaError):
+        ap.postprocess_assays(df)
 
 
 def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
@@ -46,3 +57,16 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
 
     result = pd.read_csv(output_path, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
     assert list(result["assay_with_same_target"]) == [2, 2]
+
+
+def test_assay_postprocess_schema() -> None:
+    """Direct validation against the schema works as expected."""
+
+    df_valid = pd.DataFrame(
+        {"document_chembl_id": ["doc1"], "target_chembl_id": ["t1"]}
+    )
+    AssayPostprocessSchema.validate(df_valid)
+
+    df_invalid = pd.DataFrame({"document_chembl_id": ["doc1"]})
+    with pytest.raises(pa_errors.SchemaError):
+        AssayPostprocessSchema.validate(df_invalid)


### PR DESCRIPTION
## Summary
- replace custom assay schema checks with pandera DataFrameSchema
- expose new AssayPostprocessSchema for reuse
- test schema validation and error handling

## Testing
- `python -m black library/assay_postprocessing.py schemas/__init__.py`
- `python -m ruff check library/assay_postprocessing.py library/validation.py schemas/__init__.py schemas/assay_postprocessing.py tests/test_assay_postprocessing.py`
- `python -m mypy library/assay_postprocessing.py library/validation.py schemas/__init__.py schemas/assay_postprocessing.py tests/test_assay_postprocessing.py`
- `pytest` *(fails: ImportError: cannot import name '_save_snapshot' from 'scripts.get_target_data')*
- `pytest tests/test_assay_postprocessing.py tests/test_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c471ac7938832488f5aedb09d52345