### PR TITLE
Use shared sleep utility and test retry backoff

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import io
 import random
 import threading
-import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,7 +28,7 @@ from requests import Session
 
 from .config import ApiCfg, IupharCfg, RetryCfg, session_with_retry
 from .log import logger
-from .rate_limiter import get_limiter
+from .rate_limiter import get_limiter, sleep
 
 # Default session with placeholder user agent; callers should override via
 # :func:`init_session` with a configuration that provides their own contact
@@ -193,7 +192,7 @@ def _query_gene_symbol(
                 break
             backoff = retry.backoff_factor * (2 ** (attempt - 1))
             jitter = random.uniform(0, backoff)
-            time.sleep(backoff + jitter)
+            sleep(backoff + jitter)
     return {}
 
 
@@ -671,7 +670,7 @@ class IUPHARData:
                         raise
                     backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
                     jitter = random.uniform(0, backoff)
-                    time.sleep(backoff + jitter)
+                    sleep(backoff + jitter)
             raise RuntimeError("Failed to download mapping")
 
         uni_df = _download(f"{data_base}/GtP_to_UniProt_mapping.csv")

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,7 +6,6 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import quote
@@ -17,7 +16,7 @@ from requests import Session
 
 from .config import ApiCfg, PubChemCfg, RetryCfg, session_with_retry
 from .log import logger
-from .rate_limiter import get_limiter
+from .rate_limiter import get_limiter, sleep
 
 _CACHE: LRUCache[str, dict[str, Any]] = LRUCache(maxsize=1024)
 
@@ -191,7 +190,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     extra={"url": url, "status": None, "rps": cfg.rps},
                 )
                 return None
-            time.sleep(cfg.delay)
+            sleep(cfg.delay)
             continue
 
         if response.status_code in (404, 400):
@@ -217,7 +216,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     extra={"url": url, "status": None, "rps": cfg.rps},
                 )
                 return None
-            time.sleep(cfg.delay)
+            sleep(cfg.delay)
             continue
         except ValueError:
             logger.warning("Non-JSON response for url %s", url)

--- a/tests/test_iuphar_library.py
+++ b/tests/test_iuphar_library.py
@@ -35,7 +35,7 @@ def test_websearch_gene_to_id_uses_cfg2(monkeypatch) -> None:
     sleeps: list[float] = []
     monkeypatch.setattr(ii._session, "get", fake_get)
 
-    monkeypatch.setattr(ii.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(ii, "sleep", lambda s: sleeps.append(s))
 
     cfg = IupharCfg(
         base="https://example.org/services",
@@ -94,7 +94,7 @@ def test_iuphar_upload_uses_cfg(monkeypatch):
     sleeps: list[float] = []
     monkeypatch.setattr(ii._session, "get", fake_get)
 
-    monkeypatch.setattr(ii.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(ii, "sleep", lambda s: sleeps.append(s))
 
     cfg = IupharCfg(
         base="https://example.org/services",
@@ -156,10 +156,74 @@ def test_query_gene_symbol_backoff(monkeypatch):
 
     sleeps: list[float] = []
     monkeypatch.setattr(ii._session, "get", fake_get)
-    monkeypatch.setattr(ii.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(ii, "sleep", lambda s: sleeps.append(s))
     monkeypatch.setattr(ii.random, "uniform", lambda a, b: 0)
 
     result = ii._query_gene_symbol("GENE", cfg, retry)
     assert result == {"id": 1}
     assert calls[0][0] == "https://example.org/services/targets/?geneSymbol=GENE"
     assert sleeps == [pytest.approx(1.0)]
+
+
+def test_iuphar_upload_retries(monkeypatch) -> None:
+    """``iuphar_upload`` retries failed downloads with backoff."""
+
+    target_df = pd.DataFrame({"target_id": [1], "family_id": ["F1"]})
+    family_df = pd.DataFrame(
+        {"family_id": ["F1"], "family_name": ["Fam"], "parent_family_id": [pd.NA]}
+    )
+    data = ii.IUPHARData(target_df=target_df, family_df=family_df)
+
+    cfg = IupharCfg(
+        base="https://example.org/services",
+        timeout_connect=1,
+        timeout_read=2,
+        rps=10,
+        burst=5,
+    )
+    retry = RetryCfg(max_attempts=2, backoff_factor=1)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(ii, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(ii.random, "uniform", lambda a, b: 0)
+
+    calls = {"n": 0}
+
+    def fake_get(url: str, timeout: tuple[int, int]):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise requests.RequestException("boom")
+
+        text = (
+            "GtoPdb IUPHAR ID,IUPHAR ID,UniProtKB ID\n1,1,P12345\n"
+            if "UniProt" in url
+            else "GtoPdb IUPHAR ID,HGNC ID,IUPHAR Name\n1,HG1,Name\n"
+        )
+
+        class Resp:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def raise_for_status(self) -> None:
+                return None
+
+        return Resp(text)
+
+    monkeypatch.setattr(ii._session, "get", fake_get)
+    monkeypatch.setattr(
+        ii,
+        "get_limiter",
+        lambda *a, **k: type("L", (), {"acquire": lambda self: None})(),
+    )
+
+    df = data.iuphar_upload(cfg, retry)
+
+    assert not df.empty
+    assert sleeps == [pytest.approx(1.0)]
+    assert calls["n"] == 3

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -142,7 +142,7 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
             raise requests.RequestException("boom")
         return Resp()
 
-    monkeypatch.setattr(pl.time, "sleep", fake_sleep)
+    monkeypatch.setattr(pl, "sleep", fake_sleep)
     monkeypatch.setattr(pl._session, "get", fake_get)
 
     class Limiter:


### PR DESCRIPTION
## Summary
- use rate_limiter.sleep for retry pauses in PubChem and IUPHAR clients
- update and extend tests to mock sleep and verify retry/backoff behaviour

## Testing
- `pre-commit run --files library/pubchem_library.py library/iuphar_library.py tests/test_pubchem_library.py tests/test_iuphar_library.py`
- `pytest tests/test_pubchem_library.py::test_make_request_waits_between_retries`
- `pytest tests/test_iuphar_library.py::test_query_gene_symbol_backoff tests/test_iuphar_library.py::test_iuphar_upload_retries`


------
https://chatgpt.com/codex/tasks/task_e_68c48df8f30c8324bff87efca053b59d