### PR TITLE
Add action type and properties post-processing

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -37,9 +37,96 @@
           "default": false,
           "title": "Dry Run",
           "type": "boolean"
+        },
+        "action": {
+          "$ref": "#/$defs/ActivityActionCfg"
+        },
+        "properties": {
+          "$ref": "#/$defs/ActivityPropertiesCfg"
         }
       },
       "title": "ActivityCfg",
+      "type": "object"
+    },
+    "ActivityActionCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "metrics": {
+          "default": {},
+          "title": "Metrics",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "allosteric": {
+          "default": {},
+          "title": "Allosteric",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "functionality": {
+          "default": {},
+          "title": "Functionality",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "mechanism": {
+          "default": {},
+          "title": "Mechanism",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fallback": {
+          "default": null,
+          "title": "Fallback",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "ActivityActionCfg",
+      "type": "object"
+    },
+    "ActivityPropertiesCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "allowlist": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowlist",
+          "type": "array"
+        },
+        "triage": {
+          "default": {},
+          "title": "Triage",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "hash_fields": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Hash Fields",
+          "type": "array"
+        }
+      },
+      "title": "ActivityPropertiesCfg",
       "type": "object"
     },
     "ActivityBoundsCfg": {

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,39 @@ sources:
         timeout: 30.0
         limit: null
         dry_run: false
+        action:
+          metrics:
+            ic50: inhibition
+            ki: inhibition
+            kd: binding
+            ec50: activation
+            ac50: activation
+          allosteric:
+            positive allosteric modulator: modulation_positive
+            negative allosteric modulator: modulation_negative
+          functionality:
+            agonist: agonist
+            antagonist: antagonist
+            inverse agonist: antagonist
+            partial agonist: agonist
+          mechanism:
+            inhibitor: inhibition
+            activator: activation
+            blocker: antagonist
+          fallback: unknown
+        properties:
+          allowlist:
+            - activity_comment
+            - data_validity_comment
+            - data_validity_description
+            - bao_label
+          triage:
+            data_validity_description:
+              manually validated: validated
+              manually triaged out: triaged_out
+              not determined: undetermined
+          hash_fields:
+            - data_validity_description
       assay:
         column: "assay_chembl_id"
         batch_size: 50

--- a/library/config.py
+++ b/library/config.py
@@ -387,12 +387,30 @@ class ActivityBoundsCfg(_BoolModel):
         return cls._parse_bool(v)
 
 
+class ActivityActionCfg(_BaseModel):
+    metrics: dict[str, str] = Field(default_factory=dict)
+    allosteric: dict[str, str] = Field(default_factory=dict)
+    functionality: dict[str, str] = Field(default_factory=dict)
+    mechanism: dict[str, str] = Field(default_factory=dict)
+    fallback: str | None = None
+
+
+class ActivityPropertiesCfg(_BaseModel):
+    allowlist: list[str] = Field(default_factory=list)
+    triage: dict[str, dict[str, str]] = Field(default_factory=dict)
+    hash_fields: list[str] = Field(default_factory=list)
+
+
 class ActivityCfg(_BoolModel):
     column: str = "activity_id"
     batch_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
     limit: int | None = Field(default=None, ge=0)
     dry_run: bool = False
+    action: ActivityActionCfg = Field(default_factory=lambda: ActivityActionCfg())
+    properties: ActivityPropertiesCfg = Field(
+        default_factory=lambda: ActivityPropertiesCfg()
+    )
 
     @field_validator("dry_run", mode="before")
     @classmethod
@@ -1054,6 +1072,8 @@ __all__ = [
     "PubMedCfg",
     "SemanticScholarCfg",
     "DocTypeCfg",
+    "ActivityActionCfg",
+    "ActivityPropertiesCfg",
     "ActivityCfg",
     "AssayCfg",
     "TestitemCfg",

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -13,6 +13,17 @@ from pandera.dtypes import DataType
 
 PA_ANY = cast(DataType, None)
 
+_ACTION_TYPE_VALUES = [
+    "activation",
+    "agonist",
+    "antagonist",
+    "binding",
+    "inhibition",
+    "modulation_negative",
+    "modulation_positive",
+    "unknown",
+]
+
 # Definition of the schema describing the activities table.
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
@@ -51,6 +62,16 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         ),
         "lower_value": pa.Column(float, required=False, nullable=True, coerce=True),
         "upper_value": pa.Column(float, required=False, nullable=True, coerce=True),
+        "action_type": pa.Column(
+            str,
+            pa.Check.isin(_ACTION_TYPE_VALUES),
+            required=False,
+            nullable=True,
+        ),
+        "activity_properties": pa.Column(
+            str, required=False, nullable=True
+        ),
+        "properties_hash": pa.Column(str, required=False, nullable=True),
         "pipeline_version": pa.Column(str, required=False, nullable=True),
         "timestamp_utc": pa.Column(str, required=False, nullable=True),
         #    "pA_value": pa.Column(float, pa.Check.in_range(-14, 14), required=False),

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import sys
 
@@ -32,7 +34,9 @@ from library.cli import (
     build_parser as base_parser,
 )
 from library.config import (
+    ActivityActionCfg,
     ActivityBoundsCfg,
+    ActivityPropertiesCfg,
     Config,
     _serialize_paths,
     ensure_dirs,
@@ -353,6 +357,215 @@ def compute_activity_bounds(
     return result
 
 
+def _normalize_token(value: object) -> str | None:
+    """Return a case-folded representation of *value* suitable for lookups."""
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized or None
+    return None
+
+
+def _clean_value(value: object) -> object | None:
+    """Return a cleaned representation of *value* or ``None`` for blanks."""
+
+    if value is None:
+        return None
+    if isinstance(value, float) and np.isnan(value):
+        return None
+    if pd.isna(value):
+        return None
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    return value
+
+
+def infer_action_type(
+    df: pd.DataFrame, action_cfg: ActivityActionCfg
+) -> pd.Series:
+    """Return the inferred ``action_type`` series using configuration mappings."""
+
+    if df.empty:
+        return pd.Series(dtype="object", index=df.index)
+
+    normalized_maps = {
+        "metrics": {
+            key: value
+            for raw_key, value in action_cfg.metrics.items()
+            if (key := _normalize_token(raw_key))
+        },
+        "allosteric": {
+            key: value
+            for raw_key, value in action_cfg.allosteric.items()
+            if (key := _normalize_token(raw_key))
+        },
+        "functionality": {
+            key: value
+            for raw_key, value in action_cfg.functionality.items()
+            if (key := _normalize_token(raw_key))
+        },
+        "mechanism": {
+            key: value
+            for raw_key, value in action_cfg.mechanism.items()
+            if (key := _normalize_token(raw_key))
+        },
+    }
+
+    categories: list[tuple[str, dict[str, str], tuple[str, ...]]] = [
+        ("metrics", normalized_maps["metrics"], ("standard_type", "type")),
+        (
+            "allosteric",
+            normalized_maps["allosteric"],
+            ("activity_comment", "bao_label", "bao_format"),
+        ),
+        (
+            "functionality",
+            normalized_maps["functionality"],
+            ("bao_label", "activity_comment"),
+        ),
+        (
+            "mechanism",
+            normalized_maps["mechanism"],
+            ("mechanism_of_action", "mechanism_comment", "activity_comment"),
+        ),
+    ]
+
+    unmatched: dict[str, set[str]] = {
+        name: set() for name, mapping, _ in categories if mapping
+    }
+    results: list[str | None] = []
+
+    for _, row in df.iterrows():
+        resolved: str | None = None
+        for name, mapping, columns in categories:
+            if not mapping:
+                continue
+            for column in columns:
+                if column not in row.index:
+                    continue
+                candidate = row[column]
+                token = _normalize_token(candidate)
+                if token is None:
+                    continue
+                mapped = mapping.get(token)
+                if mapped is not None:
+                    resolved = mapped
+                    break
+                unmatched[name].add(token)
+            if resolved is not None:
+                break
+        if resolved is None:
+            resolved = action_cfg.fallback
+        results.append(resolved)
+
+    for name, mapping, _ in categories:
+        values = unmatched.get(name)
+        if mapping and values:
+            logger.warning(
+                "action_type_unmapped",
+                category=name,
+                values=sorted(values),
+            )
+
+    return pd.Series(results, index=df.index, dtype="object")
+
+
+def build_activity_properties(
+    df: pd.DataFrame, properties_cfg: ActivityPropertiesCfg
+) -> tuple[pd.Series, pd.Series | None]:
+    """Return serialised ``activity_properties`` and optional ``properties_hash``."""
+
+    if df.empty:
+        empty = pd.Series(dtype="object", index=df.index)
+        hash_series = (
+            pd.Series(dtype="object", index=df.index)
+            if properties_cfg.hash_fields
+            else None
+        )
+        return empty, hash_series
+
+    allowlist = [col for col in properties_cfg.allowlist if col in df.columns]
+    triage_maps: dict[str, dict[str, str]] = {
+        column: {
+            key: value
+            for raw_key, value in mapping.items()
+            if (key := _normalize_token(raw_key))
+        }
+        for column, mapping in properties_cfg.triage.items()
+        if column in df.columns
+    }
+    triage_unmapped: dict[str, set[str]] = {col: set() for col in triage_maps}
+
+    properties_values: list[str | None] = []
+    hash_values: list[str | None] | None = (
+        [] if properties_cfg.hash_fields else None
+    )
+
+    for _, row in df.iterrows():
+        collected: dict[str, object] = {}
+        for column in allowlist:
+            raw_value = row.get(column)
+            cleaned = _clean_value(raw_value)
+            if cleaned is None:
+                continue
+            stored = cleaned
+            if column in triage_maps and isinstance(raw_value, str):
+                token = _normalize_token(raw_value)
+                if token is not None:
+                    mapped = triage_maps[column].get(token)
+                    if mapped is not None:
+                        stored = mapped
+                    else:
+                        triage_unmapped[column].add(token)
+            collected[column] = stored
+
+        ordered = dict(sorted(collected.items()))
+        if ordered:
+            serialised = json.dumps(ordered, ensure_ascii=False, separators=(",", ":"))
+        else:
+            serialised = None
+        properties_values.append(serialised)
+
+        if hash_values is not None:
+            if not ordered:
+                hash_values.append(None)
+            else:
+                subset_keys = [
+                    key for key in properties_cfg.hash_fields if key in ordered
+                ]
+                subset = (
+                    {key: ordered[key] for key in subset_keys}
+                    if subset_keys
+                    else ordered
+                )
+                if subset:
+                    payload = json.dumps(
+                        dict(sorted(subset.items())),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    hash_values.append(hashlib.sha256(payload).hexdigest())
+                else:
+                    hash_values.append(None)
+
+    for column, values in triage_unmapped.items():
+        if values:
+            logger.warning(
+                "activity_properties_unmapped_triage",
+                column=column,
+                values=sorted(values),
+            )
+
+    properties_series = pd.Series(properties_values, index=df.index, dtype="object")
+    hash_series = (
+        pd.Series(hash_values, index=df.index, dtype="object")
+        if hash_values is not None
+        else None
+    )
+    return properties_series, hash_series
+
+
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute activity retrieval from the ChEMBL API.
 
@@ -429,6 +642,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = normalize_activities(df)
         df = add_pipeline_metadata(df)
         df = compute_activity_bounds(df, cfg.activity_bounds)
+        df["action_type"] = infer_action_type(df, cfg.activity.action)
+        properties, properties_hash = build_activity_properties(
+            df, cfg.activity.properties
+        )
+        df["activity_properties"] = properties
+        if properties_hash is not None:
+            df["properties_hash"] = properties_hash
         # Determine final column order: schema-defined columns first in their
         # declared sequence, followed by any additional columns sorted
         # alphabetically to provide deterministic output.

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -101,8 +101,18 @@ def test_cli_success(
     assert exit_code == 0
     assert output_csv.exists()
     result = pd.read_csv(output_csv)
-    expected_columns = set(df.columns) | {"pipeline_version", "timestamp_utc"}
-    assert set(result.columns) == expected_columns
+    base_columns = set(df.columns) | {
+        "pipeline_version",
+        "timestamp_utc",
+        "lower_value",
+        "upper_value",
+        "action_type",
+        "activity_properties",
+    }
+    optional_columns = {"properties_hash"}
+    result_columns = set(result.columns)
+    assert base_columns.issubset(result_columns)
+    assert result_columns <= base_columns | optional_columns
     assert result["activity_id"].tolist() == ["A1", "A2"]
 
 

--- a/tests/test_activity_postprocess.py
+++ b/tests/test_activity_postprocess.py
@@ -1,0 +1,137 @@
+"""Tests for activity post-processing helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pandas as pd
+import pytest
+
+from library.config import ActivityActionCfg, ActivityPropertiesCfg
+from scripts.get_activity_data import build_activity_properties, infer_action_type
+
+
+def test_infer_action_type_priority_and_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metric mapping takes precedence and unmapped values are logged once."""
+
+    cfg = ActivityActionCfg(
+        metrics={"IC50": "inhibition"},
+        allosteric={"positive allosteric modulator": "modulation_positive"},
+        functionality={"agonist activity": "agonist"},
+        mechanism={"inhibitor": "inhibition"},
+        fallback="unknown",
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "standard_type": "IC50",
+                "activity_comment": "Positive Allosteric Modulator",
+                "bao_label": None,
+            },
+            {
+                "standard_type": None,
+                "bao_label": "Agonist Activity",
+            },
+            {
+                "standard_type": None,
+                "activity_comment": "Inhibitor",
+            },
+            {
+                "standard_type": None,
+                "activity_comment": "Unknown Effect",
+            },
+        ]
+    )
+
+    captured: list[dict[str, object]] = []
+
+    def fake_warning(event: str, **extra: object) -> None:
+        if event == "action_type_unmapped":
+            captured.append(extra)
+
+    monkeypatch.setattr(
+        "scripts.get_activity_data.logger.warning",
+        fake_warning,
+    )
+    result = infer_action_type(df, cfg)
+
+    assert result.tolist() == [
+        "inhibition",
+        "agonist",
+        "inhibition",
+        "unknown",
+    ]
+    categories = {entry.get("category") for entry in captured}
+    assert {"allosteric", "mechanism"}.issubset(categories)
+    assert any("unknown effect" in entry.get("values", []) for entry in captured)
+
+
+def test_build_activity_properties_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Properties JSON honours allowlist, mapping and hashing rules."""
+
+    cfg = ActivityPropertiesCfg(
+        allowlist=["activity_comment", "data_validity_description"],
+        triage={"data_validity_description": {"manually validated": "validated"}},
+        hash_fields=["activity_comment", "data_validity_description"],
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "activity_comment": " Strong effect ",
+                "data_validity_description": "Manually Validated",
+            },
+            {
+                "activity_comment": "   ",
+                "data_validity_description": "Unknown",
+            },
+            {
+                "activity_comment": None,
+                "data_validity_description": None,
+            },
+        ]
+    )
+
+    triage_events: list[dict[str, object]] = []
+
+    def fake_warning(event: str, **extra: object) -> None:
+        if event == "activity_properties_unmapped_triage":
+            triage_events.append(extra)
+
+    monkeypatch.setattr(
+        "scripts.get_activity_data.logger.warning",
+        fake_warning,
+    )
+    props, hashes = build_activity_properties(df, cfg)
+
+    assert props.tolist() == [
+        "{\"activity_comment\":\"Strong effect\",\"data_validity_description\":\"validated\"}",
+        "{\"data_validity_description\":\"Unknown\"}",
+        None,
+    ]
+
+    expected_first = hashlib.sha256(
+        json.dumps(
+            {
+                "activity_comment": "Strong effect",
+                "data_validity_description": "validated",
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    expected_second = hashlib.sha256(
+        json.dumps(
+            {"data_validity_description": "Unknown"},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert hashes is not None
+    assert hashes.tolist() == [expected_first, expected_second, None]
+
+    assert triage_events
+    assert triage_events[0].get("column") == "data_validity_description"
+    assert "unknown" in triage_events[0].get("values", [])

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,6 +47,27 @@ def test_activities_schema_validation() -> None:
         ActivitiesSchema.validate(invalid)
 
 
+def test_activities_schema_action_type_enforcement() -> None:
+    """``action_type`` accepts only configured values."""
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["1"],
+            "molecule_chembl_id": ["CHEMBL1"],
+            "assay_chembl_id": ["CHEMBL0"],
+            "standard_value": [1.0],
+            "standard_type": ["IC50"],
+            "action_type": ["unknown"],
+        }
+    )
+    ActivitiesSchema.validate(df)
+
+    invalid = df.copy()
+    invalid.loc[0, "action_type"] = "unsupported"
+    with pytest.raises(SchemaErrors):
+        ActivitiesSchema.validate(invalid, lazy=True)
+
+
 def test_activities_schema_accepts_object_dtypes() -> None:
     """``standard_value`` validates with object dtype."""
 


### PR DESCRIPTION
## Summary
- add configuration models and defaults for activity action mappings, triage normalization, and property allowlists
- compute action_type and activity_properties during activity extraction using the new helper functions and config metadata
- extend the activities schema and tests to cover the new columns and post-processing behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d66c4f11bc8324a29618d8db28a1c2