### PR TITLE
Run ruff format and restore mypy in CI

### DIFF
--- a/library/activity_extraction.py
+++ b/library/activity_extraction.py
@@ -163,7 +163,9 @@ def extract_activities(
     missing_required = required - set(df.columns)
     exit_code = 0
     if missing_required:
-        LOG.warning("Skipping validation; missing columns: %s", sorted(missing_required))
+        LOG.warning(
+            "Skipping validation; missing columns: %s", sorted(missing_required)
+        )
     else:
         try:
             df = ActivitiesSchema.validate(df, lazy=True)
@@ -171,7 +173,9 @@ def extract_activities(
             sidecar = SidecarErrors()
             for row in exc.failure_cases.to_dict("records"):
                 sidecar.add_error(row)
-            failure = Path(output_path).with_name(f"{Path(output_path).stem}_failure_cases.csv")
+            failure = Path(output_path).with_name(
+                f"{Path(output_path).stem}_failure_cases.csv"
+            )
             sidecar.save(failure, cfg=cfg)
             LOG.error("validation failed; see %s", failure)
             df = getattr(exc, "validated_data", df)

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -129,7 +129,7 @@ class ChemblClient:
                 logger.info(
                     "cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"}
                 )
-                return cached
+                return cast(dict[str, Any], cached)
             logger.info(
                 "cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"}
             )
@@ -163,7 +163,7 @@ class ChemblClient:
                     with self._cache_lock:
                         cached = self.cache.get(cache_key)
                         if cached is not None:
