### PR TITLE
Normalize date_code components with zero padding

### DIFF
--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -202,14 +202,37 @@ def postprocess_documents(
             result[col] = result[col].astype(str)
 
     # --- compute date_code ----------------------------------------------------
+    def _normalise_component(value: object, width: int) -> tuple[str, str]:
+        """Return raw and padded string representations of a date component."""
+
+        if pd.isna(value):
+            raw = ""
+        else:
+            raw = str(value).strip()
+        if raw.isdigit():
+            padded = raw.zfill(width)
+        else:
+            padded = raw
+        return raw, padded
+
     def build_date_code(row: pd.Series) -> str:
-        day_completed = row["PubMed.DayCompleted"]
-        if day_completed and day_completed != "0":
-            return f"{row['PubMed.YearCompleted']}-{row['PubMed.MonthCompleted']}-{day_completed}"
-        day_revised = row["PubMed.DayRevised"]
-        if day_revised and day_revised != "0":
-            return f"{row['PubMed.YearRevised']}-{row['PubMed.MonthRevised']}-{day_revised}"
-        return f"{row['PubMed.YearCompleted']}-{row['PubMed.MonthCompleted']}-01"
+        (
+            day_completed_raw,
+            day_completed,
+        ) = _normalise_component(row["PubMed.DayCompleted"], 2)
+        _, month_completed = _normalise_component(row["PubMed.MonthCompleted"], 2)
+        _, year_completed = _normalise_component(row["PubMed.YearCompleted"], 4)
+        day_revised_raw, day_revised = _normalise_component(
+            row["PubMed.DayRevised"], 2
+        )
+        _, month_revised = _normalise_component(row["PubMed.MonthRevised"], 2)
+        _, year_revised = _normalise_component(row["PubMed.YearRevised"], 4)
+
+        if day_completed_raw and day_completed_raw != "0":
+            return f"{year_completed}-{month_completed}-{day_completed}"
+        if day_revised_raw and day_revised_raw != "0":
+            return f"{year_revised}-{month_revised}-{day_revised}"
+        return f"{year_completed}-{month_completed}-01"
 
     result["date_code"] = result.apply(build_date_code, axis=1)
 

--- a/tests/test_document_postprocessing.py
+++ b/tests/test_document_postprocessing.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import pandas as pd
 
 from library import document_postprocessing as dp
@@ -32,3 +34,33 @@ def test_postprocess_documents_creates_flags_and_sorts() -> None:
         "OpenAlex.PublicationTypes",
     ]:
         assert col not in result.columns
+
+
+@pytest.fixture
+def documents_with_numeric_date_parts() -> pd.DataFrame:
+    """Return rows with numeric date components that require padding."""
+
+    return pd.DataFrame(
+        {
+            "document_chembl_id": ["DOC_A", "DOC_B", "DOC_C"],
+            "PubMed.DayCompleted": [2, 0, 0],
+            "PubMed.MonthCompleted": [5, 9, 3],
+            "PubMed.YearCompleted": [2020, 2019, 85],
+            "PubMed.DayRevised": [0, 7, 0],
+            "PubMed.MonthRevised": [0, 9, 0],
+            "PubMed.YearRevised": [0, 2019, 0],
+        }
+    )
+
+
+def test_postprocess_documents_zero_pads_date_components(
+    documents_with_numeric_date_parts: pd.DataFrame,
+) -> None:
+    """Numeric month/day values are padded in the generated ``date_code``."""
+
+    result = dp.postprocess_documents(documents_with_numeric_date_parts)
+    date_by_doc = dict(zip(result["document_chembl_id"], result["date_code"]))
+
+    assert date_by_doc["DOC_A"] == "2020-05-02"
+    assert date_by_doc["DOC_B"] == "2019-09-07"
+    assert date_by_doc["DOC_C"] == "0085-03-01"


### PR DESCRIPTION
## Summary
- normalise PubMed date components during document post-processing so that date_code values use zero-padded day and month segments while preserving the existing precedence rules
- add a regression test covering numeric date fields without leading zeros to confirm YYYY-MM-DD date_code formatting

## Testing
- pytest tests/test_document_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f9f752d88324825117dbb78e8ddc