### PR TITLE
Relax document schema type checks

### DIFF
--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -4,66 +4,100 @@ from __future__ import annotations
 
 import pandera.pandas as pa
 
+# ``pa.Any`` is not available in the current pandera version; ``object`` with
+# ``coerce=True`` permits arbitrary dtypes.
+
 DocumentsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "document_chembl_id": pa.Column(str, required=True),
+        "document_chembl_id": pa.Column(str, required=True, nullable=True),
         "doi": pa.Column(str, required=False, nullable=True),
         "title": pa.Column(str, required=False, nullable=True),
-        "Index": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.Error": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.Genre": pa.Column(str, required=False, nullable=True),
+        "Index": pa.Column(object, required=False, nullable=True, coerce=True),
+        "OpenAlex.Error": pa.Column(object, required=False, nullable=True, coerce=True),
+        "OpenAlex.Genre": pa.Column(object, required=False, nullable=True, coerce=True),
         "OpenAlex.Id": pa.Column(str, required=False, nullable=True),
         "OpenAlex.MeshDescriptors": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.MeshQualifiers": pa.Column(str, required=False, nullable=True),
+        "OpenAlex.MeshQualifiers": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
         "OpenAlex.TypeCrossref": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.Venue": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.is_review": pa.Column(str, required=False, nullable=True),
+        "OpenAlex.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
+        "OpenAlex.is_review": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
         "PubMed.Abstract": pa.Column(str, required=False, nullable=True),
         "PubMed.ArticleTitle": pa.Column(str, required=False, nullable=True),
         "PubMed.ChemicalList": pa.Column(str, required=False, nullable=True),
-        "PubMed.DOI": pa.Column(str, required=False, nullable=True),
-        "PubMed.DayCompleted": pa.Column(str, required=False, nullable=True),
-        "PubMed.DayRevised": pa.Column(str, required=False, nullable=True),
-        "PubMed.EndPage": pa.Column(str, required=False, nullable=True),
-        "PubMed.Error": pa.Column(str, required=False, nullable=True),
+        "PubMed.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
+        "PubMed.DayCompleted": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.DayRevised": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.EndPage": pa.Column(object, required=False, nullable=True, coerce=True),
+        "PubMed.Error": pa.Column(object, required=False, nullable=True, coerce=True),
         "PubMed.ISSN": pa.Column(str, required=False, nullable=True),
-        "PubMed.Issue": pa.Column(str, required=False, nullable=True),
+        "PubMed.Issue": pa.Column(object, required=False, nullable=True, coerce=True),
         "PubMed.JournalTitle": pa.Column(str, required=False, nullable=True),
         "PubMed.MeSH_Descriptors": pa.Column(str, required=False, nullable=True),
         "PubMed.MeSH_Qualifiers": pa.Column(str, required=False, nullable=True),
-        "PubMed.MonthCompleted": pa.Column(str, required=False, nullable=True),
-        "PubMed.MonthRevised": pa.Column(str, required=False, nullable=True),
-        "PubMed.PMID": pa.Column(str, required=False, nullable=True),
-        "PubMed.StartPage": pa.Column(str, required=False, nullable=True),
-        "PubMed.Volume": pa.Column(str, required=False, nullable=True),
-        "PubMed.YearCompleted": pa.Column(str, required=False, nullable=True),
-        "PubMed.YearRevised": pa.Column(str, required=False, nullable=True),
-        "PubMed.is_review": pa.Column(str, required=False, nullable=True),
+        "PubMed.MonthCompleted": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.MonthRevised": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
+        "PubMed.StartPage": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.Volume": pa.Column(object, required=False, nullable=True, coerce=True),
+        "PubMed.YearCompleted": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.YearRevised": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "PubMed.is_review": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
         "abstract": pa.Column(str, required=False, nullable=True),
         "authors": pa.Column(str, required=False, nullable=True),
         "crossref.Error": pa.Column(str, required=False, nullable=True),
-        "crossref.Subject": pa.Column(str, required=False, nullable=True),
-        "crossref.Subtitle": pa.Column(str, required=False, nullable=True),
-        "crossref.Subtype": pa.Column(str, required=False, nullable=True),
-        "crossref.Title": pa.Column(str, required=False, nullable=True),
-        "crossref.Type": pa.Column(str, required=False, nullable=True),
+        "crossref.Subject": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "crossref.Subtitle": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "crossref.Subtype": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "crossref.Title": pa.Column(object, required=False, nullable=True, coerce=True),
+        "crossref.Type": pa.Column(object, required=False, nullable=True, coerce=True),
         "date_code": pa.Column(str, required=False, nullable=True),
