### PR TITLE
Add schema validation tests for CSV samples

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ This module provides common pytest fixtures used across the test suite.
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pandas as pd
 import pytest
 
 from library.config import ApiCfg, Config
@@ -27,3 +30,28 @@ def duplicate_document_ids() -> list[str]:
     """Return sample document IDs including duplicates for testing."""
 
     return ["CHEMBL1", "CHEMBL1", "CHEMBL2"]
+
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+@pytest.fixture()
+def activities_sample_df() -> pd.DataFrame:
+    """Load the minimal activities CSV as a :class:`~pandas.DataFrame`."""
+
+    return pd.read_csv(
+        DATA_DIR / "activities_sample.csv",
+        dtype={
+            "activity_id": str,
+            "molecule_chembl_id": str,
+            "assay_chembl_id": str,
+            "standard_type": str,
+        },
+    )
+
+
+@pytest.fixture()
+def documents_sample_df() -> pd.DataFrame:
+    """Load the minimal documents CSV as a :class:`~pandas.DataFrame`."""
+
+    return pd.read_csv(DATA_DIR / "documents_sample.csv")

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,0 +1,10 @@
+# Test Data Sources
+
+This directory contains small CSV samples used by the test suite.
+The files were hand-crafted to exercise schema validation logic and
+are not drawn from production datasets.
+
+* `activities_sample.csv` – minimal activity row covering required
+  fields for `ActivitiesSchema`.
+* `documents_sample.csv` – minimal document row covering required
+  fields for `DocumentsSchema`.

--- a/tests/data/activities_sample.csv
+++ b/tests/data/activities_sample.csv
@@ -1,0 +1,2 @@
+activity_id,molecule_chembl_id,assay_chembl_id,standard_type,standard_value
+1,CHEMBL1,CHEMBL0,IC50,10.0

--- a/tests/data/documents_sample.csv
+++ b/tests/data/documents_sample.csv
@@ -1,0 +1,2 @@
+document_chembl_id,doi,title,year,month,day,citation
+CHEMBL1,10.1000/example,Example Title,2024,1,15,5

--- a/tests/test_schema_csv_rows.py
+++ b/tests/test_schema_csv_rows.py
@@ -1,0 +1,34 @@
+"""Tests validating CSV rows against DataFrame schemas."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from pandera.errors import SchemaError
+
+from schemas.activities import ActivitiesSchema
+from schemas.documents import DocumentsSchema
+
+
+def test_activities_schema_enforces_float_dtype(
+    activities_sample_df: pd.DataFrame,
+) -> None:
+    """`ActivitiesSchema` enforces column data types."""
+
+    ActivitiesSchema.validate(activities_sample_df)
+
+    bad = activities_sample_df.astype({"standard_value": str})
+    with pytest.raises(SchemaError):
+        ActivitiesSchema.validate(bad)
+
+
+def test_documents_schema_requires_identifier(
+    documents_sample_df: pd.DataFrame,
+) -> None:
+    """`DocumentsSchema` requires the document identifier column."""
+
+    DocumentsSchema.validate(documents_sample_df)
+
+    missing = documents_sample_df.drop(columns=["document_chembl_id"])
+    with pytest.raises(SchemaError):
+        DocumentsSchema.validate(missing)


### PR DESCRIPTION
## Summary
- add fixtures for sample activity and document CSVs
- validate dtype enforcement and missing-column errors via pandera schemas
- document test CSV sources

## Testing
- `python -m black tests/conftest.py tests/test_schema_csv_rows.py`
- `ruff check tests/conftest.py tests/test_schema_csv_rows.py`
- `mypy --ignore-missing-imports tests/conftest.py tests/test_schema_csv_rows.py`
- `pytest tests/test_schema_csv_rows.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6a84926cc8324b18b6af5e12b47bd