### PR TITLE
Ensure CLI scripts locate project modules when run directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ tokens should be stored in a local ``.env`` file – see
    ```
 
    The command reads the bundled test identifiers and writes a normalised CSV
-   to ``out/activities.csv``. Common CLI flags include ``--input`` and
-   ``--output`` for file paths, ``--limit`` to cap processed records,
-   ``--log-level`` for verbosity, ``--sep`` for CSV delimiter and
+   to ``out/activities.csv``. Scripts can also be invoked as modules, e.g.
+   ``python -m scripts.get_activity_data``, or after installing the package in
+   editable mode using ``pip install -e .``. Common CLI flags include
+   ``--input`` and ``--output`` for file paths, ``--limit`` to cap processed
+   records, ``--log-level`` for verbosity, ``--sep`` for CSV delimiter and
    ``--encoding`` for file encoding. Additional examples:
 
    ```bash

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -9,10 +9,15 @@ hashes differ.
 
 from __future__ import annotations
 
+# ruff: noqa: E402
 import argparse
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import perf_counter
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 try:
     import pandas as pd

--- a/scripts/chunk_io_main.py
+++ b/scripts/chunk_io_main.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import argparse
 from collections.abc import Sequence
-from pathlib import Path
 
 from library.chunk_io import process_csv_chunks
 from library.cli import LoggerConfig, add_common_arguments, configure_logger

--- a/scripts/csv_utils_main.py
+++ b/scripts/csv_utils_main.py
@@ -9,10 +9,16 @@ If ``--output`` is omitted, a file named
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
 import time
 from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import argparse
 from collections.abc import Sequence
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-import argparse
 import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import argparse
 from collections.abc import Iterable, Sequence
 from itertools import islice
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-import argparse
 import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import argparse
 from collections.abc import Sequence
 
 import requests

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -24,8 +24,15 @@ The input file must contain a ``PMID`` column.
 
 from __future__ import annotations
 
-import argparse
 import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import argparse
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import cast

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -7,6 +7,14 @@ scoring logic.
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from collections.abc import Iterable, Mapping, Sequence
 
 import pandas as pd

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -16,16 +16,16 @@ message.
 
 from __future__ import annotations
 
-# ruff: noqa: E402
-import argparse
 import sys
-from collections.abc import Sequence
+
+# ruff: noqa: E402
 from pathlib import Path
 
-# Ensure the project root is importable when executing the script directly.
-ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:  # pragma: no cover - simple environment guard
-    sys.path.insert(0, str(ROOT))
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import argparse
+from collections.abc import Sequence
 
 from library import input_initialisation_library as lib
 from library.cli import (

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -9,12 +9,16 @@ Fetch ChEMBL target information for identifiers in ``targets.csv``::
 
 from __future__ import annotations
 
+# ruff: noqa: E402
 import argparse
 import csv
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 from typing import cast
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pandas as pd
 import requests

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-import argparse
 import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import argparse
 from collections.abc import Sequence
 
 import pandas as pd

--- a/scripts/mapper_main.py
+++ b/scripts/mapper_main.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import argparse
 from collections.abc import Sequence
 from urllib.error import URLError

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import sys
+
+# ruff: noqa: E402
+from pathlib import Path
+
+if __package__ is None:  # running as a script
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import argparse
 import os
 from collections.abc import Sequence
-from pathlib import Path
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- allow CLI scripts to append the project root to `sys.path` when executed directly
- document running scripts via `python -m` or after `pip install -e .`

## Testing
- `pre-commit run --files README.md scripts/get_activity_data.py scripts/get_assay_data.py scripts/csv_utils_main.py scripts/check_determinism.py scripts/chunk_io_main.py scripts/get_activities.py scripts/get_document_data.py scripts/get_document_type.py scripts/get_input_initialisation.py scripts/get_target_data.py scripts/get_testitem_data.py scripts/mapper_main.py scripts/table_quality_main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c499d73720832481229104289caee2