### PR TITLE
Restore DataFrame defaults for schema validators

### DIFF
--- a/library/activity_extraction.py
+++ b/library/activity_extraction.py
@@ -24,6 +24,7 @@ from library.config import Config, IoCfg, _serialize_paths
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from library.validation import validate_activities
 from schemas import ActivitiesSchema, normalize_activities
 
 LOG: Final = logging.getLogger(__name__)
@@ -166,16 +167,30 @@ def extract_activities(
         LOG.warning("Skipping validation; missing columns: %s", sorted(missing_required))
     else:
         try:
-            df = ActivitiesSchema.validate(df, lazy=True)
+            validation_result = validate_activities(df, return_result=True)
         except SchemaErrors as exc:
             sidecar = SidecarErrors()
             for row in exc.failure_cases.to_dict("records"):
                 sidecar.add_error(row)
-            failure = Path(output_path).with_name(f"{Path(output_path).stem}_failure_cases.csv")
+            failure = Path(output_path).with_name(
+                f"{Path(output_path).stem}_failure_cases.csv"
+            )
             sidecar.save(failure, cfg=cfg)
             LOG.error("validation failed; see %s", failure)
             df = getattr(exc, "validated_data", df)
             exit_code = 1
+        else:
+            df = validation_result.data
+            if not validation_result.failure_cases.empty:
+                sidecar = SidecarErrors()
+                for row in validation_result.failure_cases.to_dict("records"):
+                    sidecar.add_error(row)
+                failure = Path(output_path).with_name(
+                    f"{Path(output_path).stem}_failure_cases.csv"
+                )
+                sidecar.save(failure, cfg=cfg)
+                LOG.error("validation failed; see %s", failure)
+                exit_code = 1
 
     schema_cols = list(ActivitiesSchema.columns)
     head = [c for c in schema_cols if c in df.columns]

--- a/library/validation.py
+++ b/library/validation.py
@@ -3,10 +3,126 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
 
 import pandas as pd
+from pandera.errors import SchemaErrors
 
 from .log import logger
+
+__all__ = [
+    "ValidationResult",
+    "validate_columns",
+    "validate_activities",
+    "validate_assays",
+    "validate_testitems",
+]
+
+_FAILURE_COLUMNS = [
+    "schema_context",
+    "column",
+    "check",
+    "check_number",
+    "failure_case",
+    "index",
+]
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    """Outcome of applying a pandera schema to a dataframe."""
+
+    data: pd.DataFrame
+    failure_cases: pd.DataFrame
+    schema_name: str
+
+    @property
+    def has_failures(self) -> bool:
+        """Return ``True`` when validation detected failing rows."""
+
+        return not self.failure_cases.empty
+
+
+def _empty_failure_cases() -> pd.DataFrame:
+    """Return an empty dataframe matching pandera failure case layout."""
+
+    return pd.DataFrame(columns=_FAILURE_COLUMNS)
+
+
+def _unique_indices(values: pd.Series) -> list[Any]:
+    """Return cleaned list of failing indices from ``values``."""
+
+    if values.empty:
+        return []
+    cleaned: list[Any] = []
+    for value in pd.unique(values.dropna()):
+        if isinstance(value, float) and value.is_integer():
+            cleaned.append(int(value))
+        else:
+            cleaned.append(value)
+    return cleaned
+
+
+def _combine_failure_cases(cases: list[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate collected failure case frames preserving columns."""
+
+    if not cases:
+        return _empty_failure_cases()
+    return pd.concat(cases, ignore_index=True, sort=False).reindex(
+        columns=_FAILURE_COLUMNS, fill_value=pd.NA
+    )
+
+
+def _validate_with_schema(
+    df: pd.DataFrame,
+    *,
+    schema,
+    schema_name: str,
+    return_result: bool,
+) -> ValidationResult | pd.DataFrame:
+    """Apply ``schema`` to ``df`` dropping failing rows when possible."""
+
+    logger.info(
+        "schema_validate_start",
+        extra={"schema": schema_name, "rows": len(df)},
+    )
+    current = df
+    collected: list[pd.DataFrame] = []
+    while True:
+        try:
+            validated = schema.validate(current, lazy=True)
+        except SchemaErrors as exc:
+            failure_cases = exc.failure_cases.copy()
+            indices = _unique_indices(
+                failure_cases["index"] if "index" in failure_cases else pd.Series(dtype=object)
+            )
+            if not indices:
+                logger.info(
+                    "schema_validate_error",
+                    extra={
+                        "schema": schema_name,
+                        "rows": len(current),
+                        "failures": len(failure_cases),
+                    },
+                )
+                raise
+            collected.append(failure_cases)
+            current = current.drop(index=indices, errors="ignore")
+            continue
+        collected_cases = _combine_failure_cases(collected)
+        dropped = len(df) - len(validated)
+        logger.info(
+            "schema_validate_done",
+            extra={
+                "schema": schema_name,
+                "rows": len(validated),
+                "dropped": dropped,
+                "failures": len(collected_cases),
+            },
+        )
+        result = ValidationResult(validated, collected_cases, schema_name)
+        return result if return_result else result.data
 
 
 def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
@@ -35,3 +151,48 @@ def validate_columns(df: pd.DataFrame, required: Iterable[str]) -> None:
         )
         raise ValueError(f"missing columns: {', '.join(missing)}")
     logger.info("validate_done", extra={"stage": "validate_done", "columns": columns})
+
+
+def validate_activities(
+    df: pd.DataFrame, *, return_result: bool = False
+) -> ValidationResult | pd.DataFrame:
+    """Validate activities dataframe using :data:`schemas.ActivitiesSchema`."""
+
+    from schemas import ActivitiesSchema
+
+    return _validate_with_schema(
+        df,
+        schema=ActivitiesSchema,
+        schema_name="ActivitiesSchema",
+        return_result=return_result,
+    )
+
+
+def validate_assays(
+    df: pd.DataFrame, *, return_result: bool = False
+) -> ValidationResult | pd.DataFrame:
+    """Validate assay dataframe using :data:`schemas.AssaysSchema`."""
+
+    from schemas import AssaysSchema
+
+    return _validate_with_schema(
+        df,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        return_result=return_result,
+    )
+
+
+def validate_testitems(
+    df: pd.DataFrame, *, return_result: bool = False
+) -> ValidationResult | pd.DataFrame:
+    """Validate test item dataframe using :data:`schemas.TestitemsSchema`."""
+
+    from schemas import TestitemsSchema
+
+    return _validate_with_schema(
+        df,
+        schema=TestitemsSchema,
+        schema_name="TestitemsSchema",
+        return_result=return_result,
+    )

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -38,6 +38,7 @@ from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from library.validation import validate_activities
 from schemas import ActivitiesSchema, normalize_activities
 
 
@@ -126,9 +127,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     "DataFrame is missing optional columns: %s", missing_optional
                 )
             try:
-                df = ActivitiesSchema.validate(df, lazy=True)
+                validation_result = validate_activities(df, return_result=True)
             except SchemaErrors as exc:
-                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
                 errors = SidecarErrors()
                 for row in exc.failure_cases.to_dict("records"):
                     errors.add_error(row)
@@ -140,6 +141,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 df = getattr(exc, "validated_data", df)
                 exit_code = 1
+            else:
+                df = validation_result.data
+                if not validation_result.failure_cases.empty:
+                    failure_path = Path(output).with_name(
+                        f"{Path(output).stem}_failure_cases.csv"
+                    )
+                    errors = SidecarErrors()
+                    for row in validation_result.failure_cases.to_dict("records"):
+                        errors.add_error(row)
+                    errors.save(failure_path)
+                    logger.error(
+                        "validation failed; wrote %d failure cases to %s",
+                        len(validation_result.failure_cases),
+                        failure_path,
+                    )
+                    exit_code = 1
         else:
             logger.warning(
                 "Skipping validation due to missing required columns: %s",

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -37,6 +37,7 @@ from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from library.validation import validate_assays
 from schemas import AssaysSchema, normalize_assays
 
 __all__ = ["ap", "main"]
@@ -111,9 +112,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     "DataFrame is missing optional columns: %s", missing_optional
                 )
             try:
-                df = AssaysSchema.validate(df, lazy=True)
+                validation_result = validate_assays(df, return_result=True)
             except SchemaErrors as exc:
-                failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+                failure_path = Path(output).with_name(
+                    f"{Path(output).stem}_failure_cases.csv"
+                )
                 errors = SidecarErrors()
                 for row in exc.failure_cases.to_dict("records"):
                     errors.add_error(row)
@@ -125,6 +128,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 df = getattr(exc, "validated_data", df)
                 exit_code = 1
+            else:
+                df = validation_result.data
+                if not validation_result.failure_cases.empty:
+                    failure_path = Path(output).with_name(
+                        f"{Path(output).stem}_failure_cases.csv"
+                    )
+                    errors = SidecarErrors()
+                    for row in validation_result.failure_cases.to_dict("records"):
+                        errors.add_error(row)
+                    errors.save(failure_path)
+                    logger.error(
+                        "validation failed; wrote %d failure cases to %s",
+                        len(validation_result.failure_cases),
+                        failure_path,
+                    )
+                    exit_code = 1
         else:
             logger.warning(
                 "Skipping validation due to missing required columns: %s",

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -41,6 +41,7 @@ from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
+from library.validation import validate_testitems
 from schemas import TestitemsSchema, normalize_testitems
 
 
@@ -199,9 +200,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 "DataFrame is missing optional columns: %s", missing_optional
             )
         try:
-            df = TestitemsSchema.validate(df, lazy=True)
+            validation_result = validate_testitems(df, return_result=True)
         except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+            failure_path = Path(output).with_name(
+                f"{Path(output).stem}_failure_cases.csv"
+            )
             errors = SidecarErrors()
             for row in exc.failure_cases.to_dict("records"):
                 errors.add_error(row)
@@ -213,6 +216,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             df = getattr(exc, "validated_data", df)
             exit_code = 1
+        else:
+            df = validation_result.data
+            if not validation_result.failure_cases.empty:
+                failure_path = Path(output).with_name(
+                    f"{Path(output).stem}_failure_cases.csv"
+                )
+                errors = SidecarErrors()
+                for row in validation_result.failure_cases.to_dict("records"):
+                    errors.add_error(row)
+                errors.save(failure_path)
+                logger.error(
+                    "validation failed; wrote %d failure cases to %s",
+                    len(validation_result.failure_cases),
+                    failure_path,
+                )
+                exit_code = 1
     else:
         logger.warning(
             "Skipping validation due to missing required columns: %s",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,3 +17,95 @@ def test_validate_columns_missing() -> None:
     df = pd.DataFrame({"a": [1]})
     with pytest.raises(ValueError):
         validation.validate_columns(df, ["a", "b"])
+
+
+def _activities_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "activity_id": ["1", "2"],
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "assay_chembl_id": ["ASSAY1", "ASSAY2"],
+            "standard_value": [1.0, -1.0],
+            "standard_type": ["IC50", "IC50"],
+        }
+    )
+
+
+def test_validate_activities_returns_dataframe() -> None:
+    df = _activities_frame()
+
+    result = validation.validate_activities(df)
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.index.tolist() == [0]
+    assert result["standard_value"].tolist() == [1.0]
+    assert df.index.tolist() == [0, 1]
+
+
+def test_validate_activities_result_object() -> None:
+    df = _activities_frame()
+
+    result = validation.validate_activities(df, return_result=True)
+
+    assert isinstance(result, validation.ValidationResult)
+    assert result.has_failures is True
+    assert result.failure_cases["index"].dropna().tolist() == [1]
+    assert result.data.index.tolist() == [0]
+
+
+def test_validate_assays_filters_invalid_rows() -> None:
+    df = pd.DataFrame(
+        {
+            "assay_chembl_id": ["A1", 2],
+            "document_chembl_id": ["D1", 3],
+            "target_chembl_id": ["T1", "T2"],
+        }
+    )
+
+    filtered = validation.validate_assays(df)
+
+    assert isinstance(filtered, pd.DataFrame)
+    assert filtered.index.tolist() == [0]
+
+    result = validation.validate_assays(df, return_result=True)
+
+    assert isinstance(result, validation.ValidationResult)
+    assert result.has_failures is True
+    assert result.data.index.tolist() == [0]
+    assert sorted(set(result.failure_cases["index"].dropna())) == [1]
+
+
+def test_validate_testitems_filters_invalid_rows() -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", 2],
+            "pref_name": ["Name", "Other"],
+        }
+    )
+
+    filtered = validation.validate_testitems(df)
+
+    assert isinstance(filtered, pd.DataFrame)
+    assert filtered.index.tolist() == [0]
+
+    result = validation.validate_testitems(df, return_result=True)
+
+    assert isinstance(result, validation.ValidationResult)
+    assert result.has_failures is True
+    assert result.data.index.tolist() == [0]
+    assert sorted(set(result.failure_cases["index"].dropna())) == [1]
+
+
+def test_validate_testitems_all_valid() -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1"],
+            "pref_name": ["Name"],
+        }
+    )
+
+    result = validation.validate_testitems(df, return_result=True)
+
+    assert isinstance(result, validation.ValidationResult)
+    assert result.has_failures is False
+    pd.testing.assert_frame_equal(result.data.reset_index(drop=True), df)


### PR DESCRIPTION
## Summary
- add ValidationResult wrapper and schema-specific helpers that drop failing rows while optionally returning failure metadata
- update activity, assay and testitem pipelines to use the new helpers and keep emitting failure sidecars when needed
- expand validation tests to cover both DataFrame and ValidationResult modes for all relevant schemas

## Testing
- python -m pytest tests/test_validation.py
- python -m pytest tests/test_activity_extraction.py tests/test_get_activity_data.py tests/test_get_assay_data.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d698ad4c8324ad0401e796b38386