### PR TITLE
Validate Series type for safe converters

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -693,6 +693,9 @@ def _safe_to_int(series: pd.Series, col: str) -> pd.Series:
         ``Int64`` typed series or ``string`` on failure.
     """
 
+    if not isinstance(series, pd.Series):
+        raise TypeError(f"column '{col}' has duplicate entries; expected a Series")
+
     try:
         return pd.to_numeric(series, errors="raise").astype("Int64")
     except Exception as exc:  # pragma: no cover - rare
@@ -715,6 +718,9 @@ def _safe_to_float(series: pd.Series, col: str) -> pd.Series:
     pandas.Series
         ``float64`` typed series or ``string`` on failure.
     """
+
+    if not isinstance(series, pd.Series):
+        raise TypeError(f"column '{col}' has duplicate entries; expected a Series")
 
     try:
         return pd.to_numeric(series, errors="raise").astype("float64")
@@ -739,6 +745,9 @@ def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
         ``datetime64`` typed series or ``string`` on failure.
     """
 
+    if not isinstance(series, pd.Series):
+        raise TypeError(f"column '{col}' has duplicate entries; expected a Series")
+
     try:
         return pd.to_datetime(series, errors="raise")
     except Exception as exc:  # pragma: no cover - rare
@@ -761,6 +770,9 @@ def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
     pandas.Series
         ``boolean`` typed series or ``string`` on failure.
     """
+
+    if not isinstance(series, pd.Series):
+        raise TypeError(f"column '{col}' has duplicate entries; expected a Series")
 
     def mapper(value: Any) -> object:
         if pd.isna(value):

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -11,6 +12,10 @@ from library.config import ApiCfg, Config
 from library.input_initialisation_library import (
     TableDict,
     _ensure_openpyxl,
+    _safe_to_bool,
+    _safe_to_datetime,
+    _safe_to_float,
+    _safe_to_int,
     append_entities,
     build_combined_tables,
     generate_pair_entity_tables,
@@ -36,6 +41,19 @@ def test_unify_dtypes_basic() -> None:
     assert res["shuffled_cit"].dtype == "boolean"
     assert res["mw_freebase"].dtype == "float64"
     assert str(res["publication_date"].dtype).startswith("datetime64[")
+
+
+@pytest.mark.parametrize(
+    "func",
+    [_safe_to_int, _safe_to_float, _safe_to_datetime, _safe_to_bool],
+)
+def test_safe_to_functions_reject_dataframe(func: Any) -> None:
+    df = pd.DataFrame({"col": [1]})
+    with pytest.raises(
+        TypeError,
+        match="column 'col' has duplicate entries; expected a Series",
+    ):
+        func(df, "col")
 
 
 def test_append_entities_deduplication() -> None:
@@ -645,7 +663,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
 
 
-
 @pytest.mark.parametrize(
     ("entity", "df", "col"),
     [
@@ -669,7 +686,6 @@ def test_save_tables_orders_key_column_first(
     paths = save_tables(tables, tmp_path, cfg)
     result = pd.read_csv(paths[entity])
     assert result.columns[0] == col
-
 
 
 def test_save_tables_drops_duplicate_columns_and_warns(


### PR DESCRIPTION
## Summary
- ensure `_safe_to_int`, `_safe_to_float`, `_safe_to_datetime`, and `_safe_to_bool` raise `TypeError` when passed a DataFrame
- test that safe converter helpers reject DataFrames

## Testing
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c482817a60832496a9eb3f5d8424a6