### PR TITLE
Improve CLI sessions and PubMed determinism

### DIFF
--- a/activity_extraction_main.py
+++ b/activity_extraction_main.py
@@ -1,126 +1,18 @@
-"""Command line interface for ChEMBL activity extraction."""
+"""Backward-compatible CLI wrapper for activity extraction."""
 
 from __future__ import annotations
 
-import argparse
-import logging
-import sys
 from collections.abc import Sequence
-from pathlib import Path
 
-from library.activity_extraction import extract_activities
-from library.config import Config
+from scripts import get_activity_data as _activity_cli
 
-
-def _positive_int(value: str) -> int:
-    """Return ``value`` converted to :class:`int` ensuring it is positive."""
-
-    integer = int(value)
-    if integer <= 0:
-        raise argparse.ArgumentTypeError("value must be positive")
-    return integer
-
-
-def build_parser() -> argparse.ArgumentParser:
-    """Create the argument parser for the activity extraction CLI."""
-
-    parser = argparse.ArgumentParser(
-        description="Download ChEMBL activity data into a validated CSV."
-    )
-    parser.add_argument(
-        "--input",
-        type=Path,
-        default=Path("input.csv"),
-        help="Path to the CSV file containing activity identifiers.",
-    )
-    parser.add_argument(
-        "--output",
-        type=Path,
-        help="Destination for the generated CSV file.",
-    )
-    parser.add_argument(
-        "--column",
-        default="activity_id",
-        help="Column name holding the activity identifiers.",
-    )
-    parser.add_argument(
-        "--chunk-size",
-        type=_positive_int,
-        default=5,
-        help="Maximum number of identifiers requested per API call.",
-    )
-    parser.add_argument(
-        "--timeout",
-        type=float,
-        default=30.0,
-        help="Timeout in seconds applied to API requests.",
-    )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
-        help="Optional cap on the number of identifiers processed.",
-    )
-    parser.add_argument(
-        "--sep",
-        default=None,
-        help="Field delimiter of the input CSV (defaults to configuration value).",
-    )
-    parser.add_argument(
-        "--encoding",
-        default=None,
-        help="Encoding of the input CSV (defaults to configuration value).",
-    )
-    parser.add_argument(
-        "--na-marker",
-        action="append",
-        dest="na_markers",
-        help="Additional marker interpreted as a missing value.",
-    )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        help="Logging level (e.g. DEBUG, INFO, WARNING).",
-    )
-    return parser
+build_parser = _activity_cli.build_parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Parse arguments and invoke :func:`extract_activities`."""
+    """Delegate execution to :mod:`scripts.get_activity_data`."""
 
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    if args.limit is not None and args.limit < 0:
-        parser.error("--limit must be non-negative")
-    if args.timeout < 0:
-        parser.error("--timeout must be non-negative")
-
-    level = getattr(logging, args.log_level.upper(), None)
-    if not isinstance(level, int):
-        parser.error(f"invalid log level: {args.log_level}")
-
-    logging.basicConfig(
-        level=level,
-        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
-    cfg = Config()
-
-    return extract_activities(
-        input_csv=args.input,
-        output_csv=args.output,
-        column=args.column,
-        chunk_size=args.chunk_size,
-        timeout=args.timeout,
-        limit=args.limit,
-        sep=args.sep,
-        encoding=args.encoding,
-        na_markers=args.na_markers,
-        cfg=cfg,
-        command=" ".join(sys.argv),
-    )
+    return _activity_cli.main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -13,9 +13,9 @@ from pathlib import Path
 
 import pandas as pd
 
-from .cli import LoggerConfig, configure_logger
+from .cli import LoggerConfig, apply_config_overrides, configure_logger
 from .cli import build_parser as base_parser
-from .config import ApiCfg, Config, session_with_retry
+from .config import Config, ensure_dirs, print_config, session_with_retry
 from .csv_utils import write_csv_deterministic
 from .log import logger
 from .pubmed import (
@@ -66,25 +66,52 @@ __all__ = [
 
 def parse_args(
     argv: Sequence[str] | None = None,
-) -> tuple[argparse.Namespace, LoggerConfig]:
+) -> tuple[argparse.Namespace, argparse.ArgumentParser, LoggerConfig]:
     """Parse command-line arguments."""
     parser, log_cfg = base_parser("Fetch publication metadata by PMID", column="PMID")
     parser.add_argument(
         "--input-csv",
         dest="input_csv",
+        type=Path,
+        default=argparse.SUPPRESS,
         help="Input CSV path with PMID column",
     )
     args = parser.parse_args(argv)
-    return args, log_cfg
+    return args, parser, log_cfg
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Command-line interface entry point."""
-    args, log_cfg = parse_args(argv)
+    args, parser, log_cfg = parse_args(argv)
     log_cfg.level = args.log_level
