### PR TITLE
Fix PubMed CLI invocation and semantic scholar handling

### DIFF
--- a/library/metadata.py
+++ b/library/metadata.py
@@ -91,17 +91,30 @@ def write_meta_yaml(
     path = Path(csv_path)
     meta_path = path.with_name(path.name + ".meta.yaml")
 
-    metadata: dict[str, Any] = {
-        "generated_at": datetime.now(UTC).isoformat(),
-        "git_sha": _git_sha(),
-        "python_version": platform.python_version(),
-        "platform": platform.platform(),
-        "command": command,
-        "config": _mask_secrets(dict(config_subset)),
-        "inputs": dict(inputs),
-        "stats": stats,
-        "schema": schema,
-    }
+    existing: dict[str, Any] = {}
+    if meta_path.exists():
+        try:
+            with meta_path.open("r", encoding="utf-8") as fh:
+                loaded = yaml.safe_load(fh)
+        except (OSError, yaml.YAMLError):
+            loaded = None
+        if isinstance(loaded, dict):
+            existing = dict(loaded)
+
+    metadata: dict[str, Any] = dict(existing)
+    metadata.update(
+        {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "git_sha": _git_sha(),
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "command": command,
+            "config": _mask_secrets(dict(config_subset)),
+            "inputs": dict(inputs),
+            "stats": stats,
+            "schema": schema,
+        }
+    )
 
     with meta_path.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(metadata, fh, sort_keys=False)

--- a/library/pubmed/query.py
+++ b/library/pubmed/query.py
@@ -337,39 +337,7 @@ def fetch_semantic_scholar_batch(
             for pmid in pmids
         ]
 
-    results: list[dict[str, str]] = []
-    if isinstance(data, list) and len(data) == len(pmids):
-        for pmid, item in zip(pmids, data, strict=False):
-            if item is None:
-                results.append(
-                    {
-                        "scholar.PMID": pmid,
-                        "scholar.Venue": "",
-                        "scholar.PublicationTypes": "",
-                        "scholar.SemanticScholarId": "",
-                        "scholar.ExternalIds": "",
-                        "scholar.DOI": "",
-                        "scholar.Error": "Not found",
-                    }
-                )
-                continue
-
-            external_ids = item.get("externalIds") or {}
-            doi = external_ids.get("DOI") or ""
-            pubtypes = item.get("publicationTypes") or []
-
-            results.append(
-                {
-                    "scholar.PMID": pmid,
-                    "scholar.Venue": item.get("venue", ""),
-                    "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
-                    "scholar.SemanticScholarId": item.get("paperId", ""),
-                    "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
-                    "scholar.DOI": doi,
-                    "scholar.Error": "",
-                }
-            )
-    else:
+    if not isinstance(data, list):
         return [
             {
                 "scholar.PMID": pmid,
@@ -382,6 +350,76 @@ def fetch_semantic_scholar_batch(
             }
             for pmid in pmids
         ]
+
+    def _resolve_pmid(item: dict[str, Any]) -> str | None:
+        external_ids = item.get("externalIds")
+        if isinstance(external_ids, dict):
+            for key in ("PubMed", "PMID", "pubmed", "pubMed"):
+                value = external_ids.get(key)
+                if isinstance(value, str):
+                    candidate = value.strip()
+                    if candidate:
+                        return candidate
+                elif isinstance(value, (list, tuple, set)):
+                    for entry in value:
+                        if isinstance(entry, str):
+                            candidate = entry.strip()
+                            if candidate:
+                                return candidate
+                        elif entry is not None:
+                            return str(entry)
+                elif value is not None:
+                    return str(value)
+        for key in ("pmid", "PMID"):
+            value = item.get(key)
+            if isinstance(value, str):
+                candidate = value.strip()
+                if candidate:
+                    return candidate
+            elif value is not None:
+                return str(value)
+        return None
+
+    lookup: dict[str, dict[str, Any]] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        pmid_value = _resolve_pmid(entry)
+        if pmid_value:
+            lookup.setdefault(pmid_value, entry)
+
+    results: list[dict[str, str]] = []
+    for pmid in pmids:
+        item = lookup.get(pmid)
+        if item is None:
+            results.append(
+                {
+                    "scholar.PMID": pmid,
+                    "scholar.Venue": "",
+                    "scholar.PublicationTypes": "",
+                    "scholar.SemanticScholarId": "",
+                    "scholar.ExternalIds": "",
+                    "scholar.DOI": "",
+                    "scholar.Error": "Not found",
+                }
+            )
+            continue
+
+        external_ids = item.get("externalIds") or {}
+        doi = external_ids.get("DOI") or ""
+        pubtypes = item.get("publicationTypes") or []
+
+        results.append(
+            {
+                "scholar.PMID": pmid,
+                "scholar.Venue": item.get("venue", ""),
+                "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
+                "scholar.SemanticScholarId": item.get("paperId", ""),
+                "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
+                "scholar.DOI": doi,
+                "scholar.Error": "",
+            }
+        )
 
     return results
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -204,6 +204,16 @@ def fetch_pubmed_records(
     openalex_limiter = get_limiter("openalex", openalex_cfg.rps, openalex_cfg.burst)
     crossref_limiter = get_limiter("crossref", crossref_cfg.rps, crossref_cfg.burst)
 
+    settings = cfg or Config()
+    api_cfg = settings.api
+    retry_cfg = settings.retry
+    pubmed_cfg = settings.pubmed
+    rate_cfg = settings.rate
+    pubmed_limiter = get_limiter("pubmed", rate_cfg.global_rps, rate_cfg.global_burst)
+    semantic_limiter = get_limiter(
+        "semantic_scholar", rate_cfg.global_rps, rate_cfg.global_burst
+    )
+
     def _failure_records(batch: Sequence[str], message: str) -> list[dict[str, str]]:
         """Return placeholder rows describing a failure for ``batch`` PMIDs."""
 
@@ -279,7 +289,7 @@ def fetch_pubmed_records(
         for batch in _chunked(iterator, batch_size):
             if not batch:
                 continue
-            future = ex.submit(_fetch_batch, offset, batch)
+            future = ex.submit(_fetch_batch, batch)
             tasks[future] = (offset, batch)
             offset += len(batch)
 
@@ -446,13 +456,13 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     try:
         df = fetch_pubmed_records(
             pmids,
-
-            cfg.document.pubmed.sleep,
-            cfg.semantic_scholar,
-            cfg.openalex,
-            cfg.crossref,
-            cfg.document.pubmed.workers,
-            cfg.document.pubmed.batch_size,
+            cfg,
+            sleep=cfg.document.pubmed.sleep,
+            semantic_scholar_cfg=cfg.semantic_scholar,
+            openalex_cfg=cfg.openalex,
+            crossref_cfg=cfg.crossref,
+            max_workers=cfg.document.pubmed.workers,
+            batch_size=cfg.document.pubmed.batch_size,
         )
         output = Path(
             args.output_csv or io.default_output_path(args.input_csv, cfg.io)

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -22,6 +22,11 @@ from library.document_pipeline import DOCUMENT_SCHEMA_COLUMNS
 from scripts import get_document_data as gdd
 
 
+class DummyLimiter:
+    def acquire(self) -> None:
+        return None
+
+
 def test_cli_uses_custom_column(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -144,6 +149,78 @@ def test_run_all_logs_failing_ids(
     assert "CHEMBL1" in log_output and "CHEMBL2" in log_output
 
 
+def test_run_pubmed_uses_keyword_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PubMed sub-command forwards configuration via keyword arguments."""
+
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n1\n2\n")
+
+    def fake_read_ids(
+        path: str | Path,
+        *,
+        column: str,
+        cfg: Any,
+        sep: str | None = None,
+        encoding: str | None = None,
+        na_markers: list[str] | None = None,
+    ) -> Iterable[str]:
+        assert Path(path) == input_csv
+        assert column == "PMID"
+        return iter(["1", "2"])
+
+    monkeypatch.setattr(lib_io, "read_ids", fake_read_ids)
+
+    captured: dict[str, Any] = {}
+
+    def fake_fetch_pubmed_records(
+        pmids: Iterable[str],
+        cfg_param: Config,
+        *,
+        sleep: float,
+        semantic_scholar_cfg: SemanticScholarCfg,
+        openalex_cfg: OpenAlexCfg,
+        crossref_cfg: CrossRefCfg,
+        max_workers: int,
+        batch_size: int,
+    ) -> pd.DataFrame:
+        captured["pmids"] = list(pmids)
+        captured["cfg"] = cfg_param
+        captured["sleep"] = sleep
+        captured["semantic_scholar_cfg"] = semantic_scholar_cfg
+        captured["openalex_cfg"] = openalex_cfg
+        captured["crossref_cfg"] = crossref_cfg
+        captured["max_workers"] = max_workers
+        captured["batch_size"] = batch_size
+        return pd.DataFrame({"PMID": ["1", "2"]})
+
+    monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
+    monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
+    monkeypatch.setattr(
+        gdd,
+        "_finalise_export",
+        lambda df, output, cfg, input_csv, key_columns: 0,
+    )
+
+    cfg = Config()
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "out.csv",
+    )
+
+    exit_code = gdd.run_pubmed(cfg, args)
+    assert exit_code == 0
+    assert captured["pmids"] == ["1", "2"]
+    assert captured["cfg"] is cfg
+    assert captured["sleep"] == cfg.document.pubmed.sleep
+    assert captured["semantic_scholar_cfg"] is cfg.semantic_scholar
+    assert captured["openalex_cfg"] is cfg.openalex
+    assert captured["crossref_cfg"] is cfg.crossref
+    assert captured["max_workers"] == cfg.document.pubmed.workers
+    assert captured["batch_size"] == cfg.document.pubmed.batch_size
+
+
 def test_write_csv_column_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -220,7 +297,7 @@ def test_fetch_pubmed_records_handles_generic_error(
         raise RuntimeError("boom")
 
     monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fail_fetch_pubmed_batch)
-    monkeypatch.setattr(gdd, "get_limiter", lambda *args, **kwargs: object())
+    monkeypatch.setattr(gdd, "get_limiter", lambda *args, **kwargs: DummyLimiter())
 
     df = gdd.fetch_pubmed_records(
         ["123"],
@@ -305,7 +382,7 @@ def test_fetch_pubmed_records_accepts_config(
     monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_scholar_batch)
     monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_openalex)
     monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
-    monkeypatch.setattr(gdd, "get_limiter", lambda *args, **kwargs: object())
+    monkeypatch.setattr(gdd, "get_limiter", lambda *args, **kwargs: DummyLimiter())
 
     df = gdd.fetch_pubmed_records(["1"], config)
     assert "PubMed.PMID" in df.columns

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -58,6 +58,40 @@ def test_write_meta_yaml_creates_file(tmp_path: Path) -> None:
     assert required_keys <= data.keys()
 
 
+def test_write_meta_yaml_preserves_existing_columns(tmp_path: Path) -> None:
+    csv_path = tmp_path / "output.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+    meta_path = csv_path.with_name(csv_path.name + ".meta.yaml")
+    original_meta = {
+        "columns": ["id"],
+        "dtypes": {"id": "string"},
+        "schema": "Initial",
+    }
+    meta_path.write_text(yaml.safe_dump(original_meta), encoding="utf-8")
+
+    stats: Stats = {
+        "rows_total": 1,
+        "rows_kept": 1,
+        "rows_dropped": 0,
+        "output_sha256": "feedface",
+    }
+
+    write_meta_yaml(
+        csv_path=csv_path,
+        command="unit-test",
+        config_subset={},
+        inputs={},
+        stats=stats,
+        schema="Updated",
+    )
+
+    data = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert data["columns"] == ["id"]
+    assert data["dtypes"] == {"id": "string"}
+    assert data["schema"] == "Updated"
+    assert data["stats"] == stats
+
+
 def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     """_git_sha uses the ``GIT_SHA`` environment variable when available."""
 

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -356,3 +356,42 @@ def test_fetch_semantic_scholar_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> Non
     assert captured["retries"] == 4
     assert captured["sleep"] == pytest.approx(1.0)
     assert sleeps == []
+
+
+def test_fetch_semantic_scholar_batch_partial_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batch lookup keeps valid entries when some PMIDs are missing."""
+
+    payload = [
+        {
+            "externalIds": {"PubMed": "1", "DOI": "10.1000/example"},
+            "paperId": "paper-1",
+            "publicationTypes": ["Journal"],
+            "venue": "Venue",
+        },
+        None,
+        {
+            "externalIds": {"PubMed": ["3"]},
+            "paperId": "paper-3",
+            "publicationTypes": [],
+            "venue": "",
+        },
+    ]
+
+    monkeypatch.setattr(pq, "_do_request", lambda *_, **__: (payload, ""))
+
+    session = requests.Session()
+    results = pq.fetch_semantic_scholar_batch(session, ["1", "2", "3"], 0.0)
+
+    assert results[0]["scholar.Error"] == ""
+    assert results[0]["scholar.PMID"] == "1"
+    assert results[0]["scholar.SemanticScholarId"] == "paper-1"
+    assert results[0]["scholar.DOI"] == "10.1000/example"
+
+    assert results[1]["scholar.Error"] == "Not found"
+    assert results[1]["scholar.PMID"] == "2"
+
+    assert results[2]["scholar.Error"] == ""
+    assert results[2]["scholar.PMID"] == "3"
+    assert results[2]["scholar.SemanticScholarId"] == "paper-3"


### PR DESCRIPTION
## Summary
- ensure the pubmed CLI forwards the full configuration when calling `fetch_pubmed_records`
- harden Semantic Scholar batch parsing to keep valid records when the response is partial
- preserve existing columns/dtypes when rewriting metadata sidecars and add regression tests

## Testing
- pytest tests/test_get_document_data.py tests/test_pubmed_query.py tests/test_metadata.py tests/test_sidecar.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ae0fe14083249641d80d67564702