### PR TITLE
Fix RateLimiter sleep handling for concurrency

### DIFF
--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -9,6 +9,7 @@ routed through :func:`sleep` so tests can monkeypatch it easily.
 
 from __future__ import annotations
 
+import math
 import threading
 import time
 
@@ -37,19 +38,28 @@ class RateLimiter:
         """Block until a token is available."""
         if self.rps <= 0:
             return
-        with self._lock:
-            now = time.monotonic()
-            elapsed = now - self._updated
-            self._tokens = min(float(self.burst), self._tokens + elapsed * self.rps)
-            if self._tokens < 1:
-                min_interval = 1.0 / self.rps
-                wait = max(min_interval, (1 - self._tokens) / self.rps)
+
+        wait = 0.0
+        while True:
+            if wait > 0:
                 sleep(wait)
+                wait = 0.0
+
+            with self._lock:
                 now = time.monotonic()
                 elapsed = now - self._updated
-                self._tokens = min(float(self.burst), self._tokens + elapsed * self.rps)
-            self._tokens -= 1
-            self._updated = now
+                self._tokens = min(
+                    float(self.burst), self._tokens + elapsed * self.rps
+                )
+                if self._tokens >= 1 or math.isclose(
+                    self._tokens, 1.0, rel_tol=0.0, abs_tol=1e-9
+                ):
+                    self._tokens = max(0.0, self._tokens - 1)
+                    self._updated = now
+                    return
+
+                min_interval = 1.0 / self.rps
+                wait = max(min_interval, (1 - self._tokens) / self.rps)
 
 
 _limiters: TTLCache[str, RateLimiter] = TTLCache(maxsize=128, ttl=600)

--- a/tests/test_rate_limiter_threadsafe.py
+++ b/tests/test_rate_limiter_threadsafe.py
@@ -4,7 +4,27 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from library import rate_limiter as rl
+
+
+class ThreadSafeFakeTime:
+    """Thread-safe monotonic clock for testing."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        with self._lock:
+            return self._now
+
+    def sleep(self, delay: float) -> None:
+        with self._lock:
+            self.sleeps.append(delay)
+            self._now += delay
 
 
 def test_get_limiter_thread_safe() -> None:
@@ -28,3 +48,35 @@ def test_get_limiter_thread_safe() -> None:
     with rl._limiters_lock:
         assert len(rl._limiters) == 1
         rl._limiters.clear()
+
+
+def test_acquire_releases_lock_before_sleep(monkeypatch) -> None:
+    """Ensure :meth:`RateLimiter.acquire` sleeps without holding the lock."""
+
+    fake_time = ThreadSafeFakeTime()
+    monkeypatch.setattr(rl, "time", fake_time)
+
+    limiter = rl.RateLimiter(rps=1, burst=1)
+
+    def fake_sleep(delay: float) -> None:
+        assert not limiter._lock.locked()
+        fake_time.sleep(delay)
+
+    monkeypatch.setattr(rl, "sleep", fake_sleep)
+
+    barrier = threading.Barrier(2)
+    completed: list[None] = []
+
+    def worker() -> None:
+        barrier.wait()
+        limiter.acquire()
+        completed.append(None)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(completed) == 2
+    assert fake_time.sleeps == pytest.approx([1.0])


### PR DESCRIPTION
## Summary
- release the rate limiter lock before sleeping and tolerate floating point rounding when consuming tokens
- add a thread-safe fake clock and regression test to ensure acquire sleeps without holding the lock

## Testing
- pytest tests/test_rate_limiter.py tests/test_rate_limiter_threadsafe.py
- python -m scripts.get_activities --limit 1 --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d406e6f68c8324858421904a6b5a32