-    configure_logger(log_cfg)
+    logger = configure_logger(log_cfg)
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
+    try:
+        cfg = apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={
+                "column": "document.pubmed.column",
+                "chunk_size": "document.pubmed.batch_size",
+            },
+        )
+        if args.print_config:
+            print_config(cfg)
+            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
+            return 0
+        ensure_dirs(cfg)
+        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    except (ValueError, TypeError) as exc:
+        logger.error("%s", exc)
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        logger.error("failed to set up directories: %s", exc)
+        logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
 
-    cfg = Config(api=ApiCfg(user_agent="chembl-da/0.1 (mailto:info@example.org)"))
     limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
     delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
 
@@ -94,7 +121,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     crossref_limiter = get_limiter("crossref", cfg.crossref.rps, cfg.crossref.burst)
 
     records: list[dict[str, str]] = []
-    batch_size = 100
+    batch_size = cfg.document.pubmed.batch_size
     with session_with_retry(cfg.api, cfg.retry) as session:
         for i in range(0, len(pmids), batch_size):
             batch_pmids = pmids[i : i + batch_size]
@@ -131,6 +158,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     write_csv_deterministic(df, output_path, key_cols=sorted(df.columns))
     logger.info("file_written", path=str(output_path))
+    logger.info("pipeline_done", run_id=log_cfg.run_id)
     return 0
 
 

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -110,9 +110,10 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
         If the request fails or the payload cannot be decoded as JSON.
 
     """
+    limiter = get_limiter("uniprot", cfg.rps, cfg.burst)
     if cfg.delay:
         sleep(cfg.delay)
-    get_limiter("uniprot", 1 / cfg.delay if cfg.delay else 0).acquire()
+    limiter.acquire()
     base = cfg.base.rstrip("/")
     url = f"{base}/uniprotkb/{uniprot_id}.json"
     timeout = (cfg.timeout_connect, cfg.timeout_read)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,7 +22,7 @@ dependencies = [
   "jsonschema==4.25.1",
   "pandera==0.26.1",
   "cachetools==5.3.2",
-  "pydantic==2.10.7",
+  "pydantic==2.11.9",
 ]
 
 [project.optional-dependencies]
@@ -34,13 +34,11 @@ dev = [
   "pre-commit==4.3.0",
   "psutil==7.0.0",
   "pytest==8.4.2",
-  "types-openpyxl==3.1.5",
-  "hypothesis==6.138.15",
   "responses==0.25.8",
   "ruff==0.13.0",
   "types-cachetools==6.2.0.20250827",
   "types-jsonschema==4.25.1.20250822",
-  "types-openpyxl>=3.1.5",
+  "types-openpyxl==3.1.5.20250821",
   "types-PyYAML==6.0.12.20250822",
   "types-python-dateutil",
   "types-requests==2.32.4.20250809",

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -34,7 +34,7 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections.abc import Iterable, Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from itertools import islice
 from typing import cast
 
@@ -56,12 +56,17 @@ from library.cli import (
     configure_logger,
 )
 from library.config import (
+    ApiCfg,
     Config,
     CrossRefCfg,
     OpenAlexCfg,
+    PubMedCfg,
+    RetryCfg,
+    SemanticScholarCfg,
     _serialize_paths,
     ensure_dirs,
     print_config,
+    session_with_retry,
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
@@ -73,9 +78,14 @@ from schemas import DocumentsSchema, normalize_documents
 
 def fetch_pubmed_records(
     pmids: Iterable[str],
+    *,
     sleep: float,
     openalex_cfg: OpenAlexCfg,
     crossref_cfg: CrossRefCfg,
+    api_cfg: ApiCfg,
+    retry_cfg: RetryCfg,
+    pubmed_cfg: PubMedCfg,
+    semantic_cfg: SemanticScholarCfg,
     max_workers: int = 1,
     batch_size: int = 100,
 ) -> pd.DataFrame:
@@ -92,7 +102,14 @@ def fetch_pubmed_records(
         Configuration for OpenAlex API access.
     crossref_cfg:
         Configuration for CrossRef API access.
-
+    api_cfg:
+        Shared API configuration providing retry defaults and headers.
+    retry_cfg:
+        Retry behaviour applied to outbound HTTP sessions.
+    pubmed_cfg:
+        Settings for the PubMed API, including timeouts and retry counts.
+    semantic_cfg:
+        Semantic Scholar configuration used for batch enrichment.
     max_workers:
         Maximum number of concurrent threads.
     batch_size:
@@ -105,10 +122,23 @@ def fetch_pubmed_records(
 
     """
 
