### PR TITLE
Preserve target column order

### DIFF
--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from schemas import TargetsSchema
+from schemas.targets import TARGETS_COLUMN_ORDER
 
 from .config import Config, IoCfg
 from .log import logger
@@ -246,7 +246,8 @@ def postprocess_targets(
 
     # --- final column ordering --------------------------------------------------
     schema_cols = [
-        internal_id if col == chembl_col else col for col in TargetsSchema.columns
+        internal_id if col == "target_chembl_id" else col
+        for col in TARGETS_COLUMN_ORDER
     ]
     extra_cols = sorted(c for c in df.columns if c not in schema_cols)
     ordered_cols = schema_cols + extra_cols
@@ -410,23 +411,7 @@ def finalise_targets(
         if col in df.columns:
             df[col] = df[col].astype("string").str.lower()
 
-
     # --- final column ordering --------------------------------------------------
-    schema_cols = list(TargetsSchema.columns)
-    extra_cols = sorted(c for c in df.columns if c not in schema_cols)
-    ordered_cols = [c for c in schema_cols if c in df.columns] + extra_cols
-
-    df = df[ordered_cols]
-
-    return df.rename(
-
-        columns={
-            "target_chembl_id": chembl_col,
-            "uniprotkb_Id": uniprot_col,
-            "genus": genus_col,
-        }
-    )
-
     schema_cols = [
         (
             chembl_col
@@ -435,10 +420,20 @@ def finalise_targets(
                 uniprot_col if c == "uniprotkb_Id" else genus_col if c == "genus" else c
             )
         )
-        for c in TargetsSchema.columns
+        for c in TARGETS_COLUMN_ORDER
     ]
     extra_cols = sorted(c for c in df.columns if c not in schema_cols)
-    return df.reindex(columns=schema_cols + extra_cols)
+    ordered_cols = [c for c in schema_cols if c in df.columns] + extra_cols
+
+    df = df[ordered_cols]
+
+    return df.rename(
+        columns={
+            "target_chembl_id": chembl_col,
+            "uniprotkb_Id": uniprot_col,
+            "genus": genus_col,
+        }
+    )
 
 
 def finalise_file(

--- a/schemas/targets.py
+++ b/schemas/targets.py
@@ -4,6 +4,58 @@ from __future__ import annotations
 
 import pandera.pandas as pa
 
+# Explicit column order for the targets table.
+#
+# Pandera sorts columns alphabetically when exposing ``DataFrameSchema.columns``.
+# To preserve the intended ordering in data exports, the sequence is captured in
+# ``TARGETS_COLUMN_ORDER`` and referenced by post-processing utilities.
+TARGETS_COLUMN_ORDER: list[str] = [
+    "target_chembl_id",
+    "uniprotkb_Id",
+    "recommended_name",
+    "synonyms",
+    "type",
+    "uniprot_id",
+    "secondary_uniprot_id",
+    "gene_name",
+    "genus",
+    "superkingdom",
+    "phylum",
+    "taxon_id",
+    "ec_number",
+    "hgnc_name",
+    "hgnc_id",
+    "molecular_function",
+    "cellular_component",
+    "subcellular_location",
+    "topology",
+    "transmembrane",
+    "intramembrane",
+    "glycosylation",
+    "lipidation",
+    "disulfide_bond",
+    "modified_residue",
+    "phosphorylation",
+    "acetylation",
+    "ubiquitination",
+    "signal_peptide",
+    "propeptide",
+    "isoform_names",
+    "isoform_ids",
+    "isoform_synonyms",
+    "reactions",
+    "target_id",
+    "IUPHAR_family_id",
+    "IUPHAR_type",
+    "IUPHAR_class",
+    "IUPHAR_subclass",
+    "IUPHAR_chain",
+    "full_id_path",
+    "full_name_path",
+    "GuidetoPHARMACOLOGY",
+]
+
+
 # Definition of the schema describing the targets table used in exports.
 TargetsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
@@ -50,8 +102,8 @@ TargetsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "full_id_path": pa.Column(str, required=False),
         "full_name_path": pa.Column(str, required=False),
         "GuidetoPHARMACOLOGY": pa.Column(str, required=False),
-
-    }
+    },
+    ordered=True,
 )
 
 """pa.DataFrameSchema: Validation schema for targets."""

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from library import target_postprocessing as tp
 from library.config import Config, IoCfg
-from schemas import TargetsSchema
+from schemas.targets import TARGETS_COLUMN_ORDER
 
 
 def test_postprocess_targets_merges_and_normalises() -> None:
@@ -66,13 +66,14 @@ def test_postprocess_targets_orders_columns() -> None:
     )
     out = tp.postprocess_targets(df, chembl_col="chembl_id")
 
-    schema_cols = list(TargetsSchema.columns)
-    schema_cols[schema_cols.index("target_chembl_id")] = "chembl_id"
+    schema_cols = [
+        "chembl_id" if c == "target_chembl_id" else c for c in TARGETS_COLUMN_ORDER
+    ]
     extra_cols = sorted(c for c in out.columns if c not in schema_cols)
     assert list(out.columns) == schema_cols + extra_cols
 
 
-def test_finalise_targets_orders_columns() -> None:
+def test_finalise_targets_orders_columns_default() -> None:
     """Columns from the schema appear first and others alphabetically."""
 
     df = pd.DataFrame(
@@ -94,10 +95,14 @@ def test_finalise_targets_orders_columns() -> None:
         genus_col="organism",
     )
 
-    schema_cols = list(TargetsSchema.columns)
-    schema_cols[schema_cols.index("target_chembl_id")] = "chembl_id"
-    schema_cols[schema_cols.index("uniprotkb_Id")] = "uniprot"
-    schema_cols[schema_cols.index("genus")] = "organism"
+    schema_cols = [
+        (
+            "chembl_id"
+            if c == "target_chembl_id"
+            else "uniprot" if c == "uniprotkb_Id" else "organism" if c == "genus" else c
+        )
+        for c in TARGETS_COLUMN_ORDER
+    ]
     expected_schema = [c for c in schema_cols if c in out.columns]
     extra_cols = sorted(c for c in out.columns if c not in schema_cols)
     assert list(out.columns) == expected_schema + extra_cols
@@ -194,7 +199,7 @@ def test_finalise_targets_orders_columns() -> None:
 
     out = tp.finalise_targets(df, organism)
 
-    schema_cols = list(TargetsSchema.columns)
+    schema_cols = [c for c in TARGETS_COLUMN_ORDER if c in out.columns]
     extra_cols = sorted(c for c in out.columns if c not in schema_cols)
     assert list(out.columns) == schema_cols + extra_cols
 


### PR DESCRIPTION
## Summary
- ensure target data columns respect schema-defined order
- reference explicit Targets column list instead of Pandera ordering
- update tests accordingly

## Testing
- `ruff check schemas/targets.py library/target_postprocessing.py tests/test_target_postprocessing.py`
- `mypy library/target_postprocessing.py` *(fails: Cannot find implementation or library stub for module named "pandera.pandas" and others)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c6a913fa208324914fcf35ae8af6fe