### PR TITLE
Handle missing PubChem properties as NA

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1013,6 +1013,12 @@
           "minimum": 0,
           "title": "Cache Ttl",
           "type": "integer"
+        },
+        "prefer_local_smiles": {
+          "default": false,
+          "description": "Skip PubChem lookups when local pubchem_* columns are populated",
+          "title": "Prefer Local Smiles",
+          "type": "boolean"
         }
       },
       "title": "PubChemCfg",

--- a/library/config.py
+++ b/library/config.py
@@ -260,6 +260,10 @@ class PubChemCfg(_BaseModel):
         ge=0,
         description="Time-to-live for PubChem request cache in seconds",
     )
+    prefer_local_smiles: bool = Field(
+        False,
+        description="Skip PubChem lookups when local pubchem_* columns are populated",
+    )
 
     @field_validator("base")
     @classmethod

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -392,12 +392,12 @@ def get_standard_name(cid: str, cfg: PubChemCfg) -> str | None:
 class Properties:
     """Chemical properties for a PubChem compound."""
 
-    IUPACName: str
-    MolecularFormula: str
-    iSMILES: str
-    cSMILES: str
-    InChI: str
-    InChIKey: str
+    IUPACName: str | None
+    MolecularFormula: str | None
+    iSMILES: str | None
+    cSMILES: str | None
+    InChI: str | None
+    InChIKey: str | None
 
 
 def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
@@ -413,13 +413,11 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
     Returns
     -------
     Properties
-        Chemical property record. Missing values are returned as ``"Not Found"``.
+        Chemical property record. Missing values are returned as ``None``.
     """
     validated = validate_cid(cid)
     if not validated:
-        return Properties(
-            "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
-        )
+        return Properties(None, None, None, None, None, None)
     base = cfg.base.rstrip("/")
     url = (
         f"{base}/compound/cid/{validated}/property/MolecularFormula,IUPACName,IsomericSMILES,"
@@ -427,26 +425,22 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
     )
     response = make_request(url, cfg)
     if not response:
-        return Properties(
-            "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
-        )
+        return Properties(None, None, None, None, None, None)
     props = response.get("PropertyTable", {}).get("Properties", [])
     if not props:
-        return Properties(
-            "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
-        )
+        return Properties(None, None, None, None, None, None)
     item = props[0]
     return Properties(
-        item.get("IUPACName", "Not Found"),
-        item.get("MolecularFormula", "Not Found"),
-        item.get("IsomericSMILES", "Not Found"),
-        item.get("CanonicalSMILES", "Not Found"),
-        item.get("InChI", "Not Found"),
-        item.get("InChIKey", "Not Found"),
+        cast(str | None, item.get("IUPACName")),
+        cast(str | None, item.get("MolecularFormula")),
+        cast(str | None, item.get("IsomericSMILES")),
+        cast(str | None, item.get("CanonicalSMILES")),
+        cast(str | None, item.get("InChI")),
+        cast(str | None, item.get("InChIKey")),
     )
 
 
-def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str]:
+def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str | None]:
     """Process *compound_name* into a structured record.
 
     Parameters
