### PR TITLE
Optimize parent catalog lookup and extend tests

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -11,7 +11,8 @@ if __package__ is None:  # running as a script
     sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import argparse
-from collections.abc import Mapping, Sequence
+from collections import ChainMap
+from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
 
@@ -171,9 +172,19 @@ def attach_parent_molecule_ids(
         return result, stats
 
     source_resolved = source
-    catalog_data = dict(catalog) if catalog is not None else None
     normalised_child = _normalise_chembl_ids(result[child_column])
     unique_children = normalised_child[normalised_child != ""].unique()
+    catalog_data: MutableMapping[str, str] | None
+
+    if catalog is not None:
+        base_view = {
+            key: catalog[key]
+            for key in unique_children
+            if key in catalog
+        }
+        catalog_data = ChainMap({}, base_view)
+    else:
+        catalog_data = None
     used_partial_cache = False
 
     if catalog_data is None:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 
 import pandas as pd
 import pytest
@@ -528,6 +528,66 @@ def test_attach_parent_molecule_ids_fetches_missing(
     assert stats.attached == 2
     assert stats.missing == 0
     assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+
+
+def test_attach_parent_molecule_ids_handles_large_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+        }
+    )
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    base_catalog = {
+        f"CHEMBL{i}": f"CHEMBL{i}_PARENT"
+        for i in range(1, 5000)
+    }
+
+    class TrackingMapping(Mapping[str, str]):
+        def __init__(self, data: Mapping[str, str]) -> None:
+            self._data = dict(data)
+            self.lookups: list[str] = []
+            self.iterations = 0
+
+        def __getitem__(self, key: str) -> str:
+            self.lookups.append(key)
+            return self._data[key]
+
+        def __iter__(self):  # type: ignore[override]
+            self.iterations += 1
+            return iter(self._data)
+
+        def __len__(self) -> int:
+            return len(self._data)
+
+        def __contains__(self, key: object) -> bool:
+            return key in self._data
+
+    tracking_catalog = TrackingMapping(base_catalog)
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+        catalog=tracking_catalog,
+        source=gtd.PARENT_LOOKUP_SOURCE_CACHE,
+    )
+
+    expected_values = [f"CHEMBL{i}_PARENT" for i in range(1, 4)]
+    assert result[catalog_cfg.parent_field].tolist() == expected_values
+    assert stats.unique == 3
+    assert stats.attached == 3
+    assert stats.missing == 0
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+    assert tracking_catalog.iterations == 0
+    assert set(tracking_catalog.lookups) == {"CHEMBL1", "CHEMBL2", "CHEMBL3"}
 
 
 def test_attach_parent_molecule_ids_updates_cache_for_reuse(


### PR DESCRIPTION
## Summary
- wrap provided parent catalog mappings in a lazy ChainMap that only copies requested children
- keep subsequent updates operating on the same mapping instance after cache or remote fetches
- add a regression test covering large catalog inputs to ensure consistent results without eager iteration

## Testing
- pytest tests/test_get_testitem_data.py::test_attach_parent_molecule_ids_handles_large_catalog

------
https://chatgpt.com/codex/tasks/task_e_68d6788657b48324b4accee7f993a83f