### PR TITLE
Order ChEMBL activity output columns

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -44,6 +44,10 @@ from schemas import ActivitiesSchema, normalize_activities
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute activity retrieval from the ChEMBL API.
 
+    The resulting CSV places columns defined in :data:`ActivitiesSchema`
+    first, preserving their declared order. Any additional fields appear
+    afterwards sorted alphabetically.
+
     Parameters
     ----------
     cfg : Config
@@ -101,6 +105,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_activities(df)
+        # Determine final column order: schema-defined columns first in their
+        # declared sequence, followed by any additional columns sorted
+        # alphabetically to provide deterministic output.
+        schema_cols = list(ActivitiesSchema.columns)
+        head = [c for c in schema_cols if c in df.columns]
+        tail = sorted(c for c in df.columns if c not in schema_cols)
+        col_order = head + tail
         rows_total = len(df)
         exit_code = 0
         required_cols = {
@@ -143,6 +154,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 output,
                 cfg=cfg,
                 key_cols=key_cols or None,
+                col_order=col_order,
             )
             logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -9,6 +9,7 @@ import pytest
 from library import chembl_library as cl
 from library import io
 from library.config import Config
+from schemas import ActivitiesSchema
 from scripts import get_activity_data as gad
 
 
@@ -75,3 +76,50 @@ def test_run_chembl_limit_dry_run(
     rc = gad.run_chembl(cfg, args)
     assert rc == 0
     assert called["read"] is False
+
+
+def test_run_chembl_column_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Ensure schema columns precede alphabetically sorted extras."""
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\n1\n")
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["1"]))
+
+    df = pd.DataFrame(
+        [
+            {
+                "standard_value": 1.0,
+                "assay_description": "desc",
+                "activity_id": 1,
+                "molecule_chembl_id": "CHEMBL1",
+                "bao_format": "A",
+                "standard_type": "IC50",
+                "target_id": "T1",
+                "assay_chembl_id": "A1",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(cl, "get_activities", lambda *_, **__: df)
+    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_write_csv(df, output, *, cfg, key_cols=None, col_order=None, **__) -> Path:
+        captured["col_order"] = list(col_order or [])
+        return output
+
+    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+
+    rc = gad.run_chembl(cfg, args)
+    assert rc == 0
+
+    expected_head = list(ActivitiesSchema.columns)
+    expected_tail = sorted(c for c in df.columns if c not in expected_head)
+    assert captured["col_order"] == expected_head + expected_tail


### PR DESCRIPTION
## Summary
- ensure run_chembl writes activity CSV with schema columns first and extra fields sorted alphabetically
- test column ordering for ChEMBL activity exports

## Testing
- `black scripts/get_activity_data.py tests/test_get_activity_data.py`
- `ruff check scripts/get_activity_data.py tests/test_get_activity_data.py`
- `mypy`
- `pytest tests/test_get_activity_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6915a04e8832498613515a9d5294d