### PR TITLE
Add SQLite-backed cache for molecule parent catalog

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -193,6 +193,11 @@
           "title": "Cache Path",
           "type": "string"
         },
+        "sqlite_path": {
+          "default": "data/cache/molecule_parent_catalog.sqlite",
+          "title": "Sqlite Path",
+          "type": "string"
+        },
         "endpoint": {
           "default": "molecule",
           "title": "Endpoint",

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ sources:
       cache_maxsize: 1024  # Max cached ChEMBL responses (env: CHEMBL_DA_CACHE_MAXSIZE)
     molecule_catalog:
       cache_path: "data/cache/molecule_parent_catalog.json"  # Local cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_CACHE)
+      sqlite_path: "data/cache/molecule_parent_catalog.sqlite"  # SQLite cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_SQLITE)
       endpoint: "molecule"  # API resource providing parent relationships
       child_field: "molecule_chembl_id"  # Column containing molecule identifiers
       parent_field: "parent_molecule_chembl_id"  # Column containing parent molecule identifiers

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -76,6 +76,7 @@ Each row combines ChEMBL fields (`molecule_chembl_id`, structure descriptors, li
 augmentation, and pipeline metadata, allowing the dataset to serve as the canonical compound dimension.【F:scripts/get_testitem_data.py†L36-L193】【F:schemas/testitems.py†L12-L31】
 
 Before distributing the export, join it with the parent molecule catalogue to expose
-`parent_molecule_chembl_id` for roll-ups. The mapping is stored in the JSON file configured at
-`sources.chembl.molecule_catalog.cache_path` and loaded via
-`library.molecule_catalog.load_parent_catalog`, which refreshes the cache from the ChEMBL API when needed.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
+`parent_molecule_chembl_id` for roll-ups. The mapping resides in the SQLite cache at
+`sources.chembl.molecule_catalog.sqlite_path`; `library.molecule_catalog.load_parent_catalog`
+initialises the database (migrating any legacy JSON configured via
+`cache_path`) and refreshes it from the ChEMBL API when necessary.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L108-L189】

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -74,6 +74,6 @@ data/output/
 обогащение PubChem и метаданные запуска, превращая выгрузку в опорное измерение соединений.【F:scripts/get_testitem_data.py†L36-L193】【F:schemas/testitems.py†L12-L31】
 
 Перед распространением данных выполните объединение с каталогом родительских молекул, чтобы добавить
-`parent_molecule_chembl_id` для агрегаций. Отображение хранится в JSON по пути
-`sources.chembl.molecule_catalog.cache_path` и загружается функцией
-`library.molecule_catalog.load_parent_catalog`, которая при необходимости обновляет кэш через API ChEMBL.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
+`parent_molecule_chembl_id` для агрегаций. Отображение хранится в SQLite-кэше по пути
+`sources.chembl.molecule_catalog.sqlite_path`; функция `library.molecule_catalog.load_parent_catalog`
+инициализирует базу (мигрируя legacy JSON из `cache_path`) и при необходимости обновляет её через API ChEMBL.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L108-L189】

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -98,15 +98,13 @@ Downloads compound-centric annotations for the supplied identifiers.
 
 ### Parent molecule catalogue requirements
 
-Test item exports must be reconciled with the ChEMBL parent catalogue to expose `parent_molecule_chembl_id`
-used by downstream aggregations. The cache path is configured via
-`sources.chembl.molecule_catalog.cache_path`; keep the JSON file accessible to the runner or adjust the
-location by setting `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for
-`CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) or editing `config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
- 
-[`sources.chembl.molecule_catalog`](./CONFIG_EN.md#sources-chembl-molecule-catalog) (`cache_path`); keep the JSON file accessible to the runner or override the
-location through CLI/environment aliases such as `--sources.chembl.molecule_catalog.cache-path` or
-`CHEMBL_DA_MOLECULE_CATALOG_CACHE`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
+Test item exports must be reconciled with the ChEMBL parent catalogue to expose
+`parent_molecule_chembl_id` used by downstream aggregations. The primary cache is
+stored in SQLite; configure its location via
+`sources.chembl.molecule_catalog.sqlite_path` or the
+`CHEMBL_DA_MOLECULE_CATALOG_SQLITE` alias. Legacy JSON caches referenced by
+`sources.chembl.molecule_catalog.cache_path` are migrated automatically when the
+SQLite database is initialised.【F:config.yaml†L25-L33】【F:library/config.py†L124-L137】【F:library/molecule_catalog.py†L108-L189】
  
 
 Use `library.molecule_catalog.load_parent_catalog` in a short Python snippet to initialise or refresh the

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -102,15 +102,10 @@ python scripts/get_testitem_data.py \
 ### Требования к каталогу родительских молекул
 
 Чтобы получить `parent_molecule_chembl_id` для агрегаций, выгрузку необходимо объединить с каталогом
-родителей ChEMBL. Путь к локальному JSON задаётся через `sources.chembl.molecule_catalog.cache_path`; убедитесь,
-что файл доступен исполнителю, либо задайте новое расположение переменной окружения
-`CHEMBL_DA_MOLECULE_CATALOG_CACHE` (алиас для `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) или правкой
-`config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
-
-родителей ChEMBL. Путь к локальному JSON задаётся через
-[`sources.chembl.molecule_catalog`](./CONFIG_RU.md#sources-chembl-molecule-catalog) (`cache_path`); убедитесь,
-что файл доступен исполнителю, либо переопределите расположение параметрами CLI (`--sources.chembl.molecule_catalog.cache-path`)
-или переменными окружения (`CHEMBL_DA_MOLECULE_CATALOG_CACHE`).【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
+родителей ChEMBL. Основной кэш хранится в SQLite; путь задаётся параметром
+`sources.chembl.molecule_catalog.sqlite_path` или переменной окружения
+`CHEMBL_DA_MOLECULE_CATALOG_SQLITE`. При первом запуске legacy JSON из
+`sources.chembl.molecule_catalog.cache_path` автоматически мигрируется в SQLite.【F:config.yaml†L25-L33】【F:library/config.py†L124-L137】【F:library/molecule_catalog.py†L108-L189】
 
 Для первичного создания либо обновления файла выполните небольшой Python-скрипт с вызовом
 `library.molecule_catalog.load_parent_catalog` — функция считывает готовый кэш и, при его отсутствии,

--- a/library/config.py
+++ b/library/config.py
@@ -123,6 +123,7 @@ class ChemblCacheCfg(_BaseModel):
 
 class MoleculeCatalogCfg(_BaseModel):
     cache_path: Path = Path("data/cache/molecule_parent_catalog.json")
+    sqlite_path: Path = Path("data/cache/molecule_parent_catalog.sqlite")
     endpoint: str = "molecule"
     child_field: str = "molecule_chembl_id"
     parent_field: str = "parent_molecule_chembl_id"
@@ -986,6 +987,12 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
         "chembl",
         "molecule_catalog",
         "cache_path",
+    ],
+    "CHEMBL_DA_MOLECULE_CATALOG_SQLITE": [
+        "sources",
+        "chembl",
+        "molecule_catalog",
+        "sqlite_path",
     ],
     "CHEMBL_DA_DICT_DIR": ["local", "resources", "dictionary_dir"],
     "CHEMBL_DA_GLOBAL_BURST": ["system", "rate", "global_burst"],

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import csv
 import json
+import sqlite3
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Mapping
 from urllib.parse import urlencode, urljoin
@@ -12,7 +14,60 @@ from .chembl_client import ChemblClient
 from .config import ApiCfg, MoleculeCatalogCfg
 from .log import logger
 
-__all__ = ["fetch_parent_catalog", "load_parent_catalog"]
+__all__ = [
+    "ParentCatalogStore",
+    "fetch_parent_catalog",
+    "load_parent_catalog",
+]
+
+_SQLITE_PARAMETER_LIMIT = 999
+
+
+class ParentCatalogStore:
+    """Read-only view over the cached parent catalogue stored in SQLite."""
+
+    def __init__(self, path: Path, *, refreshed: bool) -> None:
+        self._path = path
+        self._refreshed = refreshed
+
+    @property
+    def path(self) -> Path:
+        """Return the backing SQLite database path."""
+
+        return self._path
+
+    @property
+    def was_refreshed(self) -> bool:
+        """Whether the catalogue was refreshed from the remote endpoint."""
+
+        return self._refreshed
+
+    def __bool__(self) -> bool:
+        return _sqlite_has_rows(self._path)
+
+    def lookup(self, children: Sequence[str]) -> dict[str, str]:
+        """Return a mapping for ``children`` found in the cache."""
+
+        if not children:
+            return {}
+
+        # ``children`` are expected to be normalised already, yet we only
+        # retain non-empty identifiers to avoid unnecessary queries.
+        filtered = list(dict.fromkeys(child for child in children if child))
+        if not filtered:
+            return {}
+
+        result: dict[str, str] = {}
+        with sqlite3.connect(self._path) as connection:
+            for chunk in _chunked(filtered, _SQLITE_PARAMETER_LIMIT):
+                placeholders = ",".join("?" for _ in chunk)
+                query = (
+                    f"SELECT child, parent FROM parent_catalog "
+                    f"WHERE child IN ({placeholders})"
+                )
+                for child, parent in connection.execute(query, tuple(chunk)):
+                    result[str(child)] = str(parent)
+        return result
 
 
 def _normalise_chembl_id(value: str) -> str:
@@ -139,6 +194,50 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
     return result
 
 
+def _write_sqlite_cache(path: Path, data: Mapping[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TABLE IF EXISTS parent_catalog")
+        connection.execute(
+            "CREATE TABLE parent_catalog (child TEXT PRIMARY KEY, parent TEXT NOT NULL)"
+        )
+        rows = sorted((str(child), str(parent)) for child, parent in data.items())
+        connection.executemany(
+            "INSERT INTO parent_catalog (child, parent) VALUES (?, ?)",
+            rows,
+        )
+        connection.execute(
+            "CREATE INDEX IF NOT EXISTS parent_catalog_parent_idx"
+            " ON parent_catalog (parent)"
+        )
+
+
+def _sqlite_has_rows(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    with sqlite3.connect(path) as connection:
+        cursor = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='parent_catalog'"
+        )
+        if cursor.fetchone() is None:
+            return False
+        cursor = connection.execute("SELECT 1 FROM parent_catalog LIMIT 1")
+        return cursor.fetchone() is not None
+
+
+def _chunked(values: Iterable[str], limit: int) -> Iterator[list[str]]:
+    if limit <= 0:
+        raise ValueError("chunk size must be positive")
+    chunk: list[str] = []
+    for value in values:
+        chunk.append(value)
+        if len(chunk) >= limit:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
 def load_parent_catalog(
     *,
     client: ChemblClient,
@@ -146,21 +245,24 @@ def load_parent_catalog(
     catalog_cfg: MoleculeCatalogCfg,
     timeout: float | None = None,
     force_refresh: bool = False,
-) -> dict[str, str]:
-    """Return the molecule parent catalogue, using the on-disk cache if present."""
+) -> ParentCatalogStore:
+    """Ensure the parent catalogue cache exists and return a SQLite-backed view."""
 
-    cache_path = catalog_cfg.cache_path
+    sqlite_path = catalog_cfg.sqlite_path
+    refreshed = False
+
+    if not force_refresh and _sqlite_has_rows(sqlite_path):
+        return ParentCatalogStore(sqlite_path, refreshed=refreshed)
+
     if not force_refresh:
-        cached = _read_cache(cache_path, catalog_cfg)
+        cached = _read_cache(catalog_cfg.cache_path, catalog_cfg)
         if cached:
-            return cached
+            _write_sqlite_cache(sqlite_path, cached)
+            return ParentCatalogStore(sqlite_path, refreshed=refreshed)
 
     result = fetch_parent_catalog(
         client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
     )
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(
-        json.dumps(dict(sorted(result.items())), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    return result
+    _write_sqlite_cache(sqlite_path, result)
+    refreshed = True
+    return ParentCatalogStore(sqlite_path, refreshed=refreshed)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -133,10 +133,6 @@ def attach_parent_molecule_ids(
         )
         return result, stats
 
-    cache_path = catalog_cfg.cache_path
-    cache_exists = cache_path.is_file()
-    cache_mtime = cache_path.stat().st_mtime if cache_exists else None
-
     catalog = molecule_catalog.load_parent_catalog(
         client=client,
         api_cfg=api_cfg,
@@ -144,17 +140,14 @@ def attach_parent_molecule_ids(
         timeout=timeout,
     )
 
-    cache_exists_after = cache_path.is_file()
-    cache_mtime_after = cache_path.stat().st_mtime if cache_exists_after else None
-    if cache_exists_after and cache_exists and cache_mtime_after == cache_mtime:
-        source = PARENT_LOOKUP_SOURCE_CACHE
-    else:
-        source = PARENT_LOOKUP_SOURCE_REMOTE
+    source = (
+        PARENT_LOOKUP_SOURCE_REMOTE if catalog.was_refreshed else PARENT_LOOKUP_SOURCE_CACHE
+    )
 
     normalised_child = _normalise_chembl_ids(result[child_column])
     unique_children = normalised_child[normalised_child != ""].unique()
 
-    parent_map = {key: catalog[key] for key in unique_children if key in catalog}
+    parent_map = catalog.lookup(list(unique_children))
     parent_series = normalised_child.map(parent_map)
     missing_mask = parent_series.isna()
     parent_series = parent_series.astype("string")
@@ -324,7 +317,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             logger.error(
                 "parent_catalog_invalid",
                 error=str(exc),
-                path=str(cfg.molecule_catalog.cache_path),
+                path=str(cfg.molecule_catalog.sqlite_path),
             )
             return 1
 
@@ -348,7 +341,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         parent_column = cfg.molecule_catalog.parent_field
         if parent_catalog and "molecule_chembl_id" in df.columns:
             normalised_ids = _normalise_chembl_ids(df["molecule_chembl_id"])
-            mapped = normalised_ids.map(parent_catalog)
+            unique_children = [child for child in normalised_ids.unique() if child]
+            parent_map = parent_catalog.lookup(unique_children)
+            mapped = normalised_ids.map(parent_map)
             if parent_column in df.columns:
                 df[parent_column] = df[parent_column].fillna(mapped)
             else:

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -356,6 +356,21 @@ def test_get_testitem_data_smoke(
             InChIKey="LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
         )
 
+    class FakeCatalog:
+        def __init__(self, mapping: dict[str, str]) -> None:
+            self._mapping = mapping
+            self.was_refreshed = False
+
+        def __bool__(self) -> bool:
+            return bool(self._mapping)
+
+        def lookup(self, children: list[str]) -> dict[str, str]:
+            return {
+                child: self._mapping[child]
+                for child in children
+                if child in self._mapping
+            }
+
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
@@ -363,7 +378,7 @@ def test_get_testitem_data_smoke(
     monkeypatch.setattr(
         get_testitem_data,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+        lambda **__: FakeCatalog({"CHEMBL1": "CHEMBL1_PARENT"}),
     )
     monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
 

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -59,12 +59,28 @@ def test_get_testitem_parent_catalog(
             InChIKey="LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
         )
 
-    def fake_load_parent_catalog(**_: object) -> dict[str, str]:
+    class FakeCatalog:
+        def __init__(self, mapping: dict[str, str]) -> None:
+            self._mapping = mapping
+            self.was_refreshed = False
+
+        def __bool__(self) -> bool:
+            return bool(self._mapping)
+
+        def lookup(self, children: list[str]) -> dict[str, str]:
+            return {
+                child: self._mapping[child]
+                for child in children
+                if child in self._mapping
+            }
+
+    def fake_load_parent_catalog(**_: object) -> FakeCatalog:
         frame = pd.read_csv(catalog_csv)
-        return {
+        mapping = {
             str(row["molecule_chembl_id"]): str(row["parent_molecule_chembl_id"])
             for _, row in frame.iterrows()
         }
+        return FakeCatalog(mapping)
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -146,6 +146,19 @@ def test_molecule_catalog_cache_alias(
     assert cfg.molecule_catalog.cache_path == cache
 
 
+def test_molecule_catalog_sqlite_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    sqlite_path = tmp_path / "catalog.sqlite"
+    monkeypatch.setenv("CHEMBL_DA_MOLECULE_CATALOG_SQLITE", str(sqlite_path))
+
+    cfg = load_config(path)
+
+    assert cfg.molecule_catalog.sqlite_path == sqlite_path
+
+
 def test_chembl_cache_maxsize_from_yaml(tmp_path: Path) -> None:
     """Custom ``chembl.cache_maxsize`` should override the default."""
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -14,6 +14,17 @@ from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
 
 
+class DummyParentCatalog:
+    def __init__(self, data: dict[str, str], *, refreshed: bool = False) -> None:
+        self._data = data
+        self.was_refreshed = refreshed
+
+    def __bool__(self) -> bool:
+        return bool(self._data)
+
+    def lookup(self, children: list[str]) -> dict[str, str]:
+        return {child: self._data[child] for child in children if child in self._data}
+
 def test_run_chembl_column_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
@@ -41,7 +52,9 @@ def test_run_chembl_column_order(
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(
-        gtd, "load_parent_catalog", lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"}
+        gtd,
+        "load_parent_catalog",
+        lambda **__: DummyParentCatalog({"CHEMBL1": "CHEMBL1_PARENT"}),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
     monkeypatch.setattr(
@@ -101,7 +114,9 @@ def test_run_chembl_initialises_pubchem_session(
     )
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg: frame)
-    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(
+        gtd, "load_parent_catalog", lambda **__: DummyParentCatalog({})
+    )
 
     monkeypatch.setattr(
         gtd,
@@ -164,7 +179,9 @@ def test_run_chembl_merges_parent_catalog(
     monkeypatch.setattr(
         gtd,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"},
+        lambda **__: DummyParentCatalog(
+            {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"}
+        ),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
@@ -296,7 +313,7 @@ def test_run_chembl_parent_catalog_request_error(
     assert any(
         event == "parent_catalog_invalid"
         and details.get("error") == "boom"
-        and details.get("path") == str(cfg.molecule_catalog.cache_path)
+        and details.get("path") == str(cfg.molecule_catalog.sqlite_path)
         for event, details in errors
     )
 

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -8,7 +9,11 @@ import pytest
 
 from library.chembl_client import ChemblClient
 from library.config import ApiCfg, MoleculeCatalogCfg
-from library.molecule_catalog import fetch_parent_catalog, load_parent_catalog
+from library.molecule_catalog import (
+    ParentCatalogStore,
+    fetch_parent_catalog,
+    load_parent_catalog,
+)
 
 
 class DummyClient:
@@ -68,13 +73,17 @@ def test_fetch_parent_catalog_normalises_and_paginates(api_cfg: ApiCfg) -> None:
 def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
     cache = tmp_path / "catalog.json"
     cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
 
-    result = load_parent_catalog(
+    store = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == {"CHEMBL10": "CHEMBL99"}
+    assert isinstance(store, ParentCatalogStore)
+    assert store.lookup(["CHEMBL10"]) == {"CHEMBL10": "CHEMBL99"}
+    assert not store.was_refreshed
+    assert sqlite_path.is_file()
 
 
 def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
@@ -83,13 +92,35 @@ def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) ->
         "molecule_chembl_id,parent_molecule_chembl_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
 
-    result = load_parent_catalog(
+    store = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == {"CHEMBL1": "CHEMBL42"}
+    assert store.lookup(["CHEMBL1"]) == {"CHEMBL1": "CHEMBL42"}
+
+
+def test_load_parent_catalog_prefers_sqlite_over_json(
+    tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = tmp_path / "catalog.json"
+    cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
+
+    # Initial load migrates JSON into SQLite.
+    load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
+
+    def fail_loads(*args: object, **kwargs: object) -> None:  # pragma: no cover - guard
+        raise AssertionError("json.loads should not be called once SQLite exists")
+
+    monkeypatch.setattr("library.molecule_catalog.json.loads", fail_loads)
+
+    store = load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
+
+    assert store.lookup(["CHEMBL10"]) == {"CHEMBL10": "CHEMBL99"}
 
 
 def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg) -> None:
@@ -98,7 +129,7 @@ def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg
         "molecule_chembl_id,parant_molecule_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite")
 
     with pytest.raises(ValueError):
         load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
@@ -108,7 +139,8 @@ def test_load_parent_catalog_fetches_and_persists(
     tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache = tmp_path / "catalog.json"
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
     data = {"CHEMBL50": "CHEMBL60"}
 
     def fake_fetch(
@@ -125,9 +157,12 @@ def test_load_parent_catalog_fetches_and_persists(
         fake_fetch,
     )
 
-    result = load_parent_catalog(
+    store = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == data
-    assert json.loads(cache.read_text(encoding="utf-8")) == data
+    assert store.was_refreshed
+    assert store.lookup(["CHEMBL50"]) == data
+    assert sqlite_path.is_file()
+    with sqlite3.connect(sqlite_path) as connection:
+        assert dict(connection.execute("SELECT child, parent FROM parent_catalog")) == data


### PR DESCRIPTION
## Summary
- persist the ChEMBL parent catalogue in a SQLite database and expose a ParentCatalogStore helper
- extend MoleculeCatalogCfg/config schema with a sqlite_path and migrate legacy JSON caches to the database
- query parents via SQL in the CLI/tests and refresh documentation for the new cache location

## Testing
- pytest tests/test_molecule_catalog.py
- pytest tests/test_get_testitem_data.py *(completes but requires manual interrupt after printing the summary in this environment)*
- pytest tests/test_config.py


------
https://chatgpt.com/codex/tasks/task_e_68d666c6a53083248d5c2da76706e636