### PR TITLE
Normalize testitem structure column names

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -74,6 +74,12 @@ ACTIVITY_COLUMNS = [
     "assay_variant_mutation",
 ]
 
+TESTITEM_STRUCTURE_COLUMNS = {
+    "molecule_structures.canonical_smiles": "canonical_smiles",
+    "molecule_structures.standard_inchi": "standard_inchi",
+    "molecule_structures.standard_inchi_key": "standard_inchi_key",
+}
+
 TESTITEM_COLUMNS = [
     "molecule_chembl_id",
     "pref_name",
@@ -85,9 +91,9 @@ TESTITEM_COLUMNS = [
     "topical",
     "black_box_warning",
     "structure_type",
-    "molecule_structures.canonical_smiles",
-    "molecule_structures.standard_inchi",
-    "molecule_structures.standard_inchi_key",
+    "canonical_smiles",
+    "standard_inchi",
+    "standard_inchi_key",
 ]
 
 
@@ -318,6 +324,7 @@ def get_testitem(
     if not records:
         return pd.DataFrame(columns=TESTITEM_COLUMNS)
     df = pd.concat(records, ignore_index=True)
+    df = df.rename(columns=TESTITEM_STRUCTURE_COLUMNS)
     return df.reindex(columns=TESTITEM_COLUMNS)
 
 

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -15,15 +15,9 @@ TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "black_box_warning": pa.Column(PA_ANY, required=False, nullable=True),
         "first_approval": pa.Column(PA_ANY, required=False, nullable=True),
         "max_phase": pa.Column(str, required=False, nullable=True),
-        "molecule_structures.canonical_smiles": pa.Column(
-            str, required=False, nullable=True
-        ),
-        "molecule_structures.standard_inchi": pa.Column(
-            str, required=False, nullable=True
-        ),
-        "molecule_structures.standard_inchi_key": pa.Column(
-            str, required=False, nullable=True
-        ),
+        "canonical_smiles": pa.Column(str, required=False, nullable=True),
+        "standard_inchi": pa.Column(str, required=False, nullable=True),
+        "standard_inchi_key": pa.Column(str, required=False, nullable=True),
         "molecule_type": pa.Column(str, required=False, nullable=True),
         "oral": pa.Column(PA_ANY, required=False, nullable=True),
         "parenteral": pa.Column(PA_ANY, required=False, nullable=True),

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -66,10 +66,10 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
         ``df`` with additional PubChem columns.
 
     """
-    if df.empty or "molecule_structures.canonical_smiles" not in df.columns:
+    if df.empty or "canonical_smiles" not in df.columns:
         return df
 
-    smiles_list = df["molecule_structures.canonical_smiles"].fillna("").tolist()
+    smiles_list = df["canonical_smiles"].fillna("").tolist()
     # ``dict.fromkeys`` preserves the order of first occurrence while
     # removing duplicates. This allows progress output to reflect the
     # deterministic iteration order of SMILES strings.


### PR DESCRIPTION
## Summary
- rename test item structure columns to drop the molecule_structures prefix
- update schema and PubChem augmentation logic to use the new names

## Testing
- pytest tests/test_get_testitem_data.py tests/test_schemas.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e04f67208324a931e3db54c3d507