### PR TITLE
Refactor CLI scripts and add entry points

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import argparse
 import uuid
+from collections.abc import Sequence
+from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pydantic import ValidationError
 
@@ -368,6 +370,251 @@ def apply_config_overrides(
     return cfg
 
 
+# ---------------------------------------------------------------------------
+# Script entry points
+# ---------------------------------------------------------------------------
+
+
+def _run(module: str, argv: Sequence[str] | None = None) -> int:
+    """Execute ``module.main`` from the :mod:`scripts` package.
+
+    Parameters
+    ----------
+    module:
+        Name of the module inside :mod:`scripts`.
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script's ``main`` function.
+    """
+
+    main_func = import_module(f"scripts.{module}").main
+    return cast(int, main_func(argv))
+
+
+def get_activity_data(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_activity_data`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_activity_data", argv)
+
+
+def get_assay_data(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_assay_data`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_assay_data", argv)
+
+
+def get_target_data(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_target_data`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_target_data", argv)
+
+
+def get_document_data(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_document_data`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_document_data", argv)
+
+
+def get_document_type(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_document_type`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_document_type", argv)
+
+
+def get_input_initialisation(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_input_initialisation`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_input_initialisation", argv)
+
+
+def get_testitem_data(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_testitem_data`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_testitem_data", argv)
+
+
+def csv_utils(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.csv_utils_main`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("csv_utils_main", argv)
+
+
+def mapper(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.mapper_main`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("mapper_main", argv)
+
+
+def table_quality(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.table_quality_main`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("table_quality_main", argv)
+
+
+def chunk_io(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.chunk_io_main`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("chunk_io_main", argv)
+
+
+def get_activities(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.get_activities`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("get_activities", argv)
+
+
+def check_determinism(argv: Sequence[str] | None = None) -> int:
+    """Run :mod:`scripts.check_determinism`.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code from the script.
+    """
+
+    return _run("check_determinism", argv)
+
 __all__ = [
     "LoggerConfig",
     "create_logger_config",
@@ -376,4 +623,17 @@ __all__ = [
     "build_root_parser",
     "configure_logger",
     "apply_config_overrides",
+    "check_determinism",
+    "chunk_io",
+    "csv_utils",
+    "get_activities",
+    "get_activity_data",
+    "get_assay_data",
+    "get_document_data",
+    "get_document_type",
+    "get_input_initialisation",
+    "get_target_data",
+    "get_testitem_data",
+    "mapper",
+    "table_quality",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,17 +47,19 @@ dev = [
 ]
 
 [project.scripts]
-get-activity-data = "scripts.get_activity_data:main"
-get-assay-data = "scripts.get_assay_data:main"
-get-target-data = "scripts.get_target_data:main"
-get-document-data = "scripts.get_document_data:main"
-get-document-type = "scripts.get_document_type:main"
-get-input-initialisation = "scripts.get_input_initialisation:main"
-get-testitem-data = "scripts.get_testitem_data:main"
-csv-utils = "scripts.csv_utils_main:main"
-mapper = "scripts.mapper_main:main"
-table-quality = "scripts.table_quality_main:main"
-chunk-io = "scripts.chunk_io_main:main"
+get-activity-data = "library.cli:get_activity_data"
+get-assay-data = "library.cli:get_assay_data"
+get-target-data = "library.cli:get_target_data"
+get-document-data = "library.cli:get_document_data"
+get-document-type = "library.cli:get_document_type"
+get-input-initialisation = "library.cli:get_input_initialisation"
+get-testitem-data = "library.cli:get_testitem_data"
+csv-utils = "library.cli:csv_utils"
+mapper = "library.cli:mapper"
+table-quality = "library.cli:table_quality"
+chunk-io = "library.cli:chunk_io"
+get-activities = "library.cli:get_activities"
+check-determinism = "library.cli:check_determinism"
 
 [tool.setuptools]
 py-modules = [
@@ -72,6 +74,8 @@ py-modules = [
   "scripts.mapper_main",
   "scripts.table_quality_main",
   "scripts.chunk_io_main",
+  "scripts.get_activities",
+  "scripts.check_determinism",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -10,17 +10,9 @@ hashes differ.
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import perf_counter
-
-# Allow running the script directly via ``python scripts/check_determinism.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 try:
     import pandas as pd
@@ -63,8 +55,8 @@ def run_check(tmp_dir: Path) -> bool:
     write_csv_deterministic(df, second, key_cols=key_cols)
     hash2 = sha256_file(second)
 
-    logger.debug("First hash: %s", hash1)
-    logger.debug("Second hash: %s", hash2)
+    logger.debug("hash", label="first", value=hash1)
+    logger.debug("hash", label="second", value=hash2)
 
     return hash1 == hash2
 
@@ -96,10 +88,10 @@ def main() -> int:
             ok = run_check(Path(tmp))
 
         if ok:
-            logger.info("Hashes match; output is deterministic")
+            logger.info("hashes_match")
             return 0
 
-        logger.error("Hashes differ; output is not deterministic")
+        logger.error("hashes_differ")
         return 1
     finally:
         log_duration(start)

--- a/scripts/chunk_io_main.py
+++ b/scripts/chunk_io_main.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Sequence
 from pathlib import Path
-
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from library.chunk_io import process_csv_chunks
 from library.cli import LoggerConfig, add_common_arguments, configure_logger
@@ -64,7 +60,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             sep=args.sep,
             encoding=args.encoding,
         )
-        logger.info("rows_processed", extra={"rows": rows})
+        logger.info("rows_processed", rows=rows)
         return 0
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("run_fail", exc=exc)

--- a/scripts/csv_utils_main.py
+++ b/scripts/csv_utils_main.py
@@ -9,14 +9,10 @@ If ``--output`` is omitted, a file named
 
 from __future__ import annotations
 
-import sys
 import time
 from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
-
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 
@@ -72,8 +68,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start
-    logger.info("write_done", extra={"path": str(args.output_csv)})
-    logger.info("run_completed", extra={"elapsed": elapsed})
+    logger.info("write_done", path=str(args.output_csv))
+    logger.info("run_completed", elapsed=elapsed)
     return 0
 
 

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -3,16 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Sequence
-from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_activities.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from library import cli
 from library.activities import get_activities
@@ -65,11 +56,11 @@ def run(limit: int, dry_run: bool) -> int:
         Zero on success, non-zero on failure.
     """
     if dry_run:
-        logger.info("dry run: would generate %d activities", limit)
+        logger.info("dry_run", limit=limit)
         return 0
 
     activities = get_activities(limit)
-    logger.info("generated %d activities", len(activities))
+    logger.info("generated", count=len(activities))
     return 0
 
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -6,14 +6,6 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from itertools import islice
-from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_activity_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import requests
 from pandera.errors import SchemaErrors
@@ -67,7 +59,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     if cfg.activity.dry_run:
         expected = limit if limit is not None else 0
-        logger.info("dry_run", extra={"limit": expected})
+        logger.info("dry_run", limit=expected)
         return 0
 
     # Configure HTTP session with the supplied User-Agent and retry policy
@@ -87,7 +79,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         if limit is not None:
             limited = list(islice(ids_iter, limit))
             ids = limited
-            logger.info("process_limit", extra={"limit": len(limited)})
+            logger.info("process_limit", limit=len(limited))
 
         try:
             df = cl.get_activities(
@@ -145,7 +137,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 key_cols=key_cols or None,
             )
-            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+            logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
             return 1
@@ -208,7 +200,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -225,23 +217,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code: int = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
-from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_assay_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import requests
 from pandera.errors import SchemaErrors
@@ -123,7 +115,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 key_cols=key_cols or None,
             )
-            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+            logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
             return 1
@@ -172,7 +164,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -187,23 +179,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -28,15 +28,7 @@ import argparse
 import sys
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
 from typing import cast
-
-# Allow running the script directly via ``python scripts/get_document_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests
@@ -168,7 +160,7 @@ def fetch_pubmed_records(
             batch_len = futures[future]
             records.extend(future.result())
             processed += batch_len
-            logger.info("documents_processed", extra={"count": processed})
+            logger.info("documents_processed", count=processed)
     if not records:
         return pd.DataFrame()
     return pd.DataFrame(records)
@@ -246,7 +238,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        logger.info("write_done", rows=rows_kept, path=str(csv_path))
 
         stats: Stats = {
             "rows_total": rows_total,
@@ -355,7 +347,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 key_cols=key_cols or None,
             )
-            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+            logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
             return 1
@@ -475,7 +467,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 key_cols=key_cols or None,
             )
-            logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+            logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
             logger.error("failed to write output CSV: %s", exc)
             return 1
@@ -579,7 +571,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -733,7 +725,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     mapping = {"column": f"document.{args.command}.column"}
@@ -778,23 +770,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = cast(int, args.func(cfg, args))
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -7,16 +7,7 @@ scoring logic.
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterable, Mapping, Sequence
-from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_document_type.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 
@@ -137,7 +128,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger_inst = configure_logger(log_cfg)
-    logger_inst.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger_inst.info("pipeline_start", run_id=log_cfg.run_id)
 
     try:
         cfg: Config = apply_config_overrides(
@@ -156,7 +147,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger_inst.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger_inst.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger_inst = configure_logger(
@@ -164,11 +155,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger_inst.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger_inst.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 
     df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
@@ -179,7 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     df_out.to_csv(output, index=False, sep=args.sep, encoding=args.encoding)
-    logger_inst.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+    logger_inst.info("pipeline_done", run_id=log_cfg.run_id)
     return 0
 
 

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -17,16 +17,8 @@ message.
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Sequence
 from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_input_initialisation.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package.  This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from library import input_initialisation_library as lib
 from library.cli import (
@@ -105,18 +97,18 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             if not key.endswith("_status"):
                 continue
             if "Filtered.new" not in df.columns:
-                logger.warning("table '%s' lacks Filtered.new; skipping", key)
+                logger.warning("missing_filtered_new", table=key)
                 continue
 
             base_name = key.removesuffix("_status")
             entity = base_name.split("_")[0]
             id_col = id_cols.get(entity)
             if entity == "system" and id_col is None:
-                logger.info("dropping unsupported system status table '%s'", key)
+                logger.info("drop_status_table", table=key)
                 del tables[key]
                 continue
             if entity == "system":
-                logger.info("processing system status table '%s'", key)
+                logger.info("process_status_table", table=key)
 
             renamed = df.rename(columns={"Filtered.new": "Filtered"})
 
@@ -156,10 +148,10 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         report_dir = out_dir / "data_validity_report"
         report_dir.mkdir(parents=True, exist_ok=True)
         for entity, path in paths.items():
-            logger.info("profiling", extra={"entity": entity})
+            logger.info("profiling", entity=entity)
             analyze_table_quality(path, table_name=str(report_dir / path.stem))
 
-        logger.info("save_done", extra={"tables": len(paths), "path": str(out_dir)})
+        logger.info("save_done", tables=len(paths), path=str(out_dir))
         return 0
     except KeyError as exc:
         msg = exc.args[0] if exc.args else str(exc)
@@ -173,9 +165,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         ):
             # Log a column-specific message when the error clearly refers to
             # missing columns rather than an absent table.
-            logger.error("required column(s) missing: %s", msg)
+            logger.error("missing_columns", details=msg)
         else:
-            logger.error("required table '%s' missing", msg)
+            logger.error("missing_table", table=msg)
         return 1
 
 
@@ -220,7 +212,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -236,7 +228,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
 
@@ -262,17 +254,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = int(args.func(cfg, args))
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -16,13 +16,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import cast
 
-# Allow running the script directly via ``python scripts/get_target_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
@@ -461,7 +454,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -780,7 +773,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     subparser_map = getattr(parser, "subparsers_map", {})
     subparser = subparser_map.get(args.command, parser)
     try:
@@ -818,27 +811,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     if hasattr(args, "func"):
         exit_code = cast(int, args.func(cfg, args))
         if exit_code == 0:
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
         else:
-            logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return exit_code
     parser.print_help()
-    logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return 1
 
 

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
-from pathlib import Path
-
-# Allow running the script directly via ``python scripts/get_testitem_data.py``
-# by ensuring the repository root is on ``sys.path`` when the module is executed
-# outside of the ``scripts`` package. This mirrors the behaviour of installing
-# the project in editable mode.
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests
@@ -75,13 +67,13 @@ def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
 
     total = len(unique_smiles)
     if total:
-        logger.info("pubchem_start", extra={"total": total})
+        logger.info("pubchem_start", total=total)
     else:
         logger.info("pubchem_no_smiles")
 
     records: dict[str, dict[str, str]] = {}
     for idx, smi in enumerate(unique_smiles, start=1):
-        logger.info("pubchem_progress", extra={"current": idx, "total": total})
+        logger.info("pubchem_progress", current=idx, total=total)
         cid = pl.get_cid_from_smiles(smi, cfg) or ""
         first_cid = cid.split("|")[0] if cid else ""
         if first_cid:
@@ -149,8 +141,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             logger.error("%s", exc)
             return 1
 
-        logger.info("identifiers_retrieved", extra={"count": len(ids)})
-        logger.info("chembl_fetch_start", extra={"chunk_size": cfg.testitem.chunk_size})
+        logger.info("identifiers_retrieved", count=len(ids))
+        logger.info("chembl_fetch_start", chunk_size=cfg.testitem.chunk_size)
 
         try:
             df = cl.get_testitem(
@@ -163,7 +155,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         except (requests.RequestException, ValueError) as exc:
             logger.error("failed to retrieve compounds: %s", exc)
             return 1
-        logger.info("chembl_fetch_done", extra={"rows": len(df)})
+        logger.info("chembl_fetch_done", rows=len(df))
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(df, cfg.pubchem)
         logger.info("pubchem_augment_done")
@@ -212,7 +204,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             key_cols=key_cols or None,
         )
-        logger.info("write_done", extra={"rows": rows_kept, "path": str(csv_path)})
+        logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:
         logger.error("failed to write output CSV: %s", exc)
         return 1
@@ -262,7 +254,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(
             args,
@@ -277,23 +269,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/mapper_main.py
+++ b/scripts/mapper_main.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from collections.abc import Sequence
-from pathlib import Path
 from urllib.error import URLError
-
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 
@@ -54,10 +49,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 na_values=["#N/A", ""],
             )
         except (FileNotFoundError, OSError) as exc:
-            logger.error("%s", exc)
+            logger.error("read_fail", error=str(exc))
             return 1
         if args.column not in df.columns:
-            logger.error("column '%s' not found in %s", args.column, args.input_csv)
+            logger.error(
+                "missing_column", column=args.column, path=str(args.input_csv)
+            )
             return 1
 
         uniprot_ids: list[str | None] = []
@@ -71,12 +68,15 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 if uniprot_id:
                     logger.info(
                         "mapped",
-                        extra={"chembl_id": str(chembl_id), "uniprot_id": uniprot_id},
+                        chembl_id=str(chembl_id),
+                        uniprot_id=uniprot_id,
                     )
                 else:
-                    logger.warning("no UniProt ID for %s", chembl_id)
+                    logger.warning("uniprot_id_missing", chembl_id=str(chembl_id))
             except (ValueError, TimeoutError, URLError) as exc:
-                logger.warning("failed to map %s: %s", chembl_id, exc)
+                logger.warning(
+                    "map_failed", chembl_id=str(chembl_id), error=str(exc)
+                )
                 uniprot_ids.append(None)
         df["mapping_uniprot_id"] = uniprot_ids
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
@@ -89,9 +89,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 encoding=args.encoding,
                 key_cols=args.key_cols,
             )
-            logger.info("write_done", extra={"path": str(output)})
+            logger.info("write_done", path=str(output))
         except OSError as exc:
-            logger.error("failed to write output CSV: %s", exc)
+            logger.error("write_fail", error=str(exc))
             return 1
         return 0
     except Exception as exc:  # pragma: no cover - defensive
@@ -122,29 +122,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.error("config_error", error=str(exc))
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.error("setup_fail", error=str(exc))
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from collections.abc import Sequence
 from pathlib import Path
-
-if __package__ in {None, ""}:
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 
@@ -80,29 +76,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
         cfg: Config = apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
-            logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
         logger.error("%s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
         logger.error("failed to set up directories: %s", exc)
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = args.func(cfg, args)
     if exit_code == 0:
-        logger.info("pipeline_done", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:
-        logger.info("pipeline_fail", extra={"run_id": log_cfg.run_id})
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
     return exit_code
 
 

--- a/tests/test_csv_determinism_integration.py
+++ b/tests/test_csv_determinism_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import re
+import json
 import subprocess
 import sys
 
@@ -13,7 +13,7 @@ def test_csv_determinism_integration() -> None:
         text=True,
         check=True,
     )
-    match1 = re.search(r"First hash: ([0-9a-f]{64})", proc.stdout)
-    match2 = re.search(r"Second hash: ([0-9a-f]{64})", proc.stdout)
-    assert match1 and match2
-    assert match1.group(1) == match2.group(1)
+    records = [json.loads(line) for line in proc.stdout.splitlines()]
+    hashes = [r["value"] for r in records if r.get("event") == "hash"]
+    assert len(hashes) == 2
+    assert hashes[0] == hashes[1]

--- a/tests/test_csv_utils_main_smoke.py
+++ b/tests/test_csv_utils_main_smoke.py
@@ -10,13 +10,13 @@ from pathlib import Path
 
 def test_csv_utils_main_logs_runtime(tmp_path: Path) -> None:
     """The CLI should log its execution duration."""
-    root = Path(__file__).resolve().parents[1]
     input_csv = Path(__file__).parent / "data" / "csv_utils_input.csv"
     output_csv = tmp_path / "out.csv"
     proc = subprocess.run(
         [
             sys.executable,
-            str(root / "scripts" / "csv_utils_main.py"),
+            "-m",
+            "scripts.csv_utils_main",
             "--input",
             str(input_csv),
             "--output",

--- a/tests/test_determinism_script.py
+++ b/tests/test_determinism_script.py
@@ -13,7 +13,7 @@ def test_determinism_script_returns_zero() -> None:
     """
 
     result = subprocess.run(
-        [sys.executable, "scripts/check_determinism.py", "--log-level", "DEBUG"],
+        [sys.executable, "-m", "scripts.check_determinism", "--log-level", "DEBUG"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_get_activities_cli.py
+++ b/tests/test_get_activities_cli.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_get_activities_cli_smoke() -> None:
+    """Run the get-activities CLI and expect a zero exit code."""
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.get_activities", "--limit", "1", "--dry-run"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -121,7 +121,8 @@ def test_run_missing_activity_logs_error(tmp_path: Path, monkeypatch) -> None:
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
-    assert "required table 'activity' missing" in record.get("msg", "")
+    assert record["event"] == "missing_table"
+    assert record["table"] == "activity"
 
 
 @pytest.mark.parametrize(
@@ -168,7 +169,8 @@ def test_run_missing_columns_logs_specific_error(
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
-    assert f"required column(s) missing: {error_msg}" in record.get("msg", "")
+    assert record["event"] == "missing_columns"
+    assert record["details"] == error_msg
 
 
 def test_run_uses_config_output_dir(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_get_input_initialisation_script.py
+++ b/tests/test_get_input_initialisation_script.py
@@ -8,7 +8,7 @@ from pathlib import Path
 def test_help_executes() -> None:
     """The script should be executable directly via Python."""
     result = subprocess.run(
-        [sys.executable, "scripts/get_input_initialisation.py", "--help"],
+        [sys.executable, "-m", "scripts.get_input_initialisation", "--help"],
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
## Summary
- centralize CLI script entry points under `library.cli` and expose them via `pyproject.toml`
- remove manual `sys.path` manipulation and adopt structured logging in scripts
- add subprocess smoke test for the `get-activities` CLI

## Testing
- `ruff check .`
- `mypy library/cli.py` *(fails: Library stubs not installed for "pandas", "yaml", etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c47e1abeac83248d9db25be01ee1c6