### PR TITLE
refactor: modular CLI commands

### DIFF
--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -1,0 +1,23 @@
+"""Command-line interface utilities."""
+
+from .parser import (
+    Logger,
+    LoggerConfig,
+    add_common_arguments,
+    apply_config_overrides,
+    build_parser,
+    build_root_parser,
+    configure_logger,
+    create_logger_config,
+)
+
+__all__ = [
+    "Logger",
+    "LoggerConfig",
+    "add_common_arguments",
+    "apply_config_overrides",
+    "build_parser",
+    "build_root_parser",
+    "configure_logger",
+    "create_logger_config",
+]

--- a/library/cli/commands/__init__.py
+++ b/library/cli/commands/__init__.py
@@ -1,0 +1,30 @@
+"""Shared helpers for CLI command wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from importlib import import_module
+from typing import cast
+
+
+def _run(module: str, argv: Sequence[str] | None = None) -> int:
+    """Execute ``module.main`` from the :mod:`scripts` package.
+
+    Parameters
+    ----------
+    module:
+        Name of the module inside :mod:`scripts`.
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script's ``main`` function.
+    """
+
+    main_func = import_module(f"scripts.{module}").main
+    return cast(int, main_func(argv))
+
+
+__all__ = ["_run"]

--- a/library/cli/commands/check_determinism.py
+++ b/library/cli/commands/check_determinism.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.check_determinism.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("check_determinism", argv)

--- a/library/cli/commands/chunk_io.py
+++ b/library/cli/commands/chunk_io.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.chunk_io.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("chunk_io", argv)

--- a/library/cli/commands/csv_utils.py
+++ b/library/cli/commands/csv_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.csv_utils.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("csv_utils", argv)

--- a/library/cli/commands/get_activities.py
+++ b/library/cli/commands/get_activities.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_activities.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_activities", argv)

--- a/library/cli/commands/get_activity_data.py
+++ b/library/cli/commands/get_activity_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_activity_data.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_activity_data", argv)

--- a/library/cli/commands/get_assay_data.py
+++ b/library/cli/commands/get_assay_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_assay_data.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_assay_data", argv)

--- a/library/cli/commands/get_document_data.py
+++ b/library/cli/commands/get_document_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_document_data.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_document_data", argv)

--- a/library/cli/commands/get_document_type.py
+++ b/library/cli/commands/get_document_type.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_document_type.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_document_type", argv)

--- a/library/cli/commands/get_input_initialisation.py
+++ b/library/cli/commands/get_input_initialisation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_input_initialisation.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_input_initialisation", argv)

--- a/library/cli/commands/get_target_data.py
+++ b/library/cli/commands/get_target_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_target_data.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_target_data", argv)

--- a/library/cli/commands/get_testitem_data.py
+++ b/library/cli/commands/get_testitem_data.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.get_testitem_data.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("get_testitem_data", argv)

--- a/library/cli/commands/mapper.py
+++ b/library/cli/commands/mapper.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.mapper.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("mapper", argv)

--- a/library/cli/commands/table_quality.py
+++ b/library/cli/commands/table_quality.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from . import _run
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run scripts.table_quality.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of command-line arguments.
+
+    Returns
+    -------
+    int
+        Exit code returned by the script.
+    """
+
+    return _run("table_quality", argv)

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -9,18 +9,16 @@ from __future__ import annotations
 
 import argparse
 import uuid
-from collections.abc import Sequence
-from importlib import import_module
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from pydantic import ValidationError
 
-from . import log
-from .config import Config, ConfigError, load_config
-from .logging_setup import Logger, LoggerConfig
-from .logging_setup import configure_logger as _configure_logger
-from .version import require_python_version
+from .. import log
+from ..config import Config, ConfigError, load_config
+from ..logging_setup import Logger, LoggerConfig
+from ..logging_setup import configure_logger as _configure_logger
+from ..version import require_python_version
 
 require_python_version()
 
@@ -59,8 +57,8 @@ def _positive_int(value: str) -> int:
     ------
     argparse.ArgumentTypeError
         If ``value`` is not a positive integer.
-
     """
+
     try:
         ivalue = int(value)
     except ValueError as exc:  # pragma: no cover - handled by argparse
@@ -142,6 +140,7 @@ def build_parser(
     tuple[argparse.ArgumentParser, LoggerConfig]
         The parser and associated :class:`LoggerConfig`.
     """
