### PR TITLE
Add type hints to test helpers

### DIFF
--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -1,36 +1,48 @@
+from collections.abc import Iterable, Iterator
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
+import pytest
 
 from scripts import csv_utils_main as cli
 
 
-def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
+def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     input_csv = tmp_path / "in.csv"
     input_csv.write_text("a|b\n1|2\n", encoding="latin1")
     output_csv = tmp_path / "out.csv"
     called: dict[str, object] = {}
 
-    def fake_read_csv(path, sep, encoding, chunksize):  # type: ignore[override]
+    def fake_read_csv(
+        path: Path | str,
+        sep: str,
+        encoding: str,
+        chunksize: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Iterator[pd.DataFrame]:
         called["path"] = path
         called["sep"] = sep
         called["encoding"] = encoding
         called["chunksize"] = chunksize
 
-        def gen():
+        def gen() -> Iterator[pd.DataFrame]:
             yield pd.DataFrame({"a": [1], "b": [2]})
 
         return gen()
 
     def fake_write(
-        chunks,
-        output,
-        col_order=None,
-        key_cols=None,
-        chunksize=None,
-        drop_unexpected_cols=False,
-    ):  # type: ignore[override]
+        chunks: Iterable[pd.DataFrame],
+        output: Path | str,
+        col_order: list[str] | None = None,
+        key_cols: list[str] | None = None,
+        chunksize: int | None = None,
+        drop_unexpected_cols: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         called["output"] = output
         called["write_chunksize"] = chunksize
         list(chunks)  # exhaust generator
@@ -66,27 +78,38 @@ def test_cli_arguments_passed(monkeypatch, tmp_path: Path) -> None:
     assert called["write_chunksize"] == 2
 
 
-def test_cli_generates_output_path(monkeypatch, tmp_path: Path) -> None:
+def test_cli_generates_output_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("a,b\n1,2\n", encoding="utf8")
-    called: dict[str, Path] = {}
+    called: dict[str, Path | str] = {}
 
-    def fake_read_csv(path, sep, encoding, chunksize):  # type: ignore[override]
+    def fake_read_csv(
+        path: Path | str,
+        sep: str,
+        encoding: str,
+        chunksize: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Iterator[pd.DataFrame]:
         called["path"] = path
 
-        def gen():
+        def gen() -> Iterator[pd.DataFrame]:
             yield pd.DataFrame({"a": [1], "b": [2]})
 
         return gen()
 
     def fake_write(
-        chunks,
-        output,
-        col_order=None,
-        key_cols=None,
-        chunksize=None,
-        drop_unexpected_cols=True,
-    ):  # type: ignore[override]
+        chunks: Iterable[pd.DataFrame],
+        output: Path | str,
+        col_order: list[str] | None = None,
+        key_cols: list[str] | None = None,
+        chunksize: int | None = None,
+        drop_unexpected_cols: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         called["output"] = output
         list(chunks)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -73,8 +74,9 @@ def test_git_sha_missing_git_executable(monkeypatch: pytest.MonkeyPatch) -> None
     git_utils._git_sha.cache_clear()
     monkeypatch.setattr(shutil, "which", lambda _cmd: None)
     messages: list[str] = []
+    logger = cast(Any, getattr(git_utils, "logger"))  # noqa: B009
     monkeypatch.setattr(
-        git_utils.logger,
+        logger,
         "warning",
         lambda msg, *args, **kwargs: messages.append(msg % args),
     )
@@ -88,17 +90,19 @@ def test_git_sha_missing_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
 
     git_utils._git_sha.cache_clear()
     repo_root = Path(git_utils.__file__).resolve().parent.parent
-    original_exists = git_utils.Path.exists
+    path_cls = cast(type[Path], getattr(git_utils, "Path"))  # noqa: B009
+    original_exists = path_cls.exists
 
-    def mock_exists(self: Path) -> bool:  # type: ignore[override]
+    def mock_exists(self: Path) -> bool:
         if self == repo_root / ".git":
             return False
         return original_exists(self)
 
-    monkeypatch.setattr(git_utils.Path, "exists", mock_exists)
+    monkeypatch.setattr(path_cls, "exists", mock_exists)
     messages: list[str] = []
+    logger = cast(Any, getattr(git_utils, "logger"))  # noqa: B009
     monkeypatch.setattr(
-        git_utils.logger,
+        logger,
         "warning",
         lambda msg, *args, **kwargs: messages.append(msg % args),
     )

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import TracebackType
 from typing import Any, cast
 
 import pandas as pd
@@ -49,7 +50,12 @@ class DummyResponse:
     def __enter__(self) -> DummyResponse:  # pragma: no cover - context manager proto
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:  # pragma: no cover
         return None
 
     @property
@@ -168,15 +174,15 @@ def test_fetch_pubmed_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
     def fake_do_request(
-        session,
-        url,
-        sleep,
-        expect_json=True,
-        retries=2,
-        method="GET",
-        timeout=10,
-        **kwargs,
-    ):
+        session: requests.Session,
+        url: str,
+        sleep: float,
+        expect_json: bool = True,
+        retries: int = 2,
+        method: str = "GET",
+        timeout: float = 10,
+        **kwargs: Any,
+    ) -> tuple[str, str]:
         captured.update(
             {"url": url, "sleep": sleep, "retries": retries, "timeout": timeout}
         )
@@ -215,15 +221,15 @@ def test_fetch_openalex_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
     def fake_do_request(
-        session,
-        url,
-        sleep,
-        expect_json=True,
-        retries=2,
-        method="GET",
-        timeout=10,
-        **kwargs,
-    ):
+        session: requests.Session,
+        url: str,
+        sleep: float,
+        expect_json: bool = True,
+        retries: int = 2,
+        method: str = "GET",
+        timeout: float = 10,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], str]:
         captured.update(
             {"url": url, "sleep": sleep, "retries": retries, "timeout": timeout}
         )
