### PR TITLE
Add limit support across data acquisition CLIs

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -116,6 +116,18 @@
           "minimum": 0,
           "title": "Timeout",
           "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "AssayCfg",
@@ -242,6 +254,18 @@
           },
           "title": "Thresholds",
           "type": "object"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "DocTypeCfg",
@@ -285,6 +309,18 @@
           "minimum": 0,
           "title": "Timeout",
           "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "DocumentAllCfg",
@@ -346,6 +382,18 @@
           "minimum": 0,
           "title": "Timeout",
           "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "DocumentChemblCfg",
@@ -377,6 +425,18 @@
           "minimum": 1,
           "title": "Batch Size",
           "type": "integer"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "DocumentPubmedCfg",
@@ -964,6 +1024,18 @@
           ],
           "default": null,
           "title": "Iuphar Out"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "TargetAllCfg",
@@ -1026,6 +1098,18 @@
           "minimum": 0,
           "title": "Timeout",
           "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "TargetChemblCfg",
@@ -1046,6 +1130,18 @@
           "format": "path",
           "title": "Family Csv",
           "type": "string"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "TargetIupharCfg",
@@ -1065,6 +1161,18 @@
           "format": "path",
           "title": "Data Dir",
           "type": "string"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
         }
       },
       "title": "TargetUniprotCfg",
@@ -1321,7 +1429,8 @@
           "experimental": 1,
           "review": 1,
           "unknown": 2
-        }
+        },
+        "limit": null
       },
       "description": "Weights and thresholds for document type classification."
     },
@@ -1446,7 +1555,8 @@
       "default": {
         "column": "assay_chembl_id",
         "chunk_size": 10,
-        "timeout": 30.0
+        "timeout": 30.0,
+        "limit": null
       },
       "description": "Assay data fetching configuration."
     },
@@ -1455,7 +1565,8 @@
       "default": {
         "column": "molecule_chembl_id",
         "chunk_size": 5,
-        "timeout": 30.0
+        "timeout": 30.0,
+        "limit": null
       },
       "description": "Test item data fetching configuration."
     },
@@ -1466,12 +1577,14 @@
           "batch_size": 100,
           "column": "PMID",
           "sleep": 5.0,
-          "workers": 1
+          "workers": 1,
+          "limit": null
         },
         "chembl": {
           "chunk_size": 5,
           "column": "document_chembl_id",
-          "timeout": 30.0
+          "timeout": 30.0,
+          "limit": null
         },
         "all": {
           "batch_size": 50,
@@ -1479,7 +1592,8 @@
           "column": "document_chembl_id",
           "sleep": 5.0,
           "timeout": 30.0,
-          "workers": 1
+          "workers": 1,
+          "limit": null
         }
       },
       "description": "Document data fetching configuration."
@@ -1489,15 +1603,18 @@
       "default": {
         "uniprot": {
           "column": "uniprot_id",
-          "data_dir": "dictionary/uniprot"
+          "data_dir": "dictionary/uniprot",
+          "limit": null
         },
         "chembl": {
           "column": "target_chembl_id",
-          "timeout": 30.0
+          "timeout": 30.0,
+          "limit": null
         },
         "iuphar": {
           "family_csv": "dictionary/_IUPHAR/_IUPHAR_family.csv",
-          "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv"
+          "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
+          "limit": null
         },
         "all": {
           "chembl_out": null,
@@ -1508,7 +1625,8 @@
           "target_csv": "dictionary/_IUPHAR/_IUPHAR_target.csv",
           "timeout": 30.0,
           "uniprot_column": "uniprot_id",
-          "uniprot_out": null
+          "uniprot_out": null,
+          "limit": null
         }
       },
       "description": "Target data fetching configuration."

--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,7 @@ doc_type:
     review: 1
     experimental: 1
     unknown: 2
+  limit: null
 
 activity:
   column: "activity_chembl_id"
@@ -116,11 +117,13 @@ assay:
   column: "assay_chembl_id"
   chunk_size: 50
   timeout: 30.0