+    def _failure_records(batch: list[str], message: str) -> list[dict[str, str]]:
+        records: list[dict[str, str]] = []
+        for pid in batch:
+            record = pl.EMPTY_PUBMED.copy()
+            record["PubMed.PMID"] = pid
+            record["PubMed.Error"] = message
+            records.append(record)
+        return records
+
+    pubmed_rps = 1 / sleep if sleep > 0 else 0.0
+    semantic_rps = 1 / sleep if sleep > 0 else 0.0
+    pubmed_limiter = get_limiter("pubmed", pubmed_rps)
+    semantic_limiter = get_limiter("semantic_scholar", semantic_rps)
     openalex_limiter = get_limiter("openalex", openalex_cfg.rps, openalex_cfg.burst)
     crossref_limiter = get_limiter("crossref", crossref_cfg.rps, crossref_cfg.burst)
 
-    def _fetch_batch(batch: list[str]) -> list[dict[str, str]]:
+    def _fetch_batch(offset: int, batch: list[str]) -> list[dict[str, str]]:
         """Fetch metadata for a batch of PMIDs.
 
         Each worker opens its own :class:`requests.Session` and retrieves PubMed
@@ -118,13 +148,17 @@ def fetch_pubmed_records(
         abort the whole process.
         """
         try:
-            with requests.Session() as session:
-                pubmed_list = pl.fetch_pubmed_batch(session, batch, sleep)
+            with session_with_retry(api_cfg, retry_cfg) as session:
+                pubmed_limiter.acquire()
+                pubmed_list = pl.fetch_pubmed_batch(
+                    session, batch, sleep, cfg=pubmed_cfg
+                )
                 pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
 
                 # Fetch Semantic Scholar data in a single batch
+                semantic_limiter.acquire()
                 semsch_list = ssl.fetch_semantic_scholar_batch(
-                    session, pmids_in_batch, sleep
+                    session, pmids_in_batch, sleep, cfg=semantic_cfg
                 )
 
                 # Create a map for easy lookup
