### PR TITLE
Attach parent molecule metadata to test item output

### DIFF
--- a/library/metadata.py
+++ b/library/metadata.py
@@ -26,13 +26,18 @@ from .log import logger
 UTC = timezone.utc  # noqa: UP017
 
 
-class Stats(TypedDict):
-    """Execution statistics written to the metadata file."""
-
+class _StatsRequired(TypedDict):
     rows_total: int
     rows_kept: int
     rows_dropped: int
     output_sha256: str
+
+
+class Stats(_StatsRequired, total=False):
+    """Execution statistics written to the metadata file."""
+
+    parent_lookup_source: str
+    parent_lookup_missing: int
 
 
 def file_sha256(path: Path | str) -> str:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -12,6 +12,7 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections.abc import Sequence
+from dataclasses import dataclass
 from itertools import islice
 
 import pandas as pd
@@ -20,6 +21,7 @@ from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
 from library import io
+from library import molecule_catalog
 from library import pubchem_library as pl
 from library.chembl_client import ChemblClient
 from library.cli import (
@@ -31,7 +33,9 @@ from library.cli import (
     build_parser as base_parser,
 )
 from library.config import (
+    ApiCfg,
     Config,
+    MoleculeCatalogCfg,
     PubChemCfg,
     _serialize_paths,
     ensure_dirs,
@@ -44,6 +48,122 @@ from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
 from schemas import TestitemsSchema, normalize_testitems
+
+
+PARENT_LOOKUP_PLACEHOLDER = "-"
+PARENT_LOOKUP_SOURCE_CACHE = "cache"
+PARENT_LOOKUP_SOURCE_REMOTE = "remote"
+PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class ParentLookupStats:
+    """Summary information about parent molecule enrichment."""
+
+    source: str
+    missing: int
+    unique: int
+    attached: int
+
+
+def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
+    """Return ``series`` normalised to upper-case ChEMBL identifiers."""
+
+    normalised = (
+        series.fillna("")
+        .astype("string")
+        .str.strip()
+        .str.upper()
+    )
+    return normalised
+
+
+def attach_parent_molecule_ids(
+    df: pd.DataFrame,
+    *,
+    client: ChemblClient,
+    api_cfg: ApiCfg,
+    catalog_cfg: MoleculeCatalogCfg,
+    timeout: float | None,
+) -> tuple[pd.DataFrame, ParentLookupStats]:
+    """Attach parent molecule identifiers using the ChEMBL catalogue."""
+
+    if "parant_molecule_id" in df.columns:
+        raise ValueError(
+            "Input frame contains unexpected column 'parant_molecule_id'."
+        )
+
+    result = df.copy()
+
+    if result.empty:
+        if catalog_cfg.parent_field not in result.columns:
+            result[catalog_cfg.parent_field] = PARENT_LOOKUP_PLACEHOLDER
+        stats = ParentLookupStats(
+            source=PARENT_LOOKUP_SOURCE_SKIPPED,
+            missing=0,
+            unique=0,
+            attached=0,
+        )
+        return result, stats
+
+    child_column = catalog_cfg.child_field
+    parent_column = catalog_cfg.parent_field
+
+    if child_column not in result.columns:
+        logger.warning("parent_lookup_missing_child_column", column=child_column)
+        result[parent_column] = PARENT_LOOKUP_PLACEHOLDER
+        stats = ParentLookupStats(
+            source=PARENT_LOOKUP_SOURCE_SKIPPED,
+            missing=len(result),
+            unique=0,
+            attached=0,
+        )
+        return result, stats
+
+    cache_path = catalog_cfg.cache_path
+    cache_exists = cache_path.is_file()
+    cache_mtime = cache_path.stat().st_mtime if cache_exists else None
+
+    catalog = molecule_catalog.load_parent_catalog(
+        client=client,
+        api_cfg=api_cfg,
+        catalog_cfg=catalog_cfg,
+        timeout=timeout,
+    )
+
+    cache_exists_after = cache_path.is_file()
+    cache_mtime_after = cache_path.stat().st_mtime if cache_exists_after else None
+    if cache_exists_after and cache_exists and cache_mtime_after == cache_mtime:
+        source = PARENT_LOOKUP_SOURCE_CACHE
+    else:
+        source = PARENT_LOOKUP_SOURCE_REMOTE
+
+    normalised_child = _normalise_chembl_ids(result[child_column])
+    unique_children = normalised_child[normalised_child != ""].unique()
+
+    parent_map = {key: catalog[key] for key in unique_children if key in catalog}
+    parent_series = normalised_child.map(parent_map).fillna(PARENT_LOOKUP_PLACEHOLDER)
+    result[parent_column] = parent_series
+
+    missing = int((result[parent_column] == PARENT_LOOKUP_PLACEHOLDER).sum())
+    attached = len(result) - missing
+
+    stats = ParentLookupStats(
+        source=source,
+        missing=missing,
+        unique=int(len(unique_children)),
+        attached=int(attached),
+    )
+
+    logger.info(
+        "parent_lookup_progress",
+        source=stats.source,
+        unique=stats.unique,
+        attached=stats.attached,
+        missing=stats.missing,
+    )
+
+    return result, stats
 
 
 def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
@@ -151,6 +271,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     # Initialise HTTP sessions for downstream HTTP calls
     pl.init_session(cfg.api, cfg.retry)
     # Initialise HTTP session for subsequent ChEMBL requests
+    parent_stats = ParentLookupStats(
+        source=PARENT_LOOKUP_SOURCE_SKIPPED,
+        missing=0,
+        unique=0,
+        attached=0,
+    )
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
             ids_iter = io.read_ids(
@@ -192,6 +318,25 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(df, cfg.pubchem)
         logger.info("pubchem_augment_done")
+        logger.info("parent_lookup_start")
+        try:
+            df, parent_stats = attach_parent_molecule_ids(
+                df,
+                client=client,
+                api_cfg=cfg.api,
+                catalog_cfg=cfg.molecule_catalog,
+                timeout=cfg.testitem.timeout,
+            )
+        except ValueError as exc:
+            logger.error("parent_lookup_failed", error=str(exc))
+            return 1
+        logger.info(
+            "parent_lookup_done",
+            source=parent_stats.source,
+            unique=parent_stats.unique,
+            attached=parent_stats.attached,
+            missing=parent_stats.missing,
+        )
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_testitems(df)
         df = add_pipeline_metadata(df)
@@ -278,6 +423,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         "rows_kept": rows_kept,
         "rows_dropped": rows_dropped,
         "output_sha256": file_sha256(csv_path),
+        "parent_lookup_source": parent_stats.source,
+        "parent_lookup_missing": parent_stats.missing,
     }
     write_meta_yaml(
         csv_path=csv_path,

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -198,6 +198,19 @@ def test_testitem_timeout_override(
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(gtdt, "add_pubchem_data", lambda df, cfg: df)
     monkeypatch.setattr(
+        gtdt,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtdt.ParentLookupStats(
+                source=gtdt.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
         io,
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -39,6 +39,19 @@ def test_run_chembl_column_order(
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(
+        gtd,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+            ),
+        ),
+    )
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
@@ -83,6 +96,19 @@ def test_run_chembl_initialises_pubchem_session(
     )
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg: frame)
+    monkeypatch.setattr(
+        gtd,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+            ),
+        ),
+    )
 
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- load the ChEMBL parent molecule catalogue and attach parent identifiers to test item records with logging and placeholder handling
- record parent lookup source and missing counts in the metadata stats payload
- update CLI tests to patch the new parent lookup helper when exercising the pipeline

## Testing
- pytest tests/test_get_testitem_data.py tests/test_cli_timeout_override.py

------
https://chatgpt.com/codex/tasks/task_e_68d6438ab1848324b9c481acf5d8f1db