### PR TITLE
Add strict config validation for target pipeline settings

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -254,6 +254,7 @@
         "limit": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -930,6 +931,12 @@
           "format": "path",
           "title": "Family Csv",
           "type": "string"
+        },
+        "chunk_size": {
+          "default": 5,
+          "minimum": 1,
+          "title": "Chunk Size",
+          "type": "integer"
         },
         "timeout": {
           "default": 30.0,

--- a/config.yaml
+++ b/config.yaml
@@ -164,6 +164,7 @@ target:
     data_dir: "dictionary/uniprot"
     target_csv: "dictionary/_IUPHAR/_IUPHAR_target.csv"
     family_csv: "dictionary/_IUPHAR/_IUPHAR_family.csv"
+    chunk_size: 5
     timeout: 30.0
     organism_csv: "dictionary/_Target/targets_type.csv"
     uniprot_column: "uniprot_id"

--- a/library/config.py
+++ b/library/config.py
@@ -296,7 +296,7 @@ class DocTypeCfg(_BaseModel):
     thresholds: dict[str, int] = Field(
         default_factory=lambda: {"review": 1, "experimental": 1, "unknown": 2}
     )
-    limit: int | None = None
+    limit: int | None = Field(default=None, ge=0)
 
 
 class ResourcesCfg(_BaseModel):
@@ -487,6 +487,7 @@ class TargetAllCfg(_BaseModel):
     data_dir: Path = Path("dictionary/uniprot")
     target_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_target.csv")
     family_csv: Path = Path("dictionary/_IUPHAR/_IUPHAR_family.csv")
+    chunk_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
     organism_csv: Path = Path("dictionary/_Target/organism.csv")
     uniprot_column: str = "uniprot_id"
@@ -643,7 +644,7 @@ def load_config(
     path: str | Path = "config.yaml",
     cli_overrides: dict[str, Any] | None = None,
     *,
-    strict: bool = False,
+    strict: bool = True,
 ) -> Config:
     """Load configuration from *path* applying overrides."""
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -633,7 +633,12 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def fetch_chembl(
-    cfg: Config, input_csv: Path, output_csv: Path, limit: int | None = None
+    cfg: Config,
+    input_csv: Path,
+    output_csv: Path,
+    limit: int | None = None,
+    *,
+    chunk_size: int | None = None,
 ) -> pd.DataFrame:
     """Fetch target information from ChEMBL.
 
@@ -657,14 +662,19 @@ def fetch_chembl(
     logger.info("fetch_chembl_start", input=str(input_csv), output=str(output_csv))
     chembl_args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
     original_limit = cfg.target.chembl.limit
+    original_chunk_size = cfg.target.chembl.chunk_size
     if limit is not None:
         cfg.target.chembl.limit = limit
+    if chunk_size is not None:
+        cfg.target.chembl.chunk_size = chunk_size
     try:
         if run_chembl(cfg, chembl_args) != 0:
             raise RuntimeError("ChEMBL retrieval failed")
     finally:
         if limit is not None:
             cfg.target.chembl.limit = original_limit
+        if chunk_size is not None:
+            cfg.target.chembl.chunk_size = original_chunk_size
     df = pd.read_csv(
         output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
     )
@@ -956,7 +966,13 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             output.stem + "_iuphar.csv"
         )
 
-        chembl_df = fetch_chembl(cfg, args.input_csv, chembl_out, limit=limit)
+        chembl_df = fetch_chembl(
+            cfg,
+            args.input_csv,
+            chembl_out,
+            limit=limit,
+            chunk_size=cfg.target.all.chunk_size,
+        )
         uniprot_df = fetch_uniprot(cfg, chembl_df, uniprot_out)
         combined_df, iuphar_df = fetch_iuphar(cfg, chembl_df, uniprot_df, iuphar_out)
         merged = merge_results(combined_df, iuphar_df, cfg)

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -142,3 +142,38 @@ def test_negative_limit_in_config_exits(
     rc = gad.main(["--config", str(cfg)])
     assert rc != 0
     assert "activity.limit" in buf.getvalue()
+
+
+def test_doc_type_negative_limit_in_config_exits(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("doc_type:\n  limit: -1\n")
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("chembl_id\nCHEMBL1\n", encoding="utf8")
+    output_csv = tmp_path / "out.csv"
+
+    buf = io.StringIO()
+    orig = configure_logger
+
+    def _conf(cfg: LoggerConfig, *a: Any, **k: Any) -> Logger:
+        cfg.stream = buf
+        return orig(cfg, *a, **k)
+
+    monkeypatch.setattr("library.cli.configure_logger", _conf)
+    monkeypatch.setattr("scripts.get_document_type.configure_logger", _conf)
+
+    rc = gdoctype.main(
+        [
+            "--config",
+            str(cfg),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+        ]
+    )
+
+    assert rc != 0
+    assert "doc_type.limit" in buf.getvalue()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,12 +269,12 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert out.is_dir() and cache.is_dir()
 
 
-def test_unknown_key_warning(tmp_path: Path) -> None:
+def test_unknown_key_warning_non_strict(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\napi:\n  rps: 1\n")
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
-    load_config(path)
+    load_config(path, strict=False)
     lines = buf.getvalue().splitlines()
     assert lines
     record = json.loads(lines[-1])
@@ -286,7 +286,7 @@ def test_unknown_key_error(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\n")
     with pytest.raises(ValueError, match="Unknown configuration key"):
-        load_config(path, strict=True)
+        load_config(path)
 
 
 def test_config_type_coercion() -> None:

--- a/tests/test_get_target_data_all.py
+++ b/tests/test_get_target_data_all.py
@@ -46,6 +46,8 @@ def test_run_all_uses_local_inputs(
     iuphar_data = Path("tests/data/iuphar_targets_min.csv")
     organism_csv = Path("tests/data/organism_min.csv")
 
+    original_chunk = cfg.target.chembl.chunk_size
+    cfg.target.all.chunk_size = original_chunk + 2
     cfg.target.all.organism_csv = organism_csv
     cfg.target.all.chembl_out = tmp_path / "chembl_out.csv"
     cfg.target.all.uniprot_out = tmp_path / "uniprot_out.csv"
@@ -54,7 +56,10 @@ def test_run_all_uses_local_inputs(
     # ------------------------------------------------------------------
     # Patch network-dependent functions to use local files
     # ------------------------------------------------------------------
+    recorded: dict[str, int] = {}
+
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        recorded["chunk_size"] = cfg.target.chembl.chunk_size
         shutil.copy(chembl_data, args.output_csv)
         return 0
 
@@ -99,6 +104,8 @@ def test_run_all_uses_local_inputs(
     args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
     exit_code = gtd.run_all(cfg, args)
     assert exit_code == 0
+    assert recorded["chunk_size"] == cfg.target.all.chunk_size
+    assert cfg.target.chembl.chunk_size == original_chunk
 
     # ------------------------------------------------------------------
     # Intermediate files are persisted and match expectations

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -28,6 +28,29 @@ def test_fetch_chembl(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     assert df.loc[0, "uniprot_id"] == "P1"
 
 
+def test_fetch_chembl_custom_chunk_size(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    out = tmp_path / "chembl.csv"
+    inp = tmp_path / "in.csv"
+
+    recorded: dict[str, int] = {}
+    original_chunk = cfg.target.chembl.chunk_size
+
+    def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        recorded["chunk_size"] = cfg.target.chembl.chunk_size
+        pd.DataFrame({"target_chembl_id": ["C1"]}).to_csv(args.output_csv, index=False)
+        return 0
+
+    monkeypatch.setattr(gtd, "run_chembl", fake_run_chembl)
+    chunk_size = original_chunk + 3
+    df = gtd.fetch_chembl(cfg, inp, out, chunk_size=chunk_size)
+
+    assert df.loc[0, "target_chembl_id"] == "C1"
+    assert recorded["chunk_size"] == chunk_size
+    assert cfg.target.chembl.chunk_size == original_chunk
+
+
 def test_fetch_uniprot(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> None:
     chembl_df = pd.DataFrame({"uniprot_id": ["P12345"]})
     out = tmp_path / "uniprot.csv"


### PR DESCRIPTION
## Summary
- add chunk_size support for target aggregation via config, schema, and runtime handling
- enforce non-negative doc_type limits and make configuration loading strict by default
- extend CLI tests to cover the new validation and chunk size propagation

## Testing
- pytest tests/test_config.py tests/test_cli_bad_config.py tests/test_get_target_data_fetch.py tests/test_get_target_data_all.py

------
https://chatgpt.com/codex/tasks/task_e_68d415d078f483248be280ce356ad7e6