@@ -243,7 +249,7 @@ def test_fetch_openalex_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
             super().__init__(rps=1)
             self.calls = 0
 
-        def acquire(self) -> None:  # type: ignore[override]
+        def acquire(self) -> None:
             self.calls += 1
 
     limiter = DummyLimiter()
@@ -275,15 +281,15 @@ def test_fetch_crossref_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
     def fake_do_request(
-        session,
-        url,
-        sleep,
-        expect_json=True,
-        retries=2,
-        method="GET",
-        timeout=10,
-        **kwargs,
-    ):
+        session: requests.Session,
+        url: str,
+        sleep: float,
+        expect_json: bool = True,
+        retries: int = 2,
+        method: str = "GET",
+        timeout: float = 10,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], str]:
         captured.update(
             {"url": url, "sleep": sleep, "retries": retries, "timeout": timeout}
         )
@@ -296,7 +302,7 @@ def test_fetch_crossref_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
             super().__init__(rps=1)
             self.calls = 0
 
-        def acquire(self) -> None:  # type: ignore[override]
+        def acquire(self) -> None:
             self.calls += 1
 
     limiter = DummyLimiter()
@@ -324,15 +330,15 @@ def test_fetch_semantic_scholar_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> Non
     captured: dict[str, Any] = {}
 
     def fake_do_request(
-        session,
-        url,
-        sleep,
-        expect_json=True,
-        retries=2,
-        method="GET",
-        timeout=10,
-        **kwargs,
-    ):
+        session: requests.Session,
+        url: str,
+        sleep: float,
+        expect_json: bool = True,
+        retries: int = 2,
+        method: str = "GET",
+        timeout: float = 10,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], str]:
         captured.update(
             {"url": url, "sleep": sleep, "retries": retries, "timeout": timeout}
         )


### PR DESCRIPTION
## Summary
- add precise types to CSV utility test stubs
- type request helpers in PubMed query tests
- cast git utils members to avoid attribute warnings

## Testing
- `ruff check tests/test_pubmed_query.py tests/test_metadata.py tests/test_csv_utils_main_args.py`
- `mypy tests/test_metadata.py tests/test_pubmed_query.py tests/test_csv_utils_main_args.py`
- `pytest tests/test_metadata.py tests/test_pubmed_query.py tests/test_csv_utils_main_args.py`

------
https://chatgpt.com/codex/tasks/task_e_68c49ef879a48324bfd764cac4f4491f