### PR TITLE
chore: configure pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:
-      - id: ruff-check
+      - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -681,6 +681,10 @@ in ``--out-dir``.
 
 Install the optional developer tools and run the standard quality checks:
 
+* ``pre-commit`` – run formatting, linting, type checking and tests in one go::
+
+      pre-commit run --all-files
+
 * ``black`` – auto-format the code::
 
       black scripts library mapper_main.py table_quality_main.py


### PR DESCRIPTION
## Summary
- switch to canonical `ruff` hook in pre-commit config
- document how to run the pre-commit suite in the README

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md library/__init__.py` *(fails: ImportError: cannot import name '_save_snapshot')*


------
https://chatgpt.com/codex/tasks/task_e_68c471d9e1588324b1add377ade00251