### PR TITLE
Handle missing key columns during deterministic CSV writes

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -61,6 +61,37 @@ def _normalise_dates(series: pd.Series) -> pd.Series:
     return series
 
 
+def _resolve_sort_columns(
+    df: pd.DataFrame,
+    requested: Sequence[str],
+    *,
+    emit_warning: bool = True,
+) -> list[str]:
+    """Return stable row sort columns honouring ``requested`` when possible."""
+
+    sort_cols = list(requested)
+    if not sort_cols:
+        if df.empty:
+            return []
+        msg = "key_cols must contain at least one column"
+        raise ValueError(msg)
+
+    missing = [col for col in sort_cols if col not in df.columns]
+    if not missing:
+        return sort_cols
+
+    available = [col for col in sort_cols if col in df.columns]
+    fallback = available + [col for col in df.columns if col not in available]
+    if emit_warning:
+        logger.warning(
+            "missing_key_columns",
+            requested=sort_cols,
+            missing=missing,
+            fallback=fallback,
+        )
+    return fallback
+
+
 def write_csv_deterministic(
     df: pd.DataFrame,
     path: str | Path,
@@ -91,8 +122,9 @@ def write_csv_deterministic(
         ``True``, in which case they are omitted with a warning.
     key_cols:
         Sequence of column names defining row ordering. ``None`` is invalid
-        and results in a :class:`ValueError`. An empty sequence is only
-        permitted when ``df`` is empty.
+        and results in a :class:`ValueError`. Missing columns trigger a
+        deterministic fallback that appends remaining columns in their current
+        order. An empty sequence is only permitted when ``df`` is empty.
     chunksize:
         Optional number of rows to write per chunk. Passing a value enables
         streaming output via :meth:`pandas.DataFrame.to_csv`, reducing peak
@@ -170,19 +202,9 @@ def write_csv_deterministic(
     # Sort rows deterministically using a stable algorithm.
     if key_cols is None:
         raise ValueError("key_cols must be provided")
+    key_cols_list = list(key_cols)
 
-    requested_sort_cols = list(key_cols)
-    if not requested_sort_cols:
-        if work.empty:
-            sort_cols: list[str] = []
-        else:
-            raise ValueError("key_cols must contain at least one column")
-    else:
-        missing = [c for c in requested_sort_cols if c not in work.columns]
-        if missing:
-            msg = f"Missing key columns: {missing}"
-            raise ValueError(msg)
-        sort_cols = requested_sort_cols
+    sort_cols = _resolve_sort_columns(work, key_cols_list)
 
     # In-memory sort when ``sort_chunksize`` is not specified or large enough.
     if not sort_cols or sort_chunksize is None or len(work) <= sort_chunksize:
@@ -238,7 +260,7 @@ def write_csv_deterministic(
                 )
                 tmp_paths.append(chunk_path)
 
-            key_indices = [column_names.index(c) for c in sort_cols]
+            key_indices = [column_names.index(c) for c in sort_cols] if sort_cols else []
             key_funcs: list[Callable[[str], object]] = []
             for col in sort_cols:
                 dtype = work.dtypes[col]
@@ -274,8 +296,13 @@ def write_csv_deterministic(
                     except StopIteration:
                         readers[idx][1].close()
                         continue
-                    key = tuple(
-                        func(row[key_indices[i]]) for i, func in enumerate(key_funcs)
+                    key = (
+                        tuple(
+                            func(row[key_indices[i]])
+                            for i, func in enumerate(key_funcs)
+                        )
+                        if key_funcs
+                        else tuple()
                     )
                     heapq.heappush(heap, (key, idx, row))
 
@@ -287,8 +314,13 @@ def write_csv_deterministic(
                     except StopIteration:
                         readers[idx][1].close()
                         continue
-                    key = tuple(
-                        func(row[key_indices[i]]) for i, func in enumerate(key_funcs)
+                    key = (
+                        tuple(
+                            func(row[key_indices[i]])
+                            for i, func in enumerate(key_funcs)
+                        )
+                        if key_funcs
+                        else tuple()
                     )
                     heapq.heappush(heap, (key, idx, row))
 
@@ -340,7 +372,8 @@ def write_csv_chunks_deterministic(
         :func:`write_csv_deterministic`.
     key_cols:
         Columns defining row order. ``None`` is invalid and results in a
-        :class:`ValueError`.
+        :class:`ValueError`. Missing columns trigger the same deterministic
+        fallback used by :func:`write_csv_deterministic`.
     chunksize:
         Number of rows written per chunk.
 
@@ -374,6 +407,7 @@ def write_csv_chunks_deterministic(
 
     if key_cols is None:
         raise ValueError("key_cols must be provided")
+    key_cols_list = list(key_cols)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_paths: list[Path] = []
@@ -393,7 +427,7 @@ def write_csv_chunks_deterministic(
                 df_chunk,
                 tmp_path,
                 col_order=col_order,
-                key_cols=key_cols,
+                key_cols=key_cols_list,
                 chunksize=chunksize,
                 sort_chunksize=sort_chunksize,
                 sep=sep,
@@ -412,7 +446,7 @@ def write_csv_chunks_deterministic(
                 pd.DataFrame(),
                 out_path,
                 col_order=col_order,
-                key_cols=key_cols,
+                key_cols=key_cols_list,
                 chunksize=chunksize,
                 sep=sep,
                 encoding=encoding,
@@ -437,6 +471,7 @@ def write_csv_chunks_deterministic(
         first = next((c for c in current if c is not None), pd.DataFrame())
         columns = list(first.columns)
         dtypes = {col: first.dtypes[col].name for col in columns}
+        resolved_sort_cols = _resolve_sort_columns(first, key_cols_list, emit_warning=False)
 
         def _fmt(value: Any) -> Any:
             if pd.isna(value):
@@ -451,7 +486,7 @@ def write_csv_chunks_deterministic(
         for idx, frame in enumerate(current):
             if frame is not None and not frame.empty:
                 row = frame.iloc[0]
-                key = tuple(row[k] for k in key_cols)
+                key = tuple(row[k] for k in resolved_sort_cols) if resolved_sort_cols else tuple()
                 heapq.heappush(heap, (key, idx, 0))
 
         with out_path.open("w", encoding=encoding, newline="") as fh:
@@ -466,7 +501,11 @@ def write_csv_chunks_deterministic(
                 row_idx += 1
                 if row_idx < len(chunk):
                     next_row = chunk.iloc[row_idx]
-                    key = tuple(next_row[k] for k in key_cols)
+                    key = (
+                        tuple(next_row[k] for k in resolved_sort_cols)
+                        if resolved_sort_cols
+                        else tuple()
+                    )
                     heapq.heappush(heap, (key, file_idx, row_idx))
                 else:
                     try:
@@ -477,7 +516,11 @@ def write_csv_chunks_deterministic(
                         current[file_idx] = next_chunk
                         if not next_chunk.empty:
                             next_row = next_chunk.iloc[0]
-                            key = tuple(next_row[k] for k in key_cols)
+                            key = (
+                                tuple(next_row[k] for k in resolved_sort_cols)
+                                if resolved_sort_cols
+                                else tuple()
+                            )
                             heapq.heappush(heap, (key, file_idx, 0))
 
     write_meta_yaml(out_path, cfg, columns=columns, dtypes=dtypes)

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -18,6 +18,7 @@ from hypothesis.extra.pandas import column, data_frames, range_indexes
 
 import library.git_utils as git_utils
 from library.config import Config
+import library.csv_utils as csv_utils
 from library.csv_utils import sha256_file, write_csv_deterministic
 
 
@@ -124,6 +125,33 @@ def test_write_csv_deterministic_none_key_cols(tmp_path: Path) -> None:
     path = tmp_path / "out.csv"
     with pytest.raises(ValueError, match="key_cols must be provided"):
         write_csv_deterministic(df, path, key_cols=None)
+
+
+def test_write_csv_deterministic_missing_sort_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    df = pd.DataFrame({"name": ["beta", "alpha"], "value": [2, 1]})
+    path = tmp_path / "fallback.csv"
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def record(event: str, **payload: object) -> None:
+        events.append((event, payload))
+
+    monkeypatch.setattr(csv_utils.logger, "warning", record)
+
+    write_csv_deterministic(
+        df,
+        path,
+        col_order=["value", "name"],
+        key_cols=["chembl_id"],
+    )
+
+    content = path.read_text(encoding="utf-8-sig")
+    assert content == "value,name\n1,alpha\n2,beta\n"
+
+    fallback_event = [payload for event, payload in events if event == "missing_key_columns"]
+    assert fallback_event
+    assert fallback_event[0]["fallback"] == ["value", "name"]
 
 
 def test_deterministic_writes_identical_bytes(tmp_path: Path) -> None:

--- a/tests/test_write_csv_chunks_deterministic.py
+++ b/tests/test_write_csv_chunks_deterministic.py
@@ -36,3 +36,36 @@ def test_write_csv_chunks_deterministic(tmp_path: Path) -> None:
         chunksize=1000,
     )
     assert path_full.read_bytes() == path_chunks.read_bytes()
+
+
+def test_write_csv_chunks_deterministic_missing_keys(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "name": ["beta", "alpha", "gamma", "delta"],
+            "value": [2, 1, 3, 1],
+        }
+    )
+    shuffled = df.sample(frac=1, random_state=5).reset_index(drop=True)
+    path_full = tmp_path / "full_fallback.csv"
+    path_chunks = tmp_path / "chunks_fallback.csv"
+
+    write_csv_deterministic(
+        shuffled,
+        path_full,
+        col_order=["value", "name"],
+        key_cols=["chembl_id"],
+    )
+
+    chunk_iter = (
+        shuffled.iloc[i : i + 2] for i in range(0, len(shuffled), 2)
+    )
+    write_csv_chunks_deterministic(
+        chunk_iter,
+        path_chunks,
+        col_order=["value", "name"],
+        key_cols=["chembl_id"],
+        chunksize=2,
+        merge_chunksize=1,
+    )
+
+    assert path_full.read_bytes() == path_chunks.read_bytes()


### PR DESCRIPTION
## Summary
- add a helper that resolves missing sort keys with a deterministic fallback for CSV exports
- teach the chunked writer to reuse the fallback ordering so merge output stays stable
- cover the new behaviour with unit tests for both direct and chunked writers

## Testing
- pytest tests/test_csv_utils.py tests/test_write_csv_chunks_deterministic.py

------
https://chatgpt.com/codex/tasks/task_e_68d415fe6d84832485e38da43c8a46d0