### PR TITLE
Ensure deterministic column order for test items

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -169,6 +169,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("pubchem_augment_done")
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_testitems(df)
+        # Determine column order: schema columns first, followed by
+        # additional fields sorted alphabetically.
+        schema_cols = list(TestitemsSchema.columns)
+        head = [c for c in schema_cols if c in df.columns]
+        tail = sorted(c for c in df.columns if c not in schema_cols)
+        col_order = head + tail
         rows_total = len(df)
         exit_code = 0
     required_cols = {
@@ -211,6 +217,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             output,
             cfg=cfg,
             key_cols=key_cols or None,
+            col_order=col_order,
         )
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library import chembl_library as cl
+from library import io
+from library.config import Config
+from schemas import TestitemsSchema
+from scripts import get_testitem_data as gtd
+
+
+def test_run_chembl_column_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Ensure schema columns precede alphabetically sorted extras."""
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\n")
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1"]))
+
+    df = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "CHEMBL1",
+                "molecule_type": "Small molecule",
+                "salt_chembl_id": "CHEMBL1-SALT",
+                "chirality": 1,
+                "extra_b": 2,
+                "extra_a": 1,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_write_csv(
+        df: pd.DataFrame,
+        output: Path,
+        *,
+        cfg: Config,
+        key_cols: list[str] | None = None,
+        col_order: list[str] | None = None,
+        **__: object,
+    ) -> Path:
+        captured["col_order"] = list(col_order or [])
+        return output
+
+    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+
+    rc = gtd.run_chembl(cfg, args)
+    assert rc == 0
+
+    expected_head = [c for c in TestitemsSchema.columns if c in df.columns]
+    expected_tail = sorted(c for c in df.columns if c not in TestitemsSchema.columns)
+    assert captured["col_order"] == expected_head + expected_tail


### PR DESCRIPTION
## Summary
- guarantee CSV columns for test items match `TestitemsSchema` order
- sort any extra test item columns alphabetically after schema columns
- add regression test for `run_chembl` column ordering

## Testing
- `black scripts/get_testitem_data.py tests/test_get_testitem_data.py`
- `ruff check scripts/get_testitem_data.py tests/test_get_testitem_data.py`
- `mypy scripts/get_testitem_data.py tests/test_get_testitem_data.py` *(fails: Missing type parameters for generic type "Series" and other typing errors)*
- `pytest tests/test_get_testitem_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6957078d4832484310f2c4498756b