### PR TITLE
Pin dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools==61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,16 +13,16 @@ authors = [
   {name = "ChEMBL Team"}
 ]
 dependencies = [
-  "numpy>=2.3.3",
-  "pandas>=2.3.2",
-  "requests>=2.32.5",
-  "PyYAML>=6.0.2",
-  "openpyxl>=3.1.5",
-  "pyarrow>=21.0.0",
-  "jsonschema>=4.25.1",
-  "pandera>=0.26.1",
-  "cachetools>=5.3.2",
-  "pydantic>=2.10.7",
+  "numpy==2.3.3",
+  "pandas==2.3.2",
+  "requests==2.32.5",
+  "PyYAML==6.0.2",
+  "openpyxl==3.1.5",
+  "pyarrow==21.0.0",
+  "jsonschema==4.25.1",
+  "pandera==0.26.1",
+  "cachetools==5.3.2",
+  "pydantic==2.10.7",
 ]
 
 [project.optional-dependencies]
@@ -37,7 +37,7 @@ dev = [
   "types-PyYAML==6.0.12.20250822",
   "types-jsonschema==4.25.1.20250822",
   "pytest==8.4.2",
-  "types-openpyxl>=3.1.5",
+  "types-openpyxl==3.1.5",
   "hypothesis==6.138.15",
   "responses==0.25.8",
   "types-cachetools==6.2.0.20250827",


### PR DESCRIPTION
## Summary
- pin build and runtime dependencies to exact versions in pyproject

## Testing
- `pre-commit run --all-files` *(fails: black reformatted files and mypy missing target modules)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c67980bfbc8324b9b8e765324dc3ad