### PR TITLE
Close pandas reader in read_csv_chunks

### DIFF
--- a/library/chunk_io.py
+++ b/library/chunk_io.py
@@ -106,16 +106,19 @@ def read_csv_chunks(
         skiprows=to_skip,
     )
     emitted = 0
-    for chunk in reader:
-        if limit is not None and emitted >= limit:
-            break
-        if limit is not None:
-            remaining = limit - emitted
-            if len(chunk) > remaining:
-                yield chunk.iloc[:remaining]
+    try:
+        for chunk in reader:
+            if limit is not None and emitted >= limit:
                 break
-        emitted += len(chunk)
-        yield chunk
+            if limit is not None:
+                remaining = limit - emitted
+                if len(chunk) > remaining:
+                    yield chunk.iloc[:remaining]
+                    break
+            emitted += len(chunk)
+            yield chunk
+    finally:
+        reader.close()
 
 
 def process_csv_chunks(

--- a/tests/test_chunk_io.py
+++ b/tests/test_chunk_io.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import gc
+import warnings
 from pathlib import Path
 
 import pandas as pd
 
-from library.chunk_io import process_csv_chunks
+from library.chunk_io import process_csv_chunks, read_csv_chunks
 from library.config import IoCfg
 
 
@@ -44,3 +46,20 @@ def test_process_csv_chunks_resume(tmp_path: Path) -> None:
     assert rows_written == 200
     result = pd.read_csv(output_path)
     assert result.equals(df)
+
+
+def test_read_csv_chunks_no_resource_warning(tmp_path: Path) -> None:
+    """``read_csv_chunks`` should not emit ``ResourceWarning``."""
+
+    cfg = IoCfg()
+    path = tmp_path / "input.csv"
+    pd.DataFrame({"a": range(10)}).to_csv(path, index=False)
+
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter("always", ResourceWarning)
+        gen = read_csv_chunks(path, cfg=cfg, chunk_size=5)
+        next(gen)
+        del gen
+        gc.collect()
+
+    assert not any(w.category is ResourceWarning for w in warns)


### PR DESCRIPTION
## Summary
- ensure `read_csv_chunks` closes the underlying pandas reader
- add regression test guarding against `ResourceWarning`

## Testing
- `ruff check library/chunk_io.py tests/test_chunk_io.py`
- `mypy library/chunk_io.py tests/test_chunk_io.py`
- `pytest tests/test_chunk_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c47e58fe8c8324a932fbe476d7fe99