### PR TITLE
Add configurable PubChem resolver with CLI overrides

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -971,6 +971,40 @@
           "title": "Base",
           "type": "string"
         },
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "resolve_order": {
+          "default": [
+            "cid",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name"
+          ],
+          "items": {
+            "enum": [
+              "cid",
+              "smiles",
+              "inchikey",
+              "inchi",
+              "pref_name"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Resolve Order",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "timeout_seconds": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
+        },
         "timeout_connect": {
           "default": 5,
           "minimum": 1,
@@ -988,6 +1022,12 @@
           "minimum": 0,
           "title": "Retries",
           "type": "integer"
+        },
+        "backoff_initial_seconds": {
+          "default": 1.0,
+          "minimum": 0,
+          "title": "Backoff Initial Seconds",
+          "type": "number"
         },
         "rps": {
           "default": 3,
@@ -1013,6 +1053,26 @@
           "minimum": 0,
           "title": "Cache Ttl",
           "type": "integer"
+        },
+        "prefer_local_smiles": {
+          "default": true,
+          "title": "Prefer Local Smiles",
+          "type": "boolean"
+        },
+        "use_parent_for_salts": {
+          "default": true,
+          "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
+        "allow_polymer": {
+          "default": false,
+          "title": "Allow Polymer",
+          "type": "boolean"
+        },
+        "write_not_found_literal": {
+          "default": false,
+          "title": "Write Not Found Literal",
+          "type": "boolean"
         }
       },
       "title": "PubChemCfg",

--- a/config.yaml
+++ b/config.yaml
@@ -129,13 +129,21 @@ sources:
     burst: 5  # (env: CHEMBL_DA_IUPHAR_BURST)
   pubchem:
     base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"  # PubChem PUG REST API (env: CHEMBL_DA__SOURCES__PUBCHEM__BASE / CHEMBL_DA_PUBCHEM_BASE)
+    enable: true  # Enable PubChem enrichment (env: CHEMBL_DA_PUBCHEM_ENABLE)
+    resolve_order: [cid, smiles, inchikey, inchi, pref_name]  # Resolution priority (env: CHEMBL_DA_PUBCHEM_RESOLVE_ORDER)
+    timeout_seconds: 30.0  # Total timeout for resolving a record (env: CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT)
     timeout_read: 60  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_READ)
     retries: 3
+    backoff_initial_seconds: 1.0  # Initial exponential backoff interval (env: CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS)
     rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
     cache_ttl: 3600  # Request cache time-to-live in seconds
+    prefer_local_smiles: true  # Prefer ChEMBL SMILES over cached PubChem value (env: CHEMBL_DA_PUBCHEM_PREFER_LOCAL_SMILES)
+    use_parent_for_salts: true  # Use parent information for salt forms (env: CHEMBL_DA_PUBCHEM_USE_PARENT_FOR_SALTS)
+    allow_polymer: false  # Allow enrichment for polymer records (env: CHEMBL_DA_PUBCHEM_ALLOW_POLYMER)
+    write_not_found_literal: false  # Write "Not Found" for missing fields instead of blanks (env: CHEMBL_DA_PUBCHEM_WRITE_NOT_FOUND_LITERAL)
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)

--- a/library/config.py
+++ b/library/config.py
@@ -249,9 +249,19 @@ class IupharCfg(_BaseModel):
 
 class PubChemCfg(_BaseModel):
     base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    enable: bool = True
+    resolve_order: tuple[str, ...] = (
+        "cid",
+        "smiles",
+        "inchikey",
+        "inchi",
+        "pref_name",
+    )
+    timeout_seconds: float = Field(30.0, ge=0)
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(60, ge=1)
     retries: int = Field(3, ge=0)
+    backoff_initial_seconds: float = Field(1.0, ge=0)
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
@@ -260,6 +270,10 @@ class PubChemCfg(_BaseModel):
         ge=0,
         description="Time-to-live for PubChem request cache in seconds",
     )
+    prefer_local_smiles: bool = True
+    use_parent_for_salts: bool = True
+    allow_polymer: bool = False
+    write_not_found_literal: bool = False
 
     @field_validator("base")
     @classmethod
