### PR TITLE
Add protein class prediction step before target postprocessing

### DIFF
--- a/library/protein_classification.py
+++ b/library/protein_classification.py
@@ -1,0 +1,147 @@
+"""Utilities for deriving protein classification predictions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import pandas as pd
+
+from .config import Config
+from .iuphar_library import ClassificationRecord, IUPHARClassifier, IUPHARData
+
+PREDICTION_COLUMNS: tuple[str, ...] = (
+    "protein_class_pred_L1",
+    "protein_class_pred_L2",
+    "protein_class_pred_L3",
+    "protein_class_pred_rule_id",
+    "protein_class_pred_evidence",
+    "protein_class_pred_confidence",
+)
+
+_CONFIDENCE_MAP: Mapping[str, str] = {
+    "target_id": "high",
+    "family_id": "medium",
+    "ec_number": "medium",
+    "molecular_function": "low",
+    "name": "low",
+    "N/A": "low",
+}
+
+
+def classifier_from_config(cfg: Config) -> IUPHARClassifier:
+
+    data = IUPHARData.from_files(
+        target_path=cfg.target.iuphar.target_csv,
+        family_path=cfg.target.iuphar.family_csv,
+        encoding=cfg.io.csv_encoding,
+    )
+    return IUPHARClassifier(data)
+
+
+def _normalise(value: object | None) -> str:
+
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):
+        return ""
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none", "na"}:
+        return ""
+    return text
+
+
+def _select_evidence(row: pd.Series, status: str) -> str:
+
+    evidence_map: Mapping[str, str] = {
+        "target_id": _normalise(
+            row.get("target_id")
+            or row.get("IUPHAR_target_id")
+            or row.get("GuidetoPHARMACOLOGY")
+        ),
+        "family_id": _normalise(
+            row.get("IUPHAR_family_id") or row.get("family_id")
+        ),
+        "ec_number": _normalise(row.get("ec_number")),
+        "name": _normalise(
+            row.get("iuphar_name")
+            or row.get("IUPHAR_name")
+            or row.get("pref_name")
+        ),
+        "molecular_function": _normalise(row.get("molecular_function")),
+    }
+    return evidence_map.get(status, "") or "-"
+
+
+@dataclass
+class Prediction:
+
+    L1: str
+    L2: str
+    L3: str
+    rule_id: str
+    evidence: str
+    confidence: str
+
+    @classmethod
+    def from_record(cls, record: ClassificationRecord, *, evidence: str) -> Prediction:
+
+        status = record.STATUS or "N/A"
+        confidence = _CONFIDENCE_MAP.get(status, "low")
+        rule_id = status if status not in {"", "N/A"} else "-"
+        return cls(
+            L1=record.IUPHAR_class or "-",
+            L2=record.IUPHAR_subclass or "-",
+            L3=record.IUPHAR_type or "-",
+            rule_id=rule_id,
+            evidence=evidence,
+            confidence=confidence,
+        )
+
+    def as_dict(self) -> dict[str, str]:
+
+        return {
+            "protein_class_pred_L1": self.L1 or "-",
+            "protein_class_pred_L2": self.L2 or "-",
+            "protein_class_pred_L3": self.L3 or "-",
+            "protein_class_pred_rule_id": self.rule_id or "-",
+            "protein_class_pred_evidence": self.evidence or "-",
+            "protein_class_pred_confidence": self.confidence or "-",
+        }
+
+
+def append_protein_class_predictions(
+    df: pd.DataFrame, classifier: IUPHARClassifier
+) -> pd.DataFrame:
+
+    result = df.copy()
+    if result.empty:
+        for column in PREDICTION_COLUMNS:
+            result[column] = pd.Series(dtype="string")
+        return result
+
+    def _predict(row: pd.Series) -> pd.Series:
+        target_id = _normalise(row.get("target_id"))
+        family_id = _normalise(row.get("IUPHAR_family_id") or row.get("family_id"))
+        ec_number = _normalise(row.get("ec_number"))
+        name = _normalise(
+            row.get("iuphar_name")
+            or row.get("IUPHAR_name")
+            or row.get("pref_name")
+        )
+
+        record = classifier.get(target_id, family_id, ec_number, name)
+        if (record.STATUS in {"", "N/A"}) or not record.IUPHAR_class:
+            molecular_function = _normalise(row.get("molecular_function"))
+            if molecular_function:
+                record = classifier.by_molecular_function(molecular_function)
+
+        evidence = _select_evidence(row, record.STATUS or "N/A")
+        prediction = Prediction.from_record(record, evidence=evidence)
+        return pd.Series(prediction.as_dict())
+
+    predictions = result.apply(_predict, axis=1)
+    for column in PREDICTION_COLUMNS:
+        result[column] = predictions[column].fillna("-").replace("", "-").astype("string")
+    return result
+

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -29,6 +29,7 @@ from library import chembl_library as cl
 from library import io
 from library import iuphar_library as ii
 from library import target_postprocessing as tp
+from library import protein_classification as pc
 from library import uniprot_library as uu
 from library.chembl_client import ChemblClient
 from library.cli import (
@@ -943,7 +944,11 @@ def fetch_iuphar(
 
 
 def merge_results(
-    combined_df: pd.DataFrame, iuphar_df: pd.DataFrame, cfg: Config
+    combined_df: pd.DataFrame,
+    iuphar_df: pd.DataFrame,
+    cfg: Config,
+    *,
+    classifier: ii.IUPHARClassifier | None = None,
 ) -> pd.DataFrame:
     """Merge ChEMBL, UniProt and IUPHAR data into a single table.
 
