### PR TITLE
Add column ordering test for finalise_targets

### DIFF
--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -410,6 +410,13 @@ def finalise_targets(
         if col in df.columns:
             df[col] = df[col].astype("string").str.lower()
 
+    # --- final column ordering --------------------------------------------------
+    schema_cols = list(TargetsSchema.columns)
+    extra_cols = sorted(c for c in df.columns if c not in schema_cols)
+    ordered_cols = [c for c in schema_cols if c in df.columns] + extra_cols
+
+    df = df[ordered_cols]
+
     return df.rename(
         columns={
             "target_chembl_id": chembl_col,

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -72,6 +72,37 @@ def test_postprocess_targets_orders_columns() -> None:
     assert list(out.columns) == schema_cols + extra_cols
 
 
+def test_finalise_targets_orders_columns() -> None:
+    """Columns from the schema appear first and others alphabetically."""
+
+    df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniprot": ["P1"],
+            "organism": ["Homo"],
+            "b": ["1"],
+            "a": ["2"],
+        }
+    )
+    organism = pd.DataFrame({"organism": ["Homo"], "type": ["Mammal"]})
+
+    out = tp.finalise_targets(
+        df,
+        organism,
+        chembl_col="chembl_id",
+        uniprot_col="uniprot",
+        genus_col="organism",
+    )
+
+    schema_cols = list(TargetsSchema.columns)
+    schema_cols[schema_cols.index("target_chembl_id")] = "chembl_id"
+    schema_cols[schema_cols.index("uniprotkb_Id")] = "uniprot"
+    schema_cols[schema_cols.index("genus")] = "organism"
+    expected_schema = [c for c in schema_cols if c in out.columns]
+    extra_cols = sorted(c for c in out.columns if c not in schema_cols)
+    assert list(out.columns) == expected_schema + extra_cols
+
+
 def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
     """``postprocess_file`` respects ``IoCfg`` defaults for CSV options."""
 
@@ -212,7 +243,6 @@ def test_finalise_targets_no_downcast_warning() -> None:
         )
 
 
-
 def test_finalise_targets_uses_target_chembl_id_by_default() -> None:
     """Default column name ``target_chembl_id`` is preserved after finalisation."""
 
@@ -229,4 +259,3 @@ def test_finalise_targets_uses_target_chembl_id_by_default() -> None:
 
     assert "target_chembl_id" in out.columns
     assert "chembl_id" not in out.columns
-


### PR DESCRIPTION
## Summary
- ensure `finalise_targets` returns schema columns first and extras alphabetically
- add regression test for column ordering in `finalise_targets`

## Testing
- `ruff check library/target_postprocessing.py tests/test_target_postprocessing.py`
- `mypy library/target_postprocessing.py`
- `pytest tests/test_target_postprocessing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a2b0c3588324bdc53f68d5bea387