+  limit: null
 
 testitem:
   column: "molecule_chembl_id"
   chunk_size: 50
   timeout: 30.0
+  limit: null
 
 document:
   pubmed:
@@ -128,10 +131,12 @@ document:
     sleep: 5.0
     workers: 1
     batch_size: 50
+    limit: null
   chembl:
     column: "document_chembl_id"
     chunk_size: 50
     timeout: 30.0
+    limit: null
   all:
     column: "document_chembl_id"
     chunk_size: 50
@@ -139,17 +144,21 @@ document:
     workers: 1
     batch_size: 50
     timeout: 30.0
+    limit: null
 
 target:
   uniprot:
     column: "uniprot_id"
     data_dir: "dictionary/uniprot"
+    limit: null
   chembl:
     column: "target_chembl_id"
     timeout: 30.0
+    limit: null
   iuphar:
     target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"
     family_csv: "dictionary/_IUPHAR/_IUPHAR_family.csv"
+    limit: null
   all:
     data_dir: "dictionary/uniprot"
     target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"
@@ -160,6 +169,7 @@ target:
     chembl_out: null
     uniprot_out: null
     iuphar_out: null
+    limit: null
 
 resources:
   dictionary_dir: "dictionary"  # Directory with supplementary lookup tables

--- a/library/config.py
+++ b/library/config.py
@@ -296,6 +296,7 @@ class DocTypeCfg(_BaseModel):
     thresholds: dict[str, int] = Field(
         default_factory=lambda: {"review": 1, "experimental": 1, "unknown": 2}
     )
+    limit: int | None = None
 
 
 class ResourcesCfg(_BaseModel):
@@ -415,12 +416,14 @@ class AssayCfg(_BaseModel):
     column: str = "assay_chembl_id"
     chunk_size: int = Field(10, ge=1)
     timeout: float = Field(30.0, ge=0)
+    limit: int | None = None
 
 
 class TestitemCfg(_BaseModel):
     column: str = "molecule_chembl_id"
     chunk_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
+    limit: int | None = None
 
 
 class DocumentPubmedCfg(_BaseModel):
@@ -428,12 +431,14 @@ class DocumentPubmedCfg(_BaseModel):
     sleep: float = Field(5.0, ge=0)
     workers: int = Field(1, ge=1)
     batch_size: int = Field(100, ge=1)
+    limit: int | None = None
 
 
 class DocumentChemblCfg(_BaseModel):
     column: str = "document_chembl_id"
     chunk_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
+    limit: int | None = None
 
 
 class DocumentAllCfg(_BaseModel):
@@ -443,6 +448,7 @@ class DocumentAllCfg(_BaseModel):
     workers: int = Field(1, ge=1)
     batch_size: int = Field(50, ge=1)
     timeout: float = Field(30.0, ge=0)
+    limit: int | None = None
 
 
 class DocumentCfg(_BaseModel):
@@ -454,16 +460,19 @@ class DocumentCfg(_BaseModel):
 class TargetUniprotCfg(_BaseModel):
     column: str = "uniprot_id"
     data_dir: Path = Path("dictionary/uniprot")
+    limit: int | None = None
 
 
 class TargetChemblCfg(_BaseModel):
     column: str = "chembl_id"
     timeout: float = Field(30.0, ge=0)
+    limit: int | None = None
 
 
 class TargetIupharCfg(_BaseModel):
     target_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_target.csv")
     family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
+    limit: int | None = None
 
 
 class TargetAllCfg(_BaseModel):
@@ -476,6 +485,7 @@ class TargetAllCfg(_BaseModel):
     chembl_out: Path | None = None
     uniprot_out: Path | None = None
     iuphar_out: Path | None = None
+    limit: int | None = None
 
 
 class TargetCfg(_BaseModel):

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -12,6 +12,7 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections.abc import Sequence
+from itertools import islice
 
 import requests
 from pandera.errors import SchemaErrors
