### PR TITLE
Handle duplicate activity columns before concatenation

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1052,7 +1052,9 @@ def build_combined_tables(
 
     # --- activity --------------------------------------------------------
     df_same_act = unify_dtypes(same["activity"])
+    df_same_act = df_same_act.loc[:, ~df_same_act.columns.duplicated()]
     df_all_act = unify_dtypes(all_["activity"])
+    df_all_act = df_all_act.loc[:, ~df_all_act.columns.duplicated()]
     concat = pd.concat([df_same_act, df_all_act], ignore_index=True, sort=False)
     concat = concat.drop(
         columns=list(ACTIVITY_DROP_COLS & set(concat.columns)), errors="ignore"

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -173,6 +173,31 @@ def test_build_combined_tables_handles_duplicate_activity_columns() -> None:
     assert combined["activity"]["val"].tolist() == ["a", "b"]
 
 
+def test_build_combined_tables_handles_mismatched_duplicate_activity_columns() -> None:
+    """Duplicate columns in only one table should not raise an error."""
+    same: TableDict = {
+        "activity": pd.DataFrame(
+            [[1, "a", "x"]], columns=["activity_chembl_id", "val", "val"]
+        ),
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "pairs_same_document": pd.DataFrame(),
+    }
+    all_: TableDict = {
+        "activity": pd.DataFrame([[2, "b"]], columns=["activity_chembl_id", "val"]),
+        "assay": pd.DataFrame(),
+        "document": pd.DataFrame(),
+        "target": pd.DataFrame(),
+        "testitem": pd.DataFrame(),
+        "pairs": pd.DataFrame(),
+    }
+    combined = build_combined_tables(same, all_)
+    assert list(combined["activity"].columns) == ["activity_chembl_id", "val"]
+    assert combined["activity"]["val"].tolist() == ["a", "b"]
+
+
 @pytest.mark.parametrize(
     "entity,id_col",
     [
@@ -645,7 +670,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
 
 
-
 @pytest.mark.parametrize(
     ("entity", "df", "col"),
     [
@@ -671,7 +695,6 @@ def test_save_tables_orders_key_column_first(
     assert result.columns[0] == col
 
 
-
 def test_save_tables_drops_duplicate_columns_and_warns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -681,7 +704,7 @@ def test_save_tables_drops_duplicate_columns_and_warns(
     def fake_warn(msg: str, *args: object, **kwargs: object) -> None:
         messages.append(msg % args)
 
-    monkeypatch.setattr(lib.logger, "warning", fake_warn)
+    monkeypatch.setattr(lib.logger, "warning", fake_warn)  # type: ignore[attr-defined]
 
     # Create a table with duplicated column names
     df = pd.DataFrame([[1, "a", "b"]], columns=["id", "dup", "dup"])


### PR DESCRIPTION
## Summary
- ensure activity tables remove duplicate columns before combining datasets
- add regression test for mismatched duplicate activity columns

## Testing
- `ruff check tests/test_input_initialisation_library.py library/input_initialisation_library.py`
- `mypy library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_build_combined_tables_handles_duplicate_activity_columns tests/test_input_initialisation_library.py::test_build_combined_tables_handles_mismatched_duplicate_activity_columns`


------
https://chatgpt.com/codex/tasks/task_e_68c47e81b8a48324a77a3e63d5fc0d92