### PR TITLE
Add activity extraction pipeline and CLI

### DIFF
--- a/activity_extraction_main.py
+++ b/activity_extraction_main.py
@@ -1,0 +1,127 @@
+"""Command line interface for ChEMBL activity extraction."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from library.activity_extraction import extract_activities
+from library.config import Config
+
+
+def _positive_int(value: str) -> int:
+    """Return ``value`` converted to :class:`int` ensuring it is positive."""
+
+    integer = int(value)
+    if integer <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return integer
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the activity extraction CLI."""
+
+    parser = argparse.ArgumentParser(
+        description="Download ChEMBL activity data into a validated CSV."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("input.csv"),
+        help="Path to the CSV file containing activity identifiers.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Destination for the generated CSV file.",
+    )
+    parser.add_argument(
+        "--column",
+        default="activity_id",
+        help="Column name holding the activity identifiers.",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=_positive_int,
+        default=5,
+        help="Maximum number of identifiers requested per API call.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Timeout in seconds applied to API requests.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional cap on the number of identifiers processed.",
+    )
+    parser.add_argument(
+        "--sep",
+        default=None,
+        help="Field delimiter of the input CSV (defaults to configuration value).",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=None,
+        help="Encoding of the input CSV (defaults to configuration value).",
+    )
+    parser.add_argument(
+        "--na-marker",
+        action="append",
+        dest="na_markers",
+        help="Additional marker interpreted as a missing value.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (e.g. DEBUG, INFO, WARNING).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse arguments and invoke :func:`extract_activities`."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.limit is not None and args.limit < 0:
+        parser.error("--limit must be non-negative")
+    if args.timeout < 0:
+        parser.error("--timeout must be non-negative")
+
+    level = getattr(logging, args.log_level.upper(), None)
+    if not isinstance(level, int):
+        parser.error(f"invalid log level: {args.log_level}")
+
+    logging.basicConfig(
+        level=level,
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    cfg = Config()
+
+    return extract_activities(
+        input_csv=args.input,
+        output_csv=args.output,
+        column=args.column,
+        chunk_size=args.chunk_size,
+        timeout=args.timeout,
+        limit=args.limit,
+        sep=args.sep,
+        encoding=args.encoding,
+        na_markers=args.na_markers,
+        cfg=cfg,
+        command=" ".join(sys.argv),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/library/activity_extraction.py
+++ b/library/activity_extraction.py
@@ -1,0 +1,221 @@
+"""High level helpers for downloading ChEMBL activity data.
+
+The :func:`extract_activities` function orchestrates the full pipeline used in
+other scripts of the project.  It reads activity identifiers from a CSV file,
+queries the public ChEMBL API in batches and persists the validated result in a
+new CSV file alongside metadata artefacts.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from itertools import islice
+from pathlib import Path
+from typing import Final
+
+import requests
+from pandera.errors import SchemaErrors
+
+from library import chembl_library as cl
+from library import io
+from library.chembl_client import ChemblClient
+from library.config import Config, IoCfg, _serialize_paths
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
+from schemas import ActivitiesSchema, normalize_activities
+
+LOG: Final = logging.getLogger(__name__)
+
+
+def _prepare_identifiers(
+    *,
+    input_csv: Path,
+    column: str,
+    cfg: IoCfg,
+    limit: int | None,
+    sep: str | None,
+    encoding: str | None,
+    na_markers: Sequence[str] | None,
+) -> Iterable[str] | list[str]:
+    """Read identifiers from ``input_csv`` applying ``limit`` when provided."""
+
+    ids_iter: Iterable[str] = io.read_ids(
+        input_csv,
+        column=column,
+        cfg=cfg,
+        sep=sep,
+        encoding=encoding,
+        na_markers=na_markers,
+    )
+    if limit is None:
+        return ids_iter
+    limited = list(islice(ids_iter, limit))
+    LOG.info("Limiting processing to the first %d identifiers", len(limited))
+    return limited
+
+
+def extract_activities(
+    input_csv: Path | str,
+    output_csv: Path | str | None,
+    *,
+    column: str = "activity_id",
+    chunk_size: int = 5,
+    timeout: float = 30.0,
+    limit: int | None = None,
+    sep: str | None = None,
+    encoding: str | None = None,
+    na_markers: Sequence[str] | None = None,
+    cfg: Config | None = None,
+    command: str | None = None,
+) -> int:
+    """Retrieve activity data from ChEMBL and write the validated CSV.
+
+    Parameters
+    ----------
+    input_csv:
+        CSV file containing a column with activity identifiers.
+    output_csv:
+        Destination for the resulting CSV. If ``None`` the default output path
+        derived from :class:`~library.config.IoCfg` is used.
+    column:
+        Name of the column holding ``activity_id`` values.
+    chunk_size:
+        Maximum number of identifiers per HTTP request.
+    timeout:
+        Request timeout in seconds for API calls.
+    limit:
+        Optional upper bound on the number of identifiers read from the input
+        CSV. ``None`` processes the entire file.
+    sep:
+        Optional field delimiter overriding the configuration defaults.
+    encoding:
+        Optional file encoding overriding the configuration defaults.
+    na_markers:
+        Optional list of markers interpreted as missing values when reading the
+        input CSV.
+    cfg:
+        Optional :class:`~library.config.Config` instance providing runtime
+        defaults. When ``None`` a new configuration with default values is
+        created.
+    command:
+        String stored in the metadata sidecar to describe the invocation. When
+        omitted it defaults to ``"extract_activities"``.
+
+    Returns
+    -------
+    int
+        ``0`` on success, ``1`` when a recoverable error occurred during
+        retrieval, validation or file writing.
+    """
+
+    if chunk_size <= 0:
+        LOG.error("chunk_size must be positive, got %d", chunk_size)
+        return 1
+    if timeout < 0:
+        LOG.error("timeout must be non-negative, got %s", timeout)
+        return 1
+    if limit is not None and limit < 0:
+        LOG.error("limit must be non-negative, got %d", limit)
+        return 1
+
+    cfg = cfg or Config()
+    io_cfg = cfg.io
+    input_path = Path(input_csv)
+    ids: Iterable[str] | list[str]
+    try:
+        ids = _prepare_identifiers(
+            input_csv=input_path,
+            column=column,
+            cfg=io_cfg,
+            limit=limit,
+            sep=sep,
+            encoding=encoding,
+            na_markers=na_markers,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        LOG.error("%s", exc)
+        return 1
+
+    output_path = (
+        Path(output_csv)
+        if output_csv is not None
+        else io.default_output_path(input_path, io_cfg)
+    )
+
+    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+        try:
+            df = cl.get_activities(
+                ids,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=chunk_size,
+                timeout=timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            LOG.error("failed to retrieve activities: %s", exc)
+            return 1
+
+    df = normalize_activities(df)
+
+    required = {name for name, col in ActivitiesSchema.columns.items() if col.required}
+    missing_required = required - set(df.columns)
+    exit_code = 0
+    if missing_required:
+        LOG.warning("Skipping validation; missing columns: %s", sorted(missing_required))
+    else:
+        try:
+            df = ActivitiesSchema.validate(df, lazy=True)
+        except SchemaErrors as exc:
+            sidecar = SidecarErrors()
+            for row in exc.failure_cases.to_dict("records"):
+                sidecar.add_error(row)
+            failure = Path(output_path).with_name(f"{Path(output_path).stem}_failure_cases.csv")
+            sidecar.save(failure, cfg=cfg)
+            LOG.error("validation failed; see %s", failure)
+            df = getattr(exc, "validated_data", df)
+            exit_code = 1
+
+    schema_cols = list(ActivitiesSchema.columns)
+    head = [c for c in schema_cols if c in df.columns]
+    tail = sorted(c for c in df.columns if c not in schema_cols)
+    col_order = head + tail
+
+    key_cols = [col for col in ["activity_id"] if col in df.columns]
+
+    try:
+        csv_path = io.write_csv(
+            df,
+            output_path,
+            cfg=cfg,
+            key_cols=key_cols or None,
+            col_order=col_order,
+        )
+    except OSError as exc:
+        LOG.error("failed to write output CSV: %s", exc)
+        return 1
+
+    stats: Stats = {
+        "rows_total": len(df),
+        "rows_kept": len(df),
+        "rows_dropped": 0,
+        "output_sha256": file_sha256(csv_path),
+    }
+
+    write_meta_yaml(
+        csv_path=csv_path,
+        command=command or "extract_activities",
+        config_subset=_serialize_paths(cfg.to_dict()),
+        inputs={"input_csv": str(input_csv)},
+        stats=stats,
+        schema="ActivitiesSchema",
+    )
+
+    try:
+        analyze_table_quality(df, table_name=str(Path(csv_path).with_suffix("")))
+    except ValueError as exc:
+        LOG.error("failed to generate quality report: %s", exc)
+        return 1
+
+    return exit_code

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -1,0 +1,130 @@
+"""Tests for :mod:`library.activity_extraction`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.activity_extraction import extract_activities
+from library.config import Config
+
+
+class DummyChemblClient:
+    """Test double replacing :class:`library.chembl_client.ChemblClient`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - signature matches context
+        self.closed = False
+
+    def __enter__(self) -> DummyChemblClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.closed = True
+        return None
+
+
+@pytest.fixture()
+def config(tmp_path: Path) -> Config:
+    """Return a :class:`Config` instance writing outputs inside ``tmp_path``."""
+
+    cfg = Config()
+    cfg.io.output_dir = tmp_path
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def stub_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Automatically replace :class:`ChemblClient` with a dummy implementation."""
+
+    monkeypatch.setattr("library.activity_extraction.ChemblClient", DummyChemblClient)
+
+
+@pytest.fixture(autouse=True)
+def stub_quality(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid generating table quality artefacts during tests."""
+
+    def fake_quality(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return pd.DataFrame(), pd.DataFrame()
+
+    monkeypatch.setattr("library.activity_extraction.analyze_table_quality", fake_quality)
+
+
+def _write_input(path: Path, identifiers: list[str]) -> None:
+    rows = "\n".join(["activity_id"] + identifiers)
+    path.write_text(rows, encoding="utf-8")
+
+
+def test_extract_activities_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: Config) -> None:
+    """Successful run writes CSV and returns exit code ``0``."""
+
+    input_csv = tmp_path / "activities.csv"
+    output_csv = tmp_path / "result.csv"
+    _write_input(input_csv, ["A1", "A2"])
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["A1", "A2"],
+            "molecule_chembl_id": ["M1", "M2"],
+            "assay_chembl_id": ["AS1", "AS2"],
+            "standard_value": [1.0, 2.0],
+        }
+    )
+
+    def fake_get(ids, *, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+        assert list(ids) == ["A1", "A2"]
+        return df
+
+    monkeypatch.setattr("library.activity_extraction.cl.get_activities", fake_get)
+
+    exit_code = extract_activities(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        cfg=config,
+        command="pytest",
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    result = pd.read_csv(output_csv)
+    assert sorted(result.columns) == sorted(df.columns)
+    assert result["activity_id"].tolist() == ["A1", "A2"]
+
+
+def test_extract_activities_validation_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: Config
+) -> None:
+    """Schema failures are exported to a sidecar CSV and signal an error."""
+
+    input_csv = tmp_path / "activities.csv"
+    output_csv = tmp_path / "result.csv"
+    _write_input(input_csv, ["A1"])
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["A1"],
+            "molecule_chembl_id": ["M1"],
+            "assay_chembl_id": ["AS1"],
+            "standard_value": [1.0],
+            "standard_type": ["invalid"],
+        }
+    )
+
+    def fake_get(ids, *, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+        return df
+
+    monkeypatch.setattr("library.activity_extraction.cl.get_activities", fake_get)
+
+    exit_code = extract_activities(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        cfg=config,
+        command="pytest",
+    )
+
+    assert exit_code == 1
+    failure_csv = output_csv.with_name("result_failure_cases.csv")
+    assert failure_csv.exists()
+    failure_df = pd.read_csv(failure_csv)
+    assert not failure_df.empty


### PR DESCRIPTION
## Summary
- add a reusable `extract_activities` workflow that reads identifiers, downloads ChEMBL activity data, validates it and writes metadata-rich CSV output
- provide a standalone `activity_extraction_main` CLI script wrapping the workflow with configurable CSV and logging options
- introduce unit tests covering successful extraction and schema failure handling paths

## Testing
- ruff check
- mypy --follow-imports=skip library/activity_extraction.py activity_extraction_main.py
- pytest tests/test_activity_extraction.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ed87e0888324b3b742c7963c59c5