### PR TITLE
Add batched and parallel UniProt mapping

### DIFF
--- a/library/mapper_batch_library.py
+++ b/library/mapper_batch_library.py
@@ -1,0 +1,94 @@
+"""Batch mapping utilities for ChEMBL to UniProt conversion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from .config import UniprotMappingCfg
+from .log import logger
+from .mapper_library import map_chembl_to_uniprot
+from .rate_limiter import get_limiter
+
+
+def batch_iterable[T](iterable: Iterable[T], batch_size: int) -> Iterator[list[T]]:
+    """Yield items from ``iterable`` in batches of ``batch_size``.
+
+    Parameters
+    ----------
+    iterable:
+        Source of items to batch.
+    batch_size:
+        Maximum size of each batch. Must be greater than zero.
+
+    Yields
+    ------
+    list
+        Lists containing up to ``batch_size`` elements from ``iterable``.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than zero")
+
+    batch: list[T] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def map_chembl_ids_to_uniprot(
+    chembl_ids: Iterable[str],
+    cfg: UniprotMappingCfg,
+    *,
+    batch_size: int,
+    rps: float,
+    max_workers: int | None = None,
+) -> dict[str, str | None]:
+    """Map multiple ChEMBL identifiers to UniProt accessions.
+
+    Parameters
+    ----------
+    chembl_ids:
+        Iterable of ChEMBL target identifiers.
+    cfg:
+        Configuration for the UniProt mapping API.
+    batch_size:
+        Number of identifiers processed per worker.
+    rps:
+        Maximum requests per second across all workers.
+    max_workers:
+        Optional upper bound on the number of worker threads. Defaults to
+        ``None`` which lets :class:`~concurrent.futures.ThreadPoolExecutor`
+        decide.
+
+    Returns
+    -------
+    dict
+        Mapping of input ChEMBL IDs to UniProt accessions. If mapping fails for
+        an ID the value will be ``None``.
+    """
+    limiter = get_limiter("chembl_uniprot_batch", rps)
+
+    def _process(batch: list[str]) -> dict[str, str | None]:
+        results: dict[str, str | None] = {}
+        for chembl_id in batch:
+            limiter.acquire()
+            try:
+                results[chembl_id] = map_chembl_to_uniprot(chembl_id, cfg)
+            except Exception as exc:  # pragma: no cover - network issues
+                logger.warning("Failed to map %s: %s", chembl_id, exc)
+                results[chembl_id] = None
+        return results
+
+    results: dict[str, str | None] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(_process, b) for b in batch_iterable(chembl_ids, batch_size)
+        ]
+        for future in as_completed(futures):
+            batch_result = future.result()
+            results.update(batch_result)
+    return results

