### PR TITLE
Allow running input initialisation script without installing package

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -16,9 +16,16 @@ message.
 
 from __future__ import annotations
 
+# ruff: noqa: E402
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
+
+# Ensure the project root is importable when executing the script directly.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:  # pragma: no cover - simple environment guard
+    sys.path.insert(0, str(ROOT))
 
 from library import input_initialisation_library as lib
 from library.cli import (

--- a/tests/test_get_input_initialisation_script.py
+++ b/tests/test_get_input_initialisation_script.py
@@ -16,3 +16,18 @@ def test_help_executes() -> None:
     )
     assert result.returncode == 0, result.stderr
     assert "Path to same document workbook" in result.stdout
+
+
+def test_help_executes_file() -> None:
+    """The script should run when invoked via its file path."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts" / "get_input_initialisation.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo_root,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Path to same document workbook" in result.stdout


### PR DESCRIPTION
## Summary
- ensure `scripts/get_input_initialisation.py` adjusts `sys.path` so `library` can be imported when run directly
- add regression test verifying the script runs via its file path

## Testing
- `python -m black scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py`
- `python -m ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py`
- `python -m mypy scripts/get_input_initialisation.py tests/test_get_input_initialisation_script.py`
- `pytest tests/test_get_input_initialisation_script.py tests/test_get_input_initialisation.py -q`
- `python scripts/get_input_initialisation.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c4873420c4832486c8cdd3af4c7b0f