### PR TITLE
Remove obsolete target column rename

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -714,11 +714,6 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             dtype=str,
         )
         final_df = tp.finalise_targets(processed, organism_df)
-        # ``postprocess_targets`` and ``finalise_targets`` operate on the
-        # ``chembl_id`` column name, but the validation schema expects the
-        # original ``target_chembl_id``. Rename the column back before
-        # normalisation and validation to satisfy the schema requirements.
-        # final_df = final_df.rename(columns={"chembl_id": "target_chembl_id"})
         final_df = normalize_targets(final_df)
         exit_code = 0
         required_cols = {

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -210,3 +210,21 @@ def test_finalise_targets_no_downcast_warning() -> None:
             uniprot_col="uniprot",
             genus_col="organism",
         )
+
+
+def test_finalise_targets_uses_target_chembl_id_by_default() -> None:
+    """Default column name ``target_chembl_id`` is preserved after finalisation."""
+
+    df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprotkb_Id": ["P12345"],
+            "genus": ["Homo"],
+        }
+    )
+    organism = pd.DataFrame({"genus": ["Homo"], "type": ["Mammal"]})
+
+    out = tp.finalise_targets(df, organism)
+
+    assert "target_chembl_id" in out.columns
+    assert "chembl_id" not in out.columns


### PR DESCRIPTION
## Summary
- streamline target pipeline by dropping outdated chembl_id -> target_chembl_id rename
- test that finalise_targets keeps the target_chembl_id column

## Testing
- `pre-commit run ruff --files scripts/get_target_data.py tests/test_target_postprocessing.py`
- `pre-commit run black --files scripts/get_target_data.py tests/test_target_postprocessing.py`
- `mypy --ignore-missing-imports --disable-error-code import-untyped --config-file /tmp/mypy.ini scripts/get_target_data.py tests/test_target_postprocessing.py`
- `pytest tests/test_target_postprocessing.py -k uses_target_chembl_id`

------
https://chatgpt.com/codex/tasks/task_e_68c69f4e4484832484a368cb988c472b