-                            return cached
+                            return cast(dict[str, Any], cached)
                         self.cache[cache_key] = data
                         logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
                         return data

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -170,9 +170,9 @@ def build_parser(
     return parser, log_cfg
 
 
-def build_root_parser() -> (
-    tuple[argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig]
-):
+def build_root_parser() -> tuple[
+    argparse.ArgumentParser, argparse.ArgumentParser, LoggerConfig
+]:
     """Return parsers containing root-level options and logging config.
 
     Two parsers are produced:

--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -10,11 +10,10 @@ sub-commands.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
-
-import json
 
 import pandas as pd
 
@@ -101,12 +100,19 @@ DOCUMENT_SCHEMA_COLUMNS: list[str] = (
     + SEMANTIC_SCHOLAR_COLUMNS
     + OPENALEX_COLUMNS
     + CROSSREF_COLUMNS
-    + ["date_code", "Index", "PubMed.is_review", "scholar.is_review", "OpenAlex.is_review"]
+    + [
+        "date_code",
+        "Index",
+        "PubMed.is_review",
+        "scholar.is_review",
+        "OpenAlex.is_review",
+    ]
 )
 
 
 # ---------------------------------------------------------------------------
 # Normalisation helpers
+
 
 def normalise_doi(value: Any) -> str:
     """Return a canonical DOI string or ``""`` if ``value`` is falsy."""
@@ -138,9 +144,13 @@ def _collect_terms(record: Mapping[str, Any]) -> list[str]:
     ):
         value = record.get(key)
         terms.extend(parse_terms(value))
-    seen = set()
-    unique = [t for t in terms if not (t in seen or seen.add(t))]
-    return sorted(unique)
+    seen: set[str] = set()
+    unique_terms: list[str] = []
+    for term in terms:
+        if term not in seen:
+            seen.add(term)
+            unique_terms.append(term)
+    return sorted(unique_terms)
 
 
 def merge_metadata(*records: Mapping[str, Any]) -> dict[str, Any]:
@@ -184,6 +194,7 @@ def merge_metadata(*records: Mapping[str, Any]) -> dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 # DataFrame utilities
+
 
 def build_dataframe(
     data: Sequence[Mapping[str, Any]] | pd.DataFrame,
@@ -270,6 +281,7 @@ def dataframe_to_strings(
 # ---------------------------------------------------------------------------
 # Quality reporting
 
+
 def build_quality_report(df: pd.DataFrame) -> dict[str, Any]:
     """Return a JSON serialisable quality summary for ``df``."""
 
@@ -281,7 +293,11 @@ def build_quality_report(df: pd.DataFrame) -> dict[str, Any]:
         mask = series.astype(str).str.strip().astype(bool)
         return float(mask.mean())
 
-    doi_series = df["doi"] if "doi" in df.columns else df.get("doi_normalised", pd.Series(dtype=str))
+    doi_series = (
+        df["doi"]
+        if "doi" in df.columns
+        else df.get("doi_normalised", pd.Series(dtype=str))
+    )
     class_counts = (
         df.get("publication_class", pd.Series(dtype=str))
         .fillna("unknown")
@@ -353,4 +369,3 @@ __all__ = [
     "build_quality_report",
     "save_quality_report",
 ]
-

--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -104,10 +104,11 @@ def _read_head_sha(git_dir: Path) -> str | None:
         return head_content
     return None
 
+
 def _serialise_cmd(cmd: Any) -> list[str] | str:
     """Return ``cmd`` in a JSON-serialisable form."""
 
-    if isinstance(cmd, (list, tuple)):
+    if isinstance(cmd, list | tuple):
         return [str(part) for part in cmd]
     return str(cmd)
 
@@ -138,40 +139,19 @@ def _format_subprocess_error(exc: subprocess.CalledProcessError) -> str:
     """Return a descriptive message for ``exc``."""
 
     cmd = _serialise_cmd(exc.cmd)
-    if isinstance(cmd, list):
-        command = " ".join(cmd)
-    else:
-        command = cmd
+    command = " ".join(cmd) if isinstance(cmd, list) else cmd
     signed, raw = _normalise_returncode(exc.returncode)
-    if signed != raw:
-        message = f"{command} exited with status {signed} (raw: {raw})"
-    else:
-        message = f"{command} exited with status {signed}"
+    status = f"{signed} (raw: {raw})" if signed != raw else str(signed)
+    message = f"{command} exited with status {status}"
     details: list[str] = []
     stderr = _ensure_text(exc.stderr)
-    stdout = _ensure_text(exc.stdout)
     if stderr:
         details.append(stderr)
+    stdout = _ensure_text(exc.stdout)
     if stdout:
         details.append(stdout)
     if details:
         message = f"{message}: {' | '.join(details)}"
-
-def _format_subprocess_error(exc: subprocess.CalledProcessError) -> str:
-    """Return a descriptive message for ``exc``."""
-
-    if isinstance(exc.cmd, (list, tuple)):
-        command = " ".join(str(part) for part in exc.cmd)
-    else:
-        command = str(exc.cmd)
-    message = f"{command} exited with status {exc.returncode}"
-    details: list[str] = []
-    if exc.stderr:
-        details.append(exc.stderr.strip())
-    if exc.stdout:
-        details.append(exc.stdout.strip())
-    if details:
-        message = f"{message}: {' | '.join(part for part in details if part)}"
     return message
 
 
@@ -188,9 +168,8 @@ def _log_fallback(sha: str, *, reason: str, error: BaseException | None = None) 
 
     payload: dict[str, Any] = {"reason": reason}
     if error is not None:
-
         payload.update(_error_payload(error))
-        
+
     logger.info("git_sha_fallback", sha=sha, **payload)
 
 
@@ -257,8 +236,7 @@ def _git_sha() -> str:
             [git_executable, "rev-parse", "HEAD"],
             cwd=repo_root,
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         return result.stdout.strip()
@@ -269,5 +247,4 @@ def _git_sha() -> str:
             return fallback
         logger.warning("git_sha_unavailable", extra=_error_payload(exc))
 
- 
         return "UNKNOWN"

--- a/library/pipeline_targets.py
+++ b/library/pipeline_targets.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-
 from inspect import Parameter, Signature, signature
-
-from typing import Any, Sequence
+from typing import Any
 
 import pandas as pd
 
@@ -50,14 +48,12 @@ def _filter_optional_kwargs(
     return filtered, dropped
 
 
-
 def _call_fetcher(
     fetcher: OptionalFetcher,
     /,
     *args: Any,
     **kwargs: Any,
 ) -> pd.DataFrame:
-
     """Invoke ``fetcher`` handling optional keywords gracefully."""
 
     filtered_kwargs, dropped = _filter_optional_kwargs(fetcher, kwargs)
@@ -72,7 +68,9 @@ def _call_fetcher(
     try:
         return fetcher(*args, **filtered_kwargs)
     except TypeError:
-        retry_kwargs = {k: v for k, v in filtered_kwargs.items() if k not in _OPTIONAL_KEYWORDS}
+        retry_kwargs = {
+            k: v for k, v in filtered_kwargs.items() if k not in _OPTIONAL_KEYWORDS
+        }
         if len(retry_kwargs) == len(filtered_kwargs):
             raise
         dropped_retry = sorted(set(filtered_kwargs) - set(retry_kwargs))
@@ -81,12 +79,10 @@ def _call_fetcher(
             "retrying_fetcher_without_optional_kwargs",
             extra={
                 "fetcher": getattr(fetcher, "__name__", repr(fetcher)),
-
                 "dropped": dropped_retry,
             },
         )
         return fetcher(*args, **retry_kwargs)
-
 
 
 @dataclass(frozen=True)

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -171,9 +171,10 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         # Initialise or refresh the cache with the configured TTL.
         _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
 
-    if url in _CACHE:
+    cached = _CACHE.get(url)
+    if cached is not None:
         logger.info("cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"})
-        return _CACHE[url]
+        return cast(dict[str, Any], cached)
     logger.info("cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"})
 
     for attempt in range(1, cfg.retries + 1):

--- a/library/pubmed/query.py
+++ b/library/pubmed/query.py
@@ -360,7 +360,7 @@ def fetch_semantic_scholar_batch(
                     candidate = value.strip()
                     if candidate:
                         return candidate
-                elif isinstance(value, (list, tuple, set)):
+                elif isinstance(value, list | tuple | set):
                     for entry in value:
                         if isinstance(entry, str):
                             candidate = entry.strip()

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -15,9 +15,8 @@ import pandas as pd
 
 from .cli import LoggerConfig, apply_config_overrides, configure_logger
 from .cli import build_parser as base_parser
-from .config import Config, ensure_dirs, print_config, session_with_retry
+from .config import ensure_dirs, print_config, session_with_retry
 from .csv_utils import write_csv_deterministic
-from .log import logger
 from .pubmed import (
     EMPTY_PUBMED,
     _do_request,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,23 @@ warn_unused_configs = true
 exclude = ["tests"]
 plugins = ["pydantic.mypy"]
 
+[[tool.mypy.overrides]]
+module = [
+  "pandas",
+  "pandas.*",
+  "requests",
+  "requests.*",
+  "yaml",
+  "yaml.*",
+  "cachetools",
+  "cachetools.*",
+  "tabulate",
+  "tabulate.*",
+  "openpyxl",
+  "openpyxl.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "-ra -q"
 testpaths = ["tests"]

--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -6,9 +6,9 @@ This module defines :data:`AssaysSchema`, a
 ``data/input/assay.csv`` and allows flexible dtypes.  Counts such as
 ``acts_per_assay_step5`` and temporal fields (``month``, ``year`` and
 ``version``) previously used strict :class:`int` dtypes while boolean flags
-like ``cited_assay_corr`` were :class:`bool`.  These fields are now typed as
-``pa.Any`` so that CSVs representing numbers or booleans as strings remain
-valid.  All columns are nullable to accommodate missing values.
+like ``cited_assay_corr`` were :class:`bool`.  These fields now omit explicit
+dtype enforcement so that CSVs representing numbers or booleans as strings
+remain valid.  All columns are nullable to accommodate missing values.
 
 Column overview
 ---------------
@@ -40,10 +40,12 @@ Column overview
 
 from __future__ import annotations
 
+from typing import Any, Final, cast
+
 import pandera.pandas as pa
 
-# Provide ``pa.Any`` as an alias for ``None`` to disable dtype enforcement.
-pa.Any = None  # type: ignore[attr-defined]
+# ``None`` disables dtype enforcement while still allowing schema validation.
+FLEXIBLE_DTYPE: Final[Any] = cast(Any, None)
 
 AssaysSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
@@ -51,26 +53,32 @@ AssaysSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "ASSAY_ID": pa.Column(str, required=False, nullable=True),
         "Target TYPE": pa.Column(str, required=False, nullable=True),
         "accession": pa.Column(str, required=False, nullable=True),
-        "acts_per_assay_step5": pa.Column(pa.Any, required=False, nullable=True),
+        "acts_per_assay_step5": pa.Column(
+            FLEXIBLE_DTYPE, required=False, nullable=True
+        ),
         "assay_cell_type": pa.Column(str, required=False, nullable=True),
         "assay_subcellular_fraction": pa.Column(str, required=False, nullable=True),
         "assay_tissue": pa.Column(str, required=False, nullable=True),
         "bao_format": pa.Column(str, required=False, nullable=True),
-        "cited_assay_corr": pa.Column(pa.Any, required=False, nullable=True),
+        "cited_assay_corr": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
         "description": pa.Column(str, required=False, nullable=True),
         "document_chembl_id": pa.Column(str, required=False, nullable=True),
-        "error_assay_corr": pa.Column(pa.Any, required=False, nullable=True),
-        "higly_correlated_cit": pa.Column(pa.Any, required=False, nullable=True),
+        "error_assay_corr": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
+        "higly_correlated_cit": pa.Column(
+            FLEXIBLE_DTYPE, required=False, nullable=True
+        ),
         "isoform": pa.Column(str, required=False, nullable=True),
-        "month": pa.Column(pa.Any, required=False, nullable=True),
+        "month": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
         "mutation": pa.Column(str, required=False, nullable=True),
-        "shuffled_cit": pa.Column(pa.Any, required=False, nullable=True),
-        "shuffled_target_assay": pa.Column(pa.Any, required=False, nullable=True),
+        "shuffled_cit": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
+        "shuffled_target_assay": pa.Column(
+            FLEXIBLE_DTYPE, required=False, nullable=True
+        ),
         "substrate_name": pa.Column(str, required=False, nullable=True),
         "target_chembl_id": pa.Column(str, required=False, nullable=True),
         "target_name": pa.Column(str, required=False, nullable=True),
-        "version": pa.Column(pa.Any, required=False, nullable=True),
-        "year": pa.Column(pa.Any, required=False, nullable=True),
+        "version": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
+        "year": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
     }
 )
 

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -27,7 +27,6 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     "pubmed_id": pa.Column(object, required=False, nullable=True, coerce=True),
     "authors": pa.Column(str, required=False, nullable=True),
     "source": pa.Column(str, required=False, nullable=True),
-
     # Derived fields
     "doi_normalised": pa.Column(str, required=False, nullable=True),
     "publication_types_normalised": pa.Column(str, required=False, nullable=True),
@@ -41,7 +40,6 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
         int, required=False, nullable=True, coerce=True
     ),
     "publication_class": pa.Column(str, required=False, nullable=True),
-
     # PubMed fields
     "PubMed.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
@@ -50,9 +48,7 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     "PubMed.JournalTitle": pa.Column(str, required=False, nullable=True),
     "PubMed.Volume": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.Issue": pa.Column(object, required=False, nullable=True, coerce=True),
-    "PubMed.StartPage": pa.Column(
-        object, required=False, nullable=True, coerce=True
-    ),
+    "PubMed.StartPage": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.EndPage": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.PublicationType": pa.Column(str, required=False, nullable=True),
     "PubMed.MeSH_Descriptors": pa.Column(str, required=False, nullable=True),
@@ -74,13 +70,10 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     ),
     "PubMed.Error": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.ISSN": pa.Column(str, required=False, nullable=True),
-
     # Semantic Scholar
     "scholar.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
     "scholar.Venue": pa.Column(object, required=False, nullable=True, coerce=True),
-    "scholar.PublicationTypes": pa.Column(
-        str, required=False, nullable=True
-    ),
+    "scholar.PublicationTypes": pa.Column(str, required=False, nullable=True),
     "scholar.SemanticScholarId": pa.Column(
         object, required=False, nullable=True, coerce=True
     ),
@@ -89,7 +82,6 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     ),
     "scholar.DOI": pa.Column(object, required=False, nullable=True, coerce=True),
     "scholar.Error": pa.Column(str, required=False, nullable=True),
-
     # OpenAlex
     "OpenAlex.PublicationTypes": pa.Column(
         object, required=False, nullable=True, coerce=True
@@ -103,7 +95,6 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
         object, required=False, nullable=True, coerce=True
     ),
     "OpenAlex.Error": pa.Column(object, required=False, nullable=True, coerce=True),
-
     # Crossref
     "crossref.Type": pa.Column(object, required=False, nullable=True, coerce=True),
     "crossref.Subtype": pa.Column(object, required=False, nullable=True, coerce=True),
@@ -111,28 +102,18 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     "crossref.Subtitle": pa.Column(object, required=False, nullable=True, coerce=True),
     "crossref.Subject": pa.Column(object, required=False, nullable=True, coerce=True),
     "crossref.Error": pa.Column(str, required=False, nullable=True),
-
     # Post-processing fields
     "date_code": pa.Column(str, required=False, nullable=True),
     "Index": pa.Column(object, required=False, nullable=True, coerce=True),
-    "PubMed.is_review": pa.Column(
-        object, required=False, nullable=True, coerce=True
-    ),
-    "scholar.is_review": pa.Column(
-        object, required=False, nullable=True, coerce=True
-    ),
-    "OpenAlex.is_review": pa.Column(
-        object, required=False, nullable=True, coerce=True
-    ),
+    "PubMed.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
+    "scholar.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
+    "OpenAlex.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
 }
 
 
 DocumentsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
-    OrderedDict(
-        (name, _COLUMN_DEFINITIONS[name]) for name in DOCUMENT_SCHEMA_COLUMNS
-    ),
+    OrderedDict((name, _COLUMN_DEFINITIONS[name]) for name in DOCUMENT_SCHEMA_COLUMNS),
     ordered=True,
 )
 
 """pa.DataFrameSchema: Validation schema for documents."""
-

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -70,9 +70,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     # Prepare HTTP session for ChEMBL requests
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
-            ids_iter = io.read_ids(
-                args.input_csv, column=cfg.assay.column, cfg=cfg.io
-            )
+            ids_iter = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
         except (FileNotFoundError, ValueError) as exc:
             logger.error("%s", exc)
             return 1

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -56,7 +56,6 @@ from library.cli import (
     configure_logger,
 )
 from library.config import (
-    ApiCfg,
     Config,
     CrossRefCfg,
     OpenAlexCfg,
@@ -64,13 +63,7 @@ from library.config import (
     _serialize_paths,
     ensure_dirs,
     print_config,
-    session_with_retry,
 )
-from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
-from library.rate_limiter import get_limiter
-from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
 from library.document_pipeline import (
     DOCUMENT_SCHEMA_COLUMNS,
     build_dataframe,
@@ -81,6 +74,11 @@ from library.document_pipeline import (
     normalise_doi,
     save_quality_report,
 )
+from library.log import logger
+from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.rate_limiter import get_limiter
+from library.sidecar import SidecarErrors
+from library.table_quality import analyze_table_quality
 from schemas import DocumentsSchema, normalize_documents
 
 
@@ -201,11 +199,7 @@ def fetch_pubmed_records(
     crossref_limiter = get_limiter("crossref", crossref_cfg.rps, crossref_cfg.burst)
 
     settings = cfg or Config()
-    api_cfg = settings.api
-    retry_cfg = settings.retry
-    pubmed_cfg = settings.pubmed
     rate_cfg = settings.rate
-    pubmed_limiter = get_limiter("pubmed", rate_cfg.global_rps, rate_cfg.global_burst)
     semantic_limiter = get_limiter(
         "semantic_scholar", rate_cfg.global_rps, rate_cfg.global_burst
     )
@@ -222,13 +216,12 @@ def fetch_pubmed_records(
             records.append(merge_metadata(pubmed, scholar, openalex, crossref))
         return records
 
-
     def _coerce_batch_argument(*candidates: object) -> list[str]:
         """Return the first iterable batch argument from ``candidates``."""
 
         for candidate in candidates:
             if isinstance(candidate, Sequence) and not isinstance(
-                candidate, (str, bytes, bytearray)
+                candidate, str | bytes | bytearray
             ):
                 return [str(item) for item in candidate]
         raise TypeError(
@@ -239,7 +232,6 @@ def fetch_pubmed_records(
     def _fetch_batch(
         first: object, *rest: object, **__: object
     ) -> list[dict[str, str]]:
-
         """Fetch metadata for a batch of PMIDs.
 
         Each worker opens its own :class:`requests.Session` and retrieves PubMed
@@ -252,7 +244,6 @@ def fetch_pubmed_records(
         batch_list = _coerce_batch_argument(first, *rest)
 
         try:
-
             with requests.Session() as session:
                 pubmed_list = pl.fetch_pubmed_batch(session, batch_list, sleep)
 
@@ -262,7 +253,6 @@ def fetch_pubmed_records(
                 semantic_limiter.acquire()
                 semsch_list = ssl.fetch_semantic_scholar_batch(
                     session, pmids_in_batch, sleep, cfg=semantic_scholar_cfg
-
                 )
 
                 # Create a map for easy lookup
@@ -287,13 +277,11 @@ def fetch_pubmed_records(
                     combined_records.append(combined)
                 return combined_records
         except requests.RequestException as exc:  # pragma: no cover - network errors
-
             logger.warning("failed to fetch PMIDs %s: %s", batch_list, exc)
             return _failure_records(batch_list, str(exc))
         except Exception as exc:  # pragma: no cover - defensive safety net
             logger.warning("unexpected error for PMIDs %s: %s", batch_list, exc)
             return _failure_records(batch_list, str(exc))
-
 
     iterator = (p for p in pmids if p)
     records: list[dict[str, str]] = []
@@ -388,9 +376,9 @@ def _finalise_export(
         key_cols = [c for c in key_columns if c in export_df.columns]
     else:
         key_cols = []
-    col_order = [
-        c for c in DOCUMENT_SCHEMA_COLUMNS if c in export_df.columns
-    ] + sorted(c for c in export_df.columns if c not in DOCUMENT_SCHEMA_COLUMNS)
+    col_order = [c for c in DOCUMENT_SCHEMA_COLUMNS if c in export_df.columns] + sorted(
+        c for c in export_df.columns if c not in DOCUMENT_SCHEMA_COLUMNS
+    )
     try:
         csv_path = io.write_csv(
             export_df,
@@ -478,9 +466,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             max_workers=cfg.document.pubmed.workers,
             batch_size=cfg.document.pubmed.batch_size,
         )
-        output = Path(
-            args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-        )
+        output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
         df = normalize_documents(df)
         exit_code = _finalise_export(
             df,
@@ -545,9 +531,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         if "doi" in df.columns:
             df["doi"] = df["doi"].map(normalise_doi)
-        output = Path(
-            args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-        )
+        output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
         df = normalize_documents(df)
         exit_code = _finalise_export(
             df,
@@ -636,7 +620,6 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
-
         cfg.document.all.sleep,
         cfg.semantic_scholar,
         cfg.openalex,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -865,7 +865,6 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
     missing_optional = optional_cols - set(final_df.columns)
     if not missing_required:
         if missing_optional:
-
             logger.warning(
                 "DataFrame is missing optional columns: %s", missing_optional
             )

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-
 # ruff: noqa: E402
 import argparse
+import sys
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 
@@ -15,6 +14,7 @@ if __package__ is None:  # running as a script
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from library.chembl_client import _chunked
 from library.cli import (
     LoggerConfig,
     apply_config_overrides,
@@ -22,7 +22,6 @@ from library.cli import (
     configure_logger,
 )
 from library.config import Config, ensure_dirs, print_config
-from library.chembl_client import _chunked
 from library.io import default_output_path, read_ids, write_csv
 from library.log import logger
 from library.pipeline_targets import PipelineResult, run_pipeline
@@ -101,9 +100,7 @@ def _chunk_iterator(cfg: Config, options: PipelineConfig) -> Iterator[Iterable[s
         encoding=options.encoding,
         na_markers=options.na_markers,
     )
-    for chunk in _chunked(ids, options.chunk_size):
-        yield chunk
-
+    yield from _chunked(ids, options.chunk_size)
 
 
 def _cached_chembl_fetch(
@@ -121,7 +118,6 @@ def _cached_chembl_fetch(
     with :func:`library.pipeline_targets.run_pipeline`.
     """
 
-
     ids = [item for chunk in chunks for item in chunk]
     df = pd.DataFrame({"target_chembl_id": ids})
     if df.empty:
@@ -130,7 +126,9 @@ def _cached_chembl_fetch(
     return df
 
 
-def _write_outputs(cfg: Config, options: PipelineConfig, result: PipelineResult) -> Path:
+def _write_outputs(
+    cfg: Config, options: PipelineConfig, result: PipelineResult
+) -> Path:
     output = options.output_csv or default_output_path(options.input_csv, cfg.io)
     write_csv(
         result.chembl,
@@ -146,10 +144,8 @@ def run(cfg: Config, options: PipelineConfig) -> int:
     result = run_pipeline(
         lambda: _chunk_iterator(cfg, options),
         cfg,
-
         chembl_fetcher=_cached_chembl_fetch,
         chembl_kwargs={"chunk_size": options.chunk_size},
-
         batch_size=options.batch_size,
     )
     output = _write_outputs(cfg, options, result)

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -48,7 +48,9 @@ def stub_quality(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_quality(*args, **kwargs):  # type: ignore[no-untyped-def]
         return pd.DataFrame(), pd.DataFrame()
 
-    monkeypatch.setattr("library.activity_extraction.analyze_table_quality", fake_quality)
+    monkeypatch.setattr(
+        "library.activity_extraction.analyze_table_quality", fake_quality
+    )
 
 
 def _write_input(path: Path, identifiers: list[str]) -> None:
@@ -56,7 +58,9 @@ def _write_input(path: Path, identifiers: list[str]) -> None:
     path.write_text(rows, encoding="utf-8")
 
 
-def test_extract_activities_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: Config) -> None:
+def test_extract_activities_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: Config
+) -> None:
     """Successful run writes CSV and returns exit code ``0``."""
 
     input_csv = tmp_path / "activities.csv"

--- a/tests/test_chembl_assay.py
+++ b/tests/test_chembl_assay.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterator
+from collections.abc import Iterator
 
 import pandas as pd
 
@@ -10,7 +10,9 @@ from library.chembl_assay import get_assays
 from library.config import ApiCfg
 
 
-def _response_page(items: list[dict[str, str]], next_path: str | None) -> dict[str, object]:
+def _response_page(
+    items: list[dict[str, str]], next_path: str | None
+) -> dict[str, object]:
     """Return a fake paginated response payload."""
 
     page_meta: dict[str, object] = {"next": next_path}
@@ -24,7 +26,9 @@ class DummyClient:
         self._responses = responses
         self.calls: list[str] = []
 
-    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None = None) -> dict[str, object]:
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, object]:
         self.calls.append(url)
         try:
             return next(self._responses)

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -93,10 +93,7 @@ def test_write_csv_deterministic_empty_dataframe_golden(tmp_path: Path) -> None:
     write_csv_deterministic(df, path, key_cols=sorted(df.columns))
 
     expected = (
-        Path(__file__).parent
-        / "data"
-        / "golden"
-        / "empty_with_header.csv"
+        Path(__file__).parent / "data" / "golden" / "empty_with_header.csv"
     ).read_text(encoding="utf-8-sig")
     assert path.read_text(encoding="utf-8-sig") == expected
 
@@ -109,10 +106,7 @@ def test_write_csv_deterministic_empty_no_columns(tmp_path: Path) -> None:
     write_csv_deterministic(df, path, key_cols=[])
 
     expected = (
-        Path(__file__).parent
-        / "data"
-        / "golden"
-        / "empty_no_columns.csv"
+        Path(__file__).parent / "data" / "golden" / "empty_no_columns.csv"
     ).read_text(encoding="utf-8-sig")
     assert path.read_text(encoding="utf-8-sig") == expected
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import argparse
 import io
 import sys
-import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
-
-from contextlib import contextmanager
 
 import pandas as pd
 import pytest
@@ -17,8 +14,8 @@ from library import chembl_library as cl
 from library import io as lib_io
 from library.cli import LoggerConfig, configure_logger
 from library.config import Config, CrossRefCfg, OpenAlexCfg, SemanticScholarCfg
-from schemas import DocumentsSchema
 from library.document_pipeline import DOCUMENT_SCHEMA_COLUMNS
+from schemas import DocumentsSchema
 from scripts import get_document_data as gdd
 
 
@@ -292,7 +289,9 @@ def test_fetch_pubmed_records_handles_generic_error(
 ) -> None:
     """Ensure unexpected errors yield failure records rather than crashing."""
 
-    def fail_fetch_pubmed_batch(*args: object, **kwargs: object) -> list[dict[str, str]]:
+    def fail_fetch_pubmed_batch(
+        *args: object, **kwargs: object
+    ) -> list[dict[str, str]]:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fail_fetch_pubmed_batch)
@@ -339,7 +338,9 @@ def test_fetch_pubmed_records_accepts_config(
 
     monkeypatch.setattr(gdd.requests, "Session", fake_session)
 
-    def fake_pubmed_batch(session: Any, batch: list[str], sleep: float) -> list[dict[str, str]]:
+    def fake_pubmed_batch(
+        session: Any, batch: list[str], sleep: float
+    ) -> list[dict[str, str]]:
         assert sleep == expected_sleep
         assert batch == ["1"]
         return [
@@ -366,18 +367,24 @@ def test_fetch_pubmed_records_accepts_config(
             }
         ]
 
-    def fake_openalex(session: Any, pmid: str, cfg_arg: Any, limiter: Any) -> dict[str, str]:
+    def fake_openalex(
+        session: Any, pmid: str, cfg_arg: Any, limiter: Any
+    ) -> dict[str, str]:
         assert pmid == "1"
         assert cfg_arg is config.openalex
         return {"OpenAlex.PublicationTypes": "journal-article"}
 
-    def fake_crossref(session: Any, doi: str, cfg_arg: Any, limiter: Any) -> dict[str, str]:
+    def fake_crossref(
+        session: Any, doi: str, cfg_arg: Any, limiter: Any
+    ) -> dict[str, str]:
         assert doi == "10.1000/xyz"
         assert cfg_arg is config.crossref
         return {"crossref.Type": "journal-article"}
 
     monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
-    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_scholar_batch)
+    monkeypatch.setattr(
+        gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_scholar_batch
+    )
     monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_openalex)
     monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
     monkeypatch.setattr(gdd, "get_limiter", lambda *args, **kwargs: DummyLimiter())
@@ -388,12 +395,10 @@ def test_fetch_pubmed_records_accepts_config(
     assert df.loc[0, "PubMed.PMID"] == "1"
 
 
-
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])
 def test_fetch_pubmed_records_accepts_executor_context(
     monkeypatch: pytest.MonkeyPatch,
     context_position: str,
-
 ) -> None:
     """Executor passing an internal context argument should be ignored."""
 
@@ -431,7 +436,6 @@ def test_fetch_pubmed_records_accepts_executor_context(
             return None
 
         def submit(self, fn, batch):  # type: ignore[no-untyped-def]
-
             context = object()
             if context_position == "prefix":
                 value = fn(context, batch)
@@ -487,4 +491,3 @@ def test_fetch_pubmed_records_accepts_executor_context(
     )
 
     assert sorted(df["PubMed.PMID"].tolist()) == pmids
-

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -71,6 +71,7 @@ def test_run_uniprot_initialises_session(
 
     monkeypatch.setattr(gtd.uu, "init_session", fake_init_session)
     monkeypatch.setattr(gtd.uu, "process", fake_process)
+
     def fake_write_csv(
         df: pd.DataFrame,
         path: Path,

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -39,7 +39,9 @@ def _configure_failing_git(
     monkeypatch.setattr(git_utils.shutil, "which", lambda _: "git")
 
 
-def _capture_logs(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, object]]]:
+def _capture_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, dict[str, object]]]:
     records: list[tuple[str, dict[str, object]]] = []
 
     def info(event: str, *args: object, **kwargs: object) -> None:
@@ -61,7 +63,11 @@ def _assert_subprocess_payload(
         rec for event, rec in records if event == "git_sha_fallback"
     ]
     assert payloads
-    raw = expected_returncode if expected_returncode_raw is None else expected_returncode_raw
+    raw = (
+        expected_returncode
+        if expected_returncode_raw is None
+        else expected_returncode_raw
+    )
     for payload in payloads:
         assert payload.get("error")
         assert payload.get("error_returncode") == expected_returncode
@@ -73,7 +79,9 @@ def _assert_subprocess_payload(
             assert payload.get("error_stderr") == expected_stderr
 
 
-def test_git_sha_fallback_reads_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_sha_fallback_reads_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     commit = "1" * 40
     git_dir = tmp_path / ".git"
     git_dir.mkdir()
@@ -94,7 +102,9 @@ def test_git_sha_fallback_reads_head(tmp_path: Path, monkeypatch: pytest.MonkeyP
     _assert_subprocess_payload(records, expected_returncode=1)
 
 
-def test_git_sha_fallback_supports_gitdir_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_sha_fallback_supports_gitdir_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     commit = "2" * 40
     storage = tmp_path / "git_storage"
     git_dir = storage / "worktree"
@@ -118,7 +128,9 @@ def test_git_sha_fallback_supports_gitdir_file(tmp_path: Path, monkeypatch: pyte
     _assert_subprocess_payload(records, expected_returncode=1)
 
 
-def test_git_sha_fallback_reads_packed_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_sha_fallback_reads_packed_refs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     commit = "3" * 40
     git_dir = tmp_path / ".git"
     git_dir.mkdir()
@@ -167,7 +179,9 @@ def test_git_sha_fallback_normalises_large_returncode(
     )
 
 
-def test_git_sha_fallback_when_git_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_git_sha_fallback_when_git_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     commit = "4" * 40
     git_dir = tmp_path / ".git"
     git_dir.mkdir()

--- a/tests/test_pipeline_targets.py
+++ b/tests/test_pipeline_targets.py
@@ -78,7 +78,9 @@ def test_optional_stages_receive_dataframe() -> None:
         ids = [item for chunk in chunks for item in chunk]
         return pd.DataFrame({"target_chembl_id": ids})
 
-    def uniprot_fetcher(df: pd.DataFrame, cfg: object | None = None, **_: Any) -> pd.DataFrame:
+    def uniprot_fetcher(
+        df: pd.DataFrame, cfg: object | None = None, **_: Any
+    ) -> pd.DataFrame:
         assert list(df["target_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
         return pd.DataFrame({"uniprot_id": ["P1", "P2"]})
 

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -24,11 +24,13 @@ class _DummyLogger:
             storage if storage is not None else []
         )
 
-    def bind(self, **ctx: Any) -> "_DummyLogger":  # pragma: no cover - trivial
+    def bind(self, **ctx: Any) -> _DummyLogger:  # pragma: no cover - trivial
         merged = {**self._context, **ctx}
         return _DummyLogger(merged, self._records)
 
-    def info(self, event: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
+    def info(
+        self, event: str, *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - trivial
         record = {**self._context, **kwargs}
         self._records.append((event, record))
 
@@ -37,7 +39,9 @@ class _DummyLogger:
         return list(self._records)
 
 
-def test_cli_forwards_batch_size(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_forwards_batch_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     input_csv = tmp_path / "targets.csv"
     input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf8")
     output_csv = tmp_path / "out.csv"
@@ -90,8 +94,13 @@ def test_cli_forwards_batch_size(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert captured["chunks"] == [["CHEMBL1"]]
     assert captured["written_path"] == output_csv
     assert list(captured["written_df"]["target_chembl_id"]) == ["CHEMBL1"]
-    assert any(event == "pipeline_start" and rec.get("stage") == "pipeline" for event, rec in dummy_logger.records)
     assert any(
-        event == "pipeline_done" and rec.get("stage") == "pipeline" and rec.get("exit_code") == 0
+        event == "pipeline_start" and rec.get("stage") == "pipeline"
+        for event, rec in dummy_logger.records
+    )
+    assert any(
+        event == "pipeline_done"
+        and rec.get("stage") == "pipeline"
+        and rec.get("exit_code") == 0
         for event, rec in dummy_logger.records
     )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -103,11 +103,9 @@ def test_documents_schema_validation() -> None:
     valid = pd.DataFrame(
         {
             "document_chembl_id": ["CHEMBL1"],
-
             "title": ["Example"],
             "PubMed.PMID": [12345],
             "OpenAlex.Error": [None],
-
         }
     )
     DocumentsSchema.validate(valid)
@@ -239,14 +237,12 @@ def test_testitems_schema_validation() -> None:
     """Ensure :data:`TestitemsSchema` validates expected data."""
     valid = pd.DataFrame(
         {
-
             "molecule_chembl_id": ["CHEMBL1"],
             "first_approval": [1950],
             "black_box_warning": [0],
             "oral": [True],
             "parenteral": [False],
             "topical": [False],
-
         }
     )
     TestitemsSchema.validate(valid)

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -99,7 +99,11 @@ def test_finalise_targets_orders_columns_default() -> None:
         (
             "chembl_id"
             if c == "target_chembl_id"
-            else "uniprot" if c == "uniprotkb_Id" else "organism" if c == "genus" else c
+            else "uniprot"
+            if c == "uniprotkb_Id"
+            else "organism"
+            if c == "genus"
+            else c
         )
         for c in TARGETS_COLUMN_ORDER
     ]


### PR DESCRIPTION
## Summary
- apply `ruff format` to normalise style across the project
- repair mypy issues by tightening helper implementations and schema definitions
- configure mypy to tolerate third-party modules without stubs so strict checking can run in CI

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml`
- `pytest` *(fails: missing optional dev dependency `hypothesis`)*

------
https://chatgpt.com/codex/tasks/task_e_68d3db37ccf88324b290cba99e594c8d