### PR TITLE
Filter Reactome xrefs from reaction EC numbers

### DIFF
--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -39,6 +39,13 @@ EMPTY_TARGET: dict[str, str] = {field: "" for field in TARGET_FIELDS}
 
 TARGET_INCLUDE_PARAMS = "protein_classifications,cross_references"
 
+REACTION_EC_EXCLUDED_XREFS = {
+    "REACTOME",
+    "RHEA",
+    "METACYC",
+    "EC_REACTION",
+}
+
 
 def _parse_gene_synonyms(synonyms: list[dict[str, str]]) -> str:
     """Return a sorted, pipe separated list of gene synonyms."""
@@ -139,11 +146,12 @@ def _collect_reaction_ec_numbers(components: list[dict[str, Any]]) -> str:
         xrefs = _get_items(component.get("target_component_xrefs"), "target")
         for xref in xrefs:
             src = (xref.get("xref_src_db") or "").upper()
-            if src in {"REACTOME", "RHEA", "METACYC", "EC_REACTION"}:
-                value = xref.get("xref_id")
-                if isinstance(value, str) and value and value not in seen:
-                    seen.add(value)
-                    numbers.append(value)
+            if src in REACTION_EC_EXCLUDED_XREFS:
+                continue
+            value = xref.get("xref_id")
+            if isinstance(value, str) and value and value not in seen:
+                seen.add(value)
+                numbers.append(value)
     return "|".join(numbers)
 
 

--- a/tests/test_chembl_target.py
+++ b/tests/test_chembl_target.py
@@ -1,0 +1,35 @@
+"""Tests for helpers defined in ``library.chembl_target``."""
+
+from library.chembl_target import _collect_reaction_ec_numbers
+
+
+def test_collect_reaction_ec_numbers_excludes_reactome_like_xrefs() -> None:
+    """Ensure excluded xref sources are ignored while valid ones remain."""
+
+    components = [
+        {
+            "target_component_synonyms": {
+                "target_component_synonym": [
+                    {
+                        "syn_type": "REACTION",
+                        "component_synonym": "1.1.1.1",
+                    },
+                    {
+                        "syn_type": "REACTION_NUMBER",
+                        "component_synonym": "2.2.2.2",
+                    },
+                ]
+            },
+            "target_component_xrefs": {
+                "target": [
+                    {"xref_src_db": "Reactome", "xref_id": "R-HSA-111111"},
+                    {"xref_src_db": "RHEA", "xref_id": "RHEA:12345"},
+                    {"xref_src_db": "MetaCyc", "xref_id": "META:999"},
+                    {"xref_src_db": "EC_REACTION", "xref_id": "EC:9.9.9.9"},
+                    {"xref_src_db": "SABIO-RK", "xref_id": "SABIO:555"},
+                ]
+            },
+        }
+    ]
+
+    assert _collect_reaction_ec_numbers(components) == "1.1.1.1|2.2.2.2|SABIO:555"


### PR DESCRIPTION
## Summary
- introduce a constant describing the cross-reference sources to exclude when collecting reaction EC numbers
- update the collection helper to skip those sources while preserving valid identifiers
- add a unit test that ensures the filtered sources are omitted and allowed identifiers remain

## Testing
- pytest tests/test_chembl_target.py

------
https://chatgpt.com/codex/tasks/task_e_68d6493865088324825bfa5429d2f531