### PR TITLE
Add snapshot saving to target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -573,6 +573,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         chembl_df = pd.read_csv(
             chembl_out, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
         ).rename(columns={"target_chembl_id": "target_chembl_id"})
+        _save_snapshot(chembl_df, output, "chembl", cfg)
 
         # Extract UniProt IDs and write temporary CSV for downstream steps
         uids = [
@@ -661,6 +662,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         combined_df = combined_df.drop(
             columns=["ec_numbers", "reaction_ec_numbers"], errors="ignore"
         )
+        _save_snapshot(combined_df, output, "uniprot", cfg)
 
         with NamedTemporaryFile(
             "w", delete=False, encoding=cfg.io.csv_encoding, newline=""
@@ -705,6 +707,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         iuphar_df = iuphar_df[["uniprot_id", *classification_cols]].copy()
 
         merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+        _save_snapshot(merged, output, "iuphar", cfg)
         # Apply domain-specific clean-up and finalise table before exporting
         processed = tp.postprocess_targets(merged)
         organism_df = pd.read_csv(

--- a/tests/test_get_target_data_helpers.py
+++ b/tests/test_get_target_data_helpers.py
@@ -1,32 +1,113 @@
 """Tests for helper utilities in :mod:`scripts.get_target_data`."""
 
+import argparse
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
+import scripts.get_target_data as gtd
 from library.config import Config
-from scripts.get_target_data import _first_token, _pipe_merge, _save_snapshot
 
 
 def test_pipe_merge_deduplicates_and_sorts() -> None:
     values = ["b|a", "C|a", None, "", "b"]
-    assert _pipe_merge(values) == "C|a|b"
+    assert gtd._pipe_merge(values) == "C|a|b"
 
 
 def test_pipe_merge_handles_empty() -> None:
-    assert _pipe_merge([None, "", " "]) == ""
+    assert gtd._pipe_merge([None, "", " "]) == ""
 
 
 def test_first_token_extracts_head() -> None:
-    assert _first_token("a|b|c") == "a"
-    assert _first_token(None) == ""
-    assert _first_token("") == ""
+    assert gtd._first_token("a|b|c") == "a"
+    assert gtd._first_token(None) == ""
+    assert gtd._first_token("") == ""
 
 
 def test_save_snapshot_creates_unique_files(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1]})
     base = tmp_path / "out.csv"
-    _save_snapshot(df, base, "step", cfg)
-    _save_snapshot(df, base, "step", cfg)
+    gtd._save_snapshot(df, base, "step", cfg)
+    gtd._save_snapshot(df, base, "step", cfg)
     files = sorted(tmp_path.glob("out_step_*.csv"))
     assert len(files) == 2
+
+
+def test_run_all_saves_snapshots(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_all`` should snapshot data after each stage."""
+
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding)
+    output_csv = tmp_path / "final.csv"
+
+    def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        df = pd.DataFrame(
+            {
+                "target_chembl_id": ["CHEMBL1"],
+                "uniprot_id": ["P12345"],
+                "gene": ["GN1"],
+                "component_description": ["desc"],
+                "pref_name": ["name"],
+                "chembl_alternative_name": ["alt"],
+                "ec_numbers": ["1.1.1.1"],
+                "reaction_ec_numbers": ["2.2.2.2"],
+            }
+        )
+        df.to_csv(
+            args.output_csv,
+            index=False,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
+        return 0
+
+    def fake_run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
+        df = pd.DataFrame(
+            {
+                "uniprot_id": ["P12345"],
+                "names": ["prot"],
+                "secondaryAccessionNames": ["sec"],
+                "ec_numbers": ["1.1.1.1"],
+                "reaction_ec_numbers": ["2.2.2.2"],
+            }
+        )
+        df.to_csv(
+            args.output_csv,
+            index=False,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
+        return 0
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        df = pd.DataFrame({"uniprot_id": ["P12345"], "class_a": ["Enzyme"]})
+        df.to_csv(
+            args.output_csv,
+            index=False,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
+        return 0
+
+    steps: list[str] = []
+
+    def fake_snapshot(
+        df: pd.DataFrame, base: Path, step: str, cfg: Config
+    ) -> Path:  # pragma: no cover - simple recorder
+        steps.append(step)
+        return base
+
+    monkeypatch.setattr(gtd, "run_chembl", fake_run_chembl)
+    monkeypatch.setattr(gtd, "run_uniprot", fake_run_uniprot)
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+    monkeypatch.setattr(gtd, "_save_snapshot", fake_snapshot)
+    monkeypatch.setattr(gtd.tp, "postprocess_targets", lambda df: df)
+    monkeypatch.setattr(gtd.tp, "finalise_targets", lambda df, _: df)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+    rc = gtd.run_all(cfg, args)
+    assert rc == 0
+    assert steps == ["chembl", "uniprot", "iuphar"]


### PR DESCRIPTION
## Summary
- save intermediate target data after ChEMBL, UniProt and IUPHAR stages
- test snapshot helpers and `run_all` snapshot integration

## Testing
- `pre-commit run --files scripts/get_target_data.py tests/test_get_target_data_helpers.py` (fails: ModuleNotFoundError: No module named 'pandas')
- `SKIP=mypy,pytest pre-commit run --files scripts/get_target_data.py tests/test_get_target_data_helpers.py`
- `pytest tests/test_get_target_data_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68c69f4bf5e883248b5d14c48213f4e2