### PR TITLE
Align resource defaults with configuration

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -302,9 +302,9 @@ class ResourcesCfg(_BaseModel):
     dictionary_dir: Path = Path("dictionary")
     iuphar_target_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_target.csv")
     iuphar_family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
-    uniprot_data_dir: Path = Path("uniprot")
-    organism_csv: Path = Path("dictionary/organism.csv")
-    targets_type_csv: Path = Path("dictionary/targets_type.csv")
+    uniprot_data_dir: Path = Path("dictionary/uniprot")
+    organism_csv: Path = Path("dictionary/_Target/targets_type.csv")
+    targets_type_csv: Path = Path("dictionary/_Target/targets_type.csv")
 
 
 class IoCfg(_BoolModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,6 +295,30 @@ def test_config_type_coercion() -> None:
     assert isinstance(cfg.batch.pause, float)
 
 
+def test_default_resource_paths_exist() -> None:
+    """Default resource paths should exist on disk."""
+
+    cfg_path = Path(__file__).resolve().parents[1] / "config.yaml"
+    cfg = load_config(cfg_path)
+    resources = cfg.resources
+    project_root = cfg_path.parent
+    for field in (
+        "dictionary_dir",
+        "iuphar_target_csv",
+        "iuphar_family_csv",
+        "uniprot_data_dir",
+        "organism_csv",
+        "targets_type_csv",
+    ):
+        resource_path = getattr(resources, field)
+        full_path = (
+            resource_path
+            if resource_path.is_absolute()
+            else project_root / resource_path
+        )
+        assert full_path.exists(), f"Missing default resource: {full_path}"
+
+
 def test_batch_pause_negative_value(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("batch:\n  pause: -1.0\n")


### PR DESCRIPTION
## Summary
- align the `ResourcesCfg` default paths with the values defined in `config.yaml`
- add a regression test that ensures the default resource paths exist on disk

## Testing
- ruff check .
- black library/config.py tests/test_config.py
- mypy --install-types --non-interactive library/config.py
- pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cc75895f348324ba7b5ef99a5082c7