@@ -464,17 +458,11 @@ def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str]:
     """
     cid = get_cid(compound_name, cfg)
     standard = get_standard_name(cid, cfg) if cid else None
-    props = (
-        get_properties(cid, cfg)
-        if cid
-        else Properties(
-            "Not Found", "Not Found", "Not Found", "Not Found", "Not Found", "Not Found"
-        )
-    )
+    props = get_properties(cid, cfg) if cid else Properties(None, None, None, None, None, None)
     return {
         "Name": compound_name,
-        "CID": cid or "Not Found",
-        "Standard Name": standard or "Not Found",
+        "CID": cid,
+        "Standard Name": standard,
         "IUPACName": props.IUPACName,
         "MolecularFormula": props.MolecularFormula,
         "iSMILES": props.iSMILES,

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -73,6 +73,17 @@ PARENT_LOOKUP_SOURCE_REMOTE = "remote"
 PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
 
 
+PUBCHEM_COLUMNS = [
+    "pubchem_cid",
+    "pubchem_iupac_name",
+    "pubchem_molecular_formula",
+    "pubchem_isomeric_smiles",
+    "pubchem_canonical_smiles",
+    "pubchem_inchi",
+    "pubchem_inchikey",
+]
+
+
 @dataclass(frozen=True)
 class ParentLookupStats:
     """Summary information about parent molecule enrichment."""
@@ -298,20 +309,42 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
     if df.empty or "canonical_smiles" not in df.columns:
         return df
 
-    smiles_list = df["canonical_smiles"].fillna("").tolist()
+    result = df.reset_index(drop=True).copy()
+
+    smiles_list = result["canonical_smiles"].fillna("").tolist()
     # ``dict.fromkeys`` preserves the order of first occurrence while
     # removing duplicates. This allows progress output to reflect the
     # deterministic iteration order of SMILES strings.
     unique_smiles = [s for s in dict.fromkeys(smiles_list) if s]
 
-    total = len(unique_smiles)
+    prefer_local = getattr(cfg, "prefer_local_smiles", False)
+    skip_smiles: set[str] = set()
+    if prefer_local:
+        existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
+        if existing_cols:
+            normalised = pd.DataFrame(
+                {col: result[col].astype("string").replace("", pd.NA) for col in existing_cols}
+            )
+            complete_mask = normalised.notna().all(axis=1)
+            canonical = result.loc[complete_mask, "canonical_smiles"].astype("string")
+            skip_smiles = {
+                str(smi)
+                for smi in canonical[canonical.notna() & canonical.ne("")].tolist()
+            }
+
+    fetch_smiles = [s for s in unique_smiles if s not in skip_smiles]
+
+    total = len(fetch_smiles)
     if total:
         logger.info("pubchem_start", total=total)
     else:
         logger.info("pubchem_no_smiles")
 
-    records: dict[str, dict[str, str]] = {}
-    for idx, smi in enumerate(unique_smiles, start=1):
+    def _value_or_na(value: str | None) -> object:
+        return value if value not in (None, "") else pd.NA
+
+    records: dict[str, dict[str, object]] = {}
+    for idx, smi in enumerate(fetch_smiles, start=1):
         logger.info("pubchem_progress", current=idx, total=total)
         cid = pl.get_cid_from_smiles(smi, cfg) or ""
         first_cid = cid.split("|")[0] if cid else ""
@@ -319,36 +352,36 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
             props = pl.get_properties(first_cid, cfg)
             records[smi] = {
                 "pubchem_cid": first_cid,
-                "pubchem_iupac_name": props.IUPACName,
-                "pubchem_molecular_formula": props.MolecularFormula,
-                "pubchem_isomeric_smiles": props.iSMILES,
-                "pubchem_canonical_smiles": props.cSMILES,
-                "pubchem_inchi": props.InChI,
-                "pubchem_inchikey": props.InChIKey,
+                "pubchem_iupac_name": _value_or_na(props.IUPACName),
+                "pubchem_molecular_formula": _value_or_na(props.MolecularFormula),
+                "pubchem_isomeric_smiles": _value_or_na(props.iSMILES),
+                "pubchem_canonical_smiles": _value_or_na(props.cSMILES),
+                "pubchem_inchi": _value_or_na(props.InChI),
+                "pubchem_inchikey": _value_or_na(props.InChIKey),
             }
         else:
-            records[smi] = {
-                "pubchem_cid": "",
-                "pubchem_iupac_name": "",
-                "pubchem_molecular_formula": "",
-                "pubchem_isomeric_smiles": "",
-                "pubchem_canonical_smiles": "",
-                "pubchem_inchi": "",
-                "pubchem_inchikey": "",
-            }
+            records[smi] = {col: pd.NA for col in PUBCHEM_COLUMNS}
 
-    empty = {
-        "pubchem_cid": "",
-        "pubchem_iupac_name": "",
-        "pubchem_molecular_formula": "",
-        "pubchem_isomeric_smiles": "",
-        "pubchem_canonical_smiles": "",
-        "pubchem_inchi": "",
-        "pubchem_inchikey": "",
-    }
-    pubchem_rows = [records.get(smi, empty) for smi in smiles_list]
-    pubchem_df = pd.DataFrame(pubchem_rows)
-    return pd.concat([df.reset_index(drop=True), pubchem_df], axis=1)
+    empty = {col: pd.NA for col in PUBCHEM_COLUMNS}
+    pubchem_rows = [records.get(smi, empty.copy()) for smi in smiles_list]
+    pubchem_df = pd.DataFrame(pubchem_rows, index=result.index).convert_dtypes()
+
+    for col in PUBCHEM_COLUMNS:
+        if col not in pubchem_df.columns:
+            continue
+        new_series = pubchem_df[col].astype("string")
+        if col in result.columns:
+            result[col] = result[col].astype("string")
+            if prefer_local:
+                existing = result[col]
+                missing_mask = existing.isna() | existing.eq("")
+                result.loc[missing_mask, col] = new_series[missing_mask]
+            else:
+                result[col] = new_series
+        else:
+            result[col] = new_series
+
+    return result
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -11,9 +11,52 @@ import requests
 
 from library import chembl_library as cl
 from library import io
+from library import pubchem_library as pl
 from library.config import Config
 from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
+
+
+def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    cfg = pl.PubChemCfg(delay=0)
+
+    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+
+    result = gtd.add_pubchem_data(df, cfg)
+    pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
+    assert pubchem_cols
+    assert result[pubchem_cols].isna().all().all()
+    assert not (result[pubchem_cols] == "Not Found").any().any()
+
+
+def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame(
+        {
+            "canonical_smiles": ["C"],
+            "pubchem_cid": ["1"],
+            "pubchem_iupac_name": ["methane"],
+            "pubchem_molecular_formula": ["CH4"],
+            "pubchem_isomeric_smiles": ["C"],
+            "pubchem_canonical_smiles": ["C"],
+            "pubchem_inchi": ["InChI=1S/CH4/h1H4"],
+            "pubchem_inchikey": ["VNWKTOKETHGBQD-UHFFFAOYSA-N"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0, prefer_local_smiles=True)
+
+    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("PubChem lookup should not be called")
+
+    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
+    monkeypatch.setattr(pl, "get_properties", fail)
+
+    result = gtd.add_pubchem_data(df, cfg)
+
+    expected = df.copy()
+    for column in gtd.PUBCHEM_COLUMNS:
+        expected[column] = expected[column].astype("string")
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_run_chembl_column_order(

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -160,6 +160,28 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
     assert sleeps == [1]
 
 
+@responses.activate
+def test_get_properties_returns_none_for_missing() -> None:
+    """Missing PubChem fields should be returned as ``None``."""
+
+    cfg = pl.PubChemCfg(delay=0)
+    cid = "123"
+    url = (
+        f"{cfg.base.rstrip('/')}/compound/cid/{cid}/property/"
+        "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+    responses.add(responses.GET, url, json={"PropertyTable": {"Properties": [{}]}}, status=200)
+
+    props = pl.get_properties(cid, cfg)
+
+    assert props.IUPACName is None
+    assert props.MolecularFormula is None
+    assert props.iSMILES is None
+    assert props.cSMILES is None
+    assert props.InChI is None
+    assert props.InChIKey is None
+
+
 def test_cache_entry_expires(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cache entries should be evicted after the configured TTL."""
 


### PR DESCRIPTION
## Summary
- return None instead of the literal "Not Found" from PubChem property lookups and expose a configuration flag to prefer existing SMILES values
- ensure get_testitem_data populates pubchem_* columns with proper nulls, preserves local data when requested, and writes consistent string types
- add regression tests covering the updated PubChem behaviour and local SMILES preference

## Testing
- pytest tests/test_get_testitem_data.py::test_add_pubchem_data_missing_uses_na tests/test_get_testitem_data.py::test_add_pubchem_data_prefers_local_smiles


------
https://chatgpt.com/codex/tasks/task_e_68d67946e8c88324a40c03871d3c15e0