### PR TITLE
Improve git error diagnostics

### DIFF
--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from .log import logger
 
@@ -104,13 +105,97 @@ def _read_head_sha(git_dir: Path) -> str | None:
     return None
 
 
+def _serialise_cmd(cmd: Any) -> list[str] | str:
+    """Return ``cmd`` in a JSON-serialisable form."""
+
+    if isinstance(cmd, (list, tuple)):
+        return [str(part) for part in cmd]
+    return str(cmd)
+
+
+def _ensure_text(value: bytes | str | None) -> str | None:
+    """Return ``value`` decoded to text and stripped of whitespace."""
+
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf8", errors="replace")
+    text = value.strip()
+    return text or None
+
+
+def _normalise_returncode(returncode: int) -> tuple[int, int]:
+    """Return ``returncode`` as ``(signed, raw)`` integers."""
+
+    raw = int(returncode)
+    if raw >= 2**31:
+        signed = raw - 2**32
+    else:
+        signed = raw
+    return signed, raw
+
+
+def _format_subprocess_error(exc: subprocess.CalledProcessError) -> str:
+    """Return a descriptive message for ``exc``."""
+
+    cmd = _serialise_cmd(exc.cmd)
+    if isinstance(cmd, list):
+        command = " ".join(cmd)
+    else:
+        command = cmd
+    signed, raw = _normalise_returncode(exc.returncode)
+    if signed != raw:
+        message = f"{command} exited with status {signed} (raw: {raw})"
+    else:
+        message = f"{command} exited with status {signed}"
+    details: list[str] = []
+    stderr = _ensure_text(exc.stderr)
+    stdout = _ensure_text(exc.stdout)
+    if stderr:
+        details.append(stderr)
+    if stdout:
+        details.append(stdout)
+    if details:
+        message = f"{message}: {' | '.join(details)}"
+    return message
+
+
+def _format_error(exc: BaseException) -> str:
+    """Return a normalised textual representation of ``exc``."""
+
+    if isinstance(exc, subprocess.CalledProcessError):
+        return _format_subprocess_error(exc)
+    return str(exc)
+
+
 def _log_fallback(sha: str, *, reason: str, error: BaseException | None = None) -> None:
     """Log a successful SHA fallback resolution."""
 
-    payload: dict[str, str] = {"reason": reason}
+    payload: dict[str, Any] = {"reason": reason}
     if error is not None:
-        payload["error"] = str(error)
+        payload.update(_error_payload(error))
     logger.info("git_sha_fallback", sha=sha, **payload)
+
+
+def _error_payload(error: BaseException) -> dict[str, Any]:
+    """Return structured payload for ``error`` suitable for logging."""
+
+    if isinstance(error, subprocess.CalledProcessError):
+        signed, raw = _normalise_returncode(error.returncode)
+        payload: dict[str, Any] = {
+            "error": _format_subprocess_error(error),
+            "error_cmd": _serialise_cmd(error.cmd),
+            "error_returncode": signed,
+            "error_returncode_raw": raw,
+        }
+        stderr = _ensure_text(error.stderr)
+        stdout = _ensure_text(error.stdout)
+        if stderr is not None:
+            payload["error_stderr"] = stderr
+        if stdout is not None:
+            payload["error_stdout"] = stdout
+        return payload
+    return {"error": _format_error(error)}
 
 
 @functools.lru_cache(maxsize=1)
@@ -151,14 +236,19 @@ def _git_sha() -> str:
         return "UNKNOWN"
 
     try:
