### PR TITLE
Implement git SHA fallback without git executable

### DIFF
--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -17,14 +17,112 @@ from pathlib import Path
 from .log import logger
 
 
+def _repo_root() -> Path:
+    """Return the repository root used for Git metadata."""
+
+    return Path(__file__).resolve().parent.parent
+
+
+def _resolve_git_dir(repo_root: Path) -> Path | None:
+    """Return the path to the ``.git`` directory if it exists."""
+
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return git_path
+    if git_path.is_file():
+        try:
+            raw = git_path.read_text(encoding="utf8").splitlines()
+        except OSError:
+            return None
+        if not raw:
+            return None
+        prefix = "gitdir:"
+        first = raw[0].strip()
+        if first.lower().startswith(prefix):
+            target = first[len(prefix) :].strip()
+            if not target:
+                return None
+            git_dir = Path(target)
+            if not git_dir.is_absolute():
+                git_dir = (git_path.parent / git_dir).resolve()
+            if git_dir.exists():
+                return git_dir
+    return None
+
+
+def _is_sha(value: str) -> bool:
+    """Return ``True`` if ``value`` looks like a Git SHA."""
+
+    value = value.strip()
+    return len(value) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in value)
+
+
+def _read_packed_ref(git_dir: Path, ref: str) -> str | None:
+    """Return the SHA for ``ref`` from ``packed-refs`` if present."""
+
+    packed = git_dir / "packed-refs"
+    try:
+        with packed.open("r", encoding="utf8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or line.startswith("^"):
+                    continue
+                sha, _, name = line.partition(" ")
+                if name.strip() == ref and _is_sha(sha):
+                    return sha.strip()
+    except OSError:
+        return None
+    return None
+
+
+def _read_head_sha(git_dir: Path) -> str | None:
+    """Read the current commit hash directly from ``HEAD`` files."""
+
+    head_path = git_dir / "HEAD"
+    try:
+        head_content = head_path.read_text(encoding="utf8").strip()
+    except OSError:
+        return None
+    if not head_content:
+        return None
+    if head_content.startswith("ref:"):
+        ref = head_content.partition(":")[2].strip()
+        if not ref:
+            return None
+        ref_path = git_dir / Path(ref)
+        try:
+            sha = ref_path.read_text(encoding="utf8").strip()
+            if _is_sha(sha):
+                return sha
+        except OSError:
+            packed = _read_packed_ref(git_dir, ref)
+            if packed is not None:
+                return packed
+        return None
+    if _is_sha(head_content):
+        return head_content
+    return None
+
+
+def _log_fallback(sha: str, *, reason: str, error: BaseException | None = None) -> None:
+    """Log a successful SHA fallback resolution."""
+
+    payload: dict[str, str] = {"reason": reason}
+    if error is not None:
+        payload["error"] = str(error)
+    logger.info("git_sha_fallback", sha=sha, **payload)
+
+
 @functools.lru_cache(maxsize=1)
 def _git_sha() -> str:
     """Return the Git commit hash for the repository.
 
     The command is executed only once and the result cached to avoid
     repeated subprocess calls.  If Git is unavailable or the repository
-    lacks its ``.git`` directory, ``"UNKNOWN"`` is returned and a warning
-    is logged.
+    lacks its ``.git`` directory, ``"UNKNOWN"`` is returned. When the Git
+    executable is missing or fails, the function attempts to read the hash
+    directly from ``.git/HEAD`` and associated ref files before falling back
+    to ``"UNKNOWN"``.
 
     Returns
     -------
@@ -32,19 +130,24 @@ def _git_sha() -> str:
         The commit hash or ``"UNKNOWN"`` when it cannot be determined.
     """
 
-    repo_root = Path(__file__).resolve().parent.parent
+    repo_root = _repo_root()
     env_sha = os.getenv("GIT_SHA")
     if env_sha:
         logger.info("git_sha_env", sha=env_sha)
         return env_sha
 
-    git_executable = shutil.which("git")
-    if git_executable is None:
-        logger.warning("git_executable_missing")
+    git_dir = _resolve_git_dir(repo_root)
+    if git_dir is None:
+        logger.warning("git_directory_missing", path=str(repo_root))
         return "UNKNOWN"
 
-    if not (repo_root / ".git").exists():
-        logger.warning("git_directory_missing", path=str(repo_root))
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        fallback = _read_head_sha(git_dir)
+        if fallback is not None:
+            _log_fallback(fallback, reason="missing_executable")
+            return fallback
+        logger.warning("git_executable_missing")
         return "UNKNOWN"
 
     try:
@@ -52,6 +155,10 @@ def _git_sha() -> str:
             [git_executable, "rev-parse", "HEAD"], cwd=repo_root
         )
         return result.decode().strip()
-    except subprocess.CalledProcessError as exc:  # pragma: no cover - rare
+    except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
+        fallback = _read_head_sha(git_dir)
+        if fallback is not None:
+            _log_fallback(fallback, reason="subprocess_error", error=exc)
+            return fallback
         logger.warning("git_sha_unavailable", extra={"error": str(exc)})
         return "UNKNOWN"

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -274,6 +274,7 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
     """_git_sha returns 'unknown' and logs a warning on timeout."""
 
     git_utils._git_sha.cache_clear()
