### PR TITLE
Preserve existing parent IDs when enriching test items

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -11,7 +11,7 @@ if __package__ is None:  # running as a script
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
 
@@ -121,8 +121,8 @@ def attach_parent_molecule_ids(
     api_cfg: ApiCfg,
     catalog_cfg: MoleculeCatalogCfg,
     timeout: float | None,
-    catalog: dict[str, str] | None = None,
-    catalog_source: str | None = None,
+    catalog: Mapping[str, str] | None = None,
+    source: str | None = None,
 ) -> tuple[pd.DataFrame, ParentLookupStats]:
     """Attach parent molecule identifiers using the ChEMBL catalogue."""
 
@@ -160,10 +160,10 @@ def attach_parent_molecule_ids(
         )
         return result, stats
 
-    catalog_source_resolved = catalog_source
-    catalog_data = catalog
+    source_resolved = source
+    catalog_data: dict[str, str]
 
-    if catalog_data is None:
+    if catalog is None:
         cache_before = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_parent_catalog(
             client=client,
@@ -172,11 +172,12 @@ def attach_parent_molecule_ids(
             timeout=timeout,
         )
         cache_after = _cache_state(catalog_cfg.cache_path)
-        catalog_source_resolved = _resolve_parent_source(cache_before, cache_after)
+        source_resolved = _resolve_parent_source(cache_before, cache_after)
     else:
-        if catalog_source_resolved is None:
+        catalog_data = dict(catalog)
+        if source_resolved is None:
             cache_exists = catalog_cfg.cache_path.is_file()
-            catalog_source_resolved = (
+            source_resolved = (
                 PARENT_LOOKUP_SOURCE_CACHE
                 if cache_exists
                 else PARENT_LOOKUP_SOURCE_REMOTE
@@ -218,7 +219,10 @@ def attach_parent_molecule_ids(
     else:
         existing_parent = pd.Series(pd.NA, index=result.index, dtype="string")
 
-    combined_parent = existing_parent.fillna(parent_series)
+    needs_fill = existing_parent.fillna("").str.strip() == ""
+    combined_parent = existing_parent.copy()
+    combined_parent.loc[needs_fill] = parent_series.loc[needs_fill]
+    combined_parent = combined_parent.fillna(parent_series)
     result[parent_column] = combined_parent
 
     missing = int(combined_parent.isna().sum())
@@ -228,7 +232,7 @@ def attach_parent_molecule_ids(
         source=(
             PARENT_LOOKUP_SOURCE_REMOTE
             if fetched_remote
-            else catalog_source_resolved
+            else source_resolved
         ),
         missing=missing,
         unique=int(len(unique_children)),
@@ -446,7 +450,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 catalog_cfg=cfg.molecule_catalog,
                 timeout=cfg.testitem.timeout,
                 catalog=parent_catalog,
-                catalog_source=parent_catalog_source,
+                source=parent_catalog_source,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.error("parent_lookup_failed", error=str(exc))

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -183,7 +183,7 @@ def test_run_chembl_merges_parent_catalog(
     ) -> tuple[pd.DataFrame, gtd.ParentLookupStats]:
         nonlocal captured_catalog, captured_source
         captured_catalog = kwargs.get("catalog")
-        captured_source = kwargs.get("catalog_source")
+        captured_source = kwargs.get("source")
         return (
             frame,
             gtd.ParentLookupStats(
@@ -576,7 +576,7 @@ def test_attach_parent_molecule_ids_uses_cache_only(
         catalog_cfg=catalog_cfg,
         timeout=None,
         catalog={"CHEMBL1": "CHEMBL1_PARENT"},
-        catalog_source=gtd.PARENT_LOOKUP_SOURCE_CACHE,
+        source=gtd.PARENT_LOOKUP_SOURCE_CACHE,
     )
 
     assert result[catalog_cfg.parent_field].tolist() == ["CHEMBL1_PARENT"]


### PR DESCRIPTION
## Summary
- allow the parent lookup helper to accept generic mappings and capture the reported source when enriching test items
- ensure existing parent molecule identifiers are only replaced when empty while keeping placeholder behaviour for missing parents
- update the test suite for the revised helper signature and behaviour

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d6701a6d1c8324a7290570926f9a74