### PR TITLE
Add bilingual data schema documentation

### DIFF
--- a/docs/DATA_SCHEMA_EN
+++ b/docs/DATA_SCHEMA_EN
@@ -1,0 +1,312 @@
+# Data Schema
+
+## Input Tables
+
+### activity.csv
+- **Purpose:** seed list of ChEMBL activity identifiers consumed by the `get_activity_data` CLI before querying the API.【F:config.yaml†L25-L31】【356235†L1-L5】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| activity_chembl_id | string | External CSV of identifiers | Activity identifier in ChEMBL; used to request `/activity` records.|
+
+### assay.csv
+- **Purpose:** list of ChEMBL assay identifiers processed by the `get_assay_data` pipeline.【F:config.yaml†L32-L36】【29bb29†L1-L5】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| assay_chembl_id | string | External CSV of identifiers | ChEMBL assay ID used to call `/assay`.|
+
+### documents.csv
+- **Purpose:** collection of ChEMBL document identifiers that feeds the `get_document_data` CLI (`chembl`/`all` modes).【F:config.yaml†L49-L56】【fca225†L1-L5】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| document_chembl_id | string | External CSV of identifiers | Primary publication identifier in ChEMBL.|
+
+### targets.csv
+- **Purpose:** set of ChEMBL target identifiers used by the `get_target_data` pipeline.【F:config.yaml†L62-L80】【086d4d†L1-L5】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| target_chembl_id | string | External CSV of identifiers | ChEMBL target ID passed to the `/target` endpoint.|
+
+### testitem.csv
+- **Purpose:** list of ChEMBL molecule identifiers that `get_testitem_data` enriches with structural and PubChem attributes.【F:config.yaml†L37-L41】【85074e†L1-L5】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| molecule_chembl_id | string | External CSV of identifiers | ChEMBL molecule ID used when calling `/molecule`.|
+
+## Output Tables
+
+### activity.csv (processed export)
+- **Purpose:** normalized set of experimental activity measurements retrieved from the ChEMBL API and annotated with pipeline metadata.【F:scripts/get_activity_data.py†L63-L220】【F:library/chembl_assay.py†L62-L111】【F:schemas/activities.py†L16-L56】【F:library/pipeline_metadata.py†L60-L84】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| activity_id | string/number | ChEMBL `/activity` | Internal activity record identifier mirroring `ACTIVITY_ID` from the API.|
+| molecule_chembl_id | string | ChEMBL `/activity` | Identifier of the molecule whose activity was measured.|
+| assay_chembl_id | string | ChEMBL `/activity` | Identifier of the assay that produced the activity.|
+| activity_comment | string | ChEMBL `/activity` | Free-text comment describing the experiment or result.|
+| assay_description | string | ChEMBL `/activity` | Description of the linked assay.|
+| assay_variant_accession | string | ChEMBL `/activity` | UniProt accession of the assayed protein variant when provided.|
+| assay_variant_mutation | string | ChEMBL `/activity` | Mutation details for the assayed protein.|
+| bao_format | string | ChEMBL `/activity` | BioAssay Ontology format identifier.|
+| bao_label | string | ChEMBL `/activity` | BAO label describing the result type.|
+| data_validity_comment | string | ChEMBL `/activity` | Validation comment supplied by the source.|
+| data_validity_description | string | ChEMBL `/activity` | Detailed description of the validation status.|
+| document_chembl_id | string | ChEMBL `/activity` | Publication identifier linked to the experiment.|
+| pchembl_value | string/number | ChEMBL `/activity` | pChEMBL logarithmic value if computed by ChEMBL.|
+| potential_duplicate | boolean/string | ChEMBL `/activity` | Flag indicating that the activity may duplicate another record.|
+| qudt_units | string | ChEMBL `/activity` | Units expressed using the QUDT vocabulary when available.|
+| record_id | string/number | ChEMBL `/activity` | Identifier of the originating record in the source database.|
+| relation | string | ChEMBL `/activity` | Raw comparison operator (`<`, `<=`, `=`, `>=`, etc.) attached to the value.|
+| src_assay_id | string/number | ChEMBL `/activity` | Source-specific assay identifier.|
+| src_id | string/number | ChEMBL `/activity` | Identifier of the contributing data source.|
+| standard_relation | string | ChEMBL `/activity` | Normalized comparison operator applied during processing.|
+| standard_units | string | ChEMBL `/activity` | Normalized measurement units.|
+| type | string | ChEMBL `/activity` | Original measurement type returned by the API.|
+| units | string | ChEMBL `/activity` | Original units associated with `value`.|
+| value | string/number | ChEMBL `/activity` | Raw measurement reported by the API.|
+| standard_type | string | ChEMBL `/activity` | Normalized measurement type (restricted to `IC50` or `Ki`).|
+| standard_value | number (float) | ChEMBL `/activity` | Normalized numeric value in molar units; guaranteed non-negative.|
+| pipeline_version | string | Pipeline metadata | Version of the `chembl-data-acquisition` package stamped onto the export.|
+| timestamp_utc | ISO 8601 string | Pipeline metadata | UTC timestamp indicating when the export was created.|
+
+### assay.csv (processed export)
+- **Purpose:** aggregated assay descriptions with a per-target count of co-occurring assays and pipeline metadata.【F:scripts/get_assay_data.py†L47-L167】【F:library/chembl_assay.py†L22-L59】【F:library/assay_postprocessing.py†L1-L41】【F:schemas/assays.py†L1-L85】【F:library/pipeline_metadata.py†L60-L84】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| assay_chembl_id | string | ChEMBL `/assay` | Primary assay identifier.|
+| ASSAY_ID | string | ChEMBL `/assay` | Secondary identifier taken from the contributing source file.|
+| Target TYPE | string | ChEMBL `/assay` | Target category (cell-based, protein, etc.).|
+| accession | string | ChEMBL `/assay` | UniProt accession of the target when provided.|
+| acts_per_assay_step5 | string/number | ChEMBL `/assay` | Number of associated activities for step 5; preserved as returned.|
+| assay_cell_type | string | ChEMBL `/assay` | Cell type used during the experiment.|
+| assay_subcellular_fraction | string | ChEMBL `/assay` | Subcellular fraction tested in the assay.|
+| assay_tissue | string | ChEMBL `/assay` | Tissue or organ from which the material was derived.|
+| bao_format | string | ChEMBL `/assay` | BioAssay Ontology format identifier.|
+| cited_assay_corr | string/boolean | ChEMBL `/assay` | Whether the assay is cited as correlated.|
+| description | string | ChEMBL `/assay` | Human-readable description of the assay.|
+| document_chembl_id | string | ChEMBL `/assay` | Identifier of the source publication.|
+| error_assay_corr | string/boolean | ChEMBL `/assay` | Error indicator for the correlation citation flag.|
+| higly_correlated_cit | string/boolean | ChEMBL `/assay` | Flag for highly correlated citations.|
+| isoform | string | ChEMBL `/assay` | Protein isoform reference.|
+| month | string/number | ChEMBL `/assay` | Month of publication as delivered by the source.|
+| mutation | string | ChEMBL `/assay` | Mutation affecting the target protein.|
+| shuffled_cit | string/boolean | ChEMBL `/assay` | Indicator of a shuffled citation.|
+| shuffled_target_assay | string/boolean | ChEMBL `/assay` | Indicator of a shuffled target/assay pair.|
+| substrate_name | string | ChEMBL `/assay` | Name of the substrate used in the assay.|
+| target_chembl_id | string | ChEMBL `/assay` | Linked ChEMBL target identifier.|
+| target_name | string | ChEMBL `/assay` | Human-readable target name.|
+| version | string/number | ChEMBL `/assay` | Version of the assay record.|
+| year | string/number | ChEMBL `/assay` | Publication year.|
+| assay_with_same_target | number (int) | `postprocess_assays` | Count of assays sharing the same `document_chembl_id` and `target_chembl_id`.|
+| pipeline_version | string | Pipeline metadata | `chembl-data-acquisition` package version.|
+| timestamp_utc | ISO 8601 string | Pipeline metadata | Export timestamp in UTC.|
+
+### documents.csv (processed export)
+- **Purpose:** consolidated bibliographic metadata combining ChEMBL, PubMed, Semantic Scholar, OpenAlex and Crossref outputs with computed publication classes.【F:scripts/get_document_data.py†L18-L884】【F:library/document_pipeline.py†L20-L119】【F:schemas/documents.py†L14-L119】【F:library/document_postprocessing.py†L18-L154】【F:library/pipeline_metadata.py†L60-L84】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| document_chembl_id | string | ChEMBL `/document` | Primary identifier of the publication.|
+| title | string | ChEMBL `/document` | Publication title.|
+| abstract | string | ChEMBL `/document` | Abstract text.|
+| doi | string | ChEMBL `/document` and aggregators | DOI in the original format before normalization.|
+| year | number/string | ChEMBL `/document` | Publication year.|
+| journal | string | ChEMBL `/document` | Full journal title.|
+| journal_abbrev | string | ChEMBL `/document` | Journal abbreviation.|
+| volume | number/string | ChEMBL `/document` | Volume number.|
+| issue | number/string | ChEMBL `/document` | Issue number.|
+| first_page | number/string | ChEMBL `/document` | First page of the article.|
+| last_page | number/string | ChEMBL `/document` | Last page of the article.|
+| pubmed_id | number/string | ChEMBL `/document` | PubMed ID captured by ChEMBL when available.|
+| authors | string | ChEMBL `/document` | List of authors.|
+| source | string | ChEMBL `/document` | Origin of the record (typically `ChEMBL`).|
+| doi_normalised | string | Derived field | Canonical DOI computed across sources.|
+| publication_types_normalised | string | Derived field | Unified publication-type terms collected from all sources.|
+| publication_type_score_review | number (int) | Derived field | Score indicating evidence for a review article.|
+| publication_type_score_experimental | number (int) | Derived field | Score indicating experimental content.|
+| publication_type_score_unknown | number (int) | Derived field | Score assigned to unknown classes.|
+| publication_class | string | Derived field | Final publication label (`review`, `experimental`, etc.).|
+| PubMed.PMID | number/string | PubMed API | PubMed identifier returned by the API.|
+| PubMed.DOI | string | PubMed API | DOI as normalized from PubMed.|
+| PubMed.ArticleTitle | string | PubMed API | Article title from PubMed.|
+| PubMed.Abstract | string | PubMed API | Abstract text from PubMed.|
+| PubMed.JournalTitle | string | PubMed API | Journal title from PubMed.|
+| PubMed.Volume | number/string | PubMed API | Volume reported by PubMed.|
+| PubMed.Issue | number/string | PubMed API | Issue reported by PubMed.|
+| PubMed.StartPage | number/string | PubMed API | First page according to PubMed.|
+| PubMed.EndPage | number/string | PubMed API | Last page according to PubMed.|
+| PubMed.PublicationType | string | PubMed API | Raw publication-type terms.|
+| PubMed.MeSH_Descriptors | string | PubMed API | MeSH descriptors linked to the record.|
+| PubMed.MeSH_Qualifiers | string | PubMed API | MeSH qualifiers associated with the record.|
+| PubMed.ChemicalList | string | PubMed API | List of chemical entities mentioned.|
+| PubMed.DayRevised | number/string | PubMed API | Day of the last revision.|
+| PubMed.MonthRevised | number/string | PubMed API | Month of the last revision.|
+| PubMed.YearRevised | number/string | PubMed API | Year of the last revision.|
+| PubMed.YearCompleted | number/string | PubMed API | Year when indexing was completed.|
+| PubMed.MonthCompleted | number/string | PubMed API | Month when indexing was completed.|
+| PubMed.DayCompleted | number/string | PubMed API | Day when indexing was completed.|
+| PubMed.Error | string | PubMed API | Error message returned by the PubMed API.|
+| PubMed.ISSN | string | PubMed API | Journal ISSN as reported by PubMed.|
+| scholar.PMID | number/string | Semantic Scholar | PubMed ID linked by Semantic Scholar.|
+| scholar.Venue | string | Semantic Scholar | Publication venue recorded by Semantic Scholar.|
+| scholar.PublicationTypes | string | Semantic Scholar | Publication-type terms from Semantic Scholar.|
+| scholar.SemanticScholarId | string | Semantic Scholar | Semantic Scholar internal identifier.|
+| scholar.ExternalIds | string | Semantic Scholar | External identifiers serialized as JSON.|
+| scholar.DOI | string | Semantic Scholar | DOI value returned by Semantic Scholar.|
+| scholar.Error | string | Semantic Scholar | Error diagnostics from the Semantic Scholar API.|
+| OpenAlex.PublicationTypes | string | OpenAlex | Publication-type list returned by OpenAlex.|
+| OpenAlex.TypeCrossref | string | OpenAlex/Crossref | Crossref type relayed by OpenAlex.|
+| OpenAlex.Genre | string | OpenAlex | OpenAlex genre classification.|
+| OpenAlex.Id | string | OpenAlex | OpenAlex record identifier.|
+| OpenAlex.Venue | string | OpenAlex | Publication venue according to OpenAlex.|
+| OpenAlex.MeshDescriptors | string | OpenAlex | MeSH descriptors supplied by OpenAlex.|
+| OpenAlex.MeshQualifiers | string | OpenAlex | MeSH qualifiers supplied by OpenAlex.|
+| OpenAlex.Error | string | OpenAlex | Error message returned by OpenAlex.|
+| crossref.Type | string | Crossref | Crossref article type.|
+| crossref.Subtype | string | Crossref | Crossref subtype.|
+| crossref.Title | string | Crossref | Title from Crossref metadata.|
+| crossref.Subtitle | string | Crossref | Subtitle from Crossref metadata.|
+| crossref.Subject | string | Crossref | Subject categories from Crossref.|
+| crossref.Error | string | Crossref | Error message returned by Crossref.|
+| date_code | string | Post-processing | Auxiliary date code generated during normalization.|
+| Index | number/string | Post-processing | Row index preserved from the source table.|
+| PubMed.is_review | boolean/string | Post-processing | Derived review flag based on PubMed terminology.|
+| scholar.is_review | boolean/string | Post-processing | Review flag derived from Semantic Scholar.|
+| OpenAlex.is_review | boolean/string | Post-processing | Review flag derived from OpenAlex metadata.|
+| pipeline_version | string | Pipeline metadata | `chembl-data-acquisition` package version.|
+| timestamp_utc | ISO 8601 string | Pipeline metadata | Export timestamp in UTC.|
+
+### target.csv (final export)
+- **Purpose:** unified target table combining ChEMBL, UniProt and IUPHAR attributes while preserving the deterministic column order expected by downstream BI processes.【F:scripts/get_target_data.py†L31-L1148】【F:library/chembl_target.py†L185-L315】【F:library/target_postprocessing.py†L181-L442】【F:schemas/targets.py†L17-L214】【F:library/pipeline_metadata.py†L60-L84】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| target_chembl_id | string | ChEMBL `/target` | Primary identifier of the target.|
+| uniprot_id_primary | string | UniProt post-processing | Canonical UniProt accession (normalized `uniProtkbId`).|
+| uniprot_ids_all | string | UniProt post-processing | Pipe-delimited list of all known UniProt accessions (primary, secondary, mapping).|
+| isoform_ids | string | UniProt merge | List of isoform identifiers.|
+| isoform_names | string | UniProt merge | Names of the isoforms.|
+| isoform_synonyms | string | UniProt merge | Isoform synonyms converted to lowercase.|
+| hgnc_id | string | HGNC via cross references | HGNC identifier stripped of the `HGNC:` prefix.|
+| gene_symbol | string | Post-processing | Final gene symbol rendered in upper case.|
+| protein_name_canonical | string | UniProt/ChEMBL | Canonical protein name.|
+| protein_name_alt | string | UniProt/ChEMBL | Pipe-delimited list of alternative protein names.|
+| organism | string | ChEMBL/UniProt | Genus name representing the organism.|
+| taxon_id | string | ChEMBL | NCBI taxonomy identifier.|
+| lineage_superkingdom | string | UniProt taxonomy merge | Taxonomic superkingdom.|
+| lineage_phylum | string | UniProt taxonomy merge | Taxonomic phylum.|
+| lineage_class | string | UniProt taxonomy merge | Taxonomic class.|
+| sequence_length | string | UniProt | Amino-acid sequence length.|
+| features_signal_peptide | string | UniProt features | Presence of signal peptide annotations (lowercase).|
+| features_transmembrane | string | UniProt features | Presence of transmembrane segments (lowercase).|
+| features_topology | string | UniProt features | Reported membrane topology.|
+| ptm_glycosylation | string | UniProt PTM | Glycosylation annotations.|
+| ptm_lipidation | string | UniProt PTM | Lipidation annotations.|
+| ptm_disulfide_bond | string | UniProt PTM | Disulfide bond annotations.|
+| ptm_modified_residue | string | UniProt PTM | Other modified residues.|
+| xref_chembl | string | Post-processing | Duplicate of `target_chembl_id` for compatibility.|
+| xref_uniprot | string | Post-processing | Duplicate of `uniprot_id_primary`.|
+| xref_ensembl | string | ChEMBL/UniProt | Ensembl cross references serialized as a string.|
+| xref_iuphar | string | IUPHAR | IUPHAR target identifier.|
+| gtop_target_id | string | Guide to PHARMACOLOGY | Identifier used in the Guide to PHARMACOLOGY database.|
+| gtop_synonyms | string | Guide to PHARMACOLOGY | Synonyms reported by GToP (lowercase).|
+| gtop_natural_ligands_n | string | Guide to PHARMACOLOGY | Number of natural ligands as reported by GToP.|
+| gtop_interactions_n | string | Guide to PHARMACOLOGY | Number of recorded interactions.|
+| gtop_function_text_short | string | Guide to PHARMACOLOGY | Short functional description.|
+| uniprot_last_update | string | UniProt | Last update timestamp of the UniProt record.|
+| uniprot_version | string | UniProt | UniProt record version.|
+| pipeline_version | string | Pipeline metadata | `chembl-data-acquisition` package version.|
+| timestamp_utc | ISO 8601 string | Pipeline metadata | Export timestamp in UTC.|
+| pfam | string | UniProt | Pfam domains reported by UniProt.|
+| interpro | string | UniProt | InterPro domains reported by UniProt.|
+| xref_pdb | string | UniProt | PDB structure references.|
+| xref_alphafold | string | UniProt/AlphaFold | AlphaFold model references.|
+| hgnc_name | string | HGNC | HGNC gene name.|
+| uniProtkbId | string | UniProt | Original UniProt identifier before normalization.|
+| secondaryAccessions | string | UniProt | List of secondary UniProt accessions.|
+| recommendedName | string | UniProt | Recommended protein name from UniProt.|
+| geneName | string | UniProt | Primary gene symbol from UniProt.|
+| secondaryAccessionNames | string | UniProt | Names associated with secondary accessions.|
+| molecular_function | string | UniProt GO | Gene Ontology molecular function annotations.|
+| cellular_component | string | UniProt GO | Gene Ontology cellular component annotations.|
+| subcellular_location | string | UniProt | Reported subcellular localization.|
+| topology | string | UniProt | Transmembrane topology classification.|
+| transmembrane | string | UniProt | Transmembrane segment indicator (lowercase).|
+| intramembrane | string | UniProt | Intramembrane segment indicator.|
+| glycosylation | string | UniProt | Glycosylation annotation (lowercase).|
+| lipidation | string | UniProt | Lipidation annotation.|
+| disulfide_bond | string | UniProt | Disulfide bond annotation.|
+| modified_residue | string | UniProt | Miscellaneous residue modifications.|
+| phosphorylation | string | UniProt | Phosphorylation annotation.|
+| acetylation | string | UniProt | Acetylation annotation.|
+| ubiquitination | string | UniProt | Ubiquitination annotation.|
+| signal_peptide | string | UniProt | Signal peptide annotation (lowercase).|
+| propeptide | string | UniProt | Propeptide annotation.|
+| GuidetoPHARMACOLOGY | string | IUPHAR/GToP | Primary Guide to PHARMACOLOGY identifier.|
+| family | string | IUPHAR | IUPHAR family name.|
+| SUPFAM | string | UniProt/IUPHAR | Superfamily descriptor preserved from the source.|
+| PROSITE | string | UniProt | PROSITE motif annotations.|
+| InterPro | string | UniProt | InterPro domain annotations (alternate field).|
+| Pfam | string | UniProt | Pfam domain annotations (alternate field).|
+| PRINTS | string | UniProt | PRINTS motif annotations.|
+| TCDB | string | UniProt | Transporter Classification Database annotation.|
+| pref_name | string | ChEMBL | Preferred target name from ChEMBL.|
+| target_type | string | ChEMBL | Target type reported by ChEMBL (`SINGLE PROTEIN`, `PROTEIN FAMILY`, etc.).|
+| tax_id | string | ChEMBL | Taxonomy identifier as stored in ChEMBL.|
+| species_group_flag | string | ChEMBL | Species group flag from ChEMBL.|
+| target_components | JSON string | ChEMBL | Serialized representation of target components.|
+| protein_classifications | JSON string | ChEMBL | Serialized protein classification hierarchy.|
+| cross_references | JSON string | ChEMBL | Serialized list of external cross references.|
+| gene_symbol_list | string | Post-processing | Pipe-delimited list of gene symbols (upper case).|
+| protein_synonym_list | string | Post-processing | Pipe-delimited list of protein synonyms (lower case).|
+| reactions | string | ChEMBL | Reactions associated with the target, when provided.|
+| reaction_ec_numbers | string | Post-processing | Pipe-delimited list of EC numbers aggregated from synonyms and cross references.|
+| protein_class_pred_L1 | string | IUPHAR supplemental data | Predicted protein class level 1.|
+| protein_class_pred_L2 | string | IUPHAR supplemental data | Predicted protein class level 2.|
+| protein_class_pred_L3 | string | IUPHAR supplemental data | Predicted protein class level 3.|
+| protein_class_pred_rule_id | string | IUPHAR supplemental data | Identifier of the classification rule.|
+| protein_class_pred_evidence | string | IUPHAR supplemental data | Evidence type backing the prediction.|
+| protein_class_pred_confidence | string | IUPHAR supplemental data | Confidence score for the prediction.|
+| iuphar_target_id | string | IUPHAR | IUPHAR target identifier.|
+| iuphar_family_id | string | IUPHAR | IUPHAR family identifier.|
+| iuphar_type | string | IUPHAR | IUPHAR object type.|
+| iuphar_class | string | IUPHAR | IUPHAR class.|
+| iuphar_subclass | string | IUPHAR | IUPHAR subclass.|
+| iuphar_chain | string | IUPHAR | Chain or subunit identifier.|
+| iuphar_name | string | IUPHAR | Official IUPHAR name.|
+| iuphar_full_id_path | string | IUPHAR | Full identifier path within the IUPHAR hierarchy.|
+| iuphar_full_name_path | string | IUPHAR | Full name path within the IUPHAR hierarchy.|
+
+### testitem.csv (processed export)
+- **Purpose:** enriched description of ChEMBL compounds combining structural attributes and PubChem augmentation plus pipeline metadata.【F:scripts/get_testitem_data.py†L36-L114】【F:library/chembl_assay.py†L91-L111】【F:schemas/testitems.py†L12-L37】【F:library/pipeline_metadata.py†L60-L84】
+
+| Column | Data type | Source | Description |
+| --- | --- | --- | --- |
+| molecule_chembl_id | string | ChEMBL `/molecule` | Primary molecule identifier.|
+| black_box_warning | string/boolean | ChEMBL `/molecule` | Black-box warning flag.|
+| first_approval | string/date | ChEMBL `/molecule` | Year or date of the first regulatory approval (as provided).|
+| max_phase | string | ChEMBL `/molecule` | Maximum clinical phase reached.|
+| canonical_smiles | string | ChEMBL `/molecule` | Canonical SMILES reported by ChEMBL.|
+| standard_inchi | string | ChEMBL `/molecule` | Standard InChI.|
+| standard_inchi_key | string | ChEMBL `/molecule` | InChIKey derived from the standard InChI.|
+| molecule_type | string | ChEMBL `/molecule` | Molecule category (e.g., small molecule, antibody).|
+| oral | string/boolean | ChEMBL `/molecule` | Oral dosage form indicator.|
+| parenteral | string/boolean | ChEMBL `/molecule` | Parenteral administration indicator.|
+| pref_name | string | ChEMBL `/molecule` | Preferred name of the molecule.|
+| pubchem_canonical_smiles | string | PubChem | Canonical SMILES retrieved from PubChem.|
+| pubchem_cid | string/number | PubChem | PubChem Compound ID resolved from SMILES.|
+| pubchem_inchi | string | PubChem | Standard InChI from PubChem.|
+| pubchem_inchikey | string | PubChem | InChIKey from PubChem.|
+| pubchem_isomeric_smiles | string | PubChem | Isomeric SMILES from PubChem.|
+| pubchem_iupac_name | string | PubChem | IUPAC name returned by PubChem.|
+| pubchem_molecular_formula | string | PubChem | Molecular formula reported by PubChem.|
+| structure_type | string | ChEMBL `/molecule` | Structure representation type (e.g., `MOLFILE`).|
+| topical | string/boolean | ChEMBL `/molecule` | Topical administration indicator.|
+| pipeline_version | string | Pipeline metadata | `chembl-data-acquisition` package version.|
+| timestamp_utc | ISO 8601 string | Pipeline metadata | Export timestamp in UTC.|
+

