### PR TITLE
Include IUPHAR name in UniProt mapping classification

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -480,6 +480,7 @@ class IUPHARData:
                                 "IUPHAR_class": "",
                                 "IUPHAR_subclass": "",
                                 "IUPHAR_chain": "",
+                                "IUPHAR_name": "",
                             }
                         )
             return pd.Series(
@@ -489,6 +490,7 @@ class IUPHARData:
                     "IUPHAR_class": record.IUPHAR_class,
                     "IUPHAR_subclass": record.IUPHAR_subclass,
                     "IUPHAR_chain": ">".join(record.IUPHAR_tree),
+                    "IUPHAR_name": record.IUPHAR_name,
                 }
             )
 


### PR DESCRIPTION
## Summary
- extend the UniProt classification helper so each row includes the resolved IUPHAR name
- ensure rows without a classification still return an empty IUPHAR name column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ff0c2c9c8324822f414b191428a8