### PR TITLE
Deduplicate document requests and expand schema tests

### DIFF
--- a/library/chembl_document.py
+++ b/library/chembl_document.py
@@ -57,15 +57,18 @@ def get_documents(
         Data frame containing the retrieved document metadata. Missing
         identifiers result in an empty frame.
     """
+    # Filter out empty placeholders and deduplicate to avoid redundant HTTP
+    # requests for the same identifier.
     valid = [i for i in ids if i not in {"", "#N/A"}]
-    if not valid:
+    unique_ids = list(dict.fromkeys(valid))
+    if not unique_ids:
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
     base = f"{cfg.chembl_base.rstrip('/')}/document.json?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     records: list[dict[str, Any]] = []
 
-    for chunk in _chunked(valid, chunk_size):
+    for chunk in _chunked(unique_ids, chunk_size):
         url = f"{base}&document_chembl_id__in={','.join(chunk)}"
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("documents") or data.get("document") or []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,10 @@ def cfg() -> Config:
     """
 
     return Config(api=ApiCfg(user_agent="test@example.org"))
+
+
+@pytest.fixture()
+def duplicate_document_ids() -> list[str]:
+    """Return sample document IDs including duplicates for testing."""
+
+    return ["CHEMBL1", "CHEMBL1", "CHEMBL2"]

--- a/tests/test_chembl_document.py
+++ b/tests/test_chembl_document.py
@@ -61,3 +61,24 @@ def test_get_documents_handles_invalid_ids() -> None:
     df = get_documents(["", "#N/A"], cfg=cfg, client=client)
     assert df.empty
     assert not client.called
+
+
+def test_get_documents_deduplicates_ids(
+    duplicate_document_ids: list[str],
+) -> None:
+    """Duplicate identifiers should trigger at most one HTTP request each."""
+
+    cfg = ApiCfg(
+        chembl_base="https://example.com",
+        user_agent="test/0.1 (mailto:test@example.com)",
+    )
+    client = FakeClient()
+    df = get_documents(
+        duplicate_document_ids,
+        cfg=cfg,
+        client=client,
+        chunk_size=1,
+    )
+
+    assert df["document_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert len(client.called) == len({"CHEMBL1", "CHEMBL2"})

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -174,6 +174,47 @@ def test_activities_schema_hypothesis_invalid(df: pd.DataFrame) -> None:
         ActivitiesSchema.validate(df)
 
 
+@given(
+    data_frames(
+        columns=[
+            column("document_chembl_id", elements=st.text(min_size=1)),
+            column("title", elements=st.text(min_size=1)),
+            column(
+                "year",
+                dtype=int,
+                elements=st.integers(min_value=1900, max_value=2100),
+            ),
+        ],
+        index=range_indexes(min_size=1, max_size=5),
+    )
+)
+def test_documents_schema_hypothesis_valid(df: pd.DataFrame) -> None:
+    """Random valid frames pass ``DocumentsSchema``."""
+
+    DocumentsSchema.validate(df)
+
+
+@given(
+    data_frames(
+        columns=[
+            column("document_chembl_id", elements=st.text(min_size=1)),
+            column("title", elements=st.text(min_size=1)),
+            column(
+                "year",
+                dtype=int,
+                elements=st.integers(min_value=0, max_value=1899),
+            ),
+        ],
+        index=range_indexes(min_size=1, max_size=5),
+    )
+)
+def test_documents_schema_hypothesis_invalid(df: pd.DataFrame) -> None:
+    """Years below 1900 fail ``DocumentsSchema`` validation."""
+
+    with pytest.raises(SchemaError):
+        DocumentsSchema.validate(df)
+
+
 def test_activities_from_files() -> None:
     """Validate activities data from CSV/JSON files and capture failures."""
     data_dir = Path(__file__).parent / "data"


### PR DESCRIPTION
## Summary
- avoid redundant HTTP requests by deduplicating document IDs
- add fixture for duplicate IDs and test client call count
- add Hypothesis-based tests for document schema validation

## Testing
- `black library/chembl_document.py tests/conftest.py tests/test_chembl_document.py tests/test_schemas.py`
- `ruff check library/chembl_document.py tests/conftest.py tests/test_chembl_document.py tests/test_schemas.py`
- `mypy library/chembl_document.py`
- `pytest tests/test_chembl_document.py::test_get_documents_deduplicates_ids tests/test_schemas.py::test_documents_schema_hypothesis_valid tests/test_schemas.py::test_documents_schema_hypothesis_invalid`


------
https://chatgpt.com/codex/tasks/task_e_68c47224a7a4832486f9fc224a46b74a