### PR TITLE
Add configurable activity enrichment controls

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -75,6 +75,115 @@
       "title": "ActivityBoundsCfg",
       "type": "object"
     },
+    "ActivityActionTypeCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "column": {
+          "default": "action_type",
+          "title": "Column",
+          "type": "string"
+        },
+        "log_missing": {
+          "default": true,
+          "title": "Log Missing",
+          "type": "boolean"
+        },
+        "log_distribution": {
+          "default": true,
+          "title": "Log Distribution",
+          "type": "boolean"
+        }
+      },
+      "title": "ActivityActionTypeCfg",
+      "type": "object"
+    },
+    "ActivityPropertiesCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "column": {
+          "default": "activity_properties",
+          "title": "Column",
+          "type": "string"
+        },
+        "summary_column": {
+          "default": "activity_property_summary",
+          "title": "Summary Column",
+          "type": "string"
+        },
+        "name_field": {
+          "default": "type",
+          "title": "Name Field",
+          "type": "string"
+        },
+        "value_field": {
+          "default": "value",
+          "title": "Value Field",
+          "type": "string"
+        },
+        "units_field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "units",
+          "title": "Units Field"
+        },
+        "separator": {
+          "default": "; ",
+          "title": "Separator",
+          "type": "string"
+        },
+        "pair_separator": {
+          "default": "=",
+          "title": "Pair Separator",
+          "type": "string"
+        },
+        "drop_source_column": {
+          "default": true,
+          "title": "Drop Source Column",
+          "type": "boolean"
+        },
+        "log_missing": {
+          "default": false,
+          "title": "Log Missing",
+          "type": "boolean"
+        },
+        "log_distribution": {
+          "default": false,
+          "title": "Log Distribution",
+          "type": "boolean"
+        }
+      },
+      "title": "ActivityPropertiesCfg",
+      "type": "object"
+    },
+    "ActivityEnrichmentCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "action_type": {
+          "$ref": "#/$defs/ActivityActionTypeCfg"
+        },
+        "activity_properties": {
+          "$ref": "#/$defs/ActivityPropertiesCfg"
+        }
+      },
+      "title": "ActivityEnrichmentCfg",
+      "type": "object"
+    },
     "ApiCfg": {
       "additionalProperties": false,
       "description": "Settings for ChEMBL API access.",
@@ -1335,6 +1444,9 @@
     },
     "activity_bounds": {
       "$ref": "#/$defs/ActivityBoundsCfg"
+    },
+    "activity_enrichment": {
+      "$ref": "#/$defs/ActivityEnrichmentCfg"
     },
     "system": {
       "$ref": "#/$defs/SystemCfg"

--- a/config.yaml
+++ b/config.yaml
@@ -159,11 +159,32 @@ local:
     cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA_CACHE_DIR)
     csv_sep: ","  # CSV field separator
     csv_encoding: "utf-8-sig"  # Encoding for CSV files
+    na_markers:
+      - "#N/A"
     exist_ok: true  # Create directories with ensure_dirs if missing
   init:
     same_doc: "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"  # Source workbook
     all_doc: "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
     output_dir: "data/output/ChEMBL/processed"  # Output directory for processed files
+
+activity_enrichment:
+  action_type:
+    enabled: true
+    column: "action_type"
+    log_missing: true
+    log_distribution: true
+  activity_properties:
+    enabled: false
+    column: "activity_properties"
+    summary_column: "activity_property_summary"
+    name_field: "type"
+    value_field: "value"
+    units_field: "units"
+    separator: "; "
+    pair_separator: "="
+    drop_source_column: true
+    log_missing: false
+    log_distribution: false
 
 activity_bounds:
   enable_from_relation: true      # Derive bounds from relation/value pairs when explicit bounds are absent

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from urllib.parse import urljoin
 
 import pandas as pd