+    monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     with patch(
         "library.git_utils.subprocess.check_output",
         side_effect=subprocess.CalledProcessError(returncode=1, cmd=["git"]),

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import library.git_utils as git_utils
+
+
+def _prepare_head(git_dir: Path, commit: str, ref: str = "refs/heads/main") -> None:
+    head = git_dir / "HEAD"
+    head.parent.mkdir(parents=True, exist_ok=True)
+    head.write_text(f"ref: {ref}\n", encoding="utf8")
+    ref_path = git_dir / Path(ref)
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(f"{commit}\n", encoding="utf8")
+
+
+def _configure_failing_git(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
+    def fail(*args: object, **kwargs: object) -> bytes:
+        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+
+    monkeypatch.setattr(git_utils, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils.shutil, "which", lambda _: "git")
+
+
+def _capture_logs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, object]]]:
+    records: list[tuple[str, dict[str, object]]] = []
+
+    def info(event: str, *args: object, **kwargs: object) -> None:
+        records.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(git_utils.logger, "info", info)
+    monkeypatch.setattr(git_utils.logger, "warning", lambda *a, **k: None)
+    return records
+
+
+def test_git_sha_fallback_reads_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = "1" * 40
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    _prepare_head(git_dir, commit)
+    _configure_failing_git(monkeypatch, tmp_path)
+    records = _capture_logs(monkeypatch)
+    git_utils._git_sha.cache_clear()
+
+    sha = git_utils._git_sha()
+
+    assert sha == commit
+    assert any(event == "git_sha_fallback" for event, _ in records)
+    assert any(
+        rec.get("reason") == "subprocess_error"
+        for event, rec in records
+        if event == "git_sha_fallback"
+    )
+
+
+def test_git_sha_fallback_supports_gitdir_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = "2" * 40
+    storage = tmp_path / "git_storage"
+    git_dir = storage / "worktree"
+    git_dir.mkdir(parents=True)
+    _prepare_head(git_dir, commit)
+    (tmp_path / ".git").write_text("gitdir: git_storage/worktree\n", encoding="utf8")
+
+    _configure_failing_git(monkeypatch, tmp_path)
+    records = _capture_logs(monkeypatch)
+    git_utils._git_sha.cache_clear()
+
+    sha = git_utils._git_sha()
+
+    assert sha == commit
+    assert any(event == "git_sha_fallback" for event, _ in records)
+    assert any(
+        rec.get("reason") == "subprocess_error"
+        for event, rec in records
+        if event == "git_sha_fallback"
+    )
+
+
+def test_git_sha_fallback_reads_packed_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = "3" * 40
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    head = git_dir / "HEAD"
+    head.write_text("ref: refs/heads/main\n", encoding="utf8")
+    packed = git_dir / "packed-refs"
+    packed.write_text(f"# comment\n{commit} refs/heads/main\n", encoding="utf8")
+
+    _configure_failing_git(monkeypatch, tmp_path)
+    records = _capture_logs(monkeypatch)
+    git_utils._git_sha.cache_clear()
+
+    sha = git_utils._git_sha()
+
+    assert sha == commit
+    assert any(event == "git_sha_fallback" for event, _ in records)
+    assert any(
+        rec.get("reason") == "subprocess_error"
+        for event, rec in records
+        if event == "git_sha_fallback"
+    )
+
+
+def test_git_sha_fallback_when_git_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = "4" * 40
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    _prepare_head(git_dir, commit)
+    monkeypatch.setattr(git_utils, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(git_utils.shutil, "which", lambda _: None)
+    records = _capture_logs(monkeypatch)
+    git_utils._git_sha.cache_clear()
+
+    sha = git_utils._git_sha()
+
+    assert sha == commit
+    assert any(event == "git_sha_fallback" for event, _ in records)
+    assert any(
+        rec.get("reason") == "missing_executable"
+        for event, rec in records
+        if event == "git_sha_fallback"
+    )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -208,6 +208,7 @@ def test_git_sha_timeout_returns_unknown(
         raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
 
     monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     git_utils._git_sha.cache_clear()
 
     assert git_utils._git_sha() == "UNKNOWN"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -72,6 +72,7 @@ def test_git_sha_missing_git_executable(monkeypatch: pytest.MonkeyPatch) -> None
     """_git_sha returns UNKNOWN and warns when git is absent."""
 
     git_utils._git_sha.cache_clear()
+    monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     monkeypatch.setattr(shutil, "which", lambda _cmd: None)
     messages: list[str] = []
     logger = cast(Any, getattr(git_utils, "logger"))  # noqa: B009
@@ -89,16 +90,7 @@ def test_git_sha_missing_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     """_git_sha returns UNKNOWN and warns when .git directory is missing."""
 
     git_utils._git_sha.cache_clear()
-    repo_root = Path(git_utils.__file__).resolve().parent.parent
-    path_cls = cast(type[Path], getattr(git_utils, "Path"))  # noqa: B009
-    original_exists = path_cls.exists
-
-    def mock_exists(self: Path) -> bool:
-        if self == repo_root / ".git":
-            return False
-        return original_exists(self)
-
-    monkeypatch.setattr(path_cls, "exists", mock_exists)
+    monkeypatch.setattr(git_utils, "_resolve_git_dir", lambda *_: None)
     messages: list[str] = []
     logger = cast(Any, getattr(git_utils, "logger"))  # noqa: B009
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add helpers to resolve the repository .git directory and read HEAD/packed-refs when git rev-parse fails
- fall back to the parsed SHA when the git executable is missing or rev-parse errors, logging git_sha_fallback events
- extend tests to cover the fallback paths, gitdir pointers and packed-refs while adjusting existing expectations

## Testing
- pytest tests/test_git_utils.py -q
- pytest tests/test_io.py::test_git_sha_timeout_returns_unknown -q
- pytest tests/test_metadata.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d3b0ea0c5c8324847e1d3317542c9e