### PR TITLE
Add SQLite-backed molecule parent cache

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -302,6 +302,11 @@
           "title": "Cache Path",
           "type": "string"
         },
+        "sqlite_path": {
+          "default": "data/cache/molecule_parent_catalog.sqlite",
+          "title": "Sqlite Path",
+          "type": "string"
+        },
         "endpoint": {
           "default": "molecule",
           "title": "Endpoint",

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ sources:
       cache_maxsize: 1024  # Max cached ChEMBL responses (env: CHEMBL_DA_CACHE_MAXSIZE)
     molecule_catalog:
       cache_path: "data/cache/molecule_parent_catalog.json"  # Local cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_CACHE)
+      sqlite_path: "data/cache/molecule_parent_catalog.sqlite"  # SQLite cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_SQLITE)
       endpoint: "molecule"  # API resource providing parent relationships
       child_field: "molecule_chembl_id"  # Column containing molecule identifiers
       parent_field: "parent_molecule_chembl_id"  # Column containing parent molecule identifiers

--- a/library/config.py
+++ b/library/config.py
@@ -123,6 +123,7 @@ class ChemblCacheCfg(_BaseModel):
 
 class MoleculeCatalogCfg(_BaseModel):
     cache_path: Path = Path("data/cache/molecule_parent_catalog.json")
+    sqlite_path: Path = Path("data/cache/molecule_parent_catalog.sqlite")
     endpoint: str = "molecule"
     child_field: str = "molecule_chembl_id"
     parent_field: str = "parent_molecule_chembl_id"

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import sqlite3
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Mapping
@@ -21,11 +22,14 @@ _PARENT_LOOKUP_FIELDS = tuple(_DEFAULT_CATALOG_CFG.fields or ()) or (
 _PARENT_LOOKUP_CHILD_FIELD = _DEFAULT_CATALOG_CFG.child_field
 _PARENT_LOOKUP_PARENT_FIELD = _DEFAULT_CATALOG_CFG.parent_field
 _PARENT_LOOKUP_CHUNK_SIZE = _DEFAULT_CATALOG_CFG.page_size
+_SQLITE_VARIABLE_LIMIT = 900
 
 __all__ = [
     "fetch_parent_catalog",
     "fetch_parent_catalog_for",
     "load_parent_catalog",
+    "query_parent_catalog",
+    "update_parent_catalog_cache",
     "write_parent_catalog_cache",
 ]
 
@@ -226,14 +230,26 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
     return result
 
 
-def write_parent_catalog_cache(
-    catalog: Mapping[str, str], catalog_cfg: MoleculeCatalogCfg
-) -> None:
-    """Persist *catalog* to disk using the configured cache format."""
+def _ensure_sqlite_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS parent_catalog (
+            child TEXT PRIMARY KEY,
+            parent TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_parent_catalog_parent ON parent_catalog(parent)"
+    )
 
+
+def _write_cache_from_items(
+    items: Iterable[tuple[str, str]], catalog_cfg: MoleculeCatalogCfg
+) -> None:
     cache_path = catalog_cfg.cache_path
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    sorted_items = sorted(catalog.items())
+    entries = list(items)
 
     if cache_path.suffix.lower() == ".csv":
         with cache_path.open("w", encoding="utf-8", newline="") as fh:
@@ -242,7 +258,7 @@ def write_parent_catalog_cache(
                 fieldnames=[catalog_cfg.child_field, catalog_cfg.parent_field],
             )
             writer.writeheader()
-            for child, parent in sorted_items:
+            for child, parent in entries:
                 writer.writerow(
                     {
                         catalog_cfg.child_field: child,
@@ -252,9 +268,137 @@ def write_parent_catalog_cache(
         return
 
     cache_path.write_text(
-        json.dumps(dict(sorted_items), indent=2, sort_keys=True),
+        json.dumps(dict(entries), indent=2, sort_keys=True),
         encoding="utf-8",
     )
+
+
+def _write_parent_catalog_sqlite(
+    items: Iterable[tuple[str, str]],
+    catalog_cfg: MoleculeCatalogCfg,
+    *,
+    replace: bool,
+) -> None:
+    sqlite_path = catalog_cfg.sqlite_path
+    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+    entries = list(items)
+
+    with sqlite3.connect(sqlite_path) as conn:
+        _ensure_sqlite_schema(conn)
+        if replace:
+            conn.execute("DELETE FROM parent_catalog")
+        if entries:
+            conn.executemany(
+                "INSERT OR REPLACE INTO parent_catalog(child, parent) VALUES (?, ?)",
+                entries,
+            )
+        conn.commit()
+
+
+def _read_sqlite_cache(path: Path) -> tuple[dict[str, str], bool]:
+    if not path.is_file():
+        return {}, False
+    try:
+        with sqlite3.connect(path) as conn:
+            _ensure_sqlite_schema(conn)
+            rows = conn.execute("SELECT child, parent FROM parent_catalog")
+            result = {str(child): str(parent) for child, parent in rows}
+        return result, True
+    except sqlite3.DatabaseError as exc:
+        logger.warning(
+            "invalid_catalog_sqlite",
+            extra={"path": str(path), "error": str(exc)},
+        )
+        return {}, False
+
+
+def _ensure_sqlite_cache(catalog_cfg: MoleculeCatalogCfg) -> bool:
+    sqlite_path = catalog_cfg.sqlite_path
+    if sqlite_path.is_file():
+        return True
+    cached = _read_cache(catalog_cfg.cache_path, catalog_cfg)
+    if not cached:
+        return False
+    items = sorted((str(child), str(parent)) for child, parent in cached.items())
+    _write_parent_catalog_sqlite(items, catalog_cfg, replace=True)
+    return sqlite_path.is_file()
+
+
+def query_parent_catalog(
+    children: Iterable[str], catalog_cfg: MoleculeCatalogCfg
+) -> dict[str, str]:
+    """Return parent mappings for *children* from the SQLite cache."""
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in children:
+        try:
+            child_id = _normalise_chembl_id(str(value))
+        except ValueError:
+            continue
+        if child_id in seen:
+            continue
+        seen.add(child_id)
+        unique.append(child_id)
+
+    if not unique:
+        return {}
+
+    if not _ensure_sqlite_cache(catalog_cfg):
+        return {}
+
+    sqlite_path = catalog_cfg.sqlite_path
+    result: dict[str, str] = {}
+
+    try:
+        with sqlite3.connect(sqlite_path) as conn:
+            _ensure_sqlite_schema(conn)
+            for chunk in _chunked(unique, _SQLITE_VARIABLE_LIMIT):
+                if not chunk:
+                    continue
+                placeholders = ",".join("?" for _ in chunk)
+                cursor = conn.execute(
+                    f"SELECT child, parent FROM parent_catalog WHERE child IN ({placeholders})",
+                    chunk,
+                )
+                result.update({str(child): str(parent) for child, parent in cursor})
+    except sqlite3.DatabaseError as exc:
+        logger.warning(
+            "invalid_catalog_sqlite",
+            extra={"path": str(sqlite_path), "error": str(exc)},
+        )
+        return {}
+
+    return result
+
+
+def write_parent_catalog_cache(
+    catalog: Mapping[str, str], catalog_cfg: MoleculeCatalogCfg
+) -> None:
+    """Persist *catalog* to disk using the configured cache format."""
+
+    sorted_items = sorted(
+        (str(child), str(parent)) for child, parent in catalog.items()
+    )
+    _write_cache_from_items(sorted_items, catalog_cfg)
+    _write_parent_catalog_sqlite(sorted_items, catalog_cfg, replace=True)
+
+
+def update_parent_catalog_cache(
+    catalog: Mapping[str, str], catalog_cfg: MoleculeCatalogCfg
+) -> None:
+    """Update the existing cache with *catalog* entries."""
+
+    if not catalog:
+        return
+
+    sorted_items = sorted(
+        (str(child), str(parent)) for child, parent in catalog.items()
+    )
+    _write_parent_catalog_sqlite(sorted_items, catalog_cfg, replace=False)
+    data, ok = _read_sqlite_cache(catalog_cfg.sqlite_path)
+    if ok:
+        _write_cache_from_items(sorted(data.items()), catalog_cfg)
 
 
 def load_parent_catalog(
@@ -268,9 +412,15 @@ def load_parent_catalog(
     """Return the molecule parent catalogue, using the on-disk cache if present."""
 
     cache_path = catalog_cfg.cache_path
+    sqlite_path = catalog_cfg.sqlite_path
     if not force_refresh:
+        sqlite_data, sqlite_ok = _read_sqlite_cache(sqlite_path)
+        if sqlite_ok:
+            return sqlite_data
         cached = _read_cache(cache_path, catalog_cfg)
         if cached:
+            items = sorted(cached.items())
+            _write_parent_catalog_sqlite(items, catalog_cfg, replace=True)
             return cached
 
     result = fetch_parent_catalog(

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -23,7 +23,12 @@ from library import chembl_library as cl
 from library import io
 from library import molecule_catalog
 from library import pubchem_library as pl
-from library.molecule_catalog import load_parent_catalog, write_parent_catalog_cache
+from library.molecule_catalog import (
+    load_parent_catalog,
+    query_parent_catalog,
+    update_parent_catalog_cache,
+    write_parent_catalog_cache,
+)
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -162,17 +167,27 @@ def attach_parent_molecule_ids(
 
     source_resolved = source
     catalog_data = dict(catalog) if catalog is not None else None
+    normalised_child = _normalise_chembl_ids(result[child_column])
+    unique_children = normalised_child[normalised_child != ""].unique()
+    used_partial_cache = False
 
     if catalog_data is None:
         cache_before = _cache_state(catalog_cfg.cache_path)
-        catalog_data = load_parent_catalog(
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-        )
+        queried = query_parent_catalog(unique_children, catalog_cfg)
         cache_after = _cache_state(catalog_cfg.cache_path)
-        source_resolved = _resolve_parent_source(cache_before, cache_after)
+        if queried or catalog_cfg.sqlite_path.is_file():
+            catalog_data = dict(queried)
+            source_resolved = _resolve_parent_source(cache_before, cache_after)
+            used_partial_cache = True
+        else:
+            catalog_data = load_parent_catalog(
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+            )
+            cache_after = _cache_state(catalog_cfg.cache_path)
+            source_resolved = _resolve_parent_source(cache_before, cache_after)
     else:
         if source_resolved is None:
             cache_exists = catalog_cfg.cache_path.is_file()
@@ -181,9 +196,6 @@ def attach_parent_molecule_ids(
                 if cache_exists
                 else PARENT_LOOKUP_SOURCE_REMOTE
             )
-
-    normalised_child = _normalise_chembl_ids(result[child_column])
-    unique_children = normalised_child[normalised_child != ""].unique()
 
     parent_map = {
         key: catalog_data[key]
@@ -211,7 +223,10 @@ def attach_parent_molecule_ids(
             catalog_data.update(fetched)
             parent_map.update(fetched)
             if catalog is None:
-                write_parent_catalog_cache(catalog_data, catalog_cfg)
+                if used_partial_cache:
+                    update_parent_catalog_cache(fetched, catalog_cfg)
+                else:
+                    write_parent_catalog_cache(catalog_data, catalog_cfg)
 
     parent_series = normalised_child.map(parent_map).astype("string")
 
@@ -425,11 +440,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
         if need_lookup and cache_before[0]:
             try:
-                parent_catalog = load_parent_catalog(
-                    client=client,
-                    api_cfg=cfg.api,
+                parent_catalog = query_parent_catalog(
+                    need_lookup,
                     catalog_cfg=cfg.molecule_catalog,
-                    timeout=cfg.testitem.timeout,
                 )
             except (requests.RequestException, ValueError) as exc:
                 logger.error(

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
 import pytest
@@ -165,16 +166,19 @@ def test_run_chembl_merges_parent_catalog(
     cache_path = tmp_path / "parent_catalog.json"
     cache_path.write_text("{}", encoding="utf-8")
     cfg.molecule_catalog.cache_path = cache_path
+    cfg.molecule_catalog.sqlite_path = tmp_path / "parent_catalog.sqlite"
 
     parent_catalog = {"CHEMBL1": "CHEMBL1_PARENT", "CHEMBL2": "CHEMBL2_PARENT"}
-    load_calls = 0
+    query_calls = 0
 
-    def fake_load_parent_catalog(**_: object) -> dict[str, str]:
-        nonlocal load_calls
-        load_calls += 1
+    def fake_query_parent_catalog(
+        ids: Iterable[str], *, catalog_cfg: object
+    ) -> dict[str, str]:
+        nonlocal query_calls
+        query_calls += 1
         return parent_catalog
 
-    monkeypatch.setattr(gtd, "load_parent_catalog", fake_load_parent_catalog)
+    monkeypatch.setattr(gtd, "query_parent_catalog", fake_query_parent_catalog)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
     captured_catalog: dict[str, str] | None = None
     captured_source: str | None = None
@@ -224,7 +228,7 @@ def test_run_chembl_merges_parent_catalog(
         "CHEMBL1_PARENT",
         "CHEMBL2_EXISTING",
     ]
-    assert load_calls == 1
+    assert query_calls == 1
     assert captured_catalog is parent_catalog
     assert captured_source == gtd.PARENT_LOOKUP_SOURCE_CACHE
 
@@ -348,7 +352,23 @@ def test_run_chembl_parent_catalog_error(
 
     monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1"]))
 
-    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: pd.DataFrame())
+    cache_path = tmp_path / "parent_catalog.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    cfg.molecule_catalog.cache_path = cache_path
+    cfg.molecule_catalog.sqlite_path = tmp_path / "parent_catalog.sqlite"
+
+    monkeypatch.setattr(
+        cl,
+        "get_testitem",
+        lambda *_, **__: pd.DataFrame(
+            [
+                {
+                    cfg.molecule_catalog.child_field: "CHEMBL1",
+                    cfg.molecule_catalog.parent_field: pd.NA,
+                }
+            ]
+        ),
+    )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
@@ -356,8 +376,8 @@ def test_run_chembl_parent_catalog_error(
 
     monkeypatch.setattr(
         gtd,
-        "load_parent_catalog",
-        lambda **__: (_ for _ in ()).throw(
+        "query_parent_catalog",
+        lambda *_, **__: (_ for _ in ()).throw(
             ValueError("missing columns: parant_molecule_id")
         ),
     )
@@ -388,7 +408,23 @@ def test_run_chembl_parent_catalog_request_error(
 
     monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1"]))
 
-    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: pd.DataFrame())
+    cache_path = tmp_path / "parent_catalog.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    cfg.molecule_catalog.cache_path = cache_path
+    cfg.molecule_catalog.sqlite_path = tmp_path / "parent_catalog.sqlite"
+
+    monkeypatch.setattr(
+        cl,
+        "get_testitem",
+        lambda *_, **__: pd.DataFrame(
+            [
+                {
+                    cfg.molecule_catalog.child_field: "CHEMBL1",
+                    cfg.molecule_catalog.parent_field: pd.NA,
+                }
+            ]
+        ),
+    )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
@@ -396,8 +432,8 @@ def test_run_chembl_parent_catalog_request_error(
 
     monkeypatch.setattr(
         gtd,
-        "load_parent_catalog",
-        lambda **__: (_ for _ in ()).throw(requests.RequestException("boom")),
+        "query_parent_catalog",
+        lambda *_, **__: (_ for _ in ()).throw(requests.RequestException("boom")),
     )
 
     monkeypatch.setattr(
@@ -448,6 +484,7 @@ def test_attach_parent_molecule_ids_fetches_missing(
 
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
     monkeypatch.setattr(
         gtd,
@@ -505,6 +542,7 @@ def test_attach_parent_molecule_ids_updates_cache_for_reuse(
         json.dumps({"CHEMBL1": "CHEMBL1_PARENT"}, indent=2, sort_keys=True),
         encoding="utf-8",
     )
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
     fetch_calls: list[list[str]] = []
 
@@ -561,6 +599,53 @@ def test_attach_parent_molecule_ids_updates_cache_for_reuse(
     assert second_stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
 
 
+def test_attach_parent_molecule_ids_uses_sqlite_after_migration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+    catalog_cfg.cache_path.write_text(
+        json.dumps({"CHEMBL1": "CHEMBL1_PARENT"}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    original_loads = gtd.molecule_catalog.json.loads
+    calls = {"loads": 0}
+
+    def counting_loads(data: str, *args: object, **kwargs: object) -> object:
+        calls["loads"] += 1
+        return original_loads(data, *args, **kwargs)
+
+    monkeypatch.setattr(gtd.molecule_catalog.json, "loads", counting_loads)
+
+    first_result, _ = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert calls["loads"] == 1
+    assert first_result[catalog_cfg.parent_field].tolist() == ["CHEMBL1_PARENT"]
+
+    calls["loads"] = 0
+
+    second_result, _ = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert calls["loads"] == 0
+    assert second_result[catalog_cfg.parent_field].tolist() == ["CHEMBL1_PARENT"]
+
+
 def test_attach_parent_molecule_ids_fetch_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
@@ -568,6 +653,7 @@ def test_attach_parent_molecule_ids_fetch_failure(
 
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
     monkeypatch.setattr(
         gtd,
@@ -614,6 +700,7 @@ def test_attach_parent_molecule_ids_uses_cache_only(
 
     catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
     catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
     catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
 
 

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -12,6 +12,9 @@ from library.molecule_catalog import (
     fetch_parent_catalog,
     fetch_parent_catalog_for,
     load_parent_catalog,
+    query_parent_catalog,
+    update_parent_catalog_cache,
+    write_parent_catalog_cache,
 )
 
 
@@ -134,7 +137,9 @@ def test_fetch_parent_catalog_for_chunks_requests(
 def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
     cache = tmp_path / "catalog.json"
     cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cfg = MoleculeCatalogCfg(
+        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
+    )
 
     result = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
@@ -149,7 +154,9 @@ def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) ->
         "molecule_chembl_id,parent_molecule_chembl_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cfg = MoleculeCatalogCfg(
+        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
+    )
 
     result = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
@@ -164,7 +171,9 @@ def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg
         "molecule_chembl_id,parant_molecule_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cfg = MoleculeCatalogCfg(
+        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
+    )
 
     with pytest.raises(ValueError):
         load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
@@ -174,7 +183,9 @@ def test_load_parent_catalog_fetches_and_persists(
     tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache = tmp_path / "catalog.json"
-    cfg = MoleculeCatalogCfg(cache_path=cache)
+    cfg = MoleculeCatalogCfg(
+        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
+    )
     data = {"CHEMBL50": "CHEMBL60"}
 
     def fake_fetch(
@@ -197,3 +208,32 @@ def test_load_parent_catalog_fetches_and_persists(
 
     assert result == data
     assert json.loads(cache.read_text(encoding="utf-8")) == data
+    assert cfg.sqlite_path.is_file()
+
+
+def test_query_parent_catalog_reads_sqlite(tmp_path: Path) -> None:
+    cache = tmp_path / "catalog.json"
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
+    write_parent_catalog_cache({"CHEMBL1": "CHEMBL10", "CHEMBL2": "CHEMBL20"}, cfg)
+
+    result = query_parent_catalog(["chembl1", "chembl3"], cfg)
+
+    assert result == {"CHEMBL1": "CHEMBL10"}
+    assert sqlite_path.is_file()
+
+
+def test_update_parent_catalog_cache_appends(tmp_path: Path, api_cfg: ApiCfg) -> None:
+    cache = tmp_path / "catalog.json"
+    sqlite_path = tmp_path / "catalog.sqlite"
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=sqlite_path)
+    write_parent_catalog_cache({"CHEMBL1": "CHEMBL10"}, cfg)
+
+    update_parent_catalog_cache({"CHEMBL2": "CHEMBL20"}, cfg)
+
+    result = load_parent_catalog(
+        client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
+    )
+
+    assert result == {"CHEMBL1": "CHEMBL10", "CHEMBL2": "CHEMBL20"}
+    assert json.loads(cache.read_text(encoding="utf-8")) == result


### PR DESCRIPTION
## Summary
- add a SQLite-backed parent catalog cache with query and incremental update helpers
- update the test item pipeline to use parameterised SQLite lookups and refresh the cache as IDs are fetched
- extend the configuration schema and tests to cover the new SQLite path and cache migration scenarios

## Testing
- pytest tests/test_molecule_catalog.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d672b1f1188324b4ab9fdb2abecac2