@@ -267,6 +281,20 @@ class PubChemCfg(_BaseModel):
         if not _valid_url(v):
             raise ValueError("invalid URL")
         return v
+
+    @field_validator("resolve_order")
+    @classmethod
+    def _order(cls, v: tuple[str, ...]) -> tuple[str, ...]:
+        allowed = {"cid", "smiles", "inchikey", "inchi", "pref_name"}
+        order = tuple(dict.fromkeys(v))
+        invalid = [item for item in order if item not in allowed]
+        if invalid:
+            raise ValueError(
+                "resolve_order must contain only cid, smiles, inchikey, inchi, pref_name"
+            )
+        if not order:
+            raise ValueError("resolve_order must contain at least one identifier")
+        return order
 
 
 class PubMedCfg(_BaseModel):
@@ -1243,6 +1271,34 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_UNIPROT_BASE": ["sources", "uniprot", "api", "base"],
     "CHEMBL_DA_IUPHAR_BASE": ["sources", "iuphar", "base"],
     "CHEMBL_DA_PUBCHEM_BASE": ["sources", "pubchem", "base"],
+    "CHEMBL_DA_PUBCHEM_ENABLE": ["sources", "pubchem", "enable"],
+    "CHEMBL_DA_PUBCHEM_RESOLVE_ORDER": ["sources", "pubchem", "resolve_order"],
+    "CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS": ["sources", "pubchem", "timeout_seconds"],
+    "CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS": [
+        "sources",
+        "pubchem",
+        "backoff_initial_seconds",
+    ],
+    "CHEMBL_DA_PUBCHEM_PREFER_LOCAL_SMILES": [
+        "sources",
+        "pubchem",
+        "prefer_local_smiles",
+    ],
+    "CHEMBL_DA_PUBCHEM_USE_PARENT_FOR_SALTS": [
+        "sources",
+        "pubchem",
+        "use_parent_for_salts",
+    ],
+    "CHEMBL_DA_PUBCHEM_ALLOW_POLYMER": [
+        "sources",
+        "pubchem",
+        "allow_polymer",
+    ],
+    "CHEMBL_DA_PUBCHEM_WRITE_NOT_FOUND_LITERAL": [
+        "sources",
+        "pubchem",
+        "write_not_found_literal",
+    ],
     "CHEMBL_DA_LOG_LEVEL": ["system", "log", "level"],
     "CHEMBL_DA_LOG_FORMAT": ["system", "log", "format"],
     "CHEMBL_DA_LOG_DATEFMT": ["system", "log", "datefmt"],

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,8 +6,9 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Callable, Mapping, MutableMapping, cast
 from urllib.parse import quote
 
 import requests
@@ -28,6 +29,278 @@ _session: Session = session_with_retry(
     ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
 )
 
