### PR TITLE
Simplify parent molecule enrichment flow

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -124,7 +124,12 @@ def attach_parent_molecule_ids(
     catalog: Mapping[str, str] | None = None,
     source: str | None = None,
 ) -> tuple[pd.DataFrame, ParentLookupStats]:
-    """Attach parent molecule identifiers using the ChEMBL catalogue."""
+    """Attach parent molecule identifiers using the ChEMBL catalogue.
+
+    The function operates on the original ``df`` content and can enrich frames
+    that already contain parent identifiers as well as frames without the
+    ``catalog_cfg.parent_field`` column.
+    """
 
     if "parant_molecule_id" in df.columns:
         raise ValueError(
@@ -223,7 +228,7 @@ def attach_parent_molecule_ids(
     combined_parent = existing_parent.copy()
     update_mask = combined_parent.isna() | combined_parent.eq("")
     combined_parent.loc[update_mask] = parent_series.loc[update_mask]
-    result[parent_column] = combined_parent
+    result[parent_column] = combined_parent.astype("string")
 
     missing = int(combined_parent.isna().sum())
     attached = len(result) - missing
@@ -460,13 +465,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 fetched_remote = True
         if fetched_remote:
             parent_catalog_source = PARENT_LOOKUP_SOURCE_REMOTE
-
-        if parent_catalog and child_column in df.columns:
-            mapped = normalised_ids.map(parent_catalog)
-            if parent_column in df.columns:
-                df[parent_column] = df[parent_column].fillna(mapped)
-            else:
-                df[parent_column] = mapped
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(df, cfg.pubchem)
         logger.info("pubchem_augment_done")

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -106,6 +106,8 @@ def test_get_testitem_parent_catalog(
     assert output_csv.exists()
 
     df = pd.read_csv(output_csv)
+    assert "parent_molecule_chembl_id" in df.columns
+    assert df["parent_molecule_chembl_id"].isna().sum() == 0
     assert list(df["parent_molecule_chembl_id"]) == [
         "CHEMBL9001",
         "CHEMBL9002",


### PR DESCRIPTION
## Summary
- remove the interim parent column population in the ChEMBL test item pipeline
- clarify parent enrichment helper behaviour and ensure string output typing
- extend the smoke test to verify the parent column remains populated without the intermediate step

## Testing
- pytest tests/smoke/test_get_testitem_parent.py

------
https://chatgpt.com/codex/tasks/task_e_68d67301aabc832484d0f7ccd2d16694