### PR TITLE
Simplify table save path handling

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1212,10 +1212,6 @@ def save_tables(
     - ``*_same_document`` → ``same_document/``
     - ``*_independent`` → ``independent/``
     - ``*_non_independent`` → ``non_independent/``
-    - ``*_status`` tables are placed under ``status/`` with the above
-      variants nested within it.
-    - ``*_status_statistics`` tables follow the same pattern and are also
-      stored beneath ``status/``.
 
     Duplicate column names are removed prior to writing to avoid ambiguous
     headers. The dropped columns are listed in a warning message to aid
@@ -1243,23 +1239,7 @@ def save_tables(
     paths: dict[str, Path] = {}
     for entity, df in tables.items():
         # Determine subdirectory based on table type.
-        if entity.endswith("_non_independent_status_statistics"):
-            sub_dir = out_dir / "status" / "non-independent"
-        elif entity.endswith("_independent_status_statistics"):
-            sub_dir = out_dir / "status" / "independent"
-        elif entity.endswith("_same_document_status_statistics"):
-            sub_dir = out_dir / "status" / "same_document"
-        elif entity.endswith("_status_statistics"):
-            sub_dir = out_dir / "status"
-        elif entity.endswith("_non_independent_status"):
-            sub_dir = out_dir / "status" / "non-independent"
-        elif entity.endswith("_independent_status"):
-            sub_dir = out_dir / "status" / "independent"
-        elif entity.endswith("_same_document_status"):
-            sub_dir = out_dir / "status" / "same_document"
-        elif entity.endswith("_status"):
-            sub_dir = out_dir / "status"
-        elif entity.endswith("_non_independent"):
+        if entity.endswith("_non_independent"):
             sub_dir = out_dir / "non_independent"
         elif entity.endswith("_independent"):
             sub_dir = out_dir / "independent"
@@ -1268,6 +1248,7 @@ def save_tables(
         else:
             sub_dir = out_dir
 
+        sub_dir.mkdir(parents=True, exist_ok=True)
         path = sub_dir / f"{entity}.csv"
 
         chembl_id_map = {"testitem": "molecule_chembl_id"}

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -637,18 +637,6 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         "activity_independent": pd.DataFrame({"id": [1]}),
         "activity_non_independent": pd.DataFrame({"id": [2]}),
         "activity_same_document": pd.DataFrame({"id": [3]}),
-        "activity_independent_status": pd.DataFrame({"id": [1]}),
-        "activity_non_independent_status": pd.DataFrame({"id": [1]}),
-        "activity_same_document_status": pd.DataFrame({"id": [1]}),
-        "activity_independent_status_statistics": pd.DataFrame(
-            {"Filtered": ["good"], "Count": [1]}
-        ),
-        "activity_non_independent_status_statistics": pd.DataFrame(
-            {"Filtered": ["good"], "Count": [1]}
-        ),
-        "activity_same_document_status_statistics": pd.DataFrame(
-            {"Filtered": ["good"], "Count": [1]}
-        ),
     }
     cfg = Config(api=ApiCfg(user_agent="test@example.com"))
     paths = save_tables(tables, tmp_path, cfg)
@@ -660,32 +648,8 @@ def test_save_tables_writes_files(tmp_path: Path) -> None:
         meta = path.with_suffix(path.suffix + ".meta.yaml")
         assert meta.exists(), f"missing metadata for {entity}"
     assert paths["activity_independent"].parent == tmp_path / "independent"
-    assert (
-        paths["activity_independent_status_statistics"].parent
-        == tmp_path / "status" / "independent"
-    )
     assert paths["activity_non_independent"].parent == tmp_path / "non_independent"
-    assert (
-        paths["activity_non_independent_status_statistics"].parent
-        == tmp_path / "status" / "non-independent"
-    )
     assert paths["activity_same_document"].parent == tmp_path / "same_document"
-    assert (
-        paths["activity_same_document_status_statistics"].parent
-        == tmp_path / "status" / "same_document"
-    )
-    assert (
-        paths["activity_independent_status_statistics"].parent
-        == tmp_path / "status" / "independent"
-    )
-    assert (
-        paths["activity_non_independent_status_statistics"].parent
-        == tmp_path / "status" / "non-independent"
-    )
-    assert (
-        paths["activity_same_document_status_statistics"].parent
-        == tmp_path / "status" / "same_document"
-    )
     assert paths["pairs_same_document"].parent == tmp_path / "same_document"
     assert paths["pairs_independent"].parent == tmp_path / "independent"
     assert paths["pairs_non_independent"].parent == tmp_path / "non_independent"


### PR DESCRIPTION
## Summary
- remove status-specific logic from `save_tables` and support only same_document, independent, and non_independent suffixes
- update tests to match new table save behaviour

## Testing
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `python -m black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py::test_save_tables_writes_files tests/test_input_initialisation_library.py::test_save_tables_orders_key_column_first tests/test_input_initialisation_library.py::test_save_tables_drops_duplicate_columns_and_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_68c695471b548324afaea1210cc7ac7c