+_PROPERTY_FIELDS = (
+    "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey"
+)
+
+_IDENTIFIER_PATHS: dict[str, Callable[[str, str], str]] = {
+    "cid": lambda base, value: (
+        f"{base}/compound/cid/{value}/property/{_PROPERTY_FIELDS}/JSON"
+    ),
+    "smiles": lambda base, value: (
+        f"{base}/compound/smiles/{url_encode(value)}/property/{_PROPERTY_FIELDS}/JSON"
+    ),
+    "inchikey": lambda base, value: (
+        f"{base}/compound/inchikey/{url_encode(value)}/property/{_PROPERTY_FIELDS}/JSON"
+    ),
+    "inchi": lambda base, value: (
+        f"{base}/compound/inchi/{url_encode(value)}/property/{_PROPERTY_FIELDS}/JSON"
+    ),
+    "pref_name": lambda base, value: (
+        f"{base}/compound/name/{url_encode(value)}/property/{_PROPERTY_FIELDS}/JSON"
+    ),
+}
+
+_NOT_FOUND_LITERAL = "Not Found"
+
+
+def _missing_literal(cfg: PubChemCfg) -> str:
+    return _NOT_FOUND_LITERAL if cfg.write_not_found_literal else ""
+
+
+def _empty_pubchem_record(cfg: PubChemCfg) -> dict[str, str]:
+    missing = _missing_literal(cfg)
+    return {
+        "pubchem_cid": missing,
+        "pubchem_iupac_name": missing,
+        "pubchem_molecular_formula": missing,
+        "pubchem_isomeric_smiles": missing,
+        "pubchem_canonical_smiles": missing,
+        "pubchem_inchi": missing,
+        "pubchem_inchikey": missing,
+    }
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    try:
+        return bool(value)
+    except TypeError:  # pandas.NA raises TypeError
+        return False
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _build_url(identifier: str, value: str, cfg: PubChemCfg) -> str | None:
+    base = cfg.base.rstrip("/")
+    builder = _IDENTIFIER_PATHS.get(identifier)
+    if not builder:
+        return None
+    return builder(base, value)
+
+
+def _request_with_backoff(
+    url: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None,
+    now: Callable[[], float],
+    sleeper: Callable[[float], None],
+) -> dict[str, Any] | None:
+    global _CACHE
+    if _CACHE is None or _CACHE.ttl != cfg.cache_ttl:
+        _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
+
+    cached = _CACHE.get(url)
+    if cached is not None:
+        return cast(dict[str, Any], cached)
+
+    wait = cfg.backoff_initial_seconds or cfg.delay
+    attempts = max(1, cfg.retries)
+
+    for attempt in range(1, attempts + 1):
+        if deadline is not None and now() >= deadline:
+            return None
+
+        get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
+        try:
+            response = _session.get(
+                url, timeout=(cfg.timeout_connect, cfg.timeout_read)
+            )
+        except requests.RequestException:
+            status = None
+        else:
+            status = response.status_code
+            if status == 404:
+                return None
+            if status == 429 or 500 <= status < 600:
+                data = None
+            elif status is not None and status >= 400:
+                return None
+            else:
+                try:
+                    data = cast(dict[str, Any], response.json())
+                except ValueError:
+                    return None
+                _CACHE[url] = data
+                return data
+
+        if attempt >= attempts:
+            break
+        if deadline is not None and now() >= deadline:
+            break
+        if wait and wait > 0:
+            sleeper(wait)
+            wait *= 2
+
+    return None
+
+
+def _parse_properties(data: dict[str, Any], cfg: PubChemCfg) -> dict[str, str] | None:
+    properties = data.get("PropertyTable", {}).get("Properties", [])
+    if not properties:
+        return None
+    entry = properties[0]
+    cid_raw = entry.get("CID")
+    cid = validate_cid(str(cid_raw)) if cid_raw is not None else None
+    if not cid:
+        return None
+
+    missing = _missing_literal(cfg)
+
+    def field(name: str) -> str:
+        value = entry.get(name)
+        if value is None or value == "":
+            return missing
+        return str(value)
+
+    return {
+        "pubchem_cid": cid,
+        "pubchem_iupac_name": field("IUPACName"),
+        "pubchem_molecular_formula": field("MolecularFormula"),
+        "pubchem_isomeric_smiles": field("IsomericSMILES"),
+        "pubchem_canonical_smiles": field("CanonicalSMILES"),
+        "pubchem_inchi": field("InChI"),
+        "pubchem_inchikey": field("InChIKey"),
+    }
+
+
+def _resolve_with_identifier(
+    identifier: str,
+    value: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None,
+    now: Callable[[], float],
+    sleeper: Callable[[float], None],
+) -> dict[str, str] | None:
+    url = _build_url(identifier, value, cfg)
+    if not url:
+        return None
+    data = _request_with_backoff(url, cfg, deadline=deadline, now=now, sleeper=sleeper)
+    if not data:
+        return None
+    return _parse_properties(data, cfg)
+
+
+def _cid_candidates(record: Mapping[str, Any]) -> list[str]:
+    raw = record.get("pubchem_cid")
+    if not raw:
+        return []
+    parts = str(raw).split("|")
+    return _unique([validate_cid(part.strip()) or "" for part in parts])
+
+
+def _smiles_candidates(record: Mapping[str, Any], cfg: PubChemCfg) -> list[str]:
+    candidates: list[str] = []
+
+    def add(value: Any) -> None:
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                candidates.append(text)
+
+    if cfg.prefer_local_smiles:
+        add(record.get("canonical_smiles"))
+        add(record.get("smiles"))
+        add(record.get("standard_smiles"))
+        add(record.get("molecule_structures__canonical_smiles"))
+    else:
+        add(record.get("pubchem_canonical_smiles"))
+        add(record.get("pubchem_isomeric_smiles"))
+        add(record.get("canonical_smiles"))
+
+    if cfg.use_parent_for_salts and record.get("salt_chembl_id"):
+        add(record.get("parent_canonical_smiles"))
+        add(record.get("parent_isomeric_smiles"))
+
+    return _unique(candidates)
+
+
+def _inchikey_candidates(record: Mapping[str, Any]) -> list[str]:
+    value = record.get("standard_inchi_key")
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return [value]
+    return []
+
+
+def _inchi_candidates(record: Mapping[str, Any]) -> list[str]:
+    value = record.get("standard_inchi")
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return [value]
+    return []
+
+
+def _name_candidates(record: Mapping[str, Any], cfg: PubChemCfg) -> list[str]:
+    candidates: list[str] = []
+
+    def add(value: Any) -> None:
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                candidates.append(text)
+
+    if cfg.use_parent_for_salts and record.get("salt_chembl_id"):
+        add(record.get("parent_pref_name"))
+        add(record.get("parent_name"))
+        add(record.get("parent_molecule_pref_name"))
+
+    add(record.get("pref_name"))
+    add(record.get("synonyms"))
+
+    return _unique(candidates)
+
+
+def _populate_cache(
+    cache: MutableMapping[tuple[str, str], dict[str, str]],
+    identifier: str,
+    value: str,
+    record: dict[str, str],
+) -> None:
+    cache[(identifier, value)] = record
+
+    cid = record.get("pubchem_cid", "")
+    if cid:
+        cache.setdefault(("cid", cid), record)
+
+    canonical = record.get("pubchem_canonical_smiles", "")
+    if canonical:
+        cache.setdefault(("smiles", canonical), record)
+
+    isomeric = record.get("pubchem_isomeric_smiles", "")
+    if isomeric:
+        cache.setdefault(("smiles", isomeric), record)
+
+    inchikey = record.get("pubchem_inchikey", "")
+    if inchikey:
+        cache.setdefault(("inchikey", inchikey), record)
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session.
@@ -446,6 +719,94 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
     )
 
 
