### PR TITLE
Configure mypy for library and add missing stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
-      - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:
@@ -26,6 +25,7 @@ repos:
           - types-requests==2.32.4.20250809
           - types-PyYAML==6.0.12.20250822
           - types-jsonschema==4.25.1.20250822
+          - types-python-dateutil
           - types-openpyxl>=3.1.5
           - types-cachetools==6.2.0.20250827
           - types-urllib3==1.26.25.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ select = ["E", "F", "I", "B", "UP"]
 ignore = ["E501"]
 
 [tool.mypy]
+files = ["library"]
 python_version = "3.12"
 strict = true
 warn_unused_configs = true


### PR DESCRIPTION
## Summary
- restrict mypy to the `library` package
- streamline pre-commit hooks and add missing type stubs

## Testing
- `pre-commit run --all-files`
- `mypy --strict`


------
https://chatgpt.com/codex/tasks/task_e_68c679937c14832484ccac2f71188f8b