### PR TITLE
Relax activity schema type constraints

### DIFF
--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -11,9 +11,9 @@ import pandera.pandas as pa
 # Definition of the schema describing the activities table.
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "activity_id": pa.Column(str, required=True),
-        "molecule_chembl_id": pa.Column(str, required=True),
-        "assay_chembl_id": pa.Column(str, required=True),
+        "activity_id": pa.Column(str, required=True, nullable=True),
+        "molecule_chembl_id": pa.Column(str, required=True, nullable=True),
+        "assay_chembl_id": pa.Column(str, required=True, nullable=True),
         "activity_comment": pa.Column(str, required=False, nullable=True),
         "assay_description": pa.Column(str, required=False, nullable=True),
         "assay_variant_accession": pa.Column(str, required=False, nullable=True),
@@ -39,8 +39,11 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
             str,
             pa.Check.isin(["IC50", "Ki"]),
             required=False,
+            nullable=True,
         ),
-        "standard_value": pa.Column(float, pa.Check.ge(0), required=True, nullable=True),
+        "standard_value": pa.Column(
+            object, pa.Check.ge(0), required=True, nullable=True, coerce=True
+        ),
         #    "pA_value": pa.Column(float, pa.Check.in_range(-14, 14), required=False),
     }
 )

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -11,7 +11,7 @@ import pandera.pandas as pa
 # Definition of the schema describing the activities table.
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "activity_id": pa.Column(str, required=True, nullable=True),
+        "activity_id": pa.Column(object, required=True, nullable=True),
         "molecule_chembl_id": pa.Column(str, required=True, nullable=True),
         "assay_chembl_id": pa.Column(str, required=True, nullable=True),
         "activity_comment": pa.Column(str, required=False, nullable=True),
@@ -23,18 +23,18 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "data_validity_comment": pa.Column(str, required=False, nullable=True),
         "data_validity_description": pa.Column(str, required=False, nullable=True),
         "document_chembl_id": pa.Column(str, required=False, nullable=True),
-        "pchembl_value": pa.Column(str, required=False, nullable=True),
+        "pchembl_value": pa.Column(object, required=False, nullable=True),
         "potential_duplicate": pa.Column(str, required=False, nullable=True),
         "qudt_units": pa.Column(str, required=False, nullable=True),
         "record_id": pa.Column(str, required=False, nullable=True),
         "relation": pa.Column(str, required=False, nullable=True),
-        "src_assay_id": pa.Column(str, required=False, nullable=True),
-        "src_id": pa.Column(str, required=False, nullable=True),
+        "src_assay_id": pa.Column(object, required=False, nullable=True),
+        "src_id": pa.Column(object, required=False, nullable=True),
         "standard_relation": pa.Column(str, required=False, nullable=True),
         "standard_units": pa.Column(str, required=False, nullable=True),
         "type": pa.Column(str, required=False, nullable=True),
         "units": pa.Column(str, required=False, nullable=True),
-        "value": pa.Column(str, required=False, nullable=True),
+        "value": pa.Column(object, required=False, nullable=True),
         "standard_type": pa.Column(
             str,
             pa.Check.isin(["IC50", "Ki"]),

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -49,11 +49,15 @@ def test_activities_schema_accepts_object_dtypes() -> None:
 
     df = pd.DataFrame(
         {
-            "activity_id": ["1"],
+            # numeric IDs are coerced to ``object`` to allow flexible typing
+            "activity_id": pd.Series([1], dtype=object),
             "molecule_chembl_id": ["CHEMBL1"],
             "assay_chembl_id": ["CHEMBL0"],
-            # Use ``object`` dtype to ensure flexible type handling
             "standard_value": pd.Series([1.0], dtype=object),
+            "pchembl_value": pd.Series([5.0], dtype=object),
+            "src_assay_id": pd.Series([2], dtype=object),
+            "src_id": pd.Series([3], dtype=object),
+            "value": pd.Series([7.0], dtype=object),
         }
     )
     ActivitiesSchema.validate(df)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -44,6 +44,21 @@ def test_activities_schema_validation() -> None:
         ActivitiesSchema.validate(invalid)
 
 
+def test_activities_schema_accepts_object_dtypes() -> None:
+    """``standard_value`` validates with object dtype."""
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["1"],
+            "molecule_chembl_id": ["CHEMBL1"],
+            "assay_chembl_id": ["CHEMBL0"],
+            # Use ``object`` dtype to ensure flexible type handling
+            "standard_value": pd.Series([1.0], dtype=object),
+        }
+    )
+    ActivitiesSchema.validate(df)
+
+
 def test_assays_schema_validation() -> None:
     """Required columns are enforced."""
     valid = pd.DataFrame(


### PR DESCRIPTION
## Summary
- allow nulls for every ActivitiesSchema column
- coerce `standard_value` to object dtype for flexible types
- test schema with object-typed values

## Testing
- `black schemas/activities.py tests/test_schemas.py`
- `ruff check schemas/activities.py tests/test_schemas.py`
- `mypy --ignore-missing-imports schemas/activities.py`
- `pytest tests/test_schemas.py::test_activities_schema_validation tests/test_schemas.py::test_activities_schema_accepts_object_dtypes -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1d6ed0c8324b67b0c489a85a036