--- a/mapper_batch_main.py
+++ b/mapper_batch_main.py
@@ -1,0 +1,112 @@
+"""CLI for batch mapping ChEMBL IDs to UniProt accessions."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+
+import pandas as pd
+
+from library import io
+from library.cli import (
+    LoggerConfig,
+    apply_config_overrides,
+    configure_logger,
+)
+from library.cli import build_parser as base_parser
+from library.config import Config, ensure_dirs, print_config
+from library.log import logger
+from library.mapper_batch_library import map_chembl_ids_to_uniprot
+
+
+def run(cfg: Config, args: argparse.Namespace) -> int:
+    """Run batch mapping of ChEMBL IDs to UniProt accessions."""
+    try:
+        try:
+            df = io.read_csv(
+                args.input_csv,
+                cfg=cfg.io,
+                sep=args.sep,
+                encoding=args.encoding,
+                dtype=str,
+                na_values=["#N/A", ""],
+            )
+        except (FileNotFoundError, OSError) as exc:
+            logger.error("%s", exc)
+            return 1
+        if args.column not in df.columns:
+            logger.error("column '%s' not found in %s", args.column, args.input_csv)
+            return 1
+
+        ids = [
+            str(chembl_id)
+            for chembl_id in df[args.column]
+            if pd.notna(chembl_id) and str(chembl_id).strip()
+        ]
+        mappings = map_chembl_ids_to_uniprot(
+            ids,
+            cfg.uniprot_mapping,
+            batch_size=args.chunk_size,
+            rps=args.rps,
+            max_workers=args.workers,
+        )
+        for cid, uid in mappings.items():
+            if uid:
+                logger.info("mapped", extra={"chembl_id": cid, "uniprot_id": uid})
+            else:
+                logger.warning("no UniProt ID for %s", cid)
+        df["mapping_uniprot_id"] = df[args.column].map(mappings).fillna("")
+        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        try:
+            io.write_csv(
+                df,
+                output,
+                cfg=cfg,
+                sep=args.sep,
+                encoding=args.encoding,
+            )
+            logger.info("write_done", extra={"path": str(output)})
+        except OSError as exc:
+            logger.error("failed to write output CSV: %s", exc)
+            return 1
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("run_fail", exc=exc)
+        return 1
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Create CLI argument parser."""
+    parser, log_cfg = base_parser(
+        "Batch map ChEMBL IDs to UniProt accessions",
+        column="chembl_id",
+        chunk_size=10,
+    )
+    parser.add_argument(
+        "--rps", type=float, default=5.0, help="Max requests per second"
+    )
+    parser.add_argument(
+        "--workers", type=int, default=4, help="Number of worker threads"
+    )
+    parser.set_defaults(func=run)
+    return parser, log_cfg
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the batch mapper script."""
+    parser, log_cfg = build_parser()
+    args = parser.parse_args(argv)
+    log_cfg.level = args.log_level
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    cfg = apply_config_overrides(args, parser, args.config)
+    ensure_dirs(cfg)
+    print_config(cfg)
+    func: Callable[[Config, argparse.Namespace], int] = args.func
+    exit_code = func(cfg, args)
+    logger.info("pipeline_end", extra={"exit_code": exit_code})
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_mapper_batch_library.py
+++ b/tests/test_mapper_batch_library.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from library import mapper_batch_library as mbl
+from library.config import UniprotMappingCfg
+
+
+def test_batch_iterable() -> None:
+    """Ensure items are grouped into correct batch sizes."""
+    data = list(mbl.batch_iterable(range(5), 2))
+    assert data == [[0, 1], [2, 3], [4]]
+
+
+def test_map_chembl_ids_to_uniprot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify rate limiter and mapping integration."""
+    calls: list[int] = []
+
+    class DummyLimiter:
+        def acquire(self) -> None:
+            calls.append(1)
+
+    def fake_get_limiter(
+        name: str, rps: float, burst: int | None = None
+    ) -> DummyLimiter:
+        return DummyLimiter()
+
+    def fake_map(cid: str, cfg: UniprotMappingCfg) -> str:
+        return f"UNI_{cid}"
+
+    monkeypatch.setattr(mbl, "get_limiter", fake_get_limiter)
+    monkeypatch.setattr(mbl, "map_chembl_to_uniprot", fake_map)
+
+    cfg = UniprotMappingCfg()
+    ids = ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    result = mbl.map_chembl_ids_to_uniprot(
+        ids, cfg, batch_size=2, rps=10.0, max_workers=2
+    )
+
+    assert result == {cid: f"UNI_{cid}" for cid in ids}
+    assert len(calls) == len(ids)


### PR DESCRIPTION
## Summary
- add `mapper_batch_library` to batch ChEMBL IDs and map them to UniProt with rate limiting
- introduce `mapper_batch_main.py` CLI for concurrent mapping with configurable RPS and workers
- test batching and limiter integration

## Testing
- `python -m black library/mapper_batch_library.py mapper_batch_main.py tests/test_mapper_batch_library.py`
- `ruff check library/mapper_batch_library.py mapper_batch_main.py tests/test_mapper_batch_library.py`
- `mypy library/mapper_batch_library.py mapper_batch_main.py tests/test_mapper_batch_library.py`
- `pytest tests/test_mapper_batch_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c471c0d0308324b69475f8395bf883