### PR TITLE
feat: stream CSV chunk merge with memory guard

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -36,4 +36,10 @@ def build_parser() -> argparse.ArgumentParser:
         default=1000,
         help="Number of rows read per chunk",
     )
+    parser.add_argument(
+        "--merge-chunk-size",
+        type=int,
+        default=1000,
+        help="Rows loaded per temporary file during merge",
+    )
     return parser

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from pandas.api import types as ptypes
 
@@ -200,6 +201,7 @@ def write_csv_chunks_deterministic(
     col_order: Sequence[str] | None = None,
     key_cols: Sequence[str] | None = None,
     chunksize: int = 1000,
+    merge_chunksize: int = 1000,
     sep: str = ",",
     encoding: str = "utf-8-sig",
     cfg: Config | None = None,
@@ -231,6 +233,9 @@ def write_csv_chunks_deterministic(
         :class:`ValueError`.
     chunksize:
         Number of rows written per chunk.
+    merge_chunksize:
+        Number of rows loaded from each temporary file during the merge.
+        Higher values may improve throughput at the expense of memory.
     sep:
         Field delimiter.
     encoding:
@@ -256,9 +261,9 @@ def write_csv_chunks_deterministic(
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_paths: list[Path] = []
-        for idx, chunk in enumerate(chunks):
+        for idx, df_chunk in enumerate(chunks):
             # Detect duplicate column names within each chunk
-            duplicated = chunk.columns[chunk.columns.duplicated()]
+            duplicated = df_chunk.columns[df_chunk.columns.duplicated()]
             if not duplicated.empty:
                 dup_list = list(duplicated)
                 msg = (
@@ -269,7 +274,7 @@ def write_csv_chunks_deterministic(
 
             tmp_path = Path(tmpdir) / f"chunk_{idx}.csv"
             write_csv_deterministic(
-                chunk,
+                df_chunk,
                 tmp_path,
                 col_order=col_order,
                 key_cols=key_cols,
@@ -284,23 +289,84 @@ def write_csv_chunks_deterministic(
                 meta.unlink()
             tmp_paths.append(tmp_path)
 
-        if tmp_paths:
-            frames = (pd.read_csv(p, sep=sep, encoding=encoding) for p in tmp_paths)
-            combined = pd.concat(frames, ignore_index=True)
-        else:
-            combined = pd.DataFrame()
+        out_path = Path(path)
+        if not tmp_paths:
+            return write_csv_deterministic(
+                pd.DataFrame(),
+                out_path,
+                col_order=col_order,
+                key_cols=key_cols,
+                chunksize=chunksize,
+                sep=sep,
+                encoding=encoding,
+                cfg=cfg,
+                drop_unexpected_cols=drop_unexpected_cols,
+            )
 
-    return write_csv_deterministic(
-        combined,
-        path,
-        col_order=col_order,
-        key_cols=key_cols,
-        chunksize=chunksize,
-        sep=sep,
-        encoding=encoding,
-        cfg=cfg,
-        drop_unexpected_cols=drop_unexpected_cols,
-    )
+        import csv
+        import heapq
+
+        readers = [
+            pd.read_csv(p, sep=sep, encoding=encoding, chunksize=merge_chunksize)
+            for p in tmp_paths
+        ]
+        current: list[pd.DataFrame | None] = []
+        for r in readers:
+            try:
+                current.append(next(r))
+            except StopIteration:
+                current.append(None)
+
+        first = next((c for c in current if c is not None), pd.DataFrame())
+        columns = list(first.columns)
+        dtypes = {col: first.dtypes[col].name for col in columns}
+
+        from typing import Any
+
+        def _fmt(value: Any) -> Any:
+            if pd.isna(value):
+                return ""
+            if isinstance(value, float):
+                return f"{value:.6g}"
+            if isinstance(value, bool | np.bool_):
+                return "true" if bool(value) else "false"
+            return value
+
+        heap: list[tuple[tuple[Any, ...], int, int]] = []
+        for idx, frame in enumerate(current):
+            if frame is not None and not frame.empty:
+                row = frame.iloc[0]
+                key = tuple(row[k] for k in key_cols)
+                heapq.heappush(heap, (key, idx, 0))
+
+        with out_path.open("w", encoding=encoding, newline="") as fh:
+            writer = csv.writer(fh, delimiter=sep, lineterminator="\n")
+            writer.writerow(columns)
+            while heap:
+                _, file_idx, row_idx = heapq.heappop(heap)
+                chunk = current[file_idx]
+                assert chunk is not None
+                row = chunk.iloc[row_idx]
+                writer.writerow([_fmt(row[c]) for c in columns])
+                row_idx += 1
+                if row_idx < len(chunk):
+                    next_row = chunk.iloc[row_idx]
+                    key = tuple(next_row[k] for k in key_cols)
+                    heapq.heappush(heap, (key, file_idx, row_idx))
+                else:
+                    try:
+                        next_chunk = next(readers[file_idx])
+                    except StopIteration:
+                        current[file_idx] = None
+                    else:
+                        current[file_idx] = next_chunk
+                        if not next_chunk.empty:
+                            next_row = next_chunk.iloc[0]
+                            key = tuple(next_row[k] for k in key_cols)
+                            heapq.heappush(heap, (key, file_idx, 0))
+
+    write_meta_yaml(out_path, cfg, columns=columns, dtypes=dtypes)
+    return out_path
 
 
 def sha256_file(path: Path, *, block_size: int = 64 * 1024) -> str:

--- a/library/parser_schema.py
+++ b/library/parser_schema.py
@@ -36,6 +36,8 @@ class CSVExportArgs(BaseModel):
         Optional list of columns used to determine row ordering.
     chunk_size:
         Number of rows processed per chunk when streaming CSV input.
+    merge_chunk_size:
+        Rows loaded from each temporary file during the merge step.
     log_level:
         Logging verbosity passed through to the application logger.
     """
@@ -49,6 +51,7 @@ class CSVExportArgs(BaseModel):
     col_order: Optional[list[str]] = None  # noqa: UP007
     key_cols: Optional[list[str]] = None  # noqa: UP007
     chunk_size: int = 1000
+    merge_chunk_size: int = 1000
     log_level: str = "INFO"
 
 

--- a/scripts/csv_utils_main.py
+++ b/scripts/csv_utils_main.py
@@ -71,6 +71,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         col_order=args.col_order or None,
         key_cols=args.key_cols,
         chunksize=args.chunk_size,
+        merge_chunksize=args.merge_chunk_size,
         drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -39,12 +39,14 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
         col_order: list[str] | None = None,
         key_cols: list[str] | None = None,
         chunksize: int | None = None,
+        merge_chunksize: int | None = None,
         drop_unexpected_cols: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         called["output"] = output
         called["write_chunksize"] = chunksize
+        called["merge_chunksize"] = merge_chunksize
         list(chunks)  # exhaust generator
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
@@ -64,6 +66,8 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
             "a",
             "--chunk-size",
             "2",
+            "--merge-chunk-size",
+            "3",
             "--log-level",
             "INFO",
         ]
@@ -76,6 +80,7 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
 
     assert called["chunksize"] == 2
     assert called["write_chunksize"] == 2
+    assert called["merge_chunksize"] == 3
 
 
 def test_cli_generates_output_path(
@@ -106,6 +111,7 @@ def test_cli_generates_output_path(
         col_order: list[str] | None = None,
         key_cols: list[str] | None = None,
         chunksize: int | None = None,
+        merge_chunksize: int | None = None,
         drop_unexpected_cols: bool = True,
         *args: Any,
         **kwargs: Any,

--- a/tests/test_write_csv_chunks_memory.py
+++ b/tests/test_write_csv_chunks_memory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import multiprocessing as mp
+import time
+from collections.abc import Iterable
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.csv_utils import write_csv_chunks_deterministic
+
+psutil = pytest.importorskip("psutil")
+
+
+def _worker(path: str, rows: int, chunks: int) -> None:
+    df = pd.DataFrame({"a": range(rows), "b": range(rows)})
+
+    def gen() -> Iterable[pd.DataFrame]:
+        for _ in range(chunks):
+            yield df.copy()
+
+    write_csv_chunks_deterministic(
+        gen(),
+        Path(path),
+        key_cols=["a"],
+        merge_chunksize=50_000,
+    )
+
+
+def _peak_memory(path: Path, rows: int, chunks: int) -> int:
+    proc = mp.Process(target=_worker, args=(str(path), rows, chunks))
+    proc.start()
+    ps_proc = psutil.Process(proc.pid)
+    peak = 0
+    while proc.is_alive():
+        try:
+            mem = ps_proc.memory_info().rss
+            if mem > peak:
+                peak = mem
+        except psutil.NoSuchProcess:
+            break
+        time.sleep(0.05)
+    proc.join()
+    return peak
+
+
+def test_write_csv_chunks_memory_usage(tmp_path: Path) -> None:
+    rows = 200_000
+    peak_single = _peak_memory(tmp_path / "one.csv", rows, 1)
+    peak_many = _peak_memory(tmp_path / "many.csv", rows, 5)
+    assert peak_many <= peak_single * 1.5


### PR DESCRIPTION
## Summary
- stream chunk file merge to avoid `pd.concat` and add `merge_chunksize` control
- expose `--merge-chunk-size` CLI option
- test chunk merging memory usage and CLI arg wiring

## Testing
- `ruff check tests/test_csv_utils_main_args.py tests/test_write_csv_chunks_memory.py scripts/csv_utils_main.py library/cli_utils.py library/parser_schema.py`  
- `mypy library/cli_utils.py scripts/csv_utils_main.py library/parser_schema.py tests/test_csv_utils_main_args.py tests/test_write_csv_chunks_memory.py`  
- `pytest tests/test_write_csv_chunks_deterministic.py tests/test_csv_utils_main_args.py tests/test_write_csv_chunks_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68c679b1575083248728ecdfa18d33c4