### PR TITLE
Remove status_csv resource configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -812,12 +812,6 @@
           "title": "Organism Csv",
           "type": "string"
         },
-        "status_csv": {
-          "default": "dictionary/_Curation/status.csv",
-          "format": "path",
-          "title": "Status Csv",
-          "type": "string"
-        },
         "targets_type_csv": {
           "default": "dictionary/_Target/targets_type.csv",
           "format": "path",
@@ -1339,7 +1333,6 @@
         "iuphar_family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
         "uniprot_data_dir": "uniprot",
         "organism_csv": "dictionary/organism.csv",
-        "status_csv": "dictionary/_Curation/status.csv",
         "targets_type_csv": "dictionary/_Target/targets_type.csv"
       },
       "description": "Paths to local resource files used in processing."

--- a/config.yaml
+++ b/config.yaml
@@ -167,7 +167,6 @@ resources:
   iuphar_family_csv: "dictionary/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
   uniprot_data_dir: "dictionary/uniprot"  # Directory containing cached UniProt JSON files
   organism_csv: "dictionary/_Target/targets_type.csv"  # Organism taxonomy mapping file
-  status_csv: "dictionary/status.csv"  # Activity status configuration table
   targets_type_csv: "dictionary/_Target/targets_type.csv"  # Target type mapping table
 
 io:

--- a/library/config.py
+++ b/library/config.py
@@ -304,7 +304,6 @@ class ResourcesCfg(_BaseModel):
     iuphar_family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
     uniprot_data_dir: Path = Path("uniprot")
     organism_csv: Path = Path("dictionary/organism.csv")
-    status_csv: Path = Path("dictionary/status.csv")
     targets_type_csv: Path = Path("dictionary/targets_type.csv")
 
 
@@ -778,7 +777,6 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_ORGANISM_CSV": ["resources", "organism_csv"],
     "CHEMBL_DA_OUTDIR": ["io", "output_dir"],
     "CHEMBL_DA_RPS": ["api", "rps"],
-    "CHEMBL_DA_STATUS_CSV": ["resources", "status_csv"],
     "CHEMBL_DA_TARGETS_TYPE_CSV": ["resources", "targets_type_csv"],
     "CHEMBL_DA_TIMEOUT_CONNECT": ["api", "timeout_connect"],
     "CHEMBL_DA_TIMEOUT_READ": ["api", "timeout_read"],

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -78,7 +78,6 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             same,
             all_,
             dictionary_dir=args.dictionary_dir,
-            status_csv=cfg.resources.status_csv,
             targets_type_csv=cfg.resources.targets_type_csv,
         )
         logger.info("generate_pair_tables")

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -26,7 +26,6 @@ def _create_config(tmp_path: Path) -> Path:
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
         "  uniprot_data_dir: uniprot\n"
         "  organism_csv: dictionary/organism.csv\n"
-        "  status_csv: dictionary/status.csv\n"
         "  targets_type_csv: dictionary/targets_type.csv\n"
     )
     return cfg

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -50,7 +50,6 @@ def test_malformed_config_exits(
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
         "  uniprot_data_dir: uniprot\n"
         "  organism_csv: dictionary/organism.csv\n"
-        "  status_csv: dictionary/status.csv\n"
         "  targets_type_csv: dictionary/targets_type.csv\n"
     )
     argv = [*extra, "--config", str(cfg)]

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -29,7 +29,6 @@ def _create_config(tmp_path: Path) -> Path:
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
         "  uniprot_data_dir: uniprot\n"
         "  organism_csv: dictionary/organism.csv\n"
-        "  status_csv: dictionary/status.csv\n"
         "  targets_type_csv: dictionary/targets_type.csv\n"
     )
     return cfg

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -49,6 +49,7 @@ def test_assays_schema_validation() -> None:
         {
             "assay_chembl_id": ["CHEMBL1"],
             "document_chembl_id": ["CHEMBL2"],
+            "target_chembl_id": ["CHEMBL3"],
         }
     )
     AssaysSchema.validate(valid)

--- a/tests/test_target_cli_organism_csv.py
+++ b/tests/test_target_cli_organism_csv.py
@@ -17,7 +17,6 @@ def test_organism_csv_default_from_config(tmp_path, monkeypatch) -> None:
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
         "  iuphar_family_csv: dictionary/_IUPHAR/_IUPHAR_family.csv\n"
-        "  status_csv: dictionary/status.csv\n"
         "  targets_type_csv: dictionary/targets_type.csv\n"
     )
     captured: dict[str, Path] = {}


### PR DESCRIPTION
## Summary
- drop obsolete `status_csv` option from default config and schema
- update resource model and env-var aliases
- fix scripts and tests accordingly and ensure assay schema test includes required column

## Testing
- `ruff check .`
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69547c7f88324b7919f3de403a04c