### PR TITLE
Clarify logging-only behavior of get_activities helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,16 @@ pre-commit run --all-files
 3. **Run a sample script**
 
    ```bash
-   python -m scripts.get_activities --input tests/data/activity_ids_small.csv \
-       --output out/activities.csv --limit 10 --log-level INFO
+   python -m scripts.get_activities --limit 10 --log-level INFO
    ```
 
-   The command reads the bundled test identifiers and writes a normalised CSV
-   to ``out/activities.csv``. Common CLI flags include ``--input`` and
-   ``--output`` for file paths, ``--limit`` to cap processed records,
-   ``--log-level`` for verbosity, ``--sep`` for CSV delimiter and
-   ``--encoding`` for file encoding. Direct execution via ``python scripts/get_activities.py`` requires installing the project or adding the repository root to ``PYTHONPATH``; using ``-m scripts.get_activities`` avoids this extra setup. Additional examples:
+   This lightweight helper only emits structured log messages describing the
+   dummy activity rows it would generate; it neither reads input files nor
+   writes outputs. Use it to verify logging configuration and CLI wiring before
+   launching full pipelines. Common CLI flags include ``--limit`` to cap
+   processed records, ``--log-level`` for verbosity, ``--sep`` for CSV delimiter
+   and ``--encoding`` for file encoding. For end-to-end exports that create
+   files, run one of the data pipelines, for example:
 
    ```bash
    python mapper_main.py --input tests/data/assays.csv \
@@ -154,14 +155,18 @@ python -m scripts.mapper_batch_main --input tests/data/assays.csv \
 
 ## Генерация данных
 
-Скрипты из каталога `scripts/` создают CSV-файлы и сохраняют их в `data/output/`. Пример:
+Большинство скриптов из каталога `scripts/` формируют CSV-файлы и размещают их
+в `data/output/`. Пример полноценного пайплайна:
 
 ```bash
-python -m scripts.get_activities --input tests/data/activity_ids_small.csv \
+python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
     --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
-Результирующие файлы располагаются в `data/output/`. Каталог игнорируется Git и автоматически публикуется как артефакт CI.
+Команда извлекает данные из API ChEMBL, сохраняет таблицу и сопутствующий
+`*.meta.yaml`. Скрипт `scripts.get_activities` предназначен только для
+демонстрационного логирования и не выполняет файловых операций. Каталог с
+результатами игнорируется Git и автоматически публикуется как артефакт CI.
 
 ## Usage
 
@@ -414,7 +419,8 @@ python -m scripts.get_activity_data \
     --input tests/data/activity_ids_small.csv \
     --output out/activities.csv \
     --limit 10 --log-level INFO
- 
+
+# демонстрационный dry-run: только логирование без файловых операций
 python -m scripts.get_activities --limit 10 --dry-run
 ```
 

--- a/docs/SUMMARY.EN.md
+++ b/docs/SUMMARY.EN.md
@@ -145,7 +145,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (opt.) failure_cases
 4. Prepare an input CSV with the required identifier column (defaults: `input.csv`/`activity_id`).
 
 
-5. Execute the desired CLI script, e.g. `python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`.
+5. Execute the desired CLI script, e.g. `python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`, which downloads data and writes the CSV/metadata files.
 
 
 6. Alternative pipelines: `get_assay_data`, `get_target_data`, `get_document_data`, `get_testitem_data`, `get_input_initialisation`, `table_quality_main`.
@@ -298,7 +298,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (opt.) failure_cases
 
 
 
-7. Target command (`python -m scripts.get_activities ...`, etc.) executed with required flags and log level.
+7. Target command (`python -m scripts.get_activity_data ...`, etc.) executed with required flags and log level.
 
 
 
@@ -321,7 +321,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (opt.) failure_cases
 
 ## One-liner Setup & Run
 ```
-python -m venv .venv && source .venv/bin/activate && pip install .[dev] && python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output data/output/activities.csv --limit 10 --log-level INFO
+python -m venv .venv && source .venv/bin/activate && pip install .[dev] && python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 

--- a/docs/SUMMARY.RU.md
+++ b/docs/SUMMARY.RU.md
@@ -145,7 +145,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (опц.) failure_ca
 4. Подготовить входной CSV с колонкой идентификаторов (по умолчанию `input.csv`/`activity_id`).
 
 
-5. Выполнить нужный CLI-скрипт, например `python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`.
+5. Выполнить нужный CLI-скрипт, например `python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv --output out/activities.csv --limit 10 --log-level INFO`, чтобы выгрузить данные и записать CSV вместе с метаданными.
 
 
 6. Альтернативные пайплайны: `get_assay_data`, `get_target_data`, `get_document_data`, `get_testitem_data`, `get_input_initialisation`, `table_quality_main`.
@@ -298,7 +298,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (опц.) failure_ca
 
 
 
-7. Выполнена целевая команда (`python -m scripts.get_activities ...` и т.п.) с нужными флагами и лог-уровнем.
+7. Выполнена целевая команда (`python -m scripts.get_activity_data ...` и т.п.) с нужными флагами и лог-уровнем.
 
 
 
@@ -321,7 +321,7 @@ write_csv() ──► <table>.csv + <table>.csv.meta.yaml + (опц.) failure_ca
 
 ## One-liner setup & run
 ```
-python -m venv .venv && source .venv/bin/activate && pip install .[dev] && python -m scripts.get_activities --input tests/data/activity_ids_small.csv --output data/output/activities.csv --limit 10 --log-level INFO
+python -m venv .venv && source .venv/bin/activate && pip install .[dev] && python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 


### PR DESCRIPTION
## Summary
- clarify in the README quick start that `scripts.get_activities` only emits log messages and does not touch files
- update the data generation section to point to `scripts.get_activity_data` for real CSV output while flagging the dry-run helper
- revise English and Russian documentation summaries so the step-by-step examples use a pipeline that writes files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66225e5b88324948471c8f64e56aa