### PR TITLE
Handle paginated assay responses

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from urllib.parse import urljoin
 
 import pandas as pd
 
@@ -175,18 +176,28 @@ def get_assays(
         logger.info(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
-        url = f"{base}&assay_chembl_id__in={chunk_key}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("assays") or data.get("assay") or []
-        if items:
-            df_chunk = json_normalize_pyarrow(items).dropna(axis="columns", how="all")
-            if not df_chunk.empty:
-                records.append(df_chunk)
-                logger.info(
-                    "chunk_done",
-                    extra={"stage": "chunk_done", "chunk_key": chunk_key},
+        url = f"{base}&assay_chembl_id__in={chunk_key}&limit={len(chunk)}"
+        chunk_frames: list[pd.DataFrame] = []
+        next_url: str | None = url
+        while next_url:
+            data = client.request_json(next_url, cfg=cfg, timeout=effective_timeout)
+            items = data.get("assays") or data.get("assay") or []
+            if items:
+                df_chunk = json_normalize_pyarrow(items).dropna(
+                    axis="columns", how="all"
                 )
-                continue
+                if not df_chunk.empty:
+                    chunk_frames.append(df_chunk)
+            page_meta = data.get("page_meta") or {}
+            next_token = page_meta.get("next")
+            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+        if chunk_frames:
+            records.append(pd.concat(chunk_frames, ignore_index=True))
+            logger.info(
+                "chunk_done",
+                extra={"stage": "chunk_done", "chunk_key": chunk_key},
+            )
+            continue
         logger.info("chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key})
     if not records:
         return pd.DataFrame(columns=ASSAY_COLUMNS)

--- a/tests/test_chembl_assay.py
+++ b/tests/test_chembl_assay.py
@@ -1,0 +1,67 @@
+"""Tests for :mod:`library.chembl_assay`."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pandas as pd
+
+from library.chembl_assay import get_assays
+from library.config import ApiCfg
+
+
+def _response_page(items: list[dict[str, str]], next_path: str | None) -> dict[str, object]:
+    """Return a fake paginated response payload."""
+
+    page_meta: dict[str, object] = {"next": next_path}
+    return {"assays": items, "page_meta": page_meta}
+
+
+class DummyClient:
+    """Client stub that returns pre-defined responses."""
+
+    def __init__(self, responses: Iterator[dict[str, object]]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None = None) -> dict[str, object]:
+        self.calls.append(url)
+        try:
+            return next(self._responses)
+        except StopIteration:  # pragma: no cover - defensive
+            raise AssertionError("unexpected extra request") from None
+
+
+def test_get_assays_fetches_all_pages() -> None:
+    """Pagination should be followed when ChEMBL truncates responses."""
+
+    cfg = ApiCfg()
+    ids = ["A1", "A2", "A3", "A4"]
+    next_path = "/chembl/api/data/assay.json?format=json&assay_chembl_id__in=A1,A2,A3,A4&limit=4&offset=2"
+    responses = iter(
+        [
+            _response_page(
+                [
+                    {"assay_chembl_id": "A1", "document_chembl_id": "D1"},
+                    {"assay_chembl_id": "A2", "document_chembl_id": "D2"},
+                ],
+                next_path,
+            ),
+            _response_page(
+                [
+                    {"assay_chembl_id": "A3", "document_chembl_id": "D3"},
+                    {"assay_chembl_id": "A4", "document_chembl_id": "D4"},
+                ],
+                None,
+            ),
+        ]
+    )
+    client = DummyClient(responses)
+
+    df = get_assays(ids, cfg=cfg, client=client, chunk_size=4)
+
+    assert len(client.calls) == 2
+    assert "limit=4" in client.calls[0]
+    assert "offset=2" in client.calls[1]
+    assert isinstance(df, pd.DataFrame)
+    assert list(df["assay_chembl_id"]) == ids


### PR DESCRIPTION
## Summary
- ensure `get_assays` requests all pages when the ChEMBL API paginates results
- add a regression test covering paginated assay retrieval

## Testing
- `pytest tests/test_chembl_assay.py tests/test_get_assay_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3917adeec8324a9cdfeac993a16df