@@ -61,13 +62,26 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.assay.limit
+    if limit is not None and limit < 0:
+        logger.error("assay.limit must be non-negative")
+        return 1
+
     # Prepare HTTP session for ChEMBL requests
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            ids = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
+            ids_iter = io.read_ids(
+                args.input_csv, column=cfg.assay.column, cfg=cfg.io
+            )
         except (FileNotFoundError, ValueError) as exc:
             logger.error("%s", exc)
             return 1
+
+        ids = ids_iter
+        if limit is not None:
+            limited_ids = list(islice(ids_iter, limit))
+            ids = limited_ids
+            logger.info("process_limit", limit=len(limited_ids))
 
         try:
             df = cl.get_assays(
@@ -172,6 +186,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=30.0,
         help="Timeout in seconds for each HTTP request",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -180,6 +200,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    if args.limit is not None and args.limit <= 0:
+        parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
@@ -192,6 +214,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "timeout": "assay.timeout",
                 "column": "assay.column",
                 "chunk_size": "assay.chunk_size",
+                "limit": "assay.limit",
             },
         )
         if args.print_config:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -35,6 +35,7 @@ if __package__ is None:  # running as a script
 import argparse
 from collections.abc import Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from itertools import islice
 from typing import cast
 
 import pandas as pd
@@ -189,10 +190,24 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.document.pubmed.limit
+    if limit is not None and limit < 0:
+        logger.error("document.pubmed.limit must be non-negative")
+        return 1
     try:
