### PR TITLE
Support selective parent catalog fetching

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -4,15 +4,29 @@ from __future__ import annotations
 
 import csv
 import json
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Mapping
 from urllib.parse import urlencode, urljoin
 
-from .chembl_client import ChemblClient
+from .chembl_client import ChemblClient, _chunked
 from .config import ApiCfg, MoleculeCatalogCfg
 from .log import logger
 
-__all__ = ["fetch_parent_catalog", "load_parent_catalog"]
+_DEFAULT_CATALOG_CFG = MoleculeCatalogCfg()
+_PARENT_LOOKUP_FIELDS = tuple(_DEFAULT_CATALOG_CFG.fields or ()) or (
+    _DEFAULT_CATALOG_CFG.child_field,
+    _DEFAULT_CATALOG_CFG.parent_field,
+)
+_PARENT_LOOKUP_CHILD_FIELD = _DEFAULT_CATALOG_CFG.child_field
+_PARENT_LOOKUP_PARENT_FIELD = _DEFAULT_CATALOG_CFG.parent_field
+_PARENT_LOOKUP_CHUNK_SIZE = _DEFAULT_CATALOG_CFG.page_size
+
+__all__ = [
+    "fetch_parent_catalog",
+    "fetch_parent_catalog_for",
+    "load_parent_catalog",
+]
 
 
 def _normalise_chembl_id(value: str) -> str:
@@ -39,6 +53,78 @@ def _build_initial_url(api_cfg: ApiCfg, catalog_cfg: MoleculeCatalogCfg) -> str:
         params[key] = str(value)
     query = urlencode(params)
     return f"{base}/{resource}?{query}"
+
+
+def fetch_parent_catalog_for(
+    ids: Iterable[str],
+    *,
+    client: ChemblClient,
+    api_cfg: ApiCfg,
+    timeout: float | None = None,
+) -> dict[str, str]:
+    """Fetch parent mappings for *ids* from the ChEMBL API."""
+
+    normalised_ids: list[str] = []
+    for value in ids:
+        try:
+            normalised_ids.append(_normalise_chembl_id(str(value)))
+        except ValueError:
+            continue
+
+    unique_ids: list[str] = []
+    seen: set[str] = set()
+    for item in normalised_ids:
+        if item in seen:
+            continue
+        seen.add(item)
+        unique_ids.append(item)
+
+    if not unique_ids:
+        return {}
+
+    base = api_cfg.chembl_base.rstrip("/")
+    effective_timeout = timeout if timeout is not None else api_cfg.timeout_read
+    result: dict[str, str] = {}
+
+    for chunk in _chunked(unique_ids, _PARENT_LOOKUP_CHUNK_SIZE):
+        params = {
+            "format": "json",
+            "limit": str(len(chunk)),
+            f"{_PARENT_LOOKUP_CHILD_FIELD}__in": ",".join(chunk),
+            "fields": ",".join(_PARENT_LOOKUP_FIELDS),
+        }
+        for key, value in _DEFAULT_CATALOG_CFG.filters.items():
+            params[key] = value
+        url = f"{base}/molecule.json?{urlencode(params)}"
+        data = client.request_json(url, cfg=api_cfg, timeout=effective_timeout)
+        items = (
+            data.get("molecules")
+            or data.get("molecule")
+            or data.get("molecule_parents")
+            or data.get("molecule_parent")
+            or []
+        )
+        if not isinstance(items, list):
+            logger.warning("unexpected_response_items", extra={"url": url})
+            continue
+        allowed = set(chunk)
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            child = item.get(_PARENT_LOOKUP_CHILD_FIELD)
+            parent = item.get(_PARENT_LOOKUP_PARENT_FIELD)
+            if not child or not parent:
+                continue
+            try:
+                child_id = _normalise_chembl_id(str(child))
+                parent_id = _normalise_chembl_id(str(parent))
+            except ValueError:
+                continue
+            if child_id not in allowed:
+                continue
+            result[child_id] = parent_id
+
+    return result
 
 
 def fetch_parent_catalog(

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -155,6 +155,27 @@ def attach_parent_molecule_ids(
     unique_children = normalised_child[normalised_child != ""].unique()
 
     parent_map = {key: catalog[key] for key in unique_children if key in catalog}
+    missing_ids = [key for key in unique_children if key not in parent_map]
+    fetched_remote = False
+
+    if missing_ids:
+        try:
+            fetched = molecule_catalog.fetch_parent_catalog_for(
+                missing_ids,
+                client=client,
+                api_cfg=api_cfg,
+                timeout=timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
+            fetched = {}
+        else:
+            if fetched:
+                fetched_remote = True
+        if fetched:
+            catalog.update(fetched)
+            parent_map.update(fetched)
+
     parent_series = normalised_child.map(parent_map)
     missing_mask = parent_series.isna()
     parent_series = parent_series.astype("string")
@@ -164,7 +185,7 @@ def attach_parent_molecule_ids(
     attached = len(result) - missing
 
     stats = ParentLookupStats(
-        source=source,
+        source=PARENT_LOOKUP_SOURCE_REMOTE if fetched_remote else source,
         missing=missing,
         unique=int(len(unique_children)),
         attached=int(attached),

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -300,3 +300,144 @@ def test_run_chembl_parent_catalog_request_error(
         for event, details in errors
     )
 
+
+def test_attach_parent_molecule_ids_fetches_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1", "CHEMBL2"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "load_parent_catalog",
+        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+    )
+
+    fetched: dict[str, str] = {"CHEMBL2": "CHEMBL2_PARENT"}
+    captured_ids: dict[str, list[str]] = {}
+
+    def fake_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        captured_ids["ids"] = list(ids)
+        return fetched
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch,
+    )
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert captured_ids["ids"] == ["CHEMBL2"]
+    assert result[catalog_cfg.parent_field].tolist() == [
+        "CHEMBL1_PARENT",
+        "CHEMBL2_PARENT",
+    ]
+    assert stats.unique == 2
+    assert stats.attached == 2
+    assert stats.missing == 0
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+
+
+def test_attach_parent_molecule_ids_fetch_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "load_parent_catalog",
+        lambda **__: {},
+    )
+
+    def failing_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        failing_fetch,
+    )
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    parent_values = result[catalog_cfg.parent_field].tolist()
+    assert parent_values == [pd.NA]
+    assert stats.unique == 1
+    assert stats.attached == 0
+    assert stats.missing == 1
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+
+
+def test_attach_parent_molecule_ids_uses_cache_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "load_parent_catalog",
+        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+    )
+
+    def unexpected_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        raise AssertionError("fetch_parent_catalog_for should not be called")
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        unexpected_fetch,
+    )
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert result[catalog_cfg.parent_field].tolist() == ["CHEMBL1_PARENT"]
+    assert stats.missing == 0
+    assert stats.attached == 1
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -8,7 +8,11 @@ import pytest
 
 from library.chembl_client import ChemblClient
 from library.config import ApiCfg, MoleculeCatalogCfg
