### PR TITLE
Use ChEMBL DOIs for CrossRef fallback queries

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -33,7 +33,7 @@ if __package__ is None:  # running as a script
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import argparse
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from itertools import islice
 from typing import cast
@@ -93,6 +93,7 @@ def fetch_pubmed_records(
     crossref_cfg: CrossRefCfg | None = None,
     max_workers: int | None = None,
     batch_size: int | None = None,
+    fallback_doi_map: Mapping[str, str] | None = None,
 ) -> pd.DataFrame:
     """Retrieve metadata for a sequence of PubMed identifiers.
 
@@ -278,7 +279,15 @@ def fetch_pubmed_records(
                     openalex = ocl.fetch_openalex(
                         session, pmid, openalex_cfg, openalex_limiter
                     )
-                    doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
+                    fallback_doi = ""
+                    if fallback_doi_map:
+                        fallback_doi = fallback_doi_map.get(pmid, "")
+                    doi = (
+                        pubmed.get("PubMed.DOI")
+                        or semsch.get("scholar.DOI")
+                        or fallback_doi
+                        or ""
+                    )
                     crossref = ocl.fetch_crossref(
                         session, doi, crossref_cfg, crossref_limiter
                     )
@@ -633,6 +642,15 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
     pubmed_ids = pd.to_numeric(doc_df["pubmed_id"], errors="coerce").astype("Int64")
+    doi_fallback_map: dict[str, str] = {}
+    if "doi" in doc_df.columns:
+        doi_series = doc_df["doi"].astype("string")
+        mask = pubmed_ids.notna() & doi_series.notna() & (doi_series != "")
+        if mask.any():
+            doi_fallback_map = {
+                str(pmid): str(doi)
+                for pmid, doi in zip(pubmed_ids[mask], doi_series[mask])
+            }
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
@@ -643,6 +661,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         cfg.crossref,
         cfg.document.all.workers,
         cfg.document.all.batch_size,
+        fallback_doi_map=doi_fallback_map or None,
     )
     doc_df["pubmed_id"] = pubmed_ids.astype("Int64").astype("string").fillna("")
     merged = merge_with_chembl(doc_df, pub_df)

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -184,6 +184,7 @@ def test_run_pubmed_uses_keyword_arguments(
         crossref_cfg: CrossRefCfg,
         max_workers: int,
         batch_size: int,
+        fallback_doi_map: dict[str, str] | None = None,
     ) -> pd.DataFrame:
         captured["pmids"] = list(pmids)
         captured["cfg"] = cfg_param
@@ -193,6 +194,7 @@ def test_run_pubmed_uses_keyword_arguments(
         captured["crossref_cfg"] = crossref_cfg
         captured["max_workers"] = max_workers
         captured["batch_size"] = batch_size
+        captured["fallback_doi_map"] = fallback_doi_map
         return pd.DataFrame({"PMID": ["1", "2"]})
 
     monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
@@ -219,6 +221,7 @@ def test_run_pubmed_uses_keyword_arguments(
     assert captured["crossref_cfg"] is cfg.crossref
     assert captured["max_workers"] == cfg.document.pubmed.workers
     assert captured["batch_size"] == cfg.document.pubmed.batch_size
+    assert captured["fallback_doi_map"] is None
 
 
 def test_write_csv_column_order(
@@ -388,6 +391,71 @@ def test_fetch_pubmed_records_accepts_config(
     assert df.loc[0, "PubMed.PMID"] == "1"
 
 
+def test_fetch_pubmed_records_uses_fallback_doi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CrossRef queries should fall back to supplied DOI mapping when needed."""
+
+    fallback = {"123": "10.9999/fallback"}
+
+    class DummySession:
+        def __enter__(self) -> "DummySession":  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd.requests, "Session", lambda: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any, batch: list[str], sleep: float
+    ) -> list[dict[str, str]]:
+        assert batch == ["123"]
+        return [{"PubMed.PMID": "123"}]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        assert pmids == ["123"]
+        return [{"scholar.PMID": "123"}]
+
+    def fake_openalex(
+        session: Any, pmid: str, cfg_arg: Any, limiter: Any
+    ) -> dict[str, str]:
+        assert pmid == "123"
+        return {}
+
+    captured: dict[str, str] = {}
+
+    def fake_crossref(
+        session: Any, doi: str, cfg_arg: Any, limiter: Any
+    ) -> dict[str, str]:
+        captured["doi"] = doi
+        return {"crossref.DOI": doi}
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_openalex)
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    df = gdd.fetch_pubmed_records(
+        ["123"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+        fallback_doi_map=fallback,
+    )
+
+    assert captured["doi"] == fallback["123"]
+    assert df.loc[0, "crossref.DOI"] == fallback["123"]
+
 
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])
 def test_fetch_pubmed_records_accepts_executor_context(
@@ -487,4 +555,3 @@ def test_fetch_pubmed_records_accepts_executor_context(
     )
 
     assert sorted(df["PubMed.PMID"].tolist()) == pmids
-


### PR DESCRIPTION
## Summary
- add an optional fallback DOI map to the PubMed fetcher so CrossRef requests still resolve when other sources lack a DOI
- pass ChEMBL DOIs into the fallback map during the combined pipeline to populate CrossRef metadata for more documents
- extend the test suite to cover the new fallback behaviour and updated function signature

## Testing
- pytest tests/test_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d71e67dc8324b00f0c13ee8f4bf8