### PR TITLE
Capture DOI from PubMed data block

### DIFF
--- a/library/pubmed/parsing.py
+++ b/library/pubmed/parsing.py
@@ -38,6 +38,55 @@ def find_all(node: ET.Element | None, xpath: str) -> list[ET.Element]:
     return node.findall(xpath) if node is not None else []
 
 
+def _clean_doi(raw: str | None) -> str | None:
+    """Normalise DOI strings by stripping known prefixes."""
+
+    if not raw:
+        return None
+
+    doi = raw.strip()
+    lower = doi.lower()
+    if lower.startswith("doi:"):
+        doi = doi[4:].strip()
+        lower = doi.lower()
+
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi.org/"):
+        if lower.startswith(prefix):
+            doi = doi[len(prefix) :].strip()
+            break
+        lower = doi.lower()
+
+    return doi or None
+
+
+def _extract_doi(
+    article: ET.Element | None, pubmed_data: ET.Element | None
+) -> str | None:
+    """Extract DOI from ``Article`` or ``PubmedData`` blocks."""
+
+    candidates: list[str] = []
+
+    if article is not None:
+        for node in find_all(article, "./ArticleIdList/ArticleId"):
+            if node.get("IdType") == "doi" and node.text:
+                candidates.append(node.text)
+        for node in find_all(article, "./ELocationID"):
+            if node.get("EIdType") == "doi" and node.text:
+                candidates.append(node.text)
+
+    if pubmed_data is not None:
+        for node in find_all(pubmed_data, "./ArticleIdList/ArticleId"):
+            if node.get("IdType") == "doi" and node.text:
+                candidates.append(node.text)
+
+    for candidate in candidates:
+        doi = _clean_doi(candidate)
+        if doi:
+            return doi
+
+    return None
+
+
 def parse_pubmed_article(art: ET.Element) -> dict[str, Any]:
     """Parse ``PubMedArticle`` into a dictionary of selected fields."""
     mc = find_one(art, "./MedlineCitation")
@@ -45,29 +94,12 @@ def parse_pubmed_article(art: ET.Element) -> dict[str, Any]:
     journal = find_one(article, "./Journal") if article is not None else None
     journal_issue = find_one(journal, "./JournalIssue") if journal is not None else None
     pagination = find_one(article, "./Pagination") if article is not None else None
+    pubmed_data = find_one(art, "./PubmedData")
 
     pmid = text_or_none(find_one(mc, "./PMID")) if mc is not None else None
 
-    # DOI: prefer ArticleIdList[@IdType='doi'], fallback to ELocationID[@EIdType='doi']
-    doi = None
-    if article is not None:
-        for a in find_all(article, "./ArticleIdList/ArticleId"):
-            if a.get("IdType") == "doi" and a.text:
-                doi = a.text.strip()
-                break
-        if not doi:
-            for el in find_all(article, "./ELocationID"):
-                if el.get("EIdType") == "doi" and el.text:
-                    doi = el.text.strip()
-                    break
-        if doi:
-            lower = doi.lower()
-            if lower.startswith("doi:"):
-                doi = doi[4:].strip()
-            for pref in ("https://doi.org/", "http://doi.org/", "doi.org/"):
-                if doi.lower().startswith(pref):
-                    doi = doi[len(pref) :].strip()
-                    break
+    # DOI: prefer Article block, fallback to PubmedData block
+    doi = _extract_doi(article, pubmed_data)
 
     article_title = (
         text_or_none(find_one(article, "./ArticleTitle"))

--- a/tests/test_pubmed_parsing.py
+++ b/tests/test_pubmed_parsing.py
@@ -60,3 +60,24 @@ def test_parse_pubmed_article() -> None:
     assert rec["PubMed.Issue"] == "2"
     assert rec["PubMed.StartPage"] == "10"
     assert rec["PubMed.EndPage"] == "12"
+
+
+def test_parse_pubmed_article_uses_pubmed_data_doi() -> None:
+    xml = """
+    <PubmedArticle>
+      <MedlineCitation>
+        <PMID>999</PMID>
+        <Article>
+          <ArticleTitle>Another</ArticleTitle>
+        </Article>
+      </MedlineCitation>
+      <PubmedData>
+        <ArticleIdList>
+          <ArticleId IdType="doi">https://doi.org/10.1000/example</ArticleId>
+        </ArticleIdList>
+      </PubmedData>
+    </PubmedArticle>
+    """
+    art = ET.fromstring(xml)
+    rec = pp.parse_pubmed_article(art)
+    assert rec["PubMed.DOI"] == "10.1000/example"


### PR DESCRIPTION
## Summary
- normalise DOI strings through a dedicated helper
- fall back to `<PubmedData>/<ArticleIdList>` when `<Article>` does not expose a DOI
- cover the new extraction path with a focused parsing test

## Testing
- pytest tests/test_pubmed_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d6d2a8388324bcd91765682f7f55