+def resolve_pubchem_record(
+    record: Mapping[str, Any],
+    cfg: PubChemCfg,
+    *,
+    cache: MutableMapping[tuple[str, str], dict[str, str]] | None = None,
+    now: Callable[[], float] | None = None,
+    sleeper: Callable[[float], None] | None = None,
+) -> dict[str, str]:
+    """Resolve a PubChem record using multiple identifiers.
+
+    The function iterates over identifiers defined in ``cfg.resolve_order`` and
+    queries the PubChem API until a match is found. Responses are cached in
+    ``cache`` by identifier and CID to avoid duplicate lookups.
+
+    Parameters
+    ----------
+    record:
+        Mapping containing ChEMBL test item fields such as
+        ``canonical_smiles`` and ``standard_inchi_key``.
+    cfg:
+        PubChem configuration.
+    cache:
+        Optional cache mapping ``(identifier, value)`` tuples to resolved
+        PubChem records. When provided, results are reused across calls.
+    now, sleeper:
+        Optional callables used for timeout calculations and sleeping between
+        retries. They default to :func:`time.monotonic` and
+        :func:`library.rate_limiter.sleep` respectively and exist primarily for
+        testing.
+
+    Returns
+    -------
+    dict[str, str]
+        Dictionary containing PubChem enrichment fields. When no identifier can
+        be resolved, the dictionary contains empty strings or ``"Not Found"``
+        depending on ``cfg.write_not_found_literal``.
+    """
+
+    if not cfg.enable:
+        return _empty_pubchem_record(cfg)
+
+    polymer_flag = record.get("polymer_flag")
+    if not cfg.allow_polymer and _is_truthy(polymer_flag):
+        return _empty_pubchem_record(cfg)
+
+    molecule_type = record.get("molecule_type")
+    if (
+        not cfg.allow_polymer
+        and isinstance(molecule_type, str)
+        and molecule_type.strip().lower() == "polymer"
+    ):
+        return _empty_pubchem_record(cfg)
+
+    now_fn = now or time.monotonic
+    sleep_fn = sleeper or sleep
+    deadline = now_fn() + cfg.timeout_seconds if cfg.timeout_seconds > 0 else None
+
+    candidates: dict[str, list[str]] = {
+        "cid": _cid_candidates(record),
+        "smiles": _smiles_candidates(record, cfg),
+        "inchikey": _inchikey_candidates(record),
+        "inchi": _inchi_candidates(record),
+        "pref_name": _name_candidates(record, cfg),
+    }
+
+    for identifier in cfg.resolve_order:
+        values = candidates.get(identifier, [])
+        for value in values:
+            key = (identifier, value)
+            if cache is not None and key in cache:
+                return cache[key]
+
+            resolved = _resolve_with_identifier(
+                identifier,
+                value,
+                cfg,
+                deadline=deadline,
+                now=now_fn,
+                sleeper=sleep_fn,
+            )
+            if resolved:
+                if cache is not None:
+                    _populate_cache(cache, identifier, value, resolved)
+                return resolved
+
+    return _empty_pubchem_record(cfg)
+
+
 def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str]:
     """Process *compound_name* into a structured record.
 
@@ -493,6 +854,7 @@ __all__ = [
     "get_all_cid",
     "get_standard_name",
     "get_properties",
+    "resolve_pubchem_record",
     "process_compound",
     "Properties",
 ]

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -14,6 +14,7 @@ import argparse
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
+from typing import Any, Callable
 
 import pandas as pd
 import requests
@@ -71,6 +72,15 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
 PARENT_LOOKUP_SOURCE_REMOTE = "remote"
 PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
+
+
+def _parse_resolve_order(value: str) -> tuple[str, ...]:
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError(
+            "--pubchem-resolve-order requires at least one identifier"
+        )
+    return tuple(parts)
 
 
 @dataclass(frozen=True)
@@ -274,7 +284,12 @@ def attach_parent_molecule_ids(
     return result, stats
 
 
-def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
+def add_pubchem_data(
+    df: pd.DataFrame,
+    cfg: PubChemCfg,
+    *,
+    resolver: Callable[[Mapping[str, Any], PubChemCfg], dict[str, str]] = pl.resolve_pubchem_record,
+) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -295,59 +310,25 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
         ``df`` with additional PubChem columns.
 
     """
