### PR TITLE
Use molecule key for testitem CSV

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -451,7 +451,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept
     try:
-        key_cols = [c for c in ["salt_chembl_id"] if c in df.columns]
+        key_cols = ["molecule_chembl_id"]
         csv_path = io.write_csv(
             df,
             output,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -167,6 +167,19 @@ def test_run_chembl_merges_parent_catalog(
         lambda **__: {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"},
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(
+        gtd,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+            ),
+        ),
+    )
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")


### PR DESCRIPTION
## Summary
- ensure the testitem export always uses `molecule_chembl_id` as the key column
- adjust the test suite to stub parent lookup in the merge scenario for faster execution

## Testing
- pytest tests/test_get_testitem_data.py::test_run_chembl_column_order -q
- pytest tests/test_get_testitem_data.py::test_run_chembl_initialises_pubchem_session -q
- pytest tests/test_get_testitem_data.py::test_run_chembl_merges_parent_catalog -q
- pytest tests/test_get_testitem_data.py::test_run_chembl_parent_catalog_error -q
- pytest tests/test_get_testitem_data.py::test_run_chembl_parent_catalog_request_error -q


------
https://chatgpt.com/codex/tasks/task_e_68d668ba696c8324bfd491c63925f0ee