-        pmids = io.read_ids(
+        pmids_iter = io.read_ids(
             args.input_csv, column=cfg.document.pubmed.column, cfg=cfg.io
         )
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error("%s", exc)
+        return 1
+    pmids: Iterable[str] = pmids_iter
+    if limit is not None:
+        limited_pmids = list(islice(pmids_iter, limit))
+        pmids = limited_pmids
+        logger.info("process_limit", limit=len(limited_pmids))
+
+    try:
         df = fetch_pubmed_records(
             pmids,
             cfg.document.pubmed.sleep,
@@ -293,15 +308,26 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.document.chembl.limit
+    if limit is not None and limit < 0:
+        logger.error("document.chembl.limit must be non-negative")
+        return 1
+
     # Configure session for ChEMBL requests
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            ids = io.read_ids(
+            ids_iter = io.read_ids(
                 args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
             logger.error("%s", exc)
             return 1
+
+        ids = ids_iter
+        if limit is not None:
+            limited_ids = list(islice(ids_iter, limit))
+            ids = limited_ids
+            logger.info("process_limit", limit=len(limited_ids))
 
         try:
             df = cl.get_documents(
@@ -409,17 +435,30 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.document.all.limit
+    if limit is not None and limit < 0:
+        logger.error("document.all.limit must be non-negative")
+        return 1
+
     # Prepare shared session before performing any API calls
     try:
-        ids = io.read_ids(args.input_csv, column=cfg.document.all.column, cfg=cfg.io)
+        ids_iter = io.read_ids(
+            args.input_csv, column=cfg.document.all.column, cfg=cfg.io
+        )
     except (FileNotFoundError, ValueError) as exc:
         logger.error("%s", exc)
         return 1
 
+    ids_source: Iterable[str] = ids_iter
+    if limit is not None:
+        limited_ids = list(islice(ids_iter, limit))
+        ids_source = limited_ids
+        logger.info("process_limit", limit=len(limited_ids))
+
     chunk_ids: list[str] = []
     try:
         with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-            chunk_ids = list(ids)  # capture IDs for logging on failure
+            chunk_ids = list(ids_source)  # capture IDs for logging on failure
             doc_df = cl.get_documents(
                 chunk_ids,
                 cfg=cfg.api,
@@ -661,6 +700,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Maximum PMIDs per PubMed request",
     )
     pubmed.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    pubmed.add_argument(
         "--openalex-rps",
         type=float,
         default=None,
@@ -690,6 +735,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=30.0,
         help="Timeout in seconds for each HTTP request",
+    )
+    chembl.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -726,6 +777,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Timeout in seconds for each HTTP request",
     )
     all_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    all_cmd.add_argument(
         "--openalex-rps",
         type=float,
         default=None,
@@ -752,12 +809,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    subparser_map = getattr(parser, "subparsers_map", {})
+    subparser = subparser_map.get(args.command, parser)
+    limit_value = getattr(args, "limit", None)
+    if limit_value is not None and limit_value <= 0:
+        subparser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
-    subparser_map = getattr(parser, "subparsers_map", {})
-    subparser = subparser_map.get(args.command, parser)
-    mapping = {"column": f"document.{args.command}.column"}
+    mapping = {
+        "column": f"document.{args.command}.column",
+        "limit": f"document.{args.command}.limit",
+    }
     if args.command == "pubmed":
         mapping.update(
             {

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -133,7 +133,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=None,
         help="Minimum score for unknown label",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of rows to process",
+    )
     args = parser.parse_args(argv)
+    if args.limit is not None and args.limit <= 0:
+        parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger_inst = configure_logger(log_cfg)
     logger_inst.info("pipeline_start", run_id=log_cfg.run_id)
@@ -150,6 +158,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "threshold_review": "doc_type.thresholds.review",
                 "threshold_experimental": "doc_type.thresholds.experimental",
                 "threshold_unknown": "doc_type.thresholds.unknown",
+                "limit": "doc_type.limit",
             },
         )
         if args.print_config:
@@ -170,7 +179,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 
-    df_in = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+    limit_cfg = cfg.doc_type.limit
+    if limit_cfg is not None and limit_cfg < 0:
+        logger.error("doc_type.limit must be non-negative")
+        logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+
+    df_in = pd.read_csv(
+        args.input_csv,
+        sep=args.sep,
+        encoding=args.encoding,
+        nrows=limit_cfg,
+    )
+    if limit_cfg is not None:
+        logger_inst.info("process_limit", limit=len(df_in))
     df_out = classify_dataframe(
         df_in,
         weights=cfg.doc_type.weights,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -14,6 +14,7 @@ import argparse
 import csv
 import sys
 from collections.abc import Sequence
+from itertools import islice
 from pathlib import Path
 from typing import cast
 
@@ -153,6 +154,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
             "(default: config resources.uniprot_data_dir)"
         ),
     )
+    uniprot.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
     uniprot.set_defaults(func=run_uniprot)
 
     # ----------------------------
@@ -173,6 +180,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=30.0,
         help="Timeout in seconds for each HTTP request",
+    )
+    chembl.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -201,6 +214,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
             "Path to the _IUPHAR_family.csv file "
             "(default: config resources.iuphar_family_csv)"
         ),
+    )
+    iuphar.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of rows to process",
     )
     iuphar.set_defaults(func=run_iuphar)
 
@@ -278,6 +297,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         choices=["uniprot_id", "mapping_uniprot_id"],
         help="Column from ChEMBL output to use for UniProt processing",
     )
