### PR TITLE
Add overview of data acquisition scripts

### DIFF
--- a/data_acquisition.txt
+++ b/data_acquisition.txt
@@ -1,0 +1,137 @@
+Data acquisition utilities
+==========================
+This document summarises how the ``get_*`` scripts in ``scripts/`` collect and process data for the ChEMBL data acquisition workflows.
+
+Утилиты получения данных
+========================
+Этот документ описывает, как скрипты ``scripts/get_*`` собирают и обрабатывают данные в процессе получения данных ChEMBL.
+
+get_target_data.py (English)
+----------------------------
+Provides a multi-source command line interface for building target annotation tables. Depending on the chosen sub-command, the script
+
+* reads identifiers from a CSV column specified via ``--column``;
+* retrieves records from UniProt, ChEMBL or IUPHAR using helper libraries;
+* merges outputs from individual sources and snapshots intermediate results;
+* normalises the final table with ``TargetsSchema`` and validates it;
+* writes the result and accompanying metadata to disk and analyses table quality.
+
+get_target_data.py (Русский)
+---------------------------
+Надстраивает командный интерфейс, объединяющий несколько источников, для построения таблиц аннотации целей. В зависимости от выбранной подкоманды скрипт
+
+* читает идентификаторы из столбца CSV, заданного параметром ``--column``;
+* извлекает записи из UniProt, ChEMBL или IUPHAR при помощи вспомогательных библиотек;
+* объединяет результаты из отдельных источников и сохраняет промежуточные версии;
+* нормализует итоговую таблицу по ``TargetsSchema`` и проверяет её;
+* сохраняет результат и сопутствующие метаданные на диск и анализирует качество таблицы.
+
+get_activity_data.py (English)
+------------------------------
+Fetches activity information from the ChEMBL API. The script
+
+* obtains activity identifiers from the input CSV and optionally limits their number;
+* uses ``ChemblClient`` to pull activity rows in chunks with a configurable timeout;
+* normalises and validates the data against ``ActivitiesSchema``;
+* writes the cleaned CSV, records statistics such as SHA256 hashes and emits a quality report.
+
+get_activity_data.py (Русский)
+------------------------------
+Получает сведения об активностях из API ChEMBL. Скрипт
+
+* получает идентификаторы активностей из входного CSV и при необходимости ограничивает их количество;
+* использует ``ChemblClient`` для пакетной загрузки строк активностей с настраиваемым тайм-аутом;
+* нормализует данные и проверяет их соответствие ``ActivitiesSchema``;
+* записывает очищенный CSV, фиксирует статистику, например SHA256-хэши, и формирует отчёт о качестве.
+
+get_document_data.py (English)
+------------------------------
+Collects document metadata from multiple public APIs. It
+
+* supports ``pubmed``, ``chembl`` and ``all`` sub-commands;
+* for PubMed identifiers, fetches batches in parallel and augments each record with Semantic Scholar, OpenAlex and CrossRef information;
+* for ChEMBL identifiers, retrieves document details via ``ChemblClient``;
+* combines and post-processes results, validates with ``DocumentsSchema`` and saves the merged output with metadata and quality assessment.
+
+get_document_data.py (Русский)
+------------------------------
+Собирает метаданные документов из нескольких публичных API. Скрипт
+
+* поддерживает подкоманды ``pubmed``, ``chembl`` и ``all``;
+* для идентификаторов PubMed загружает пакеты параллельно и дополняет каждую запись сведениями из Semantic Scholar, OpenAlex и CrossRef;
+* для идентификаторов ChEMBL получает сведения о документах через ``ChemblClient``;
+* объединяет и постобрабатывает результаты, проверяет их с помощью ``DocumentsSchema`` и сохраняет объединённый вывод с метаданными и оценкой качества.
+
+get_assay_data.py (English)
+---------------------------
+Retrieves assay data from ChEMBL. The program
+
+* reads assay ChEMBL identifiers from an input file;
+* downloads assay records through ``ChemblClient`` and applies ``assay_postprocessing`` to harmonise fields;
+* validates the normalised frame with ``AssaysSchema`` and writes the output CSV along with statistics and a quality report.
+
+get_assay_data.py (Русский)
+---------------------------
+Получает данные биотестов из ChEMBL. Программа
+
+* читает идентификаторы биотестов ChEMBL из входного файла;
+* загружает данные биотестов через ``ChemblClient`` и применяет ``assay_postprocessing`` для приведения полей к общему виду;
+* проверяет нормализованный фрейм на соответствие ``AssaysSchema`` и записывает выходной CSV вместе со статистикой и отчётом о качестве.
+
+get_activities.py (English)
+---------------------------
+A minimal utility for generating synthetic activity rows. It parses ``--limit`` and ``--dry-run`` arguments, calls ``library.activities.get_activities`` to create the requested number of rows and logs the outcome.
+
+get_activities.py (Русский)
+---------------------------
+Небольшая утилита для генерации синтетических записей об активностях. Она разбирает параметры ``--limit`` и ``--dry-run``, вызывает ``library.activities.get_activities`` для создания нужного числа строк и журналирует результат.
+
+get_testitem_data.py (English)
+------------------------------
+Retrieves compound information from ChEMBL and enriches it with PubChem properties. The pipeline
+
+* loads molecule identifiers from the input CSV and requests test item data from ChEMBL;
+* iterates over canonical SMILES to look up PubChem CIDs and chemical properties, merging them back into the table;
+* validates against ``TestitemsSchema`` and writes the augmented dataset with metadata and table quality information.
+
+get_testitem_data.py (Русский)
+------------------------------
+Получает информацию о соединениях из ChEMBL и дополняет её свойствами PubChem. Конвейер
+
+* загружает идентификаторы молекул из входного CSV и запрашивает данные тестовых элементов в ChEMBL;
+* перебирает канонические SMILES, чтобы найти PubChem CID и химические свойства, и объединяет их с таблицей;
+* проверяет соответствие ``TestitemsSchema`` и сохраняет расширенный набор данных с метаданными и сведениями о качестве таблицы.
+
+get_document_type.py (English)
+------------------------------
+Classifies publications into document types. The script
+
+* accepts weighting and threshold parameters for PubMed, Scholar and OpenAlex publication type fields;
+* computes source-specific scores and uses them to assign a ``class_label`` to each row;
+* outputs the classified table.
+
+get_document_type.py (Русский)
+------------------------------
+Классифицирует публикации по типам документов. Скрипт
+
+* принимает параметры весов и порогов для полей типов публикаций из PubMed, Scholar и OpenAlex;
+* вычисляет оценки для каждого источника и по ним присваивает каждой строке ``class_label``;
+* выводит классифицированную таблицу.
+
+get_input_initialisation.py (English)
+------------------------------------
+Combines initialisation Excel workbooks to prepare pair tables and associated entity tables. It
+
+* loads the ``same_doc`` and ``all_doc`` workbooks;
+* builds combined tables using dictionary and status resources;
+* generates pair and entity tables, merging status information and computing statistics;
+* saves all tables and produces data validity reports for each output.
+
+get_input_initialisation.py (Русский)
+------------------------------------
+Объединяет стартовые Excel-книги для подготовки таблиц пар и соответствующих таблиц сущностей. Скрипт
+
+* загружает рабочие книги ``same_doc`` и ``all_doc``;
+* формирует объединённые таблицы, используя ресурсы словаря и статусов;
+* генерирует таблицы пар и сущностей, объединяя статусную информацию и вычисляя статистику;
+* сохраняет все таблицы и создаёт отчёты о корректности данных для каждого результата.


### PR DESCRIPTION
## Summary
- document how each `get_*` script processes data in English and Russian

## Testing
- `pre-commit run --files data_acquisition.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandera', 'cachetools', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c67fee7fec8324a77203cf09092d66