### PR TITLE
Remove unused batch and jobs config sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,8 @@ All scripts share a common set of flags:
 
 Default settings live in ``config.yaml`` and are split into sections for each
 API (``api``, ``openalex``, ``crossref``, ``uniprot``, ``iuphar``, ``pubchem``),
-I/O and processing (``io``, ``jobs``, ``batch``, ``quality``, ``mapper``) and
-general infrastructure (``init``, ``rate``, ``retry``, ``log``). The companion
+I/O (``io``) and general infrastructure (``init``, ``rate``, ``retry``, ``log``).
+The companion
 ``config.schema.json`` file documents these fields and is useful for editor
 validation, but it must **not** be passed to ``--config`` because it lacks
 runtime values such as ``api.user_agent``. A minimal configuration looks like::
@@ -514,8 +514,6 @@ runtime values such as ``api.user_agent``. A minimal configuration looks like::
       rps: 5
     io:
       output_dir: data/output
-    jobs:
-      concurrency: 8
 
 ### Переменные окружения
 
@@ -551,8 +549,6 @@ Most options also provide short aliases. The table lists the supported mappings:
 | `CHEMBL_DA_PUBCHEM_TIMEOUT_READ` | `CHEMBL_DA__PUBCHEM__TIMEOUT_READ` |
 | `CHEMBL_DA_PUBCHEM_RPS` | `CHEMBL_DA__PUBCHEM__RPS` |
 | `CHEMBL_DA_OUTDIR` | `CHEMBL_DA__IO__OUTPUT_DIR` |
