### PR TITLE
Add action property annotations and smoke tests for activities CLI

### DIFF
--- a/library/activity_action_properties.py
+++ b/library/activity_action_properties.py
@@ -1,0 +1,233 @@
+"""Derive action annotations and structured metadata for activity records."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Any
+
+import pandas as pd
+
+from .log import logger
+
+# Keywords describing allosteric modulation effects.  The lists intentionally
+# focus on clear-cut textual cues that commonly appear in ChEMBL annotations.
+_POSITIVE_KEYWORDS = {
+    "positive allosteric",  # explicit mention in comments/assay descriptions
+    "pam",  # abbreviation frequently used by submitters
+}
+_NEGATIVE_KEYWORDS = {
+    "negative allosteric",
+    "nam",
+}
+_ALLOSTERIC_KEYWORDS = {
+    "allosteric modulator",
+    "allosteric inhibitor",
+    "allosteric activator",
+}
+
+# Mapping between measurement types and a coarse category used for downstream
+# aggregation.  The mapping is intentionally small; values falling outside the
+# dictionary keep their ``standard_type`` but trigger a log entry so that data
+# engineers notice new metrics.
+_MEASUREMENT_KIND = {
+    "IC50": "inhibition",
+    "EC50": "activation",
+    "AC50": "activation",
+    "Ki": "binding",
+    "Kd": "binding",
+}
+
+
+def _has_value(value: Any) -> bool:
+    """Return ``True`` if *value* should be preserved in the JSON payload."""
+
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set)):
+        return any(_has_value(item) for item in value)
+    if isinstance(value, Mapping):
+        return any(_has_value(item) for item in value.values())
+    try:
+        return not pd.isna(value)
+    except TypeError:  # pragma: no cover - non-numeric objects
+        return True
+
+
+def _clean_structure(data: Any) -> Any:
+    """Recursively remove empty values from nested ``dict``/``list`` objects."""
+
+    if isinstance(data, Mapping):
+        cleaned = {
+            key: _clean_structure(value)
+            for key, value in data.items()
+            if _has_value(value)
+        }
+        return cleaned if cleaned else None
+    if isinstance(data, list):
+        cleaned_list = [item for item in (_clean_structure(v) for v in data) if _has_value(item)]
+        return cleaned_list if cleaned_list else None
+    if isinstance(data, tuple):
+        cleaned_tuple = tuple(
+            item for item in (_clean_structure(v) for v in data) if _has_value(item)
+        )
+        return cleaned_tuple if cleaned_tuple else None
+    return data
+
+
+def _coalesce(*values: Any) -> Any:
+    """Return the first non-empty entry from ``values``."""
+
+    for value in values:
+        if _has_value(value):
+            return value
+    return None
+
+
+def _collect_text(record: Mapping[str, Any]) -> str:
+    """Concatenate textual annotations for keyword detection."""
+
+    parts: list[str] = []
+    for key in (
+        "activity_comment",
+        "data_validity_comment",
+        "data_validity_description",
+        "assay_description",
+    ):
+        value = record.get(key)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                parts.append(stripped)
+    return " ".join(parts).lower()
+
+
+def _extract_effect_features(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return effect flags inferred from textual annotations in ``record``."""
+
+    text = _collect_text(record)
+    positive_hits = sorted({kw for kw in _POSITIVE_KEYWORDS if kw in text})
+    negative_hits = sorted({kw for kw in _NEGATIVE_KEYWORDS if kw in text})
+    is_allosteric = bool(positive_hits or negative_hits or any(kw in text for kw in _ALLOSTERIC_KEYWORDS))
+    return {
+        "allosteric": is_allosteric,
+        "positive": bool(positive_hits),
+        "negative": bool(negative_hits),
+        "positive_terms": positive_hits,
+        "negative_terms": negative_hits,
+    }
+
+
+def infer_action_type(features: Mapping[str, Any]) -> str | None:
+    """Infer the high-level action type from *features* flags.
+
+    ``features`` is expected to contain boolean flags ``positive`` and
+    ``negative``.  When both are present the effect is ambiguous and the
+    function returns ``None`` after logging a warning.  Positive hits map to the
+    ``PAM`` label and negative hits map to ``NAM``.
+    """
+
+    positive = bool(features.get("positive"))
+    negative = bool(features.get("negative"))
+    if positive and negative:
+        logger.warning(
+            "effect_conflict",
+            positive_terms=features.get("positive_terms", []),
+            negative_terms=features.get("negative_terms", []),
+        )
+        return None
+    if positive:
+        return "PAM"
+    if negative:
+        return "NAM"
+    return None
+
+
+def build_activity_properties(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a structured metadata payload for ``record`` suitable for JSON."""
+
+    features = _extract_effect_features(record)
+    measurement_type = _coalesce(record.get("standard_type"), record.get("type"))
+    units = _coalesce(record.get("standard_units"), record.get("units"))
+    relation = _coalesce(record.get("standard_relation"), record.get("relation"))
+    measurement: dict[str, Any] = {
+        "type": measurement_type,
+        "value": record.get("standard_value"),
+        "relation": relation,
+        "units": units,
+        "lower_value": record.get("lower_value"),
+        "upper_value": record.get("upper_value"),
+        "pchembl_value": record.get("pchembl_value"),
+        "qudt_units": record.get("qudt_units"),
+    }
+    kind = _MEASUREMENT_KIND.get(measurement_type)
+    if measurement_type and kind is None:
+        logger.info("metric_unmapped", standard_type=measurement_type)
+    if kind:
+        measurement["kind"] = kind
+    measurement = _clean_structure(measurement) or {}
+
+    assay_info = _clean_structure(
+        {
+            "assay_chembl_id": record.get("assay_chembl_id"),
+            "description": record.get("assay_description"),
+            "bao_label": record.get("bao_label"),
+            "bao_format": record.get("bao_format"),
+            "variant": {
+                "accession": record.get("assay_variant_accession"),
+                "mutation": record.get("assay_variant_mutation"),
+            },
+        }
+    )
+
+    comments = [
+        value.strip()
+        for value in (
+            record.get("activity_comment"),
+            record.get("data_validity_comment"),
+            record.get("data_validity_description"),
+        )
+        if isinstance(value, str) and value.strip()
+    ]
+
+    payload: dict[str, Any] = {"measurement": measurement}
+    if assay_info:
+        payload["assay"] = assay_info
+    if comments:
+        payload["comments"] = comments
+    if features:
+        payload["effect_features"] = features
+    return payload
+
+
+def annotate_action_properties(df: pd.DataFrame) -> pd.DataFrame:
+    """Attach ``activity_properties`` JSON and ``action_type`` to ``df``."""
+
+    if df.empty:
+        result = df.copy()
+        result["activity_properties"] = pd.Series(dtype=object)
+        result["action_type"] = pd.Series(dtype=object)
+        return result
+
+    properties: list[str] = []
+    action_types: list[str | None] = []
+    for record in df.to_dict(orient="records"):
+        payload = build_activity_properties(record)
+        features = payload.get("effect_features", {})
+        action_types.append(infer_action_type(features))
+        properties.append(json.dumps(payload, sort_keys=True))
+
+    result = df.copy()
+    result["activity_properties"] = properties
+    result["action_type"] = action_types
+    return result
+
+
+__all__ = [
+    "annotate_action_properties",
+    "build_activity_properties",
+    "infer_action_type",
+]
+

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -51,6 +51,8 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         ),
         "lower_value": pa.Column(float, required=False, nullable=True, coerce=True),
         "upper_value": pa.Column(float, required=False, nullable=True, coerce=True),
+        "activity_properties": pa.Column(str, required=False, nullable=True),
+        "action_type": pa.Column(str, required=False, nullable=True),
         "pipeline_version": pa.Column(str, required=False, nullable=True),
         "timestamp_utc": pa.Column(str, required=False, nullable=True),
         #    "pA_value": pa.Column(float, pa.Check.in_range(-14, 14), required=False),

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -22,6 +22,7 @@ from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
 from library import io
+from library.activity_action_properties import annotate_action_properties
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -427,6 +428,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_activities(df)
+        df = annotate_action_properties(df)
         df = add_pipeline_metadata(df)
         df = compute_activity_bounds(df, cfg.activity_bounds)
         # Determine final column order: schema-defined columns first in their

--- a/tests/data/activities_invalid.json
+++ b/tests/data/activities_invalid.json
@@ -2,10 +2,16 @@
     {
         "activity_id": 2,
         "molecule_chembl_id": "CHEMBL3",
+        "assay_chembl_id": "A0",
         "target_id": "CHEMBL4",
         "standard_type": "IC50",
         "standard_value": -1.0,
+        "standard_relation": ">=",
         "relation": ">",
+        "standard_units": "uM",
         "units": "10 μM",
+        "activity_comment": "negative allosteric modulator",
+        "assay_description": "Binding displacement assay",
+        "data_validity_comment": "Out of range",
     }
 ]

--- a/tests/data/activities_mixed.csv
+++ b/tests/data/activities_mixed.csv
@@ -1,3 +1,3 @@
-activity_id,molecule_chembl_id,target_id,standard_type,standard_value,relation,units
-1,CHEMBL1,CHEMBL2,IC50,5.0,<,5 μM
-2,CHEMBL3,CHEMBL4,IC50,-1.0,>,10 μM
+activity_id,molecule_chembl_id,assay_chembl_id,target_id,standard_type,standard_value,standard_relation,relation,standard_units,units,activity_comment,assay_description,assay_variant_accession,assay_variant_mutation,data_validity_comment
+1,CHEMBL1,A0,CHEMBL2,IC50,5.0,<=,<,uM,5 μM,,Cell-based potency assay,,,Valid measurement
+2,CHEMBL3,A0,CHEMBL4,IC50,-1.0,>=,>,uM,10 μM,Outlier,N/A,,,Value below detection

--- a/tests/data/activities_valid.csv
+++ b/tests/data/activities_valid.csv
@@ -1,2 +1,2 @@
-activity_id,molecule_chembl_id,target_id,standard_type,standard_value,relation,units
-1,CHEMBL1,CHEMBL2,IC50,5.0,<,5 μM
+activity_id,molecule_chembl_id,assay_chembl_id,target_id,standard_type,standard_value,standard_relation,relation,standard_units,units,activity_comment,assay_description,assay_variant_accession,assay_variant_mutation,data_validity_comment
+1,CHEMBL1,A0,CHEMBL2,IC50,5.0,<=,<,uM,5 μM,,Calcium flux assay,,,

--- a/tests/smoke/test_activity_action_properties_smoke.py
+++ b/tests/smoke/test_activity_action_properties_smoke.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import yaml
+
+from library.config import Config
+from tests.test_activity_extraction import DummyChemblClient  # type: ignore
+
+
+def test_activity_action_properties_cli(tmp_path: Path, monkeypatch) -> None:
+    from scripts import get_activity_data
+
+    input_csv = tmp_path / "activities.csv"
+    input_csv.write_text("activity_id\nA1\nA2\n", encoding="utf-8")
+    output_csv = tmp_path / "result.csv"
+
+    df = pd.DataFrame(
+        [
+            {
+                "activity_id": "A1",
+                "molecule_chembl_id": "CHEMBL1",
+                "assay_chembl_id": "AS1",
+                "standard_value": 1.0,
+                "standard_type": "IC50",
+                "activity_comment": "positive allosteric modulator",
+                "assay_description": "Calcium flux",
+            },
+            {
+                "activity_id": "A2",
+                "molecule_chembl_id": "CHEMBL2",
+                "assay_chembl_id": "AS1",
+                "standard_value": 2.0,
+                "standard_type": "IC50",
+                "activity_comment": "negative allosteric modulator",
+                "assay_description": "Binding displacement",
+            },
+        ]
+    )
+
+    monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
+    monkeypatch.setattr("scripts.get_activity_data.cl.get_activities", lambda *_, **__: df)
+    monkeypatch.setattr("scripts.get_activity_data.analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr("scripts.get_activity_data.write_meta_yaml", lambda **__: None)
+    monkeypatch.setattr("scripts.get_activity_data.file_sha256", lambda _: "deadbeef")
+
+    cfg = Config()
+    cfg.io.output_dir = tmp_path / "output"
+    cfg.io.cache_dir = tmp_path / "cache"
+    cfg.activity.column = "activity_id"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(cfg.model_dump(mode="json"), sort_keys=False),
+        encoding="utf-8",
+    )
+
+    exit_code = get_activity_data.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+        ]
+    )
+    assert exit_code == 0
+
+    result = pd.read_csv(output_csv)
+    assert set(["action_type", "activity_properties"]).issubset(result.columns)
+    assert result["action_type"].tolist() == ["PAM", "NAM"]
+
+    payloads = result["activity_properties"].map(json.loads).tolist()
+    assert payloads[0]["effect_features"]["positive"] is True
+    assert payloads[1]["effect_features"]["negative"] is True

--- a/tests/test_activity_action_properties.py
+++ b/tests/test_activity_action_properties.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from library.activity_action_properties import (
+    annotate_action_properties,
+    build_activity_properties,
+    infer_action_type,
+)
+
+
+def _activity_record(**overrides: object) -> dict[str, object]:
+    base = {
+        "activity_comment": "",
+        "assay_description": "",
+        "standard_type": "IC50",
+        "standard_value": 10.0,
+        "standard_relation": "=",
+        "standard_units": "nM",
+        "relation": "=",
+        "units": "nM",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_infer_action_type_positive_allosteric() -> None:
+    features = {"positive": True, "negative": False, "positive_terms": ["pam"]}
+    assert infer_action_type(features) == "PAM"
+
+
+def test_infer_action_type_negative_allosteric() -> None:
+    features = {"positive": False, "negative": True, "negative_terms": ["nam"]}
+    assert infer_action_type(features) == "NAM"
+
+
+def test_infer_action_type_conflict_logged(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def capture(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr("library.activity_action_properties.logger.warning", capture)
+
+    result = infer_action_type(
+        {
+            "positive": True,
+            "negative": True,
+            "positive_terms": ["pam"],
+            "negative_terms": ["nam"],
+        }
+    )
+    assert result is None
+    assert calls and calls[0]["args"][0] == "effect_conflict"
+
+
+def test_build_activity_properties_logs_unmapped_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def capture(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr("library.activity_action_properties.logger.info", capture)
+
+    payload = build_activity_properties(
+        _activity_record(standard_type="TGI50", activity_comment="Positive allosteric modulator")
+    )
+    assert payload["measurement"]["type"] == "TGI50"
+    assert calls and calls[0]["args"][0] == "metric_unmapped"
+
+
+def test_build_activity_properties_filters_empty_values() -> None:
+    payload = build_activity_properties(
+        _activity_record(
+            activity_comment=" ",
+            data_validity_comment="",
+            assay_description="Calcium flux",
+            assay_variant_accession=None,
+            assay_variant_mutation="",
+            standard_units="",
+            qudt_units=None,
+        )
+    )
+    assert "comments" not in payload
+    assert payload["assay"] == {"description": "Calcium flux"}
+    assert "qudt_units" not in payload["measurement"]
+
+
+def test_annotate_action_properties_generates_json() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "activity_id": "A1",
+                "molecule_chembl_id": "CHEMBL1",
+                "assay_chembl_id": "AS1",
+                "standard_type": "IC50",
+                "standard_value": 1.0,
+                "activity_comment": "positive allosteric modulator",
+            }
+        ]
+    )
+    result = annotate_action_properties(df)
+    assert "activity_properties" in result
+    payload = json.loads(result.loc[0, "activity_properties"])
+    assert result.loc[0, "action_type"] == "PAM"
+    assert payload["measurement"]["value"] == 1.0
+

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -126,6 +126,8 @@ def test_run_chembl_column_order(
         "timestamp_utc",
         "lower_value",
         "upper_value",
+        "activity_properties",
+        "action_type",
     }
     expected_head = [c for c in schema_cols if c in available]
     expected_tail = sorted(available - set(schema_cols))


### PR DESCRIPTION
## Summary
- add a helper module that derives effect features, action types, and a filtered JSON payload for activities
- enrich the get_activity_data CLI and schema/fixtures to emit the new action_type and activity_properties columns
- cover the new behaviour with dedicated unit tests and a CLI smoke test exercising PAM/NAM detection

## Testing
- pytest tests/test_activity_action_properties.py
- pytest tests/smoke/test_activity_action_properties_smoke.py
- pytest tests/test_get_activity_data.py tests/test_activity_schema_sidecar.py tests/test_schemas.py


------
https://chatgpt.com/codex/tasks/task_e_68d66c5d28f48324a3b714023265ef97