### PR TITLE
Update CI checks and document determinism workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
           pip install .[dev]
       - name: Check formatting
         run: ruff format --check .
-      - name: Verify deterministic CSV output
-        run: python scripts/check_determinism.py --log-level DEBUG
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+      - name: Lint
+        run: ruff check .
       - name: Type check
         run: mypy --strict library
-      - name: Smoke test cache
-        run: pytest -q tests/test_chembl_client.py::test_request_json_cache
+      - name: Run tests
+        run: pytest
+      - name: Verify deterministic CSV output
+        run: python scripts/check_determinism.py --log-level DEBUG
       - name: Upload output data
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@
 
 Полный список приведён в `requirements-dev.txt` или `pyproject.toml`.
 
+### Среда выполнения
+
+* ОС Linux или macOS с доступом к bash/PowerShell. На Windows рекомендуется
+  устанавливать через WSL2.
+* `pip` версии 23+ и `setuptools`/`wheel` последних релизов:
+
+  ```bash
+  python -m pip install --upgrade pip setuptools wheel
+  ```
+
+* Изолированное окружение:
+
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+  ```
+
+* Разрешение на сетевые запросы к API ChEMBL/PubChem/UniProt (порт 443).
+
 ## Установка
 
 ```bash
@@ -112,6 +131,16 @@ pre-commit run --all-files
 ```bash
 pytest
 ```
+
+Проверка детерминизма итоговых CSV выполняется отдельным скриптом; он сравнивает
+контрольные срезы с актуальным выводом и сигнализирует о дрейфе данных:
+
+```bash
+python scripts/check_determinism.py --log-level DEBUG
+```
+
+Перед запуском убедитесь, что зависимости установлены командой `pip install .[dev]`
+и все файлы в `data/output/` доступны для чтения/записи.
 
 Для smoke-теста CLI выполните:
 


### PR DESCRIPTION
## Summary
- ensure the CI job installs the project with development extras before running Ruff linting, mypy, pytest, and the determinism guard
- extend the README with environment preparation guidance and explicit determinism-check instructions

## Testing
- pytest *(fails: existing tests `test_fetch_pubmed_records_order_and_limiters` and `test_pubmed_library_single_config`)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a2433af883248ddaccd1f5112e77