### PR TITLE
Clarify document data CLI usage docs

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -53,14 +53,16 @@ Fetches assay metadata from ChEMBL using the configured identifier column.
 ## Document metadata (`get_document_data.py`)
 
 ```bash
-python scripts/get_document_data.py \
+python scripts/get_document_data.py all \
   --input data/input-smoke/documents.csv \
   --column document_chembl_id \
-  --sources.chembl.pipelines.document.pubmed.batch_size 20
+  --batch-size 20
 ```
 
-The script merges ChEMBL and PubMed sources. CLI overrides accept dotted paths, enabling fine-tuned adjustments such as increasing
-the PubMed batch size.
+Choose the `pubmed`, `chembl`, or `all` sub-command depending on the desired sources.
+Consult `python scripts/get_document_data.py --help` for a summary and
+`python scripts/get_document_data.py <sub-command> --help` for the
+allowed switches (for example, `--batch-size` for PubMed batching).
 
 ## Target aggregation (`get_target_data.py`)
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -53,14 +53,16 @@ python scripts/get_assay_data.py \
 ## Метаданные документов (`get_document_data.py`)
 
 ```bash
-python scripts/get_document_data.py \
+python scripts/get_document_data.py all \
   --input data/input-smoke/documents.csv \
   --column document_chembl_id \
-  --sources.chembl.pipelines.document.pubmed.batch_size 20
+  --batch-size 20
 ```
 
-Команда объединяет данные ChEMBL и PubMed. Для точечных настроек используйте точечную нотацию аргументов, например для увеличения
-`batch_size` при работе с PubMed.
+Выберите подкоманду `pubmed`, `chembl` или `all` в зависимости от требуемых источников.
+Сводку и список ключей смотрите в справке: `python scripts/get_document_data.py --help`
+и `python scripts/get_document_data.py <подкоманда> --help`
+(например, `--batch-size` управляет размером пакета для PubMed).
 
 ## Агрегация таргетов (`get_target_data.py`)
 


### PR DESCRIPTION
## Summary
- update the document metadata CLI example to include an explicit sub-command and valid options in both languages
- add guidance on picking the appropriate sub-command and where to find the full list of switches

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d66227de3c8324a653dc3108bce834