@@ -238,6 +238,7 @@ def get_activities(
     client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
+    extra_columns: Sequence[str] | None = None,
 ) -> pd.DataFrame:
     """Fetch activity records for *ids*.
 
@@ -284,9 +285,19 @@ def get_activities(
                 "chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key}
             )
     if not records:
-        return pd.DataFrame(columns=ACTIVITY_COLUMNS)
+        columns = list(ACTIVITY_COLUMNS)
+        if extra_columns:
+            for column in extra_columns:
+                if column not in columns:
+                    columns.append(column)
+        return pd.DataFrame(columns=columns)
     df = pd.concat(records, ignore_index=True)
-    return df.reindex(columns=ACTIVITY_COLUMNS)
+    columns = list(ACTIVITY_COLUMNS)
+    if extra_columns:
+        for column in extra_columns:
+            if column not in columns:
+                columns.append(column)
+    return df.reindex(columns=columns)
 
 
 def get_testitem(

--- a/library/config.py
+++ b/library/config.py
@@ -387,6 +387,73 @@ class ActivityBoundsCfg(_BoolModel):
         return cls._parse_bool(v)
 
 
+class ActivityActionTypeCfg(_BoolModel):
+    enabled: bool = True
+    column: str = "action_type"
+    log_missing: bool = True
+    log_distribution: bool = True
+
+    @field_validator("enabled", "log_missing", "log_distribution", mode="before")
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+    @field_validator("column")
+    @classmethod
+    def _column(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("activity_enrichment.action_type.column must be non-empty")
+        return v
+
+
+class ActivityPropertiesCfg(_BoolModel):
+    enabled: bool = False
+    column: str = "activity_properties"
+    summary_column: str = "activity_property_summary"
+    name_field: str = "type"
+    value_field: str = "value"
+    units_field: str | None = "units"
+    separator: str = "; "
+    pair_separator: str = "="
+    drop_source_column: bool = True
+    log_missing: bool = False
+    log_distribution: bool = False
+
+    @field_validator(
+        "enabled",
+        "drop_source_column",
+        "log_missing",
+        "log_distribution",
+        mode="before",
+    )
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+    @field_validator(
+        "column",
+        "summary_column",
+        "name_field",
+        "value_field",
+        "separator",
+        "pair_separator",
+    )
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v or not str(v).strip():
+            raise ValueError("activity_enrichment.activity_properties fields must be non-empty")
+        return v
+
+
+class ActivityEnrichmentCfg(_BaseModel):
+    action_type: ActivityActionTypeCfg = Field(
+        default_factory=lambda: ActivityActionTypeCfg()
+    )
+    activity_properties: ActivityPropertiesCfg = Field(
+        default_factory=lambda: ActivityPropertiesCfg()
+    )
+
+
 class ActivityCfg(_BoolModel):
     column: str = "activity_id"
     batch_size: int = Field(5, ge=1)
@@ -550,6 +617,9 @@ class Config(_BaseModel):
     system: SystemCfg = Field(default_factory=lambda: SystemCfg())
     activity_bounds: ActivityBoundsCfg = Field(
         default_factory=lambda: ActivityBoundsCfg()
+    )
+    activity_enrichment: ActivityEnrichmentCfg = Field(
+        default_factory=lambda: ActivityEnrichmentCfg()
     )
 
     # -- Compatibility accessors -------------------------------------------------
@@ -1055,6 +1125,9 @@ __all__ = [
     "SemanticScholarCfg",
     "DocTypeCfg",
     "ActivityCfg",
+    "ActivityActionTypeCfg",
+    "ActivityEnrichmentCfg",
+    "ActivityPropertiesCfg",
     "AssayCfg",
     "TestitemCfg",
     "DocumentPubmedCfg",

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -12,7 +12,8 @@ if __package__ is None:  # running as a script
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import argparse
-from collections.abc import Iterable, Sequence
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
 from itertools import islice
 
 import numpy as np
@@ -32,7 +33,9 @@ from library.cli import (
     build_parser as base_parser,
 )
 from library.config import (
+    ActivityActionTypeCfg,
     ActivityBoundsCfg,
+    ActivityPropertiesCfg,
     Config,
     _serialize_paths,
     ensure_dirs,
@@ -353,6 +356,135 @@ def compute_activity_bounds(
     return result
 
 
+def _normalise_text(value: object) -> str | None:
+    """Return a stripped string representation or ``None`` for blanks."""
+
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except TypeError:
+        pass
+    text = str(value).strip()
+    return text or None
+
+
+def enrich_action_type(
+    df: pd.DataFrame, cfg: ActivityActionTypeCfg
+) -> pd.DataFrame:
+    """Normalise and optionally retain ``action_type`` values."""
+
+    needs_column = cfg.enabled or cfg.log_missing or cfg.log_distribution
+    column = cfg.column
+    if column not in df.columns:
+        if needs_column:
+            logger.info("activity_action_type_column_missing", column=column)
+        return df
+
+    series = df[column].astype("string").str.strip().replace({"": pd.NA})
+    result = df.copy()
+    if cfg.enabled:
+        result[column] = series
+    else:
+        result = result.drop(columns=[column])
+
+    if cfg.log_missing:
+        missing = int(series.isna().sum())
+        if missing:
+            logger.warning("activity_action_type_missing", rows=missing)
+
+    if cfg.log_distribution:
+        counts = series.dropna().value_counts()
+        if not counts.empty:
+            logger.info(
+                "activity_action_type_distribution",
+                counts={str(key): int(value) for key, value in sorted(counts.items())},
+            )
+
+    return result
+
+
+def enrich_activity_properties(
+    df: pd.DataFrame, cfg: ActivityPropertiesCfg
+) -> pd.DataFrame:
+    """Summarise nested ``activity_properties`` entries."""
+
+    needs_column = cfg.enabled or cfg.log_missing or cfg.log_distribution
+    if not needs_column:
+        return df
+
+    column = cfg.column
+    if column not in df.columns:
+        logger.info("activity_properties_column_missing", column=column)
+        return df
+
+    result = df.copy()
+    series = result[column]
+    summaries: list[object] = []
+    name_counts: Counter[str] = Counter()
+
+    for value in series:
+        if value is None:
+            summaries.append(pd.NA)
+            continue
+        if value is pd.NA:  # pragma: no cover - pandas-specific sentinel
+            summaries.append(pd.NA)
+            continue
+        if isinstance(value, Mapping):
+            items = [value]
+        elif isinstance(value, (list, tuple)):
+            items = list(value)
+        else:
+            summaries.append(pd.NA)
+            continue
+
+        entries: list[str] = []
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            name = _normalise_text(item.get(cfg.name_field))
+            if not name:
+                continue
+            name_counts[name] += 1
+            value_text = _normalise_text(item.get(cfg.value_field))
+            if value_text is None:
+                continue
+            pair = f"{name}{cfg.pair_separator}{value_text}"
+            if cfg.units_field:
+                units_text = _normalise_text(item.get(cfg.units_field))
+                if units_text:
+                    pair = f"{pair} ({units_text})"
+            entries.append(pair)
+
+        if entries:
+            summaries.append(cfg.separator.join(entries))
+        else:
+            summaries.append(pd.NA)
+
+    summary_series = pd.Series(summaries, index=result.index, dtype="string")
+
+    if cfg.enabled:
+        result[cfg.summary_column] = summary_series
+        if cfg.drop_source_column and column in result:
+            result = result.drop(columns=[column])
+    elif cfg.drop_source_column and column in result:
+        result = result.drop(columns=[column])
+
+    if cfg.log_missing:
+        missing_rows = int(summary_series.isna().sum())
+        if missing_rows:
+            logger.warning("activity_properties_missing", rows=missing_rows)
+
+    if cfg.log_distribution and name_counts:
+        logger.info(
+            "activity_properties_distribution",
+            counts={name: int(count) for name, count in sorted(name_counts.items())},
+        )
+
+    return result
+
+
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute activity retrieval from the ChEMBL API.
 
@@ -408,6 +540,24 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             ids = limited
             logger.info("process_limit", limit=len(limited))
 
+        enrichment_cfg = cfg.activity_enrichment
+        extra_columns: list[str] = []
+        action_cfg = enrichment_cfg.action_type
+        if (
+            action_cfg.enabled
+            or action_cfg.log_missing
+            or action_cfg.log_distribution
+        ):
+            extra_columns.append(action_cfg.column)
+        properties_cfg = enrichment_cfg.activity_properties
+        if (
+            properties_cfg.enabled
+            or properties_cfg.log_missing
+            or properties_cfg.log_distribution
+        ):
+            extra_columns.append(properties_cfg.column)
+        extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}
+
         try:
             df = cl.get_activities(
                 ids,
@@ -415,6 +565,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 client=client,
                 chunk_size=cfg.activity.batch_size,
                 timeout=cfg.activity.timeout,
+                **extra_kwargs,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.error(
@@ -429,6 +580,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = normalize_activities(df)
         df = add_pipeline_metadata(df)
         df = compute_activity_bounds(df, cfg.activity_bounds)
+        df = enrich_action_type(df, enrichment_cfg.action_type)
+        df = enrich_activity_properties(df, enrichment_cfg.activity_properties)
         # Determine final column order: schema-defined columns first in their
         # declared sequence, followed by any additional columns sorted
         # alphabetically to provide deterministic output.

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -64,7 +64,9 @@ def test_get_activity_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.Mon
     output_csv = smoke_output_dir / "activity.csv"
     _cleanup_output(output_csv)
 
-    def fake_get_activities(ids, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+    def fake_get_activities(
+        ids, cfg, client, chunk_size, timeout, **kwargs
+    ):  # type: ignore[no-untyped-def]
         rows: list[dict[str, object]] = []
         for idx, raw_id in enumerate(ids, start=1):
             activity_id = int(str(raw_id))

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -56,9 +56,11 @@ def _run(
         client: Any,
         chunk_size: int,
         timeout: float,
+        **kwargs: object,
     ) -> pd.DataFrame:
         data = list(ids)
         called["batch_size"] = chunk_size
+        called["extra_columns"] = kwargs.get("extra_columns")
         return pd.DataFrame({"activity_id": data})
 
     def fake_write(

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -81,7 +81,9 @@ def test_cli_success(
 
     monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
 
-    def fake_get(ids, *, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+    def fake_get(
+        ids, *, cfg, client, chunk_size, timeout, **kwargs
+    ):  # type: ignore[no-untyped-def]
         assert list(ids) == ["A1", "A2"]
         return df
 
@@ -101,7 +103,12 @@ def test_cli_success(
     assert exit_code == 0
     assert output_csv.exists()
     result = pd.read_csv(output_csv)
-    expected_columns = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    expected_columns = set(df.columns) | {
+        "pipeline_version",
+        "timestamp_utc",
+        "lower_value",
+        "upper_value",
+    }
     assert set(result.columns) == expected_columns
     assert result["activity_id"].tolist() == ["A1", "A2"]
 
@@ -129,7 +136,9 @@ def test_cli_validation_failure(
 
     monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
 
-    def fake_get(ids, *, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+    def fake_get(
+        ids, *, cfg, client, chunk_size, timeout, **kwargs
+    ):  # type: ignore[no-untyped-def]
         return df
 
     monkeypatch.setattr("scripts.get_activity_data.cl.get_activities", fake_get)

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -31,11 +31,12 @@ def test_run_chembl_respects_limit(
 
     monkeypatch.setattr(io, "read_ids", fake_read_ids)
 
-    captured: dict[str, list[str]] = {}
+    captured: dict[str, object] = {}
 
-    def fake_get(ids, cfg, client, chunk_size, timeout):
+    def fake_get(ids, cfg, client, chunk_size, timeout, **kwargs):
         data = list(ids)
         captured["ids"] = data
+        captured["extra_columns"] = kwargs.get("extra_columns")
         return pd.DataFrame({"activity_id": data})
 
     monkeypatch.setattr(cl, "get_activities", fake_get)
@@ -53,6 +54,7 @@ def test_run_chembl_respects_limit(
     assert rc == 0
     assert captured["ids"] == ["1", "2"]
     assert read_ids == ["1", "2"]
+    assert captured["extra_columns"] == ["action_type"]
 
 
 def test_run_chembl_limit_dry_run(

--- a/tests/test_get_activity_data_smoke.py
+++ b/tests/test_get_activity_data_smoke.py
@@ -14,7 +14,7 @@ def test_get_activity_data_smoke(
 ) -> None:
     input_csv = Path("tests/data/activity_ids_small.csv")
 
-    def fake_get(ids, cfg, client, chunk_size, timeout):
+    def fake_get(ids, cfg, client, chunk_size, timeout, **kwargs):
         int_ids = [int(i) for i in ids]
         return pd.DataFrame(
             {


### PR DESCRIPTION
## Summary
- add an activity_enrichment section to the default configuration and schema so action_type logging and activity_properties summarisation can be tuned
- extend the configuration models and ChEMBL activity fetching to honour the enrichment settings
- update the activity pipeline and supporting tests to exercise the new enrichment flow

## Testing
- pytest tests/test_get_activity_data.py tests/test_activity_cli_overrides.py tests/test_get_activity_data_smoke.py -q
- pytest tests/smoke/test_get_data_scripts.py::test_get_assay_data_smoke tests/smoke/test_get_data_scripts.py::test_get_document_data_smoke tests/smoke/test_get_data_scripts.py::test_get_target_data_smoke tests/smoke/test_get_data_scripts.py::test_get_testitem_data_smoke -q
- pytest tests/test_activity_extraction.py::test_cli_success -q

------
https://chatgpt.com/codex/tasks/task_e_68d66c59b818832499a30bd2a85b38dc