### PR TITLE
refactor: log git SHA errors with extra

### DIFF
--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -53,5 +53,5 @@ def _git_sha() -> str:
         )
         return result.decode().strip()
     except subprocess.CalledProcessError as exc:  # pragma: no cover - rare
-        logger.warning("git_sha_unavailable", error=str(exc))
+        logger.warning("git_sha_unavailable", extra={"error": str(exc)})
         return "UNKNOWN"

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -230,10 +230,21 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
         "library.git_utils.subprocess.check_output",
         side_effect=subprocess.CalledProcessError(returncode=1, cmd=["git"]),
     ):
-        messages: list[str] = []
-        monkeypatch.setattr(
-            git_utils.logger, "warning", lambda msg, *args: messages.append(msg % args)
-        )
+        records: list[tuple[str, dict[str, str] | None]] = []
+
+        def fake_warning(
+            event: str,
+            *args: object,
+            extra: dict[str, str] | None = None,
+            **kwargs: object,
+        ) -> None:
+            records.append((event, extra))
+
+        monkeypatch.setattr(git_utils.logger, "warning", fake_warning)
         result = git_utils._git_sha()
+
     assert result == "UNKNOWN"
-    assert any("Unable to determine git SHA" in msg for msg in messages)
+    assert any(
+        event == "git_sha_unavailable" and extra is not None and "error" in extra
+        for event, extra in records
+    )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import hashlib
+import json
 import subprocess
 from io import StringIO
 from pathlib import Path
@@ -210,4 +211,6 @@ def test_git_sha_timeout_returns_unknown(
     git_utils._git_sha.cache_clear()
 
     assert git_utils._git_sha() == "UNKNOWN"
-    assert "git_sha_unavailable" in stream.getvalue()
+    record = json.loads(stream.getvalue().splitlines()[0])
+    assert record["event"] == "git_sha_unavailable"
+    assert "error" in record


### PR DESCRIPTION
## Summary
- use `extra` to record git SHA errors in logging
- adjust git SHA tests for new logging schema

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c47e0394c4832488aa67950c83fabf