### PR TITLE
Add configurable chunk size for target retrieval

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1056,6 +1056,7 @@
           "$ref": "#/$defs/TargetChemblCfg",
           "default": {
             "column": "target_chembl_id",
+            "chunk_size": 5,
             "timeout": 30.0
           }
         },
@@ -1092,6 +1093,12 @@
           "default": "target_chembl_id",
           "title": "Column",
           "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
         },
         "timeout": {
           "default": 30.0,

--- a/config.yaml
+++ b/config.yaml
@@ -153,6 +153,7 @@ target:
     limit: null
   chembl:
     column: "target_chembl_id"
+    chunk_size: 5
     timeout: 30.0
     limit: null
   iuphar:

--- a/library/config.py
+++ b/library/config.py
@@ -465,6 +465,7 @@ class TargetUniprotCfg(_BaseModel):
 
 class TargetChemblCfg(_BaseModel):
     column: str = "chembl_id"
+    chunk_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
     limit: int | None = None
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -36,6 +36,7 @@ from library.cli import (
     apply_config_overrides,
     build_root_parser,
     configure_logger,
+    positive_int,
 )
 from library.config import (
     Config,
@@ -174,6 +175,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--column",
         default="target_chembl_id",
         help="Column name in the input CSV containing identifiers",
+    )
+    chembl.add_argument(
+        "--chunk-size",
+        type=positive_int,
+        default=5,
+        help="Maximum number of identifiers to request per call",
     )
     chembl.add_argument(
         "--timeout",
@@ -451,6 +458,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg.api,
                 client=client,
                 mapping_cfg=cfg.uniprot_mapping,
+                chunk_size=cfg.target.chembl.chunk_size,
                 timeout=cfg.target.chembl.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
@@ -959,6 +967,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "chembl":
             mapping = {
                 "column": "target.chembl.column",
+                "chunk_size": "target.chembl.chunk_size",
                 "timeout": "target.chembl.timeout",
                 "limit": "target.chembl.limit",
             }

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -232,6 +232,7 @@ def test_target_timeout_override(
         cfg: Config,
         client: Any,
         mapping_cfg: Any,
+        chunk_size: int,
         timeout: float,
     ) -> pd.DataFrame:
         data = list(ids)
@@ -262,3 +263,63 @@ def test_target_timeout_override(
     )
     assert rc == 0
     assert called["timeout"] == 11
+
+
+def test_target_chunk_size_override(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "target.csv"
+    input_csv.write_text("target_chembl_id\nt1\n")
+    config_path = _create_config(tmp_path)
+    called: dict[str, int] = {}
+
+    monkeypatch.setattr(io, "read_ids", lambda *a, **k: ["t1"])
+
+    def fake_apply_chunk(
+        a: Any,
+        p: Any,
+        c: Config,
+        mapping: Any | None = None,
+        **kwargs: Any,
+    ) -> Config:
+        cfg.target.chembl.chunk_size = int(a.chunk_size)
+        return cfg
+
+    monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply_chunk)
+
+    def fake_get_targets(
+        ids: Sequence[str],
+        cfg: Config,
+        client: Any,
+        mapping_cfg: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
+        data = list(ids)
+        called["chunk_size"] = chunk_size
+        return pd.DataFrame({"target_chembl_id": data})
+
+    monkeypatch.setattr(cl, "get_targets", fake_get_targets)
+    monkeypatch.setattr(
+        io,
+        "write_csv",
+        lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
+    )
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **__: None)
+    rc = gtd.main(
+        [
+            "chembl",
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(tmp_path / "out.csv"),
+            "--chunk-size",
+            "7",
+        ]
+    )
+    assert rc == 0
+    assert called["chunk_size"] == 7


### PR DESCRIPTION
## Summary
- add a chunk_size option to the Target Chembl configuration and default YAML/schema values
- expose a --chunk-size argument in the target CLI and forward it to cl.get_targets
- cover the new CLI flag with an integration test that verifies the override is honoured

## Testing
- pytest tests/test_cli_timeout_override.py
- pytest tests/test_dtype_inspector.py

------
https://chatgpt.com/codex/tasks/task_e_68d400cff45c8324a13134a3ed651336