### PR TITLE
Persist fetched parent catalog updates

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -26,6 +26,7 @@ __all__ = [
     "fetch_parent_catalog",
     "fetch_parent_catalog_for",
     "load_parent_catalog",
+    "write_parent_catalog_cache",
 ]
 
 
@@ -225,6 +226,37 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
     return result
 
 
+def write_parent_catalog_cache(
+    catalog: Mapping[str, str], catalog_cfg: MoleculeCatalogCfg
+) -> None:
+    """Persist *catalog* to disk using the configured cache format."""
+
+    cache_path = catalog_cfg.cache_path
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    sorted_items = sorted(catalog.items())
+
+    if cache_path.suffix.lower() == ".csv":
+        with cache_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(
+                fh,
+                fieldnames=[catalog_cfg.child_field, catalog_cfg.parent_field],
+            )
+            writer.writeheader()
+            for child, parent in sorted_items:
+                writer.writerow(
+                    {
+                        catalog_cfg.child_field: child,
+                        catalog_cfg.parent_field: parent,
+                    }
+                )
+        return
+
+    cache_path.write_text(
+        json.dumps(dict(sorted_items), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
 def load_parent_catalog(
     *,
     client: ChemblClient,
@@ -244,9 +276,5 @@ def load_parent_catalog(
     result = fetch_parent_catalog(
         client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
     )
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(
-        json.dumps(dict(sorted(result.items())), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+    write_parent_catalog_cache(result, catalog_cfg)
     return result

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -23,7 +23,7 @@ from library import chembl_library as cl
 from library import io
 from library import molecule_catalog
 from library import pubchem_library as pl
-from library.molecule_catalog import load_parent_catalog
+from library.molecule_catalog import load_parent_catalog, write_parent_catalog_cache
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -210,6 +210,8 @@ def attach_parent_molecule_ids(
         if fetched:
             catalog_data.update(fetched)
             parent_map.update(fetched)
+            if catalog is None:
+                write_parent_catalog_cache(catalog_data, catalog_cfg)
 
     parent_series = normalised_child.map(parent_map).astype("string")
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -490,6 +491,74 @@ def test_attach_parent_molecule_ids_fetches_missing(
     assert stats.attached == 2
     assert stats.missing == 0
     assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+
+
+def test_attach_parent_molecule_ids_updates_cache_for_reuse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1", "CHEMBL2"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.cache_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_cfg.cache_path.write_text(
+        json.dumps({"CHEMBL1": "CHEMBL1_PARENT"}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    fetch_calls: list[list[str]] = []
+
+    def fake_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        fetch_calls.append(list(ids))
+        return {"CHEMBL2": "CHEMBL2_PARENT"}
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch,
+    )
+
+    first_result, first_stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert fetch_calls == [["CHEMBL2"]]
+    assert first_result[catalog_cfg.parent_field].tolist() == [
+        "CHEMBL1_PARENT",
+        "CHEMBL2_PARENT",
+    ]
+    assert first_stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+
+    stored_catalog = json.loads(catalog_cfg.cache_path.read_text(encoding="utf-8"))
+    assert stored_catalog == {
+        "CHEMBL1": "CHEMBL1_PARENT",
+        "CHEMBL2": "CHEMBL2_PARENT",
+    }
+
+    second_result, second_stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert fetch_calls == [["CHEMBL2"]]
+    assert second_result[catalog_cfg.parent_field].tolist() == [
+        "CHEMBL1_PARENT",
+        "CHEMBL2_PARENT",
+    ]
+    assert second_stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
 
 
 def test_attach_parent_molecule_ids_fetch_failure(


### PR DESCRIPTION
## Summary
- add a helper to persist parent catalog caches in the same format used for loading
- refresh the cached parent catalog when new parent IDs are fetched on demand
- extend attach_parent_molecule_ids tests to ensure the updated cache is reused without network access

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d670731a5c83248f0da0a2096e2ee4