### PR TITLE
refactor target column ordering

### DIFF
--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from schemas import TargetsSchema
+
 from .config import Config, IoCfg
 from .log import logger
 
@@ -243,60 +245,15 @@ def postprocess_targets(
     df["gene"] = df["gene"].apply(lambda v: _pipe_merge([v]))
 
     # --- final column ordering --------------------------------------------------
-    columns = [
-        internal_id,
-        "uniprotkb_Id",
-        "uniprot_id",
-        "secondary_uniprot_id",
-        "gene_name",
-        "recommended_name",
-        "synonyms",
-        "genus",
-        "superkingdom",
-        "phylum",
-        "taxon_id",
-        "ec_number",
-        "hgnc_name",
-        "hgnc_id",
-        "molecular_function",
-        "cellular_component",
-        "subcellular_location",
-        "topology",
-        "transmembrane",
-        "intramembrane",
-        "glycosylation",
-        "lipidation",
-        "disulfide_bond",
-        "modified_residue",
-        "phosphorylation",
-        "acetylation",
-        "ubiquitination",
-        "signal_peptide",
-        "propeptide",
-        "isoform_names",
-        "isoform_ids",
-        "isoform_synonyms",
-        "reactions",
-        "target_id",
-        "IUPHAR_family_id",
-        "IUPHAR_type",
-        "IUPHAR_class",
-        "IUPHAR_subclass",
-        "IUPHAR_chain",
-        "full_id_path",
-        "full_name_path",
-        "GuidetoPHARMACOLOGY",
-        "SUPFAM",
-        "PROSITE",
-        "InterPro",
-        "Pfam",
-        "PRINTS",
-        "TCDB",
+    schema_cols = [
+        internal_id if col == chembl_col else col for col in TargetsSchema.columns
     ]
-    for col in columns:
+    extra_cols = sorted(c for c in df.columns if c not in schema_cols)
+    ordered_cols = schema_cols + extra_cols
+    for col in ordered_cols:
         if col not in df.columns:
             df[col] = "-"
-    return df[columns].rename(columns={internal_id: chembl_col})
+    return df[ordered_cols].rename(columns={internal_id: chembl_col})
 
 
 def postprocess_file(

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from library import target_postprocessing as tp
 from library.config import Config, IoCfg
+from schemas import TargetsSchema
 
 
 def test_postprocess_targets_merges_and_normalises() -> None:
@@ -51,6 +52,26 @@ def test_postprocess_targets_merges_and_normalises() -> None:
     assert row["synonyms"].startswith("g2|g3|g1|name2|name3")
 
 
+def test_postprocess_targets_orders_columns() -> None:
+    """Columns from the schema appear first and others alphabetically."""
+
+    df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P1"],
+            "gene": ["g1"],
+            "b": ["1"],
+            "a": ["2"],
+        }
+    )
+    out = tp.postprocess_targets(df, chembl_col="chembl_id")
+
+    schema_cols = list(TargetsSchema.columns)
+    schema_cols[schema_cols.index("target_chembl_id")] = "chembl_id"
+    extra_cols = sorted(c for c in out.columns if c not in schema_cols)
+    assert list(out.columns) == schema_cols + extra_cols
+
+
 def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
     """``postprocess_file`` respects ``IoCfg`` defaults for CSV options."""
 
@@ -85,7 +106,11 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
 
     expected = tp.postprocess_targets(df, chembl_col="chembl_id").astype(str)
     result = pd.read_csv(
-        output_path, dtype=str, sep=cfg.csv_sep, encoding=cfg.csv_encoding
+        output_path,
+        dtype=str,
+        sep=cfg.csv_sep,
+        encoding=cfg.csv_encoding,
+        keep_default_na=False,
     )
     pd.testing.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
## Summary
- derive target post-processing column order from `TargetsSchema` and append extra columns alphabetically
- test column order priorities and ensure CSV round-trip uses consistent NA handling

## Testing
- `black library/target_postprocessing.py tests/test_target_postprocessing.py`
- `ruff check library/target_postprocessing.py tests/test_target_postprocessing.py`
- `mypy library/target_postprocessing.py`
- `pytest tests/test_target_postprocessing.py`


------
https://chatgpt.com/codex/tasks/task_e_68c69887177c83249ced8d65d1c4c31c