### PR TITLE
Make testitem schema nullable and accept non-string types

### DIFF
--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -2,20 +2,31 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pandera.pandas as pa
+from pandera.dtypes import DataType
+
+PA_ANY = cast(DataType, None)
 
 TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
-        "molecule_chembl_id": pa.Column(str, required=True),
-        "black_box_warning": pa.Column(str, required=False, nullable=True),
-        "first_approval": pa.Column(str, required=False, nullable=True),
+        "molecule_chembl_id": pa.Column(str, required=True, nullable=True),
+        "black_box_warning": pa.Column(PA_ANY, required=False, nullable=True),
+        "first_approval": pa.Column(PA_ANY, required=False, nullable=True),
         "max_phase": pa.Column(str, required=False, nullable=True),
-        "molecule_structures.canonical_smiles": pa.Column(str, required=False, nullable=True),
-        "molecule_structures.standard_inchi": pa.Column(str, required=False, nullable=True),
-        "molecule_structures.standard_inchi_key": pa.Column(str, required=False, nullable=True),
+        "molecule_structures.canonical_smiles": pa.Column(
+            str, required=False, nullable=True
+        ),
+        "molecule_structures.standard_inchi": pa.Column(
+            str, required=False, nullable=True
+        ),
+        "molecule_structures.standard_inchi_key": pa.Column(
+            str, required=False, nullable=True
+        ),
         "molecule_type": pa.Column(str, required=False, nullable=True),
-        "oral": pa.Column(str, required=False, nullable=True),
-        "parenteral": pa.Column(str, required=False, nullable=True),
+        "oral": pa.Column(PA_ANY, required=False, nullable=True),
+        "parenteral": pa.Column(PA_ANY, required=False, nullable=True),
         "pref_name": pa.Column(str, required=False, nullable=True),
         "pubchem_canonical_smiles": pa.Column(str, required=False, nullable=True),
         "pubchem_cid": pa.Column(str, required=False, nullable=True),
@@ -25,8 +36,7 @@ TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "pubchem_iupac_name": pa.Column(str, required=False, nullable=True),
         "pubchem_molecular_formula": pa.Column(str, required=False, nullable=True),
         "structure_type": pa.Column(str, required=False, nullable=True),
-        "topical": pa.Column(str, required=False, nullable=True),
-
+        "topical": pa.Column(PA_ANY, required=False, nullable=True),
     }
 )
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -173,13 +173,12 @@ def test_testitems_schema_validation() -> None:
     """Ensure :data:`TestitemsSchema` validates expected data."""
     valid = pd.DataFrame(
         {
-            "salt_chembl_id": ["CHEMBL1"],
             "molecule_chembl_id": ["CHEMBL1"],
-            "molecule_type": ["Small molecule"],
-            "chirality": [1],
-            "mw_freebase": [100.0],
-            "num_ro5_violations": [0.0],
-            "is_radical": [False],
+            "first_approval": [1950],
+            "black_box_warning": [0],
+            "oral": [True],
+            "parenteral": [False],
+            "topical": [False],
         }
     )
     TestitemsSchema.validate(valid)


### PR DESCRIPTION
## Summary
- allow numeric and boolean columns in TestitemsSchema by using an unrestricted dtype
- mark all testitem columns as nullable and add PA_ANY helper
- extend tests to cover non-string testitem fields

## Testing
- `ruff check schemas/testitems.py tests/test_schemas.py`
- `mypy schemas/testitems.py`
- `pytest tests/test_schemas.py::test_testitems_schema_validation`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1f585288324a57acb68c1cf8d81