### PR TITLE
Ensure parent catalog lookup reuses cached state

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -77,6 +77,28 @@ class ParentLookupStats:
     attached: int
 
 
+def _determine_parent_source(
+    *,
+    cache_exists_before: bool,
+    cache_mtime_before: float | None,
+    cache_exists_after: bool,
+    cache_mtime_after: float | None,
+) -> str:
+    """Return the lookup source based on cache state transitions."""
+
+    if (
+        cache_exists_before
+        and cache_exists_after
+        and cache_mtime_before == cache_mtime_after
+    ):
+        return PARENT_LOOKUP_SOURCE_CACHE
+    if cache_exists_after:
+        return PARENT_LOOKUP_SOURCE_REMOTE
+    if cache_exists_before:
+        return PARENT_LOOKUP_SOURCE_CACHE
+    return PARENT_LOOKUP_SOURCE_REMOTE
+
+
 def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
     """Return ``series`` normalised to upper-case ChEMBL identifiers."""
 
@@ -96,6 +118,8 @@ def attach_parent_molecule_ids(
     api_cfg: ApiCfg,
     catalog_cfg: MoleculeCatalogCfg,
     timeout: float | None,
+    catalog: dict[str, str] | None = None,
+    source: str | None = None,
 ) -> tuple[pd.DataFrame, ParentLookupStats]:
     """Attach parent molecule identifiers using the ChEMBL catalogue."""
 
@@ -133,32 +157,43 @@ def attach_parent_molecule_ids(
         )
         return result, stats
 
-    cache_path = catalog_cfg.cache_path
-    cache_exists = cache_path.is_file()
-    cache_mtime = cache_path.stat().st_mtime if cache_exists else None
-
-    catalog = load_parent_catalog(
-        client=client,
-        api_cfg=api_cfg,
-        catalog_cfg=catalog_cfg,
-        timeout=timeout,
-    )
-
-    cache_exists_after = cache_path.is_file()
-    cache_mtime_after = cache_path.stat().st_mtime if cache_exists_after else None
-    if cache_exists_after and cache_exists and cache_mtime_after == cache_mtime:
-        source = PARENT_LOOKUP_SOURCE_CACHE
+    allow_fetch_missing = catalog is None
+    if catalog is None:
+        cache_path = catalog_cfg.cache_path
+        cache_exists_before = cache_path.is_file()
+        cache_mtime_before = (
+            cache_path.stat().st_mtime if cache_exists_before else None
+        )
+        catalog_data = load_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=catalog_cfg,
+            timeout=timeout,
+        )
+        cache_exists_after = cache_path.is_file()
+        cache_mtime_after = (
+            cache_path.stat().st_mtime if cache_exists_after else None
+        )
+        parent_source = _determine_parent_source(
+            cache_exists_before=cache_exists_before,
+            cache_mtime_before=cache_mtime_before,
+            cache_exists_after=cache_exists_after,
+            cache_mtime_after=cache_mtime_after,
+        )
     else:
-        source = PARENT_LOOKUP_SOURCE_REMOTE
+        catalog_data = dict(catalog)
+        parent_source = source or PARENT_LOOKUP_SOURCE_REMOTE
 
     normalised_child = _normalise_chembl_ids(result[child_column])
     unique_children = normalised_child[normalised_child != ""].unique()
 
-    parent_map = {key: catalog[key] for key in unique_children if key in catalog}
+    parent_map = {
+        key: catalog_data[key] for key in unique_children if key in catalog_data
+    }
     missing_ids = [key for key in unique_children if key not in parent_map]
     fetched_remote = False
 
