### PR TITLE
Ensure dataclasses import

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -7,9 +7,15 @@ common column types, merge entity tables and persist the final CSV files.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
+
+try:
+    from dataclasses import dataclass
+except ImportError as exc:  # pragma: no cover - Python <3.7
+    raise ImportError(
+        "dataclasses module is required; upgrade to Python 3.7 or newer"
+    ) from exc
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- handle absence of dataclasses module for Python <3.7

## Testing
- `ruff check library/input_initialisation_library.py`
- `black library/input_initialisation_library.py`
- `mypy library/input_initialisation_library.py`
- `pytest tests/test_input_initialisation_library.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6a1de49488324aaa16d7fa3b9fbc3