### PR TITLE
Add salt enrichment and molecule flag mapping for test items

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1340,6 +1340,95 @@
       "title": "TestitemCfg",
       "type": "object"
     },
+    "TestitemMoleculeEnrichmentSourcesCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "molecule_catalog_path": {
+          "default": "dictionary/molecule_catalog.csv",
+          "format": "path",
+          "title": "Molecule Catalog Path",
+          "type": "string"
+        },
+        "molecule_hierarchy_path": {
+          "default": "dictionary/molecule_hierarchy.csv",
+          "format": "path",
+          "title": "Molecule Hierarchy Path",
+          "type": "string"
+        }
+      },
+      "title": "TestitemMoleculeEnrichmentSourcesCfg",
+      "type": "object"
+    },
+    "TestitemMoleculeEnrichmentOutputCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "salt_as_null_when_absent": {
+          "default": true,
+          "title": "Salt As Null When Absent",
+          "type": "boolean"
+        }
+      },
+      "title": "TestitemMoleculeEnrichmentOutputCfg",
+      "type": "object"
+    },
+    "TestitemMoleculeEnrichmentFlagsCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "coerce_to_bool": {
+          "default": true,
+          "title": "Coerce To Bool",
+          "type": "boolean"
+        },
+        "parent_fallback": {
+          "default": true,
+          "title": "Parent Fallback",
+          "type": "boolean"
+        }
+      },
+      "title": "TestitemMoleculeEnrichmentFlagsCfg",
+      "type": "object"
+    },
+    "TestitemMoleculeEnrichmentLoggingCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "warn_missing_molecule": {
+          "default": true,
+          "title": "Warn Missing Molecule",
+          "type": "boolean"
+        },
+        "warn_inconsistent_flags": {
+          "default": true,
+          "title": "Warn Inconsistent Flags",
+          "type": "boolean"
+        }
+      },
+      "title": "TestitemMoleculeEnrichmentLoggingCfg",
+      "type": "object"
+    },
+    "TestitemMoleculeEnrichmentCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "sources": {
+          "$ref": "#/$defs/TestitemMoleculeEnrichmentSourcesCfg"
+        },
+        "output": {
+          "$ref": "#/$defs/TestitemMoleculeEnrichmentOutputCfg"
+        },
+        "flags": {
+          "$ref": "#/$defs/TestitemMoleculeEnrichmentFlagsCfg"
+        },
+        "logging": {
+          "$ref": "#/$defs/TestitemMoleculeEnrichmentLoggingCfg"
+        }
+      },
+      "title": "TestitemMoleculeEnrichmentCfg",
+      "type": "object"
+    },
     "UniprotCfg": {
       "additionalProperties": false,
       "properties": {
@@ -1447,6 +1536,9 @@
     },
     "activity_enrichment": {
       "$ref": "#/$defs/ActivityEnrichmentCfg"
+    },
+    "testitem_molecule_enrichment": {
+      "$ref": "#/$defs/TestitemMoleculeEnrichmentCfg"
     },
     "system": {
       "$ref": "#/$defs/SystemCfg"

--- a/config.yaml
+++ b/config.yaml
@@ -186,6 +186,20 @@ activity_enrichment:
     log_missing: false
     log_distribution: false
 
+testitem_molecule_enrichment:
+  enable: true
+  sources:
+    molecule_catalog_path: "dictionary/molecule_catalog.csv"
+    molecule_hierarchy_path: "dictionary/molecule_hierarchy.csv"
+  output:
+    salt_as_null_when_absent: true
+  flags:
+    coerce_to_bool: true
+    parent_fallback: true
+  logging:
+    warn_missing_molecule: true
+    warn_inconsistent_flags: true
+
 activity_bounds:
   enable_from_relation: true      # Derive bounds from relation/value pairs when explicit bounds are absent
   enable_from_uncertainty: false  # Parse ± expressions when available

--- a/dictionary/molecule_catalog.csv
+++ b/dictionary/molecule_catalog.csv
@@ -1,0 +1,3 @@
+molecule_chembl_id,natural_product,prodrug,polymer_flag
+CHEMBL1903,Y,,0
+CHEMBL19,N,N,0

--- a/dictionary/molecule_hierarchy.csv
+++ b/dictionary/molecule_hierarchy.csv
@@ -1,0 +1,3 @@
+molecule_chembl_id,parent_molecule_chembl_id
+CHEMBL1903,CHEMBL19
+CHEMBL19,CHEMBL19

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -121,6 +121,19 @@ The CLI only exposes high-level switches such as `--batch-size` or `--dry-run`; 
 | `timeout` | `30.0` | Request timeout in seconds. |
 | `limit` | `null` | Optional cap on identifiers processed. |
 
+#### Test item molecule enrichment (`testitem_molecule_enrichment`)
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `enable` | `true` | Master switch for the enrichment stage that derives salt identifiers and catalogue flags. |
+| `sources.molecule_catalog_path` | `dictionary/molecule_catalog.csv` | CSV with `molecule_chembl_id` and the `natural_product`/`prodrug`/`polymer_flag` columns. |
+| `sources.molecule_hierarchy_path` | `dictionary/molecule_hierarchy.csv` | CSV that maps derivatives to their parent molecule (`molecule_chembl_id`, `parent_molecule_chembl_id`). |
+| `output.salt_as_null_when_absent` | `true` | Emit `null` (or `-` when set to `false`) when the compound is not a salt. |
+| `flags.coerce_to_bool` | `true` | Normalise catalogue values such as `Y/N`, `1/0`, `yes/no` to pandas nullable booleans. |
+| `flags.parent_fallback` | `true` | Reuse parent flag values when the child entry is missing. |
+| `logging.warn_missing_molecule` | `true` | Log warnings when a molecule listed in the export is not present in the hierarchy or catalogue. |
+| `logging.warn_inconsistent_flags` | `true` | Emit warnings when child and parent flags disagree before fallback. |
+
 #### Document pipeline (`document`)
 
 | Sub-section | Key | Default | Description |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -121,6 +121,19 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `timeout` | `30.0` | Таймаут запроса (сек.). |
 | `limit` | `null` | Ограничение на число идентификаторов. |
 
+#### Обогащение тест-объектов (`testitem_molecule_enrichment`)
+
+| Ключ | Значение по умолчанию | Описание |
+| --- | --- | --- |
+| `enable` | `true` | Включает стадию расчёта `salt_chembl_id` и флагов из каталога молекул. |
+| `sources.molecule_catalog_path` | `dictionary/molecule_catalog.csv` | CSV со столбцами `molecule_chembl_id`, `natural_product`, `prodrug`, `polymer_flag`. |
+| `sources.molecule_hierarchy_path` | `dictionary/molecule_hierarchy.csv` | CSV с соответствиями дочерней и родительской молекулы. |
+| `output.salt_as_null_when_absent` | `true` | При `true` несолевые соединения дают `null`, при `false` — символ `-`. |
+| `flags.coerce_to_bool` | `true` | Нормализует значения вида `Y/N`, `1/0`, `yes/no` в булев тип pandas. |
+| `flags.parent_fallback` | `true` | Подтягивает флаги из родителя, если у дочерней записи они пусты. |
+| `logging.warn_missing_molecule` | `true` | Логирует предупреждение, если молекулы нет в иерархии или каталоге. |
+| `logging.warn_inconsistent_flags` | `true` | Сообщает о расхождении флагов между дочерней и родительской записью. |
+
 #### Пайплайн документов (`document`)
 
 | Подсекция | Ключ | Значение | Описание |

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -125,3 +125,12 @@ Before distributing the export, join it with the parent molecule catalogue to ex
 `parent_molecule_chembl_id` for roll-ups. The mapping is stored in the JSON file configured at
 `sources.chembl.molecule_catalog.cache_path` and loaded via
 `library.molecule_catalog.load_parent_catalog`, which refreshes the cache from the ChEMBL API when needed.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
+
+An additional enrichment stage reads `dictionary/molecule_hierarchy.csv` and
+`dictionary/molecule_catalog.csv` to populate the salt identifier and the
+`natural_product`, `prodrug`, `polymer_flag` booleans before validation. The
+pipeline detects salts when `parent_molecule_chembl_id` differs from
+`molecule_chembl_id`, fills `salt_chembl_id` with the child identifier, and
+normalises catalogue flags to the pandas nullable boolean dtype. Missing child
+flags fall back to the parent entry when available, while absent parent/child
+records are surfaced via warning events for troubleshooting.【F:scripts/get_testitem_data.py†L205-L233】【F:library/testitem_enrichment.py†L17-L216】

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -114,3 +114,12 @@ JSON-файл содержит:
 `parent_molecule_chembl_id` для агрегаций. Отображение хранится в JSON по пути
 `sources.chembl.molecule_catalog.cache_path` и загружается функцией
 `library.molecule_catalog.load_parent_catalog`, которая при необходимости обновляет кэш через API ChEMBL.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
+
+Дополнительный этап обогащения использует `dictionary/molecule_hierarchy.csv` и
+`dictionary/molecule_catalog.csv`, чтобы до валидации заполнить `salt_chembl_id`
+и булевы признаки `natural_product`, `prodrug`, `polymer_flag`. Соль
+распознаётся, когда `parent_molecule_chembl_id` отличается от
+`molecule_chembl_id`, после чего в `salt_chembl_id` попадает идентификатор
+дочерней молекулы. Флаги нормализуются в nullable-тип pandas `boolean`, а
+пропуски у дочерних записей при необходимости подтягиваются из родителя. Если
+молекула отсутствует в словарях, лог пишется с предупреждением для диагностики.【F:scripts/get_testitem_data.py†L205-L233】【F:library/testitem_enrichment.py†L17-L216】

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -155,6 +155,28 @@ Use `library.molecule_catalog.load_parent_catalog` in a short Python snippet to 
 file before executing the pipeline. The helper reuses the cached mapping when present and fetches the latest
 relationships from the ChEMBL API otherwise.【F:library/molecule_catalog.py†L43-L136】
 
+### Salt and catalogue enrichment
+
+The optional `testitem_molecule_enrichment` stage augments `testitem.csv` with
+`salt_chembl_id`, `natural_product`, `prodrug`, and `polymer_flag` using two
+CSV dictionaries:
+
+* `dictionary/molecule_hierarchy.csv` (columns `molecule_chembl_id`,
+  `parent_molecule_chembl_id`) maps salts to their parent molecules.
+* `dictionary/molecule_catalog.csv` (columns `molecule_chembl_id`,
+  `natural_product`, `prodrug`, `polymer_flag`) stores boolean attributes.
+
+Missing dictionary rows trigger warnings such as
+`testitem_enrichment_missing_child_flags` or
+`testitem_enrichment_missing_parent_flags`; check the catalogue contents or
+disable the stage with `testitem_molecule_enrichment.enable=false` when
+running without the dictionaries. Logs named
+`testitem_enrichment_inconsistent_flag` highlight disagreements between child
+and parent rows before the fallback logic copies the parent values. Adjust the
+behaviour via `testitem_molecule_enrichment.flags.*` to disable the parent
+fallback or boolean coercion when feeding downstream systems that expect the
+raw catalogue tokens.【F:library/testitem_enrichment.py†L17-L216】
+
 ## Input initialisation (`get_input_initialisation.py`)
 
 ```bash

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -157,6 +157,27 @@ PubChem-дополнение добавляет детерминированны
 `library.molecule_catalog.load_parent_catalog` — функция считывает готовый кэш и, при его отсутствии,
 подкачивает свежие связи ребёнок→родитель из API ChEMBL.【F:library/molecule_catalog.py†L43-L136】
 
+### Обогащение солей и флагов каталога
+
+Опциональный блок `testitem_molecule_enrichment` добавляет к `testitem.csv`
+столбцы `salt_chembl_id`, `natural_product`, `prodrug`, `polymer_flag` на
+основе двух CSV-словарей:
+
+* `dictionary/molecule_hierarchy.csv` со столбцами `molecule_chembl_id`,
+  `parent_molecule_chembl_id` описывает связи соли и родителя.
+* `dictionary/molecule_catalog.csv` со столбцами `molecule_chembl_id`,
+  `natural_product`, `prodrug`, `polymer_flag` содержит булевы признаки.
+
+Если молекулы нет в словарях, в лог попадают предупреждения
+`testitem_enrichment_missing_child_flags` или
+`testitem_enrichment_missing_parent_flags` — проверьте данные или временно
+отключите блок через `testitem_molecule_enrichment.enable=false`. Сообщение
+`testitem_enrichment_inconsistent_flag` сигнализирует о расхождении флагов
+между дочерней и родительской записью до применения фолбэка. Поведение можно
+тонко настроить через `testitem_molecule_enrichment.flags.*`, отключив
+фолбэк или приведение к булевому типу, если downstream-потребители требуют
+исходные текстовые значения.【F:library/testitem_enrichment.py†L17-L216】
+
 ## Инициализация входных данных (`get_input_initialisation.py`)
 
 ```bash

--- a/library/config.py
+++ b/library/config.py
@@ -481,6 +481,61 @@ class TestitemCfg(_BaseModel):
     limit: int | None = Field(default=None, ge=0)
 
 
+class TestitemMoleculeEnrichmentSourcesCfg(_BaseModel):
+    molecule_catalog_path: Path = Path("dictionary/molecule_catalog.csv")
+    molecule_hierarchy_path: Path = Path("dictionary/molecule_hierarchy.csv")
+
+
+class TestitemMoleculeEnrichmentOutputCfg(_BoolModel):
+    salt_as_null_when_absent: bool = True
+
+    @field_validator("salt_as_null_when_absent", mode="before")
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+
+class TestitemMoleculeEnrichmentFlagsCfg(_BoolModel):
+    coerce_to_bool: bool = True
+    parent_fallback: bool = True
+
+    @field_validator("coerce_to_bool", "parent_fallback", mode="before")
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+
+class TestitemMoleculeEnrichmentLoggingCfg(_BoolModel):
+    warn_missing_molecule: bool = True
+    warn_inconsistent_flags: bool = True
+
+    @field_validator("warn_missing_molecule", "warn_inconsistent_flags", mode="before")
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+
+class TestitemMoleculeEnrichmentCfg(_BoolModel):
+    enable: bool = True
+    sources: TestitemMoleculeEnrichmentSourcesCfg = Field(
+        default_factory=lambda: TestitemMoleculeEnrichmentSourcesCfg()
+    )
+    output: TestitemMoleculeEnrichmentOutputCfg = Field(
+        default_factory=lambda: TestitemMoleculeEnrichmentOutputCfg()
+    )
+    flags: TestitemMoleculeEnrichmentFlagsCfg = Field(
+        default_factory=lambda: TestitemMoleculeEnrichmentFlagsCfg()
+    )
+    logging: TestitemMoleculeEnrichmentLoggingCfg = Field(
+        default_factory=lambda: TestitemMoleculeEnrichmentLoggingCfg()
+    )
+
+    @field_validator("enable", mode="before")
+    @classmethod
+    def _bools(cls, v: Any) -> bool:
+        return cls._parse_bool(v)
+
+
 class DocumentPubmedCfg(_BaseModel):
     column: str = "PMID"
     sleep: float = Field(5.0, ge=0)
@@ -620,6 +675,9 @@ class Config(_BaseModel):
     )
     activity_enrichment: ActivityEnrichmentCfg = Field(
         default_factory=lambda: ActivityEnrichmentCfg()
+    )
+    testitem_molecule_enrichment: TestitemMoleculeEnrichmentCfg = Field(
+        default_factory=lambda: TestitemMoleculeEnrichmentCfg()
     )
 
     # -- Compatibility accessors -------------------------------------------------
@@ -1130,6 +1188,11 @@ __all__ = [
     "ActivityPropertiesCfg",
     "AssayCfg",
     "TestitemCfg",
+    "TestitemMoleculeEnrichmentCfg",
+    "TestitemMoleculeEnrichmentFlagsCfg",
+    "TestitemMoleculeEnrichmentLoggingCfg",
+    "TestitemMoleculeEnrichmentOutputCfg",
+    "TestitemMoleculeEnrichmentSourcesCfg",
     "DocumentPubmedCfg",
     "DocumentChemblCfg",
     "DocumentAllCfg",

--- a/library/testitem_enrichment.py
+++ b/library/testitem_enrichment.py
@@ -1,0 +1,276 @@
+"""Enrich test item data with salt information and molecule catalog flags."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from . import io
+from .config import IoCfg, TestitemMoleculeEnrichmentCfg
+from .log import logger
+
+_FLAG_COLUMNS: tuple[str, ...] = ("natural_product", "prodrug", "polymer_flag")
+_TRUE_VALUES: frozenset[str] = frozenset({"1", "true", "t", "yes", "y"})
+_FALSE_VALUES: frozenset[str] = frozenset({"0", "false", "f", "no", "n"})
+
+
+@dataclass(frozen=True)
+class _SourceFrames:
+    hierarchy: pd.DataFrame
+    catalog: pd.DataFrame
+
+
+def _read_source(path: Path, *, io_cfg: IoCfg) -> pd.DataFrame:
+    """Read a CSV file using the shared I/O configuration."""
+
+    return io.read_csv(path, cfg=io_cfg, dtype="string")
+
+
+def _normalise_ids(series: pd.Series) -> pd.Series:
+    """Return ``series`` with whitespace trimmed and converted to upper case."""
+
+    normalised = (
+        series.fillna("")
+        .astype("string")
+        .str.strip()
+        .str.upper()
+    )
+    return normalised.mask(normalised == "", other=pd.NA)
+
+
+def _coerce_flag_values(series: pd.Series, column: str) -> tuple[pd.Series, set[str]]:
+    """Coerce string flags to pandas nullable booleans."""
+
+    unknown: set[str] = set()
+    result: list[object] = []
+    for value in series.astype(object).tolist():
+        if value is None or pd.isna(value):
+            result.append(pd.NA)
+            continue
+        text = str(value).strip()
+        if not text:
+            result.append(pd.NA)
+            continue
+        text_lower = text.lower()
+        if text_lower in _TRUE_VALUES:
+            result.append(True)
+        elif text_lower in _FALSE_VALUES:
+            result.append(False)
+        else:
+            result.append(pd.NA)
+            unknown.add(text_lower)
+    return pd.Series(result, index=series.index, dtype="boolean"), unknown
+
+
+def _load_sources(
+    cfg: TestitemMoleculeEnrichmentCfg, *, io_cfg: IoCfg
+) -> _SourceFrames:
+    """Load hierarchy and catalog frames according to configuration."""
+
+    hierarchy_required = {"molecule_chembl_id", "parent_molecule_chembl_id"}
+    catalog_required = {"molecule_chembl_id", *_FLAG_COLUMNS}
+
+    hierarchy = pd.DataFrame(columns=list(hierarchy_required))
+    catalog = pd.DataFrame(columns=list(catalog_required))
+
+    try:
+        hierarchy = _read_source(cfg.sources.molecule_hierarchy_path, io_cfg=io_cfg)
+    except FileNotFoundError:
+        logger.warning(
+            "testitem_enrichment_missing_hierarchy",
+            path=str(cfg.sources.molecule_hierarchy_path),
+        )
+    else:
+        missing = hierarchy_required - set(hierarchy.columns)
+        if missing:
+            raise ValueError(
+                "missing columns in hierarchy file: " + ", ".join(sorted(missing))
+            )
+        hierarchy = hierarchy.loc[:, list(hierarchy_required)].copy()
+
+    try:
+        catalog = _read_source(cfg.sources.molecule_catalog_path, io_cfg=io_cfg)
+    except FileNotFoundError:
+        logger.warning(
+            "testitem_enrichment_missing_catalog",
+            path=str(cfg.sources.molecule_catalog_path),
+        )
+    else:
+        missing = catalog_required - set(catalog.columns)
+        if missing:
+            raise ValueError(
+                "missing columns in molecule catalog: " + ", ".join(sorted(missing))
+            )
+        catalog = catalog.loc[:, list(catalog_required)].copy()
+
+    return _SourceFrames(hierarchy=hierarchy, catalog=catalog)
+
+
+def _prepare_catalog(
+    catalog: pd.DataFrame,
+    cfg: TestitemMoleculeEnrichmentCfg,
+) -> tuple[pd.DataFrame, dict[str, set[str]]]:
+    """Return normalised catalog frame and unknown flag values."""
+
+    unknown_by_column: dict[str, set[str]] = {column: set() for column in _FLAG_COLUMNS}
+
+    if catalog.empty:
+        return catalog, unknown_by_column
+
+    catalog["molecule_chembl_id"] = _normalise_ids(catalog["molecule_chembl_id"])
+    catalog = catalog.dropna(subset=["molecule_chembl_id"]).drop_duplicates(
+        subset=["molecule_chembl_id"], keep="first"
+    )
+
+    if cfg.flags.coerce_to_bool:
+        for column in _FLAG_COLUMNS:
+            catalog[column], unknown_values = _coerce_flag_values(catalog[column], column)
+            unknown_by_column[column] = unknown_values
+    else:
+        for column in _FLAG_COLUMNS:
+            catalog[column] = catalog[column].astype("string")
+
+    return catalog.set_index("molecule_chembl_id"), unknown_by_column
+
+
+def _map_flags(ids: pd.Series, mapping: pd.Series) -> pd.Series:
+    """Map identifiers to boolean flag values using the provided mapping."""
+
+    values: list[object] = []
+    lookup = mapping.to_dict()
+    for value in ids.astype(object).tolist():
+        if value is None:
+            values.append(pd.NA)
+        else:
+            values.append(lookup.get(str(value), pd.NA))
+    return pd.Series(values, index=ids.index, dtype="boolean")
+
+
+def enrich(
+    df: pd.DataFrame,
+    *,
+    cfg: TestitemMoleculeEnrichmentCfg,
+    io_cfg: IoCfg,
+) -> pd.DataFrame:
+    """Attach salt identifiers and molecule flags to ``df``."""
+
+    if df.empty:
+        df = df.copy()
+        df["salt_chembl_id"] = pd.Series(dtype="string")
+        for column in _FLAG_COLUMNS:
+            df[column] = pd.Series(dtype="boolean")
+        return df
+
+    frames = _load_sources(cfg, io_cfg=io_cfg)
+
+    result = df.copy()
+    if "molecule_chembl_id" in result.columns:
+        child_ids = _normalise_ids(result["molecule_chembl_id"])
+    else:
+        child_ids = pd.Series(pd.NA, index=result.index, dtype="string")
+
+    if "parent_molecule_chembl_id" in result.columns:
+        parent_ids = _normalise_ids(result["parent_molecule_chembl_id"])
+    else:
+        parent_ids = pd.Series(pd.NA, index=result.index, dtype="string")
+        result["parent_molecule_chembl_id"] = parent_ids
+
+    if not frames.hierarchy.empty:
+        hierarchy = frames.hierarchy.copy()
+        hierarchy["molecule_chembl_id"] = _normalise_ids(
+            hierarchy["molecule_chembl_id"]
+        )
+        hierarchy["parent_molecule_chembl_id"] = _normalise_ids(
+            hierarchy["parent_molecule_chembl_id"]
+        )
+        hierarchy = hierarchy.dropna(subset=["molecule_chembl_id"])
+        hierarchy = hierarchy.drop_duplicates(
+            subset=["molecule_chembl_id"], keep="first"
+        ).set_index("molecule_chembl_id")
+        parent_from_hierarchy = child_ids.map(hierarchy["parent_molecule_chembl_id"].to_dict())
+        parent_ids = parent_ids.fillna(parent_from_hierarchy)
+
+    parent_ids = parent_ids.astype("string")
+    result["parent_molecule_chembl_id"] = parent_ids
+
+    salt_mask = parent_ids.notna() & (parent_ids != child_ids)
+    salt_series = pd.Series(pd.NA, index=result.index, dtype="string")
+    salt_series[salt_mask] = child_ids[salt_mask]
+    if not cfg.output.salt_as_null_when_absent:
+        salt_series = salt_series.fillna("-")
+    result["salt_chembl_id"] = salt_series
+
+    catalog, unknown_flags = _prepare_catalog(frames.catalog, cfg)
+
+    if cfg.logging.warn_missing_molecule and not catalog.empty:
+        known_ids = set(catalog.index)
+        missing_children = sorted({value for value in child_ids.dropna() if value not in known_ids})
+        missing_parents = sorted(
+            {
+                value
+                for value in parent_ids.dropna()
+                if value not in known_ids
+            }
+        )
+        if missing_children:
+            logger.warning(
+                "testitem_enrichment_missing_child_flags",
+                count=len(missing_children),
+            )
+        if missing_parents:
+            logger.warning(
+                "testitem_enrichment_missing_parent_flags",
+                count=len(missing_parents),
+            )
+
+    for column, values in unknown_flags.items():
+        if values and cfg.flags.coerce_to_bool:
+            logger.warning(
+                "testitem_enrichment_unknown_flag_values",
+                column=column,
+                values=sorted(values),
+            )
+
+    if catalog.empty:
+        for column in _FLAG_COLUMNS:
+            result[column] = pd.Series(pd.NA, index=result.index, dtype="boolean")
+        return result
+
+    for column in _FLAG_COLUMNS:
+        mapping = catalog[column]
+        if cfg.flags.coerce_to_bool:
+            child_flag = _map_flags(child_ids, mapping)
+            parent_flag = _map_flags(parent_ids, mapping)
+        else:
+            lookup = mapping.to_dict()
+            child_flag = child_ids.map(lookup).astype("string")
+            parent_flag = parent_ids.map(lookup).astype("string")
+
+        if cfg.logging.warn_inconsistent_flags:
+            inconsistent = (
+                child_flag.notna()
+                & parent_flag.notna()
+                & (child_flag != parent_flag)
+            )
+            if inconsistent.any():
+                logger.warning(
+                    "testitem_enrichment_inconsistent_flag",
+                    column=column,
+                    count=int(inconsistent.sum()),
+                )
+
+        if cfg.flags.parent_fallback:
+            missing_mask = child_flag.isna()
+            child_flag[missing_mask] = parent_flag[missing_mask]
+
+        if cfg.flags.coerce_to_bool:
+            result[column] = child_flag.astype("boolean")
+        else:
+            result[column] = child_flag
+
+    return result
+
+
+__all__ = ["enrich"]

--- a/schemas/normalize.py
+++ b/schemas/normalize.py
@@ -19,6 +19,8 @@ def _apply_if_string(series: pd.Series, func: Callable[[str], str]) -> pd.Series
 
     Non-string values are returned unchanged.
     """
+    if pd.api.types.is_bool_dtype(series):
+        return series
     return series.map(lambda x: func(x) if isinstance(x, str) else x)
 
 

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import cast
 
+import pandas as pd
 import pandera.pandas as pa
 from pandera.dtypes import DataType
 
@@ -16,6 +17,10 @@ TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "parent_molecule_chembl_id": pa.Column(
             str, required=False, nullable=True
         ),
+        "salt_chembl_id": pa.Column(str, required=False, nullable=True),
+        "natural_product": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
+        "prodrug": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
+        "polymer_flag": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
 
         "black_box_warning": pa.Column(PA_ANY, required=False, nullable=True),
         "first_approval": pa.Column(PA_ANY, required=False, nullable=True),

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -22,6 +22,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import io
 from library import molecule_catalog
+from library import testitem_enrichment
 from library import pubchem_library as pl
 from library.molecule_catalog import load_parent_catalog, write_parent_catalog_cache
 from library.chembl_client import ChemblClient
@@ -500,7 +501,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             attached=parent_stats.attached,
             missing=parent_stats.missing,
         )
- 
+
+        enrichment_cfg = cfg.testitem_molecule_enrichment
+        if enrichment_cfg.enable:
+            logger.info("testitem_enrichment_start")
+            try:
+                df = testitem_enrichment.enrich(
+                    df,
+                    cfg=enrichment_cfg,
+                    io_cfg=cfg.io,
+                )
+            except ValueError as exc:
+                logger.error("testitem_enrichment_failed", error=str(exc))
+                return 1
+            logger.info("testitem_enrichment_done")
+
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_testitems(df)
         df = add_pipeline_metadata(df)

--- a/tests/data/input-smoke/molecule_catalog.csv
+++ b/tests/data/input-smoke/molecule_catalog.csv
@@ -1,3 +1,3 @@
-molecule_chembl_id,parent_molecule_chembl_id
-CHEMBL1,CHEMBL9001
-CHEMBL2,CHEMBL9002
+molecule_chembl_id,parent_molecule_chembl_id,natural_product,prodrug,polymer_flag
+CHEMBL1,CHEMBL9001,Y,N,0
+CHEMBL2,CHEMBL9002,,Y,1

--- a/tests/data/input-smoke/molecule_hierarchy.csv
+++ b/tests/data/input-smoke/molecule_hierarchy.csv
@@ -1,0 +1,4 @@
+molecule_chembl_id,parent_molecule_chembl_id
+CHEMBL100,CHEMBL0100P
+CHEMBL200,CHEMBL0200P
+CHEMBL201,CHEMBL0201P

--- a/tests/smoke/test_testitem_salt_flags_smoke.py
+++ b/tests/smoke/test_testitem_salt_flags_smoke.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from library import chembl_library as cl
+from library import pubchem_library as pl
+from library import testitem_enrichment
+from scripts import get_testitem_data
+
+
+def _cleanup_output(path: Path) -> None:
+    for candidate in (
+        path,
+        path.with_name(path.name + ".meta.yaml"),
+        path.with_suffix(".quality.json"),
+        path.with_name(f"{path.stem}_failure_cases.csv"),
+    ):
+        if candidate.exists() and candidate.is_file():
+            candidate.unlink()
+
+
+@pytest.mark.usefixtures("smoke_output_dir")
+def test_testitem_salt_flags_smoke(
+    smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = Path("tests/data/input-smoke/testitem.csv")
+    output_csv = smoke_output_dir / "testitem_flags.csv"
+    _cleanup_output(output_csv)
+
+    def fake_get_testitem(ids, cfg, client, chunk_size, timeout):  # type: ignore[no-untyped-def]
+        rows: list[dict[str, object]] = []
+        for mol_id in ids:
+            if mol_id == "CHEMBL1":
+                child = "CHEMBL100"
+                parent = None
+            elif mol_id == "CHEMBL2":
+                child = "CHEMBL200"
+                parent = "CHEMBL0200P"
+            else:
+                child = str(mol_id)
+                parent = None
+            rows.append(
+                {
+                    "molecule_chembl_id": child,
+                    "parent_molecule_chembl_id": parent,
+                    "max_phase": "4",
+                }
+            )
+        rows.append(
+            {
+                "molecule_chembl_id": "CHEMBL300",
+                "parent_molecule_chembl_id": "CHEMBL300",
+                "max_phase": "4",
+            }
+        )
+        return pd.DataFrame(rows)
+
+    def fake_get_cid(smiles: str, cfg):  # type: ignore[no-untyped-def]
+        return "12345"
+
+    def fake_get_properties(cid: str, cfg):  # type: ignore[no-untyped-def]
+        return SimpleNamespace(
+            IUPACName="Mock acid",
+            MolecularFormula="C2H6O",
+            iSMILES="CCO",
+            cSMILES="CCO",
+            InChI="InChI=1S/C2H6O",
+            InChIKey="LFQSCWFLJHTTHZ-UHFFFAOYSA-N",
+        )
+
+    hierarchy = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL100", "CHEMBL200", "CHEMBL201"],
+            "parent_molecule_chembl_id": ["CHEMBL0100P", "CHEMBL0200P", "CHEMBL0201P"],
+        }
+    )
+    catalog = pd.DataFrame(
+        {
+            "molecule_chembl_id": [
+                "CHEMBL100",
+                "CHEMBL0100P",
+                "CHEMBL200",
+                "CHEMBL0200P",
+                "CHEMBL300",
+            ],
+            "natural_product": ["Y", "N", "N", "", ""],
+            "prodrug": ["", "Y", "N", "N", ""],
+            "polymer_flag": ["0", "0", "1", "0", ""],
+        }
+    )
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+    monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
+    monkeypatch.setattr(pl, "get_properties", fake_get_properties)
+    monkeypatch.setattr(
+        testitem_enrichment,
+        "_load_sources",
+        lambda cfg, io_cfg: testitem_enrichment._SourceFrames(
+            hierarchy=hierarchy, catalog=catalog
+        ),
+    )
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
+
+    exit_code = get_testitem_data.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "ERROR",
+            "--config",
+            str(Path("config.yaml")),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+
+    df = pd.read_csv(output_csv)
+    assert {"salt_chembl_id", "natural_product"}.issubset(df.columns)
+
+    salt_row = df.loc[df["molecule_chembl_id"] == "CHEMBL100"].iloc[0]
+    assert salt_row["salt_chembl_id"] == "CHEMBL100"
+    assert salt_row["prodrug"] is True
+
+    direct_row = df.loc[df["molecule_chembl_id"] == "CHEMBL200"].iloc[0]
+    assert direct_row["salt_chembl_id"] == "CHEMBL200"
+    assert direct_row["natural_product"] is False
+
+    nonsalt_row = df.loc[df["molecule_chembl_id"] == "CHEMBL300"].iloc[0]
+    assert pd.isna(nonsalt_row["salt_chembl_id"])

