### PR TITLE
chore: expand mypy coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
-        args: ["--strict", "library"]
+        args: []
         pass_filenames: false
         additional_dependencies:
           - pandas-stubs==2.3.2.250827
@@ -24,6 +24,7 @@ repos:
           - types-cachetools==6.2.0.20250827
           - types-urllib3==1.26.25.14
           - types-tabulate
+          - pytest
           - pydantic
           - pandera
   - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   "types-cachetools==6.2.0.20250827",
   "types-urllib3==1.26.25.14",
   "types-tabulate",
+  "types-pytest",
   "psutil>=5",
 ]
 
@@ -97,7 +98,14 @@ ignore = ["E501"]
 python_version = "3.12"
 strict = true
 warn_unused_configs = true
-exclude = "^(?!library/).*"
+files = [
+  "library",
+  "scripts",
+  "tests/test_activity_cli_overrides.py",
+  "tests/test_activity_cli_error.py",
+  "tests/test_cli_timeout_override.py",
+  "tests/test_cli_bad_config.py",
+]
 plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -18,9 +18,7 @@ from library.cli import (
     apply_config_overrides,
     configure_logger,
 )
-from library.cli import (
-    build_parser as base_parser,
-)
+from library.cli import build_parser as base_parser
 from library.config import (
     Config,
     _serialize_paths,
@@ -32,6 +30,8 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from schemas import AssaysSchema, normalize_assays
+
+__all__ = ["ap", "main"]
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -191,7 +191,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code: int = args.func(cfg, args)
     if exit_code == 0:
         logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -24,6 +24,7 @@ from library.cli import (
 )
 from library.config import (
     Config,
+    PubChemCfg,
     _serialize_paths,
     ensure_dirs,
     print_config,
@@ -35,7 +36,7 @@ from library.table_quality import analyze_table_quality
 from schemas import TestitemsSchema, normalize_testitems
 
 
-def add_pubchem_data(df: pd.DataFrame, cfg: pl.PubChemCfg) -> pd.DataFrame:
+def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -281,7 +282,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code: int = args.func(cfg, args)
     if exit_code == 0:
         logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:

--- a/scripts/mapper_main.py
+++ b/scripts/mapper_main.py
@@ -52,9 +52,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             logger.error("read_fail", error=str(exc))
             return 1
         if args.column not in df.columns:
-            logger.error(
-                "missing_column", column=args.column, path=str(args.input_csv)
-            )
+            logger.error("missing_column", column=args.column, path=str(args.input_csv))
             return 1
 
         uniprot_ids: list[str | None] = []
@@ -74,9 +72,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 else:
                     logger.warning("uniprot_id_missing", chembl_id=str(chembl_id))
             except (ValueError, TimeoutError, URLError) as exc:
-                logger.warning(
-                    "map_failed", chembl_id=str(chembl_id), error=str(exc)
-                )
+                logger.warning("map_failed", chembl_id=str(chembl_id), error=str(exc))
                 uniprot_ids.append(None)
         df["mapping_uniprot_id"] = uniprot_ids
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
@@ -140,7 +136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("setup_fail", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code: int = args.func(cfg, args)
     if exit_code == 0:
         logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -94,7 +94,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.error("failed to set up directories: %s", exc)
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
-    exit_code = args.func(cfg, args)
+    exit_code: int = args.func(cfg, args)
     if exit_code == 0:
         logger.info("pipeline_done", run_id=log_cfg.run_id)
     else:

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import requests
+from pytest import MonkeyPatch
 
 from library import chembl_library as cl
 from library import io as lib_io
@@ -12,7 +13,9 @@ from library.config import Config
 from scripts import get_activity_data as gad
 
 
-def test_run_chembl_handles_request_error(monkeypatch, cfg: Config) -> None:
+def test_run_chembl_handles_request_error(
+    monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
     args = argparse.Namespace(
         input_csv=Path("dummy.csv"),
         output_csv=None,
@@ -26,7 +29,7 @@ def test_run_chembl_handles_request_error(monkeypatch, cfg: Config) -> None:
     )
     monkeypatch.setattr(lib_io, "read_ids", lambda *a, **k: iter(["1"]))
 
-    def _raise(*_a, **_k):
+    def _raise(*_a: object, **_k: object) -> None:
         raise requests.RequestException("boom")
 
     monkeypatch.setattr(cl, "get_activities", _raise)

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
+from pytest import MonkeyPatch
 
 from library import chembl_library as cl
 from library import io
+from library.config import Config
 from scripts import get_activity_data as gad
 
 
@@ -29,7 +33,7 @@ def _create_config(tmp_path: Path) -> Path:
 
 
 def _run(
-    tmp_path: Path, monkeypatch, extra: list[str]
+    tmp_path: Path, monkeypatch: MonkeyPatch, extra: list[str]
 ) -> tuple[int, dict[str, object]]:
     input_csv = tmp_path / "activity.csv"
     input_csv.write_text("activity_id\n1\n")
@@ -37,7 +41,13 @@ def _run(
     called: dict[str, object] = {}
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: iter(["1"]))
 
-    def fake_get(ids, cfg, client, chunk_size, timeout):
+    def fake_get(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
         data = list(ids)
         called["chunk_size"] = chunk_size
         return pd.DataFrame({"activity_id": data})
@@ -46,11 +56,11 @@ def _run(
         df: pd.DataFrame,
         output: Path,
         *,
-        cfg: object | None = None,
+        cfg: Config | None = None,
         sep: str | None = None,
         encoding: str | None = None,
         **_: object,
-    ) -> None:
+    ) -> Path:
         if sep is None and cfg is not None:
             sep = cfg.io.csv_sep
         if encoding is None and cfg is not None:
@@ -68,7 +78,7 @@ def _run(
     return rc, called
 
 
-def test_default_config_used(tmp_path: Path, monkeypatch) -> None:
+def test_default_config_used(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     rc, called = _run(tmp_path, monkeypatch, [])
     assert rc == 0
     assert called["chunk_size"] == 10
@@ -76,7 +86,7 @@ def test_default_config_used(tmp_path: Path, monkeypatch) -> None:
     assert called["encoding"] == "iso-8859-1"
 
 
-def test_cli_overrides(tmp_path: Path, monkeypatch) -> None:
+def test_cli_overrides(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     rc, called = _run(
         tmp_path,
         monkeypatch,

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -1,10 +1,14 @@
 import io
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
 
-from library.cli import configure_logger
+from library.cli import LoggerConfig, configure_logger
+from library.logging_setup import Logger
 from scripts import get_activity_data as gad
 from scripts import get_assay_data as gas
 from scripts import get_document_data as gdd
@@ -30,7 +34,12 @@ CLIS = [
 
 @pytest.mark.parametrize("entry, extra, use_sys", CLIS)
 def test_malformed_config_exits(
-    tmp_path: Path, entry, extra, use_sys, monkeypatch, caplog: pytest.LogCaptureFixture
+    tmp_path: Path,
+    entry: Callable[..., int],
+    extra: list[str],
+    use_sys: bool,
+    monkeypatch: MonkeyPatch,
+    caplog: LogCaptureFixture,
 ) -> None:
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
@@ -48,7 +57,7 @@ def test_malformed_config_exits(
     buf = io.StringIO()
     orig = configure_logger
 
-    def _conf(cfg, *a, **k):
+    def _conf(cfg: LoggerConfig, *a: Any, **k: Any) -> Logger:
         cfg.stream = buf
         return orig(cfg, *a, **k)
 

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
+from pytest import MonkeyPatch
 
 from library import chembl_library as cl
 from library import io
@@ -32,20 +35,30 @@ def _create_config(tmp_path: Path) -> Path:
     return cfg
 
 
-def test_assay_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
+def test_assay_timeout_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
     input_csv = tmp_path / "assay.csv"
     input_csv.write_text("assay_chembl_id\na1\n")
     config_path = _create_config(tmp_path)
     called: dict[str, float] = {}
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["a1"])
 
-    def fake_apply(a, p, c, mapping=None):
+    def fake_apply(
+        a: Any, p: Any, c: Config, mapping: dict[str, str] | None = None
+    ) -> Config:
         cfg.assay.timeout = float(a.timeout)
         return cfg
 
     monkeypatch.setattr(gas, "apply_config_overrides", fake_apply)
 
-    def fake_get_assays(ids, cfg, client, chunk_size, timeout):
+    def fake_get_assays(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"assay_chembl_id": data})
@@ -76,7 +89,9 @@ def test_assay_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> Non
     assert called["timeout"] == 5
 
 
-def test_document_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
+def test_document_timeout_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
     input_csv = tmp_path / "doc.csv"
     input_csv.write_text("document_chembl_id\nd1\n")
     config_path = _create_config(tmp_path)
@@ -84,14 +99,26 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> 
 
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["d1"])
 
-    def fake_apply_doc(a, p, c, mapping=None, **kwargs):
+    def fake_apply_doc(
+        a: Any,
+        p: Any,
+        c: Config,
+        mapping: Any | None = None,
+        **kwargs: Any,
+    ) -> Config:
         cfg.document.chembl.timeout = float(a.timeout)
         cfg.api.user_agent = "test/0.1 (mailto:test@example.com)"
         return cfg
 
     monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply_doc)
 
-    def fake_get_documents(ids, cfg, client, chunk_size, timeout):
+    def fake_get_documents(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"document_chembl_id": data})
@@ -124,7 +151,9 @@ def test_document_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> 
     assert cfg.api.timeout_read == 7
 
 
-def test_testitem_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
+def test_testitem_timeout_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
     input_csv = tmp_path / "testitem.csv"
     input_csv.write_text("molecule_chembl_id\nt1\n")
     config_path = _create_config(tmp_path)
@@ -132,13 +161,21 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> 
 
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
 
-    def fake_apply_test(a, p, c, mapping=None):
+    def fake_apply_test(
+        a: Any, p: Any, c: Config, mapping: Any | None = None
+    ) -> Config:
         cfg.testitem.timeout = float(a.timeout)
         return cfg
 
     monkeypatch.setattr(gtdt, "apply_config_overrides", fake_apply_test)
 
-    def fake_get_testitem(ids, cfg, client, chunk_size, timeout):
+    def fake_get_testitem(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"molecule_chembl_id": data})
@@ -169,7 +206,9 @@ def test_testitem_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> 
     assert called["timeout"] == 9
 
 
-def test_target_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> None:
+def test_target_timeout_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
     input_csv = tmp_path / "target.csv"
     input_csv.write_text("target_chembl_id\nt1\n")
     config_path = _create_config(tmp_path)
@@ -177,13 +216,25 @@ def test_target_timeout_override(tmp_path: Path, monkeypatch, cfg: Config) -> No
 
     monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
 
-    def fake_apply_target(a, p, c, mapping=None, **kwargs):
+    def fake_apply_target(
+        a: Any,
+        p: Any,
+        c: Config,
+        mapping: Any | None = None,
+        **kwargs: Any,
+    ) -> Config:
         cfg.target.chembl.timeout = float(a.timeout)
         return cfg
 
     monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply_target)
 
-    def fake_get_targets(ids, cfg, client, mapping_cfg, timeout):
+    def fake_get_targets(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        mapping_cfg: Any,
+        timeout: float,
+    ) -> pd.DataFrame:
         data = list(ids)
         called["timeout"] = timeout
         return pd.DataFrame({"target_chembl_id": data})


### PR DESCRIPTION
## Summary
- run mypy on scripts and selected tests by configuring explicit targets
- allow mypy via pre-commit without filename arguments and include pytest stubs
- add missing type hints and explicit return codes in CLI helpers and tests

## Testing
- `python -m pre_commit run --files pyproject.toml .pre-commit-config.yaml scripts/get_assay_data.py scripts/get_testitem_data.py scripts/table_quality_main.py scripts/mapper_main.py tests/test_activity_cli_overrides.py tests/test_activity_cli_error.py tests/test_cli_timeout_override.py tests/test_cli_bad_config.py`
- `python -m pre_commit run mypy --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68c48dd3b6b083248c02f0e845c1ee54