### PR TITLE
Align document batch size defaults with config schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -298,7 +298,7 @@
           "type": "integer"
         },
         "batch_size": {
-          "default": 50,
+          "default": 5,
           "minimum": 1,
           "title": "Batch Size",
           "type": "integer"
@@ -400,7 +400,7 @@
           "type": "integer"
         },
         "batch_size": {
-          "default": 100,
+          "default": 5,
           "minimum": 1,
           "title": "Batch Size",
           "type": "integer"


### PR DESCRIPTION
## Summary
- set the DocumentAllCfg and DocumentPubmedCfg batch_size defaults to 5 so the schema aligns with config.yaml
- verified the schema definitions for these document pipelines contain no lingering references to the previous defaults

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5b4f77e9883248a4ca16461fdd3e5