### PR TITLE
ci: install dev extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-
-          pip install -r requirements-dev.txt
+          pip install .[dev]
       - name: Check formatting
         run: ruff format --check .
       - name: Verify deterministic CSV output


### PR DESCRIPTION
## Summary
- ensure CI installs project with dev extras

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q` *(fails: could not import 'responses', 'hypothesis', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68c49d5781548324bbdd984f4f947e7f