### PR TITLE
Remove configurable UniProt mapping cache size

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1211,12 +1211,6 @@
           "title": "Timeout",
           "type": "number"
         },
-        "cache_maxsize": {
-          "default": 128,
-          "minimum": 0,
-          "title": "Cache Maxsize",
-          "type": "integer"
-        },
         "cache_ttl": {
           "anyOf": [
             {

--- a/config.yaml
+++ b/config.yaml
@@ -113,7 +113,6 @@ sources:
       base: "https://rest.uniprot.org/idmapping"  # UniProt ID mapping API (env: CHEMBL_DA_UNIPROT_MAPPING_BASE)
       poll_interval: 0.5  # Seconds between polling attempts (env: CHEMBL_DA_UNIPROT_MAPPING_POLL_INTERVAL)
       timeout: 300.0  # Maximum time in seconds to wait for a mapping job (env: CHEMBL_DA_UNIPROT_MAPPING_TIMEOUT)
-      cache_maxsize: 128  # Max cached UniProt mapping responses (env: CHEMBL_DA_UNIPROT_MAPPING_CACHE_MAXSIZE)
       cache_ttl: null  # TTL for cached mappings in seconds; null disables expiry (env: CHEMBL_DA_UNIPROT_MAPPING_CACHE_TTL)
   iuphar:
     base: "https://www.guidetopharmacology.org/services"  # IUPHAR API base (env: CHEMBL_DA__SOURCES__IUPHAR__BASE / CHEMBL_DA_IUPHAR_BASE)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -44,7 +44,6 @@
 | `mapping.base`           | `https://rest.uniprot.org/idmapping` | Сервис ID‑маппинга. |
 | `mapping.poll_interval`  | `0.5`                 | Интервал повторного опроса задачи. |
 | `mapping.timeout`        | `300`                 | Максимальное время ожидания результата. |
-| `mapping.cache_maxsize`  | `128`                 | Размер кэша ответов. |
 
 ### `sources.iuphar`, `sources.pubchem`, `sources.pubmed`, `sources.semantic_scholar`
 

--- a/docs/ru/CONFIG.md
+++ b/docs/ru/CONFIG.md
@@ -45,7 +45,7 @@
 * `delay`, `poll_interval` (`float`) — паузы между запросами (UniProt, PubChem).
 * `mailto` (`str`, обязателен где требуется) — контактная почта согласно
   требованиям API (CrossRef, OpenAlex).
-* `cache_ttl`, `cache_maxsize` (`int` | `null`) — параметры кэша для ID mapping.
+* `cache_ttl` (`int` | `null`) — параметр кэша для ID mapping.
 * `encodings` (`list[str]`) — fallback-кодировки при чтении публикаций.
 
 > **Совет:** значения по умолчанию подходят для публичных лимитов. При работе с

--- a/library/config.py
+++ b/library/config.py
@@ -191,7 +191,6 @@ class UniprotMappingCfg(_BaseModel):
     base: str = "https://rest.uniprot.org/idmapping"
     poll_interval: float = Field(0.5, gt=0)
     timeout: float = Field(300.0, ge=1)
-    cache_maxsize: int = Field(128, ge=0)
     cache_ttl: float | None = Field(None, ge=0)
 
     @field_validator("base")
@@ -212,7 +211,6 @@ class UniprotMappingCfg(_BaseModel):
                 self.base,
                 self.poll_interval,
                 self.timeout,
-                self.cache_maxsize,
                 self.cache_ttl,
             )
         )

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -16,6 +16,9 @@ from .log import logger
 from .rate_limiter import get_limiter
 
 
+_UNIPROT_MAPPING_CACHE_MAXSIZE = 128
+
+
 def _map_chembl_to_uniprot(
     chembl_target_id: str,
     cfg: UniprotMappingCfg,
@@ -104,7 +107,7 @@ def _map_chembl_to_uniprot(
     return str(accession)
 
 
-@lru_cache(maxsize=UniprotMappingCfg().cache_maxsize)
+@lru_cache(maxsize=_UNIPROT_MAPPING_CACHE_MAXSIZE)
 def _map_chembl_to_uniprot_cached(
     chembl_target_id: str,
     cfg: UniprotMappingCfg,
@@ -143,9 +146,8 @@ def map_chembl_to_uniprot(
     Notes
     -----
     Results are cached using :func:`functools.lru_cache` with a maximum size
-    defined by :class:`~library.config.UniprotMappingCfg`. If
-    ``cfg.cache_ttl`` is provided, cache entries expire after the given number
-    of seconds.
+    of :data:`_UNIPROT_MAPPING_CACHE_MAXSIZE` entries. If ``cfg.cache_ttl`` is
+    provided, cache entries expire after the given number of seconds.
     """
 
     ttl_hash = int(time.time() // cfg.cache_ttl) if cfg.cache_ttl else None


### PR DESCRIPTION
## Summary
- remove the `cache_maxsize` setting from the UniProt mapping configuration and schema
- hard-code the UniProt mapper cache capacity while keeping TTL-based expiry
- update configuration documentation to reflect the streamlined cache controls

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d5911576ac83249bceb50cffb8ce24