### PR TITLE
feat: add dtype inspector utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,19 @@ ChEMBL_data_acquisition/
 Рядом создаются файлы `*.meta.yaml` с коммитом Git, параметрами запуска,
 контрольной суммой SHA‑256 и статистикой строк/колонок.
 
+## Dtype Inspector
+
+The ``dtype_inspector`` utility executes each ``get_*_data`` helper on a small
+set of identifiers and logs the resulting pandas dtypes.  Run this periodically
+to spot schema drift when upstream services change their responses.
+
+```bash
+python scripts/dtype_inspector_main.py --log-level INFO
+```
+
+Consider wiring the script into CI to detect dtype changes early.  The tool is
+lightweight and makes only a handful of requests per dataset.
+
 ## Разработка и тестирование
 
 ```bash

--- a/library/dtype_inspector.py
+++ b/library/dtype_inspector.py
@@ -1,0 +1,101 @@
+"""Inspect data retrieval dtypes.
+
+This module executes the various ``get_*_data`` retrieval functions on small
+sample inputs and reports the resulting :class:`pandas.DataFrame` dtypes.  The
+utility aids schema development by showing how external APIs currently
+serialise their payloads.  It intentionally keeps the number of records small
+so the calls remain inexpensive.
+
+Example
+-------
+Run interactively from a Python shell::
+
+    from library.dtype_inspector import inspect_dtypes
+    inspect_dtypes()
+
+The function logs the dtypes for activities, assays, documents, targets and
+special test items.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import pandas as pd
+
+from . import chembl_library as cl
+from .chembl_client import ChemblClient
+from .config import Config
+from .log import logger
+
+# Default sample identifiers for each dataset.  These are deliberately minimal
+# and can be overridden via the ``samples`` argument to :func:`inspect_dtypes`.
+DEFAULT_SAMPLES: Mapping[str, Sequence[str]] = {
+    "activities": ["1"],
+    "assays": ["1"],
+    "documents": ["1"],
+    "targets": ["1"],
+    "testitems": ["1"],
+}
+
+
+def _dtype_map(df: pd.DataFrame) -> dict[str, str]:
+    """Return column dtypes for ``df`` as plain strings."""
+
+    return {str(col): str(dtype) for col, dtype in df.dtypes.items()}
+
+
+def inspect_dtypes(
+    samples: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Log and return dtypes produced by retrieval helpers.
+
+    Parameters
+    ----------
+    samples:
+        Optional mapping of dataset name to sample identifiers.  Missing keys
+        fall back to :data:`DEFAULT_SAMPLES`.
+
+    Returns
+    -------
+    dict[str, dict[str, str]]
+        Nested mapping of dataset names to column dtype mappings.
+    """
+
+    cfg = Config()
+    combined = {**DEFAULT_SAMPLES, **(samples or {})}
+    results: dict[str, dict[str, str]] = {}
+
+    # ``ChemblClient`` manages HTTP connections and retries.  The context
+    # manager ensures the underlying ``requests.Session`` is properly closed
+    # even if one of the retrieval functions fails.
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+        df = cl.get_activities(combined["activities"], cfg=cfg.api, client=client)
+        results["activities"] = _dtype_map(df)
+        logger.info("dtypes", dataset="activities", dtypes=results["activities"])
+
+        df = cl.get_assays(combined["assays"], cfg=cfg.api, client=client)
+        results["assays"] = _dtype_map(df)
+        logger.info("dtypes", dataset="assays", dtypes=results["assays"])
+
+        df = cl.get_documents(combined["documents"], cfg=cfg.api, client=client)
+        results["documents"] = _dtype_map(df)
+        logger.info("dtypes", dataset="documents", dtypes=results["documents"])
+
+        df = cl.get_targets(
+            combined["targets"],
+            cfg=cfg.api,
+            client=client,
+            mapping_cfg=cfg.uniprot_mapping,
+        )
+        results["targets"] = _dtype_map(df)
+        logger.info("dtypes", dataset="targets", dtypes=results["targets"])
+
+        df = cl.get_testitem(combined["testitems"], cfg=cfg.api, client=client)
+        results["testitems"] = _dtype_map(df)
+        logger.info("dtypes", dataset="testitems", dtypes=results["testitems"])
+
+    return results
+
+
+__all__ = ["inspect_dtypes"]

--- a/scripts/dtype_inspector_main.py
+++ b/scripts/dtype_inspector_main.py
@@ -1,0 +1,42 @@
+"""CLI entry point for the dtype inspector.
+
+The script executes a small sample retrieval for each ``get_*_data`` helper and
+logs the resulting pandas dtypes.  Use this during development to spot schema
+changes when upstream APIs evolve.
+
+Example
+-------
+Run with default settings::
+
+    python scripts/dtype_inspector_main.py --log-level INFO
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from library.cli import LoggerConfig, configure_logger
+from library.dtype_inspector import inspect_dtypes
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the argument parser."""
+
+    parser = argparse.ArgumentParser(description="Inspect dtypes from sample data")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Program entry point."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logger(LoggerConfig(level=args.log_level))
+    inspect_dtypes()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/test_dtype_inspector.py
+++ b/tests/test_dtype_inspector.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library import chembl_library as cl
+from library.chembl_client import ChemblClient
+from library.dtype_inspector import inspect_dtypes, logger
+
+
+def _make_df(name: str) -> pd.DataFrame:
+    """Return a single-row data frame with deterministic dtypes."""
+
+    return pd.DataFrame({f"{name}_id": pd.Series([1], dtype="int64")})
+
+
+def test_inspect_dtypes_uses_mocked_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inspector returns dtypes and avoids network access."""
+
+    monkeypatch.setattr(cl, "get_activities", lambda *a, **k: _make_df("activity"))
+    monkeypatch.setattr(cl, "get_assays", lambda *a, **k: _make_df("assay"))
+    monkeypatch.setattr(cl, "get_documents", lambda *a, **k: _make_df("document"))
+    monkeypatch.setattr(cl, "get_targets", lambda *a, **k: _make_df("target"))
+    monkeypatch.setattr(cl, "get_testitem", lambda *a, **k: _make_df("testitem"))
+
+    def fail_request_json(
+        self, url: str, *, cfg, timeout=None
+    ) -> None:  # pragma: no cover - safety
+        raise AssertionError("network access not allowed")
+
+    monkeypatch.setattr(ChemblClient, "request_json", fail_request_json)
+
+    log_calls: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        logger,
+        "info",
+        lambda event, **kw: log_calls.append((event, kw)),
+    )
+
+    result = inspect_dtypes()
+
+    assert result["activities"]["activity_id"] == "int64"
+    assert any(
+        ev == "dtypes" and data.get("dataset") == "activities" for ev, data in log_calls
+    )


### PR DESCRIPTION
## Summary
- add dtype inspector to sample get_*_data outputs and log dtypes
- expose CLI script to run dtype inspection
- document dtype inspector usage and add unit test

## Testing
- `SKIP=pytest pre-commit run --files library/dtype_inspector.py scripts/dtype_inspector_main.py tests/test_dtype_inspector.py README.md`
- `pytest tests/test_dtype_inspector.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6b20ec7e883248ca28a5b38cc9e3a