### PR TITLE
Preserve reaction EC numbers in target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -888,6 +888,42 @@ def fetch_iuphar(
         combined_df = combined_df.drop(columns=["uniprot_id_x"], errors="ignore")
         combined_df = combined_df.rename(columns={"uniprot_id_y": "uniprot_id"})
 
+    ec_number_columns = [
+        column
+        for column in combined_df.columns
+        if column.startswith("ec_numbers")
+    ]
+    if ec_number_columns:
+        combined_df["ec_numbers"] = combined_df.apply(
+            lambda r: _pipe_merge([r.get(column) for column in ec_number_columns]),
+            axis=1,
+        )
+        extra_ec_columns = [
+            column for column in ec_number_columns if column != "ec_numbers"
+        ]
+        if extra_ec_columns:
+            combined_df = combined_df.drop(columns=extra_ec_columns, errors="ignore")
+
+    reaction_ec_columns = [
+        column
+        for column in combined_df.columns
+        if column.startswith("reaction_ec_numbers")
+    ]
+    if reaction_ec_columns:
+        combined_df["reaction_ec_numbers"] = combined_df.apply(
+            lambda r: _pipe_merge([r.get(column) for column in reaction_ec_columns]),
+            axis=1,
+        )
+        extra_reaction_columns = [
+            column
+            for column in reaction_ec_columns
+            if column != "reaction_ec_numbers"
+        ]
+        if extra_reaction_columns:
+            combined_df = combined_df.drop(
+                columns=extra_reaction_columns, errors="ignore"
+            )
+
     combined_df["synonyms"] = combined_df.apply(
         lambda r: _pipe_merge(
             [
@@ -908,9 +944,7 @@ def fetch_iuphar(
     combined_df["gene_name"] = combined_df.get("gene", pd.Series(dtype=str)).apply(
         _first_token
     )
-    combined_df = combined_df.drop(
-        columns=["ec_numbers", "reaction_ec_numbers"], errors="ignore"
-    )
+    combined_df = combined_df.drop(columns=["ec_numbers"], errors="ignore")
 
     from tempfile import NamedTemporaryFile
 

--- a/tests/data/uniprot_targets_min.csv
+++ b/tests/data/uniprot_targets_min.csv
@@ -1,2 +1,2 @@
-uniprot_id,uniProtkbId,geneName,recommendedName
-P12345,P12345-1,GENEA,Recommended
+uniprot_id,uniProtkbId,geneName,recommendedName,ec_numbers,reaction_ec_numbers
+P12345,P12345-1,GENEA,Recommended,3.3.3.3,4.4.4.4

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 from pathlib import Path
 
 import pandas as pd
@@ -11,6 +12,7 @@ from pytest import MonkeyPatch
 
 from library.config import Config
 from scripts import get_target_data as gtd
+from schemas import TargetsSchema
 
 
 def test_fetch_chembl(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> None:
@@ -214,3 +216,61 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
     assert "synonyms" in combined_df.columns
     assert iuphar_df.loc[0, "IUPHAR_class"] == "Enzyme"
+
+
+def test_run_all_preserves_reaction_ec_numbers(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    chembl_data = Path("tests/data/chembl_targets_min.csv")
+    uniprot_data = Path("tests/data/uniprot_targets_min.csv")
+    iuphar_data = Path("tests/data/iuphar_targets_min.csv")
+    organism_csv = Path("tests/data/organism_min.csv")
+
+    cfg.target.all.organism_csv = organism_csv
+    cfg.target.all.chembl_out = tmp_path / "chembl_out.csv"
+    cfg.target.all.uniprot_out = tmp_path / "uniprot_out.csv"
+    cfg.target.all.iuphar_out = tmp_path / "iuphar_out.csv"
+    cfg.target.all.uniprot_column = "uniprot_id"
+
+    def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        shutil.copy(chembl_data, args.output_csv)
+        return 0
+
+    def fake_run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
+        shutil.copy(uniprot_data, args.output_csv)
+        return 0
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        shutil.copy(iuphar_data, args.output_csv)
+        return 0
+
+    monkeypatch.setattr(gtd, "run_chembl", fake_run_chembl)
+    monkeypatch.setattr(gtd, "run_uniprot", fake_run_uniprot)
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
+
+    original_finalise = gtd.tp.finalise_targets
+
+    def patched_finalise(
+        df: pd.DataFrame, organism: pd.DataFrame, **kwargs: object
+    ) -> pd.DataFrame:
+        df = df.drop(columns=["type"], errors="ignore")
+        return original_finalise(df, organism, **kwargs)
+
+    monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)
+    monkeypatch.setattr(
+        TargetsSchema, "validate", staticmethod(lambda df, lazy=True: df)
+    )
+
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text(
+        "target_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding
+    )
+    output_csv = tmp_path / "out.csv"
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+    exit_code = gtd.run_all(cfg, args)
+    assert exit_code == 0
+
+    result = pd.read_csv(output_csv, dtype=str)
+    assert result.loc[0, "reaction_ec_numbers"] == "2.2.2.2|4.4.4.4"


### PR DESCRIPTION
## Summary
- merge overlapping EC number columns in the IUPHAR fetch step so reaction-specific values persist after the ChEMBL/UniProt merge
- extend the UniProt fixture and add a regression test that runs the combined pipeline and asserts the reaction EC numbers reach the final CSV

## Testing
- pytest tests/test_get_target_data_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68d63a3568b083249b9fa2aa23a08eb9