@@ -154,21 +188,34 @@ def fetch_pubmed_records(
                 return combined_records
         except requests.RequestException as exc:  # pragma: no cover - network errors
             logger.warning("failed to fetch PMIDs %s: %s", batch, exc)
-            return [{} for _ in batch]
+            return _failure_records(batch, str(exc))
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.warning("unexpected error for PMIDs %s: %s", batch, exc)
+            return _failure_records(batch, str(exc))
 
     iterator = (p for p in pmids if p)
     records: list[dict[str, str]] = []
+    tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        futures = {
-            ex.submit(_fetch_batch, batch): len(batch)
-            for batch in _chunked(iterator, batch_size)
-        }
+        offset = 0
+        for batch in _chunked(iterator, batch_size):
+            if not batch:
+                continue
+            future = ex.submit(_fetch_batch, offset, batch)
+            tasks[future] = (offset, batch)
+            offset += len(batch)
+
         processed = 0
-        for future in as_completed(futures):
-            batch_len = futures[future]
-            records.extend(future.result())
-            processed += batch_len
+        ordered: dict[int, list[dict[str, str]]] = {}
+        for future in as_completed(tasks):
+            offset, batch = tasks[future]
+            result = future.result()
+            ordered[offset] = result
+            processed += len(batch)
             logger.info("documents_processed", count=processed)
+
+    for offset in sorted(ordered):
+        records.extend(ordered[offset])
     if not records:
         return pd.DataFrame()
     return pd.DataFrame(records)
@@ -210,11 +257,15 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     try:
         df = fetch_pubmed_records(
             pmids,
-            cfg.document.pubmed.sleep,
-            cfg.openalex,
-            cfg.crossref,
-            cfg.document.pubmed.workers,
-            cfg.document.pubmed.batch_size,
+            sleep=cfg.document.pubmed.sleep,
+            openalex_cfg=cfg.openalex,
+            crossref_cfg=cfg.crossref,
+            api_cfg=cfg.api,
+            retry_cfg=cfg.retry,
+            pubmed_cfg=cfg.pubmed,
+            semantic_cfg=cfg.semantic_scholar,
+            max_workers=cfg.document.pubmed.workers,
+            batch_size=cfg.document.pubmed.batch_size,
         )
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_documents(df)
@@ -561,11 +612,15 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
-        cfg.document.all.sleep,
-        cfg.openalex,
-        cfg.crossref,
-        cfg.document.all.workers,
-        cfg.document.all.batch_size,
+        sleep=cfg.document.all.sleep,
+        openalex_cfg=cfg.openalex,
+        crossref_cfg=cfg.crossref,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.retry,
+        pubmed_cfg=cfg.pubmed,
+        semantic_cfg=cfg.semantic_scholar,
+        max_workers=cfg.document.all.workers,
+        batch_size=cfg.document.all.batch_size,
     )
     doc_df["pubmed_id"] = pubmed_ids.astype("Int64").astype("string").fillna("")
     if not pub_df.empty and "PubMed.PMID" in pub_df.columns:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -372,6 +372,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
 
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         data_dir = cfg.target.uniprot.data_dir
+        uu.init_session(cfg.api, cfg.retry)
         try:
             uu.process(
                 input_csv=str(tmp_path),

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -142,6 +142,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("testitem.limit must be non-negative")
         return 1
 
+    # Initialise HTTP sessions for downstream HTTP calls
+    pl.init_session(cfg.api, cfg.retry)
     # Initialise HTTP session for subsequent ChEMBL requests
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import argparse
 import io
 import sys
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+
+from contextlib import contextmanager
 
 import pandas as pd
 import pytest
@@ -200,3 +203,110 @@ def test_write_csv_column_order(
         c for c in df.columns if c not in schema_cols
     )
     assert captured["col_order"] == expected
+
+
+def test_fetch_pubmed_records_order_and_limiters(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    pmids = ["1", "2"]
+
+    acquisitions: list[str] = []
+    limiters: dict[str, FakeLimiter] = {}
+
+    class FakeLimiter:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def acquire(self) -> None:
+            acquisitions.append(self.name)
+
+    def fake_get_limiter(name: str, rps: float, burst: int | None = None) -> FakeLimiter:
+        limiter = limiters.get(name)
+        if limiter is None:
+            limiter = FakeLimiter(name)
+            limiters[name] = limiter
+        return limiter
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    def fake_fetch_pubmed_batch(
+        session: object,
+        batch: list[str],
+        sleep: float,
+        cfg: object | None = None,
+    ) -> list[dict[str, str]]:
+        pmid = batch[0]
+        if pmid == "1":
+            time.sleep(0.02)
+        return [
+            {
+                "PubMed.PMID": pmid,
+                "PubMed.DOI": f"doi-{pmid}",
+                "PubMed.Error": "",
+            }
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_fetch_pubmed_batch)
+
+    def fake_semantic_batch(
+        session: object,
+        batch_pmids: list[str],
+        sleep: float,
+        cfg: object | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "scholar.PMID": pmid,
+                "scholar.DOI": f"doi-{pmid}",
+                "scholar.Error": "",
+            }
+            for pmid in batch_pmids
+        ]
+
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar_batch",
+        fake_semantic_batch,
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda session, pmid, cfg, limiter: (
+            limiter.acquire(),
+            {"OpenAlex.Id": f"oa-{pmid}"},
+        )[1],
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda session, doi, cfg, limiter: (
+            limiter.acquire(),
+            {"crossref.Type": "journal"},
+        )[1],
+    )
+
+    @contextmanager
+    def fake_session_with_retry(api_cfg: object, retry_cfg: object) -> object:
+        yield object()
+
+    monkeypatch.setattr(gdd, "session_with_retry", fake_session_with_retry)
+
+    df = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        openalex_cfg=cfg.openalex,
+        crossref_cfg=cfg.crossref,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.retry,
+        pubmed_cfg=cfg.pubmed,
+        semantic_cfg=cfg.semantic_scholar,
+        max_workers=2,
+        batch_size=1,
+    )
+
+    assert df["PubMed.PMID"].tolist() == pmids
+    assert acquisitions.count("pubmed") == len(pmids)
+    assert acquisitions.count("semantic_scholar") == len(pmids)
+    assert acquisitions.count("openalex") == len(pmids)
+    assert acquisitions.count("crossref") == len(pmids)
+    assert set(limiters) == {"pubmed", "semantic_scholar", "openalex", "crossref"}

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -42,6 +42,56 @@ def test_fetch_uniprot(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) ->
     assert list(df["original_id"]) == ["P12345"]
 
 