-| `CHEMBL_DA_CONCURRENCY` | `CHEMBL_DA__JOBS__CONCURRENCY` |
-| `CHEMBL_DA_CHUNK_SIZE` | `CHEMBL_DA__JOBS__CHUNK_SIZE` |
 | `CHEMBL_DA_RETRY_MAX_ATTEMPTS` | `CHEMBL_DA__RETRY__MAX_ATTEMPTS` |
 | `CHEMBL_DA_RETRY_BACKOFF_FACTOR` | `CHEMBL_DA__RETRY__BACKOFF_FACTOR` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__LOG__LEVEL` |

--- a/config.schema.json
+++ b/config.schema.json
@@ -133,41 +133,6 @@
       "title": "AssayCfg",
       "type": "object"
     },
-    "BatchCfg": {
-      "additionalProperties": false,
-      "properties": {
-        "size": {
-          "default": 1000,
-          "minimum": 1,
-          "title": "Size",
-          "type": "integer"
-        },
-        "pause": {
-          "default": 0.0,
-          "minimum": 0,
-          "title": "Pause",
-          "type": "number"
-        },
-        "concurrency": {
-          "default": 2,
-          "minimum": 1,
-          "title": "Concurrency",
-          "type": "integer"
-        },
-        "fail_fast": {
-          "default": true,
-          "title": "Fail Fast",
-          "type": "boolean"
-        },
-        "retry_failed": {
-          "default": true,
-          "title": "Retry Failed",
-          "type": "boolean"
-        }
-      },
-      "title": "BatchCfg",
-      "type": "object"
-    },
     "ChemblCfg": {
       "additionalProperties": false,
       "properties": {
@@ -486,11 +451,6 @@
           ],
           "title": "Na Markers"
         },
-        "csv_index": {
-          "default": false,
-          "title": "Csv Index",
-          "type": "boolean"
-        },
         "exist_ok": {
           "default": true,
           "title": "Exist Ok",
@@ -542,25 +502,6 @@
       "title": "IupharCfg",
       "type": "object"
     },
-    "JobsCfg": {
-      "additionalProperties": false,
-      "properties": {
-        "concurrency": {
-          "default": 8,
-          "minimum": 1,
-          "title": "Concurrency",
-          "type": "integer"
-        },
-        "chunk_size": {
-          "default": 500,
-          "minimum": 1,
-          "title": "Chunk Size",
-          "type": "integer"
-        }
-      },
-      "title": "JobsCfg",
-      "type": "object"
-    },
     "LogCfg": {
       "additionalProperties": false,
       "properties": {
@@ -581,28 +522,6 @@
         }
       },
       "title": "LogCfg",
-      "type": "object"
-    },
-    "MapperCfg": {
-      "additionalProperties": false,
-      "properties": {
-        "enable_cache": {
-          "default": true,
-          "title": "Enable Cache",
-          "type": "boolean"
-        },
-        "strict_schema": {
-          "default": true,
-          "title": "Strict Schema",
-          "type": "boolean"
-        },
-        "warn_on_cast": {
-          "default": true,
-          "title": "Warn On Cast",
-          "type": "boolean"
-        }
-      },
-      "title": "MapperCfg",
       "type": "object"
     },
     "OpenAlexCfg": {
@@ -742,36 +661,6 @@
         }
       },
       "title": "PubMedCfg",
-      "type": "object"
-    },
-    "QualityCfg": {
-      "additionalProperties": false,
-      "properties": {
-        "sample_rows": {
-          "default": 0,
-          "minimum": 0,
-          "title": "Sample Rows",
-          "type": "integer"
-        },
-        "corr_method": {
-          "default": "pearson",
-          "title": "Corr Method",
-          "type": "string"
-        },
-        "max_unique_preview": {
-          "default": 50,
-          "minimum": 1,
-          "title": "Max Unique Preview",
-          "type": "integer"
-        },
-        "bin_count": {
-          "default": 20,
-          "minimum": 1,
-          "title": "Bin Count",
-          "type": "integer"
-        }
-      },
-      "title": "QualityCfg",
       "type": "object"
     },
     "RateCfg": {
@@ -1302,23 +1191,11 @@
     "io": {
       "$ref": "#/$defs/IoCfg"
     },
-    "jobs": {
-      "$ref": "#/$defs/JobsCfg"
-    },
     "log": {
       "$ref": "#/$defs/LogCfg"
     },
     "init": {
       "$ref": "#/$defs/InitCfg"
-    },
-    "batch": {
-      "$ref": "#/$defs/BatchCfg"
-    },
-    "quality": {
-      "$ref": "#/$defs/QualityCfg"
-    },
-    "mapper": {
-      "$ref": "#/$defs/MapperCfg"
     },
     "rate": {
       "$ref": "#/$defs/RateCfg"

--- a/config.yaml
+++ b/config.yaml
@@ -186,30 +186,7 @@ io:
   cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA__IO__CACHE_DIR)
   csv_sep: ","  # CSV field separator
   csv_encoding: "utf-8-sig"  # Encoding for CSV files
-  csv_index: false  # Include index column when writing CSV
   exist_ok: true  # Create directories with ensure_dirs if missing
-
-jobs:
-  concurrency: 8  # Number of parallel workers (env: CHEMBL_DA__JOBS__CONCURRENCY / CHEMBL_DA_CONCURRENCY)
-  chunk_size: 500  # Records per job chunk (env: CHEMBL_DA__JOBS__CHUNK_SIZE / CHEMBL_DA_CHUNK_SIZE)
-
-batch:
-  size: 1000  # Number of rows per batch (env: CHEMBL_DA__BATCH__SIZE)
-  pause: 0.0  # Delay between batches in seconds (env: CHEMBL_DA__BATCH__PAUSE)
-  concurrency: 2  # Number of concurrent batch workers (env: CHEMBL_DA__BATCH__CONCURRENCY)
-  fail_fast: true  # Abort on first error (env: CHEMBL_DA__BATCH__FAIL_FAST)
-  retry_failed: true  # Retry failed batches (env: CHEMBL_DA__BATCH__RETRY_FAILED)
-
-quality:
-  sample_rows: 0  # Rows to sample for previews (0 = all)
-  corr_method: "pearson"  # Correlation method
-  max_unique_preview: 50  # Preview unique values up to this count
-  bin_count: 20  # Histogram bins for numeric columns
-
-mapper:
-  enable_cache: true  # Cache mapping results
-  strict_schema: true  # Enforce input schema
-  warn_on_cast: true  # Warn when casting types
 
 init:
   same_doc: "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"  # Source workbook

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -85,9 +85,9 @@ python table_quality_main.py \
 
 ## Конфигурационные переопределения
 
-Параметры CLI заменяют значения `config.yaml`.  
+Параметры CLI заменяют значения `config.yaml`.
 Например, `--sep` → `io.csv_sep`, `--encoding` → `io.csv_encoding`,
-`--chunk-size` → `jobs.chunk_size`, `--timeout` → `api.timeout_read`,
+`--chunk-size` → профильный раздел (например, `activity.chunk_size`), `--timeout` → `api.timeout_read`,
 `--log-level` → `log.level`.
 
 ## Переменные окружения

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -273,7 +273,6 @@ _DEFAULT_OVERRIDES: dict[str, str] = {
     "sep": "io.csv_sep",
     "encoding": "io.csv_encoding",
     "log_level": "log.level",
-    "chunk_size": "jobs.chunk_size",
     "timeout": "api.timeout_read",
 }
 

--- a/library/config.py
+++ b/library/config.py
@@ -314,18 +314,12 @@ class IoCfg(_BoolModel):
     csv_sep: str = ","
     csv_encoding: str = "utf-8-sig"
     na_markers: Sequence[str] | None = ("#N/A",)
-    csv_index: bool = False
     exist_ok: bool = True
 
-    @field_validator("csv_index", "exist_ok", mode="before")
+    @field_validator("exist_ok", mode="before")
     @classmethod
     def _bools(cls, v: Any) -> bool:
         return cls._parse_bool(v)
-
-
-class JobsCfg(_BaseModel):
-    concurrency: int = Field(8, ge=1)
-    chunk_size: int = Field(500, ge=1)
 
 
 class LogCfg(_BaseModel):
@@ -351,38 +345,6 @@ class InitCfg(_BaseModel):
     same_doc: Path = Path("data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx")
     all_doc: Path = Path("data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx")
     output_dir: Path = Path("data/output/ChEMBL/processed")
-
-
-class BatchCfg(_BoolModel):
-    size: int = Field(1000, ge=1)
-    pause: float = Field(0.0, ge=0)
-    concurrency: int = Field(2, ge=1)
-    fail_fast: bool = True
-    retry_failed: bool = True
-
-    @field_validator("fail_fast", "retry_failed", mode="before")
-    @classmethod
-    def _bools(cls, v: Any) -> bool:
-        return cls._parse_bool(v)
-
-
-class QualityCfg(_BaseModel):
-    sample_rows: int = Field(0, ge=0)
-    corr_method: str = "pearson"
-    max_unique_preview: int = Field(50, ge=1)
-    bin_count: int = Field(20, ge=1)
-
-
-class MapperCfg(_BoolModel):
-    enable_cache: bool = True
-    strict_schema: bool = True
-    warn_on_cast: bool = True
-
-    @field_validator("enable_cache", "strict_schema", "warn_on_cast", mode="before")
-    @classmethod
-    def _bools(cls, v: Any) -> bool:
-        return cls._parse_bool(v)
-
 
 class RateCfg(_BaseModel):
     global_rps: int = Field(8, ge=1)
@@ -522,12 +484,8 @@ class Config(_BaseModel):
     doc_type: DocTypeCfg = Field(default_factory=lambda: DocTypeCfg())
     resources: ResourcesCfg = Field(default_factory=lambda: ResourcesCfg())
     io: IoCfg = Field(default_factory=lambda: IoCfg())
-    jobs: JobsCfg = Field(default_factory=lambda: JobsCfg())
     log: LogCfg = Field(default_factory=lambda: LogCfg())
     init: InitCfg = Field(default_factory=lambda: InitCfg())
-    batch: BatchCfg = Field(default_factory=lambda: BatchCfg())
-    quality: QualityCfg = Field(default_factory=lambda: QualityCfg())
-    mapper: MapperCfg = Field(default_factory=lambda: MapperCfg())
     rate: RateCfg = Field(default_factory=lambda: RateCfg())
     retry: RetryCfg = Field(default_factory=lambda: RetryCfg())
     activity: ActivityCfg = Field(default_factory=lambda: ActivityCfg())
@@ -784,8 +742,6 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_CACHE_DIR": ["io", "cache_dir"],
     "CHEMBL_DA_CACHE_MAXSIZE": ["chembl", "cache_maxsize"],
     "CHEMBL_DA_CACHE_TTL": ["chembl", "cache_ttl"],
-    "CHEMBL_DA_CHUNK_SIZE": ["jobs", "chunk_size"],
-    "CHEMBL_DA_CONCURRENCY": ["jobs", "concurrency"],
     "CHEMBL_DA_DICT_DIR": ["resources", "dictionary_dir"],
     "CHEMBL_DA_GLOBAL_BURST": ["rate", "global_burst"],
     "CHEMBL_DA_GLOBAL_RPS": ["rate", "global_rps"],
@@ -834,10 +790,6 @@ __all__ = [
     "TargetCfg",
     "ResourcesCfg",
     "IoCfg",
-    "JobsCfg",
-    "BatchCfg",
-    "QualityCfg",
-    "MapperCfg",
     "InitCfg",
     "RateCfg",
     "RetryCfg",

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -43,7 +43,7 @@ def test_malformed_config_exits(
 ) -> None:
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        "jobs:\n  chunk_size: bad\n"
+        "activity:\n  chunk_size: bad\n"
         "resources:\n"
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
@@ -69,7 +69,7 @@ def test_malformed_config_exits(
     assert rc != 0
 
     if caplog.text:
-        assert "jobs.chunk_size" in caplog.text
+        assert "activity.chunk_size" in caplog.text
 
 
 @pytest.mark.parametrize("entry, extra, use_sys", CLIS)
@@ -82,7 +82,7 @@ def test_unknown_key_config_exits(
 ) -> None:
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        "jobs:\n  chunk_size: 5\n"
+        "activity:\n  chunk_size: 5\n"
         "resources:\n"
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"
@@ -120,7 +120,7 @@ def test_negative_limit_in_config_exits(
 ) -> None:
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        "jobs:\n  chunk_size: 5\n"
+        "activity:\n  chunk_size: 5\n"
         "resources:\n"
         "  dictionary_dir: dictionary\n"
         "  iuphar_target_csv: dictionary/_IUPHAR/_IUPHAR_target.csv\n"

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -19,7 +19,6 @@ from scripts import get_testitem_data as gtdt
 def _create_config(tmp_path: Path) -> Path:
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
-        "jobs:\n  chunk_size: 10\n"
         "io:\n  csv_sep: ','\n  csv_encoding: utf8\n"
         "log:\n  level: INFO\n"
         "api:\n  timeout_read: 30\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -297,7 +297,6 @@ def test_config_type_coercion() -> None:
     path = Path(__file__).resolve().parents[1] / "config.yaml"
     cfg = load_config(path, strict=True)
     assert isinstance(cfg.pubchem.delay, float)
-    assert isinstance(cfg.batch.pause, float)
 
 
 def test_default_resource_paths_exist() -> None:
@@ -322,15 +321,6 @@ def test_default_resource_paths_exist() -> None:
             else project_root / resource_path
         )
         assert full_path.exists(), f"Missing default resource: {full_path}"
-
-
-def test_batch_pause_negative_value(tmp_path: Path) -> None:
-    path = tmp_path / "cfg.yaml"
-    path.write_text("batch:\n  pause: -1.0\n")
-    with pytest.raises(ValidationError):
-        load_config(path)
-
-
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("api: [\n")  # malformed YAML


### PR DESCRIPTION
## Summary
- drop the unused jobs, batch, quality, and mapper sections along with io.csv_index from the default configuration
- update the Pydantic models, JSON schema, CLI defaults, docs, and tests to align with the trimmed configuration surface

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d57441e0d88324bd21cd2923ffdc4e