### PR TITLE
Refactor logging to structured events

### DIFF
--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -41,7 +41,7 @@ def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
     AssayPostprocessSchema.validate(df)
     group_cols = ["document_chembl_id", "target_chembl_id"]
     groups = df.groupby(group_cols)
-    logger.debug("Calculated counts for %d document/target groups", groups.ngroups)
+    logger.debug("assay_group_counts_calculated", group_count=groups.ngroups)
     result = df.copy()
     result["assay_with_same_target"] = groups["document_chembl_id"].transform("size")
     return result

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -69,7 +69,9 @@ def _parse_uniprot_id(
     try:
         mapping_uniprot_id = map_chembl_to_uniprot(chembl_id, mapping_cfg) or ""
     except Exception as exc:  # pragma: no cover - network failure paths
-        logger.warning("UniProt mapping request failed for %s: %s", chembl_id, exc)
+        logger.warning(
+            "uniprot_mapping_failed", chembl_id=chembl_id, error=str(exc)
+        )
         mapping_uniprot_id = ""
     return uniprot_id, mapping_uniprot_id
 
@@ -104,7 +106,11 @@ def _parse_target_record(
     """Transform a raw target record into a flat dictionary."""
     components = _get_items(data.get("target_components"), "target_component")
     if not components:
-        logger.debug("No components found in target record: %s", data)
+        logger.debug(
+            "target_components_missing",
+            target_chembl_id=str(data.get("target_chembl_id", "")),
+            record=data,
+        )
         return dict(EMPTY_TARGET)
 
     comp = components[0]

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -360,7 +360,7 @@ def apply_config_overrides(
             strict=True,
         )
     except ConfigError as exc:
-        log.logger.error("%s", exc)
+        log.logger.error("config_error", error=str(exc))
         parser.error(str(exc))
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc

--- a/library/config.py
+++ b/library/config.py
@@ -600,7 +600,7 @@ def _apply_env_overrides(data: dict[str, Any]) -> None:
             continue
         parts = [p.lower() for p in path]
         if not _is_valid_path(parts):
-            logger.warning(f"Environment variable {key} ignored")
+            logger.warning("env_override_ignored", variable=key)
             continue
         _set_by_path(data, parts, env_val)
 

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -716,7 +716,9 @@ def _safe_to_int(series: pd.Series, col: str) -> pd.Series:
     try:
         return pd.to_numeric(series, errors="raise").astype("Int64")
     except Exception as exc:  # pragma: no cover - rare
-        logger.warning("Failed to convert column '%s' to Int64: %s", col, exc)
+        logger.warning(
+            "column_cast_failed", column=col, target_dtype="Int64", error=str(exc)
+        )
         return series.astype("string")
 
 
@@ -742,7 +744,9 @@ def _safe_to_float(series: pd.Series, col: str) -> pd.Series:
     try:
         return pd.to_numeric(series, errors="raise").astype("float64")
     except Exception as exc:  # pragma: no cover - rare
-        logger.warning("Failed to convert column '%s' to float: %s", col, exc)
+        logger.warning(
+            "column_cast_failed", column=col, target_dtype="float64", error=str(exc)
+        )
         return series.astype("string")
 
 
@@ -768,7 +772,9 @@ def _safe_to_datetime(series: pd.Series, col: str) -> pd.Series:
     try:
         return pd.to_datetime(series, errors="raise")
     except Exception as exc:  # pragma: no cover - rare
-        logger.warning("Failed to convert column '%s' to datetime: %s", col, exc)
+        logger.warning(
+            "column_cast_failed", column=col, target_dtype="datetime64", error=str(exc)
+        )
         return series.astype("string")
 
 
@@ -807,7 +813,9 @@ def _safe_to_bool(series: pd.Series, col: str) -> pd.Series:
         mapped = series.map(mapper)
         return mapped.astype("boolean")
     except Exception as exc:  # pragma: no cover - rare
-        logger.warning("Failed to convert column '%s' to boolean: %s", col, exc)
+        logger.warning(
+            "column_cast_failed", column=col, target_dtype="boolean", error=str(exc)
+        )
         return series.astype("string")
 
 
@@ -867,10 +875,17 @@ def generate_pair_entity_tables(
 
     activity_df = tables.get("activity")
     if activity_df is None:
-        logger.warning("'activity' table missing; cannot generate pair tables")
+        logger.warning(
+            "activity_table_missing", table="activity", context="pair_tables"
+        )
         return result
     if "activity_chembl_id" not in activity_df.columns:
-        logger.warning("'activity' table missing column 'activity_chembl_id'")
+        logger.warning(
+            "table_column_missing",
+            table="activity",
+            column="activity_chembl_id",
+            context="pair_tables",
+        )
         return result
 
     # Columns linking activities to related entities use CHEMBL identifiers.
@@ -889,7 +904,7 @@ def generate_pair_entity_tables(
     for pair_key, suffix in pair_keys.items():
         pairs_df = tables.get(pair_key)
         if pairs_df is None:
-            logger.warning("pair table '%s' missing", pair_key)
+            logger.warning("pair_table_missing", table=pair_key)
             continue
 
         # Harmonise activity identifier column names to ensure downstream
@@ -902,7 +917,7 @@ def generate_pair_entity_tables(
         missing = required - set(pairs_df.columns)
         if missing:
             logger.warning(
-                "pair table '%s' missing columns %s", pair_key, sorted(missing)
+                "pair_table_columns_missing", table=pair_key, columns=sorted(missing)
             )
             continue
 
@@ -921,20 +936,22 @@ def generate_pair_entity_tables(
         for entity, id_col in entity_cols.items():
             if id_col not in filtered_activity.columns:
                 logger.warning(
-                    "activity table missing column '%s'; skipping %s_%s",
-                    id_col,
-                    entity,
-                    suffix,
+                    "activity_column_missing",
+                    column=id_col,
+                    entity=entity,
+                    suffix=suffix,
                 )
                 continue
 
             ids = pd.unique(filtered_activity[id_col].dropna())
             entity_df = tables.get(entity)
             if entity_df is None:
-                logger.warning("entity table '%s' missing", entity)
+                logger.warning("entity_table_missing", table=entity)
                 continue
             if id_col not in entity_df.columns:
-                logger.warning("entity table '%s' missing column '%s'", entity, id_col)
+                logger.warning(
+                    "entity_column_missing", table=entity, column=id_col
+                )
                 continue
             result[f"{entity}_{suffix}"] = entity_df[entity_df[id_col].isin(ids)].copy()
 
@@ -982,7 +999,9 @@ def add_pair_metric_columns(df: pd.DataFrame) -> pd.DataFrame:
             result[col] = 0
         missing = [c for c in (indep_col, type_col) if c not in result.columns]
         logger.warning(
-            "pair table missing columns %s; metric flags set to zero", missing
+            "pair_table_columns_missing",
+            columns=missing,
+            action="fill_zero",
         )
     return result
 
@@ -1060,11 +1079,11 @@ def build_combined_tables(
         else:
             df = df_tmp
         logger.info(
-            "Entity %s: rows_same=%d rows_all=%d rows_after_dedup=%d",
-            entity,
-            len(df_same),
-            len(df_all),
-            len(df),
+            "entity_merge_stats",
+            entity=entity,
+            rows_same=len(df_same),
+            rows_all=len(df_all),
+            rows_after_dedup=len(df),
         )
         combined[entity] = df
 
@@ -1077,11 +1096,15 @@ def build_combined_tables(
     # ``concat`` requires unique column names across inputs.
     same_dups = df_same_act.columns[df_same_act.columns.duplicated()].tolist()
     if same_dups:
-        logger.info("Removed duplicate activity columns from 'same': %s", same_dups)
+        logger.info(
+            "activity_duplicate_columns_removed", source="same", columns=same_dups
+        )
         df_same_act = df_same_act.loc[:, ~df_same_act.columns.duplicated()]
     all_dups = df_all_act.columns[df_all_act.columns.duplicated()].tolist()
     if all_dups:
-        logger.info("Removed duplicate activity columns from 'all_': %s", all_dups)
+        logger.info(
+            "activity_duplicate_columns_removed", source="all_", columns=all_dups
+        )
         df_all_act = df_all_act.loc[:, ~df_all_act.columns.duplicated()]
 
     concat = pd.concat([df_same_act, df_all_act], ignore_index=True, sort=False)
@@ -1096,11 +1119,11 @@ def build_combined_tables(
     if dict_dir is not None:
         df_activity = process_activity_table(df_activity, dict_dir, targets_path)
     logger.info(
-        "Entity activity: rows_same=%d rows_all=%d rows_concat=%d rows_after_dedup=%d",
-        len(df_same_act),
-        len(df_all_act),
-        len(concat),
-        len(df_activity),
+        "activity_merge_stats",
+        rows_same=len(df_same_act),
+        rows_all=len(df_all_act),
+        rows_concat=len(concat),
+        rows_after_dedup=len(df_activity),
     )
     remaining = ACTIVITY_DROP_COLS & set(df_activity.columns)
     if remaining:
@@ -1732,9 +1755,9 @@ def aggregate_activity(
     missing = [m for m in metrics if m not in df_pairs.columns]
     if missing:
         logger.warning(
-            "pair table missing %s %s; filling with zeros",
-            "column" if len(missing) == 1 else "columns",
-            ", ".join(missing),
+            "pair_table_columns_missing",
+            columns=missing,
+            action="fill_zero",
         )
         for col in missing:
             df_pairs[col] = 0
@@ -1769,9 +1792,9 @@ def aggregate_activity(
     missing_sys = [c for c in system_cols if c not in merged.columns]
     if missing_sys:
         logger.warning(
-            "activity table missing %s %s; skipping system aggregation",
-            "column" if len(missing_sys) == 1 else "columns",
-            ", ".join(missing_sys),
+            "activity_columns_missing",
+            columns=missing_sys,
+            action="skip_system_aggregation",
         )
         system_status = pd.DataFrame(columns=["system_id", "Filtered.new", *metrics])
     else:
@@ -1793,7 +1816,9 @@ def aggregate_activity(
         testitem_status = _aggregate_entity(merged, "molecule_chembl_id", status_api)
     elif "molecule_chembl_id" not in missing_sys:
         logger.warning(
-            "activity table missing column molecule_chembl_id; skipping testitem aggregation"
+            "activity_column_missing",
+            column="molecule_chembl_id",
+            action="skip_testitem_aggregation",
         )
         testitem_status = pd.DataFrame(
             columns=["molecule_chembl_id", "Filtered.new", *metrics]
@@ -1808,7 +1833,9 @@ def aggregate_activity(
         target_status = _aggregate_entity(merged, "target_chembl_id", status_api)
     else:
         logger.warning(
-            "activity table missing column target_chembl_id; skipping target aggregation"
+            "activity_column_missing",
+            column="target_chembl_id",
+            action="skip_target_aggregation",
         )
         target_status = pd.DataFrame(
             columns=["target_chembl_id", "Filtered.new", *metrics]

--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -188,7 +188,12 @@ def _query_gene_symbol(
                     return data[0] if data else {}
         except requests.RequestException as exc:  # pragma: no cover - network errors
             if attempt >= retry.max_attempts:
-                logger.error("IUPHAR web request failed: %s", exc)
+                logger.error(
+                    "iuphar_gene_request_failed",
+                    gene_symbol=gene_name,
+                    url=url,
+                    error=str(exc),
+                )
                 break
             backoff = retry.backoff_factor * (2 ** (attempt - 1))
             jitter = random.uniform(0, backoff)
@@ -666,7 +671,11 @@ class IUPHARData:
                             return pd.read_csv(io.StringIO(resp.text))
                 except requests.RequestException as exc:  # pragma: no cover - network
                     if attempt >= retry_cfg.max_attempts:
-                        logger.error("IUPHAR mapping request failed: %s", exc)
+                        logger.error(
+                            "iuphar_mapping_request_failed",
+                            url=url,
+                            error=str(exc),
+                        )
                         raise
                     backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
                     jitter = random.uniform(0, backoff)

--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -187,32 +187,29 @@ class Logger:
     def debug(
         self,
         event: str,
-        *args: Any,
+        *,
         extra: dict[str, Any] | None = None,
         **kv: Any,
     ) -> None:
-        msg = event % args if args else None
-        self.log("DEBUG", event, msg=msg, extra=extra, **kv)
+        self.log("DEBUG", event, extra=extra, **kv)
 
     def info(
         self,
         event: str,
-        *args: Any,
+        *,
         extra: dict[str, Any] | None = None,
         **kv: Any,
     ) -> None:
-        msg = event % args if args else None
-        self.log("INFO", event, msg=msg, extra=extra, **kv)
+        self.log("INFO", event, extra=extra, **kv)
 
     def warn(
         self,
         event: str,
-        *args: Any,
+        *,
         extra: dict[str, Any] | None = None,
         **kv: Any,
     ) -> None:
-        msg = event % args if args else None
-        self.log("WARN", event, msg=msg, extra=extra, **kv)
+        self.log("WARN", event, extra=extra, **kv)
 
     # ``warning`` is an alias for compatibility with :mod:`logging` APIs.
     warning = warn
@@ -220,18 +217,18 @@ class Logger:
     def error(
         self,
         event: str,
-        *args: Any,
+        *,
         extra: dict[str, Any] | None = None,
         **kv: Any,
     ) -> None:
-        msg = event % args if args else None
-        self.log("ERROR", event, msg=msg, extra=extra, **kv)
+        self.log("ERROR", event, extra=extra, **kv)
 
     def exception(
         self,
         event: str,
-        *args: Any,
         exc: BaseException | None = None,
+        *,
+        msg: str | None = None,
         extra: dict[str, Any] | None = None,
         **kv: Any,
     ) -> None:
@@ -250,7 +247,8 @@ class Logger:
             exc = sys.exc_info()[1]
         if exc is None:  # pragma: no cover - defensive
             exc = Exception("unknown")
-        msg = event % args if args else str(exc)
+        if msg is None:
+            msg = str(exc)
         tb = "".join(
             traceback.format_exception(exc.__class__, exc, exc.__traceback__, limit=3)
         ).strip()

--- a/library/mapper_batch_library.py
+++ b/library/mapper_batch_library.py
@@ -79,7 +79,9 @@ def map_chembl_ids_to_uniprot(
             try:
                 results[chembl_id] = map_chembl_to_uniprot(chembl_id, cfg)
             except Exception as exc:  # pragma: no cover - network issues
-                logger.warning("Failed to map %s: %s", chembl_id, exc)
+                logger.warning(
+                    "uniprot_mapping_failed", chembl_id=chembl_id, error=str(exc)
+                )
                 results[chembl_id] = None
         return results
 

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -52,7 +52,7 @@ def _map_chembl_to_uniprot(
     data = urllib.parse.urlencode(
         {"from": "ChEMBL", "to": "UniProtKB", "ids": chembl_target_id}
     ).encode()
-    logger.debug("Submitting ID mapping job for %s", chembl_target_id)
+    logger.debug("uniprot_mapping_submit", chembl_target_id=chembl_target_id)
     base = cfg.base.rstrip("/")
     run_data = _open_json(f"{base}/run", data=data, timeout=cfg.timeout)
     job_id = run_data.get("jobId")
@@ -77,7 +77,7 @@ def _map_chembl_to_uniprot(
         else:
             status = status_data.get("jobStatus") or status_data.get("status")
 
-        logger.debug("Job %s status: %s", job_id, status)
+        logger.debug("uniprot_mapping_status", job_id=job_id, status=status)
         if status == "FINISHED":
             break
         if status == "FAILED":

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -173,13 +173,13 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
 
     cached = _CACHE.get(url)
     if cached is not None:
-        logger.info("cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"})
+        logger.info("cache_hit", url=url, rps=cfg.rps, status="hit")
         return cast(dict[str, Any], cached)
-    logger.info("cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"})
+    logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
 
     for attempt in range(1, cfg.retries + 1):
         event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(event, extra={"url": url, "attempt": attempt, "rps": cfg.rps})
+        logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
         try:
             response = _session.get(
@@ -188,24 +188,24 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         except requests.RequestException as exc:  # pragma: no cover - network
             if attempt >= cfg.retries:
                 logger.error(
-                    "HTTP request failed for url %s: %s",
-                    url,
-                    exc,
-                    extra={"url": url, "rps": cfg.rps},
+                    "pubchem_request_failed",
+                    url=url,
+                    error=str(exc),
+                    rps=cfg.rps,
                 )
-                logger.info(
-                    "request_fail",
-                    extra={"url": url, "status": None, "rps": cfg.rps},
-                )
+                logger.info("request_fail", url=url, status=None, rps=cfg.rps)
                 return None
             sleep(cfg.delay)
             continue
 
         if response.status_code in (404, 400):
-            logger.warning("Request returned %d for url %s", response.status_code, url)
+            logger.warning(
+                "pubchem_request_unexpected_status",
+                url=url,
+                status=response.status_code,
+            )
             logger.info(
-                "request_fail",
-                extra={"url": url, "status": response.status_code, "rps": cfg.rps},
+                "request_fail", url=url, status=response.status_code, rps=cfg.rps
             )
             return None
         try:
@@ -214,33 +214,28 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         except requests.RequestException as exc:  # pragma: no cover - network
             if attempt >= cfg.retries:
                 logger.error(
-                    "HTTP request failed for url %s: %s",
-                    url,
-                    exc,
-                    extra={"url": url, "rps": cfg.rps},
+                    "pubchem_request_failed",
+                    url=url,
+                    error=str(exc),
+                    rps=cfg.rps,
                 )
-                logger.info(
-                    "request_fail",
-                    extra={"url": url, "status": None, "rps": cfg.rps},
-                )
+                logger.info("request_fail", url=url, status=None, rps=cfg.rps)
                 return None
             sleep(cfg.delay)
             continue
         except ValueError:
-            logger.warning("Non-JSON response for url %s", url)
+            logger.warning("pubchem_invalid_json", url=url)
             logger.info(
-                "request_fail",
-                extra={"url": url, "status": response.status_code, "rps": cfg.rps},
+                "request_fail", url=url, status=response.status_code, rps=cfg.rps
             )
             return None
 
         logger.info(
-            "request_ok",
-            extra={"url": url, "status": response.status_code, "rps": cfg.rps},
+            "request_ok", url=url, status=response.status_code, rps=cfg.rps
         )
         assert _CACHE is not None  # for type checker; cache initialised above
         _CACHE[url] = data
-        logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
+        logger.info("cache_set", url=url, rps=cfg.rps)
         return data
     return None
 

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -105,11 +105,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 

--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -58,7 +58,7 @@ def _load_table(table: pd.DataFrame | str | Path) -> pd.DataFrame:
                 warnings.filterwarnings("ignore", category=DtypeWarning)
                 return pd.read_csv(path, encoding=enc, low_memory=False)
         except UnicodeDecodeError:
-            logger.debug("failed to decode %s with %s", path, enc)
+            logger.debug("csv_decode_failed", path=str(path), encoding=enc)
             continue
     raise UnicodeDecodeError("utf-8", b"", 0, 1, "Unable to decode CSV")
 

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -540,13 +540,15 @@ def finalise_targets(
     # Drop rows where uniprotkb_Id is the string "nan"
     mask_nan = df["uniprotkb_Id"].astype(str) == "nan"
     if mask_nan.any():
-        logger.debug("Dropping %d rows with missing UniProt IDs", mask_nan.sum())
+        logger.debug("uniprot_rows_dropped", rows=int(mask_nan.sum()))
     df = df[~mask_nan]
 
     # Remove duplicate chembl_id entries
     before = len(df)
     df = df.drop_duplicates(subset="target_chembl_id", keep="first")
-    logger.debug("Removed %d duplicate %s rows", before - len(df), chembl_col)
+    logger.debug(
+        "duplicate_rows_removed", removed=before - len(df), column=chembl_col
+    )
 
     # Enforce column types
     for col in TEXT_COLUMNS:
@@ -572,7 +574,7 @@ def finalise_targets(
     # existing column beforehand and restore the organism classification as the
     # canonical ``type`` field afterwards.
     if "type" in df.columns:
-        logger.debug("Renaming existing 'type' column to 'target_type'")
+        logger.debug("target_type_column_renamed", original="type")
         df = df.rename(columns={"type": "target_type"})
 
     organism_types = organism[["genus", "type"]].rename(

--- a/library/version.py
+++ b/library/version.py
@@ -31,5 +31,7 @@ def require_python_version(min_version: tuple[int, int] = (3, 12)) -> None:
     if current < required:
         current_str = f"{current_info.major}.{current_info.minor}"
         needed = f"{min_version[0]}.{min_version[1]}"
-        logger.error("Python %s or later is required (found %s)", needed, current_str)
+        logger.error(
+            "python_version_unsupported", required=needed, current=current_str
+        )
         raise RuntimeError(f"Python {needed} or later is required; found {current_str}")

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -81,7 +81,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 args.input_csv, column=cfg.activity.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
         # Apply the ``limit`` without materialising the entire iterator first.
@@ -102,7 +106,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.activity.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
-            logger.error("failed to retrieve activities: %s", exc)
+            logger.error("activities_fetch_failed", error=str(exc))
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_activities(df)
@@ -124,7 +128,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         if not missing_required:
             if missing_optional:
                 logger.warning(
-                    "DataFrame is missing optional columns: %s", missing_optional
+                    "optional_columns_missing",
+                    columns=sorted(missing_optional),
                 )
             try:
                 validation_result = validate_activities(df, return_result=True)
@@ -135,9 +140,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     errors.add_error(row)
                 errors.save(failure_path)
                 logger.error(
-                    "validation failed; wrote %d failure cases to %s",
-                    len(exc.failure_cases),
-                    failure_path,
+                    "activity_validation_failed",
+                    failure_cases=len(exc.failure_cases),
+                    path=str(failure_path),
                 )
                 df = getattr(exc, "validated_data", df)
                 exit_code = 1
@@ -152,15 +157,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                         errors.add_error(row)
                     errors.save(failure_path)
                     logger.error(
-                        "validation failed; wrote %d failure cases to %s",
-                        len(validation_result.failure_cases),
-                        failure_path,
+                        "activity_validation_failed",
+                        failure_cases=len(validation_result.failure_cases),
+                        path=str(failure_path),
                     )
                     exit_code = 1
         else:
             logger.warning(
-                "Skipping validation due to missing required columns: %s",
-                missing_required,
+                "validation_skipped",
+                reason="missing_required_columns",
+                columns=sorted(missing_required),
             )
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
@@ -175,7 +181,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
-            logger.error("failed to write output CSV: %s", exc)
+            logger.error(
+                "output_csv_write_failed", error=str(exc), path=str(output)
+            )
             return 1
 
         stats: Stats = {
@@ -196,7 +204,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         try:
             analyze_table_quality(df, table_name=str(output.with_suffix("")))
         except ValueError as exc:
-            logger.error("failed to generate quality report: %s", exc)
+            logger.error("quality_report_generation_failed", error=str(exc))
             return 1
         return exit_code
 
@@ -258,11 +266,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code: int = args.func(cfg, args)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -73,7 +73,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         try:
             ids_iter = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
         except (FileNotFoundError, ValueError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
         ids = ids_iter
@@ -91,7 +95,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.assay.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
-            logger.error("failed to retrieve assays: %s", exc)
+            logger.error("assays_fetch_failed", error=str(exc))
             return 1
         df = ap.postprocess_assays(df)
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
@@ -107,7 +111,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         if not missing_required:
             if missing_optional:
                 logger.warning(
-                    "DataFrame is missing optional columns: %s", missing_optional
+                    "optional_columns_missing",
+                    columns=sorted(missing_optional),
                 )
             try:
                 validation_result = validate_assays(df, return_result=True)
@@ -120,9 +125,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     errors.add_error(row)
                 errors.save(failure_path)
                 logger.error(
-                    "validation failed; wrote %d failure cases to %s",
-                    len(exc.failure_cases),
-                    failure_path,
+                    "assay_validation_failed",
+                    failure_cases=len(exc.failure_cases),
+                    path=str(failure_path),
                 )
                 df = getattr(exc, "validated_data", df)
                 exit_code = 1
@@ -137,15 +142,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                         errors.add_error(row)
                     errors.save(failure_path)
                     logger.error(
-                        "validation failed; wrote %d failure cases to %s",
-                        len(validation_result.failure_cases),
-                        failure_path,
+                        "assay_validation_failed",
+                        failure_cases=len(validation_result.failure_cases),
+                        path=str(failure_path),
                     )
                     exit_code = 1
         else:
             logger.warning(
-                "Skipping validation due to missing required columns: %s",
-                missing_required,
+                "validation_skipped",
+                reason="missing_required_columns",
+                columns=sorted(missing_required),
             )
         rows_kept = len(df)
         rows_dropped = rows_total - rows_kept
@@ -166,7 +172,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:
-            logger.error("failed to write output CSV: %s", exc)
+            logger.error(
+                "output_csv_write_failed", error=str(exc), path=str(output)
+            )
             return 1
 
         stats: Stats = {
@@ -187,7 +195,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         try:
             analyze_table_quality(df, table_name=str(output.with_suffix("")))
         except ValueError as exc:
-            logger.error("failed to generate quality report: %s", exc)
+            logger.error("quality_report_generation_failed", error=str(exc))
             return 1
         return exit_code
 
@@ -242,11 +250,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code: int = args.func(cfg, args)

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -171,11 +171,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt
         )
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger_inst.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -206,11 +206,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code = int(args.func(cfg, args))

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -427,12 +427,12 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             schema="UniProtExport",
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
-        logger.error("%s", exc)
+        logger.error("uniprot_pipeline_failed", error=str(exc))
         return 1
     try:
         analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     return 0
 
@@ -465,7 +465,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
         ids = ids_iter
@@ -484,7 +488,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.target.chembl.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
-            logger.error("failed to retrieve targets: %s", exc)
+            logger.error("targets_fetch_failed", error=str(exc))
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_targets(df)
@@ -501,7 +505,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if not missing_required:
         if missing_optional:
             logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
+                "optional_columns_missing",
+                columns=sorted(missing_optional),
             )
         try:
             df = TargetsSchema.validate(df, lazy=True)
@@ -512,16 +517,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 errors.add_error(row)
             errors.save(failure_path)
             logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+                "target_validation_failed",
+                failure_cases=len(exc.failure_cases),
+                path=str(failure_path),
             )
             df = getattr(exc, "validated_data", df)
             exit_code = 1
     else:
         logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
+            "validation_skipped",
+            reason="missing_required_columns",
+            columns=sorted(missing_required),
         )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
@@ -535,7 +541,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
+        logger.error(
+            "output_csv_write_failed", error=str(exc), path=str(output)
+        )
         return 1
 
     stats: Stats = {
@@ -555,7 +563,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     try:
         analyze_table_quality(df, table_name=str(output.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     return exit_code
 
@@ -619,7 +627,7 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
             sep=cfg.io.csv_sep,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
-        logger.error("%s", exc)
+        logger.error("iuphar_pipeline_failed", error=str(exc))
         return 1
     finally:
         if tmp_path is not None:
@@ -627,7 +635,7 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     try:
         analyze_table_quality(output, table_name=str(output.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     return 0
 
@@ -896,7 +904,8 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
     if not missing_required:
         if missing_optional:
             logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
+                "optional_columns_missing",
+                columns=sorted(missing_optional),
             )
         try:
             final_df = TargetsSchema.validate(final_df, lazy=True)
@@ -907,16 +916,17 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
                 errors.add_error(row)
             errors.save(failure_path)
             logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+                "target_validation_failed",
+                failure_cases=len(exc.failure_cases),
+                path=str(failure_path),
             )
             final_df = getattr(exc, "validated_data", final_df)
             exit_code = 1
     else:
         logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
+            "validation_skipped",
+            reason="missing_required_columns",
+            columns=sorted(missing_required),
         )
     final_df = final_df.drop_duplicates()
     io.write_csv(
@@ -930,7 +940,7 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
     try:
         analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     logger.info("validate_write_done", rows=len(final_df))
     return exit_code
@@ -963,7 +973,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         exit_code = validate_and_write(merged, output, cfg)
         return exit_code
     except (FileNotFoundError, ValueError, OSError, RuntimeError) as exc:
-        logger.error("%s", exc)
+        logger.error("target_pipeline_error", error=str(exc))
         return 1
 
 
@@ -1024,11 +1034,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     if hasattr(args, "func"):

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -157,7 +157,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             else:
                 ids = list(ids_iter)
         except (FileNotFoundError, ValueError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
         logger.info("identifiers_retrieved", count=len(ids))
@@ -172,7 +176,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 timeout=cfg.testitem.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
-            logger.error("failed to retrieve compounds: %s", exc)
+            logger.error("compounds_fetch_failed", error=str(exc))
             return 1
         logger.info("chembl_fetch_done", rows=len(df))
         logger.info("pubchem_augment_start")
@@ -197,7 +201,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if not missing_required:
         if missing_optional:
             logger.warning(
-                "DataFrame is missing optional columns: %s", missing_optional
+                "optional_columns_missing",
+                columns=sorted(missing_optional),
             )
         try:
             validation_result = validate_testitems(df, return_result=True)
@@ -210,9 +215,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 errors.add_error(row)
             errors.save(failure_path)
             logger.error(
-                "validation failed; wrote %d failure cases to %s",
-                len(exc.failure_cases),
-                failure_path,
+                "testitem_validation_failed",
+                failure_cases=len(exc.failure_cases),
+                path=str(failure_path),
             )
             df = getattr(exc, "validated_data", df)
             exit_code = 1
@@ -227,15 +232,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     errors.add_error(row)
                 errors.save(failure_path)
                 logger.error(
-                    "validation failed; wrote %d failure cases to %s",
-                    len(validation_result.failure_cases),
-                    failure_path,
+                    "testitem_validation_failed",
+                    failure_cases=len(validation_result.failure_cases),
+                    path=str(failure_path),
                 )
                 exit_code = 1
     else:
         logger.warning(
-            "Skipping validation due to missing required columns: %s",
-            missing_required,
+            "validation_skipped",
+            reason="missing_required_columns",
+            columns=sorted(missing_required),
         )
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
@@ -250,7 +256,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
     except OSError as exc:
-        logger.error("failed to write output CSV: %s", exc)
+        logger.error(
+            "output_csv_write_failed", error=str(exc), path=str(output)
+        )
         return 1
 
     stats: Stats = {
@@ -270,7 +278,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     try:
         analyze_table_quality(df, table_name=str(output.with_suffix("")))
     except ValueError as exc:
-        logger.error("failed to generate quality report: %s", exc)
+        logger.error("quality_report_generation_failed", error=str(exc))
         return 1
     return exit_code
 
@@ -327,11 +335,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code: int = args.func(cfg, args)

--- a/scripts/mapper_batch_main.py
+++ b/scripts/mapper_batch_main.py
@@ -32,10 +32,16 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 na_values=["#N/A", ""],
             )
         except (FileNotFoundError, OSError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
         if args.column not in df.columns:
-            logger.error("column '%s' not found in %s", args.column, args.input_csv)
+            logger.error(
+                "column_missing", column=args.column, path=str(args.input_csv)
+            )
             return 1
 
         ids = [
@@ -52,9 +58,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         )
         for cid, uid in mappings.items():
             if uid:
-                logger.info("mapped", extra={"chembl_id": cid, "uniprot_id": uid})
+                logger.info("mapped", chembl_id=cid, uniprot_id=uid)
             else:
-                logger.warning("no UniProt ID for %s", cid)
+                logger.warning("uniprot_id_missing", chembl_id=cid)
         df["mapping_uniprot_id"] = df[args.column].map(mappings).fillna("")
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         try:
@@ -65,9 +71,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 sep=args.sep,
                 encoding=args.encoding,
             )
-            logger.info("write_done", extra={"path": str(output)})
+            logger.info("write_done", path=str(output))
         except OSError as exc:
-            logger.error("failed to write output CSV: %s", exc)
+            logger.error(
+                "output_csv_write_failed", error=str(exc), path=str(output)
+            )
             return 1
         return 0
     except Exception as exc:  # pragma: no cover - defensive
@@ -98,13 +106,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
-    logger.info("pipeline_start", extra={"run_id": log_cfg.run_id})
+    logger.info("pipeline_start", run_id=log_cfg.run_id)
     cfg = apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     print_config(cfg)
     func: Callable[[Config, argparse.Namespace], int] = args.func
     exit_code = func(cfg, args)
-    logger.info("pipeline_end", extra={"exit_code": exit_code})
+    logger.info("pipeline_end", exit_code=exit_code)
     return exit_code
 
 

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -49,7 +49,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         try:
             df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
         except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
-            logger.error("%s", exc)
+            logger.error(
+                "input_csv_read_failed",
+                error=str(exc),
+                path=str(args.input_csv),
+            )
             return 1
 
         original_cwd = Path.cwd()
@@ -94,11 +98,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_dirs(cfg)
         logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
     except (ValueError, TypeError) as exc:
-        logger.error("%s", exc)
+        logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     except (FileNotFoundError, NotADirectoryError) as exc:
-        logger.error("failed to set up directories: %s", exc)
+        logger.error("directory_setup_failed", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
     exit_code: int = args.func(cfg, args)

--- a/tests/test_activity_cli_error.py
+++ b/tests/test_activity_cli_error.py
@@ -40,4 +40,5 @@ def test_run_chembl_handles_request_error(
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
-    assert "boom" in record.get("msg", "")
+    assert record["event"] == "activities_fetch_failed"
+    assert record["error"] == "boom"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -427,8 +427,8 @@ def test_unknown_env_var_warning(
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
-    msg = record.get("msg", "") or record.get("event", "")
-    assert "Environment variable CHEMBL_DA__FOO__BAR ignored" in msg
+    assert record["event"] == "env_override_ignored"
+    assert record["variable"] == "CHEMBL_DA__FOO__BAR"
 
 
 def test_new_field_auto_alias() -> None:

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -115,3 +115,11 @@ def test_multithreaded_logging_emits_valid_json(
     assert len(lines) == 10
     for line in lines:
         json.loads(line)
+
+
+def test_logger_rejects_positional_arguments() -> None:
+    """Structured helpers require keyword arguments instead of printf patterns."""
+
+    logger = configure_logger(LoggerConfig(stream=sys.stdout))
+    with pytest.raises(TypeError):
+        logger.info("event", "value")


### PR DESCRIPTION
## Summary
- enforce keyword-only structured logging and add regression coverage for rejecting positional arguments
- replace printf-style logging across libraries and CLIs with named events and structured fields
- adjust CLI error tests to assert the new structured payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d415db2f8c83248be61ec30dfa380f