### PR TITLE
Preserve existing parent molecule IDs during enrichment

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -155,11 +155,18 @@ def attach_parent_molecule_ids(
     unique_children = normalised_child[normalised_child != ""].unique()
 
     parent_map = {key: catalog[key] for key in unique_children if key in catalog}
-    parent_series = normalised_child.map(parent_map)
-    missing_mask = parent_series.isna()
-    parent_series = parent_series.astype("string")
-    result[parent_column] = parent_series
+    parent_series = normalised_child.map(parent_map).astype("string")
 
+    if parent_column in result.columns:
+        existing_parent = result[parent_column].astype("string")
+        combined_parent = existing_parent.fillna(parent_series)
+    else:
+        combined_parent = parent_series
+
+    combined_parent = combined_parent.astype("string")
+    result[parent_column] = combined_parent
+
+    missing_mask = combined_parent.isna()
     missing = int(missing_mask.sum())
     attached = len(result) - missing
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -197,6 +197,39 @@ def test_run_chembl_merges_parent_catalog(
     ]
 
 
+def test_attach_parent_preserves_existing_value(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "CHEMBL1",
+                "parent_molecule_chembl_id": "CHEMBL_PARENT_EXISTING",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "load_parent_catalog",
+        lambda *, client, api_cfg, catalog_cfg, timeout: {},
+    )
+
+    enriched, stats = gtd.attach_parent_molecule_ids(
+        frame,
+        client=object(),
+        api_cfg=cfg.api,
+        catalog_cfg=cfg.molecule_catalog,
+        timeout=cfg.testitem.timeout,
+    )
+
+    assert enriched[cfg.molecule_catalog.parent_field].tolist() == [
+        "CHEMBL_PARENT_EXISTING"
+    ]
+    assert stats.missing == 0
+    assert stats.attached == 1
+
+
 def test_run_chembl_parent_catalog_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- merge catalog lookups into existing parent_molecule_chembl_id values with fillna instead of overwriting them outright
- recompute enrichment statistics from the final parent column so attached/missing figures stay accurate
- cover the regression with a test that ensures pre-populated parent IDs survive when the catalog lacks a record

## Testing
- pytest tests/test_get_testitem_data.py -k attach_parent_preserves_existing_value -vv

------
https://chatgpt.com/codex/tasks/task_e_68d668bbf0e4832494eff25f7547d5bc