### PR TITLE
Improve parent catalog enrichment fallbacks

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -68,7 +68,8 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
 
 
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
-PARENT_LOOKUP_SOURCE_REMOTE = "remote"
+PARENT_LOOKUP_SOURCE_PARTIAL = "partial"
+PARENT_LOOKUP_SOURCE_SYNC = "sync"
 PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
 
 
@@ -102,9 +103,9 @@ def _resolve_parent_source(
 
     if after_exists and before_exists and after_mtime == before_mtime:
         return PARENT_LOOKUP_SOURCE_CACHE
-    if after_exists or before_exists != after_exists:
-        return PARENT_LOOKUP_SOURCE_REMOTE
-    return PARENT_LOOKUP_SOURCE_REMOTE
+    if after_exists and (not before_exists or after_mtime != before_mtime):
+        return PARENT_LOOKUP_SOURCE_SYNC
+    return PARENT_LOOKUP_SOURCE_CACHE
 
 
 def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
@@ -176,40 +177,27 @@ def attach_parent_molecule_ids(
     unique_children = normalised_child[normalised_child != ""].unique()
     used_partial_cache = False
 
+    partial_fetch_performed = False
+    full_sync_performed = False
+
     if catalog_data is None:
         cache_before = _cache_state(catalog_cfg.cache_path)
         queried = query_parent_catalog(unique_children, catalog_cfg)
         cache_after = _cache_state(catalog_cfg.cache_path)
-        if queried or catalog_cfg.sqlite_path.is_file():
-            catalog_data = dict(queried)
+        catalog_data = dict(queried)
+        used_partial_cache = bool(queried) or catalog_cfg.sqlite_path.is_file()
+        if queried:
             source_resolved = _resolve_parent_source(cache_before, cache_after)
-            used_partial_cache = True
-        else:
-            catalog_data = load_parent_catalog(
-                client=client,
-                api_cfg=api_cfg,
-                catalog_cfg=catalog_cfg,
-                timeout=timeout,
-            )
-            cache_after = _cache_state(catalog_cfg.cache_path)
+        elif source_resolved is None and cache_after[0]:
             source_resolved = _resolve_parent_source(cache_before, cache_after)
     else:
         if source_resolved is None:
-            cache_exists = catalog_cfg.cache_path.is_file()
-            source_resolved = (
-                PARENT_LOOKUP_SOURCE_CACHE
-                if cache_exists
-                else PARENT_LOOKUP_SOURCE_REMOTE
-            )
+            source_resolved = PARENT_LOOKUP_SOURCE_CACHE
 
-    parent_map = {
-        key: catalog_data[key]
-        for key in unique_children
-        if key in catalog_data
-    }
-    missing_ids = [key for key in unique_children if key not in parent_map]
-    fetched_remote = False
+    catalog_data = catalog_data or {}
+    missing_ids = [key for key in unique_children if key not in catalog_data]
 
+    fetched: dict[str, str] = {}
     if missing_ids and catalog is None:
         try:
             fetched = molecule_catalog.fetch_parent_catalog_for(
@@ -221,17 +209,33 @@ def attach_parent_molecule_ids(
         except (requests.RequestException, ValueError) as exc:
             logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
             fetched = {}
-        else:
-            if fetched:
-                fetched_remote = True
         if fetched:
             catalog_data.update(fetched)
-            parent_map.update(fetched)
-            if catalog is None:
-                if used_partial_cache:
-                    update_parent_catalog_cache(fetched, catalog_cfg)
-                else:
-                    write_parent_catalog_cache(catalog_data, catalog_cfg)
+            partial_fetch_performed = True
+            if used_partial_cache:
+                update_parent_catalog_cache(fetched, catalog_cfg)
+            else:
+                write_parent_catalog_cache(catalog_data, catalog_cfg)
+        missing_ids = [key for key in unique_children if key not in catalog_data]
+
+    if missing_ids and catalog is None:
+        cache_before = _cache_state(catalog_cfg.cache_path)
+        loaded_catalog = load_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=catalog_cfg,
+            timeout=timeout,
+        )
+        catalog_data.update(loaded_catalog)
+        cache_after = _cache_state(catalog_cfg.cache_path)
+        source_resolved = _resolve_parent_source(cache_before, cache_after)
+        full_sync_performed = True
+
+    parent_map = {
+        key: catalog_data[key]
+        for key in unique_children
+        if key in catalog_data
+    }
 
     parent_series = normalised_child.map(parent_map).astype("string")
 
@@ -249,12 +253,14 @@ def attach_parent_molecule_ids(
     attached = len(result) - missing
 
     if source_resolved is None:
-        source_resolved = PARENT_LOOKUP_SOURCE_REMOTE
+        source_resolved = PARENT_LOOKUP_SOURCE_CACHE
 
     stats = ParentLookupStats(
         source=(
-            PARENT_LOOKUP_SOURCE_REMOTE
-            if fetched_remote
+            PARENT_LOOKUP_SOURCE_SYNC
+            if full_sync_performed
+            else PARENT_LOOKUP_SOURCE_PARTIAL
+            if partial_fetch_performed
             else source_resolved
         ),
         missing=missing,
@@ -457,11 +463,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 return 1
             cache_after = _cache_state(cfg.molecule_catalog.cache_path)
-            parent_catalog_source = _resolve_parent_source(cache_before, cache_after)
             if parent_catalog:
+                parent_catalog_source = _resolve_parent_source(
+                    cache_before, cache_after
+                )
                 need_lookup -= set(parent_catalog)
 
-        fetched_remote = False
+        partial_fetch_performed = False
         if need_lookup:
             try:
                 fetched = molecule_catalog.fetch_parent_catalog_for(
@@ -475,9 +483,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 return 1
             if fetched:
                 parent_catalog.update(fetched)
-                fetched_remote = True
-        if fetched_remote:
-            parent_catalog_source = PARENT_LOOKUP_SOURCE_REMOTE
+                partial_fetch_performed = True
+        if partial_fetch_performed:
+            parent_catalog_source = PARENT_LOOKUP_SOURCE_PARTIAL
+
+        if parent_catalog:
+            lookup_series = pd.Series(
+                normalised_ids.map(parent_catalog),
+                index=df.index,
+                dtype="string",
+            )
+            if parent_column not in df.columns:
+                df[parent_column] = pd.Series(
+                    pd.NA, index=df.index, dtype="string"
+                )
+            to_update = need_lookup_mask & lookup_series.notna() & lookup_series.ne("")
+            if to_update.any():
+                df.loc[to_update, parent_column] = lookup_series.loc[to_update]
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(df, cfg.pubchem)
         logger.info("pubchem_augment_done")

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -486,11 +486,13 @@ def test_attach_parent_molecule_ids_fetches_missing(
     catalog_cfg.cache_path = tmp_path / "catalog.json"
     catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
-    monkeypatch.setattr(
-        gtd,
-        "load_parent_catalog",
-        lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
-    )
+    load_calls: list[str] = []
+
+    def fake_load_parent_catalog(**__: object) -> dict[str, str]:
+        load_calls.append("load")
+        return {"CHEMBL1": "CHEMBL1_PARENT"}
+
+    monkeypatch.setattr(gtd, "load_parent_catalog", fake_load_parent_catalog)
 
     fetched: dict[str, str] = {"CHEMBL2": "CHEMBL2_PARENT"}
     captured_ids: dict[str, list[str]] = {}
@@ -519,7 +521,7 @@ def test_attach_parent_molecule_ids_fetches_missing(
         timeout=None,
     )
 
-    assert captured_ids["ids"] == ["CHEMBL2"]
+    assert captured_ids["ids"] == ["CHEMBL1", "CHEMBL2"]
     assert result[catalog_cfg.parent_field].tolist() == [
         "CHEMBL1_PARENT",
         "CHEMBL2_PARENT",
@@ -527,7 +529,59 @@ def test_attach_parent_molecule_ids_fetches_missing(
     assert stats.unique == 2
     assert stats.attached == 2
     assert stats.missing == 0
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_SYNC
+    assert load_calls == ["load"]
+
+
+def test_attach_parent_molecule_ids_partial_fetch_without_full_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1", "CHEMBL2"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    fetch_calls: list[list[str]] = []
+
+    def fake_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        fetch_calls.append(list(ids))
+        return {
+            "CHEMBL1": "CHEMBL1_PARENT",
+            "CHEMBL2": "CHEMBL2_PARENT",
+        }
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch,
+    )
+
+    def unexpected_load(**__: object) -> dict[str, str]:  # pragma: no cover
+        raise AssertionError("load_parent_catalog should not be called")
+
+    monkeypatch.setattr(gtd, "load_parent_catalog", unexpected_load)
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert fetch_calls == [["CHEMBL1", "CHEMBL2"]]
+    assert result[catalog_cfg.parent_field].tolist() == [
+        "CHEMBL1_PARENT",
+        "CHEMBL2_PARENT",
+    ]
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_PARTIAL
 
 
 def test_attach_parent_molecule_ids_updates_cache_for_reuse(
@@ -575,7 +629,7 @@ def test_attach_parent_molecule_ids_updates_cache_for_reuse(
         "CHEMBL1_PARENT",
         "CHEMBL2_PARENT",
     ]
-    assert first_stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert first_stats.source == gtd.PARENT_LOOKUP_SOURCE_PARTIAL
 
     stored_catalog = json.loads(catalog_cfg.cache_path.read_text(encoding="utf-8"))
     assert stored_catalog == {
@@ -690,7 +744,7 @@ def test_attach_parent_molecule_ids_fetch_failure(
     assert stats.unique == 1
     assert stats.attached == 0
     assert stats.missing == 1
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_SYNC
 
 
 def test_attach_parent_molecule_ids_uses_cache_only(


### PR DESCRIPTION
## Summary
- refine parent lookup to attempt targeted fetches before full catalog loads and track cache/partial/sync sources
- prefill cached parent assignments into test item data prior to the enrichment stage
- expand parent lookup unit tests to cover partial fetch behaviour and new source reporting

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d67884d0f483249e32ddf7f813d5e7