--- a/tests/test_testitem_enrichment.py
+++ b/tests/test_testitem_enrichment.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.config import Config
+from library import testitem_enrichment
+
+
+def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    frame = pd.DataFrame(rows)
+    frame.to_csv(path, index=False)
+
+
+def test_enrich_adds_flags_and_salt(
+    tmp_path: Path, cfg: Config
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL100"},
+            {"molecule_chembl_id": "CHEMBL200", "parent_molecule_chembl_id": "CHEMBL0200P"},
+            {"molecule_chembl_id": "CHEMBL300", "parent_molecule_chembl_id": "CHEMBL300"},
+        ]
+    )
+
+    hierarchy_path = tmp_path / "hierarchy.csv"
+    _write_csv(
+        hierarchy_path,
+        [
+            {"molecule_chembl_id": "CHEMBL100", "parent_molecule_chembl_id": "CHEMBL0100P"},
+            {"molecule_chembl_id": "CHEMBL200", "parent_molecule_chembl_id": "CHEMBL0200P"},
+        ],
+    )
+
+    catalog_path = tmp_path / "catalog.csv"
+    _write_csv(
+        catalog_path,
+        [
+            {"molecule_chembl_id": "CHEMBL100", "natural_product": "Y", "prodrug": "", "polymer_flag": "0"},
+            {"molecule_chembl_id": "CHEMBL0100P", "natural_product": "", "prodrug": "N", "polymer_flag": ""},
+            {"molecule_chembl_id": "CHEMBL200", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
+            {"molecule_chembl_id": "CHEMBL0200P", "natural_product": "", "prodrug": "Y", "polymer_flag": "0"},
+        ],
+    )
+
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = hierarchy_path
+    cfg.testitem_molecule_enrichment.sources.molecule_catalog_path = catalog_path
+
+    result = testitem_enrichment.enrich(
+        df,
+        cfg=cfg.testitem_molecule_enrichment,
+        io_cfg=cfg.io,
+    )
+
+    assert list(result["parent_molecule_chembl_id"]) == [
+        "CHEMBL0100P",
+        "CHEMBL0200P",
+        "CHEMBL300",
+    ]
+    assert result["salt_chembl_id"].tolist()[:2] == ["CHEMBL100", "CHEMBL200"]
+    assert pd.isna(result.loc[2, "salt_chembl_id"])
+    assert result["natural_product"].dtype == "boolean"
+    assert result["prodrug"].dtype == "boolean"
+    assert bool(result.loc[0, "natural_product"]) is True
+    assert bool(result.loc[0, "prodrug"]) is False
+    assert bool(result.loc[1, "polymer_flag"]) is True
+    assert pd.isna(result.loc[2, "natural_product"])
+
+
+def test_enrich_logs_missing_and_inconsistent(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL500", "parent_molecule_chembl_id": "CHEMBL0500P"},
+            {"molecule_chembl_id": "CHEMBL600", "parent_molecule_chembl_id": "CHEMBL0600P"},
+        ]
+    )
+
+    hierarchy_path = tmp_path / "hierarchy.csv"
+    _write_csv(
+        hierarchy_path,
+        [
+            {"molecule_chembl_id": "CHEMBL500", "parent_molecule_chembl_id": "CHEMBL0500P"},
+        ],
+    )
+
+    catalog_path = tmp_path / "catalog.csv"
+    _write_csv(
+        catalog_path,
+        [
+            {"molecule_chembl_id": "CHEMBL500", "natural_product": "Y", "prodrug": "N", "polymer_flag": "0"},
+            {"molecule_chembl_id": "CHEMBL0500P", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
+        ],
+    )
+
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = hierarchy_path
+    cfg.testitem_molecule_enrichment.sources.molecule_catalog_path = catalog_path
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, *args: object, **kwargs: object) -> None:
+        events.append((event, kwargs))
+
+    monkeypatch.setattr(testitem_enrichment.logger, "warning", capture)
+
+    testitem_enrichment.enrich(
+        df,
+        cfg=cfg.testitem_molecule_enrichment,
+        io_cfg=cfg.io,
+    )
+
+    event_names = [event for event, _ in events]
+    assert "testitem_enrichment_inconsistent_flag" in event_names
+    assert "testitem_enrichment_missing_child_flags" in event_names
+    assert "testitem_enrichment_missing_parent_flags" in event_names
+
+
+def test_enrich_respects_configuration_options(
+    tmp_path: Path, cfg: Config
+) -> None:
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL800", "parent_molecule_chembl_id": "CHEMBL0800P"},
+            {"molecule_chembl_id": "CHEMBL810", "parent_molecule_chembl_id": "CHEMBL0810P"},
+            {"molecule_chembl_id": "CHEMBL900", "parent_molecule_chembl_id": "CHEMBL900"},
+        ]
+    )
+
+    hierarchy_path = tmp_path / "hierarchy.csv"
+    _write_csv(
+        hierarchy_path,
+        [
+            {"molecule_chembl_id": "CHEMBL800", "parent_molecule_chembl_id": "CHEMBL0800P"},
+            {"molecule_chembl_id": "CHEMBL810", "parent_molecule_chembl_id": "CHEMBL0810P"},
+        ],
+    )
+
+    catalog_path = tmp_path / "catalog.csv"
+    _write_csv(
+        catalog_path,
+        [
+            {"molecule_chembl_id": "CHEMBL800", "natural_product": "Y", "prodrug": "N", "polymer_flag": "0"},
+            {"molecule_chembl_id": "CHEMBL0800P", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
+            {"molecule_chembl_id": "CHEMBL0810P", "natural_product": "N", "prodrug": "N", "polymer_flag": "0"},
+        ],
+    )
+
+    cfg.testitem_molecule_enrichment.output.salt_as_null_when_absent = False
+    cfg.testitem_molecule_enrichment.flags.parent_fallback = False
+    cfg.testitem_molecule_enrichment.flags.coerce_to_bool = False
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = hierarchy_path
+    cfg.testitem_molecule_enrichment.sources.molecule_catalog_path = catalog_path
+
+    result = testitem_enrichment.enrich(
+        df,
+        cfg=cfg.testitem_molecule_enrichment,
+        io_cfg=cfg.io,
+    )
+
+    assert result["natural_product"].dtype == "string"
+    assert result.loc[0, "natural_product"] == "Y"
+    assert pd.isna(result.loc[1, "natural_product"])
+    assert result.loc[2, "salt_chembl_id"] == "-"


### PR DESCRIPTION
## Summary
- add a reusable enrichment module that derives `salt_chembl_id` and normalises natural-product, prodrug and polymer flags with optional parent fallbacks
- extend the CLI, configuration schema and docs to expose the new `testitem_molecule_enrichment` settings and default dictionary locations
- cover the behaviour with unit and smoke tests plus sample hierarchy/catalog CSV fixtures

## Testing
- pytest tests/test_testitem_enrichment.py tests/smoke/test_testitem_salt_flags_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d672f7d57c83249efc3fbb755f948f