### PR TITLE
Enhance UniProt export metadata

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -363,6 +363,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             df = df.head(limit)
             logger.info("process_limit", limit=len(df))
         ids = df[column].tolist()
+        rows_total = len(ids)
 
         from tempfile import NamedTemporaryFile
 
@@ -395,14 +396,34 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         out_df = pd.read_csv(
             output, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
         )
+        rows_kept = len(out_df)
         if "mapping_uniprot_id" in df.columns:
             out_df.insert(1, "mapping_uniprot_id", df["mapping_uniprot_id"].tolist())
-        io.write_csv(
+        csv_path = io.write_csv(
             out_df,
             output,
             cfg=cfg,
             sep=cfg.io.csv_sep,
             encoding=cfg.io.csv_encoding,
+            key_cols=["uniprot_id"],
+        )
+        rows_dropped = max(rows_total - rows_kept, 0)
+        stats: Stats = {
+            "rows_total": rows_total,
+            "rows_kept": rows_kept,
+            "rows_dropped": rows_dropped,
+            "output_sha256": file_sha256(csv_path),
+        }
+        inputs = {"input_csv": str(args.input_csv)}
+        if cfg.target.uniprot.data_dir:
+            inputs["data_dir"] = str(cfg.target.uniprot.data_dir)
+        write_meta_yaml(
+            csv_path=csv_path,
+            command=" ".join(sys.argv),
+            config_subset=_serialize_paths(cfg.to_dict()),
+            inputs=inputs,
+            stats=stats,
+            schema="UniProtExport",
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("%s", exc)

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
+import yaml
 from pytest import MonkeyPatch
 
 from library.config import Config
@@ -91,6 +92,64 @@ def test_run_uniprot_initialises_session(
     assert rc == 0
     assert called["init"] == (cfg.api, cfg.retry)
     assert called["cfg"] is cfg.uniprot
+
+
+def test_run_uniprot_writes_sidecar(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text(
+        "uniprot_id\nP12345\nP23456\n", encoding=cfg.io.csv_encoding
+    )
+    output_csv = tmp_path / "uniprot.csv"
+    cfg.target.uniprot.data_dir = tmp_path
+
+    def fake_init_session(api: object, retry: object) -> None:
+        pass
+
+    def fake_process(
+        input_csv: str,
+        output_csv: str,
+        data_dir: Path | str | None = None,
+        *,
+        cfg: object,
+        sep: str = ",",
+        encoding: str = "utf-8",
+    ) -> None:
+        pd.DataFrame(
+            {
+                "uniprot_id": ["P23456", "P12345"],
+                "names": ["Beta", "Alpha"],
+            }
+        ).to_csv(output_csv, index=False)
+
+    monkeypatch.setattr(gtd.uu, "init_session", fake_init_session)
+    monkeypatch.setattr(gtd.uu, "process", fake_process)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+    rc = gtd.run_uniprot(cfg, args)
+
+    assert rc == 0
+
+    df = pd.read_csv(output_csv)
+    assert list(df["uniprot_id"]) == ["P12345", "P23456"]
+
+    meta_path = output_csv.with_name(output_csv.name + ".meta.yaml")
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+
+    assert "uniprot_id" in metadata.get("columns", [])
+    assert metadata["schema"] == "UniProtExport"
+
+    stats = metadata["stats"]
+    assert stats["rows_total"] == 2
+    assert stats["rows_kept"] == 2
+    assert stats["rows_dropped"] == 0
+    assert len(stats["output_sha256"]) == 64
+
+    inputs = metadata["inputs"]
+    assert inputs["input_csv"] == str(input_csv)
+    assert inputs["data_dir"] == str(cfg.target.uniprot.data_dir)
 
 
 def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> None:


### PR DESCRIPTION
## Summary
- ensure UniProt export writes deterministic rows keyed by accession and records Stats metadata
- append pipeline execution metadata to the UniProt sidecar YAML file
- add regression test checking UniProt CSV ordering and sidecar contents

## Testing
- pytest tests/test_get_target_data_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68d4072d638c832499186f5c5fa10a16