### PR TITLE
Add TTL-based caching for PubChem requests

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -666,6 +666,12 @@
           "minimum": 0,
           "title": "Delay",
           "type": "number"
+        },
+        "cache_ttl": {
+          "default": 3600,
+          "minimum": 0,
+          "title": "Cache Ttl",
+          "type": "integer"
         }
       },
       "title": "PubChemCfg",

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,7 @@ pubchem:
   rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
   burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
   delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
+  cache_ttl: 3600  # Request cache time-to-live in seconds
 
 
 pubmed:

--- a/library/config.py
+++ b/library/config.py
@@ -243,6 +243,11 @@ class PubChemCfg(_BaseModel):
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    cache_ttl: int = Field(
+        3600,
+        ge=0,
+        description="Time-to-live for PubChem request cache in seconds",
+    )
 
     @field_validator("base")
     @classmethod

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -11,14 +11,16 @@ from typing import Any, cast
 from urllib.parse import quote
 
 import requests
-from cachetools import LRUCache
+from cachetools import TTLCache
 from requests import Session
 
 from .config import ApiCfg, PubChemCfg, RetryCfg, session_with_retry
 from .log import logger
 from .rate_limiter import get_limiter, sleep
 
-_CACHE: LRUCache[str, dict[str, Any]] = LRUCache(maxsize=1024)
+# Cache is initialised lazily to allow configuration of the TTL via
+# :class:`PubChemCfg`. The cache is recreated when the TTL changes.
+_CACHE: TTLCache[str, dict[str, Any]] | None = None
 
 # Shared session with placeholder user agent; production code should call
 # :func:`init_session` to supply real contact details.
@@ -164,6 +166,11 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         Parsed JSON response on success, otherwise ``None`` when all retries
         are exhausted or a non-recoverable error occurs.
     """
+    global _CACHE
+    if _CACHE is None or _CACHE.ttl != cfg.cache_ttl:
+        # Initialise or refresh the cache with the configured TTL.
+        _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
+
     if url in _CACHE:
         logger.info("cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"})
         return _CACHE[url]
@@ -230,6 +237,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             "request_ok",
             extra={"url": url, "status": response.status_code, "rps": cfg.rps},
         )
+        assert _CACHE is not None  # for type checker; cache initialised above
         _CACHE[url] = data
         logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
         return data

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 import requests
 
@@ -55,7 +57,7 @@ def test_make_request_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
         "get_limiter",
         lambda *a, **k: type("L", (), {"acquire": lambda self: None})(),
     )
-    pl._CACHE.clear()
+    pl._CACHE = None
 
     cfg = pl.PubChemCfg(timeout_connect=1, timeout_read=2, retries=1, rps=1)
 
@@ -95,7 +97,7 @@ def test_make_request_rate_limited(monkeypatch: pytest.MonkeyPatch) -> None:
             return None
 
     monkeypatch.setattr(pl._session, "get", lambda url, timeout: Resp())
-    pl._CACHE.clear()
+    pl._CACHE = None
 
     cfg = pl.PubChemCfg(rps=1, burst=1, retries=1)
     pl.make_request("https://example.org/a", cfg)
@@ -150,9 +152,47 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
             return None
 
     monkeypatch.setattr(pl, "get_limiter", lambda *a, **k: Limiter())
-    pl._CACHE.clear()
+    pl._CACHE = None
 
     cfg = pl.PubChemCfg(retries=2, delay=1)
     pl.make_request("https://example.org", cfg)
 
     assert sleeps == [1]
+
+
+def test_cache_entry_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache entries should be evicted after the configured TTL."""
+
+    class Resp:
+        status_code = 200
+
+        def json(self) -> dict[str, object]:
+            return {}
+
+        def raise_for_status(self) -> None:  # pragma: no cover - no error
+            return None
+
+    calls = {"n": 0}
+
+    def capture(url: str, timeout: tuple[int, int]) -> Resp:
+        calls["n"] += 1
+        return Resp()
+
+    monkeypatch.setattr(pl._session, "get", capture)
+    monkeypatch.setattr(
+        pl,
+        "get_limiter",
+        lambda *a, **k: type("L", (), {"acquire": lambda self: None})(),
+    )
+    pl._CACHE = None
+
+    cfg = pl.PubChemCfg(cache_ttl=1, delay=0, retries=1)
+    url = "https://example.org"
+
+    pl.make_request(url, cfg)
+    pl.make_request(url, cfg)
+    assert calls["n"] == 1  # cached
+
+    time.sleep(1.1)
+    pl.make_request(url, cfg)
+    assert calls["n"] == 2  # cache expired


### PR DESCRIPTION
## Summary
- switch to `TTLCache` with configurable TTL for PubChem API responses
- expose `cache_ttl` setting in `PubChemCfg` and sample config
- test cache expiration behaviour

## Testing
- `python -m black library/pubchem_library.py library/config.py tests/test_pubchem_library.py`
- `python -m ruff check library/pubchem_library.py library/config.py tests/test_pubchem_library.py`
- `python -m mypy library/pubchem_library.py library/config.py`
- `pytest tests/test_pubchem_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c49b69955083249afbd261d5e536fd