### PR TITLE
refactor: remove redundant rename in target data script

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -572,7 +572,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         chembl_df = pd.read_csv(
             chembl_out, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
-        ).rename(columns={"target_chembl_id": "target_chembl_id"})
+        )
 
         # Extract UniProt IDs and write temporary CSV for downstream steps
         uids = [


### PR DESCRIPTION
## Summary
- remove no-op rename when loading ChEMBL results in get_target_data

## Testing
- `python -m black scripts/get_target_data.py`
- `python -m ruff check scripts/get_target_data.py`
- `python -m mypy scripts/get_target_data.py`
- `pytest tests/test_target_cli_organism_csv.py tests/test_get_target_data_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c69f4cd3ec83248c82922e6ec696a7