### PR TITLE
Add metadata sidecar generation for CSV exports

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -184,7 +184,12 @@ def write_csv_deterministic(
             sep=sep,
         )
     os.replace(tmp_path, out_path)
-    write_meta_yaml(out_path, cfg)
+    write_meta_yaml(
+        out_path,
+        cfg,
+        columns=list(work.columns),
+        dtypes={col: work.dtypes[col].name for col in work.columns},
+    )
     return out_path
 
 

--- a/library/io.py
+++ b/library/io.py
@@ -269,8 +269,14 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
 
 
-def write_meta_yaml(path: Path | str, cfg: Config | None = None) -> Path:
-    """Write minimal metadata for ``path`` to ``<path>.meta.yaml``.
+def write_meta_yaml(
+    path: Path | str,
+    cfg: Config | None = None,
+    *,
+    columns: Sequence[str] | None = None,
+    dtypes: Mapping[str, str] | None = None,
+) -> Path:
+    """Write metadata for ``path`` to ``<path>.meta.yaml``.
 
     Parameters
     ----------
@@ -281,6 +287,12 @@ def write_meta_yaml(path: Path | str, cfg: Config | None = None) -> Path:
         objects inside the configuration are serialised as plain strings to make
         the resulting YAML portable. When ``None`` an empty mapping is written
         under the ``config`` key.
+    columns:
+        Optional sequence of column names present in the exported table.
+    dtypes:
+        Optional mapping from column names to their data types. When omitted
+        and ``columns`` are provided each column is assumed to contain
+        ``"string"`` values.
 
     Returns
     -------
@@ -288,9 +300,15 @@ def write_meta_yaml(path: Path | str, cfg: Config | None = None) -> Path:
         Path to the generated ``.meta.yaml`` file.
     """
 
+    if dtypes is None and columns is not None:
+        dtypes = {col: "string" for col in columns}
+
     meta = {
+        "generated_at": datetime.now().isoformat(),
         "git_sha": _git_sha(),
         "command": " ".join(sys.argv),
+        "columns": list(columns or []),
+        "dtypes": dict(dtypes or {}),
         "config": _serialize_paths(cfg.to_dict()) if cfg is not None else {},
     }
     meta_path = Path(f"{path}.meta.yaml")

--- a/library/sidecar.py
+++ b/library/sidecar.py
@@ -54,4 +54,4 @@ class SidecarErrors:
             writer = csv.DictWriter(fh, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(self._errors)
-        write_meta_yaml(path, cfg)
+        write_meta_yaml(path, cfg, columns=fieldnames)

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -4,6 +4,7 @@ from .activities import ActivitiesSchema
 from .assay_postprocessing import AssayPostprocessSchema
 from .assays import AssaysSchema
 from .documents import DocumentsSchema
+from .meta import CsvMetaSchema
 from .normalize import (
     normalize_activities,
     normalize_assays,
@@ -21,6 +22,7 @@ __all__ = [
     "DocumentsSchema",
     "TargetsSchema",
     "TestitemsSchema",
+    "CsvMetaSchema",
     "normalize_activities",
     "normalize_assays",
     "normalize_documents",

--- a/schemas/meta.py
+++ b/schemas/meta.py
@@ -1,0 +1,38 @@
+"""Schema for CSV metadata sidecar files."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CsvMetaSchema(BaseModel):
+    """Pydantic model describing ``.meta.yaml`` sidecars.
+
+    Attributes
+    ----------
+    generated_at:
+        Timestamp when the export was created.
+    git_sha:
+        Git commit hash of the repository at creation time.
+    columns:
+        Ordered list of column names present in the CSV file.
+    dtypes:
+        Mapping of column names to their dtypes as reported by pandas.
+    command:
+        Optional command line invocation string.
+    config:
+        Optional serialised configuration used to generate the file.
+    """
+
+    generated_at: datetime
+    git_sha: str
+    columns: list[str] = Field(default_factory=list)
+    dtypes: dict[str, str] = Field(default_factory=dict)
+    command: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+__all__ = ["CsvMetaSchema"]

--- a/tests/test_meta_yaml.py
+++ b/tests/test_meta_yaml.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from library.config import Config
+from library.io import write_csv
+from library.sidecar import SidecarErrors
+from schemas import CsvMetaSchema
+
+
+def test_write_csv_creates_meta(tmp_path: Path) -> None:
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+    cfg = Config()
+    out_path = tmp_path / "out.csv"
+    write_csv(df, out_path, cfg=cfg, key_cols=["id"])
+    meta_path = Path(f"{out_path}.meta.yaml")
+    assert meta_path.exists()
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf8"))
+    CsvMetaSchema.model_validate(meta)
+    assert meta["columns"] == ["id", "name"]
+    assert meta["dtypes"] == {"id": "int64", "name": "object"}
+    assert meta["git_sha"]
+    datetime.fromisoformat(meta["generated_at"])  # raises if invalid
+
+
+def test_sidecar_writes_meta(tmp_path: Path) -> None:
+    errors = SidecarErrors()
+    errors.add_error({"col_a": "foo", "col_b": 1})
+    out = tmp_path / "errors.csv"
+    errors.save(out, cfg=Config())
+    meta_path = Path(f"{out}.meta.yaml")
+    assert meta_path.exists()
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf8"))
+    CsvMetaSchema.model_validate(meta)
+    assert meta["columns"] == ["col_a", "col_b"]
+    assert meta["dtypes"] == {"col_a": "string", "col_b": "string"}
+    assert meta["git_sha"]
+    datetime.fromisoformat(meta["generated_at"])  # raises if invalid


### PR DESCRIPTION
## Summary
- generate `.meta.yaml` after CSV writes with columns, dtypes, timestamp and git SHA
- expose `CsvMetaSchema` for validating sidecar files
- test metadata creation for standard and sidecar outputs

## Testing
- `ruff check .`
- `mypy library/io.py library/csv_utils.py library/sidecar.py schemas/meta.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c48accc0c0832491ee28576fcbc092