+def test_run_uniprot_initialises_session(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text("uniprot_id\nP12345\n", encoding=cfg.io.csv_encoding)
+    output_csv = tmp_path / "uniprot.csv"
+    cfg.target.uniprot.data_dir = tmp_path
+
+    called: dict[str, object] = {}
+
+    def fake_init_session(api: object, retry: object) -> None:
+        called["init"] = (api, retry)
+
+    def fake_process(
+        input_csv: str,
+        output_csv: str,
+        data_dir: Path | str | None = None,
+        *,
+        cfg: object,
+        sep: str = ",",
+        encoding: str = "utf-8",
+    ) -> None:
+        called["cfg"] = cfg
+        pd.DataFrame({"uniprot_id": ["P12345"], "names": ["Foo"]}).to_csv(
+            output_csv, index=False
+        )
+
+    monkeypatch.setattr(gtd.uu, "init_session", fake_init_session)
+    monkeypatch.setattr(gtd.uu, "process", fake_process)
+    def fake_write_csv(
+        df: pd.DataFrame,
+        path: Path,
+        *,
+        cfg: Config,
+        sep: str | None = None,
+        encoding: str | None = None,
+        **__: object,
+    ) -> Path:
+        return path
+
+    monkeypatch.setattr(gtd.io, "write_csv", fake_write_csv)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+    rc = gtd.run_uniprot(cfg, args)
+
+    assert rc == 0
+    assert called["init"] == (cfg.api, cfg.retry)
+    assert called["cfg"] is cfg.uniprot
+
+
 def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> None:
     chembl_df = pd.DataFrame(
         {

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -65,3 +65,40 @@ def test_run_chembl_column_order(
     expected_head = [c for c in TestitemsSchema.columns if c in df.columns]
     expected_tail = sorted(c for c in df.columns if c not in TestitemsSchema.columns)
     assert captured["col_order"] == expected_head + expected_tail
+
+
+def test_run_chembl_initialises_pubchem_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1"]))
+
+    df = pd.DataFrame(
+        {"molecule_chembl_id": ["CHEMBL1"], "molecule_type": ["Small molecule"]}
+    )
+    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg: frame)
+
+    captured: dict[str, object] = {}
+
+    def fake_init_session(api: object, retry: object) -> None:
+        captured["init"] = (api, retry)
+
+    monkeypatch.setattr(gtd.pl, "init_session", fake_init_session)
+    monkeypatch.setattr(
+        io,
+        "write_csv",
+        lambda df, path, *, cfg, key_cols=None, col_order=None, **__: path,
+    )
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
+
+    rc = gtd.run_chembl(cfg, args)
+
+    assert rc == 0
+    assert captured["init"] == (cfg.api, cfg.retry)


### PR DESCRIPTION
## Summary
- update the build configuration and dev extras in `pyproject.toml`
- enforce shared API sessions for UniProt and PubChem CLIs and simplify the activity wrapper
- harden PubMed retrieval by introducing limiter wiring, deterministic ordering, and a config-driven CLI entry point
- extend the CLI regression tests to cover session initialisation and limiter usage

## Testing
- python -m pip install .[dev]
- pytest tests/test_get_target_data_fetch.py::test_fetch_uniprot
- pytest tests/test_get_testitem_data.py
- pytest tests/test_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d390f69e9c832486b92cdc81ab786b