### PR TITLE
Align document export columns with custom schema

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -357,6 +357,115 @@ _NUMERIC_EXPORT_COLUMNS = {
 }
 
 
+_EXPORT_COLUMNS = [
+    "PubMed.JournalTitle",
+    "scholar.PMID",
+    "scholar.DOI",
+    "scholar.PublicationTypes",
+    "scholar.Venue",
+    "scholar.SemanticScholarId",
+    "scholar.ExternalIds",
+    "scholar.Error",
+    "OpenAlex.PMID",
+    "OpenAlex.DOI",
+    "OpenAlex.PublicationTypes",
+    "OpenAlex.TypeCrossref",
+    "OpenAlex.Genre",
+    "OpenAlex.Venue",
+    "OpenAlex.MeshDescriptors",
+    "OpenAlex.MeshQualifiers",
+    "OpenAlex.Id",
+    "OpenAlex.Error",
+    "crossref.DOI",
+    "crossref.Type",
+    "crossref.Subtype",
+    "crossref.Title",
+    "crossref.Subtitle",
+    "crossref.Subject",
+    "crossref.Error",
+    "publication_types_normalised",
+    "publication_review_score",
+    "publication_experimental_score",
+    "publication_class",
+    "ChEMBL.title",
+    "ChEMBL.abstract",
+    "ChEMBL.doi",
+    "ChEMBL.year",
+    "ChEMBL.journal",
+    "ChEMBL.journal_abbrev",
+    "ChEMBL.volume",
+    "ChEMBL.issue",
+    "ChEMBL.first_page",
+    "ChEMBL.last_page",
+    "ChEMBL.pubmed_id",
+    "ChEMBL.authors",
+    "ChEMBL.source",
+]
+
+_EXPORT_COLUMN_RENAMES = {
+    "title": "ChEMBL.title",
+    "abstract": "ChEMBL.abstract",
+    "doi": "ChEMBL.doi",
+    "year": "ChEMBL.year",
+    "journal": "ChEMBL.journal",
+    "journal_abbrev": "ChEMBL.journal_abbrev",
+    "volume": "ChEMBL.volume",
+    "issue": "ChEMBL.issue",
+    "first_page": "ChEMBL.first_page",
+    "last_page": "ChEMBL.last_page",
+    "pubmed_id": "ChEMBL.pubmed_id",
+    "authors": "ChEMBL.authors",
+    "source": "ChEMBL.source",
+    "publication_type_score_review": "publication_review_score",
+    "publication_type_score_experimental": "publication_experimental_score",
+}
+
+_EXPORT_COALESCE_SOURCES = {
+    "OpenAlex.PMID": ["OpenAlex.PMID", "PubMed.PMID", "scholar.PMID"],
+    "OpenAlex.DOI": ["OpenAlex.DOI", "PubMed.DOI", "scholar.DOI", "doi_normalised"],
+    "crossref.DOI": ["crossref.DOI", "doi_normalised", "PubMed.DOI", "scholar.DOI"],
+}
+
+_EXPORT_SORT_FALLBACK = [
+    "ChEMBL.pubmed_id",
+    "scholar.PMID",
+    "OpenAlex.PMID",
+    "PubMed.JournalTitle",
+]
+
+
+def _coalesce_columns(df: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
+    """Return the first non-empty value across ``columns`` for each row."""
+
+    result = pd.Series("", index=df.index, dtype=object)
+    for col in columns:
+        if col not in df.columns:
+            continue
+        values = df[col].fillna("").astype(str)
+        mask = result.eq("")
+        if mask.any():
+            result.loc[mask] = values.loc[mask]
+    return result
+
+
+def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename and project columns to match the export schema."""
+
+    frame = df.copy()
+    rename_map = {k: v for k, v in _EXPORT_COLUMN_RENAMES.items() if k in frame.columns}
+    if rename_map:
+        frame = frame.rename(columns=rename_map)
+
+    for target, sources in _EXPORT_COALESCE_SOURCES.items():
+        frame[target] = _coalesce_columns(frame, sources)
+
+    for column in _EXPORT_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = ""
+
+    return frame[_EXPORT_COLUMNS]
+
+
 def _finalise_export(
     df: pd.DataFrame,
     output: Path,
@@ -413,19 +522,29 @@ def _finalise_export(
         validated, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
     )
     export_df = dataframe_to_strings(export_df, skip=_NUMERIC_EXPORT_COLUMNS)
+    export_df = _prepare_export_frame(export_df)
+
+    key_cols: list[str] = []
     if key_columns:
-        key_cols = [c for c in key_columns if c in export_df.columns]
-    else:
-        key_cols = []
-    col_order = [c for c in DOCUMENT_SCHEMA_COLUMNS if c in export_df.columns] + sorted(
-        c for c in export_df.columns if c not in DOCUMENT_SCHEMA_COLUMNS
-    )
+        for column in key_columns:
+            mapped = _EXPORT_COLUMN_RENAMES.get(column, column)
+            if mapped in export_df.columns and mapped not in key_cols:
+                key_cols.append(mapped)
+    if not key_cols:
+        for candidate in _EXPORT_SORT_FALLBACK:
+            if candidate in export_df.columns:
+                key_cols = [candidate]
+                break
+    if not key_cols:
+        key_cols = [_EXPORT_COLUMNS[0]]
+
+    col_order = list(_EXPORT_COLUMNS)
     try:
         csv_path = io.write_csv(
             export_df,
             output,
             cfg=cfg,
-            key_cols=key_cols or None,
+            key_cols=key_cols,
             col_order=col_order,
         )
     except OSError as exc:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -307,7 +307,7 @@ def test_write_csv_column_order(
     monkeypatch.setattr(cl, "get_documents", lambda *_, **__: df)
     monkeypatch.setattr(gdd, "normalize_documents", lambda frame: frame)
 
-    captured: dict[str, list[str]] = {}
+    captured: dict[str, Any] = {}
 
     def fake_write_csv(
         frame: pd.DataFrame,
@@ -321,6 +321,8 @@ def test_write_csv_column_order(
         chunksize: int | None = None,
     ) -> Path:
         captured["col_order"] = list(col_order or [])
+        captured["columns"] = list(frame.columns)
+        captured["key_cols"] = list(key_cols or [])
         return path
 
     monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
@@ -337,11 +339,9 @@ def test_write_csv_column_order(
     )
     rc = gdd.run_chembl(cfg, args)
     assert rc == 0
-    schema_cols = list(DocumentsSchema.columns)
-    expected = [c for c in DOCUMENT_SCHEMA_COLUMNS if c in df.columns] + sorted(
-        c for c in df.columns if c not in schema_cols
-    )
-    assert captured["col_order"] == expected
+    assert captured["col_order"] == gdd._EXPORT_COLUMNS
+    assert captured["columns"] == gdd._EXPORT_COLUMNS
+    assert captured["key_cols"] == ["ChEMBL.pubmed_id"]
 
 
 def test_fetch_pubmed_records_handles_generic_error(


### PR DESCRIPTION
## Summary
- reshape the get_document_data export to emit the requested column list and derived values
- add column renaming/coalesce helpers so ChEMBL, OpenAlex and CrossRef data land in the new schema
- update the column-order regression test to cover the revised export contract

## Testing
- pytest tests/test_get_document_data.py
- pytest *(fails: missing optional dependency `hypothesis`)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f892402c83249d84170c4c9c3a1b