### PR TITLE
Add optional limit to target pipeline CLI

### DIFF
--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Iterable, Iterator, Sequence
+from itertools import islice
 from pathlib import Path
 
 if __package__ is None:  # running as a script
@@ -40,6 +41,7 @@ class PipelineConfig(BaseModel):
     sep: str | None = None
     encoding: str | None = None
     na_markers: list[str] | None = None
+    limit: int | None = Field(default=None, ge=1)
 
 
 def _positive_int(value: str) -> int:
@@ -83,6 +85,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Batch size forwarded to fetchers supporting it",
     )
     parser.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=None,
+        help="Maximum number of identifiers to process",
+    )
+    parser.add_argument(
         "--na-marker",
         action="append",
         dest="na_markers",
@@ -100,6 +108,8 @@ def _chunk_iterator(cfg: Config, options: PipelineConfig) -> Iterator[Iterable[s
         encoding=options.encoding,
         na_markers=options.na_markers,
     )
+    if options.limit is not None:
+        ids = islice(ids, options.limit)
     yield from _chunked(ids, options.chunk_size)
 
 
@@ -177,6 +187,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "sep": args.sep,
                 "encoding": args.encoding,
                 "na_markers": args.na_markers,
+                "limit": args.limit,
             }
         )
     except ValidationError as exc:

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -104,3 +104,61 @@ def test_cli_forwards_batch_size(
         and rec.get("exit_code") == 0
         for event, rec in dummy_logger.records
     )
+
+
+def test_cli_limit_restricts_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text(
+        "target_chembl_id\nCHEMBL1\nCHEMBL2\nCHEMBL3\n", encoding="utf8"
+    )
+    output_csv = tmp_path / "out.csv"
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_pipeline(
+        chunk_iterator: Any,
+        cfg: Config,
+        *,
+        chembl_fetcher: Any,
+        batch_size: int | None,
+        **_: Any,
+    ) -> PipelineResult:
+        captured["chunks"] = [list(chunk) for chunk in chunk_iterator()]
+        captured["batch_size"] = batch_size
+        return PipelineResult(chembl=pd.DataFrame({"target_chembl_id": ["CHEMBL1"]}))
+
+    def fake_write_csv(
+        df: pd.DataFrame,
+        path: Path | str,
+        *,
+        cfg: Config,
+        sep: str | None = None,
+        encoding: str | None = None,
+    ) -> Path:
+        captured["written_path"] = Path(path)
+        captured["written_df"] = df.copy()
+        return Path(path)
+
+    dummy_logger = _DummyLogger()
+    monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
+    monkeypatch.setattr(cli, "apply_config_overrides", lambda *a: Config())
+    monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
+    monkeypatch.setattr(cli, "print_config", lambda cfg: None)
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(cli, "write_csv", fake_write_csv)
+
+    args = [
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--limit",
+        "2",
+    ]
+    exit_code = cli.main(args)
+    assert exit_code == 0
+    assert captured["batch_size"] == 100
+    assert captured["chunks"] == [["CHEMBL1", "CHEMBL2"]]
+    assert captured["written_path"] == output_csv


### PR DESCRIPTION
## Summary
- add a --limit argument to the target pipeline CLI and apply it when chunking identifiers
- validate and store the limit value in the pipeline configuration model
- extend the CLI test suite to cover the new limiting behaviour

## Testing
- pytest tests/test_pipeline_targets_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e34f6cec8324a6c099ca5e2f6261