@@ -964,6 +969,9 @@ def merge_results(
 
     logger.info("merge_results_start")
     merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+    if classifier is None:
+        classifier = pc.classifier_from_config(cfg)
+    merged = pc.append_protein_class_predictions(merged, classifier)
     processed = tp.postprocess_targets(merged)
     organism_df = pd.read_csv(
         cfg.target.all.organism_csv,

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pytest import MonkeyPatch
 
 import library.target_postprocessing as tp
+from library import protein_classification as pc
 from library.config import Config
 from scripts import get_target_data as gtd
 
@@ -29,6 +30,8 @@ def test_iuphar_merge_preserves_ec_number(
 
     monkeypatch.setattr(tp, "postprocess_targets", lambda df: df)
     monkeypatch.setattr(tp, "finalise_targets", lambda df, org: df)
+    monkeypatch.setattr(pc, "classifier_from_config", lambda cfg: None)
+    monkeypatch.setattr(pc, "append_protein_class_predictions", lambda df, _cls: df)
     cfg.target.all.organism_csv = tmp_path / "organism.csv"
     pd.DataFrame({"genus": [], "type": []}).to_csv(
         cfg.target.all.organism_csv, index=False

--- a/tests/test_protein_classification.py
+++ b/tests/test_protein_classification.py
@@ -1,0 +1,75 @@
+"""Tests for :mod:`library.protein_classification`."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from library.iuphar_library import ClassificationRecord
+from library import protein_classification as pc
+
+
+class DummyClassifier:
+    """Simple stand-in for :class:`IUPHARClassifier` used in tests."""
+
+    def __init__(
+        self,
+        record: ClassificationRecord,
+        *,
+        fallback: ClassificationRecord | None = None,
+    ) -> None:
+        self.record = record
+        self.fallback = fallback or record
+
+    def get(self, *_args: object, **_kwargs: object) -> ClassificationRecord:
+        return self.record
+
+    def by_molecular_function(self, *_args: object, **_kwargs: object) -> ClassificationRecord:
+        return self.fallback
+
+
+def test_append_predictions_uses_classifier_record() -> None:
+    """Classifier output is translated into ``protein_class_pred_*`` columns."""
+
+    record = ClassificationRecord(
+        IUPHAR_target_id="123",
+        IUPHAR_family_id="456",
+        IUPHAR_class="Enzyme",
+        IUPHAR_subclass="Transferase",
+        IUPHAR_type="Enzyme.Transferase",
+        IUPHAR_name="Example",
+        STATUS="target_id",
+    )
+    classifier = DummyClassifier(record)
+    df = pd.DataFrame({"target_id": ["123"], "ec_number": ["1.1.1.1"]})
+
+    result = pc.append_protein_class_predictions(df, classifier)
+
+    row = result.iloc[0]
+    assert row["protein_class_pred_L1"] == "Enzyme"
+    assert row["protein_class_pred_L2"] == "Transferase"
+    assert row["protein_class_pred_L3"] == "Enzyme.Transferase"
+    assert row["protein_class_pred_rule_id"] == "target_id"
+    assert row["protein_class_pred_confidence"] == "high"
+    assert row["protein_class_pred_evidence"] == "123"
+
+
+def test_append_predictions_falls_back_to_molecular_function() -> None:
+    """Missing classifications fall back to molecular function keywords."""
+
+    empty = ClassificationRecord()
+    fallback = ClassificationRecord(
+        IUPHAR_class="Transporter",
+        IUPHAR_subclass="SLC superfamily of solute carrier",
+        IUPHAR_type="Transporter.SLC superfamily of solute carrier",
+        STATUS="molecular_function",
+    )
+    classifier = DummyClassifier(empty, fallback=fallback)
+    df = pd.DataFrame({"molecular_function": ["solute carrier activity"]})
+
+    result = pc.append_protein_class_predictions(df, classifier)
+
+    row = result.iloc[0]
+    assert row["protein_class_pred_rule_id"] == "molecular_function"
+    assert row["protein_class_pred_confidence"] == "low"
+    assert row["protein_class_pred_L1"] == "Transporter"
+    assert row["protein_class_pred_L2"] == "SLC superfamily of solute carrier"


### PR DESCRIPTION
## Summary
- add a protein_classification helper that builds predictions from the IUPHARClassifier and exposes a configurable classifier factory
- call the new predictor from merge_results so the aligned target table includes populated protein_class_pred_* columns
- extend the merge unit test and add a dedicated suite covering the predictor logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ff097e64832483a2a19afe2cfeea