-        result = subprocess.check_output(
-            [git_executable, "rev-parse", "HEAD"], cwd=repo_root
+        result = subprocess.run(
+            [git_executable, "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
-        return result.decode().strip()
+        return result.stdout.strip()
     except (subprocess.CalledProcessError, UnicodeDecodeError, OSError) as exc:
         fallback = _read_head_sha(git_dir)
         if fallback is not None:
             _log_fallback(fallback, reason="subprocess_error", error=exc)
             return fallback
-        logger.warning("git_sha_unavailable", extra={"error": str(exc)})
+        logger.warning("git_sha_unavailable", extra=_error_payload(exc))
         return "UNKNOWN"

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -276,8 +276,12 @@ def test_git_sha_timeout_returns_unknown_and_logs_warning(
     git_utils._git_sha.cache_clear()
     monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     with patch(
-        "library.git_utils.subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(returncode=1, cmd=["git"]),
+        "library.git_utils.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr="fatal: simulated error",
+        ),
     ):
         records: list[tuple[str, dict[str, str] | None]] = []
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -17,12 +18,24 @@ def _prepare_head(git_dir: Path, commit: str, ref: str = "refs/heads/main") -> N
     ref_path.write_text(f"{commit}\n", encoding="utf8")
 
 
-def _configure_failing_git(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
-    def fail(*args: object, **kwargs: object) -> bytes:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+def _configure_failing_git(
+    monkeypatch: pytest.MonkeyPatch,
+    repo_root: Path,
+    *,
+    returncode: int = 1,
+    stderr: str = "fatal: simulated error",
+    stdout: str | None = None,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=returncode,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr=stderr,
+            output=stdout,
+        )
 
     monkeypatch.setattr(git_utils, "_repo_root", lambda: repo_root)
-    monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils.subprocess, "run", fail)
     monkeypatch.setattr(git_utils.shutil, "which", lambda _: "git")
 
 
@@ -35,6 +48,29 @@ def _capture_logs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, 
     monkeypatch.setattr(git_utils.logger, "info", info)
     monkeypatch.setattr(git_utils.logger, "warning", lambda *a, **k: None)
     return records
+
+
+def _assert_subprocess_payload(
+    records: list[tuple[str, dict[str, object]]],
+    *,
+    expected_returncode: int,
+    expected_returncode_raw: int | None = None,
+    expected_stderr: str | None = "fatal: simulated error",
+) -> None:
+    payloads: list[dict[str, Any]] = [
+        rec for event, rec in records if event == "git_sha_fallback"
+    ]
+    assert payloads
+    raw = expected_returncode if expected_returncode_raw is None else expected_returncode_raw
+    for payload in payloads:
+        assert payload.get("error")
+        assert payload.get("error_returncode") == expected_returncode
+        assert payload.get("error_returncode_raw") == raw
+        assert payload.get("error_cmd") == ["git", "rev-parse", "HEAD"]
+        if expected_stderr is None:
+            assert "error_stderr" not in payload
+        else:
+            assert payload.get("error_stderr") == expected_stderr
 
 
 def test_git_sha_fallback_reads_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -55,6 +91,7 @@ def test_git_sha_fallback_reads_head(tmp_path: Path, monkeypatch: pytest.MonkeyP
         for event, rec in records
         if event == "git_sha_fallback"
     )
+    _assert_subprocess_payload(records, expected_returncode=1)
 
 
 def test_git_sha_fallback_supports_gitdir_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,6 +115,7 @@ def test_git_sha_fallback_supports_gitdir_file(tmp_path: Path, monkeypatch: pyte
         for event, rec in records
         if event == "git_sha_fallback"
     )
+    _assert_subprocess_payload(records, expected_returncode=1)
 
 
 def test_git_sha_fallback_reads_packed_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -101,6 +139,31 @@ def test_git_sha_fallback_reads_packed_refs(tmp_path: Path, monkeypatch: pytest.
         rec.get("reason") == "subprocess_error"
         for event, rec in records
         if event == "git_sha_fallback"
+    )
+    _assert_subprocess_payload(records, expected_returncode=1)
+
+
+def test_git_sha_fallback_normalises_large_returncode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commit = "5" * 40
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    _prepare_head(git_dir, commit)
+
+    raw_code = 0xFFFFFFFF
+    _configure_failing_git(monkeypatch, tmp_path, returncode=raw_code)
+    records = _capture_logs(monkeypatch)
+    git_utils._git_sha.cache_clear()
+
+    sha = git_utils._git_sha()
+
+    assert sha == commit
+    assert any(event == "git_sha_fallback" for event, _ in records)
+    _assert_subprocess_payload(
+        records,
+        expected_returncode=-1,
+        expected_returncode_raw=raw_code,
     )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -204,10 +204,14 @@ def test_git_sha_timeout_returns_unknown(
         configure_logger(LoggerConfig(level="WARNING", stream=stream)),
     )
 
-    def fail(*args: object, **kwargs: object) -> bytes:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    def fail(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "rev-parse", "HEAD"],
+            stderr="fatal: simulated error",
+        )
 
-    monkeypatch.setattr(git_utils.subprocess, "check_output", fail)
+    monkeypatch.setattr(git_utils.subprocess, "run", fail)
     monkeypatch.setattr(git_utils, "_read_head_sha", lambda *_: None)
     git_utils._git_sha.cache_clear()
 
@@ -215,3 +219,7 @@ def test_git_sha_timeout_returns_unknown(
     record = json.loads(stream.getvalue().splitlines()[0])
     assert record["event"] == "git_sha_unavailable"
     assert "error" in record
+    assert record["error_returncode"] == 1
+    assert record["error_returncode_raw"] == 1
+    assert record["error_cmd"] == ["git", "rev-parse", "HEAD"]
+    assert record["error_stderr"] == "fatal: simulated error"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -97,7 +97,7 @@ def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
 
     git_utils._git_sha.cache_clear()
     monkeypatch.setenv("GIT_SHA", "envsha")
-    with patch("library.git_utils.subprocess.check_output") as mock:
+    with patch("library.git_utils.subprocess.run") as mock:
         assert git_utils._git_sha() == "envsha"
         mock.assert_not_called()
 


### PR DESCRIPTION
## Summary
- capture stdout and stderr when resolving the repository commit hash
- normalise subprocess error messages surfaced via git_sha_fallback and git_sha_unavailable
- log git fallbacks with structured payloads (command, normalised return codes, stdout/stderr) for better diagnostics
- extend git utility and IO tests to assert structured payloads and cover Windows-style return codes

## Testing
- pytest tests/test_git_utils.py tests/test_io.py tests/test_csv_utils.py tests/test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c5c1d988832495af4a8f6a67085c