### PR TITLE
Preserve existing parent IDs when catalog lookup misses

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -137,7 +137,7 @@ def attach_parent_molecule_ids(
     cache_exists = cache_path.is_file()
     cache_mtime = cache_path.stat().st_mtime if cache_exists else None
 
-    catalog = molecule_catalog.load_parent_catalog(
+    catalog = load_parent_catalog(
         client=client,
         api_cfg=api_cfg,
         catalog_cfg=catalog_cfg,
@@ -158,7 +158,13 @@ def attach_parent_molecule_ids(
     parent_series = normalised_child.map(parent_map)
     missing_mask = parent_series.isna()
     parent_series = parent_series.astype("string")
-    result[parent_column] = parent_series
+
+    if parent_column not in result.columns:
+        result[parent_column] = pd.Series(pd.NA, index=result.index, dtype="string")
+
+    result[parent_column] = (
+        result[parent_column].astype("string").fillna(parent_series)
+    )
 
     missing = int(missing_mask.sum())
     attached = len(result) - missing

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -197,6 +197,43 @@ def test_run_chembl_merges_parent_catalog(
     ]
 
 
+def test_attach_parent_ids_preserves_existing_values_when_cache_has_no_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: Config,
+) -> None:
+    parent_field = cfg.molecule_catalog.parent_field
+    cache_path = tmp_path / "parent_cache.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    cfg.molecule_catalog.cache_path = cache_path
+
+    source = pd.DataFrame(
+        {
+            cfg.molecule_catalog.child_field: ["CHEMBL1", "CHEMBL2"],
+            parent_field: ["CHEMBL1_EXISTING", pd.NA],
+        }
+    )
+
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        source,
+        client=object(),
+        api_cfg=cfg.api,
+        catalog_cfg=cfg.molecule_catalog,
+        timeout=None,
+    )
+
+    expected = pd.Series(
+        ["CHEMBL1_EXISTING", pd.NA], index=result.index, dtype="string"
+    )
+    pd.testing.assert_series_equal(
+        result[parent_field], expected, check_names=False
+    )
+    assert stats.missing == 2
+    assert stats.attached == 0
+
+
 def test_run_chembl_parent_catalog_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure the parent enrichment step only fills missing parent identifiers instead of overwriting existing data
- add a regression test covering cached lookups with partial parent data and no catalog matches

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d666d8d2a48324954caed98c065787