### PR TITLE
Preserve reaction EC numbers in target export

### DIFF
--- a/docs/reaction_ec_numbers_analysis.md
+++ b/docs/reaction_ec_numbers_analysis.md
@@ -1,0 +1,23 @@
+# Анализ заполнения `reaction_ec_numbers`
+
+## 1. Источник и обработка в `scripts/get_target_data.py`
+- Колонка `reaction_ec_numbers` приходит в объединённый датафрейм из выгрузки UniProt (`fetch_uniprot`) и сохраняется в таблице `combined_df` вместе с колонкой `ec_numbers` из UniProt.【F:scripts/get_target_data.py†L880-L907】
+- При подготовке данных для обогащения IUPHAR значения `reaction_ec_numbers` используются только для расчёта агрегированной колонки `ec_number`, после чего исходные столбцы `ec_numbers` и `reaction_ec_numbers` целиком удаляются вызовом `DataFrame.drop(...)`. Это означает, что дальнейшие шаги конвейера больше не видят `reaction_ec_numbers`.【F:scripts/get_target_data.py†L904-L913】
+
+## 2. Постобработка и финализация таргетов
+- На этапе финализации `target_postprocessing.align_target_columns` ожидает наличие колонки `reaction_ec_numbers`. Если столбца нет, хелпер `_series_or_default` создаёт заполнение из дефолтного значения `"-"`, что и приводит к пустым данным в готовом `output/target.csv`.【F:library/target_postprocessing.py†L160-L170】【F:library/target_postprocessing.py†L268-L287】
+
+## 3. Формирование `reaction_ec_numbers` в `output/target_uniprot.csv`
+- Выгрузка UniProt строится функцией `collect_info`, которая извлекает каталитические реакции и EC-номера (через `extract_activity`) и добавляет их в результирующий словарь перед записью в CSV.【F:library/uniprot_library.py†L1129-L1185】
+- Список колонок для UniProt-выхода включает `reaction_ec_numbers`, поэтому значение без изменений оказывается в `output/target_uniprot.csv`.【F:library/uniprot_library.py†L88-L140】【F:library/uniprot_library.py†L1239-L1265】
+
+## 4. Причина расхождения
+- В конвейере `all` колонка удаляется из объединённых данных перед постобработкой, поэтому финальный CSV получает дефолтные `"-"` вместо реальных значений.
+- В чистой UniProt-выгрузке колонка не удаляется и записывается как есть.
+
+## 5. Рекомендации по исправлению
+1. **Не удалять колонку при сборке комбинированных данных.** Убрать `reaction_ec_numbers` из списка на удаление или сохранить его под отдельным именем, чтобы финализация увидела исходные данные.
+2. **Опционально:** если колонка `ec_number` нужна одновременно с исходным списком реакций, можно оставить оба столбца или пересчитать `ec_number` на более позднем шаге (например, в `target_postprocessing`).
+3. После изменений убедиться, что `TargetsSchema` допускает наличие обеих колонок (она уже объявлена как необязательная) и что в `target_postprocessing.finalise_targets` данные больше не заменяются на дефолтные значения.
+
+Внесение этих правок позволит `reaction_ec_numbers` из UniProt пройти весь конвейер и сохраниться в итоговом `output/target.csv`.

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -92,6 +92,24 @@ def _pipe_merge(values: Sequence[str | None]) -> str:
     return "|".join(sorted(tokens))
 
 
+def _merge_pipe_columns(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Normalise duplicate ``column`` variants (e.g. ``*_x``/``*_y``) into one."""
+
+    variants = [column, *(c for c in df.columns if c.startswith(f"{column}_"))]
+    available = [c for c in variants if c in df.columns]
+    if not available:
+        df[column] = pd.Series([""] * len(df), index=df.index, dtype=str)
+        return df
+
+    df[column] = df.apply(
+        lambda r: _pipe_merge([r.get(name) for name in available]), axis=1
+    )
+    drop_cols = [c for c in available if c != column]
+    if drop_cols:
+        df = df.drop(columns=drop_cols)
+    return df
+
+
 def _first_token(value: str | None) -> str:
     """Return the first token from a pipe-delimited ``value``."""
     if isinstance(value, str) and value:
@@ -888,6 +906,9 @@ def fetch_iuphar(
         combined_df = combined_df.drop(columns=["uniprot_id_x"], errors="ignore")
         combined_df = combined_df.rename(columns={"uniprot_id_y": "uniprot_id"})
 
+    for column in ["ec_numbers", "reaction_ec_numbers"]:
+        combined_df = _merge_pipe_columns(combined_df, column)
+
     combined_df["synonyms"] = combined_df.apply(
         lambda r: _pipe_merge(
             [
@@ -908,9 +929,7 @@ def fetch_iuphar(
     combined_df["gene_name"] = combined_df.get("gene", pd.Series(dtype=str)).apply(
         _first_token
     )
-    combined_df = combined_df.drop(
-        columns=["ec_numbers", "reaction_ec_numbers"], errors="ignore"
-    )
+    combined_df = combined_df.drop(columns=["ec_numbers"], errors="ignore")
 
     from tempfile import NamedTemporaryFile
 

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -213,4 +213,5 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
     combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
     assert "synonyms" in combined_df.columns
+    assert combined_df.loc[0, "reaction_ec_numbers"] == "2.2.2.2|4.4.4.4"
     assert iuphar_df.loc[0, "IUPHAR_class"] == "Enzyme"


### PR DESCRIPTION
## Summary
- normalize EC-related columns after merging ChEMBL and UniProt data so reaction EC numbers persist into the combined dataset
- retain reaction_ec_numbers when preparing IUPHAR input instead of replacing the column with dashes downstream
- extend the fetch_iuphar unit test to assert that reaction EC numbers survive the merge

## Testing
- pytest tests/test_get_target_data_fetch.py::test_fetch_iuphar

------
https://chatgpt.com/codex/tasks/task_e_68d638b706ec8324961e0977de99ea00