-        "first_page": pa.Column(str, required=False, nullable=True),
-        "issue": pa.Column(str, required=False, nullable=True),
+        "first_page": pa.Column(object, required=False, nullable=True, coerce=True),
+        "issue": pa.Column(object, required=False, nullable=True, coerce=True),
         "journal": pa.Column(str, required=False, nullable=True),
         "journal_abbrev": pa.Column(str, required=False, nullable=True),
-        "last_page": pa.Column(str, required=False, nullable=True),
-        "pubmed_id": pa.Column(str, required=False, nullable=True),
-        "scholar.DOI": pa.Column(str, required=False, nullable=True),
+        "last_page": pa.Column(object, required=False, nullable=True, coerce=True),
+        "pubmed_id": pa.Column(object, required=False, nullable=True, coerce=True),
+        "scholar.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
         "scholar.Error": pa.Column(str, required=False, nullable=True),
-        "scholar.ExternalIds": pa.Column(str, required=False, nullable=True),
-        "scholar.PMID": pa.Column(str, required=False, nullable=True),
-        "scholar.SemanticScholarId": pa.Column(str, required=False, nullable=True),
-        "scholar.Venue": pa.Column(str, required=False, nullable=True),
-        "scholar.is_review": pa.Column(str, required=False, nullable=True),
+        "scholar.ExternalIds": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "scholar.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
+        "scholar.SemanticScholarId": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
+        "scholar.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
+        "scholar.is_review": pa.Column(
+            object, required=False, nullable=True, coerce=True
+        ),
         "source": pa.Column(str, required=False, nullable=True),
-        "volume": pa.Column(str, required=False, nullable=True),
-
+        "volume": pa.Column(object, required=False, nullable=True, coerce=True),
     }
 )
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -66,12 +66,9 @@ def test_documents_schema_validation() -> None:
     valid = pd.DataFrame(
         {
             "document_chembl_id": ["CHEMBL1"],
-            "doi": ["10.1000/xyz123"],
             "title": ["Example"],
-            "year": [2020],
-            "month": [1],
-            "day": [15],
-            "citation": [0],
+            "PubMed.PMID": [12345],
+            "OpenAlex.Error": [None],
         }
     )
     DocumentsSchema.validate(valid)
@@ -235,9 +232,9 @@ def test_activities_schema_hypothesis_invalid(df: pd.DataFrame) -> None:
             column("document_chembl_id", elements=st.text(min_size=1)),
             column("title", elements=st.text(min_size=1)),
             column(
-                "year",
+                "PubMed.PMID",
                 dtype=int,
-                elements=st.integers(min_value=1900, max_value=2100),
+                elements=st.integers(min_value=0, max_value=2**63 - 1),
             ),
         ],
         index=range_indexes(min_size=1, max_size=5),
@@ -253,18 +250,17 @@ def test_documents_schema_hypothesis_valid(df: pd.DataFrame) -> None:
     data_frames(
         columns=[
             column("document_chembl_id", elements=st.text(min_size=1)),
-            column("title", elements=st.text(min_size=1)),
             column(
-                "year",
+                "PubMed.PMID",
                 dtype=int,
-                elements=st.integers(min_value=0, max_value=1899),
+                elements=st.integers(min_value=0, max_value=2**63 - 1),
             ),
         ],
         index=range_indexes(min_size=1, max_size=5),
     )
 )
 def test_documents_schema_hypothesis_invalid(df: pd.DataFrame) -> None:
-    """Years below 1900 fail ``DocumentsSchema`` validation."""
+    """Missing required columns fail ``DocumentsSchema`` validation."""
     df = df.drop(columns=["document_chembl_id"])
     with pytest.raises(SchemaError):
         DocumentsSchema.validate(df)


### PR DESCRIPTION
## Summary
- allow nullable `document_chembl_id` and coerce non-string document columns to `object`
- expand document schema tests to cover flexible typing

## Testing
- `ruff check schemas/documents.py tests/test_schemas.py`
- `mypy`
- `pytest tests/test_schemas.py::test_documents_schema_validation tests/test_schemas.py::test_documents_schema_hypothesis_valid tests/test_schemas.py::test_documents_schema_hypothesis_invalid -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1e26c748324a7a8d9f525f48d3a