### PR TITLE
Remove status handling from input initialization

### DIFF
--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -9,9 +9,7 @@ Exports pair tables without merging:
 Additionally, for each pair table the corresponding ``activity``, ``assay``,
 ``document``, ``target``, ``testitem`` and ``system`` entries are exported with
 matching suffixes, for example ``activity_independent.csv`` or
-``assay_same_document.csv``. Status tables for these entities are merged into
-the outputs; tables for unknown entities are skipped with an informational log
-message.
+``assay_same_document.csv``.
 """
 
 from __future__ import annotations
@@ -78,7 +76,6 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             same,
             all_,
             dictionary_dir=args.dictionary_dir,
-            status_csv=cfg.resources.status_csv,
             targets_type_csv=cfg.resources.targets_type_csv,
         )
         logger.info("generate_pair_tables")
@@ -90,60 +87,6 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 "pairs_same_document": "same_document",
             },
         )
-        logger.info("prepare_status_outputs")
-        id_cols = {
-            "activity": "activity_chembl_id",
-            "assay": "assay_chembl_id",
-            "document": "document_chembl_id",
-            "target": "target_chembl_id",
-            "testitem": "molecule_chembl_id",
-            "molecule": "molecule_chembl_id",
-            "system": "system_id",
-        }
-        for key, df in list(tables.items()):
-            if not key.endswith("_status"):
-                continue
-            if "Filtered.new" not in df.columns:
-                logger.warning("missing_filtered_new", table=key)
-                continue
-
-            base_name = key.removesuffix("_status")
-            entity = base_name.split("_")[0]
-            id_col = id_cols.get(entity)
-            if entity == "system" and id_col is None:
-                logger.info("drop_status_table", table=key)
-                del tables[key]
-                continue
-            if entity == "system":
-                logger.info("process_status_table", table=key)
-
-            renamed = df.rename(columns={"Filtered.new": "Filtered"})
-
-            if id_col and base_name in tables and id_col in tables[base_name].columns:
-                tables[base_name] = tables[base_name].merge(
-                    renamed, on=id_col, how="left"
-                )
-            else:
-                if id_col is None:
-                    logger.warning(
-                        "unknown entity '%s' for status table '%s'", entity, key
-                    )
-                elif base_name not in tables:
-                    logger.warning(
-                        "base table '%s' missing; using status table directly",
-                        base_name,
-                    )
-                else:
-                    logger.warning(
-                        "id column '%s' missing in table '%s'; using status table directly",
-                        id_col,
-                        base_name,
-                    )
-                tables[base_name] = renamed
-
-            tables[f"{key}_statistics"] = lib.compute_status_statistics(df, base_name)
-            del tables[key]
-
         logger.info("save_output")
         paths = lib.save_tables(tables, out_dir, cfg, fmt=args.format)
         # Ensure that files were actually written to disk
@@ -196,7 +139,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=Path,
         default=None,
         help=(
-            "Directory with _Target/targets_type.csv, _Curation/citation_fraction.csv and status.csv "
+            "Directory with _Target/targets_type.csv and _Curation/citation_fraction.csv "
             "(default: config resources.dictionary_dir)"
         ),
     )

--- a/tests/test_get_input_initialisation.py
+++ b/tests/test_get_input_initialisation.py
@@ -60,18 +60,11 @@ def test_run_creates_quality_reports(tmp_path: Path, monkeypatch) -> None:
     result = cli.run(cfg, args)
     assert result == 0
 
-    assert (out_dir / "independent" / "activity_independent.csv").exists()
-
     assert (
-        out_dir
-        / "status"
-        / "independent"
-        / "activity_independent_status_statistics.csv"
+        out_dir / "status" / "independent" / "activity_independent_status.csv"
     ).exists()
 
     expected = set(tables)
-    expected.remove("activity_independent_status")
-    expected.update({"activity_independent", "activity_independent_status_statistics"})
 
     for name in expected:
         quality = out_dir / "data_validity_report" / f"{name}_quality_report_table.csv"
@@ -228,99 +221,3 @@ def test_main_missing_dictionary_dir(tmp_path: Path, monkeypatch) -> None:
         ]
     )
     assert result == 0
-
-
-def test_status_merge_preserves_columns(tmp_path: Path, monkeypatch) -> None:
-    """Status merging should retain original entity columns."""
-
-    same_doc = tmp_path / "same.xlsx"
-    all_doc = tmp_path / "all.xlsx"
-    same_doc.write_text("dummy")
-    all_doc.write_text("dummy")
-    out_dir = tmp_path / "out"
-
-    id_cols = {
-        "activity": "activity_chembl_id",
-        "assay": "assay_chembl_id",
-        "document": "document_chembl_id",
-        "target": "target_chembl_id",
-        "testitem": "molecule_chembl_id",
-    }
-    tables: dict[str, pd.DataFrame] = {}
-    for entity, id_col in id_cols.items():
-        base = pd.DataFrame({id_col: [f"{entity}1"], "orig": [1]})
-        status = pd.DataFrame(
-            {id_col: [f"{entity}1"], "Filtered.new": ["good"], "independent_IC50": [1]}
-        )
-        tables[f"{entity}_independent"] = base
-        tables[f"{entity}_independent_status"] = status
-
-    monkeypatch.setattr(cli.lib, "load_same_doc", lambda _p: {})
-    monkeypatch.setattr(cli.lib, "load_all_doc", lambda _p: {})
-    monkeypatch.setattr(cli.lib, "build_combined_tables", lambda *_a, **_k: tables)
-    monkeypatch.setattr(cli.lib, "generate_pair_entity_tables", lambda t, _m: t)
-    monkeypatch.setattr(cli, "analyze_table_quality", lambda *_a, **_k: None)
-
-    args = argparse.Namespace(
-        same_doc=same_doc,
-        all_doc=all_doc,
-        out_dir=out_dir,
-        format="csv",
-        dictionary_dir=tmp_path,
-    )
-    cfg = Config.model_validate({"api": {"user_agent": "test@example.org"}})
-    assert cli.run(cfg, args) == 0
-
-    for entity, id_col in id_cols.items():
-        df = pd.read_csv(out_dir / "independent" / f"{entity}_independent.csv")
-        assert id_col in df.columns
-        assert "orig" in df.columns
-
-
-def test_run_handles_system_status_table(tmp_path: Path, monkeypatch) -> None:
-    """System status tables should be merged or emitted with logging."""
-
-    same_doc = tmp_path / "same.xlsx"
-    all_doc = tmp_path / "all.xlsx"
-    same_doc.write_text("dummy")
-    all_doc.write_text("dummy")
-    out_dir = tmp_path / "out"
-
-    tables = {
-        "system_independent_status": pd.DataFrame(
-            {
-                "system_id": ["T1_TG1_IC50"],
-                "Filtered.new": ["good"],
-                "independent_IC50": [1],
-            }
-        )
-    }
-
-    monkeypatch.setattr(cli.lib, "load_same_doc", lambda _p: {})
-    monkeypatch.setattr(cli.lib, "load_all_doc", lambda _p: {})
-    monkeypatch.setattr(cli.lib, "build_combined_tables", lambda *_a, **_k: tables)
-    monkeypatch.setattr(cli.lib, "generate_pair_entity_tables", lambda t, _m: t)
-    monkeypatch.setattr(cli, "analyze_table_quality", lambda *_a, **_k: None)
-
-    buf = io.StringIO()
-    configure_logger(LoggerConfig(stream=buf))
-    args = argparse.Namespace(
-        same_doc=same_doc,
-        all_doc=all_doc,
-        out_dir=out_dir,
-        format="csv",
-        dictionary_dir=tmp_path,
-    )
-    cfg = Config.model_validate({"api": {"user_agent": "test@example.org"}})
-    assert cli.run(cfg, args) == 0
-
-    out_file = out_dir / "independent" / "system_independent.csv"
-    assert out_file.exists()
-    df = pd.read_csv(out_file)
-    assert "system_id" in df.columns
-    assert "Filtered" in df.columns
-
-    logs = [json.loads(line) for line in buf.getvalue().splitlines() if line]
-    assert any(
-        "base table 'system_independent' missing" in rec.get("msg", "") for rec in logs
-    )


### PR DESCRIPTION
## Summary
- drop status_csv and status merge logic from `get_input_initialisation` CLI
- simplify dictionary directory description
- update tests for removed status handling

## Testing
- `black scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `ruff check scripts/get_input_initialisation.py tests/test_get_input_initialisation.py`
- `mypy scripts/get_input_initialisation.py` *(fails: Library stubs not installed for "cachetools", "pandas", "yaml", "requests", "pandera", etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandera' and 'cachetools')*
- `pytest tests/test_get_input_initialisation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c69542707c8324ab6bb8c333829371