### PR TITLE
Use SQLite-backed molecule catalog cache

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -193,6 +193,11 @@
           "title": "Cache Path",
           "type": "string"
         },
+        "sqlite_path": {
+          "default": "data/cache/molecule_parent_catalog.sqlite3",
+          "title": "Sqlite Path",
+          "type": "string"
+        },
         "endpoint": {
           "default": "molecule",
           "title": "Endpoint",

--- a/library/config.py
+++ b/library/config.py
@@ -123,6 +123,7 @@ class ChemblCacheCfg(_BaseModel):
 
 class MoleculeCatalogCfg(_BaseModel):
     cache_path: Path = Path("data/cache/molecule_parent_catalog.json")
+    sqlite_path: Path = Path("data/cache/molecule_parent_catalog.sqlite3")
     endpoint: str = "molecule"
     child_field: str = "molecule_chembl_id"
     parent_field: str = "parent_molecule_chembl_id"

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import csv
 import json
-from collections.abc import Iterable
+import sqlite3
+from collections.abc import Iterable, Mapping as ABCMapping
 from pathlib import Path
 from typing import Mapping
 from urllib.parse import urlencode, urljoin
@@ -21,8 +22,108 @@ _PARENT_LOOKUP_FIELDS = tuple(_DEFAULT_CATALOG_CFG.fields or ()) or (
 _PARENT_LOOKUP_CHILD_FIELD = _DEFAULT_CATALOG_CFG.child_field
 _PARENT_LOOKUP_PARENT_FIELD = _DEFAULT_CATALOG_CFG.parent_field
 _PARENT_LOOKUP_CHUNK_SIZE = _DEFAULT_CATALOG_CFG.page_size
+_SQLITE_TABLE = "parent_catalog"
+_SQLITE_CREATE_TABLE = (
+    f"CREATE TABLE IF NOT EXISTS {_SQLITE_TABLE} ("
+    "child TEXT PRIMARY KEY,"
+    "parent TEXT NOT NULL"
+    ")"
+)
+_SQLITE_PARENT_INDEX = (
+    f"CREATE INDEX IF NOT EXISTS ix_{_SQLITE_TABLE}_parent ON {_SQLITE_TABLE} (parent)"
+)
+_SQLITE_MAX_PARAMETERS = 900
+
+
+class ParentCatalog:
+    """SQLite-backed view of the parent molecule catalogue."""
+
+    def __init__(
+        self,
+        sqlite_path: Path,
+        *,
+        has_rows: bool,
+        refreshed: bool,
+    ) -> None:
+        self._sqlite_path = sqlite_path
+        self._has_rows = has_rows
+        self.refreshed = refreshed
+
+    @property
+    def sqlite_path(self) -> Path:
+        """Return the backing SQLite database path."""
+
+        return self._sqlite_path
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return self._has_rows
+
+    def lookup_many(self, children: Iterable[str]) -> dict[str, str]:
+        """Return parent mappings for ``children`` from the SQLite cache."""
+
+        normalised: list[str] = []
+        seen: set[str] = set()
+        for value in children:
+            try:
+                child_id = _normalise_chembl_id(str(value))
+            except ValueError:
+                continue
+            if child_id in seen:
+                continue
+            seen.add(child_id)
+            normalised.append(child_id)
+
+        if not normalised:
+            return {}
+
+        result: dict[str, str] = {}
+        with sqlite3.connect(self._sqlite_path) as conn:
+            conn.row_factory = sqlite3.Row
+            for chunk in _chunked(normalised, _SQLITE_MAX_PARAMETERS):
+                placeholders = ",".join("?" for _ in chunk)
+                query = (
+                    f"SELECT child, parent FROM {_SQLITE_TABLE} "
+                    f"WHERE child IN ({placeholders})"
+                )
+                cursor = conn.execute(query, chunk)
+                result.update({row["child"]: row["parent"] for row in cursor})
+        return result
+
+    def upsert_many(self, mapping: Mapping[str, str]) -> None:
+        """Insert or update ``mapping`` in the SQLite cache."""
+
+        rows: list[tuple[str, str]] = []
+        for child, parent in mapping.items():
+            try:
+                child_id = _normalise_chembl_id(str(child))
+                parent_id = _normalise_chembl_id(str(parent))
+            except ValueError:
+                continue
+            rows.append((child_id, parent_id))
+
+        if not rows:
+            return
+
+        with sqlite3.connect(self._sqlite_path) as conn:
+            conn.execute("BEGIN")
+            conn.executemany(
+                f"INSERT INTO {_SQLITE_TABLE} (child, parent) VALUES (?, ?) "
+                "ON CONFLICT(child) DO UPDATE SET parent=excluded.parent",
+                rows,
+            )
+            conn.commit()
+        self._has_rows = True
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the entire parent catalogue as a dictionary."""
+
+        with sqlite3.connect(self._sqlite_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(f"SELECT child, parent FROM {_SQLITE_TABLE}")
+            return {row["child"]: row["parent"] for row in cursor}
 
 __all__ = [
+    "ParentCatalog",
     "fetch_parent_catalog",
     "fetch_parent_catalog_for",
     "load_parent_catalog",
@@ -36,6 +137,46 @@ def _normalise_chembl_id(value: str) -> str:
     if not normalised:
         raise ValueError("empty identifier")
     return normalised
+
+
+def _ensure_sqlite_schema(sqlite_path: Path) -> None:
+    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.execute(_SQLITE_CREATE_TABLE)
+        conn.execute(_SQLITE_PARENT_INDEX)
+        conn.commit()
+
+
+def _sqlite_has_rows(sqlite_path: Path) -> bool:
+    with sqlite3.connect(sqlite_path) as conn:
+        cursor = conn.execute(f"SELECT 1 FROM {_SQLITE_TABLE} LIMIT 1")
+        return cursor.fetchone() is not None
+
+
+def _normalise_catalog_mapping(mapping: Mapping[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for child, parent in mapping.items():
+        try:
+            child_id = _normalise_chembl_id(str(child))
+            parent_id = _normalise_chembl_id(str(parent))
+        except ValueError:
+            continue
+        result[child_id] = parent_id
+    return result
+
+
+def _replace_catalog(sqlite_path: Path, mapping: Mapping[str, str]) -> bool:
+    normalised = _normalise_catalog_mapping(mapping)
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.execute("BEGIN")
+        conn.execute(f"DELETE FROM {_SQLITE_TABLE}")
+        if normalised:
+            conn.executemany(
+                f"INSERT INTO {_SQLITE_TABLE} (child, parent) VALUES (?, ?)",
+                list(normalised.items()),
+            )
+        conn.commit()
+    return bool(normalised)
 
 
 def _build_initial_url(api_cfg: ApiCfg, catalog_cfg: MoleculeCatalogCfg) -> str:
@@ -109,7 +250,7 @@ def fetch_parent_catalog_for(
             continue
         allowed = set(chunk)
         for item in items:
-            if not isinstance(item, Mapping):
+            if not isinstance(item, ABCMapping):
                 continue
             child = item.get(_PARENT_LOOKUP_CHILD_FIELD)
             parent = item.get(_PARENT_LOOKUP_PARENT_FIELD)
@@ -154,7 +295,7 @@ def fetch_parent_catalog(
             logger.warning("unexpected_response_items", extra={"url": next_url})
             items = []
         for item in items:
-            if not isinstance(item, Mapping):
+            if not isinstance(item, ABCMapping):
                 continue
             child = item.get(catalog_cfg.child_field)
             parent = item.get(catalog_cfg.parent_field)
@@ -201,7 +342,7 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
                     except ValueError:
                         continue
                     result[child_id] = parent_id
-                return result
+                return _normalise_catalog_mapping(result)
         except csv.Error as exc:  # pragma: no cover - defensive
             raise ValueError(f"invalid CSV catalog: {path}: {exc}") from exc
     try:
@@ -209,7 +350,7 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
     except json.JSONDecodeError:
         logger.warning("invalid_catalog_cache", extra={"path": str(path)})
         return {}
-    if not isinstance(raw, Mapping):
+    if not isinstance(raw, ABCMapping):
         logger.warning("unexpected_catalog_cache", extra={"path": str(path)})
         return {}
     result: dict[str, str] = {}
@@ -232,21 +373,39 @@ def load_parent_catalog(
     catalog_cfg: MoleculeCatalogCfg,
     timeout: float | None = None,
     force_refresh: bool = False,
-) -> dict[str, str]:
-    """Return the molecule parent catalogue, using the on-disk cache if present."""
+) -> ParentCatalog:
+    """Ensure the parent catalogue cache exists and return a SQLite handle."""
 
+    sqlite_path = catalog_cfg.sqlite_path
     cache_path = catalog_cfg.cache_path
-    if not force_refresh:
+    _ensure_sqlite_schema(sqlite_path)
+
+    refreshed = False
+
+    if force_refresh:
+        data = fetch_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=catalog_cfg,
+            timeout=timeout,
+        )
+        has_rows = _replace_catalog(sqlite_path, data)
+        refreshed = True
+        return ParentCatalog(sqlite_path, has_rows=has_rows, refreshed=refreshed)
+
+    has_rows = _sqlite_has_rows(sqlite_path)
+    if not has_rows:
         cached = _read_cache(cache_path, catalog_cfg)
         if cached:
-            return cached
+            has_rows = _replace_catalog(sqlite_path, cached)
+        else:
+            data = fetch_parent_catalog(
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+            )
+            has_rows = _replace_catalog(sqlite_path, data)
+            refreshed = True
 
-    result = fetch_parent_catalog(
-        client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
-    )
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(
-        json.dumps(dict(sorted(result.items())), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    return result
+    return ParentCatalog(sqlite_path, has_rows=has_rows, refreshed=refreshed)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -133,10 +133,6 @@ def attach_parent_molecule_ids(
         )
         return result, stats
 
-    cache_path = catalog_cfg.cache_path
-    cache_exists = cache_path.is_file()
-    cache_mtime = cache_path.stat().st_mtime if cache_exists else None
-
     catalog = molecule_catalog.load_parent_catalog(
         client=client,
         api_cfg=api_cfg,
@@ -144,17 +140,16 @@ def attach_parent_molecule_ids(
         timeout=timeout,
     )
 
-    cache_exists_after = cache_path.is_file()
-    cache_mtime_after = cache_path.stat().st_mtime if cache_exists_after else None
-    if cache_exists_after and cache_exists and cache_mtime_after == cache_mtime:
-        source = PARENT_LOOKUP_SOURCE_CACHE
-    else:
-        source = PARENT_LOOKUP_SOURCE_REMOTE
+    source = (
+        PARENT_LOOKUP_SOURCE_REMOTE
+        if catalog.refreshed
+        else PARENT_LOOKUP_SOURCE_CACHE
+    )
 
     normalised_child = _normalise_chembl_ids(result[child_column])
     unique_children = normalised_child[normalised_child != ""].unique()
 
-    parent_map = {key: catalog[key] for key in unique_children if key in catalog}
+    parent_map = catalog.lookup_many(unique_children)
     missing_ids = [key for key in unique_children if key not in parent_map]
     fetched_remote = False
 
@@ -173,8 +168,8 @@ def attach_parent_molecule_ids(
             if fetched:
                 fetched_remote = True
         if fetched:
-            catalog.update(fetched)
             parent_map.update(fetched)
+            catalog.upsert_many(fetched)
 
     parent_series = normalised_child.map(parent_map)
     missing_mask = parent_series.isna()
@@ -369,7 +364,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         parent_column = cfg.molecule_catalog.parent_field
         if parent_catalog and "molecule_chembl_id" in df.columns:
             normalised_ids = _normalise_chembl_ids(df["molecule_chembl_id"])
-            mapped = normalised_ids.map(parent_catalog)
+            lookup_keys = normalised_ids[normalised_ids != ""].unique()
+            mapped_values = parent_catalog.lookup_many(lookup_keys)
+            mapped = normalised_ids.map(mapped_values)
             if parent_column in df.columns:
                 df[parent_column] = df[parent_column].fillna(mapped)
             else:

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -363,7 +363,18 @@ def test_get_testitem_data_smoke(
     monkeypatch.setattr(
         get_testitem_data,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+        lambda **__: type(
+            "_Catalog",
+            (),
+            {
+                "refreshed": False,
+                "lookup_many": lambda self, children: {
+                    c: "CHEMBL1_PARENT" for c in children if c == "CHEMBL1"
+                },
+                "upsert_many": lambda self, values: None,
+                "__bool__": lambda self: True,
+            },
+        )(),
     )
     monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
 

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -59,12 +59,28 @@ def test_get_testitem_parent_catalog(
             InChIKey="LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
         )
 
-    def fake_load_parent_catalog(**_: object) -> dict[str, str]:
+    def fake_load_parent_catalog(**_: object):  # type: ignore[no-untyped-def]
         frame = pd.read_csv(catalog_csv)
-        return {
+        mapping = {
             str(row["molecule_chembl_id"]): str(row["parent_molecule_chembl_id"])
             for _, row in frame.iterrows()
         }
+
+        class _Catalog:
+            def __init__(self) -> None:
+                self._mapping = mapping
+                self.refreshed = False
+
+            def lookup_many(self, children):  # type: ignore[no-untyped-def]
+                return {c: self._mapping[c] for c in children if c in self._mapping}
+
+            def upsert_many(self, values):  # type: ignore[no-untyped-def]
+                self._mapping.update(values)
+
+            def __bool__(self) -> bool:
+                return bool(self._mapping)
+
+        return _Catalog()
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +14,29 @@ from library.config import Config
 from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
 
+
+class DummyParentCatalog:
+    def __init__(
+        self,
+        mapping: dict[str, str] | None = None,
+        *,
+        refreshed: bool = False,
+    ) -> None:
+        self._mapping = dict(mapping or {})
+        self.refreshed = refreshed
+
+    def lookup_many(self, children: Iterable[str]) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for child in children:
+            if child in self._mapping:
+                result[child] = self._mapping[child]
+        return result
+
+    def upsert_many(self, mapping: dict[str, str]) -> None:
+        self._mapping.update(mapping)
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return bool(self._mapping)
 
 def test_run_chembl_column_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
@@ -41,7 +65,9 @@ def test_run_chembl_column_order(
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(
-        gtd, "load_parent_catalog", lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"}
+        gtd,
+        "load_parent_catalog",
+        lambda **__: DummyParentCatalog({"CHEMBL1": "CHEMBL1_PARENT"}),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
     monkeypatch.setattr(
@@ -101,7 +127,7 @@ def test_run_chembl_initialises_pubchem_session(
     )
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg: frame)
-    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: DummyParentCatalog())
 
     monkeypatch.setattr(
         gtd,
@@ -164,7 +190,9 @@ def test_run_chembl_merges_parent_catalog(
     monkeypatch.setattr(
         gtd,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"},
+        lambda **__: DummyParentCatalog(
+            {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"}
+        ),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
@@ -308,11 +336,12 @@ def test_attach_parent_molecule_ids_fetches_missing(
 
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite3"
 
     monkeypatch.setattr(
         gtd.molecule_catalog,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+        lambda **__: DummyParentCatalog({"CHEMBL1": "CHEMBL1_PARENT"}),
     )
 
     fetched: dict[str, str] = {"CHEMBL2": "CHEMBL2_PARENT"}
@@ -360,11 +389,12 @@ def test_attach_parent_molecule_ids_fetch_failure(
 
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite3"
 
     monkeypatch.setattr(
         gtd.molecule_catalog,
         "load_parent_catalog",
-        lambda **__: {},
+        lambda **__: DummyParentCatalog(),
     )
 
     def failing_fetch(
@@ -406,11 +436,12 @@ def test_attach_parent_molecule_ids_uses_cache_only(
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
     catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite3"
 
     monkeypatch.setattr(
         gtd.molecule_catalog,
         "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
+        lambda **__: DummyParentCatalog({"CHEMBL1": "CHEMBL1_PARENT"}),
     )
 
     def unexpected_fetch(

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -133,14 +132,15 @@ def test_fetch_parent_catalog_for_chunks_requests(
 
 def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
     cache = tmp_path / "catalog.json"
-    cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cache.write_text('{"chembl10": "chembl99"}', encoding="utf-8")
+    sqlite_path = tmp_path / "catalog.sqlite3"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
 
-    result = load_parent_catalog(
+    catalog = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == {"CHEMBL10": "CHEMBL99"}
+    assert catalog.lookup_many(["CHEMBL10"]) == {"CHEMBL10": "CHEMBL99"}
 
 
 def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
@@ -149,13 +149,14 @@ def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) ->
         "molecule_chembl_id,parent_molecule_chembl_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite3"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
 
-    result = load_parent_catalog(
+    catalog = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == {"CHEMBL1": "CHEMBL42"}
+    assert catalog.lookup_many(["CHEMBL1"]) == {"CHEMBL1": "CHEMBL42"}
 
 
 def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg) -> None:
@@ -164,7 +165,8 @@ def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg
         "molecule_chembl_id,parant_molecule_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite3"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
 
     with pytest.raises(ValueError):
         load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
@@ -174,7 +176,8 @@ def test_load_parent_catalog_fetches_and_persists(
     tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache = tmp_path / "catalog.json"
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    sqlite_path = tmp_path / "catalog.sqlite3"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
     data = {"CHEMBL50": "CHEMBL60"}
 
     def fake_fetch(
@@ -191,9 +194,42 @@ def test_load_parent_catalog_fetches_and_persists(
         fake_fetch,
     )
 
-    result = load_parent_catalog(
+    catalog = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
     )
 
-    assert result == data
-    assert json.loads(cache.read_text(encoding="utf-8")) == data
+    assert catalog.lookup_many(["CHEMBL50"]) == data
+    assert catalog.sqlite_path == sqlite_path
+    assert sqlite_path.is_file()
+    assert catalog.refreshed is True
+
+
+def test_load_parent_catalog_avoids_reloading_json(
+    tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = tmp_path / "catalog.json"
+    cache.write_text('{"chembl1": "chembl10"}', encoding="utf-8")
+    sqlite_path = tmp_path / "catalog.sqlite3"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
+
+    first = load_parent_catalog(
+        client=DummyClient([]),
+        api_cfg=api_cfg,
+        catalog_cfg=cfg,
+    )
+
+    assert first.lookup_many(["CHEMBL1"]) == {"CHEMBL1": "CHEMBL10"}
+
+    def fail_json_loads(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - defensive
+        raise AssertionError("json.loads should not be called on subsequent runs")
+
+    monkeypatch.setattr("library.molecule_catalog.json.loads", fail_json_loads)
+
+    second = load_parent_catalog(
+        client=DummyClient([]),
+        api_cfg=api_cfg,
+        catalog_cfg=cfg,
+    )
+
+    assert second.lookup_many(["CHEMBL1"]) == {"CHEMBL1": "CHEMBL10"}
+    assert second.refreshed is False


### PR DESCRIPTION
## Summary
- add a SQLite-backed ParentCatalog handle and migrate load_parent_catalog to populate parent_catalog after JSON/CSV migration or remote fetch
- switch parent ID enrichment to query the SQLite cache with lookup_many and persist incremental updates, exposing the sqlite_path option in configuration
- refresh unit and smoke tests to use catalog stubs and cover JSON migration avoidance with the new SQLite cache

## Testing
- pytest --color=no tests/test_molecule_catalog.py::test_load_parent_catalog_avoids_reloading_json
- pytest --color=no tests/test_get_testitem_data.py::test_attach_parent_molecule_ids_fetches_missing


------
https://chatgpt.com/codex/tasks/task_e_68d66bf3fe808324ba2268c84e3a8ea0