-from library.molecule_catalog import fetch_parent_catalog, load_parent_catalog
+from library.molecule_catalog import (
+    fetch_parent_catalog,
+    fetch_parent_catalog_for,
+    load_parent_catalog,
+)
 
 
 class DummyClient:
@@ -63,6 +67,68 @@ def test_fetch_parent_catalog_normalises_and_paginates(api_cfg: ApiCfg) -> None:
 
     assert client.calls  # ensure requests were issued
     assert result == {"CHEMBL1": "CHEMBL42", "CHEMBL2": "CHEMBL43"}
+
+
+def test_fetch_parent_catalog_for_returns_only_requested(api_cfg: ApiCfg) -> None:
+    responses = [
+        {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "chembl1",
+                    "parent_molecule_chembl_id": "chembl10",
+                },
+                {
+                    "molecule_chembl_id": "CHEMBL_EXTRA",
+                    "parent_molecule_chembl_id": "CHEMBL99",
+                },
+            ]
+        }
+    ]
+    client = DummyClient(responses)
+
+    result = fetch_parent_catalog_for(
+        [" chembl1 ", "CHEMBL_MISSING"],
+        client=client,
+        api_cfg=api_cfg,
+    )
+
+    assert len(client.calls) == 1
+    assert "CHEMBL1%2CCHEMBL_MISSING" in client.calls[0]
+    assert result == {"CHEMBL1": "CHEMBL10"}
+
+
+def test_fetch_parent_catalog_for_chunks_requests(
+    api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("library.molecule_catalog._PARENT_LOOKUP_CHUNK_SIZE", 1)
+    responses = [
+        {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "CHEMBL1",
+                    "parent_molecule_chembl_id": "CHEMBL10",
+                }
+            ]
+        },
+        {
+            "molecules": [
+                {
+                    "molecule_chembl_id": "CHEMBL2",
+                    "parent_molecule_chembl_id": "CHEMBL20",
+                }
+            ]
+        },
+    ]
+    client = DummyClient(responses)
+
+    result = fetch_parent_catalog_for(
+        ["CHEMBL1", "CHEMBL2"],
+        client=client,
+        api_cfg=api_cfg,
+    )
+
+    assert len(client.calls) == 2
+    assert result == {"CHEMBL1": "CHEMBL10", "CHEMBL2": "CHEMBL20"}
 
 
 def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:


### PR DESCRIPTION
## Summary
- add a selective `fetch_parent_catalog_for` helper that pages the ChEMBL molecule endpoint
- update parent enrichment to fetch only missing identifiers and fall back to cached data on failures
- extend unit tests to cover selective fetching and cache/remote fallback paths

## Testing
- pytest tests/test_molecule_catalog.py
- pytest tests/test_get_testitem_data.py -k "attach_parent_molecule_ids_"


------
https://chatgpt.com/codex/tasks/task_e_68d666c342588324bd095bfc88a32e35