### PR TITLE
Handle Semantic Scholar batch fallbacks

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -260,20 +260,42 @@ def fetch_pubmed_records(
                 )
 
                 pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
+                semantic_pmids = [pmid for pmid in pmids_in_batch if pmid]
 
-                # Fetch Semantic Scholar data in a single batch
-                semantic_limiter.acquire()
-                semsch_list = ssl.fetch_semantic_scholar_batch(
-                    session, pmids_in_batch, sleep, cfg=semantic_scholar_cfg
-                )
+                semsch_map: dict[str, dict[str, str]] = {}
+                if semantic_pmids:
+                    # Fetch Semantic Scholar data in a single batch
+                    semantic_limiter.acquire()
+                    semsch_list = ssl.fetch_semantic_scholar_batch(
+                        session, semantic_pmids, sleep, cfg=semantic_scholar_cfg
+                    )
 
-                # Create a map for easy lookup
-                semsch_map = {s.get("scholar.PMID"): s for s in semsch_list}
+                    # Create a map for easy lookup
+                    semsch_map = {
+                        s.get("scholar.PMID"): s for s in semsch_list if s.get("scholar.PMID")
+                    }
+
+                    # Fallback to the single-record endpoint when the batch request fails
+                    fallback_pmids: list[str] = []
+                    seen: set[str] = set()
+                    for pmid in semantic_pmids:
+                        if pmid in seen:
+                            continue
+                        seen.add(pmid)
+                        record = semsch_map.get(pmid)
+                        if record is None or record.get("scholar.Error"):
+                            fallback_pmids.append(pmid)
+                    for pmid in fallback_pmids:
+                        semantic_limiter.acquire()
+                        fallback_record = ssl.fetch_semantic_scholar(
+                            session, pmid, sleep, cfg=semantic_scholar_cfg
+                        )
+                        semsch_map[pmid] = fallback_record
 
                 combined_records: list[dict[str, str]] = []
                 for pubmed in pubmed_list:
                     pmid = pubmed.get("PubMed.PMID", "")
-                    semsch = semsch_map.get(pmid, {})
+                    semsch = semsch_map.get(pmid, {}) if pmid else {}
 
                     # Still fetching these individually for now
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -568,6 +568,74 @@ def test_fetch_pubmed_records_uses_fallback_doi(
     assert df.loc[0, "crossref.DOI"] == fallback["123"]
 
 
+def test_fetch_pubmed_records_falls_back_to_single_semantic_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Semantic Scholar batch failures should be retried via the single endpoint."""
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd.requests, "Session", lambda: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any, batch: list[str], sleep: float, cfg: Any | None = None
+    ) -> list[dict[str, str]]:
+        assert batch == ["123"]
+        return [{"PubMed.PMID": "123"}]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        assert pmids == ["123"]
+        return [
+            {
+                "scholar.PMID": "123",
+                "scholar.Error": "Bad Request",
+                "scholar.DOI": "",
+            }
+        ]
+
+    single_calls: list[str] = []
+
+    def fake_semantic_single(
+        session: Any, pmid: str, sleep: float, cfg: Any | None = None
+    ) -> dict[str, str]:
+        single_calls.append(pmid)
+        return {
+            "scholar.PMID": pmid,
+            "scholar.DOI": "10.1000/fallback",
+            "scholar.Error": "",
+        }
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", fake_semantic_single)
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    df = gdd.fetch_pubmed_records(
+        ["123"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert single_calls == ["123"]
+    assert df.loc[0, "scholar.DOI"] == "10.1000/fallback"
+
+
 def test_finalise_export_falls_back_to_default_key(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- filter Semantic Scholar batch payloads to skip falsy PMIDs and keep the request body valid
- retry batch entries through the single-record Semantic Scholar endpoint when the batch response returns errors
- cover the new fallback behaviour with a dedicated regression test

## Testing
- pytest tests/test_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d502d53ca883248e04f4862e67a3da