-    if df.empty or "canonical_smiles" not in df.columns:
+    if df.empty or not cfg.enable:
         return df
 
-    smiles_list = df["canonical_smiles"].fillna("").tolist()
-    # ``dict.fromkeys`` preserves the order of first occurrence while
-    # removing duplicates. This allows progress output to reflect the
-    # deterministic iteration order of SMILES strings.
-    unique_smiles = [s for s in dict.fromkeys(smiles_list) if s]
-
-    total = len(unique_smiles)
+    records = df.to_dict("records")
+    total = len(records)
     if total:
         logger.info("pubchem_start", total=total)
     else:
         logger.info("pubchem_no_smiles")
+        return df
 
-    records: dict[str, dict[str, str]] = {}
-    for idx, smi in enumerate(unique_smiles, start=1):
+    cache: dict[tuple[str, str], dict[str, str]] = {}
+    enriched: list[dict[str, str]] = []
+
+    for idx, row in enumerate(records, start=1):
         logger.info("pubchem_progress", current=idx, total=total)
-        cid = pl.get_cid_from_smiles(smi, cfg) or ""
-        first_cid = cid.split("|")[0] if cid else ""
-        if first_cid:
-            props = pl.get_properties(first_cid, cfg)
-            records[smi] = {
-                "pubchem_cid": first_cid,
-                "pubchem_iupac_name": props.IUPACName,
-                "pubchem_molecular_formula": props.MolecularFormula,
-                "pubchem_isomeric_smiles": props.iSMILES,
-                "pubchem_canonical_smiles": props.cSMILES,
-                "pubchem_inchi": props.InChI,
-                "pubchem_inchikey": props.InChIKey,
-            }
-        else:
-            records[smi] = {
-                "pubchem_cid": "",
-                "pubchem_iupac_name": "",
-                "pubchem_molecular_formula": "",
-                "pubchem_isomeric_smiles": "",
-                "pubchem_canonical_smiles": "",
-                "pubchem_inchi": "",
-                "pubchem_inchikey": "",
-            }
+        enriched.append(resolver(row, cfg, cache=cache))
 
