### PR TITLE
Include protein classification and cross reference data in target fetch

### DIFF
--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -37,6 +37,8 @@ TARGET_FIELDS = [
 
 EMPTY_TARGET: dict[str, str] = {field: "" for field in TARGET_FIELDS}
 
+TARGET_INCLUDE_PARAMS = "protein_classifications,cross_references"
+
 
 def _parse_gene_synonyms(synonyms: list[dict[str, str]]) -> str:
     """Return a sorted, pipe separated list of gene synonyms."""
@@ -257,7 +259,7 @@ def get_target(
     if chembl_target_id in {"", "#N/A"}:
         return dict(EMPTY_TARGET)
     base = cfg.chembl_base.rstrip("/")
-    url = f"{base}/target/{chembl_target_id}.json"
+    url = f"{base}/target/{chembl_target_id}.json?include={TARGET_INCLUDE_PARAMS}"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
     payload = _extract_target_payload(data)
@@ -297,7 +299,10 @@ def get_targets(
         return pd.DataFrame(columns=TARGET_FIELDS)
 
     records: list[dict[str, Any]] = []
-    base = f"{cfg.chembl_base.rstrip('/')}/target.json?format=json"
+    base = (
+        f"{cfg.chembl_base.rstrip('/')}/target.json?format=json"
+        f"&include={TARGET_INCLUDE_PARAMS}"
+    )
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         url = f"{base}&target_chembl_id__in={','.join(chunk)}"


### PR DESCRIPTION
## Summary
- add a shared constant listing the ChEMBL target include parameters we require
- append the include parameters to both single-target and batched target fetch URLs so the API returns protein classifications and cross references

## Testing
- `pytest tests/test_get_target_data_all.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4f9b9e02c8324b4223889a09d351f