### PR TITLE
Add robust status fallback

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -1428,6 +1428,46 @@ class StatusAPI:
         """
         return self.max_status(statuses)
 
+    def get_min(self, statuses: Iterable[str]) -> str:
+        """Return the lowest ranked status among ``statuses``.
+
+        This method preserves backwards compatibility with code that
+        previously relied on a ``get_min`` helper. When none of the provided
+        values match a known status label, the first element of
+        :attr:`status_list` is returned, mirroring :meth:`min_status`.
+
+        Parameters
+        ----------
+        statuses:
+            Iterable of status values.
+
+        Returns
+        -------
+        str
+            Result of :meth:`min_status`.
+        """
+        return self.min_status(statuses)
+
+    def get_max(self, statuses: Iterable[str]) -> str:
+        """Return the highest ranked status among ``statuses``.
+
+        The function mirrors the behaviour of :meth:`max_status` but uses a
+        name compatible with legacy code. Unknown values are ignored; if none
+        of the provided statuses are recognised the last element of
+        :attr:`status_list` is returned instead of raising an exception.
+
+        Parameters
+        ----------
+        statuses:
+            Iterable of status values.
+
+        Returns
+        -------
+        str
+            Result of :meth:`max_status`.
+        """
+        return self.max_status(statuses)
+
     def Ascending(self, s1: str, s2: str) -> bool:
         """Compatibility alias for :meth:`ascending`.
 

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -729,3 +729,22 @@ def test_read_sheet_drops_duplicate_columns(tmp_path: Path) -> None:
     record = next(r for r in records if r.get("event") == "duplicate columns dropped")
     assert record["sheet"] == "Sheet1"
     assert record["duplicates"] == ["b"]
+
+
+def test_status_api_get_max_unknown_status() -> None:
+    """``get_max`` returns the final status when none match."""
+
+    # Minimal status configuration with two ordered labels
+    status_df = pd.DataFrame(
+        {
+            "status": ["low", "high"],
+            "order": [0, 1],
+            "condition_field": ["cond", "cond"],
+            "condition_value": ["null", "null"],
+            "score": [0, 1],
+        }
+    )
+    api = lib.build_status_helpers(status_df)
+
+    # Unknown statuses should fall back to the last entry
+    assert api.get_max(["missing"]) == "high"


### PR DESCRIPTION
## Summary
- ensure StatusAPI gracefully handles unknown statuses via new get_min and get_max helpers
- cover missing status behaviour with dedicated unit test

## Testing
- `black library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `ruff check library/input_initialisation_library.py tests/test_input_initialisation_library.py`
- `mypy library/input_initialisation_library.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_input_initialisation_library.py::test_status_api_get_max_unknown_status`


------
https://chatgpt.com/codex/tasks/task_e_68c7224791d08324973b530df5eb0541