### PR TITLE
Configure pre-commit hooks and document usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,9 @@
+# This file configures pre-commit hooks for formatting, linting and type checking.
+# Install the hooks with `pre-commit install` and run them with `pre-commit run --all-files`.
+
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Install the project together with development tools such as
 tokens should be stored in a local ``.env`` file – see
 [`Конфигурация через .env`](#конфигурация-через-env) for details.
 
+After installing the dependencies, enable the pre-commit hooks so that
+formatting, linting and type checking run automatically before each commit:
+
+```bash
+pre-commit install
+```
+
+To trigger all checks manually across the repository, execute:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Quick Start
  
 


### PR DESCRIPTION
## Summary
- define Python 3.12 in pre-commit config and include ruff, black and mypy hooks
- add README instructions on installing and running the hooks

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c49ee0a1208324b9ca526b12a43742