### PR TITLE
Add molecule catalog configuration and helpers

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -152,6 +152,60 @@
       "title": "ChemblCacheCfg",
       "type": "object"
     },
+    "MoleculeCatalogCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "cache_path": {
+          "default": "data/cache/molecule_parent_catalog.json",
+          "title": "Cache Path",
+          "type": "string"
+        },
+        "endpoint": {
+          "default": "molecule",
+          "title": "Endpoint",
+          "type": "string"
+        },
+        "child_field": {
+          "default": "molecule_chembl_id",
+          "title": "Child Field",
+          "type": "string"
+        },
+        "parent_field": {
+          "default": "parent_molecule_chembl_id",
+          "title": "Parent Field",
+          "type": "string"
+        },
+        "fields": {
+          "default": [
+            "molecule_chembl_id",
+            "parent_molecule_chembl_id"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "filters": {
+          "default": {
+            "parent_molecule_chembl_id__isnull": "false"
+          },
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Filters",
+          "type": "object"
+        },
+        "page_size": {
+          "default": 500,
+          "minimum": 1,
+          "title": "Page Size",
+          "type": "integer"
+        }
+      },
+      "title": "MoleculeCatalogCfg",
+      "type": "object"
+    },
     "ChemblPipelinesCfg": {
       "additionalProperties": false,
       "properties": {
@@ -182,6 +236,9 @@
         },
         "cache": {
           "$ref": "#/$defs/ChemblCacheCfg"
+        },
+        "molecule_catalog": {
+          "$ref": "#/$defs/MoleculeCatalogCfg"
         },
         "pipelines": {
           "$ref": "#/$defs/ChemblPipelinesCfg"

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,12 @@ sources:
     cache:
       cache_ttl: 3600  # Seconds to cache ChEMBL API responses (env: CHEMBL_DA_CACHE_TTL)
       cache_maxsize: 1024  # Max cached ChEMBL responses (env: CHEMBL_DA_CACHE_MAXSIZE)
+    molecule_catalog:
+      cache_path: "data/cache/molecule_parent_catalog.json"  # Local cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_CACHE)
+      endpoint: "molecule"  # API resource providing parent relationships
+      child_field: "molecule_chembl_id"  # Column containing molecule identifiers
+      parent_field: "parent_molecule_chembl_id"  # Column containing parent molecule identifiers
+      page_size: 500  # Page size for catalog fetching
     pipelines:
       activity:
         column: "activity_chembl_id"

--- a/library/config.py
+++ b/library/config.py
@@ -121,6 +121,21 @@ class ChemblCacheCfg(_BaseModel):
     cache_maxsize: int = Field(1024, ge=1)
 
 
+class MoleculeCatalogCfg(_BaseModel):
+    cache_path: Path = Path("data/cache/molecule_parent_catalog.json")
+    endpoint: str = "molecule"
+    child_field: str = "molecule_chembl_id"
+    parent_field: str = "parent_molecule_chembl_id"
+    fields: tuple[str, ...] = (
+        "molecule_chembl_id",
+        "parent_molecule_chembl_id",
+    )
+    filters: dict[str, str] = Field(
+        default_factory=lambda: {"parent_molecule_chembl_id__isnull": "false"}
+    )
+    page_size: int = Field(500, ge=1)
+
+
 class OpenAlexCfg(_BaseModel):
     base: str = "https://api.openalex.org"
     timeout_connect: int = Field(5, ge=1)
@@ -469,6 +484,9 @@ class ChemblPipelinesCfg(_BaseModel):
 class ChemblSourceCfg(_BaseModel):
     api: ApiCfg = Field(default_factory=lambda: ApiCfg())
     cache: ChemblCacheCfg = Field(default_factory=lambda: ChemblCacheCfg())
+    molecule_catalog: MoleculeCatalogCfg = Field(
+        default_factory=lambda: MoleculeCatalogCfg()
+    )
     pipelines: ChemblPipelinesCfg = Field(
         default_factory=lambda: ChemblPipelinesCfg()
     )
@@ -526,6 +544,10 @@ class Config(_BaseModel):
     @property
     def chembl(self) -> ChemblCacheCfg:
         return self.sources.chembl.cache
+
+    @property
+    def molecule_catalog(self) -> MoleculeCatalogCfg:
+        return self.sources.chembl.molecule_catalog
 
     @property
     def openalex(self) -> OpenAlexCfg:
@@ -937,6 +959,12 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA__IO__EXIST_OK": ["local", "io", "exist_ok"],
     "CHEMBL_DA_CACHE_MAXSIZE": ["sources", "chembl", "cache", "cache_maxsize"],
     "CHEMBL_DA_CACHE_TTL": ["sources", "chembl", "cache", "cache_ttl"],
+    "CHEMBL_DA_MOLECULE_CATALOG_CACHE": [
+        "sources",
+        "chembl",
+        "molecule_catalog",
+        "cache_path",
+    ],
     "CHEMBL_DA_DICT_DIR": ["local", "resources", "dictionary_dir"],
     "CHEMBL_DA_GLOBAL_BURST": ["system", "rate", "global_burst"],
     "CHEMBL_DA_GLOBAL_RPS": ["system", "rate", "global_rps"],
@@ -994,6 +1022,7 @@ _ALIAS_MAP: dict[str, list[str]] = {
 __all__ = [
     "ApiCfg",
     "ChemblCacheCfg",
+    "MoleculeCatalogCfg",
     "OpenAlexCfg",
     "CrossRefCfg",
     "UniprotCfg",

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -1,0 +1,137 @@
+"""Utilities for retrieving and caching the ChEMBL molecule parent catalogue."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlencode, urljoin
+
+from .chembl_client import ChemblClient
+from .config import ApiCfg, MoleculeCatalogCfg
+from .log import logger
+
+__all__ = ["fetch_parent_catalog", "load_parent_catalog"]
+
+
+def _normalise_chembl_id(value: str) -> str:
+    """Return *value* normalised as an upper-case ChEMBL identifier."""
+
+    normalised = value.strip().upper()
+    if not normalised:
+        raise ValueError("empty identifier")
+    return normalised
+
+
+def _build_initial_url(api_cfg: ApiCfg, catalog_cfg: MoleculeCatalogCfg) -> str:
+    base = api_cfg.chembl_base.rstrip("/")
+    resource = catalog_cfg.endpoint.lstrip("/")
+    if not resource.endswith(".json"):
+        resource = f"{resource}.json"
+    params: dict[str, str] = {
+        "format": "json",
+        "limit": str(catalog_cfg.page_size),
+    }
+    if catalog_cfg.fields:
+        params["fields"] = ",".join(catalog_cfg.fields)
+    for key, value in catalog_cfg.filters.items():
+        params[key] = str(value)
+    query = urlencode(params)
+    return f"{base}/{resource}?{query}"
+
+
+def fetch_parent_catalog(
+    *,
+    client: ChemblClient,
+    api_cfg: ApiCfg,
+    catalog_cfg: MoleculeCatalogCfg,
+    timeout: float | None = None,
+) -> dict[str, str]:
+    """Fetch the molecule parent catalogue from ChEMBL."""
+
+    url = _build_initial_url(api_cfg, catalog_cfg)
+    next_url: str | None = url
+    result: dict[str, str] = {}
+    effective_timeout = timeout if timeout is not None else api_cfg.timeout_read
+
+    while next_url:
+        data = client.request_json(next_url, cfg=api_cfg, timeout=effective_timeout)
+        items = (
+            data.get("molecules")
+            or data.get("molecule")
+            or data.get("molecule_parents")
+            or data.get("molecule_parent")
+            or []
+        )
+        if not isinstance(items, list):
+            logger.warning("unexpected_response_items", extra={"url": next_url})
+            items = []
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            child = item.get(catalog_cfg.child_field)
+            parent = item.get(catalog_cfg.parent_field)
+            if not child or not parent:
+                continue
+            try:
+                child_id = _normalise_chembl_id(str(child))
+                parent_id = _normalise_chembl_id(str(parent))
+            except ValueError:
+                continue
+            result[child_id] = parent_id
+        page_meta = data.get("page_meta") or {}
+        next_token = page_meta.get("next")
+        next_url = urljoin(api_cfg.chembl_base, next_token) if next_token else None
+
+    return result
+
+
+def _read_cache(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        logger.warning("invalid_catalog_cache", extra={"path": str(path)})
+        return {}
+    if not isinstance(raw, Mapping):
+        logger.warning("unexpected_catalog_cache", extra={"path": str(path)})
+        return {}
+    result: dict[str, str] = {}
+    for child, parent in raw.items():
+        if not isinstance(child, str) or not isinstance(parent, str):
+            continue
+        try:
+            child_id = _normalise_chembl_id(child)
+            parent_id = _normalise_chembl_id(parent)
+        except ValueError:
+            continue
+        result[child_id] = parent_id
+    return result
+
+
+def load_parent_catalog(
+    *,
+    client: ChemblClient,
+    api_cfg: ApiCfg,
+    catalog_cfg: MoleculeCatalogCfg,
+    timeout: float | None = None,
+    force_refresh: bool = False,
+) -> dict[str, str]:
+    """Return the molecule parent catalogue, using the on-disk cache if present."""
+
+    cache_path = catalog_cfg.cache_path
+    if not force_refresh:
+        cached = _read_cache(cache_path)
+        if cached:
+            return cached
+
+    result = fetch_parent_catalog(
+        client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
+    )
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(dict(sorted(result.items())), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,6 +133,19 @@ def test_cache_dir_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert cfg.io.cache_dir == cache
 
 
+def test_molecule_catalog_cache_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    cache = tmp_path / "catalog.json"
+    monkeypatch.setenv("CHEMBL_DA_MOLECULE_CATALOG_CACHE", str(cache))
+
+    cfg = load_config(path)
+
+    assert cfg.molecule_catalog.cache_path == cache
+
+
 def test_chembl_cache_maxsize_from_yaml(tmp_path: Path) -> None:
     """Custom ``chembl.cache_maxsize`` should override the default."""
 

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from library.chembl_client import ChemblClient
+from library.config import ApiCfg, MoleculeCatalogCfg
+from library.molecule_catalog import fetch_parent_catalog, load_parent_catalog
+
+
+class DummyClient:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, Any]:
+        self.calls.append(url)
+        try:
+            return self._responses.pop(0)
+        except IndexError:  # pragma: no cover - defensive
+            raise AssertionError("unexpected request")
+
+
+@pytest.fixture()
+def api_cfg() -> ApiCfg:
+    return ApiCfg(user_agent="chembl-da-tests (mailto:test@example.org)")
+
+
+def test_fetch_parent_catalog_normalises_and_paginates(api_cfg: ApiCfg) -> None:
+    responses = [
+        {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "chembl1",
+                    "parent_molecule_chembl_id": "CHEMBL42",
+                },
+                {
+                    "molecule_chembl_id": " chembl2 ",
+                    "parent_molecule_chembl_id": " chembl43 ",
+                },
+            ],
+            "page_meta": {"next": "/molecule.json?page=2"},
+        },
+        {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "CHEMBL3",
+                    "parent_molecule_chembl_id": None,
+                }
+            ],
+            "page_meta": {},
+        },
+    ]
+    client = DummyClient(responses)
+    cfg = MoleculeCatalogCfg(page_size=2)
+
+    result = fetch_parent_catalog(client=client, api_cfg=api_cfg, catalog_cfg=cfg)
+
+    assert client.calls  # ensure requests were issued
+    assert result == {"CHEMBL1": "CHEMBL42", "CHEMBL2": "CHEMBL43"}
+
+
+def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
+    cache = tmp_path / "catalog.json"
+    cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
+    cfg = MoleculeCatalogCfg(cache_path=cache)
+
+    result = load_parent_catalog(
+        client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
+    )
+
+    assert result == {"CHEMBL10": "CHEMBL99"}
+
+
+def test_load_parent_catalog_fetches_and_persists(
+    tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = tmp_path / "catalog.json"
+    cfg = MoleculeCatalogCfg(cache_path=cache)
+    data = {"CHEMBL50": "CHEMBL60"}
+
+    def fake_fetch(
+        *,
+        client: ChemblClient,
+        api_cfg: ApiCfg,
+        catalog_cfg: MoleculeCatalogCfg,
+        timeout: float | None = None,
+    ) -> dict[str, str]:
+        return data
+
+    monkeypatch.setattr(
+        "library.molecule_catalog.fetch_parent_catalog",
+        fake_fetch,
+    )
+
+    result = load_parent_catalog(
+        client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
+    )
+
+    assert result == data
+    assert json.loads(cache.read_text(encoding="utf-8")) == data


### PR DESCRIPTION
## Summary
- add MoleculeCatalogCfg with cache alias, expose it on ChemblSourceCfg/Config, and extend the JSON schema and default YAML
- implement molecule_catalog helpers to fetch and cache parent identifiers
- cover the new helpers and configuration alias with focused tests

## Testing
- pytest tests/test_molecule_catalog.py tests/test_config.py::test_molecule_catalog_cache_alias

------
https://chatgpt.com/codex/tasks/task_e_68d6422208a88324a1a792971cc9d693