### PR TITLE
Optimize parent lookup API usage for testitem data

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -378,26 +378,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("identifiers_retrieved", count=len(ids))
         logger.info("chembl_fetch_start", batch_size=cfg.testitem.batch_size)
 
-        cache_before = _cache_state(cfg.molecule_catalog.cache_path)
-
-        try:
-            parent_catalog = load_parent_catalog(
-                client=client,
-                api_cfg=cfg.api,
-                catalog_cfg=cfg.molecule_catalog,
-                timeout=cfg.testitem.timeout,
-            )
-        except (requests.RequestException, ValueError) as exc:
-            logger.error(
-                "parent_catalog_invalid",
-                error=str(exc),
-                path=str(cfg.molecule_catalog.cache_path),
-            )
-            return 1
-
-        cache_after = _cache_state(cfg.molecule_catalog.cache_path)
-        parent_catalog_source = _resolve_parent_source(cache_before, cache_after)
-
         try:
             df = cl.get_testitem(
                 ids,
@@ -416,8 +396,65 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         logger.info("chembl_fetch_done", rows=len(df))
         parent_column = cfg.molecule_catalog.parent_field
-        if parent_catalog and "molecule_chembl_id" in df.columns:
-            normalised_ids = _normalise_chembl_ids(df["molecule_chembl_id"])
+        child_column = cfg.molecule_catalog.child_field
+
+        if child_column in df.columns:
+            normalised_ids = _normalise_chembl_ids(df[child_column])
+        else:
+            normalised_ids = pd.Series("", index=df.index, dtype="string")
+
+        if parent_column in df.columns:
+            existing_parent = _normalise_chembl_ids(df[parent_column])
+        else:
+            existing_parent = pd.Series("", index=df.index, dtype="string")
+
+        need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
+        need_lookup = set(normalised_ids[need_lookup_mask])
+
+        cache_before = _cache_state(cfg.molecule_catalog.cache_path)
+        cache_after = cache_before
+        parent_catalog: dict[str, str] = {}
+        parent_catalog_source = PARENT_LOOKUP_SOURCE_SKIPPED
+
+        if need_lookup and cache_before[0]:
+            try:
+                parent_catalog = load_parent_catalog(
+                    client=client,
+                    api_cfg=cfg.api,
+                    catalog_cfg=cfg.molecule_catalog,
+                    timeout=cfg.testitem.timeout,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.error(
+                    "parent_catalog_invalid",
+                    error=str(exc),
+                    path=str(cfg.molecule_catalog.cache_path),
+                )
+                return 1
+            cache_after = _cache_state(cfg.molecule_catalog.cache_path)
+            parent_catalog_source = _resolve_parent_source(cache_before, cache_after)
+            if parent_catalog:
+                need_lookup -= set(parent_catalog)
+
+        fetched_remote = False
+        if need_lookup:
+            try:
+                fetched = molecule_catalog.fetch_parent_catalog_for(
+                    need_lookup,
+                    client=client,
+                    api_cfg=cfg.api,
+                    timeout=cfg.testitem.timeout,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.error("parent_lookup_partial_fetch_failed", error=str(exc))
+                return 1
+            if fetched:
+                parent_catalog.update(fetched)
+                fetched_remote = True
+        if fetched_remote:
+            parent_catalog_source = PARENT_LOOKUP_SOURCE_REMOTE
+
+        if parent_catalog and child_column in df.columns:
             mapped = normalised_ids.map(parent_catalog)
             if parent_column in df.columns:
                 df[parent_column] = df[parent_column].fillna(mapped)

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -71,6 +71,22 @@ def test_get_testitem_parent_catalog(
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
     monkeypatch.setattr(pl, "get_properties", fake_get_properties)
     monkeypatch.setattr(get_testitem_data, "load_parent_catalog", fake_load_parent_catalog)
+    monkeypatch.setattr(
+        get_testitem_data,
+        "_cache_state",
+        lambda _path: (True, 0.0),
+    )
+    fetch_calls: list[list[str]] = []
+
+    def fake_fetch_parent_catalog_for(ids, **_: object) -> dict[str, str]:
+        fetch_calls.append(list(ids))
+        return {}
+
+    monkeypatch.setattr(
+        get_testitem_data.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch_parent_catalog_for,
+    )
     monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
 
     exit_code = get_testitem_data.main(
@@ -94,3 +110,82 @@ def test_get_testitem_parent_catalog(
         "CHEMBL9001",
         "CHEMBL9002",
     ]
+    assert fetch_calls == []
+
+
+def test_get_testitem_skips_parent_lookup_when_present(
+    smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure parent lookups are skipped when data already contains parents."""
+
+    input_csv = Path("tests/data/input-smoke/testitem.csv")
+    output_csv = smoke_output_dir / "testitem_parent_present.csv"
+    _cleanup_output(output_csv)
+
+    def fake_get_testitem(ids, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+        rows: list[dict[str, object]] = []
+        for idx, mol_id in enumerate(ids, start=1):
+            rows.append(
+                {
+                    "molecule_chembl_id": str(mol_id),
+                    "parent_molecule_chembl_id": f"CHEMBL90{idx:02d}",
+                    "canonical_smiles": f"C{idx}H{2 * idx + 2}",
+                    "max_phase": "4",
+                }
+            )
+        return pd.DataFrame(rows)
+
+    def fake_get_cid(smiles: str, cfg):  # type: ignore[no-untyped-def]
+        return "12345"
+
+    def fake_get_properties(cid: str, cfg):  # type: ignore[no-untyped-def]
+        return SimpleNamespace(
+            IUPACName="Mock acid",
+            MolecularFormula="C2H6O",
+            iSMILES="CCO",
+            cSMILES="CCO",
+            InChI="InChI=1S/C2H6O",
+            InChIKey="LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        )
+
+    def fail_load_parent_catalog(**_: object) -> dict[str, str]:
+        pytest.fail("load_parent_catalog should not be called when parents exist")
+
+    fetch_called = False
+
+    def fake_fetch_parent_catalog_for(ids, **_: object) -> dict[str, str]:
+        nonlocal fetch_called
+        fetch_called = True
+        return {}
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+    monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
+    monkeypatch.setattr(pl, "get_properties", fake_get_properties)
+    monkeypatch.setattr(get_testitem_data, "load_parent_catalog", fail_load_parent_catalog)
+    monkeypatch.setattr(
+        get_testitem_data.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch_parent_catalog_for,
+    )
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
+
+    exit_code = get_testitem_data.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "ERROR",
+            "--config",
+            str(Path("config.yaml")),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+
+    df = pd.read_csv(output_csv)
+    assert list(df["parent_molecule_chembl_id"]) == ["CHEMBL9001", "CHEMBL9002"]
+    assert fetch_called is False


### PR DESCRIPTION
## Summary
- compute the set of molecule identifiers lacking parent data before consulting the catalog cache
- load cached parent mappings when available and fetch only the missing entries instead of traversing the full catalog
- extend smoke tests to assert that the parent lookup API is skipped when parent identifiers are already populated

## Testing
- pytest tests/smoke/test_get_testitem_parent.py

------
https://chatgpt.com/codex/tasks/task_e_68d6706f19ec83248e3a934218012037