### PR TITLE
feat: add chunked merge sort for CSV export

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -8,12 +8,15 @@ runs produce identical files.
 
 from __future__ import annotations
 
+import csv
 import hashlib
+import heapq
 import os
 import tempfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any, TextIO, cast
 
 import pandas as pd
 from pandas.api import types as ptypes
@@ -64,6 +67,7 @@ def write_csv_deterministic(
     col_order: Sequence[str] | None = None,
     key_cols: Sequence[str] | None = None,
     chunksize: int | None = None,
+    sort_chunksize: int | None = None,
     sep: str = ",",
     encoding: str = "utf-8-sig",
     cfg: Config | None = None,
@@ -92,6 +96,12 @@ def write_csv_deterministic(
         streaming output via :meth:`pandas.DataFrame.to_csv`, reducing peak
         memory usage for large tables. ``None`` (the default) writes the
         dataframe in a single call.
+    sort_chunksize:
+        Optional number of rows sorted per chunk. When provided, the
+        dataframe is sorted using an external merge-sort algorithm that
+        writes intermediate sorted chunks to disk, reducing peak memory
+        usage during sorting. ``None`` (the default) performs an in-memory
+        sort.
     drop_unexpected_cols:
         When ``True`` and ``col_order`` is provided, columns not present in
         ``col_order`` are dropped from the output with a log warning.
@@ -121,6 +131,9 @@ def write_csv_deterministic(
     # Validate optional chunksize to avoid infinite loops or crashes
     if chunksize is not None and chunksize <= 0:
         msg = f"chunksize must be a positive integer, got {chunksize}"
+        raise ValueError(msg)
+    if sort_chunksize is not None and sort_chunksize <= 0:
+        msg = f"sort_chunksize must be a positive integer, got {sort_chunksize}"
         raise ValueError(msg)
 
     # Ensure column names are unique to avoid ambiguous output
@@ -152,7 +165,7 @@ def write_csv_deterministic(
     else:
         work = work.reindex(columns=sorted(work.columns), copy=False)
 
-    # Sort rows deterministically in-place using a stable algorithm.
+    # Sort rows deterministically using a stable algorithm.
     if key_cols is None:
         raise ValueError("key_cols must be provided")
     sort_cols = list(key_cols)
@@ -160,30 +173,116 @@ def write_csv_deterministic(
     if missing:
         msg = f"Missing key columns: {missing}"
         raise ValueError(msg)
-    work.sort_values(by=sort_cols, kind="mergesort", inplace=True)
 
-    # Normalise bool and date columns without creating intermediary frames.
-    for col in work.columns:
-        s = work[col]
-        if ptypes.is_bool_dtype(s):
-            work[col] = _normalise_bool(s)
-        else:
-            work[col] = _normalise_dates(s)
+    # In-memory sort when ``sort_chunksize`` is not specified or large enough.
+    if sort_chunksize is None or len(work) <= sort_chunksize:
+        work.sort_values(by=sort_cols, kind="mergesort", inplace=True)
 
-    # Write via temporary file for atomicity
-    with tempfile.NamedTemporaryFile(
-        "w", encoding=encoding, newline="\n", delete=False, dir=str(out_path.parent)
-    ) as fh:
-        tmp_path = Path(fh.name)
-        work.to_csv(
-            fh,
-            index=False,
-            float_format="%.6g",
-            na_rep="",
-            chunksize=chunksize,
-            sep=sep,
-        )
-    os.replace(tmp_path, out_path)
+        # Normalise bool and date columns without creating intermediary frames.
+        for col in work.columns:
+            s = work[col]
+            if ptypes.is_bool_dtype(s):
+                work[col] = _normalise_bool(s)
+            else:
+                work[col] = _normalise_dates(s)
+
+        # Write via temporary file for atomicity
+        with tempfile.NamedTemporaryFile(
+            "w", encoding=encoding, newline="\n", delete=False, dir=str(out_path.parent)
+        ) as fh:
+            tmp_path = Path(fh.name)
+            work.to_csv(
+                fh,
+                index=False,
+                float_format="%.6g",
+                na_rep="",
+                chunksize=chunksize,
+                sep=sep,
+            )
+        os.replace(tmp_path, out_path)
+    else:
+        # External merge sort writing intermediate chunks to disk.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_paths: list[Path] = []
+            n = len(work)
+            column_names = list(work.columns)
+            for start in range(0, n, sort_chunksize):
+                sub = work.iloc[start : start + sort_chunksize].sort_values(
+                    by=sort_cols, kind="mergesort"
+                )
+                for col in sub.columns:
+                    s = sub[col]
+                    if ptypes.is_bool_dtype(s):
+                        sub[col] = _normalise_bool(s)
+                    else:
+                        sub[col] = _normalise_dates(s)
+                chunk_path = Path(tmpdir) / f"chunk_{start}.csv"
+                sub.to_csv(
+                    chunk_path,
+                    index=False,
+                    float_format="%.6g",
+                    na_rep="",
+                    sep=sep,
+                    encoding=encoding,
+                )
+                tmp_paths.append(chunk_path)
+
+            key_indices = [column_names.index(c) for c in sort_cols]
+            key_funcs: list[Callable[[str], object]] = []
+            for col in sort_cols:
+                dtype = work.dtypes[col]
+                if ptypes.is_integer_dtype(dtype):
+                    key_funcs.append(int)
+                elif ptypes.is_float_dtype(dtype):
+                    key_funcs.append(float)
+                else:
+                    key_funcs.append(lambda x: x)
+
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding=encoding,
+                newline="\n",
+                delete=False,
+                dir=str(out_path.parent),
+            ) as fh:
+                tmp_path = Path(fh.name)
+                writer = csv.writer(fh, delimiter=sep, lineterminator="\n")
+                writer.writerow(column_names)
+
+                readers: list[tuple[Any, TextIO]] = []
+                for p in tmp_paths:
+                    f = p.open("r", encoding=encoding, newline="")
+                    r = csv.reader(f, delimiter=sep)
+                    next(r, None)
+                    readers.append((r, f))
+
+                heap: list[tuple[tuple[object, ...], int, list[str]]] = []
+                for idx, (reader, _) in enumerate(readers):
+                    try:
+                        row: list[str] = next(reader)
+                    except StopIteration:
+                        readers[idx][1].close()
+                        continue
+                    key = tuple(
+                        func(row[key_indices[i]]) for i, func in enumerate(key_funcs)
+                    )
+                    heapq.heappush(heap, (key, idx, row))
+
+                while heap:
+                    _, idx, row = heapq.heappop(heap)
+                    writer.writerow(row)
+                    try:
+                        row = cast(list[str], next(readers[idx][0]))
+                    except StopIteration:
+                        readers[idx][1].close()
+                        continue
+                    key = tuple(
+                        func(row[key_indices[i]]) for i, func in enumerate(key_funcs)
+                    )
+                    heapq.heappush(heap, (key, idx, row))
+
+        os.replace(tmp_path, out_path)
+
     write_meta_yaml(
         out_path,
         cfg,
@@ -200,6 +299,7 @@ def write_csv_chunks_deterministic(
     col_order: Sequence[str] | None = None,
     key_cols: Sequence[str] | None = None,
     chunksize: int = 1000,
+    sort_chunksize: int | None = None,
     sep: str = ",",
     encoding: str = "utf-8-sig",
     cfg: Config | None = None,
@@ -231,6 +331,9 @@ def write_csv_chunks_deterministic(
         :class:`ValueError`.
     chunksize:
         Number of rows written per chunk.
+    sort_chunksize:
+        Optional number of rows sorted per chunk during final write. Passed to
+        :func:`write_csv_deterministic`.
     sep:
         Field delimiter.
     encoding:
@@ -274,6 +377,7 @@ def write_csv_chunks_deterministic(
                 col_order=col_order,
                 key_cols=key_cols,
                 chunksize=chunksize,
+                sort_chunksize=sort_chunksize,
                 sep=sep,
                 encoding=encoding,
                 cfg=None,
@@ -296,6 +400,7 @@ def write_csv_chunks_deterministic(
         col_order=col_order,
         key_cols=key_cols,
         chunksize=chunksize,
+        sort_chunksize=sort_chunksize,
         sep=sep,
         encoding=encoding,
         cfg=cfg,

--- a/tests/test_csv_utils_memory.py
+++ b/tests/test_csv_utils_memory.py
@@ -46,3 +46,12 @@ def test_write_csv_deterministic_memory_usage(tmp_path: Path) -> None:
     # ``peak_with_copy`` should not be smaller as it includes an additional
     # DataFrame allocation.
     assert peak_with_copy >= peak_no_copy
+
+
+def test_write_csv_deterministic_memory_usage_large(tmp_path: Path) -> None:
+    """Handles DataFrames larger than one million rows."""
+    n = 1_200_000
+    peak_no_copy = _peak_memory(n, False, tmp_path / "large_no_copy.csv")
+    peak_with_copy = _peak_memory(n, True, tmp_path / "large_with_copy.csv")
+    # Allow minor fluctuations in memory measurements on different platforms
+    assert peak_with_copy >= 0.9 * peak_no_copy


### PR DESCRIPTION
## Summary
- support chunked merge-sort via `sort_chunksize` in CSV utilities
- stream merge-sorted chunks directly to disk
- cover memory usage for >1e6 rows

## Testing
- `python -m black library/csv_utils.py tests/test_csv_utils_memory.py`
- `python -m ruff check library/csv_utils.py tests/test_csv_utils_memory.py`
- `python -m mypy library/csv_utils.py tests/test_csv_utils_memory.py`
- `pytest tests/test_csv_utils_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c679acdd6883249848993ed665ced8