### PR TITLE
Deduplicate duplicate column names in Excel sheets

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -611,6 +611,8 @@ def _read_sheet(
 ) -> pd.DataFrame:
     """Read ``sheet`` from an Excel file.
 
+    Duplicate column names are dropped with a warning.
+
     Parameters
     ----------
     path:
@@ -636,8 +638,17 @@ def _read_sheet(
             header = raw.iloc[0].astype(str).tolist()
             df = raw.iloc[1:].reset_index(drop=True)
             df.columns = pd.Index(header)
-            return df
-        return pd.read_excel(path, sheet_name=sheet, engine="openpyxl")
+        else:
+            df = pd.read_excel(path, sheet_name=sheet, engine="openpyxl")
+
+        if df.columns.has_duplicates:
+            logger.warning(
+                "duplicate columns dropped",
+                sheet=sheet,
+                duplicates=df.columns[df.columns.duplicated()].tolist(),
+            )
+            df = df.loc[:, ~df.columns.duplicated()]
+        return df
     except ValueError as exc:  # missing sheet
         raise ValueError(f"sheet '{sheet}' not found in {path}") from exc
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import json
 import sys
 from pathlib import Path
 
@@ -7,6 +9,7 @@ import pandas as pd
 import pytest
 
 from library import input_initialisation_library as lib
+from library.cli import LoggerConfig, configure_logger
 from library.config import ApiCfg, Config
 from library.input_initialisation_library import (
     TableDict,
@@ -645,7 +648,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"
 
 
-
 @pytest.mark.parametrize(
     ("entity", "df", "col"),
     [
@@ -669,7 +671,6 @@ def test_save_tables_orders_key_column_first(
     paths = save_tables(tables, tmp_path, cfg)
     result = pd.read_csv(paths[entity])
     assert result.columns[0] == col
-
 
 
 def test_save_tables_drops_duplicate_columns_and_warns(
@@ -932,3 +933,23 @@ def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
 
     for col in ["IUPHAR_class", "IUPHAR_subclass", "gene_index", "taxon_index"]:
         assert col in res.columns
+
+
+def test_read_sheet_drops_duplicate_columns(tmp_path: Path) -> None:
+    """``_read_sheet`` removes duplicate headers and logs a warning."""
+
+    df = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "b"])
+    xlsx = tmp_path / "dup.xlsx"
+    with pd.ExcelWriter(xlsx, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name="Sheet1", index=False)
+
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(level="WARNING", stream=buffer))
+    result = lib._read_sheet(xlsx, "Sheet1", header_promotion=True)
+    configure_logger(LoggerConfig(stream=sys.stdout))
+
+    assert list(result.columns) == ["a", "b"]
+    records = [json.loads(line) for line in buffer.getvalue().splitlines() if line]
+    record = next(r for r in records if r.get("event") == "duplicate columns dropped")
+    assert record["sheet"] == "Sheet1"
+    assert record["duplicates"] == ["b"]


### PR DESCRIPTION
## Summary
- drop duplicate columns from Excel sheets and log their names
- add regression test to ensure duplicates are removed

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_read_sheet_drops_duplicate_columns`


------
https://chatgpt.com/codex/tasks/task_e_68c482781e188324a643ce5e13f62cec