### PR TITLE
Ensure assay CSV columns follow schema order

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -44,6 +44,10 @@ __all__ = ["ap", "main"]
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute assay retrieval from the ChEMBL API.
 
+    The output CSV arranges columns so that fields defined in
+    :class:`~schemas.assays.AssaysSchema` appear first.  Any additional columns
+    are appended alphabetically.
+
     Parameters
     ----------
     cfg : Config
@@ -114,6 +118,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
+        # Arrange columns so schema-defined fields appear first while any
+        # additional columns are sorted alphabetically and placed at the end.
+        schema_cols: list[str] = list(AssaysSchema.columns)
+        head = [c for c in schema_cols if c in df.columns]
+        tail = sorted(c for c in df.columns if c not in schema_cols)
+        col_order = head + tail
         try:
             key_cols = [c for c in ["assay_chembl_id"] if c in df.columns]
             csv_path = io.write_csv(
@@ -121,6 +131,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 output,
                 cfg=cfg,
                 key_cols=key_cols or None,
+                col_order=col_order,
             )
             logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library import chembl_library as cl
+from library import io
+from library.config import Config
+from scripts import get_assay_data as gas
+
+
+def test_run_chembl_orders_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Output columns should follow `AssaysSchema` order with extras alphabetic."""
+    input_csv = tmp_path / "assays.csv"
+    input_csv.write_text("assay_chembl_id\nA1\n")
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["A1"]))
+
+    df = pd.DataFrame(
+        {
+            "zzz": ["z"],
+            "document_chembl_id": ["D1"],
+            "aaa": ["a"],
+            "assay_chembl_id": ["A1"],
+            "target_chembl_id": ["T1"],
+        }
+    )
+    monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
+    monkeypatch.setattr(gas.ap, "postprocess_assays", lambda df: df)
+    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gas, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gas, "file_sha256", lambda p: "deadbeef")
+
+    rc = gas.run_chembl(cfg, args)
+    assert rc == 0
+    out_df = pd.read_csv(args.output_csv)
+    assert list(out_df.columns) == [
+        "assay_chembl_id",
+        "document_chembl_id",
+        "target_chembl_id",
+        "aaa",
+        "zzz",
+    ]


### PR DESCRIPTION
## Summary
- Order assay CSV columns per `AssaysSchema` and append extra fields alphabetically
- Document new column ordering behavior in `run_chembl`
- Add unit test verifying CSV column order

## Testing
- `ruff check scripts/get_assay_data.py tests/test_get_assay_data.py`
- `black scripts/get_assay_data.py tests/test_get_assay_data.py`
- `mypy scripts/get_assay_data.py tests/test_get_assay_data.py`
- `pytest tests/test_get_assay_data.py::test_run_chembl_orders_columns -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68cac31d48324af2e8609f32230eb