### PR TITLE
Add shared document schema metadata

### DIFF
--- a/library/chembl_document.py
+++ b/library/chembl_document.py
@@ -9,23 +9,9 @@ import pandas as pd
 
 from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg
+from .document_schema import CH_EMBL_COLUMNS
 
-DOCUMENT_COLUMNS = [
-    "document_chembl_id",
-    "title",
-    "abstract",
-    "doi",
-    "year",
-    "journal",
-    "journal_abbrev",
-    "volume",
-    "issue",
-    "first_page",
-    "last_page",
-    "pubmed_id",
-    "authors",
-    "source",
-]
+DOCUMENT_COLUMNS = list(CH_EMBL_COLUMNS)
 
 
 def get_documents(

--- a/library/document_schema.py
+++ b/library/document_schema.py
@@ -1,0 +1,123 @@
+"""Shared column definitions for the document pipeline.
+
+The original Power Query implementation relied on a number of hard coded
+column lists to keep the output schema deterministic.  The data acquisition
+scripts translate the logic to ``pandas`` and re-use the same collections to
+guarantee stable ordering across the different execution modes.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Column order expected by the downstream schema validation.  The names are
+# derived from the dictionary files used by the legacy ETL and extended with
+# the publication type metrics calculated during post-processing.
+DOCUMENT_SCHEMA_COLUMNS: Final[tuple[str, ...]] = (
+    "Index",
+    "OpenAlex.Error",
+    "OpenAlex.Genre",
+    "OpenAlex.Id",
+    "OpenAlex.MeshDescriptors",
+    "OpenAlex.MeshQualifiers",
+    "OpenAlex.PublicationTypes",
+    "OpenAlex.TypeCrossref",
+    "OpenAlex.Venue",
+    "OpenAlex.is_review",
+    "PubMed.Abstract",
+    "PubMed.ArticleTitle",
+    "PubMed.ChemicalList",
+    "PubMed.DOI",
+    "PubMed.DayCompleted",
+    "PubMed.DayRevised",
+    "PubMed.EndPage",
+    "PubMed.Error",
+    "PubMed.ISSN",
+    "PubMed.Issue",
+    "PubMed.JournalTitle",
+    "PubMed.MeSH_Descriptors",
+    "PubMed.MeSH_Qualifiers",
+    "PubMed.MonthCompleted",
+    "PubMed.MonthRevised",
+    "PubMed.PMID",
+    "PubMed.PublicationType",
+    "PubMed.StartPage",
+    "PubMed.Volume",
+    "PubMed.YearCompleted",
+    "PubMed.YearRevised",
+    "PubMed.is_review",
+    "abstract",
+    "authors",
+    "crossref.Error",
+    "crossref.Subject",
+    "crossref.Subtitle",
+    "crossref.Subtype",
+    "crossref.Title",
+    "crossref.Type",
+    "date_code",
+    "document_chembl_id",
+    "doi",
+    "first_page",
+    "issue",
+    "journal",
+    "journal_abbrev",
+    "last_page",
+    "pubmed_id",
+    "scholar.DOI",
+    "scholar.Error",
+    "scholar.ExternalIds",
+    "scholar.PMID",
+    "scholar.PublicationTypes",
+    "scholar.SemanticScholarId",
+    "scholar.Venue",
+    "scholar.is_review",
+    "source",
+    "title",
+    "volume",
+    "year",
+    "publication_types_normalised",
+    "publication_type_score_review",
+    "publication_type_score_experimental",
+    "publication_type_score_unknown",
+    "publication_class",
+)
+
+# Columns provided by the ChEMBL API.  ``get_document_data`` relies on the list
+# to reindex partial responses and guarantee a deterministic output order when
+# ChEMBL is the only source.
+CH_EMBL_COLUMNS: Final[tuple[str, ...]] = (
+    "document_chembl_id",
+    "title",
+    "abstract",
+    "doi",
+    "year",
+    "journal",
+    "journal_abbrev",
+    "volume",
+    "issue",
+    "first_page",
+    "last_page",
+    "pubmed_id",
+    "authors",
+    "source",
+)
+
+# Subset of columns originating from the Semantic Scholar API.  The combined
+# dataset aligns the field names with the legacy export to ease downstream
+# comparisons.
+SEMANTIC_SCHOLAR_COLUMNS: Final[tuple[str, ...]] = (
+    "scholar.PMID",
+    "scholar.Venue",
+    "scholar.SemanticScholarId",
+    "scholar.ExternalIds",
+    "scholar.DOI",
+    "scholar.PublicationTypes",
+    "scholar.is_review",
+    "scholar.Error",
+)
+
+__all__ = [
+    "DOCUMENT_SCHEMA_COLUMNS",
+    "CH_EMBL_COLUMNS",
+    "SEMANTIC_SCHOLAR_COLUMNS",
+]

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -4,101 +4,128 @@ from __future__ import annotations
 
 import pandera.pandas as pa
 
+from library.document_schema import DOCUMENT_SCHEMA_COLUMNS
+
 # ``pa.Any`` is not available in the current pandera version; ``object`` with
 # ``coerce=True`` permits arbitrary dtypes.
 
+_COLUMN_DEFINITIONS: dict[str, pa.Column] = {
+    "document_chembl_id": pa.Column(str, required=True, nullable=True),
+    "doi": pa.Column(str, required=False, nullable=True),
+    "title": pa.Column(str, required=False, nullable=True),
+    "Index": pa.Column(object, required=False, nullable=True, coerce=True),
+    "OpenAlex.Error": pa.Column(object, required=False, nullable=True, coerce=True),
+    "OpenAlex.Genre": pa.Column(object, required=False, nullable=True, coerce=True),
+    "OpenAlex.Id": pa.Column(str, required=False, nullable=True),
+    "OpenAlex.MeshDescriptors": pa.Column(str, required=False, nullable=True),
+    "OpenAlex.MeshQualifiers": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "OpenAlex.PublicationTypes": pa.Column(
+        str, required=False, nullable=True
+    ),
+    "OpenAlex.TypeCrossref": pa.Column(str, required=False, nullable=True),
+    "OpenAlex.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
+    "OpenAlex.is_review": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.Abstract": pa.Column(str, required=False, nullable=True),
+    "PubMed.ArticleTitle": pa.Column(str, required=False, nullable=True),
+    "PubMed.ChemicalList": pa.Column(str, required=False, nullable=True),
+    "PubMed.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.DayCompleted": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.DayRevised": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.EndPage": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.Error": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.ISSN": pa.Column(str, required=False, nullable=True),
+    "PubMed.Issue": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.JournalTitle": pa.Column(str, required=False, nullable=True),
+    "PubMed.MeSH_Descriptors": pa.Column(str, required=False, nullable=True),
+    "PubMed.MeSH_Qualifiers": pa.Column(str, required=False, nullable=True),
+    "PubMed.MonthCompleted": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.MonthRevised": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.PublicationType": pa.Column(
+        str, required=False, nullable=True
+    ),
+    "PubMed.StartPage": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.Volume": pa.Column(object, required=False, nullable=True, coerce=True),
+    "PubMed.YearCompleted": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.YearRevised": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "PubMed.is_review": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "abstract": pa.Column(str, required=False, nullable=True),
+    "authors": pa.Column(str, required=False, nullable=True),
+    "crossref.Error": pa.Column(str, required=False, nullable=True),
+    "crossref.Subject": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "crossref.Subtitle": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "crossref.Subtype": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "crossref.Title": pa.Column(object, required=False, nullable=True, coerce=True),
+    "crossref.Type": pa.Column(object, required=False, nullable=True, coerce=True),
+    "date_code": pa.Column(str, required=False, nullable=True),
+    "first_page": pa.Column(object, required=False, nullable=True, coerce=True),
+    "issue": pa.Column(object, required=False, nullable=True, coerce=True),
+    "journal": pa.Column(str, required=False, nullable=True),
+    "journal_abbrev": pa.Column(str, required=False, nullable=True),
+    "last_page": pa.Column(object, required=False, nullable=True, coerce=True),
+    "pubmed_id": pa.Column(object, required=False, nullable=True, coerce=True),
+    "scholar.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
+    "scholar.Error": pa.Column(str, required=False, nullable=True),
+    "scholar.ExternalIds": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "scholar.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
+    "scholar.PublicationTypes": pa.Column(
+        str, required=False, nullable=True
+    ),
+    "scholar.SemanticScholarId": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "scholar.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
+    "scholar.is_review": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "source": pa.Column(str, required=False, nullable=True),
+    "volume": pa.Column(object, required=False, nullable=True, coerce=True),
+    "year": pa.Column(object, required=False, nullable=True, coerce=True),
+    "publication_types_normalised": pa.Column(
+        str, required=False, nullable=True
+    ),
+    "publication_type_score_review": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "publication_type_score_experimental": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "publication_type_score_unknown": pa.Column(
+        object, required=False, nullable=True, coerce=True
+    ),
+    "publication_class": pa.Column(str, required=False, nullable=True),
+}
+
 DocumentsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
-    {
-        "document_chembl_id": pa.Column(str, required=True, nullable=True),
-        "doi": pa.Column(str, required=False, nullable=True),
-        "title": pa.Column(str, required=False, nullable=True),
-        "Index": pa.Column(object, required=False, nullable=True, coerce=True),
-        "OpenAlex.Error": pa.Column(object, required=False, nullable=True, coerce=True),
-        "OpenAlex.Genre": pa.Column(object, required=False, nullable=True, coerce=True),
-        "OpenAlex.Id": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.MeshDescriptors": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.MeshQualifiers": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "OpenAlex.TypeCrossref": pa.Column(str, required=False, nullable=True),
-        "OpenAlex.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
-        "OpenAlex.is_review": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.Abstract": pa.Column(str, required=False, nullable=True),
-        "PubMed.ArticleTitle": pa.Column(str, required=False, nullable=True),
-        "PubMed.ChemicalList": pa.Column(str, required=False, nullable=True),
-        "PubMed.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.DayCompleted": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.DayRevised": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.EndPage": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.Error": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.ISSN": pa.Column(str, required=False, nullable=True),
-        "PubMed.Issue": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.JournalTitle": pa.Column(str, required=False, nullable=True),
-        "PubMed.MeSH_Descriptors": pa.Column(str, required=False, nullable=True),
-        "PubMed.MeSH_Qualifiers": pa.Column(str, required=False, nullable=True),
-        "PubMed.MonthCompleted": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.MonthRevised": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.StartPage": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.Volume": pa.Column(object, required=False, nullable=True, coerce=True),
-        "PubMed.YearCompleted": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.YearRevised": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "PubMed.is_review": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "abstract": pa.Column(str, required=False, nullable=True),
-        "authors": pa.Column(str, required=False, nullable=True),
-        "crossref.Error": pa.Column(str, required=False, nullable=True),
-        "crossref.Subject": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "crossref.Subtitle": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "crossref.Subtype": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "crossref.Title": pa.Column(object, required=False, nullable=True, coerce=True),
-        "crossref.Type": pa.Column(object, required=False, nullable=True, coerce=True),
-        "date_code": pa.Column(str, required=False, nullable=True),
-        "first_page": pa.Column(object, required=False, nullable=True, coerce=True),
-        "issue": pa.Column(object, required=False, nullable=True, coerce=True),
-        "journal": pa.Column(str, required=False, nullable=True),
-        "journal_abbrev": pa.Column(str, required=False, nullable=True),
-        "last_page": pa.Column(object, required=False, nullable=True, coerce=True),
-        "pubmed_id": pa.Column(object, required=False, nullable=True, coerce=True),
-        "scholar.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
-        "scholar.Error": pa.Column(str, required=False, nullable=True),
-        "scholar.ExternalIds": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "scholar.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
-        "scholar.SemanticScholarId": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "scholar.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
-        "scholar.is_review": pa.Column(
-            object, required=False, nullable=True, coerce=True
-        ),
-        "source": pa.Column(str, required=False, nullable=True),
-        "volume": pa.Column(object, required=False, nullable=True, coerce=True),
-    }
+    {name: _COLUMN_DEFINITIONS[name] for name in DOCUMENT_SCHEMA_COLUMNS}
 )
 
 """pa.DataFrameSchema: Validation schema for documents."""

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -49,6 +49,7 @@ from library import openalex_crossref_library as ocl
 from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
 from library.chembl_client import ChemblClient, _chunked
+from library.document_schema import DOCUMENT_SCHEMA_COLUMNS
 from library.cli import (
     LoggerConfig,
     apply_config_overrides,
@@ -69,6 +70,20 @@ from library.rate_limiter import get_limiter
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from schemas import DocumentsSchema, normalize_documents
+
+
+def _apply_schema_column_order(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    """Ensure ``df`` contains all schema columns and return ordered names."""
+
+    schema_cols = list(DOCUMENT_SCHEMA_COLUMNS)
+    missing = [col for col in schema_cols if col not in df.columns]
+    if missing:
+        df = df.copy()
+        for col in missing:
+            df[col] = pd.NA
+    head = [col for col in schema_cols if col in df.columns]
+    tail = sorted(col for col in df.columns if col not in schema_cols)
+    return df, head + tail
 
 
 def fetch_pubmed_records(
@@ -254,10 +269,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
         key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
-        schema_cols = list(DocumentsSchema.columns)
-        head = [c for c in schema_cols if c in df.columns]  # schema-defined order
-        tail = sorted(c for c in df.columns if c not in schema_cols)  # other columns
-        col_order = head + tail
+        df, col_order = _apply_schema_column_order(df)
         csv_path = io.write_csv(
             df,
             output,
@@ -379,12 +391,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         rows_dropped = rows_total - rows_kept
         try:
             key_cols = [c for c in ["document_chembl_id"] if c in df.columns]
-            schema_cols = list(DocumentsSchema.columns)
-            head = [c for c in schema_cols if c in df.columns]  # schema-defined order
-            tail = sorted(
-                c for c in df.columns if c not in schema_cols
-            )  # other columns
-            col_order = head + tail
+            df, col_order = _apply_schema_column_order(df)
             csv_path = io.write_csv(
                 df,
                 output,
@@ -519,10 +526,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         rows_dropped = rows_total - rows_kept
         try:
             key_cols = [c for c in ["document_chembl_id"] if c in processed.columns]
-            schema_cols = list(DocumentsSchema.columns)
-            head = [c for c in schema_cols if c in processed.columns]
-            tail = sorted(c for c in processed.columns if c not in schema_cols)
-            col_order = head + tail
+            processed, col_order = _apply_schema_column_order(processed)
             csv_path = io.write_csv(
                 processed,
                 output,
@@ -628,10 +632,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     rows_dropped = rows_total - rows_kept
     try:
         key_cols = [c for c in ["document_chembl_id"] if c in processed.columns]
-        schema_cols = list(DocumentsSchema.columns)
-        head = [c for c in schema_cols if c in processed.columns]
-        tail = sorted(c for c in processed.columns if c not in schema_cols)
-        col_order = head + tail
+        processed, col_order = _apply_schema_column_order(processed)
         csv_path = io.write_csv(
             processed,
             output,

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -196,7 +196,5 @@ def test_write_csv_column_order(
     rc = gdd.run_chembl(cfg, args)
     assert rc == 0
     schema_cols = list(DocumentsSchema.columns)
-    expected = [c for c in schema_cols if c in df.columns] + sorted(
-        c for c in df.columns if c not in schema_cols
-    )
+    expected = schema_cols + sorted(c for c in df.columns if c not in schema_cols)
     assert captured["col_order"] == expected


### PR DESCRIPTION
## Summary
- introduce `library/document_schema.py` with shared column order definitions for documents
- extend the document Pandera schema to cover publication-type fields and reuse the shared ordering
- update `get_document_data` to fill missing schema columns before export and align tests with the new behaviour

## Testing
- `pytest tests/test_get_document_data.py`
- `pytest` *(fails: existing suite has unrelated schema/memory expectations on this branch)*

------
https://chatgpt.com/codex/tasks/task_e_68d390a135008324897553a0c27801b1