### PR TITLE
Add pipeline metadata columns to exports

### DIFF
--- a/library/activity_extraction.py
+++ b/library/activity_extraction.py
@@ -27,6 +27,8 @@ from library.table_quality import analyze_table_quality
 from library.validation import validate_activities
 from schemas import ActivitiesSchema, normalize_activities
 
+from .pipeline_metadata import add_pipeline_metadata
+
 LOG: Final = logging.getLogger(__name__)
 
 
@@ -159,6 +161,7 @@ def extract_activities(
             return 1
 
     df = normalize_activities(df)
+    df = add_pipeline_metadata(df)
 
     required = {name for name, col in ActivitiesSchema.columns.items() if col.required}
     missing_required = required - set(df.columns)

--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -106,6 +106,8 @@ DOCUMENT_SCHEMA_COLUMNS: list[str] = (
         "PubMed.is_review",
         "scholar.is_review",
         "OpenAlex.is_review",
+        "pipeline_version",
+        "timestamp_utc",
     ]
 )
 

--- a/library/pipeline_metadata.py
+++ b/library/pipeline_metadata.py
@@ -1,0 +1,93 @@
+"""Helpers for annotating exported tables with pipeline metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from functools import lru_cache
+from importlib import metadata
+from pathlib import Path
+from typing import Final
+
+import pandas as pd
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_PACKAGE_NAME: Final[str] = "chembl-data-acquisition"
+_DEFAULT_VERSION: Final[str] = "0.0.0"
+_PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+_PYPROJECT_PATH: Final[Path] = _PROJECT_ROOT / "pyproject.toml"
+
+
+@lru_cache(maxsize=1)
+def _read_version_from_pyproject() -> str:
+    """Return the project version declared in ``pyproject.toml``."""
+
+    if not _PYPROJECT_PATH.exists():
+        return _DEFAULT_VERSION
+    try:
+        with _PYPROJECT_PATH.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):  # pragma: no cover - unlikely during tests
+        return _DEFAULT_VERSION
+    project = data.get("project")
+    if isinstance(project, dict):
+        version = project.get("version")
+        if isinstance(version, str) and version.strip():
+            return version
+    return _DEFAULT_VERSION
+
+
+@lru_cache(maxsize=1)
+def get_pipeline_version() -> str:
+    """Return the installed package version or the value from ``pyproject.toml``."""
+
+    try:
+        return metadata.version(_PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return _read_version_from_pyproject()
+
+
+@lru_cache(maxsize=1)
+def get_timestamp_utc() -> str:
+    """Return an ISO 8601 timestamp representing the pipeline execution time."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+@lru_cache(maxsize=1)
+def pipeline_metadata() -> dict[str, str]:
+    """Return a mapping with pipeline metadata columns."""
+
+    return {
+        "pipeline_version": get_pipeline_version(),
+        "timestamp_utc": get_timestamp_utc(),
+    }
+
+
+def add_pipeline_metadata(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with pipeline metadata columns added."""
+
+    if df.empty:
+        # Preserve dtypes while ensuring the columns exist for empty frames.
+        metadata_values = pipeline_metadata()
+        result = df.copy()
+        for column, value in metadata_values.items():
+            result[column] = pd.Series(dtype="string")
+        return result
+
+    result = df.copy()
+    for column, value in pipeline_metadata().items():
+        result[column] = value
+    return result
+
+
+__all__ = [
+    "add_pipeline_metadata",
+    "get_pipeline_version",
+    "get_timestamp_utc",
+    "pipeline_metadata",
+]
+

--- a/library/pipeline_targets.py
+++ b/library/pipeline_targets.py
@@ -10,6 +10,7 @@ from typing import Any
 import pandas as pd
 
 from .log import logger
+from .pipeline_metadata import add_pipeline_metadata
 
 OptionalFetcher = Callable[..., pd.DataFrame]
 
@@ -153,6 +154,7 @@ def run_pipeline(
         chembl_cfg,
         **chembl_kwargs,
     )
+    chembl_df = add_pipeline_metadata(chembl_df)
 
     uniprot_df: pd.DataFrame | None = None
     if uniprot_fetcher is not None:
@@ -169,6 +171,7 @@ def run_pipeline(
             *uniprot_positional,
             **uniprot_kwargs,
         )
+        uniprot_df = add_pipeline_metadata(uniprot_df)
 
     isoform_df: pd.DataFrame | None = None
     if isoform_fetcher is not None:
@@ -185,6 +188,7 @@ def run_pipeline(
             *isoform_positional,
             **isoform_kwargs,
         )
+        isoform_df = add_pipeline_metadata(isoform_df)
 
     ortholog_df: pd.DataFrame | None = None
     if ortholog_fetcher is not None:
@@ -201,6 +205,7 @@ def run_pipeline(
             *ortholog_positional,
             **ortholog_kwargs,
         )
+        ortholog_df = add_pipeline_metadata(ortholog_df)
 
     iuphar_df: pd.DataFrame | None = None
     if iuphar_fetcher is not None:
@@ -217,6 +222,7 @@ def run_pipeline(
             *iuphar_positional,
             **iuphar_kwargs,
         )
+        iuphar_df = add_pipeline_metadata(iuphar_df)
 
     return PipelineResult(
         chembl=chembl_df,

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -49,6 +49,8 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "standard_value": pa.Column(
             float, pa.Check.ge(0), required=True, nullable=True, coerce=True
         ),
+        "pipeline_version": pa.Column(str, required=False, nullable=True),
+        "timestamp_utc": pa.Column(str, required=False, nullable=True),
         #    "pA_value": pa.Column(float, pa.Check.in_range(-14, 14), required=False),
     }
 )

--- a/schemas/assays.py
+++ b/schemas/assays.py
@@ -79,6 +79,8 @@ AssaysSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "target_name": pa.Column(str, required=False, nullable=True),
         "version": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
         "year": pa.Column(FLEXIBLE_DTYPE, required=False, nullable=True),
+        "pipeline_version": pa.Column(str, required=False, nullable=True),
+        "timestamp_utc": pa.Column(str, required=False, nullable=True),
     }
 )
 

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -108,6 +108,8 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
     "PubMed.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
     "scholar.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
     "OpenAlex.is_review": pa.Column(object, required=False, nullable=True, coerce=True),
+    "pipeline_version": pa.Column(str, required=False, nullable=True),
+    "timestamp_utc": pa.Column(str, required=False, nullable=True),
 }
 
 

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -33,6 +33,8 @@ TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "pubchem_molecular_formula": pa.Column(str, required=False, nullable=True),
         "structure_type": pa.Column(str, required=False, nullable=True),
         "topical": pa.Column(PA_ANY, required=False, nullable=True),
+        "pipeline_version": pa.Column(str, required=False, nullable=True),
+        "timestamp_utc": pa.Column(str, required=False, nullable=True),
     }
 )
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -36,6 +36,7 @@ from library.config import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_activities
@@ -116,6 +117,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_activities(df)
+        df = add_pipeline_metadata(df)
         # Determine final column order: schema-defined columns first in their
         # declared sequence, followed by any additional columns sorted
         # alphabetically to provide deterministic output.

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -35,6 +35,7 @@ from library.config import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_assays
@@ -106,6 +107,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = ap.postprocess_assays(df)
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_assays(df)
+        df = add_pipeline_metadata(df)
         rows_total = len(df)
         exit_code = 0
         required_cols = {

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -78,6 +78,7 @@ from library.document_pipeline import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.pipeline_metadata import add_pipeline_metadata
 from library.rate_limiter import get_limiter
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -523,6 +524,7 @@ def _finalise_export(
 ) -> int:
     """Validate ``df`` and write CSV/metadata artefacts."""
 
+    df = add_pipeline_metadata(df)
     ordered = build_dataframe(df, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False)
     rows_total = len(ordered)
     exit_code = 0

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -47,6 +47,7 @@ from library.config import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from schemas import TargetsSchema, normalize_targets
@@ -572,6 +573,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_targets(df)
+        df = add_pipeline_metadata(df)
         rows_total = len(df)
         exit_code = 0
     validation_df, missing_required, missing_optional = _prepare_targets_for_schema(df)
@@ -1005,6 +1007,7 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
 
     logger.info("validate_write_start", output=str(output))
     normalized = normalize_targets(df)
+    normalized = add_pipeline_metadata(normalized)
     final_df, missing_required, missing_optional = _prepare_targets_for_schema(
         normalized
     )

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -39,6 +39,7 @@ from library.config import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
@@ -193,6 +194,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("pubchem_augment_done")
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_testitems(df)
+        df = add_pipeline_metadata(df)
         # Determine column order: schema columns first, followed by
         # additional fields sorted alphabetically.
         schema_cols = list(TestitemsSchema.columns)

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -26,6 +26,7 @@ from library.config import Config, ensure_dirs, print_config
 from library.io import default_output_path, read_ids, write_csv
 from library.log import logger
 from library.pipeline_targets import PipelineResult, run_pipeline
+from library.pipeline_metadata import add_pipeline_metadata
 
 
 class PipelineConfig(BaseModel):
@@ -140,8 +141,9 @@ def _write_outputs(
     cfg: Config, options: PipelineConfig, result: PipelineResult
 ) -> Path:
     output = options.output_csv or default_output_path(options.input_csv, cfg.io)
+    annotated = add_pipeline_metadata(result.chembl)
     write_csv(
-        result.chembl,
+        annotated,
         output,
         cfg=cfg,
         sep=options.sep,

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -92,7 +92,8 @@ def test_extract_activities_success(
     assert exit_code == 0
     assert output_csv.exists()
     result = pd.read_csv(output_csv)
-    assert sorted(result.columns) == sorted(df.columns)
+    expected_columns = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    assert set(result.columns) == expected_columns
     assert result["activity_id"].tolist() == ["A1", "A2"]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -524,7 +524,10 @@ def test_target_chembl_defaults_match_cli(
     assert exit_code == 0
     assert output_csv.exists()
     header = output_csv.read_text(encoding=cfg.io.csv_encoding).splitlines()[0]
-    assert header == "target_chembl_id"
+    expected_header = cfg.io.csv_sep.join(
+        ["pipeline_version", "target_chembl_id", "timestamp_utc"]
+    )
+    assert header == expected_header
 
 
 def test_log_level_invalid_no_mapping(

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -121,6 +121,7 @@ def test_run_chembl_column_order(
     assert rc == 0
 
     schema_cols = list(ActivitiesSchema.columns)
-    expected_head = [c for c in schema_cols if c in df.columns]
-    expected_tail = sorted(c for c in df.columns if c not in schema_cols)
+    available = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    expected_head = [c for c in schema_cols if c in available]
+    expected_tail = sorted(available - set(schema_cols))
     assert captured["col_order"] == expected_head + expected_tail

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -44,6 +44,8 @@ def test_run_chembl_orders_columns(
         "assay_chembl_id",
         "document_chembl_id",
         "target_chembl_id",
+        "pipeline_version",
+        "timestamp_utc",
         "aaa",
         "zzz",
     ]

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -85,10 +85,12 @@ def test_run_uniprot_initialises_session(
         data_dir: Path | str | None = None,
         *,
         cfg: object,
+        gtop_cfg: object | None = None,
         sep: str = ",",
         encoding: str = "utf-8",
     ) -> None:
         called["cfg"] = cfg
+        called["gtop_cfg"] = gtop_cfg
         pd.DataFrame({"uniprot_id": ["P12345"], "names": ["Foo"]}).to_csv(
             output_csv, index=False
         )
@@ -115,6 +117,7 @@ def test_run_uniprot_initialises_session(
     assert rc == 0
     assert called["init"] == (cfg.api, cfg.retry)
     assert called["cfg"] is cfg.uniprot
+    assert called["gtop_cfg"] is cfg.iuphar
 
 
 def test_run_uniprot_writes_sidecar(
@@ -136,6 +139,7 @@ def test_run_uniprot_writes_sidecar(
         data_dir: Path | str | None = None,
         *,
         cfg: object,
+        gtop_cfg: object | None = None,
         sep: str = ",",
         encoding: str = "utf-8",
     ) -> None:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -62,8 +62,9 @@ def test_run_chembl_column_order(
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
 
-    expected_head = [c for c in TestitemsSchema.columns if c in df.columns]
-    expected_tail = sorted(c for c in df.columns if c not in TestitemsSchema.columns)
+    available = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    expected_head = [c for c in TestitemsSchema.columns if c in available]
+    expected_tail = sorted(available - set(TestitemsSchema.columns))
     assert captured["col_order"] == expected_head + expected_tail
 
 


### PR DESCRIPTION
## Summary
- add a shared pipeline metadata helper that exposes pipeline version and UTC timestamp and reuse it across pipelines
- update activity, assay, document, target and test item export flows to append `pipeline_version` and `timestamp_utc`
- extend the corresponding schemas and tests so the new metadata columns are validated and ordered correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5056506408324954a618fed50ac00