### PR TITLE
Add DOI fallback support to PubMed CLI

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -84,6 +84,41 @@ from library.table_quality import analyze_table_quality
 from schemas import DocumentsSchema, normalize_documents
 
 
+def _build_fallback_doi_map(
+    frame: pd.DataFrame,
+    *,
+    pmid_column: str,
+    doi_column: str,
+) -> dict[str, str]:
+    """Return a mapping of PubMed identifiers to DOI overrides."""
+
+    if pmid_column not in frame.columns or doi_column not in frame.columns:
+        missing = [
+            column
+            for column in (pmid_column, doi_column)
+            if column not in frame.columns
+        ]
+        raise ValueError(
+            "missing columns in fallback DOI file: "
+            f"{', '.join(missing)}"
+        )
+
+    mapping: dict[str, str] = {}
+    for pmid_value, doi_value in frame[[pmid_column, doi_column]].itertuples(index=False):
+        if pd.isna(pmid_value):
+            pmid = ""
+        else:
+            pmid = str(pmid_value).strip()
+        if pd.isna(doi_value):
+            doi = ""
+        else:
+            doi = normalise_doi(doi_value)
+        if not pmid or not doi:
+            continue
+        mapping[pmid] = doi
+    return mapping
+
+
 def fetch_pubmed_records(
     pmids: Iterable[str],
     *args: object,
@@ -653,6 +688,33 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         pmids = limited_pmids
         logger.info("process_limit", limit=len(limited_pmids))
 
+    fallback_doi_map: Mapping[str, str] | None = None
+    fallback_csv = getattr(args, "fallback_doi_csv", None)
+    if fallback_csv:
+        try:
+            fallback_frame = io.read_csv(fallback_csv, cfg=cfg.io)
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error(
+                "fallback_doi_read_failed",
+                error=str(exc),
+                path=str(fallback_csv),
+            )
+            return 1
+        try:
+            fallback_map = _build_fallback_doi_map(
+                fallback_frame,
+                pmid_column=getattr(args, "fallback_doi_pmid_column", "PMID"),
+                doi_column=getattr(args, "fallback_doi_value_column", "DOI"),
+            )
+        except ValueError as exc:
+            logger.error(
+                "fallback_doi_invalid",
+                error=str(exc),
+                path=str(fallback_csv),
+            )
+            return 1
+        fallback_doi_map = fallback_map or None
+
     try:
         df = fetch_pubmed_records(
             pmids,
@@ -664,6 +726,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             crossref_cfg=cfg.crossref,
             max_workers=cfg.document.pubmed.workers,
             batch_size=cfg.document.pubmed.batch_size,
+            fallback_doi_map=fallback_doi_map,
         )
         output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
         df = normalize_documents(df)
@@ -929,6 +992,22 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=None,
         help="Requests per second limit for CrossRef",
+    )
+    pubmed.add_argument(
+        "--fallback-doi-csv",
+        type=Path,
+        default=None,
+        help="Optional CSV file providing PMID to DOI overrides",
+    )
+    pubmed.add_argument(
+        "--fallback-doi-pmid-column",
+        default="PMID",
+        help="Column containing PubMed identifiers in fallback CSV",
+    )
+    pubmed.add_argument(
+        "--fallback-doi-value-column",
+        default="DOI",
+        help="Column containing DOI values in fallback CSV",
     )
     pubmed.set_defaults(func=run_pubmed)
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -145,6 +145,9 @@ def test_run_all_logs_failing_ids(
     args = argparse.Namespace(
         input_csv=input_csv,
         output_csv=tmp_path / "out.csv",
+        fallback_doi_csv=None,
+        fallback_doi_pmid_column="PMID",
+        fallback_doi_value_column="DOI",
     )
     rc = gdd.run_all(cfg, args)
     assert rc == 1
@@ -262,6 +265,9 @@ def test_run_pubmed_uses_keyword_arguments(
     args = argparse.Namespace(
         input_csv=input_csv,
         output_csv=tmp_path / "out.csv",
+        fallback_doi_csv=None,
+        fallback_doi_pmid_column="PMID",
+        fallback_doi_value_column="DOI",
     )
 
     exit_code = gdd.run_pubmed(cfg, args)
@@ -276,6 +282,73 @@ def test_run_pubmed_uses_keyword_arguments(
     assert captured["max_workers"] == cfg.document.pubmed.workers
     assert captured["batch_size"] == cfg.document.pubmed.batch_size
     assert captured["fallback_doi_map"] is None
+
+
+def test_build_fallback_doi_map() -> None:
+    """Fallback DOI helper should normalise values and ignore blanks."""
+
+    df = pd.DataFrame(
+        {
+            "PMID": ["1", "2", "3", None],
+            "DOI": ["10.1000/XYZ", "", None, "10.2000/abc"],
+        }
+    )
+
+    result = gdd._build_fallback_doi_map(df, pmid_column="PMID", doi_column="DOI")
+
+    assert result == {"1": "10.1000/xyz"}
+
+
+def test_run_pubmed_uses_fallback_csv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PubMed pipeline should forward fallback DOI mappings when provided."""
+
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n1\n2\n")
+    fallback_csv = tmp_path / "fallback.csv"
+    fallback_csv.write_text("PMID,DOI\n1,10.1000/FOO\n2,\n")
+
+    monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
+    monkeypatch.setattr(
+        gdd,
+        "_finalise_export",
+        lambda df, output, cfg, input_csv, key_columns: 0,
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_fetch_pubmed_records(
+        pmids: Iterable[str],
+        cfg_param: Config,
+        *,
+        sleep: float,
+        pubmed_cfg: Any | None = None,
+        semantic_scholar_cfg: SemanticScholarCfg,
+        openalex_cfg: OpenAlexCfg,
+        crossref_cfg: CrossRefCfg,
+        max_workers: int,
+        batch_size: int,
+        fallback_doi_map: dict[str, str] | None = None,
+    ) -> pd.DataFrame:
+        captured["fallback_doi_map"] = fallback_doi_map
+        return pd.DataFrame({"PMID": list(pmids)})
+
+    monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
+
+    cfg = Config()
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "out.csv",
+        fallback_doi_csv=fallback_csv,
+        fallback_doi_pmid_column="PMID",
+        fallback_doi_value_column="DOI",
+    )
+
+    exit_code = gdd.run_pubmed(cfg, args)
+
+    assert exit_code == 0
+    assert captured["fallback_doi_map"] == {"1": "10.1000/foo"}
 
 
 def test_write_csv_column_order(


### PR DESCRIPTION
## Summary
- add a helper to build DOI fallback mappings and wire it into the pubmed CLI
- extend the pubmed sub-command with options to load fallback DOI CSV files
- cover DOI overrides with new unit tests for the CLI helper and pipeline

## Testing
- pytest tests/test_get_document_data.py


------
https://chatgpt.com/codex/tasks/task_e_68d50486019c8324b4e2aa2caee51717