+
     parser = argparse.ArgumentParser(description=description)
     add_common_arguments(parser)
     parser.add_argument(
@@ -171,9 +170,9 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> tuple[
-    argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig
-]:
+def build_root_parser() -> (
+    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
+):
     """Return parsers containing root-level options and logging config.
 
     Two parsers are produced:
@@ -246,7 +245,7 @@ def configure_logger(
     """
 
     # ``fmt`` and ``datefmt`` are ignored because JSON logs have a fixed
-    # structure.  They are accepted to remain API compatible with the previous
+    # structure. They are accepted to remain API compatible with the previous
     # implementation that configured :mod:`logging`.
     new_logger = _configure_logger(
         LoggerConfig(level=cfg.level, run_id=cfg.run_id, stream=cfg.stream)
@@ -370,271 +369,13 @@ def apply_config_overrides(
     return cfg
 
 
-# ---------------------------------------------------------------------------
-# Script entry points
-# ---------------------------------------------------------------------------
-
-
-def _run(module: str, argv: Sequence[str] | None = None) -> int:
-    """Execute ``module.main`` from the :mod:`scripts` package.
-
-    Parameters
-    ----------
-    module:
-        Name of the module inside :mod:`scripts`.
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code returned by the script's ``main`` function.
-    """
-
-    main_func = import_module(f"scripts.{module}").main
-    return cast(int, main_func(argv))
-
-
-def get_activity_data(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_activity_data`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_activity_data", argv)
-
-
-def get_assay_data(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_assay_data`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_assay_data", argv)
-
-
-def get_target_data(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_target_data`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_target_data", argv)
-
-
-def get_document_data(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_document_data`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_document_data", argv)
-
-
-def get_document_type(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_document_type`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_document_type", argv)
-
-
-def get_input_initialisation(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_input_initialisation`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_input_initialisation", argv)
-
-
-def get_testitem_data(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_testitem_data`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_testitem_data", argv)
-
-
-def csv_utils(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.csv_utils_main`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("csv_utils_main", argv)
-
-
-def mapper(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.mapper_main`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("mapper_main", argv)
-
-
-def table_quality(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.table_quality_main`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("table_quality_main", argv)
-
-
-def chunk_io(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.chunk_io_main`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("chunk_io_main", argv)
-
-
-def get_activities(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.get_activities`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("get_activities", argv)
-
-
-def check_determinism(argv: Sequence[str] | None = None) -> int:
-    """Run :mod:`scripts.check_determinism`.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of command-line arguments.
-
-    Returns
-    -------
-    int
-        Exit code from the script.
-    """
-
-    return _run("check_determinism", argv)
-
-
 __all__ = [
     "LoggerConfig",
+    "Logger",
     "create_logger_config",
     "add_common_arguments",
     "build_parser",
     "build_root_parser",
     "configure_logger",
     "apply_config_overrides",
-    "check_determinism",
-    "chunk_io",
-    "csv_utils",
-    "get_activities",
-    "get_activity_data",
-    "get_assay_data",
-    "get_document_data",
-    "get_document_type",
-    "get_input_initialisation",
-    "get_target_data",
-    "get_testitem_data",
-    "mapper",
-    "table_quality",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,19 +50,19 @@ dev = [
 ]
 
 [project.scripts]
-get-activity-data = "library.cli:get_activity_data"
-get-assay-data = "library.cli:get_assay_data"
-get-target-data = "library.cli:get_target_data"
-get-document-data = "library.cli:get_document_data"
-get-document-type = "library.cli:get_document_type"
-get-input-initialisation = "library.cli:get_input_initialisation"
-get-testitem-data = "library.cli:get_testitem_data"
-csv-utils = "library.cli:csv_utils"
-mapper = "library.cli:mapper"
-table-quality = "library.cli:table_quality"
-chunk-io = "library.cli:chunk_io"
-get-activities = "library.cli:get_activities"
-check-determinism = "library.cli:check_determinism"
+get-activity-data = "library.cli.commands.get_activity_data:main"
+get-assay-data = "library.cli.commands.get_assay_data:main"
+get-target-data = "library.cli.commands.get_target_data:main"
+get-document-data = "library.cli.commands.get_document_data:main"
+get-document-type = "library.cli.commands.get_document_type:main"
+get-input-initialisation = "library.cli.commands.get_input_initialisation:main"
+get-testitem-data = "library.cli.commands.get_testitem_data:main"
+csv-utils = "library.cli.commands.csv_utils:main"
+mapper = "library.cli.commands.mapper:main"
+table-quality = "library.cli.commands.table_quality:main"
+chunk-io = "library.cli.commands.chunk_io:main"
+get-activities = "library.cli.commands.get_activities:main"
+check-determinism = "library.cli.commands.check_determinism:main"
 
 [tool.setuptools]
 py-modules = [

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,36 @@
+"""Tests for command module wrappers in :mod:`library.cli.commands`."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+COMMANDS = [
+    "get_activity_data",
+    "get_assay_data",
+    "get_target_data",
+    "get_document_data",
+    "get_document_type",
+    "get_input_initialisation",
+    "get_testitem_data",
+    "csv_utils",
+    "mapper",
+    "table_quality",
+    "chunk_io",
+    "get_activities",
+    "check_determinism",
+]
+
+
+@pytest.mark.parametrize("command", COMMANDS)
+def test_command_import_and_run(monkeypatch: pytest.MonkeyPatch, command: str) -> None:
+    """Each command module should be importable and runnable.
+
+    The actual script invocation is patched to avoid executing heavy logic.
+    """
+
+    module = importlib.import_module(f"library.cli.commands.{command}")
+    monkeypatch.setattr(module, "_run", lambda mod, argv=None: 0)
+    result = module.main([])
+    assert result == 0


### PR DESCRIPTION
## Summary
- restructure CLI into a package with shared parser utilities
- split each CLI command into its own module under `library.cli.commands`
- add tests ensuring each command module imports and executes

## Testing
- `poetry run ruff check library/cli tests/test_cli_commands.py`
- `poetry run mypy library/cli tests/test_cli_commands.py --install-types --non-interactive`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c49b733f94832486dc5ababfd54543