### PR TITLE
Document configurable activity identifier column in summaries

### DIFF
--- a/docs/SUMMARY.EN.md
+++ b/docs/SUMMARY.EN.md
@@ -142,7 +142,8 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (opt.) failure_cases
 3. Run `pre-commit install` and optionally `pre-commit run --all-files` for an initial quality sweep.
 
 
-4. Prepare an input CSV with the required identifier column (defaults: `input.csv`/`activity_id`).
+4. Prepare an input CSV with the required identifier column (defaults: `input.csv`/`activity_chembl_id`).
+   - The column name is loaded from `sources.chembl.pipelines.activity.column` in the configuration (default `activity_chembl_id`) and can be overridden via `--column` or `config.yaml`.
 
 
 5. Execute the desired CLI script, e.g. `python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`.

--- a/docs/SUMMARY.RU.md
+++ b/docs/SUMMARY.RU.md
@@ -142,7 +142,8 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (опц.) failure_ca
 3. Запустить `pre-commit install` и (при необходимости) `pre-commit run --all-files` для первичной проверки качества.
 
 
-4. Подготовить входной CSV с колонкой идентификаторов (по умолчанию `input.csv`/`activity_id`).
+4. Подготовить входной CSV с колонкой идентификаторов (по умолчанию `input.csv`/`activity_chembl_id`).
+   - Название колонки берётся из `sources.chembl.pipelines.activity.column` в конфигурации (дефолт `activity_chembl_id`) и может быть переопределено флагом `--column` или через `config.yaml`.
 
 
 5. Выполнить нужный CLI-скрипт, например `python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`.


### PR DESCRIPTION
## Summary
- update the English quickstart summary to reference the default `activity_chembl_id` column
- note that the column name is sourced from configuration and can be overridden via `--column` or `config.yaml`
- apply the same clarification to the Russian summary

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d662342d208324ae8ef8e4c46645fd