### PR TITLE
Propagate PubMed config and retry safeguards

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -135,8 +135,9 @@ class ChemblClient:
             )
 
         last_exc: requests.RequestException | ValueError | None = None
+        attempts = max(1, cfg.retries)
 
-        for attempt in range(1, cfg.retries + 1):
+        for attempt in range(1, attempts + 1):
             limiter.acquire()
             event = "request_start" if attempt == 1 else "request_retry"
             logger.info(event, extra={"url": url, "attempt": attempt, "rps": cfg.rps})
@@ -169,7 +170,7 @@ class ChemblClient:
                         return data
             except (requests.RequestException, ValueError) as exc:
                 last_exc = exc
-                if attempt >= cfg.retries:
+                if attempt >= attempts:
                     logger.exception(
                         "request_fail",
                         extra={"url": url, "status": None, "rps": cfg.rps},
@@ -179,8 +180,9 @@ class ChemblClient:
                 delay += random.uniform(0, cfg.backoff_factor)
                 sleep(delay)
 
-        assert last_exc is not None
-        raise last_exc
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError(f"Request loop exited unexpectedly for {url}")
 
     def clear_cache(self) -> None:
         """Remove all entries from the in-memory cache."""

--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -9,6 +9,7 @@ from .parser import (
     build_root_parser,
     configure_logger,
     create_logger_config,
+    positive_int,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "build_root_parser",
     "configure_logger",
     "create_logger_config",
+    "positive_int",
 ]

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -68,6 +68,12 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
+def positive_int(value: str) -> int:
+    """Public wrapper around :func:`_positive_int` for CLI validators."""
+
+    return _positive_int(value)
+
+
 def add_common_arguments(
     parser: argparse.ArgumentParser, *, defaults: bool = True
 ) -> argparse.ArgumentParser:

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from .cli import LoggerConfig, apply_config_overrides, configure_logger
 from .cli import build_parser as base_parser
-from .config import ensure_dirs, print_config, session_with_retry
+from .config import Config, ensure_dirs, print_config, session_with_retry
 from .csv_utils import write_csv_deterministic
 from .pubmed import (
     EMPTY_PUBMED,
@@ -40,6 +40,7 @@ from .pubmed import (
 from .rate_limiter import get_limiter
 
 __all__ = [
+    "Config",
     "read_pmids",
     "_make_request",
     "_handle_response",
@@ -95,6 +96,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "chunk_size": "document.pubmed.batch_size",
             },
         )
+        cfg = Config.model_validate(cfg.model_dump())
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -54,11 +54,13 @@ from library.cli import (
     apply_config_overrides,
     build_root_parser,
     configure_logger,
+    positive_int,
 )
 from library.config import (
     Config,
     CrossRefCfg,
     OpenAlexCfg,
+    PubMedCfg,
     SemanticScholarCfg,
     _serialize_paths,
     ensure_dirs,
@@ -86,6 +88,7 @@ def fetch_pubmed_records(
     pmids: Iterable[str],
     *args: object,
     sleep: float | None = None,
+    pubmed_cfg: PubMedCfg | None = None,
     semantic_scholar_cfg: SemanticScholarCfg | None = None,
     openalex_cfg: OpenAlexCfg | None = None,
     crossref_cfg: CrossRefCfg | None = None,
@@ -102,6 +105,8 @@ def fetch_pubmed_records(
     sleep:
 
         Seconds to pause between PubMed and Semantic Scholar requests.
+    pubmed_cfg:
+        Configuration for the PubMed API including base URL and timeouts.
     semantic_scholar_cfg:
         Configuration for Semantic Scholar API access.
     openalex_cfg:
@@ -168,6 +173,8 @@ def fetch_pubmed_records(
     if cfg is not None:
         if sleep is None:
             sleep = cfg.document.pubmed.sleep
+        if pubmed_cfg is None:
+            pubmed_cfg = cfg.pubmed
         if semantic_scholar_cfg is None:
             semantic_scholar_cfg = cfg.semantic_scholar
         if openalex_cfg is None:
@@ -201,6 +208,8 @@ def fetch_pubmed_records(
 
     settings = cfg or Config()
     rate_cfg = settings.rate
+    if pubmed_cfg is None:
+        pubmed_cfg = settings.pubmed
     semantic_limiter = get_limiter(
         "semantic_scholar", rate_cfg.global_rps, rate_cfg.global_burst
     )
@@ -246,7 +255,9 @@ def fetch_pubmed_records(
 
         try:
             with requests.Session() as session:
-                pubmed_list = pl.fetch_pubmed_batch(session, batch_list, sleep)
+                pubmed_list = pl.fetch_pubmed_batch(
+                    session, batch_list, sleep, cfg=pubmed_cfg
+                )
 
                 pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
 
@@ -286,31 +297,50 @@ def fetch_pubmed_records(
                     combined_records.append(combined)
                 return combined_records
         except requests.RequestException as exc:  # pragma: no cover - network errors
-            logger.warning("failed to fetch PMIDs %s: %s", batch_list, exc)
+            logger.warning(
+                "pubmed_batch_request_failed",
+                pmids=batch_list,
+                error=str(exc),
+            )
             return _failure_records(batch_list, str(exc))
         except Exception as exc:  # pragma: no cover - defensive safety net
-            logger.warning("unexpected error for PMIDs %s: %s", batch_list, exc)
+            logger.warning(
+                "pubmed_batch_unexpected_error",
+                pmids=batch_list,
+                error=str(exc),
+            )
             return _failure_records(batch_list, str(exc))
 
     iterator = (p for p in pmids if p)
     records: list[dict[str, str]] = []
     tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
+    ordered: dict[int, list[dict[str, str]]] = {}
+    processed = 0
+    max_in_flight = max(1, max_workers * 2)
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
         offset = 0
+        pending: set[Future[list[dict[str, str]]]] = set()
         for batch in _chunked(iterator, batch_size):
             if not batch:
                 continue
             future = ex.submit(_fetch_batch, batch)
             tasks[future] = (offset, batch)
+            pending.add(future)
             offset += len(batch)
+            if len(pending) >= max_in_flight:
+                done_future = next(as_completed(list(pending)))
+                pending.remove(done_future)
+                batch_offset, submitted_batch = tasks.pop(done_future)
+                ordered[batch_offset] = done_future.result()
+                processed += len(submitted_batch)
+                logger.info("documents_processed", count=processed)
 
-        processed = 0
-        ordered: dict[int, list[dict[str, str]]] = {}
-        for future in as_completed(tasks):
-            offset, batch = tasks[future]
-            result = future.result()
-            ordered[offset] = result
-            processed += len(batch)
+        while pending:
+            done_future = next(as_completed(list(pending)))
+            pending.remove(done_future)
+            batch_offset, submitted_batch = tasks.pop(done_future)
+            ordered[batch_offset] = done_future.result()
+            processed += len(submitted_batch)
             logger.info("documents_processed", count=processed)
 
     for offset in sorted(ordered):
@@ -351,7 +381,8 @@ def _finalise_export(
     if not missing_required:
         if missing_optional:
             logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
+                "missing_optional_columns",
+                columns=sorted(missing_optional),
             )
         try:
             validated = DocumentsSchema.validate(ordered, lazy=True)
@@ -362,16 +393,17 @@ def _finalise_export(
                 errors.add_error(row)
             errors.save(failure_path)
             logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+                "document_validation_failed",
+                failure_count=len(exc.failure_cases),
+                failure_path=str(failure_path),
+                error=str(exc),
             )
             validated = getattr(exc, "validated_data", ordered)
             exit_code = 1
     else:
         logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
+            "validation_skipped_missing_required",
+            columns=sorted(missing_required),
         )
 
     rows_kept = len(validated)
@@ -397,7 +429,7 @@ def _finalise_export(
             col_order=col_order,
         )
     except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
+        logger.error("csv_write_failed", error=str(exc), path=str(output))
         return 1
     logger.info("write_done", rows=rows_kept, path=str(csv_path))
 
@@ -416,17 +448,22 @@ def _finalise_export(
         schema="DocumentsSchema",
     )
 
+    quality_path = csv_path.with_suffix(".quality.json")
     try:
         report = build_quality_report(validated)
-        save_quality_report(report, csv_path.with_suffix(".quality.json"))
+        save_quality_report(report, quality_path)
     except (OSError, TypeError, ValueError) as exc:
-        logger.error("failed to write quality report: %s", exc)
+        logger.error(
+            "quality_report_write_failed",
+            error=str(exc),
+            path=str(quality_path),
+        )
         return 1
 
     try:
         analyze_table_quality(validated, table_name=str(csv_path.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     return exit_code
 
@@ -449,14 +486,22 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     """
     limit = cfg.document.pubmed.limit
     if limit is not None and limit < 0:
-        logger.error("document.pubmed.limit must be non-negative")
+        logger.error(
+            "invalid_limit",
+            section="document.pubmed",
+            limit=limit,
+        )
         return 1
     try:
         pmids_iter = io.read_ids(
             args.input_csv, column=cfg.document.pubmed.column, cfg=cfg.io
         )
     except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
+        logger.error(
+            "input_read_failed",
+            error=str(exc),
+            path=str(args.input_csv),
+        )
         return 1
     pmids: Iterable[str] = pmids_iter
     if limit is not None:
@@ -469,6 +514,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             pmids,
             cfg,
             sleep=cfg.document.pubmed.sleep,
+            pubmed_cfg=cfg.pubmed,
             semantic_scholar_cfg=cfg.semantic_scholar,
             openalex_cfg=cfg.openalex,
             crossref_cfg=cfg.crossref,
@@ -485,7 +531,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             key_columns=["document_chembl_id"],
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
-        logger.error("%s", exc)
+        logger.error("pubmed_pipeline_failed", error=str(exc))
         return 1
     return exit_code
 
@@ -508,7 +554,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """
     limit = cfg.document.chembl.limit
     if limit is not None and limit < 0:
-        logger.error("document.chembl.limit must be non-negative")
+        logger.error("invalid_limit", section="document.chembl", limit=limit)
         return 1
 
     # Configure session for ChEMBL requests
@@ -518,10 +564,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
-        ids = ids_iter
+        ids: Iterable[str] = ids_iter
         if limit is not None:
             limited_ids = list(islice(ids_iter, limit))
             ids = limited_ids
@@ -536,7 +586,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.document.chembl.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
-            logger.error("failed to retrieve documents: %s", exc)
+            logger.error(
+                "chembl_documents_fetch_failed",
+                error=str(exc),
+                chunk_size=cfg.document.chembl.chunk_size,
+            )
             return 1
         if "doi" in df.columns:
             df["doi"] = df["doi"].map(normalise_doi)
@@ -570,7 +624,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     """
     limit = cfg.document.all.limit
     if limit is not None and limit < 0:
-        logger.error("document.all.limit must be non-negative")
+        logger.error("invalid_limit", section="document.all", limit=limit)
         return 1
 
     # Prepare shared session before performing any API calls
@@ -579,7 +633,11 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             args.input_csv, column=cfg.document.all.column, cfg=cfg.io
         )
     except (FileNotFoundError, ValueError) as exc:
-        logger.error("%s", exc)
+        logger.error(
+            "input_read_failed",
+            error=str(exc),
+            path=str(args.input_csv),
+        )
         return 1
 
     ids_source: Iterable[str] = ids_iter
@@ -600,7 +658,12 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.document.all.timeout,
             )
     except (requests.RequestException, ValueError) as exc:
-        logger.error("failed to retrieve documents for %s: %s", chunk_ids, exc)
+        logger.error(
+            "chembl_documents_fetch_failed",
+            ids=chunk_ids,
+            error=str(exc),
+            chunk_size=cfg.document.all.chunk_size,
+        )
         return 1
     output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
     if "doi" in doc_df.columns:
@@ -631,9 +694,13 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         doi_series = doc_df["doi"].astype("string")
         mask = pubmed_ids.notna() & doi_series.notna() & (doi_series != "")
         if mask.any():
+            masked_pmids = pubmed_ids[mask].tolist()
+            masked_dois = doi_series[mask].tolist()
+            if len(masked_pmids) != len(masked_dois):
+                raise ValueError("mismatched DOI fallback map lengths")
             doi_fallback_map = {
                 str(pmid): str(doi)
-                for pmid, doi in zip(pubmed_ids[mask], doi_series[mask])
+                for pmid, doi in zip(masked_pmids, masked_dois, strict=True)
             }
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
@@ -644,6 +711,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         cfg.crossref,
         cfg.document.all.workers,
         cfg.document.all.batch_size,
+        pubmed_cfg=cfg.pubmed,
         fallback_doi_map=doi_fallback_map or None,
     )
     doc_df["pubmed_id"] = pubmed_ids.astype("Int64").astype("string").fillna("")
@@ -696,7 +764,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     pubmed.add_argument(
         "--batch-size",
-        type=int,
+        type=positive_int,
         default=100,
         help="Maximum PMIDs per PubMed request",
     )
@@ -729,7 +797,10 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Column name containing identifiers",
     )
     chembl.add_argument(
-        "--chunk-size", type=int, default=5, help="Maximum number of IDs per request"
+        "--chunk-size",
+        type=positive_int,
+        default=5,
+        help="Maximum number of IDs per request",
     )
     chembl.add_argument(
         "--timeout",
@@ -754,7 +825,10 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Column in the input CSV",
     )
     all_cmd.add_argument(
-        "--chunk-size", type=int, default=5, help="Maximum IDs per request"
+        "--chunk-size",
+        type=positive_int,
+        default=5,
+        help="Maximum IDs per request",
     )
     all_cmd.add_argument(
         "--sleep",
@@ -767,7 +841,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     all_cmd.add_argument(
         "--batch-size",
-        type=int,
+        type=positive_int,
         default=50,
         help="Maximum PMIDs per PubMed request",
     )
@@ -868,11 +942,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_override_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = cast(int, args.func(cfg, args))

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -123,6 +123,20 @@ def test_request_json_backoff_grows(monkeypatch) -> None:
     assert sleep_times == [1.0, 2.0]
 
 
+def test_request_json_respects_zero_retries() -> None:
+    """Retry count of zero should perform exactly one HTTP attempt."""
+
+    session = DummySession(failures=1)
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)
+    client.clear_cache()
+
+    cfg = api_cfg(retries=0, backoff_factor=0)
+    with pytest.raises(requests.RequestException):
+        client.request_json("http://example.com", cfg=cfg)
+
+    assert len(session.calls) == 1
+
+
 def test_request_json_retries_with_mocked_session() -> None:
     """Failing requests should be retried using the provided session."""
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -13,7 +14,13 @@ import pytest
 from library import chembl_library as cl
 from library import io as lib_io
 from library.cli import LoggerConfig, configure_logger
-from library.config import Config, CrossRefCfg, OpenAlexCfg, SemanticScholarCfg
+from library.config import (
+    Config,
+    CrossRefCfg,
+    OpenAlexCfg,
+    PubMedCfg,
+    SemanticScholarCfg,
+)
 from library.document_pipeline import DOCUMENT_SCHEMA_COLUMNS
 from schemas import DocumentsSchema
 from scripts import get_document_data as gdd
@@ -143,7 +150,54 @@ def test_run_all_logs_failing_ids(
     assert rc == 1
     log_output = buffer.getvalue()
     configure_logger(LoggerConfig(stream=sys.stdout))
-    assert "CHEMBL1" in log_output and "CHEMBL2" in log_output
+    records = [json.loads(line) for line in log_output.splitlines() if line.strip()]
+    assert any(
+        record.get("event") == "chembl_documents_fetch_failed"
+        and record.get("ids") == ["CHEMBL1", "CHEMBL2"]
+        for record in records
+    )
+
+
+def test_pubmed_cli_rejects_non_positive_batch_size(tmp_path: Path) -> None:
+    """PubMed CLI should reject zero or negative batch sizes."""
+
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n1\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        gdd.main(
+            [
+                "pubmed",
+                "--input",
+                str(input_csv),
+                "--output",
+                str(tmp_path / "out.csv"),
+                "--batch-size",
+                "0",
+            ]
+        )
+    assert exc_info.value.code == 2
+
+
+def test_chembl_cli_rejects_non_positive_chunk_size(tmp_path: Path) -> None:
+    """ChEMBL CLI should reject zero or negative chunk sizes."""
+
+    input_csv = tmp_path / "docs.csv"
+    input_csv.write_text("document_chembl_id\nCHEMBL1\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        gdd.main(
+            [
+                "chembl",
+                "--input",
+                str(input_csv),
+                "--output",
+                str(tmp_path / "out.csv"),
+                "--chunk-size",
+                "0",
+            ]
+        )
+    assert exc_info.value.code == 2
 
 
 def test_run_pubmed_uses_keyword_arguments(
@@ -176,6 +230,7 @@ def test_run_pubmed_uses_keyword_arguments(
         cfg_param: Config,
         *,
         sleep: float,
+        pubmed_cfg: Any | None = None,
         semantic_scholar_cfg: SemanticScholarCfg,
         openalex_cfg: OpenAlexCfg,
         crossref_cfg: CrossRefCfg,
@@ -186,6 +241,7 @@ def test_run_pubmed_uses_keyword_arguments(
         captured["pmids"] = list(pmids)
         captured["cfg"] = cfg_param
         captured["sleep"] = sleep
+        captured["pubmed_cfg"] = pubmed_cfg
         captured["semantic_scholar_cfg"] = semantic_scholar_cfg
         captured["openalex_cfg"] = openalex_cfg
         captured["crossref_cfg"] = crossref_cfg
@@ -213,6 +269,7 @@ def test_run_pubmed_uses_keyword_arguments(
     assert captured["pmids"] == ["1", "2"]
     assert captured["cfg"] is cfg
     assert captured["sleep"] == cfg.document.pubmed.sleep
+    assert captured["pubmed_cfg"] is cfg.pubmed
     assert captured["semantic_scholar_cfg"] is cfg.semantic_scholar
     assert captured["openalex_cfg"] is cfg.openalex
     assert captured["crossref_cfg"] is cfg.crossref
@@ -342,10 +399,11 @@ def test_fetch_pubmed_records_accepts_config(
     monkeypatch.setattr(gdd.requests, "Session", fake_session)
 
     def fake_pubmed_batch(
-        session: Any, batch: list[str], sleep: float
+        session: Any, batch: list[str], sleep: float, cfg: Any | None = None
     ) -> list[dict[str, str]]:
         assert sleep == expected_sleep
         assert batch == ["1"]
+        assert cfg is config.pubmed
         return [
             {
                 "PubMed.PMID": "1",
@@ -398,6 +456,50 @@ def test_fetch_pubmed_records_accepts_config(
     assert df.loc[0, "PubMed.PMID"] == "1"
 
 
+def test_fetch_pubmed_records_uses_explicit_pubmed_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit PubMed configuration should be passed to the batch fetcher."""
+
+    sentinel_cfg = PubMedCfg(base="https://example.org/api")
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd.requests, "Session", lambda: DummySession())
+
+    seen_cfg: dict[str, PubMedCfg | None] = {"value": None}
+
+    def fake_pubmed_batch(
+        session: Any, batch: list[str], sleep: float, cfg: PubMedCfg | None = None
+    ) -> list[dict[str, str]]:
+        seen_cfg["value"] = cfg
+        return [{"PubMed.PMID": pmid} for pmid in batch]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", lambda *_, **__: [])
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    df = gdd.fetch_pubmed_records(
+        ["1"],
+        sleep=0.0,
+        pubmed_cfg=sentinel_cfg,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert seen_cfg["value"] is sentinel_cfg
+    assert df.loc[0, "PubMed.PMID"] == "1"
+
 
 def test_fetch_pubmed_records_uses_fallback_doi(
     monkeypatch: pytest.MonkeyPatch,
@@ -407,7 +509,7 @@ def test_fetch_pubmed_records_uses_fallback_doi(
     fallback = {"123": "10.9999/fallback"}
 
     class DummySession:
-        def __enter__(self) -> "DummySession":  # pragma: no cover - trivial
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
             return self
 
         def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
@@ -416,7 +518,7 @@ def test_fetch_pubmed_records_uses_fallback_doi(
     monkeypatch.setattr(gdd.requests, "Session", lambda: DummySession())
 
     def fake_pubmed_batch(
-        session: Any, batch: list[str], sleep: float
+        session: Any, batch: list[str], sleep: float, cfg: Any | None = None
     ) -> list[dict[str, str]]:
         assert batch == ["123"]
         return [{"PubMed.PMID": "123"}]
@@ -463,7 +565,6 @@ def test_fetch_pubmed_records_uses_fallback_doi(
 
     assert captured["doi"] == fallback["123"]
     assert df.loc[0, "crossref.DOI"] == fallback["123"]
-
 
 
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])
@@ -528,7 +629,9 @@ def test_fetch_pubmed_records_accepts_executor_context(
         combined.update(crossref)
         return combined
 
-    def fake_pubmed_batch(session, batch, sleep):  # type: ignore[no-untyped-def]
+    def fake_pubmed_batch(  # type: ignore[no-untyped-def]
+        session, batch, sleep, cfg=None
+    ):
         return [{"PubMed.PMID": pmid, "PubMed.DOI": pmid} for pmid in batch]
 
     def fake_sem_batch(session, batch, sleep, cfg=None):  # type: ignore[no-untyped-def]
@@ -541,7 +644,7 @@ def test_fetch_pubmed_records_accepts_executor_context(
         return {"crossref.DOI": doi}
 
     monkeypatch.setattr(gdd, "ThreadPoolExecutor", DummyExecutor)
-    monkeypatch.setattr(gdd, "as_completed", lambda futures: list(futures.keys()))
+    monkeypatch.setattr(gdd, "as_completed", lambda futures: iter(futures))
     monkeypatch.setattr(gdd, "build_dataframe", fake_build_dataframe)
     monkeypatch.setattr(gdd, "merge_metadata", fake_merge_metadata)
     monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)


### PR DESCRIPTION
## Summary
- ensure the document pipeline passes the configured PubMed settings through `fetch_pubmed_records`, adds bounded parallelism, tightens structured logging, and validates positive CLI sizes for document commands
- expose a reusable `positive_int` validator via `library.cli`, fix ChemblClient retry handling when retries are zero, and surface the shared Config in the PubMed CLI module
- expand the document and Chembl client test suites to cover the new configuration plumbing, CLI validation, and retry behaviour

## Testing
- `ruff check .`
- `mypy --strict --ignore-missing-imports .` *(fails: existing typing issues in unrelated modules)*
- `pytest -q` *(fails: known memory/dtype expectations in existing tests)*
- `pytest tests/test_get_document_data.py -q`
- `pytest tests/test_pubmed_library_config_single.py -q`
- `pytest tests/test_chembl_client.py::test_request_json_respects_zero_retries -q`


------
https://chatgpt.com/codex/tasks/task_e_68d3de12ba20832481345d6cc386d45e