### PR TITLE
Improve parent catalog lookup modes and tests

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -70,7 +70,8 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
 
 
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
-PARENT_LOOKUP_SOURCE_REMOTE = "remote"
+PARENT_LOOKUP_SOURCE_PARTIAL = "partial"
+PARENT_LOOKUP_SOURCE_SYNC = "sync"
 PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
 
 
@@ -94,19 +95,21 @@ def _cache_state(path: Path) -> tuple[bool, float | None]:
     return True, stat.st_mtime
 
 
-def _resolve_parent_source(
+def _resolve_catalog_load_source(
     before: tuple[bool, float | None], after: tuple[bool, float | None]
 ) -> str:
-    """Determine parent lookup source from cache state transitions."""
+    """Determine the lookup source after invoking ``load_parent_catalog``."""
 
     before_exists, before_mtime = before
     after_exists, after_mtime = after
 
     if after_exists and before_exists and after_mtime == before_mtime:
         return PARENT_LOOKUP_SOURCE_CACHE
-    if after_exists or before_exists != after_exists:
-        return PARENT_LOOKUP_SOURCE_REMOTE
-    return PARENT_LOOKUP_SOURCE_REMOTE
+    if after_exists:
+        return PARENT_LOOKUP_SOURCE_SYNC
+    if before_exists and not after_exists:
+        return PARENT_LOOKUP_SOURCE_SYNC
+    return PARENT_LOOKUP_SOURCE_SYNC
 
 
 def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
@@ -175,7 +178,11 @@ def attach_parent_molecule_ids(
     source_resolved = source
     normalised_child = _normalise_chembl_ids(result[child_column])
     unique_children = normalised_child[normalised_child != ""].unique()
-    catalog_data: MutableMapping[str, str] | None
+    catalog_data: MutableMapping[str, str]
+    used_partial_cache = False
+    needs_full_sync = False
+    partial_fetch_used = False
+    full_sync_used = False
 
     if catalog is not None:
         base_view = {
@@ -185,34 +192,21 @@ def attach_parent_molecule_ids(
         }
         catalog_data = ChainMap({}, base_view)
     else:
-        catalog_data = None
-    used_partial_cache = False
-
-    if catalog_data is None:
-        cache_before = _cache_state(catalog_cfg.cache_path)
+        catalog_data = {}
         queried = query_parent_catalog(unique_children, catalog_cfg)
-        cache_after = _cache_state(catalog_cfg.cache_path)
-        if queried or catalog_cfg.sqlite_path.is_file():
-            catalog_data = dict(queried)
-            source_resolved = _resolve_parent_source(cache_before, cache_after)
+        if queried:
+            catalog_data.update(queried)
             used_partial_cache = True
+            if source_resolved is None:
+                source_resolved = PARENT_LOOKUP_SOURCE_CACHE
         else:
-            catalog_data = load_parent_catalog(
-                client=client,
-                api_cfg=api_cfg,
-                catalog_cfg=catalog_cfg,
-                timeout=timeout,
-            )
-            cache_after = _cache_state(catalog_cfg.cache_path)
-            source_resolved = _resolve_parent_source(cache_before, cache_after)
-    else:
-        if source_resolved is None:
-            cache_exists = catalog_cfg.cache_path.is_file()
-            source_resolved = (
-                PARENT_LOOKUP_SOURCE_CACHE
-                if cache_exists
-                else PARENT_LOOKUP_SOURCE_REMOTE
-            )
+            sqlite_exists = catalog_cfg.sqlite_path.is_file()
+            used_partial_cache = sqlite_exists
+            if sqlite_exists:
+                if source_resolved is None:
+                    source_resolved = PARENT_LOOKUP_SOURCE_CACHE
+            else:
+                needs_full_sync = True
 
     parent_map = {
         key: catalog_data[key]
@@ -220,8 +214,8 @@ def attach_parent_molecule_ids(
         if key in catalog_data
     }
     missing_ids = [key for key in unique_children if key not in parent_map]
-    fetched_remote = False
 
+    fetched: dict[str, str] = {}
     if missing_ids and catalog is None:
         try:
             fetched = molecule_catalog.fetch_parent_catalog_for(
@@ -233,17 +227,38 @@ def attach_parent_molecule_ids(
         except (requests.RequestException, ValueError) as exc:
             logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
             fetched = {}
-        else:
-            if fetched:
-                fetched_remote = True
         if fetched:
+            partial_fetch_used = True
             catalog_data.update(fetched)
             parent_map.update(fetched)
-            if catalog is None:
-                if used_partial_cache:
-                    update_parent_catalog_cache(fetched, catalog_cfg)
-                else:
-                    write_parent_catalog_cache(catalog_data, catalog_cfg)
+            missing_ids = [key for key in unique_children if key not in parent_map]
+            if used_partial_cache:
+                update_parent_catalog_cache(fetched, catalog_cfg)
+            else:
+                write_parent_catalog_cache(catalog_data, catalog_cfg)
+                used_partial_cache = True
+
+    if missing_ids and catalog is None and needs_full_sync:
+        cache_before_load = _cache_state(catalog_cfg.cache_path)
+        catalog_data = load_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=catalog_cfg,
+            timeout=timeout,
+        )
+        cache_after_load = _cache_state(catalog_cfg.cache_path)
+        full_sync_used = True
+        source_resolved = _resolve_catalog_load_source(
+            cache_before_load, cache_after_load
+        )
+        if partial_fetch_used:
+            catalog_data.update(fetched)
+        parent_map = {
+            key: catalog_data.get(key, parent_map.get(key, ""))
+            for key in unique_children
+            if key in catalog_data or key in parent_map
+        }
+        missing_ids = [key for key in unique_children if key not in parent_map]
 
     parent_series = normalised_child.map(parent_map).astype("string")
 
@@ -260,15 +275,20 @@ def attach_parent_molecule_ids(
     missing = int(combined_parent.isna().sum())
     attached = len(result) - missing
 
-    if source_resolved is None:
-        source_resolved = PARENT_LOOKUP_SOURCE_REMOTE
+    final_source = source_resolved
+    if full_sync_used:
+        final_source = PARENT_LOOKUP_SOURCE_SYNC
+    elif partial_fetch_used:
+        final_source = PARENT_LOOKUP_SOURCE_PARTIAL
+    elif final_source is None:
+        final_source = (
+            PARENT_LOOKUP_SOURCE_CACHE
+            if used_partial_cache or catalog is not None
+            else PARENT_LOOKUP_SOURCE_SYNC
+        )
 
     stats = ParentLookupStats(
-        source=(
-            PARENT_LOOKUP_SOURCE_REMOTE
-            if fetched_remote
-            else source_resolved
-        ),
+        source=final_source,
         missing=missing,
         unique=int(len(unique_children)),
         attached=int(attached),
@@ -469,11 +489,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 return 1
             cache_after = _cache_state(cfg.molecule_catalog.cache_path)
-            parent_catalog_source = _resolve_parent_source(cache_before, cache_after)
+            parent_catalog_source = (
+                PARENT_LOOKUP_SOURCE_CACHE
+                if cache_after == cache_before
+                else PARENT_LOOKUP_SOURCE_SYNC
+            )
             if parent_catalog:
                 need_lookup -= set(parent_catalog)
 
-        fetched_remote = False
         if need_lookup:
             try:
                 fetched = molecule_catalog.fetch_parent_catalog_for(
@@ -488,10 +511,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             if fetched:
                 parent_catalog.update(fetched)
                 update_parent_catalog_cache(fetched, cfg.molecule_catalog)
-                fetched_remote = True
-                parent_catalog_source = PARENT_LOOKUP_SOURCE_REMOTE
-        if fetched_remote:
-            parent_catalog_source = PARENT_LOOKUP_SOURCE_REMOTE
+                parent_catalog_source = PARENT_LOOKUP_SOURCE_PARTIAL
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(df, cfg.pubchem)
         logger.info("pubchem_augment_done")

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -45,6 +45,11 @@ def test_run_chembl_column_order(
     monkeypatch.setattr(
         gtd, "load_parent_catalog", lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"}
     )
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *_, **__: {},
+    )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
     monkeypatch.setattr(
         gtd,
@@ -75,6 +80,7 @@ def test_run_chembl_column_order(
         **__: object,
     ) -> Path:
         captured["col_order"] = list(col_order or [])
+        captured["columns"] = list(df.columns)
         return output
 
     monkeypatch.setattr(io, "write_csv", fake_write_csv)
@@ -82,7 +88,7 @@ def test_run_chembl_column_order(
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
 
-    available = set(df.columns) | {"pipeline_version", "timestamp_utc"}
+    available = set(captured.get("columns", []))
     expected_head = [c for c in TestitemsSchema.columns if c in available]
     expected_tail = sorted(available - set(TestitemsSchema.columns))
     assert captured["col_order"] == expected_head + expected_tail
@@ -325,7 +331,7 @@ def test_run_chembl_updates_parent_cache_and_reuses_results(
     assert fetch_calls == [["CHEMBL1"]]
     assert update_calls == [{"CHEMBL1": "CHEMBL1_PARENT"}]
     assert [source for _, source in attach_calls] == [
-        gtd.PARENT_LOOKUP_SOURCE_REMOTE,
+        gtd.PARENT_LOOKUP_SOURCE_PARTIAL,
         gtd.PARENT_LOOKUP_SOURCE_CACHE,
     ]
 
@@ -616,7 +622,7 @@ def test_attach_parent_molecule_ids_fetches_missing(
         timeout=None,
     )
 
-    assert captured_ids["ids"] == ["CHEMBL2"]
+    assert captured_ids["ids"] == ["CHEMBL1", "CHEMBL2"]
     assert result[catalog_cfg.parent_field].tolist() == [
         "CHEMBL1_PARENT",
         "CHEMBL2_PARENT",
@@ -624,7 +630,58 @@ def test_attach_parent_molecule_ids_fetches_missing(
     assert stats.unique == 2
     assert stats.attached == 2
     assert stats.missing == 0
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_SYNC
+
+
+def test_attach_parent_molecule_ids_prefers_partial_fetch_when_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    child_field = cfg.sources.chembl.molecule_catalog.child_field
+    parent_field = cfg.sources.chembl.molecule_catalog.parent_field
+    df = pd.DataFrame({child_field: ["CHEMBL10", "CHEMBL11"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    fetch_calls: list[list[str]] = []
+
+    def fake_fetch(
+        ids: list[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        ordered = sorted(ids)
+        fetch_calls.append(ordered)
+        return {value: f"{value}_PARENT" for value in ordered}
+
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        fake_fetch,
+    )
+
+    monkeypatch.setattr(
+        gtd,
+        "load_parent_catalog",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("load_parent_catalog should not be called")
+        ),
+    )
+
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+    )
+
+    assert fetch_calls == [["CHEMBL10", "CHEMBL11"]]
+    assert result[parent_field].tolist() == ["CHEMBL10_PARENT", "CHEMBL11_PARENT"]
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_PARTIAL
 
 
 def test_attach_parent_molecule_ids_handles_large_catalog(
@@ -732,7 +789,7 @@ def test_attach_parent_molecule_ids_updates_cache_for_reuse(
         "CHEMBL1_PARENT",
         "CHEMBL2_PARENT",
     ]
-    assert first_stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert first_stats.source == gtd.PARENT_LOOKUP_SOURCE_PARTIAL
 
     stored_catalog = json.loads(catalog_cfg.cache_path.read_text(encoding="utf-8"))
     assert stored_catalog == {
@@ -847,7 +904,7 @@ def test_attach_parent_molecule_ids_fetch_failure(
     assert stats.unique == 1
     assert stats.attached == 0
     assert stats.missing == 1
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_REMOTE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_SYNC
 
 
 def test_attach_parent_molecule_ids_uses_cache_only(


### PR DESCRIPTION
## Summary
- differentiate parent lookup modes by introducing cache, partial fetch, and full sync states in the enrichment pipeline
- attempt targeted parent fetches before running a full catalog sync and propagate the new source metadata through the CLI
- extend and update unit tests to cover the new lookup behaviour and prevent unnecessary full synchronisations

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d67bd5e7d08324ab7e8987a1faac32