-    empty = {
-        "pubchem_cid": "",
-        "pubchem_iupac_name": "",
-        "pubchem_molecular_formula": "",
-        "pubchem_isomeric_smiles": "",
-        "pubchem_canonical_smiles": "",
-        "pubchem_inchi": "",
-        "pubchem_inchikey": "",
-    }
-    pubchem_rows = [records.get(smi, empty) for smi in smiles_list]
-    pubchem_df = pd.DataFrame(pubchem_rows)
+    pubchem_df = pd.DataFrame(enriched)
     return pd.concat([df.reset_index(drop=True), pubchem_df], axis=1)
 
 
@@ -659,6 +640,91 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    parser.add_argument(
+        "--pubchem-enable",
+        dest="pubchem_enable",
+        action="store_true",
+        help="Enable PubChem enrichment",
+    )
+    parser.add_argument(
+        "--pubchem-disable",
+        dest="pubchem_enable",
+        action="store_false",
+        help="Disable PubChem enrichment",
+    )
+    parser.set_defaults(pubchem_enable=None)
+    parser.add_argument(
+        "--pubchem-resolve-order",
+        type=_parse_resolve_order,
+        default=None,
+        help="Comma-separated identifier priority for PubChem resolution",
+    )
+    parser.add_argument(
+        "--pubchem-timeout-seconds",
+        dest="pubchem_timeout_seconds",
+        type=float,
+        default=None,
+        help="Overall timeout in seconds for resolving a PubChem record",
+    )
+    parser.add_argument(
+        "--pubchem-backoff-initial-seconds",
+        dest="pubchem_backoff_initial_seconds",
+        type=float,
+        default=None,
+        help="Initial exponential backoff delay after HTTP 429/5xx",
+    )
+    parser.add_argument(
+        "--pubchem-prefer-local-smiles",
+        dest="pubchem_prefer_local_smiles",
+        action="store_true",
+        help="Prefer ChEMBL SMILES during PubChem resolution",
+    )
+    parser.add_argument(
+        "--pubchem-prefer-pubchem-smiles",
+        dest="pubchem_prefer_local_smiles",
+        action="store_false",
+        help="Prefer cached PubChem SMILES during resolution",
+    )
+    parser.set_defaults(pubchem_prefer_local_smiles=None)
+    parser.add_argument(
+        "--pubchem-use-parent-for-salts",
+        dest="pubchem_use_parent_for_salts",
+        action="store_true",
+        help="Use parent compound identifiers for salt forms",
+    )
+    parser.add_argument(
+        "--pubchem-ignore-parent-for-salts",
+        dest="pubchem_use_parent_for_salts",
+        action="store_false",
+        help="Ignore parent compound identifiers for salt forms",
+    )
+    parser.set_defaults(pubchem_use_parent_for_salts=None)
+    parser.add_argument(
+        "--pubchem-allow-polymer",
+        dest="pubchem_allow_polymer",
+        action="store_true",
+        help="Allow PubChem enrichment for polymer molecules",
+    )
+    parser.add_argument(
+        "--pubchem-skip-polymer",
+        dest="pubchem_allow_polymer",
+        action="store_false",
+        help="Skip PubChem enrichment for polymer molecules",
+    )
+    parser.set_defaults(pubchem_allow_polymer=None)
+    parser.add_argument(
+        "--pubchem-write-not-found-literal",
+        dest="pubchem_write_not_found_literal",
+        action="store_true",
+        help="Write 'Not Found' for missing PubChem fields",
+    )
+    parser.add_argument(
+        "--pubchem-write-empty",
+        dest="pubchem_write_not_found_literal",
+        action="store_false",
+        help="Write empty strings for missing PubChem fields",
+    )
+    parser.set_defaults(pubchem_write_not_found_literal=None)
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -682,6 +748,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "column": "testitem.column",
                 "batch_size": "testitem.batch_size",
                 "limit": "testitem.limit",
