### PR TITLE
Clarify configuration sections in documentation summaries

### DIFF
--- a/docs/SUMMARY.EN.md
+++ b/docs/SUMMARY.EN.md
@@ -94,7 +94,19 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (opt.) failure_cases
 
 
 ## Configuration
-- The primary `config.yaml` contains sections such as `api`, `chembl`, `openalex`, `crossref`, `uniprot`, `pubchem`, `document`, `target`, `resources`, `io`, `jobs`, `batch`, etc., with defaults for URLs, timeouts, RPS limits, chunk sizes, and dictionary paths.
+- The top-level structure of `config.yaml` is split into `sources`, `local`, `activity_bounds`, and `system`.
+
+
+- `sources` enumerates every remote dependency: `sources.chembl.api` tunes base URLs, retries, throttling, and headers; `sources.chembl.cache` and `sources.chembl.molecule_catalog` manage on-disk caches; `sources.chembl.pipelines.*` defines identifier columns, batching, and per-pipeline limits; sibling blocks (`sources.openalex`, `sources.crossref`, `sources.uniprot.api`/`mapping`, `sources.iuphar`, `sources.pubchem`, `sources.pubmed`, `sources.semantic_scholar`) provide analogous network and rate-limit settings.
+
+
+- `local` collects filesystem expectations: `local.resources` resolves dictionary folders and reference CSV paths, `local.io` standardises output/cache directories and CSV formatting, while `local.init` lists Excel inputs and destinations for the initialisation workflow.
+
+
+- `activity_bounds` toggles how relation strings are converted into numeric ranges, including rounding digits, clamping, and logging of unknown relations.
+
+
+- `system` centralises application-wide behaviour via `system.log`, `system.rate`, `system.retry`, and `system.doc_type` weighting tables.
 
 
 - Pydantic models enforce typing, URL validation, and a mandatory `user_agent` with an email; precedence order: YAML < environment < CLI.

--- a/docs/SUMMARY.RU.md
+++ b/docs/SUMMARY.RU.md
@@ -94,7 +94,19 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (опц.) failure_ca
 
 
 ## Конфигурация
-- Основной файл `config.yaml` содержит секции `api`, `chembl`, `openalex`, `crossref`, `uniprot`, `pubchem`, `document`, `target`, `resources`, `io`, `jobs`, `batch` и др., с дефолтами для URL, таймаутов, лимитов RPS, chunk-size и путей словарей.
+- Верхний уровень `config.yaml` разделён на блоки `sources`, `local`, `activity_bounds` и `system`.
+
+
+- `sources` описывает все удалённые зависимости: `sources.chembl.api` задаёт базовые URL, ретраи, троттлинг и заголовки; `sources.chembl.cache` и `sources.chembl.molecule_catalog` управляют локальными кешами; `sources.chembl.pipelines.*` фиксирует колонки идентификаторов, размеры батчей и лимиты для пайплайнов; соседние секции (`sources.openalex`, `sources.crossref`, `sources.uniprot.api`/`mapping`, `sources.iuphar`, `sources.pubchem`, `sources.pubmed`, `sources.semantic_scholar`) аналогично настраивают сети и rate limit.
+
+
+- `local` агрегирует файловую структуру: `local.resources` описывает каталоги словарей и ссылочных CSV, `local.io` унифицирует каталоги вывода/кеша и CSV-параметры, а `local.init` перечисляет Excel-источники и директории для пайплайна инициализации.
+
+
+- `activity_bounds` управляет вычислением диапазонов из relation-строк, включая точность округления, ограничение отрицательных значений и логирование неизвестных токенов.
+
+
+- `system` централизует глобальное поведение через `system.log`, `system.rate`, `system.retry` и весовые таблицы `system.doc_type`.
 
 
 - Pydantic-модели обеспечивают типизацию, валидацию адресов и обязательного `user_agent` с email; порядок приоритетов: YAML < env < CLI.


### PR DESCRIPTION
## Summary
- rewrite the English configuration summary to describe the actual `sources`, `local`, `activity_bounds`, and `system` sections
- mirror the updated configuration description in the Russian summary and align terminology
- remove references to obsolete configuration sections from both documents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66238d39483248605650a893cb9aa