### PR TITLE
Add pipeline stage context to target pipeline CLI logs

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -163,7 +163,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     log_cfg.level = args.log_level
     log_cfg = LoggerConfig(level=log_cfg.level, run_id=log_cfg.run_id)
     logger_inst = configure_logger(log_cfg)
-    logger_inst.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    pipeline_logger = logger_inst.bind(stage="pipeline")
+    pipeline_logger.info("pipeline_start")
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     print_config(cfg)
@@ -185,7 +186,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValidationError as exc:
         parser.error(str(exc))
     exit_code = run(cfg, options)
-    logger_inst.info("pipeline_done", extra={"exit_code": exit_code})
+    pipeline_logger.info("pipeline_done", exit_code=exit_code)
     return exit_code
 
 

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -14,8 +14,27 @@ from scripts import pipeline_targets_main as cli
 
 
 class _DummyLogger:
-    def info(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
-        pass
+    def __init__(
+        self,
+        context: dict[str, Any] | None = None,
+        storage: list[tuple[str, dict[str, Any]]] | None = None,
+    ) -> None:
+        self._context: dict[str, Any] = context or {}
+        self._records: list[tuple[str, dict[str, Any]]] = (
+            storage if storage is not None else []
+        )
+
+    def bind(self, **ctx: Any) -> "_DummyLogger":  # pragma: no cover - trivial
+        merged = {**self._context, **ctx}
+        return _DummyLogger(merged, self._records)
+
+    def info(self, event: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
+        record = {**self._context, **kwargs}
+        self._records.append((event, record))
+
+    @property
+    def records(self) -> list[tuple[str, dict[str, Any]]]:  # pragma: no cover - trivial
+        return list(self._records)
 
 
 def test_cli_forwards_batch_size(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -49,7 +68,8 @@ def test_cli_forwards_batch_size(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         captured["written_df"] = df.copy()
         return Path(path)
 
-    monkeypatch.setattr(cli, "configure_logger", lambda cfg: _DummyLogger())
+    dummy_logger = _DummyLogger()
+    monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
     monkeypatch.setattr(cli, "apply_config_overrides", lambda *a: Config())
     monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
     monkeypatch.setattr(cli, "print_config", lambda cfg: None)
@@ -70,3 +90,8 @@ def test_cli_forwards_batch_size(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert captured["chunks"] == [["CHEMBL1"]]
     assert captured["written_path"] == output_csv
     assert list(captured["written_df"]["target_chembl_id"]) == ["CHEMBL1"]
+    assert any(event == "pipeline_start" and rec.get("stage") == "pipeline" for event, rec in dummy_logger.records)
+    assert any(
+        event == "pipeline_done" and rec.get("stage") == "pipeline" and rec.get("exit_code") == 0
+        for event, rec in dummy_logger.records
+    )


### PR DESCRIPTION
## Summary
- bind the target pipeline CLI logger with the "pipeline" stage before emitting start/done events
- extend the CLI test helper logger to support bind() and record emitted events for validation
- assert that pipeline_start and pipeline_done logs carry the stage context and exit code

## Testing
- pytest tests/test_pipeline_targets_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c22592188324bc5efcbe6c2f67c2