### PR TITLE
Improve git error diagnostics

### DIFF
--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -104,12 +104,38 @@ def _read_head_sha(git_dir: Path) -> str | None:
     return None
 
 
+def _format_subprocess_error(exc: subprocess.CalledProcessError) -> str:
+    """Return a descriptive message for ``exc``."""
+
+    if isinstance(exc.cmd, (list, tuple)):
+        command = " ".join(str(part) for part in exc.cmd)
+    else:
+        command = str(exc.cmd)
+    message = f"{command} exited with status {exc.returncode}"
+    details: list[str] = []
+    if exc.stderr:
+        details.append(exc.stderr.strip())
+    if exc.stdout:
+        details.append(exc.stdout.strip())
+    if details:
+        message = f"{message}: {' | '.join(part for part in details if part)}"
+    return message
+
+
+def _format_error(exc: BaseException) -> str:
+    """Return a normalised textual representation of ``exc``."""
+
+    if isinstance(exc, subprocess.CalledProcessError):
+        return _format_subprocess_error(exc)
+    return str(exc)
+
+
 def _log_fallback(sha: str, *, reason: str, error: BaseException | None = None) -> None:
     """Log a successful SHA fallback resolution."""
 
     payload: dict[str, str] = {"reason": reason}
     if error is not None:
-        payload["error"] = str(error)
+        payload["error"] = _format_error(error)
     logger.info("git_sha_fallback", sha=sha, **payload)
 
 
@@ -151,14 +177,19 @@ def _git_sha() -> str:
         return "UNKNOWN"
 
     try:
-        result = subprocess.check_output(
-            [git_executable, "rev-parse", "HEAD"], cwd=repo_root
+        result = subprocess.run(
+            [git_executable, "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
-        return result.decode().strip()
+        return result.stdout.strip()
     except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
         fallback = _read_head_sha(git_dir)
         if fallback is not None:
             _log_fallback(fallback, reason="subprocess_error", error=exc)
             return fallback
-        logger.warning("git_sha_unavailable", extra={"error": str(exc)})
+        logger.warning("git_sha_unavailable", extra={"error": _format_error(exc)})
         return "UNKNOWN"

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -276,8 +276,12 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
     git_utils._git_sha.cache_clear()
     monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     with patch(
-        "library.git_utils.subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(returncode=1, cmd=["git"]),
+        "library.git_utils.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr="fatal: simulated error",
+        ),
     ):
         records: list[tuple[str, dict[str, str] | None]] = []
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -18,11 +18,15 @@ def _prepare_head(git_dir: Path, commit: str, ref: str = "refs/heads/main") -> N
 
 
 def _configure_failing_git(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
-    def fail(*args: object, **kwargs: object) -> bytes:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    def fail(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr="fatal: simulated error",
+        )
 
     monkeypatch.setattr(git_utils, "_repo_root", lambda: repo_root)
-    monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils.subprocess, "run", fail)
     monkeypatch.setattr(git_utils.shutil, "which", lambda _: "git")
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -204,10 +204,14 @@ def test_git_sha_timeout_returns_unknown(
         configure_logger(LoggerConfig(level="WARNING", stream=stream)),
     )
 
-    def fail(*args: object, **kwargs: object) -> bytes:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    def fail(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr="fatal: simulated error",
+        )
 
-    monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils.subprocess, "run", fail)
     monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     git_utils._git_sha.cache_clear()
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -97,7 +97,7 @@ def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
 
     git_utils._git_sha.cache_clear()
     monkeypatch.setenv("GIT_SHA", "envsha")
-    with patch("library.git_utils.subprocess.check_output") as mock:
+    with patch("library.git_utils.subprocess.run") as mock:
         assert git_utils._git_sha() == "envsha"
         mock.assert_not_called()
 


### PR DESCRIPTION
## Summary
- capture stdout and stderr when resolving the repository commit hash
- normalise subprocess error messages surfaced via git_sha_fallback and git_sha_unavailable
- update git utility tests to patch subprocess.run instead of check_output

## Testing
- pytest tests/test_git_utils.py tests/test_io.py tests/test_csv_utils.py tests/test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c5c1d988832495af4a8f6a67085c