-    if missing_ids:
+    if missing_ids and allow_fetch_missing:
         try:
             fetched = molecule_catalog.fetch_parent_catalog_for(
                 missing_ids,
@@ -173,7 +208,7 @@ def attach_parent_molecule_ids(
             if fetched:
                 fetched_remote = True
         if fetched:
-            catalog.update(fetched)
+            catalog_data.update(fetched)
             parent_map.update(fetched)
 
     parent_series = normalised_child.map(parent_map)
@@ -191,7 +226,7 @@ def attach_parent_molecule_ids(
     attached = len(result) - missing
 
     stats = ParentLookupStats(
-        source=PARENT_LOOKUP_SOURCE_REMOTE if fetched_remote else source,
+        source=PARENT_LOOKUP_SOURCE_REMOTE if fetched_remote else parent_source,
         missing=missing,
         unique=int(len(unique_children)),
         attached=int(attached),
@@ -340,6 +375,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("identifiers_retrieved", count=len(ids))
         logger.info("chembl_fetch_start", batch_size=cfg.testitem.batch_size)
 
+        cache_path = cfg.molecule_catalog.cache_path
+        cache_exists_before = cache_path.is_file()
+        cache_mtime_before = (
+            cache_path.stat().st_mtime if cache_exists_before else None
+        )
         try:
             parent_catalog = load_parent_catalog(
                 client=client,
@@ -354,6 +394,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 path=str(cfg.molecule_catalog.cache_path),
             )
             return 1
+        cache_exists_after = cache_path.is_file()
+        cache_mtime_after = (
+            cache_path.stat().st_mtime if cache_exists_after else None
+        )
+        parent_source = _determine_parent_source(
+            cache_exists_before=cache_exists_before,
+            cache_mtime_before=cache_mtime_before,
+            cache_exists_after=cache_exists_after,
+            cache_mtime_after=cache_mtime_after,
+        )
 
         try:
             df = cl.get_testitem(
@@ -402,6 +452,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 api_cfg=cfg.api,
                 catalog_cfg=cfg.molecule_catalog,
                 timeout=cfg.testitem.timeout,
+                catalog=parent_catalog,
+                source=parent_source,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.error("parent_lookup_failed", error=str(exc))

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -150,6 +150,15 @@ def test_run_chembl_merges_parent_catalog(
 
     monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1", "CHEMBL2"]))
 
+    cache_path = tmp_path / "parent_catalog.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    cfg.molecule_catalog.cache_path = cache_path
+
+    catalog_data = {
+        "CHEMBL1": "CHEMBL1_PARENT",
+        "CHEMBL2": "CHEMBL2_PARENT",
+    }
+
     source = pd.DataFrame(
         [
             {"molecule_chembl_id": "CHEMBL1", "parent_molecule_chembl_id": None},
@@ -164,13 +173,16 @@ def test_run_chembl_merges_parent_catalog(
     monkeypatch.setattr(
         gtd,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"},
+        lambda **__: dict(catalog_data),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
-    monkeypatch.setattr(
-        gtd,
-        "attach_parent_molecule_ids",
-        lambda frame, **kwargs: (
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_attach(frame: pd.DataFrame, **kwargs: object) -> tuple[pd.DataFrame, object]:
+        captured_kwargs["catalog"] = kwargs.get("catalog")
+        captured_kwargs["source"] = kwargs.get("source")
+        return (
             frame,
             gtd.ParentLookupStats(
                 source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
@@ -178,8 +190,9 @@ def test_run_chembl_merges_parent_catalog(
                 unique=0,
                 attached=0,
             ),
-        ),
-    )
+        )
+
+    monkeypatch.setattr(gtd, "attach_parent_molecule_ids", fake_attach)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
@@ -208,6 +221,8 @@ def test_run_chembl_merges_parent_catalog(
         "CHEMBL1_PARENT",
         "CHEMBL2_EXISTING",
     ]
+    assert captured_kwargs["catalog"] == catalog_data
+    assert captured_kwargs["source"] == gtd.PARENT_LOOKUP_SOURCE_CACHE
 
 
 def test_attach_parent_ids_preserves_existing_values_when_cache_has_no_matches(
@@ -228,6 +243,11 @@ def test_attach_parent_ids_preserves_existing_values_when_cache_has_no_matches(
     )
 
     monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *args, **kwargs: {},
+    )
 
     result, stats = gtd.attach_parent_molecule_ids(
         source,
@@ -245,6 +265,35 @@ def test_attach_parent_ids_preserves_existing_values_when_cache_has_no_matches(
     )
     assert stats.missing == 2
     assert stats.attached == 0
+
+
+def test_attach_parent_molecule_ids_uses_provided_catalog(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    monkeypatch.setattr(
+        gtd,
+        "load_parent_catalog",
+        lambda **__: (_ for _ in ()).throw(AssertionError("load should not be called")),
+    )
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.api,
+        catalog_cfg=cfg.molecule_catalog,
+        timeout=None,
+        catalog={"CHEMBL1": "CHEMBL1_PARENT"},
+        source=gtd.PARENT_LOOKUP_SOURCE_CACHE,
+    )
+
+    assert result[cfg.molecule_catalog.parent_field].tolist() == [
+        "CHEMBL1_PARENT"
+    ]
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+    assert stats.missing == 0
+    assert stats.attached == 1
 
 
 def test_run_chembl_parent_catalog_error(
@@ -360,7 +409,7 @@ def test_attach_parent_molecule_ids_fetches_missing(
     catalog_cfg.cache_path = tmp_path / "catalog.json"
 
     monkeypatch.setattr(
-        gtd.molecule_catalog,
+        gtd,
         "load_parent_catalog",
         lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
     )
@@ -412,7 +461,7 @@ def test_attach_parent_molecule_ids_fetch_failure(
     catalog_cfg.cache_path = tmp_path / "catalog.json"
 
     monkeypatch.setattr(
-        gtd.molecule_catalog,
+        gtd,
         "load_parent_catalog",
         lambda **__: {},
     )
@@ -458,7 +507,7 @@ def test_attach_parent_molecule_ids_uses_cache_only(
     catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
 
     monkeypatch.setattr(
-        gtd.molecule_catalog,
+        gtd,
         "load_parent_catalog",
         lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
     )


### PR DESCRIPTION
## Summary
- determine the parent catalog source in `run_chembl` by comparing cache state before and after loading
- allow `attach_parent_molecule_ids` to accept a pre-loaded catalog and source so additional API calls are skipped
- extend test coverage to verify catalog reuse, reported lookup source, and the absence of redundant loads

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d66d01e9088324b203030937e912bf