### PR TITLE
chore: format parser CLI

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -170,9 +170,9 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> (
-    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
-):
+def build_root_parser() -> tuple[
+    argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig
+]:
     """Return parsers containing root-level options and logging config.
 
     Two parsers are produced:


### PR DESCRIPTION
## Summary
- format CLI parser module with `ruff format`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68c6832439b083249e19bb93f53cf62e