--- a/docs/DATA_SCHEMA_RU
+++ b/docs/DATA_SCHEMA_RU
@@ -1,0 +1,312 @@
+# Схема данных
+
+## Входные таблицы
+
+### activity.csv
+- **Назначение:** исходный список идентификаторов активностей ChEMBL, который читает CLI `get_activity_data` перед обращением к API.【F:config.yaml†L25-L31】【356235†L1-L5】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| activity_chembl_id | строка | Внешний CSV с идентификаторами | Идентификатор активности в базе ChEMBL, используется для поиска записей `/activity`.| 
+
+### assay.csv
+- **Назначение:** перечень идентификаторов биологических тестов ChEMBL, которые обрабатываются скриптом `get_assay_data`.【F:config.yaml†L32-L36】【29bb29†L1-L5】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| assay_chembl_id | строка | Внешний CSV с идентификаторами | ChEMBL ID теста, ключ для запроса `/assay`.|
+
+### documents.csv
+- **Назначение:** список идентификаторов документов ChEMBL, являющийся входом для `get_document_data` (режимы `chembl`/`all`).【F:config.yaml†L49-L56】【fca225†L1-L5】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| document_chembl_id | строка | Внешний CSV с идентификаторами | Основной идентификатор публикации в ChEMBL.| 
+
+### targets.csv
+- **Назначение:** входной набор идентификаторов целей ChEMBL для пайплайна `get_target_data`.【F:config.yaml†L62-L80】【086d4d†L1-L5】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| target_chembl_id | строка | Внешний CSV с идентификаторами | ChEMBL ID белковой мишени, используется при извлечении `/target`.|
+
+### testitem.csv
+- **Назначение:** перечень идентификаторов молекул ChEMBL, которые обогащаются структурной и PubChem информацией в `get_testitem_data`.【F:config.yaml†L37-L41】【85074e†L1-L5】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| molecule_chembl_id | строка | Внешний CSV с идентификаторами | ChEMBL ID молекулы, служит ключом для `/molecule`.|
+
+## Выходные таблицы
+
+### activity.csv (обработанный экспорт)
+- **Назначение:** нормализованный набор экспериментальных значений активности, полученный через ChEMBL API и дополненный метаданными пайплайна.【F:scripts/get_activity_data.py†L63-L220】【F:library/chembl_assay.py†L62-L111】【F:schemas/activities.py†L16-L56】【F:library/pipeline_metadata.py†L60-L84】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| activity_id | строка/число | ChEMBL `/activity` | Внутренний идентификатор измерения активности, дублирует `ACTIVITY_ID` из API.|
+| molecule_chembl_id | строка | ChEMBL `/activity` | Идентификатор молекулы, для которой снята активность.|
+| assay_chembl_id | строка | ChEMBL `/activity` | Ссылка на тест (`assay_chembl_id`), в котором измерена активность.|
+| activity_comment | строка | ChEMBL `/activity` | Текстовый комментарий к эксперименту или результату.|
+| assay_description | строка | ChEMBL `/activity` | Описание связанного теста.|
+| assay_variant_accession | строка | ChEMBL `/activity` | UniProt-акцессия варианта белка, если указана в записи активности.|
+| assay_variant_mutation | строка | ChEMBL `/activity` | Информация о мутации белка в тесте.|
+| bao_format | строка | ChEMBL `/activity` | Идентификатор формата BAO (BioAssay Ontology).|
+| bao_label | строка | ChEMBL `/activity` | Метка BAO, описывающая тип результата.|
+| data_validity_comment | строка | ChEMBL `/activity` | Комментарий о валидности данных (например, предупреждения).|
+| data_validity_description | строка | ChEMBL `/activity` | Подробное описание статуса валидности.|
+| document_chembl_id | строка | ChEMBL `/activity` | Ссылка на исходный документ-публикацию.|
+| pchembl_value | строка/число | ChEMBL `/activity` | Логарифмическое значение pChEMBL, если рассчитано источником.|
+| potential_duplicate | булево/строка | ChEMBL `/activity` | Флаг возможного дублирования записи.|
+| qudt_units | строка | ChEMBL `/activity` | Единицы измерения в терминах QUDT (если доступны).|
+| record_id | строка/число | ChEMBL `/activity` | Идентификатор записи в исходной базе.|
+| relation | строка | ChEMBL `/activity` | Оператор отношения (`<`, `<=`, `=`, `>=` и т. п.) для исходного значения.|
+| src_assay_id | строка/число | ChEMBL `/activity` | Внутренний идентификатор теста в источнике.|
+| src_id | строка/число | ChEMBL `/activity` | Идентификатор источника данных (база/партнёр).|
+| standard_relation | строка | ChEMBL `/activity` | Нормализованный оператор отношения после обработки.|
+| standard_units | строка | ChEMBL `/activity` | Нормализованные единицы измерения.|
+| type | строка | ChEMBL `/activity` | Тип исходного измерения (как в API).|
+| units | строка | ChEMBL `/activity` | Единицы исходного значения `value`.|
+| value | строка/число | ChEMBL `/activity` | Первичное численное значение, как возвращает API.|
+| standard_type | строка | ChEMBL `/activity` | Нормализованный тип (ограничен значениями `IC50` или `Ki`).|
+| standard_value | число (float) | ChEMBL `/activity` | Нормализованное числовое значение (молярные единицы), гарантированно неотрицательное.|
+| pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`, добавляется при экспорте.|
+| timestamp_utc | строка (ISO 8601) | Пайплайн | Метка времени выполнения экспорта в UTC.|
+
+### assay.csv (обработанный экспорт)
+- **Назначение:** агрегированный набор описаний биологических тестов с подсчётом числа тестов на ту же пару документ/мишень и метаданными пайплайна.【F:scripts/get_assay_data.py†L47-L167】【F:library/chembl_assay.py†L22-L59】【F:library/assay_postprocessing.py†L1-L41】【F:schemas/assays.py†L1-L85】【F:library/pipeline_metadata.py†L60-L84】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| assay_chembl_id | строка | ChEMBL `/assay` | Основной идентификатор теста.|
+| ASSAY_ID | строка | ChEMBL `/assay` | Дополнительный идентификатор теста из первичного источника.|
+| Target TYPE | строка | ChEMBL `/assay` | Тип биологической мишени (клеточный, белковый и т. д.).|
+| accession | строка | ChEMBL `/assay` | UniProt-акцессия мишени, если известна.|
+| acts_per_assay_step5 | строка/число | ChEMBL `/assay` | Количество активностей, зафиксированных на шаге 5 (тип поля сохраняется как в API).|
+| assay_cell_type | строка | ChEMBL `/assay` | Тип клетки, использованной в эксперименте.|
+| assay_subcellular_fraction | строка | ChEMBL `/assay` | Фракция клетки (например, мембрана), на которой проводился тест.|
+| assay_tissue | строка | ChEMBL `/assay` | Ткань или орган, откуда взят материал.|
+| bao_format | строка | ChEMBL `/assay` | Идентификатор формата BAO.|
+| cited_assay_corr | строка/булево | ChEMBL `/assay` | Флаг, указывает цитируется ли тест как коррелированный.|
+| description | строка | ChEMBL `/assay` | Текстовое описание теста.|
+| document_chembl_id | строка | ChEMBL `/assay` | Ссылка на документ-источник.|
+| error_assay_corr | строка/булево | ChEMBL `/assay` | Признак ошибки в пометке корреляции.|
+| higly_correlated_cit | строка/булево | ChEMBL `/assay` | Флаг высокой коррелированности по цитированию.|
+| isoform | строка | ChEMBL `/assay` | Номер/описание белкового изоформа.|
+| month | строка/число | ChEMBL `/assay` | Месяц публикации, как указан в исходных данных.|
+| mutation | строка | ChEMBL `/assay` | Описание мутации мишени.|
+| shuffled_cit | строка/булево | ChEMBL `/assay` | Индикатор «перемешанной» цитаты.|
+| shuffled_target_assay | строка/булево | ChEMBL `/assay` | Индикатор перемешанной пары мишень/тест.|
+| substrate_name | строка | ChEMBL `/assay` | Название субстрата.|
+| target_chembl_id | строка | ChEMBL `/assay` | Ссылка на мишень ChEMBL.|
+| target_name | строка | ChEMBL `/assay` | Человеко-читаемое имя мишени.|
+| version | строка/число | ChEMBL `/assay` | Версия записи теста.|
+| year | строка/число | ChEMBL `/assay` | Год публикации.|
+| assay_with_same_target | число (int) | Произведено `postprocess_assays` | Количество тестов с той же комбинацией `document_chembl_id` и `target_chembl_id`.|
+| pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`.|
+| timestamp_utc | строка (ISO 8601) | Пайплайн | Метка времени выгрузки.|
+
+### documents.csv (обработанный экспорт)
+- **Назначение:** консолидированное библиографическое описание публикаций с объединением данных ChEMBL, PubMed, Semantic Scholar, OpenAlex и Crossref, а также вычисленными классами публикаций.【F:scripts/get_document_data.py†L18-L884】【F:library/document_pipeline.py†L20-L119】【F:schemas/documents.py†L14-L119】【F:library/document_postprocessing.py†L18-L154】【F:library/pipeline_metadata.py†L60-L84】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| document_chembl_id | строка | ChEMBL `/document` | Основной идентификатор публикации.|
+| title | строка | ChEMBL `/document` | Название публикации.|
+| abstract | строка | ChEMBL `/document` | Аннотация.|
+| doi | строка | ChEMBL `/document` и агрегаторы | DOI в исходном формате (позже нормализуется).|
+| year | число/строка | ChEMBL `/document` | Год публикации.|
+| journal | строка | ChEMBL `/document` | Полное название журнала.|
+| journal_abbrev | строка | ChEMBL `/document` | Сокращение журнала.|
+| volume | число/строка | ChEMBL `/document` | Номер тома.|
+| issue | число/строка | ChEMBL `/document` | Номер выпуска.|
+| first_page | число/строка | ChEMBL `/document` | Первая страница.|
+| last_page | число/строка | ChEMBL `/document` | Последняя страница.|
+| pubmed_id | число/строка | ChEMBL `/document` | PubMed ID, если ChEMBL его содержит.|
+| authors | строка | ChEMBL `/document` | Список авторов.|
+| source | строка | ChEMBL `/document` | Источник записи (обычно `ChEMBL`).|
+| doi_normalised | строка | Производное поле | DOI приведённый к каноническому виду.|
+| publication_types_normalised | строка | Производное поле | Объединённые типы публикаций из всех источников.|
+| publication_type_score_review | число (int) | Производное поле | Балл принадлежности к обзорам (scoring).|
+| publication_type_score_experimental | число (int) | Производное поле | Балл экспериментальной публикации.|
+| publication_type_score_unknown | число (int) | Производное поле | Балл неопределённого типа.|
+| publication_class | строка | Производное поле | Итоговая классификация (например, `review`/`experimental`).|
+| PubMed.PMID | число/строка | PubMed API | Основной идентификатор PubMed.|
+| PubMed.DOI | строка | PubMed API | DOI из PubMed после нормализации.|
+| PubMed.ArticleTitle | строка | PubMed API | Название статьи из PubMed.|
+| PubMed.Abstract | строка | PubMed API | Аннотация из PubMed.|
+| PubMed.JournalTitle | строка | PubMed API | Название журнала в PubMed.|
+| PubMed.Volume | число/строка | PubMed API | Номер тома из PubMed.|
+| PubMed.Issue | число/строка | PubMed API | Номер выпуска из PubMed.|
+| PubMed.StartPage | число/строка | PubMed API | Стартовая страница.|
+| PubMed.EndPage | число/строка | PubMed API | Конечная страница.|
+| PubMed.PublicationType | строка | PubMed API | Сырые термины типов публикаций.|
+| PubMed.MeSH_Descriptors | строка | PubMed API | Перечень MeSH-дескрипторов.|
+| PubMed.MeSH_Qualifiers | строка | PubMed API | Перечень MeSH-квалификаторов.|
+| PubMed.ChemicalList | строка | PubMed API | Перечень химических сущностей.|
+| PubMed.DayRevised | число/строка | PubMed API | День последней правки записи.|
+| PubMed.MonthRevised | число/строка | PubMed API | Месяц последней правки.|
+| PubMed.YearRevised | число/строка | PubMed API | Год последней правки.|
+| PubMed.YearCompleted | число/строка | PubMed API | Год завершения индексации.|
+| PubMed.MonthCompleted | число/строка | PubMed API | Месяц завершения индексации.|
+| PubMed.DayCompleted | число/строка | PubMed API | День завершения индексации.|
+| PubMed.Error | строка | PubMed API | Сообщение об ошибке запроса (если было).|
+| PubMed.ISSN | строка | PubMed API | ISSN журнала.|
+| scholar.PMID | число/строка | Semantic Scholar | Привязанный PubMed ID.|
+| scholar.Venue | строка | Semantic Scholar | Площадка/журнал в Semantic Scholar.|
+| scholar.PublicationTypes | строка | Semantic Scholar | Типы публикаций.|
+| scholar.SemanticScholarId | строка | Semantic Scholar | Внутренний ID Semantic Scholar.|
+| scholar.ExternalIds | строка | Semantic Scholar | Внешние идентификаторы (JSON).|
+| scholar.DOI | строка | Semantic Scholar | DOI из Semantic Scholar.|
+| scholar.Error | строка | Semantic Scholar | Диагностика ошибок вызова.|
+| OpenAlex.PublicationTypes | строка | OpenAlex | Типы публикаций (список).|
+| OpenAlex.TypeCrossref | строка | OpenAlex/Crossref | Классификация Crossref, возвращаемая OpenAlex.|
+| OpenAlex.Genre | строка | OpenAlex | Жанр публикации.|
+| OpenAlex.Id | строка | OpenAlex | Идентификатор записи OpenAlex.|
+| OpenAlex.Venue | строка | OpenAlex | Площадка публикации по данным OpenAlex.|
+| OpenAlex.MeshDescriptors | строка | OpenAlex | MeSH-дескрипторы от OpenAlex.|
+| OpenAlex.MeshQualifiers | строка | OpenAlex | MeSH-квалификаторы от OpenAlex.|
+| OpenAlex.Error | строка | OpenAlex | Сообщение об ошибке.|
+| crossref.Type | строка | Crossref | Тип публикации из Crossref.|
+| crossref.Subtype | строка | Crossref | Подтип публикации.|
+| crossref.Title | строка | Crossref | Заголовок по Crossref.|
+| crossref.Subtitle | строка | Crossref | Подзаголовок.|
+| crossref.Subject | строка | Crossref | Тематические рубрики.|
+| crossref.Error | строка | Crossref | Сообщение об ошибке запроса.|
+| date_code | строка | Постобработка | Служебный код даты (формируется при нормализации).|
+| Index | число/строка | Постобработка | Порядковый индекс из исходной таблицы.|
+| PubMed.is_review | булево/строка | Постобработка | Флаг «обзор» на основе PubMed терминов.|
+| scholar.is_review | булево/строка | Постобработка | Флаг «обзор» из Semantic Scholar.|
+| OpenAlex.is_review | булево/строка | Постобработка | Флаг «обзор» по данным OpenAlex.|
+| pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`.|
+| timestamp_utc | строка (ISO 8601) | Пайплайн | Время формирования выгрузки.|
+
+### target.csv (финализированный экспорт)
+- **Назначение:** унифицированная таблица белковых мишеней с объединением атрибутов ChEMBL, UniProt и IUPHAR, приведённая к детерминированному порядку колонок и форматам, совместимым с исходной BI-процессингом.【F:scripts/get_target_data.py†L31-L1148】【F:library/chembl_target.py†L185-L315】【F:library/target_postprocessing.py†L181-L442】【F:schemas/targets.py†L17-L214】【F:library/pipeline_metadata.py†L60-L84】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| target_chembl_id | строка | ChEMBL `/target` | Основной идентификатор мишени.|
+| uniprot_id_primary | строка | Постобработка UniProt | Основная UniProt-акцессия (нормализованный `uniProtkbId`).|
+| uniprot_ids_all | строка | Постобработка UniProt | Слитый список всех доступных UniProt идентификаторов (основной, вторичные, карта ID).|
+| isoform_ids | строка | UniProt (через merge) | Список идентификаторов изоформ, если доступны.|
+| isoform_names | строка | UniProt (через merge) | Названия изоформ.|
+| isoform_synonyms | строка | UniProt (через merge) | Синонимы изоформ (нижний регистр).|
+| hgnc_id | строка | HGNC (через cross-references) | Идентификатор HGNC без префикса.|
+| gene_symbol | строка | Постобработка | Итоговый символ гена (верхний регистр).|
+| protein_name_canonical | строка | UniProt/ChEMBL | Каноническое название белка.|
+| protein_name_alt | строка | UniProt/ChEMBL | Альтернативные названия (pipe-разделённый список).|
+| organism | строка | ChEMBL/UniProt | Род (genus) организма, для которого описана мишень.|
+| taxon_id | строка | ChEMBL | Идентификатор таксона NCBI.|
+| lineage_superkingdom | строка | UniProt taxon merge | Надцарство организма.|
+| lineage_phylum | строка | UniProt taxon merge | Тип организма.|
+| lineage_class | строка | UniProt taxon merge | Класс организма.|
+| sequence_length | строка | UniProt | Длина аминокислотной последовательности.|
+| features_signal_peptide | строка | UniProt features | Наличие сигнального пептида (нижний регистр).|
+| features_transmembrane | строка | UniProt features | Признак трансмембранных сегментов (нижний регистр).|
+| features_topology | строка | UniProt features | Топология (например, внутриклеточная/внеклеточная).|
+| ptm_glycosylation | строка | UniProt PTM | Аннотации гликозилирования.|
+| ptm_lipidation | строка | UniProt PTM | Аннотации липидирования.|
+| ptm_disulfide_bond | строка | UniProt PTM | Аннотации дисульфидных мостиков.|
+| ptm_modified_residue | строка | UniProt PTM | Прочие модифицированные остатки.|
+| xref_chembl | строка | Постобработка | Повторяет `target_chembl_id` для совместимости.|
+| xref_uniprot | строка | Постобработка | Повторяет `uniprot_id_primary`.|
+| xref_ensembl | строка | ChEMBL/UniProt | Список Ensembl ID из cross-references.|
+| xref_iuphar | строка | IUPHAR | Идентификатор мишени в IUPHAR.|
+| gtop_target_id | строка | Guide to PHARMACOLOGY | Идентификатор объекта в базе GToP.|
+| gtop_synonyms | строка | Guide to PHARMACOLOGY | Синонимы из GToP (нижний регистр).|
+| gtop_natural_ligands_n | строка | Guide to PHARMACOLOGY | Количество естественных лигандов (как в источнике).|
+| gtop_interactions_n | строка | Guide to PHARMACOLOGY | Количество взаимодействий (как в источнике).|
+| gtop_function_text_short | строка | Guide to PHARMACOLOGY | Краткое описание функции.|
+| uniprot_last_update | строка | UniProt | Дата последнего обновления записи.|
+| uniprot_version | строка | UniProt | Версия UniProt записи.|
+| pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`.|
+| timestamp_utc | строка (ISO 8601) | Пайплайн | Время формирования выгрузки.|
+| pfam | строка | UniProt | Список доменов Pfam из UniProt.|
+| interpro | строка | UniProt | Список доменов InterPro из UniProt.|
+| xref_pdb | строка | UniProt | Ссылки на структуры PDB.|
+| xref_alphafold | строка | UniProt/AlphaFold | Ссылки на модели AlphaFold.|
+| hgnc_name | строка | HGNC | Полное имя гена в HGNC.|
+| uniProtkbId | строка | UniProt | Исходное поле UniProt ID до нормализации.|
+| secondaryAccessions | строка | UniProt | Список вторичных акцессий UniProt.|
+| recommendedName | строка | UniProt | Рекомендованное название белка (как в UniProt).|
+| geneName | строка | UniProt | Основной символ гена из UniProt.|
+| secondaryAccessionNames | строка | UniProt | Названия, связанные со вторичными акцессиями.|
+| molecular_function | строка | UniProt GO | GO-аннотации молекулярной функции.|
+| cellular_component | строка | UniProt GO | GO-аннотации клеточной локализации.|
+| subcellular_location | строка | UniProt | Локализация белка.|
+| topology | строка | UniProt | Топология трансмембранного белка.|
+| transmembrane | строка | UniProt | Индикатор трансмембранных сегментов (после нормализации).|
+| intramembrane | строка | UniProt | Индикатор внутримембранных сегментов.|
+| glycosylation | строка | UniProt | Аннотация гликозилирования (нижний регистр).|
+| lipidation | строка | UniProt | Аннотация липидирования.|
+| disulfide_bond | строка | UniProt | Аннотация дисульфидных связей.|
+| modified_residue | строка | UniProt | Прочие модификации остатков.|
+| phosphorylation | строка | UniProt | Аннотации фосфорилирования.|
+| acetylation | строка | UniProt | Аннотации ацетилирования.|
+| ubiquitination | строка | UniProt | Аннотации убиквитинирования.|
+| signal_peptide | строка | UniProt | Аннотации сигнального пептида (нижний регистр).|
+| propeptide | строка | UniProt | Аннотации пропептида.|
+| GuidetoPHARMACOLOGY | строка | IUPHAR/GToP | Основной ID в Guide to PHARMACOLOGY.|
+| family | строка | IUPHAR | Название семейства по IUPHAR.|
+| SUPFAM | строка | UniProt/IUPHAR | Суперсемейство (как в источнике).|
+| PROSITE | строка | UniProt | Доменные мотивы PROSITE.|
+| InterPro | строка | UniProt | Домены InterPro (альтернативный источник).|
+| Pfam | строка | UniProt | Домены Pfam (альтернативное поле).|
+| PRINTS | строка | UniProt | Мотивы PRINTS.|
+| TCDB | строка | UniProt | Классификация транспортеров TCDB.|
+| pref_name | строка | ChEMBL | Преферируемое имя мишени в ChEMBL.|
+| target_type | строка | ChEMBL | Тип мишени по ChEMBL (`SINGLE PROTEIN`, `PROTEIN FAMILY` и т. п.).|
+| tax_id | строка | ChEMBL | Значение `tax_id` из ChEMBL (строковое представление).|
+| species_group_flag | строка | ChEMBL | Флаг группировки видов.|
+| target_components | строка (JSON) | ChEMBL | Сериализованное описание компонент мишени.|
+| protein_classifications | строка (JSON) | ChEMBL | Иерархия белковых классов.|
+| cross_references | строка (JSON) | ChEMBL | Внешние ссылки из записи ChEMBL.|
+| gene_symbol_list | строка | Постобработка | Объединённый список символов гена (pipe-разделитель, верхний регистр).|
+| protein_synonym_list | строка | Постобработка | Сводный список синонимов белка (нижний регистр).|
+| reactions | строка | ChEMBL | Связанные реакции (если присутствуют).|
+| reaction_ec_numbers | строка | Постобработка | Список EC-номеров реакций, собранный из синонимов и xref.|
+| protein_class_pred_L1 | строка | IUPHAR доп.данные | Предсказанный класс белка (уровень 1).|
+| protein_class_pred_L2 | строка | IUPHAR доп.данные | Предсказанный класс (уровень 2).|
+| protein_class_pred_L3 | строка | IUPHAR доп.данные | Предсказанный класс (уровень 3).|
+| protein_class_pred_rule_id | строка | IUPHAR доп.данные | Идентификатор правила классификации.|
+| protein_class_pred_evidence | строка | IUPHAR доп.данные | Тип доказательств классификации.|
+| protein_class_pred_confidence | строка | IUPHAR доп.данные | Оценка уверенности классификации.|
+| iuphar_target_id | строка | IUPHAR | Идентификатор мишени в IUPHAR.|
+| iuphar_family_id | строка | IUPHAR | Идентификатор семейства в IUPHAR.|
+| iuphar_type | строка | IUPHAR | Тип объекта по IUPHAR.|
+| iuphar_class | строка | IUPHAR | Класс объекта.|
+| iuphar_subclass | строка | IUPHAR | Подкласс объекта.|
+| iuphar_chain | строка | IUPHAR | Идентификатор цепи/подъединицы.|
+| iuphar_name | строка | IUPHAR | Официальное название в IUPHAR.|
+| iuphar_full_id_path | строка | IUPHAR | Полный путь идентификаторов в иерархии.|
+| iuphar_full_name_path | строка | IUPHAR | Полный путь названий в иерархии.|
+
+### testitem.csv (обработанный экспорт)
+- **Назначение:** описание лекарственных веществ/соединений из ChEMBL, дополненное структурными полями и обогащением из PubChem, нормализованное и снабжённое метаданными пайплайна.【F:scripts/get_testitem_data.py†L36-L114】【F:library/chembl_assay.py†L91-L111】【F:schemas/testitems.py†L12-L37】【F:library/pipeline_metadata.py†L60-L84】
+
+| Колонка | Тип данных | Источник | Описание |
+| --- | --- | --- | --- |
+| molecule_chembl_id | строка | ChEMBL `/molecule` | Основной идентификатор молекулы.|
+| black_box_warning | строка/булево | ChEMBL `/molecule` | Флаг наличия «black box» предупреждения.|
+| first_approval | строка/дата | ChEMBL `/molecule` | Год/дата первого одобрения препарата (как в источнике).|
+| max_phase | строка | ChEMBL `/molecule` | Максимальная стадия клинических испытаний.|
+| canonical_smiles | строка | ChEMBL `/molecule` | Канонический SMILES из ChEMBL.|
+| standard_inchi | строка | ChEMBL `/molecule` | Стандартный InChI.|
+| standard_inchi_key | строка | ChEMBL `/molecule` | Ключ InChIKey.|
+| molecule_type | строка | ChEMBL `/molecule` | Тип молекулы (small molecule, antibody и т. п.).|
+| oral | строка/булево | ChEMBL `/molecule` | Признак оральной формы.|
+| parenteral | строка/булево | ChEMBL `/molecule` | Признак парентерального применения.|
+| pref_name | строка | ChEMBL `/molecule` | Преферируемое название.|
+| pubchem_canonical_smiles | строка | PubChem | Канонический SMILES, полученный по CID.|
+| pubchem_cid | строка/число | PubChem | Идентификатор PubChem CID для SMILES.|
+| pubchem_inchi | строка | PubChem | Стандартный InChI из PubChem.|
+| pubchem_inchikey | строка | PubChem | InChIKey из PubChem.|
+| pubchem_isomeric_smiles | строка | PubChem | Изомерический SMILES из PubChem.|
+| pubchem_iupac_name | строка | PubChem | IUPAC-название из PubChem.|
+| pubchem_molecular_formula | строка | PubChem | Молекулярная формула из PubChem.|
+| structure_type | строка | ChEMBL `/molecule` | Тип структуры (например, `MOLFILE`).|
+| topical | строка/булево | ChEMBL `/molecule` | Признак топического применения.|
+| pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`.|
+| timestamp_utc | строка (ISO 8601) | Пайплайн | Время формирования выгрузки.|
+


### PR DESCRIPTION
## Summary
- add `DATA_SCHEMA_RU` with structured descriptions of pipeline input and output tables
- add `DATA_SCHEMA_EN` containing the English translation of the same schema information

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5a60768948324828fb692509e9186