### PR TITLE
Align assay schema with input data

### DIFF
--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -3,10 +3,11 @@
 This module defines :data:`AssaysSchema`, a
 :class:`pandera.DataFrameSchema` describing the expected structure of the
 ``assay.csv`` input table.  The schema mirrors the columns distributed with
-``data/input/assay.csv`` and assigns concrete dtypes.  Counts such as
-``acts_per_assay_step5``, temporal fields (``month``, ``year`` and ``version``)
-use :class:`int`, boolean indicators like ``cited_assay_corr`` are :class:`bool`,
-and the remaining descriptive fields are :class:`str`.
+``data/input/assay.csv`` and assigns concrete dtypes.  Numeric fields such as
+``acts_per_assay_step5``, ``assay_tax_id``, ``month``, ``version`` and ``year``
+use :class:`int`, boolean indicators like ``cited_assay_corr`` are
+:class:`bool`, and the remaining descriptive fields are :class:`str`.  All
+columns are declared as optional and nullable to accommodate missing values.
 
 Column overview
 ---------------
@@ -17,6 +18,7 @@ Column overview
 * ``acts_per_assay_step5`` (:class:`int`): Number of activities per assay step 5.
 * ``assay_cell_type`` (:class:`str`): Cell type used in the assay.
 * ``assay_subcellular_fraction`` (:class:`str`): Sub-cellular fraction tested.
+* ``assay_tax_id`` (:class:`int`): NCBI taxonomy identifier of the assay organism.
 * ``assay_tissue`` (:class:`str`): Tissue or organ where the assay is performed.
 * ``bao_format`` (:class:`str`): BAO format code.
 * ``cited_assay_corr`` (:class:`bool`): Whether the assay is cited as correlated.
@@ -42,30 +44,31 @@ import pandera.pandas as pa
 
 AssaysSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "assay_chembl_id": pa.Column(str, required=True),
-        "ASSAY_ID": pa.Column(str, required=False),
-        "Target TYPE": pa.Column(str, required=False),
-        "accession": pa.Column(str, required=False),
-        "acts_per_assay_step5": pa.Column(int, required=False),
-        "assay_cell_type": pa.Column(str, required=False),
-        "assay_subcellular_fraction": pa.Column(str, required=False),
-        "assay_tissue": pa.Column(str, required=False),
-        "bao_format": pa.Column(str, required=False),
-        "cited_assay_corr": pa.Column(bool, required=False),
-        "description": pa.Column(str, required=False),
-        "document_chembl_id": pa.Column(str, required=False),
-        "error_assay_corr": pa.Column(bool, required=False),
-        "higly_correlated_cit": pa.Column(bool, required=False),
-        "isoform": pa.Column(str, required=False),
-        "month": pa.Column(int, required=False),
-        "mutation": pa.Column(str, required=False),
-        "shuffled_cit": pa.Column(bool, required=False),
-        "shuffled_target_assay": pa.Column(bool, required=False),
-        "substrate_name": pa.Column(str, required=False),
-        "target_chembl_id": pa.Column(str, required=False),
-        "target_name": pa.Column(str, required=False),
-        "version": pa.Column(int, required=False),
-        "year": pa.Column(int, required=False),
+        "assay_chembl_id": pa.Column(str, nullable=True, required=False),
+        "ASSAY_ID": pa.Column(str, nullable=True, required=False),
+        "Target TYPE": pa.Column(str, nullable=True, required=False),
+        "accession": pa.Column(str, nullable=True, required=False),
+        "acts_per_assay_step5": pa.Column(int, nullable=True, required=False),
+        "assay_cell_type": pa.Column(str, nullable=True, required=False),
+        "assay_subcellular_fraction": pa.Column(str, nullable=True, required=False),
+        "assay_tax_id": pa.Column(int, nullable=True, required=False),
+        "assay_tissue": pa.Column(str, nullable=True, required=False),
+        "bao_format": pa.Column(str, nullable=True, required=False),
+        "cited_assay_corr": pa.Column(bool, nullable=True, required=False),
+        "description": pa.Column(str, nullable=True, required=False),
+        "document_chembl_id": pa.Column(str, nullable=True, required=False),
+        "error_assay_corr": pa.Column(bool, nullable=True, required=False),
+        "higly_correlated_cit": pa.Column(bool, nullable=True, required=False),
+        "isoform": pa.Column(str, nullable=True, required=False),
+        "month": pa.Column(int, nullable=True, required=False),
+        "mutation": pa.Column(str, nullable=True, required=False),
+        "shuffled_cit": pa.Column(bool, nullable=True, required=False),
+        "shuffled_target_assay": pa.Column(bool, nullable=True, required=False),
+        "substrate_name": pa.Column(str, nullable=True, required=False),
+        "target_chembl_id": pa.Column(str, nullable=True, required=False),
+        "target_name": pa.Column(str, nullable=True, required=False),
+        "version": pa.Column(int, nullable=True, required=False),
+        "year": pa.Column(int, nullable=True, required=False),
     }
 )
 


### PR DESCRIPTION
## Summary
- add assay_tax_id column and set numeric/boolean dtypes
- mark all assay schema columns as optional and nullable
- document revised assay schema

## Testing
- `pre-commit run --files schemas/assays.py` *(fails: tests/test_activity_schema_sidecar.py::test_activity_validation_pass - KeyError: '[None] not found in axis'; tests/test_activity_schema_sidecar.py::test_activity_validation_failures - KeyError: '[None] not found in axis'; tests/test_get_activity_data.py::test_run_chembl_column_order - assert 1 == 0; tests/test_input_initialisation_library.py::test_read_sheet_drops_duplicate_columns - ModuleNotFoundError: No module named 'openpyxl'; tests/test_schemas.py::test_assays_schema_validation - Failed: DID NOT RAISE <class 'pandera.errors.SchemaError'>; tests/test_schemas.py::test_targets_schema_defines_expected_columns - AssertionError: assert {'GuidetoPHAR...AR_type', ..} == {'GuidetoPHAR...AR_type', ...}; tests/test_target_postprocessing.py::test_finalise_targets_orders_columns - AssertionError: assert ['target_chem...us', 'a', 'b'] == ['target_chem...prot_id', ...]`)

------
https://chatgpt.com/codex/tasks/task_e_68c6ac1ed5d88324b5f0816f17b84d4a