+                "pubchem_enable": "pubchem.enable",
+                "pubchem_resolve_order": "pubchem.resolve_order",
+                "pubchem_timeout_seconds": "pubchem.timeout_seconds",
+                "pubchem_backoff_initial_seconds": "pubchem.backoff_initial_seconds",
+                "pubchem_prefer_local_smiles": "pubchem.prefer_local_smiles",
+                "pubchem_use_parent_for_salts": "pubchem.use_parent_for_salts",
+                "pubchem_allow_polymer": "pubchem.allow_polymer",
+                "pubchem_write_not_found_literal": "pubchem.write_not_found_literal",
             },
         )
         if args.print_config:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 
 import pandas as pd
 import pytest
@@ -11,6 +11,7 @@ import requests
 
 from library import chembl_library as cl
 from library import io
+from library import pubchem_library as pl
 from library.config import Config
 from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
@@ -82,7 +83,14 @@ def test_run_chembl_column_order(
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
 
-    available = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    available = set(df.columns) | {
+        "pipeline_version",
+        "timestamp_utc",
+        cfg.molecule_catalog.parent_field,
+        "natural_product",
+        "prodrug",
+        "polymer_flag",
+    }
     expected_head = [c for c in TestitemsSchema.columns if c in available]
     expected_tail = sorted(available - set(TestitemsSchema.columns))
     assert captured["col_order"] == expected_head + expected_tail
@@ -141,6 +149,61 @@ def test_run_chembl_initialises_pubchem_session(
     assert captured["init"] == (cfg.api, cfg.retry)
 
 
+def test_add_pubchem_data_respects_enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When PubChem enrichment is disabled the resolver is not invoked."""
+
+    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    cfg = pl.PubChemCfg(enable=False)
+
+    def unexpected_resolver(*_: object, **__: object) -> dict[str, str]:
+        raise AssertionError("resolver should not be called when disabled")
+
+    result = gtd.add_pubchem_data(df, cfg, resolver=unexpected_resolver)
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_add_pubchem_data_reuses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`add_pubchem_data` should allow resolver cache reuse across rows."""
+
+    df = pd.DataFrame(
+        {
+            "canonical_smiles": ["C", "C", "CC"],
+            "pref_name": ["foo", "foo", "bar"],
+        }
+    )
+    cfg = pl.PubChemCfg()
+
+    seen: list[tuple[str, str]] = []
+
+    def fake_resolver(
+        row: Mapping[str, object],
+        _: pl.PubChemCfg,
+        *,
+        cache: dict[tuple[str, str], dict[str, str]],
+    ) -> dict[str, str]:
+        key = ("smiles", str(row.get("canonical_smiles", "")))
+        if key in cache:
+            return cache[key]
+        record = {
+            "pubchem_cid": key[1],
+            "pubchem_iupac_name": row.get("pref_name", ""),
+            "pubchem_molecular_formula": "",
+            "pubchem_isomeric_smiles": key[1],
+            "pubchem_canonical_smiles": key[1],
+            "pubchem_inchi": "",
+            "pubchem_inchikey": "",
+        }
+        cache[key] = record
+        seen.append(key)
+        return record
+
+    result = gtd.add_pubchem_data(df, cfg, resolver=fake_resolver)
+
+    assert seen == [("smiles", "C"), ("smiles", "CC")]
+    assert "pubchem_cid" in result.columns
+    assert result["pubchem_cid"].tolist() == ["C", "C", "CC"]
+
+
 
 def test_run_chembl_merges_parent_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
@@ -183,21 +246,15 @@ def test_run_chembl_merges_parent_catalog(
     captured_catalog: dict[str, str] | None = None
     captured_source: str | None = None
 
+    original_attach = gtd.attach_parent_molecule_ids
+
     def fake_attach_parent_molecule_ids(
         frame: pd.DataFrame, **kwargs: object
     ) -> tuple[pd.DataFrame, gtd.ParentLookupStats]:
         nonlocal captured_catalog, captured_source
         captured_catalog = kwargs.get("catalog")
         captured_source = kwargs.get("source")
-        return (
-            frame,
-            gtd.ParentLookupStats(
-                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
-                missing=0,
-                unique=0,
-                attached=0,
-            ),
-        )
+        return original_attach(frame, **kwargs)
 
     monkeypatch.setattr(gtd, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -196,3 +196,116 @@ def test_cache_entry_expires(monkeypatch: pytest.MonkeyPatch) -> None:
     time.sleep(1.1)
     pl.make_request(url, cfg)
     assert calls["n"] == 2  # cache expired
+
+
+@responses.activate
+def test_resolve_pubchem_record_falls_back_to_name() -> None:
+    """The resolver should follow ``resolve_order`` when lookups fail."""
+
+    cfg = pl.PubChemCfg(
+        resolve_order=("smiles", "pref_name"),
+        retries=1,
+        delay=0,
+        cache_ttl=0,
+    )
+
+    smiles_url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/C/"
+        "property/MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+    name_url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/Aspirin/"
+        "property/MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+
+    responses.add(responses.GET, smiles_url, status=404)
+    responses.add(
+        responses.GET,
+        name_url,
+        json={
+            "PropertyTable": {
+                "Properties": [
+                    {
+                        "CID": 2244,
+                        "IUPACName": "Aspirin",
+                        "MolecularFormula": "C9H8O4",
+                        "IsomericSMILES": "O=C(O)C1=CC=CC=C1OC(=O)C",
+                        "CanonicalSMILES": "CC(=O)OC1=CC=CC=C1C(=O)O",
+                        "InChI": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)",
+                        "InChIKey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+                    }
+                ]
+            }
+        },
+        status=200,
+    )
+
+    record = pl.resolve_pubchem_record(
+        {"canonical_smiles": "C", "pref_name": "Aspirin"},
+        cfg,
+        cache={},
+    )
+
+    assert record["pubchem_cid"] == "2244"
+    assert record["pubchem_iupac_name"] == "Aspirin"
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.url == smiles_url
+    assert responses.calls[1].request.url == name_url
+
+
+@responses.activate
+def test_resolve_pubchem_record_backoff_on_status() -> None:
+    """HTTP 429 and 5xx responses should trigger exponential backoff."""
+
+    cfg = pl.PubChemCfg(
+        resolve_order=("smiles",),
+        retries=3,
+        delay=0,
+        cache_ttl=0,
+        backoff_initial_seconds=0.1,
+        timeout_seconds=5,
+    )
+
+    url = (
+        "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/C/"
+        "property/MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+
+    responses.add(responses.GET, url, status=429)
+    responses.add(responses.GET, url, status=503)
+    responses.add(
+        responses.GET,
+        url,
+        json={
+            "PropertyTable": {
+                "Properties": [
+                    {
+                        "CID": 5793,
+                        "IUPACName": "Acetic acid",
+                        "MolecularFormula": "C2H4O2",
+                        "IsomericSMILES": "CC(=O)O",
+                        "CanonicalSMILES": "CC(=O)O",
+                        "InChI": "InChI=1S/C2H4O2/c1-2(3)4/h1H3,(H,3,4)",
+                        "InChIKey": "QTBSBXVTEAMEQO-UHFFFAOYSA-N",
+                    }
+                ]
+            }
+        },
+        status=200,
+    )
+
+    sleeps: list[float] = []
+
+    def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    record = pl.resolve_pubchem_record(
+        {"canonical_smiles": "C"},
+        cfg,
+        cache={},
+        sleeper=fake_sleep,
+    )
+
+    assert record["pubchem_cid"] == "5793"
+    assert len(responses.calls) == 3
+    assert sleeps == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- extend the PubChem configuration with resolver toggles, retry/backoff options, and environment aliases
- implement a cached PubChem record resolver with fallback identifiers and exponential backoff
- expose new PubChem controls via the get_testitem_data CLI and cover the resolver with integration tests

## Testing
- pytest tests/test_pubchem_library.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d67942e9388324b3ea121bd87e8445