### PR TITLE
Add coverage for config, logging, and client helpers

### DIFF
--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import random
 import time
+from types import TracebackType
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -66,6 +67,19 @@ def test_client_closes_session() -> None:
     session = MagicMock(spec=requests.Session)
     with ChemblClient(api_cfg(), RetryCfg(), session=session):
         pass
+    session.close.assert_called_once()
+
+
+def test_client_closes_session_on_error() -> None:
+    """Context manager must close sessions even when exceptions occur."""
+
+    session = MagicMock(spec=requests.Session)
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)
+
+    with pytest.raises(RuntimeError):
+        with client:
+            raise RuntimeError("boom")
+
     session.close.assert_called_once()
 
 
@@ -185,6 +199,50 @@ def test_request_json_cache(monkeypatch) -> None:
 
     assert url in client.cache
     assert len(responses.calls) == 1
+
+
+def test_request_json_uses_cache_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cache mutations should be synchronised with the internal lock."""
+
+    session = DummySession()
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)
+
+    class RecordingLock:
+        def __init__(self) -> None:
+            self.history: list[str] = []
+
+        def __enter__(self) -> RecordingLock:
+            self.history.append("enter")
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            self.history.append("exit")
+            return False
+
+    lock = RecordingLock()
+    client._cache_lock = lock  # type: ignore[assignment]
+
+    class DummyLimiter:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def acquire(self) -> None:
+            self.calls += 1
+
+    limiter = DummyLimiter()
+    monkeypatch.setattr("library.chembl_client.get_limiter", lambda *a, **k: limiter)
+    monkeypatch.setattr("library.chembl_client.sleep", lambda delay: None)
+
+    result = client.request_json("http://example.com", cfg=api_cfg(retries=1))
+
+    assert result == {"ok": True}
+    assert lock.history == ["enter", "exit", "enter", "exit"]
+    assert limiter.calls == 1
 
 
 @responses.activate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,6 +269,25 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert out.is_dir() and cache.is_dir()
 
 
+def test_load_config_requires_existing_dirs(tmp_path: Path) -> None:
+    """``exist_ok`` disabled should require pre-existing directories."""
+
+    output_dir = tmp_path / "missing_out"
+    cache_dir = tmp_path / "missing_cache"
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        "io:\n"
+        "  exist_ok: false\n"
+        f"  output_dir: {output_dir}\n"
+        f"  cache_dir: {cache_dir}\n"
+    )
+
+    with pytest.raises(FileNotFoundError) as exc:
+        load_config(cfg_path)
+
+    assert str(output_dir) in str(exc.value)
+
+
 def test_unknown_key_warning(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\napi:\n  rps: 1\n")

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -568,6 +568,50 @@ def test_fetch_pubmed_records_uses_fallback_doi(
     assert df.loc[0, "crossref.DOI"] == fallback["123"]
 
 
+def test_finalise_export_falls_back_to_default_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CSV export should default to known key columns when none are provided."""
+
+    cfg = Config()
+    df = pd.DataFrame({"document_chembl_id": ["CHEMBL1"], "PubMed.PMID": ["123"]})
+    output = tmp_path / "documents.csv"
+    captured: dict[str, Any] = {}
+
+    def fake_write_csv(
+        frame: pd.DataFrame,
+        path: Path,
+        *,
+        cfg: Any,
+        sep: str | None = None,
+        encoding: str | None = None,
+        key_cols: list[str] | None = None,
+        col_order: list[str] | None = None,
+        chunksize: int | None = None,
+    ) -> Path:
+        captured["key_cols"] = list(key_cols) if key_cols is not None else None
+        return path
+
+    monkeypatch.setattr(gdd.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "file_sha256", lambda p: "hash")
+    monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
+    monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})
+    monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
+    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
+
+    exit_code = gdd._finalise_export(
+        df,
+        output,
+        cfg,
+        input_csv=tmp_path / "input.csv",
+        key_columns=None,
+    )
+
+    assert exit_code == 0
+    assert captured["key_cols"] == ["ChEMBL.document_chembl_id"]
+
+
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])
 def test_fetch_pubmed_records_accepts_executor_context(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -115,3 +115,21 @@ def test_multithreaded_logging_emits_valid_json(
     assert len(lines) == 10
     for line in lines:
         json.loads(line)
+
+
+def test_logger_bind_preserves_parent_context(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Binding context should not mutate the original logger."""
+
+    base = configure_logger(LoggerConfig(level="INFO", run_id="rid", stream=sys.stdout))
+    child = base.bind(stage="extract")
+
+    child.info("child_event")
+    base.info("parent_event")
+
+    records = _parse(capfd.readouterr().out)
+    assert records[0]["event"] == "child_event"
+    assert records[0]["stage"] == "extract"
+    parent = next(rec for rec in records if rec["event"] == "parent_event")
+    assert "stage" not in parent


### PR DESCRIPTION
## Summary
- add a configuration test that verifies `exist_ok=False` enforces pre-created directories
- extend logging tests to cover `Logger.bind` context isolation
- add document export fallback coverage and Chembl client session/cache tests

## Testing
- pytest tests/test_config.py::test_load_config_requires_existing_dirs
- pytest tests/test_logging_setup.py::test_logger_bind_preserves_parent_context
- pytest tests/test_get_document_data.py::test_finalise_export_falls_back_to_default_key
- pytest tests/test_chembl_client.py::test_client_closes_session_on_error
- pytest tests/test_chembl_client.py::test_request_json_uses_cache_lock

------
https://chatgpt.com/codex/tasks/task_e_68d4166b3cd08324b04bc1fc29315048