+    all_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
     all_cmd.set_defaults(func=run_all)
 
     parser.subparsers_map = {  # type: ignore[attr-defined]
@@ -311,6 +336,11 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
     :mod:`tests.test_target_postprocessing`.
 
     """
+    limit = cfg.target.uniprot.limit
+    if limit is not None and limit < 0:
+        logger.error("target.uniprot.limit must be non-negative")
+        return 1
+
     try:
         df = pd.read_csv(
             args.input_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
@@ -322,6 +352,9 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         df = df[(df[column].str.strip() != "") & (df[column] != "#N/A")].reset_index(
             drop=True
         )
+        if limit is not None:
+            df = df.head(limit)
+            logger.info("process_limit", limit=len(df))
         ids = df[column].tolist()
 
         from tempfile import NamedTemporaryFile
@@ -390,15 +423,26 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.target.chembl.limit
+    if limit is not None and limit < 0:
+        logger.error("target.chembl.limit must be non-negative")
+        return 1
+
     # Set up HTTP session with proper headers and retry behaviour
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            ids = io.read_ids(
+            ids_iter = io.read_ids(
                 args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
             logger.error("%s", exc)
             return 1
+
+        ids = ids_iter
+        if limit is not None:
+            limited_ids = list(islice(ids_iter, limit))
+            ids = limited_ids
+            logger.info("process_limit", limit=len(limited_ids))
 
         try:
             df = cl.get_targets(
@@ -501,7 +545,36 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.target.iuphar.limit
+    if limit is not None and limit < 0:
+        logger.error("target.iuphar.limit must be non-negative")
+        return 1
+
+    tmp_path: Path | None = None
+    source_csv = args.input_csv
+
     try:
+        if limit is not None:
+            df_limited = pd.read_csv(
+                args.input_csv,
+                sep=cfg.io.csv_sep,
+                encoding=cfg.io.csv_encoding,
+                dtype=str,
+                nrows=limit,
+            )
+            logger.info("process_limit", limit=len(df_limited))
+            from tempfile import NamedTemporaryFile
+
+            with NamedTemporaryFile(delete=False) as tmp:
+                tmp_path = Path(tmp.name)
+            df_limited.to_csv(
+                tmp_path,
+                index=False,
+                sep=cfg.io.csv_sep,
+                encoding=cfg.io.csv_encoding,
+            )
+            source_csv = tmp_path
+
         data = ii.IUPHARData.from_files(
             target_path=cfg.target.iuphar.target_csv,
             family_path=cfg.target.iuphar.family_csv,
@@ -509,7 +582,7 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
         )
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         data.map_uniprot_file(
-            input_path=args.input_csv,
+            input_path=source_csv,
             output_path=output,
             encoding=cfg.io.csv_encoding,
             sep=cfg.io.csv_sep,
@@ -517,6 +590,9 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("%s", exc)
         return 1
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
     try:
         analyze_table_quality(output, table_name=str(output.with_suffix("")))
     except ValueError as exc:
@@ -525,7 +601,9 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
-def fetch_chembl(cfg: Config, input_csv: Path, output_csv: Path) -> pd.DataFrame:
+def fetch_chembl(
+    cfg: Config, input_csv: Path, output_csv: Path, limit: int | None = None
+) -> pd.DataFrame:
     """Fetch target information from ChEMBL.
 
     Parameters
@@ -536,6 +614,8 @@ def fetch_chembl(cfg: Config, input_csv: Path, output_csv: Path) -> pd.DataFrame
         Source of ChEMBL identifiers.
     output_csv:
         Destination for the retrieved records.
+    limit:
+        Optional maximum number of identifiers to process.
 
     Returns
     -------
@@ -545,8 +625,15 @@ def fetch_chembl(cfg: Config, input_csv: Path, output_csv: Path) -> pd.DataFrame
 
     logger.info("fetch_chembl_start", input=str(input_csv), output=str(output_csv))
     chembl_args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
-    if run_chembl(cfg, chembl_args) != 0:
-        raise RuntimeError("ChEMBL retrieval failed")
+    original_limit = cfg.target.chembl.limit
+    if limit is not None:
+        cfg.target.chembl.limit = limit
+    try:
+        if run_chembl(cfg, chembl_args) != 0:
+            raise RuntimeError("ChEMBL retrieval failed")
+    finally:
+        if limit is not None:
+            cfg.target.chembl.limit = original_limit
     df = pd.read_csv(
         output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
     )
@@ -821,6 +908,11 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
 def run_all(cfg: Config, args: argparse.Namespace) -> int:
     """Run the full target acquisition pipeline."""
 
+    limit = cfg.target.all.limit
+    if limit is not None and limit < 0:
+        logger.error("target.all.limit must be non-negative")
+        return 1
+
     try:
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         chembl_out = cfg.target.all.chembl_out or output.with_name(
@@ -833,7 +925,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             output.stem + "_iuphar.csv"
         )
 
-        chembl_df = fetch_chembl(cfg, args.input_csv, chembl_out)
+        chembl_df = fetch_chembl(cfg, args.input_csv, chembl_out, limit=limit)
         uniprot_df = fetch_uniprot(cfg, chembl_df, uniprot_out)
         combined_df, iuphar_df = fetch_iuphar(cfg, chembl_df, uniprot_df, iuphar_out)
         merged = merge_results(combined_df, iuphar_df, cfg)
@@ -848,27 +940,33 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    subparser_map = getattr(parser, "subparsers_map", {})
+    subparser = subparser_map.get(args.command, parser)
+    limit_value = getattr(args, "limit", None)
+    if limit_value is not None and limit_value <= 0:
+        subparser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
-    subparser_map = getattr(parser, "subparsers_map", {})
-    subparser = subparser_map.get(args.command, parser)
     try:
         mapping: dict[str, str] = {}
         if args.command == "uniprot":
             mapping = {
                 "column": "target.uniprot.column",
                 "data_dir": "target.uniprot.data_dir",
+                "limit": "target.uniprot.limit",
             }
         elif args.command == "chembl":
             mapping = {
                 "column": "target.chembl.column",
                 "timeout": "target.chembl.timeout",
+                "limit": "target.chembl.limit",
             }
         elif args.command == "iuphar":
             mapping = {
                 "target_csv": "target.iuphar.target_csv",
                 "family_csv": "target.iuphar.family_csv",
+                "limit": "target.iuphar.limit",
             }
         elif args.command == "all":
             mapping = {
@@ -881,6 +979,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "chembl_out": "target.all.chembl_out",
                 "uniprot_out": "target.all.uniprot_out",
                 "iuphar_out": "target.all.iuphar_out",
+                "limit": "target.all.limit",
             }
         cfg: Config = apply_config_overrides(
             args, subparser, args.config, mapping=mapping, base_parser=parser

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -12,6 +12,7 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections.abc import Sequence
+from itertools import islice
 
 import pandas as pd
 import requests
@@ -136,15 +137,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
+    limit = cfg.testitem.limit
+    if limit is not None and limit < 0:
+        logger.error("testitem.limit must be non-negative")
+        return 1
+
     # Initialise HTTP session for subsequent ChEMBL requests
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            # ``read_ids`` returns a generator to minimise memory use. Convert to a
-            # list so we can log the total number of identifiers and iterate over the
-            # values multiple times if needed.
-            ids = list(
-                io.read_ids(args.input_csv, column=cfg.testitem.column, cfg=cfg.io)
+            ids_iter = io.read_ids(
+                args.input_csv, column=cfg.testitem.column, cfg=cfg.io
             )
+            if limit is not None:
+                ids = list(islice(ids_iter, limit))
+                logger.info("process_limit", limit=len(ids))
+            else:
+                ids = list(ids_iter)
         except (FileNotFoundError, ValueError) as exc:
             logger.error("%s", exc)
             return 1
@@ -259,6 +267,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=30.0,
         help="Timeout in seconds for each HTTP request",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -267,6 +281,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Command line entry point using :class:`Config` for defaults."""
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    if args.limit is not None and args.limit <= 0:
+        parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
@@ -279,6 +295,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "timeout": "testitem.timeout",
                 "column": "testitem.column",
                 "chunk_size": "testitem.chunk_size",
+                "limit": "testitem.limit",
             },
         )
         if args.print_config:


### PR DESCRIPTION
## Summary
- add `limit` configuration fields and defaults for document, assay, test item, and target pipelines
- wire a new `--limit` option through get_assay_data, get_testitem_data, get_document_data, and document type CLIs with validation and iterator slicing
- extend get_target_data to honour per-subcommand limits, including temporary CSV trimming for IUPHAR and combined runs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d2f9f4e0c0832497d1dc20aa1fffdc