### PR TITLE
feat: add configurable PubChem resolution with backoff

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -971,6 +971,32 @@
           "title": "Base",
           "type": "string"
         },
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "resolve_order": {
+          "default": [
+            "cid",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name"
+          ],
+          "items": {
+            "enum": [
+              "cid",
+              "smiles",
+              "inchikey",
+              "inchi",
+              "pref_name"
+            ],
+            "type": "string"
+          },
+          "title": "Resolve Order",
+          "type": "array"
+        },
         "timeout_connect": {
           "default": 5,
           "minimum": 1,
@@ -982,6 +1008,12 @@
           "minimum": 1,
           "title": "Timeout Read",
           "type": "integer"
+        },
+        "timeout_seconds": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1007,6 +1039,12 @@
           "title": "Delay",
           "type": "number"
         },
+        "backoff_initial_seconds": {
+          "default": 1.0,
+          "minimum": 0,
+          "title": "Backoff Initial Seconds",
+          "type": "number"
+        },
         "cache_ttl": {
           "default": 3600,
           "description": "Time-to-live for PubChem request cache in seconds",
@@ -1018,6 +1056,24 @@
           "default": false,
           "description": "Skip PubChem lookups when local pubchem_* columns are populated",
           "title": "Prefer Local Smiles",
+          "type": "boolean"
+        },
+        "use_parent_for_salts": {
+          "default": true,
+          "description": "Reuse parent molecule data for salts when available",
+          "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
+        "allow_polymer": {
+          "default": false,
+          "description": "Allow PubChem lookups for polymer flagged molecules",
+          "title": "Allow Polymer",
+          "type": "boolean"
+        },
+        "write_not_found_literal": {
+          "default": false,
+          "description": "Write 'NOT_FOUND' literal when PubChem lookup fails",
+          "title": "Write Not Found Literal",
           "type": "boolean"
         }
       },

--- a/config.yaml
+++ b/config.yaml
@@ -129,13 +129,21 @@ sources:
     burst: 5  # (env: CHEMBL_DA_IUPHAR_BURST)
   pubchem:
     base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"  # PubChem PUG REST API (env: CHEMBL_DA__SOURCES__PUBCHEM__BASE / CHEMBL_DA_PUBCHEM_BASE)
+    enable: true  # Toggle PubChem enrichment (env: CHEMBL_DA_PUBCHEM_ENABLE)
+    resolve_order: ["cid", "smiles", "inchikey", "inchi", "pref_name"]  # Identifier fallback order (env: CHEMBL_DA_PUBCHEM_RESOLVE_ORDER)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT)
     timeout_read: 60  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_READ)
+    timeout_seconds: 30.0  # Total timeout per record resolution (env: CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS)
     retries: 3
     rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
+    backoff_initial_seconds: 1.0  # Initial wait before retrying 429/5xx responses (env: CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS)
     cache_ttl: 3600  # Request cache time-to-live in seconds
+    prefer_local_smiles: false  # Reuse existing pubchem_* columns when populated (env: CHEMBL_DA_PUBCHEM_PREFER_LOCAL_SMILES)
+    use_parent_for_salts: true  # Share PubChem data between salts and their parents (env: CHEMBL_DA_PUBCHEM_USE_PARENT_FOR_SALTS)
+    allow_polymer: false  # Skip molecules flagged as polymer unless enabled (env: CHEMBL_DA_PUBCHEM_ALLOW_POLYMER)
+    write_not_found_literal: false  # Write NOT_FOUND literal when lookups fail (env: CHEMBL_DA_PUBCHEM_WRITE_NOT_FOUND_LITERAL)
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)

--- a/library/config.py
+++ b/library/config.py
@@ -249,12 +249,22 @@ class IupharCfg(_BaseModel):
 
 class PubChemCfg(_BaseModel):
     base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    enable: bool = True
+    resolve_order: tuple[str, ...] = (
+        "cid",
+        "smiles",
+        "inchikey",
+        "inchi",
+        "pref_name",
+    )
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(60, ge=1)
+    timeout_seconds: float = Field(30.0, ge=0)
     retries: int = Field(3, ge=0)
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    backoff_initial_seconds: float = Field(1.0, ge=0)
     cache_ttl: int = Field(
         3600,
         ge=0,
@@ -264,6 +274,18 @@ class PubChemCfg(_BaseModel):
         False,
         description="Skip PubChem lookups when local pubchem_* columns are populated",
     )
+    use_parent_for_salts: bool = Field(
+        True,
+        description="Reuse parent molecule data for salts when available",
+    )
+    allow_polymer: bool = Field(
+        False,
+        description="Allow PubChem lookups for polymer flagged molecules",
+    )
+    write_not_found_literal: bool = Field(
+        False,
+        description="Write 'NOT_FOUND' literal when PubChem lookup fails",
+    )
 
     @field_validator("base")
     @classmethod
@@ -271,6 +293,31 @@ class PubChemCfg(_BaseModel):
         if not _valid_url(v):
             raise ValueError("invalid URL")
         return v
+
+    @field_validator("resolve_order", mode="before")
+    @classmethod
+    def _normalize_order(cls, value: Any) -> tuple[str, ...]:
+        allowed = {"cid", "smiles", "inchikey", "inchi", "pref_name"}
+        if isinstance(value, str):
+            parts = [item.strip() for item in value.split(",") if item.strip()]
+        elif isinstance(value, Sequence):
+            parts = list(value)
+        elif value is None:
+            parts = []
+        else:
+            raise TypeError("resolve_order must be a sequence or comma separated string")
+        for item in parts:
+            if item not in allowed:
+                raise ValueError(
+                    "resolve_order entries must be one of 'cid', 'smiles', 'inchikey', 'inchi', 'pref_name'"
+                )
+        return tuple(parts) if parts else (
+            "cid",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name",
+        )
 
 
 class PubMedCfg(_BaseModel):
@@ -1247,6 +1294,34 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_UNIPROT_BASE": ["sources", "uniprot", "api", "base"],
     "CHEMBL_DA_IUPHAR_BASE": ["sources", "iuphar", "base"],
     "CHEMBL_DA_PUBCHEM_BASE": ["sources", "pubchem", "base"],
+    "CHEMBL_DA_PUBCHEM_ENABLE": ["sources", "pubchem", "enable"],
+    "CHEMBL_DA_PUBCHEM_RESOLVE_ORDER": ["sources", "pubchem", "resolve_order"],
+    "CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS": ["sources", "pubchem", "timeout_seconds"],
+    "CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS": [
+        "sources",
+        "pubchem",
+        "backoff_initial_seconds",
+    ],
+    "CHEMBL_DA_PUBCHEM_PREFER_LOCAL_SMILES": [
+        "sources",
+        "pubchem",
+        "prefer_local_smiles",
+    ],
+    "CHEMBL_DA_PUBCHEM_USE_PARENT_FOR_SALTS": [
+        "sources",
+        "pubchem",
+        "use_parent_for_salts",
+    ],
+    "CHEMBL_DA_PUBCHEM_ALLOW_POLYMER": [
+        "sources",
+        "pubchem",
+        "allow_polymer",
+    ],
+    "CHEMBL_DA_PUBCHEM_WRITE_NOT_FOUND_LITERAL": [
+        "sources",
+        "pubchem",
+        "write_not_found_literal",
+    ],
     "CHEMBL_DA_LOG_LEVEL": ["system", "log", "level"],
     "CHEMBL_DA_LOG_FORMAT": ["system", "log", "format"],
     "CHEMBL_DA_LOG_DATEFMT": ["system", "log", "datefmt"],

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,8 +6,9 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Callable, Mapping, cast
 from urllib.parse import quote
 
 import requests
@@ -17,6 +18,16 @@ from requests import Session
 from .config import ApiCfg, PubChemCfg, RetryCfg, session_with_retry
 from .log import logger
 from .rate_limiter import get_limiter, sleep
+
+PUBCHEM_FIELDS = (
+    "pubchem_cid",
+    "pubchem_iupac_name",
+    "pubchem_molecular_formula",
+    "pubchem_isomeric_smiles",
+    "pubchem_canonical_smiles",
+    "pubchem_inchi",
+    "pubchem_inchikey",
+)
 
 # Cache is initialised lazily to allow configuration of the TTL via
 # :class:`PubChemCfg`. The cache is recreated when the TTL changes.
@@ -66,7 +77,39 @@ def _cids_from_identifier_list(data: dict[str, Any]) -> list[str]:
     return [str(cid) for cid in data.get("IdentifierList", {}).get("CID", [])]
 
 
-def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> str | None:
+def _fetch_cids(
+    url: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None = None,
+) -> tuple[int | None, list[str]]:
+    status, payload = make_request(url, cfg, deadline=deadline, return_status=True)
+    if status != 200 or payload is None:
+        return status, []
+    cids = _cids_from_identifier_list(payload)
+    return status, sorted(set(cids))
+
+
+def _fetch_cids_for_name(
+    name: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None = None,
+) -> tuple[int | None, list[str]]:
+    safe_name = url_encode(name)
+    rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
+    url = f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={safe_name}"
+    status, payload = make_request(url, cfg, deadline=deadline, return_status=True)
+    if status != 200 or payload is None:
+        return status, []
+    bindings = payload.get("results", {}).get("bindings", [])
+    cids = _extract_cids(bindings)
+    return status, sorted(set(cids))
+
+
+def get_cid_from_smiles(
+    smiles: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> str | None:
     """Retrieve PubChem CID(s) for a SMILES string.
 
     Parameters
@@ -86,15 +129,15 @@ def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> str | None:
     safe_smiles = url_encode(smiles)
     base = cfg.base.rstrip("/")
     url = f"{base}/compound/smiles/{safe_smiles}/cids/JSON"
-    response = make_request(url, cfg)
-    if not response:
+    status, cids = _fetch_cids(url, cfg, deadline=deadline)
+    if status != 200 or not cids:
         return None
-    cids = _cids_from_identifier_list(response)
-    unique_cids = sorted(set(cids))
-    return "|".join(unique_cids) if unique_cids else None
+    return "|".join(cids)
 
 
-def get_cid_from_inchi(inchi: str, cfg: PubChemCfg) -> str | None:
+def get_cid_from_inchi(
+    inchi: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> str | None:
     """Retrieve PubChem CID(s) for an InChI string.
 
     Parameters
@@ -114,15 +157,15 @@ def get_cid_from_inchi(inchi: str, cfg: PubChemCfg) -> str | None:
     safe_inchi = url_encode(inchi)
     base = cfg.base.rstrip("/")
     url = f"{base}/compound/inchi/{safe_inchi}/cids/JSON"
-    response = make_request(url, cfg)
-    if not response:
+    status, cids = _fetch_cids(url, cfg, deadline=deadline)
+    if status != 200 or not cids:
         return None
-    cids = _cids_from_identifier_list(response)
-    unique_cids = sorted(set(cids))
-    return "|".join(unique_cids) if unique_cids else None
+    return "|".join(cids)
 
 
-def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> str | None:
+def get_cid_from_inchikey(
+    inchikey: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> str | None:
     """Retrieve PubChem CID(s) for an InChIKey.
 
     Parameters
@@ -141,15 +184,19 @@ def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> str | None:
     safe_inchikey = url_encode(inchikey)
     base = cfg.base.rstrip("/")
     url = f"{base}/compound/inchikey/{safe_inchikey}/cids/JSON"
-    response = make_request(url, cfg)
-    if not response:
+    status, cids = _fetch_cids(url, cfg, deadline=deadline)
+    if status != 200 or not cids:
         return None
-    cids = _cids_from_identifier_list(response)
-    unique_cids = sorted(set(cids))
-    return "|".join(unique_cids) if unique_cids else None
+    return "|".join(cids)
 
 
-def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
+def make_request(
+    url: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None = None,
+    return_status: bool = False,
+) -> dict[str, Any] | tuple[int | None, dict[str, Any] | None] | None:
     """Make an HTTP GET request and return parsed JSON.
 
     Parameters
@@ -168,16 +215,31 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     """
     global _CACHE
     if _CACHE is None or _CACHE.ttl != cfg.cache_ttl:
-        # Initialise or refresh the cache with the configured TTL.
         _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
 
     cached = _CACHE.get(url)
     if cached is not None:
         logger.info("cache_hit", url=url, rps=cfg.rps, status="hit")
-        return cast(dict[str, Any], cached)
+        data = cast(dict[str, Any], cached)
+        if return_status:
+            return 200, data
+        return data
     logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
 
+    effective_deadline = deadline
+    if effective_deadline is None and cfg.timeout_seconds > 0:
+        effective_deadline = time.monotonic() + cfg.timeout_seconds
+
+    backoff_delay = cfg.backoff_initial_seconds if cfg.backoff_initial_seconds else cfg.delay
+    last_status: int | None = None
+
     for attempt in range(1, cfg.retries + 1):
+        if effective_deadline is not None and time.monotonic() > effective_deadline:
+            logger.info("request_timeout", url=url, attempt=attempt, rps=cfg.rps)
+            if return_status:
+                return 408, None
+            return None
+
         event = "request_start" if attempt == 1 else "request_retry"
         logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
@@ -186,6 +248,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)
             )
         except requests.RequestException as exc:  # pragma: no cover - network
+            last_status = None
             if attempt >= cfg.retries:
                 logger.error(
                     "request_error",
@@ -200,10 +263,13 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     status=None,
                     rps=cfg.rps,
                 )
+                if return_status:
+                    return None, None
                 return None
             sleep(cfg.delay)
             continue
 
+        last_status = response.status_code
         if response.status_code in (404, 400):
             logger.warning(
                 "request_unexpected_status",
@@ -217,7 +283,28 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 status=response.status_code,
                 rps=cfg.rps,
             )
+            if return_status:
+                return response.status_code, None
             return None
+
+        if response.status_code == 429 or 500 <= response.status_code < 600:
+            if attempt >= cfg.retries:
+                logger.info(
+                    "request_fail",
+                    url=url,
+                    status=response.status_code,
+                    rps=cfg.rps,
+                )
+                if return_status:
+                    return response.status_code, None
+                return None
+            wait = max(backoff_delay, 0.0)
+            if wait:
+                sleep(wait)
+            if cfg.backoff_initial_seconds:
+                backoff_delay = backoff_delay * 2 if backoff_delay else cfg.backoff_initial_seconds
+            continue
+
         try:
             response.raise_for_status()
             data = cast(dict[str, Any], response.json())
@@ -236,6 +323,8 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     status=response.status_code,
                     rps=cfg.rps,
                 )
+                if return_status:
+                    return response.status_code, None
                 return None
             sleep(cfg.delay)
             continue
@@ -252,6 +341,8 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 status=response.status_code,
                 rps=cfg.rps,
             )
+            if return_status:
+                return response.status_code, None
             return None
 
         logger.info(
@@ -260,10 +351,15 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             status=response.status_code,
             rps=cfg.rps,
         )
-        assert _CACHE is not None  # for type checker; cache initialised above
+        assert _CACHE is not None
         _CACHE[url] = data
         logger.info("cache_set", url=url, rps=cfg.rps)
+        if return_status:
+            return response.status_code, data
         return data
+
+    if return_status:
+        return last_status, None
     return None
 
 
@@ -283,6 +379,8 @@ def validate_cid(cid: str) -> str | None:
 
     """
     if cid in {"", "0", "-1"}:
+        return None
+    if not cid.isdigit():
         return None
     return cid
 
@@ -304,7 +402,9 @@ def _extract_cids(bindings: list[dict[str, Any]]) -> list[str]:
     return cids
 
 
-def get_cid(compound_name: str, cfg: PubChemCfg) -> str | None:
+def get_cid(
+    compound_name: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> str | None:
     """Retrieve PubChem CID(s) for *compound_name* (exact match).
 
     Parameters
@@ -323,7 +423,7 @@ def get_cid(compound_name: str, cfg: PubChemCfg) -> str | None:
     safe_name = url_encode(compound_name)
     rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
     url = f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={safe_name}"
-    response = make_request(url, cfg)
+    response = make_request(url, cfg, deadline=deadline)
     if not response:
         return None
     bindings = response.get("results", {}).get("bindings", [])
@@ -332,7 +432,9 @@ def get_cid(compound_name: str, cfg: PubChemCfg) -> str | None:
     return "|".join(unique_cids) if unique_cids else None
 
 
-def get_all_cid(compound_name: str, cfg: PubChemCfg) -> str | None:
+def get_all_cid(
+    compound_name: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> str | None:
     """Retrieve PubChem CID(s) for *compound_name* (partial match).
 
     Parameters
@@ -350,7 +452,7 @@ def get_all_cid(compound_name: str, cfg: PubChemCfg) -> str | None:
     safe_name = url_encode(compound_name)
     rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
     url = f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={safe_name}&contain=true"
-    response = make_request(url, cfg)
+    response = make_request(url, cfg, deadline=deadline)
     if not response:
         return None
     bindings = response.get("results", {}).get("bindings", [])
@@ -400,7 +502,35 @@ class Properties:
     InChIKey: str | None
 
 
-def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
+def _empty_record(write_literal: bool) -> dict[str, str | None]:
+    record = {field: None for field in PUBCHEM_FIELDS}
+    if write_literal:
+        record["pubchem_cid"] = "NOT_FOUND"
+    return record
+
+
+def _build_record(cid: str, props: Properties) -> dict[str, str | None]:
+    return {
+        "pubchem_cid": cid,
+        "pubchem_iupac_name": props.IUPACName,
+        "pubchem_molecular_formula": props.MolecularFormula,
+        "pubchem_isomeric_smiles": props.iSMILES,
+        "pubchem_canonical_smiles": props.cSMILES,
+        "pubchem_inchi": props.InChI,
+        "pubchem_inchikey": props.InChIKey,
+    }
+
+
+def _normalize_identifier(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def get_properties(
+    cid: str, cfg: PubChemCfg, *, deadline: float | None = None
+) -> Properties:
     """Retrieve chemical properties for a compound by CID.
 
     Parameters
@@ -423,7 +553,7 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
         f"{base}/compound/cid/{validated}/property/MolecularFormula,IUPACName,IsomericSMILES,"
         "CanonicalSMILES,InChI,InChIKey/JSON"
     )
-    response = make_request(url, cfg)
+    response = make_request(url, cfg, deadline=deadline)
     if not response:
         return Properties(None, None, None, None, None, None)
     props = response.get("PropertyTable", {}).get("Properties", [])
@@ -438,6 +568,102 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
         cast(str | None, item.get("InChI")),
         cast(str | None, item.get("InChIKey")),
     )
+
+
+def resolve_pubchem_record(
+    identifiers: Mapping[str, str | None],
+    cfg: PubChemCfg,
+    *,
+    cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]] | None = None,
+) -> dict[str, str | None]:
+    """Resolve PubChem information using identifier fallbacks."""
+
+    deadline: float | None = None
+    if cfg.timeout_seconds > 0:
+        deadline = time.monotonic() + cfg.timeout_seconds
+
+    def cache_get(key: tuple[str, str]) -> tuple[bool, dict[str, str | None] | None] | None:
+        if cache is None:
+            return None
+        return cache.get(key)
+
+    def cache_set(
+        key: tuple[str, str],
+        found: bool,
+        record: dict[str, str | None] | None = None,
+    ) -> None:
+        if cache is None:
+            return
+        cache[key] = (found, dict(record) if record is not None else None)
+
+    fetchers: dict[str, Callable[[str], tuple[int | None, list[str]]]] = {
+        "smiles": lambda value: _fetch_cids(
+            f"{cfg.base.rstrip('/')}/compound/smiles/{url_encode(value)}/cids/JSON",
+            cfg,
+            deadline=deadline,
+        ),
+        "inchikey": lambda value: _fetch_cids(
+            f"{cfg.base.rstrip('/')}/compound/inchikey/{url_encode(value)}/cids/JSON",
+            cfg,
+            deadline=deadline,
+        ),
+        "inchi": lambda value: _fetch_cids(
+            f"{cfg.base.rstrip('/')}/compound/inchi/{url_encode(value)}/cids/JSON",
+            cfg,
+            deadline=deadline,
+        ),
+        "pref_name": lambda value: _fetch_cids_for_name(
+            value,
+            cfg,
+            deadline=deadline,
+        ),
+    }
+
+    for method in cfg.resolve_order:
+        raw_value = identifiers.get(method)
+        value = _normalize_identifier(raw_value)
+        if not value:
+            continue
+        key = (method, value)
+        cached = cache_get(key)
+        if cached is not None:
+            found, record = cached
+            if found and record is not None:
+                return dict(record)
+            if not found:
+                continue
+
+        if method == "cid":
+            cid = validate_cid(value)
+            if not cid:
+                cache_set(key, False)
+                continue
+            props = get_properties(cid, cfg, deadline=deadline)
+            record = _build_record(cid, props)
+            cache_set(key, True, record)
+            cache_set(("cid", cid), True, record)
+            return dict(record)
+
+        fetcher = fetchers.get(method)
+        if fetcher is None:
+            continue
+        status, cids = fetcher(value)
+        if status == 404 or (status == 200 and not cids):
+            cache_set(key, False)
+            continue
+        if not cids:
+            continue
+        cid_candidate = validate_cid(cids[0])
+        if not cid_candidate:
+            cache_set(key, False)
+            continue
+        props = get_properties(cid_candidate, cfg, deadline=deadline)
+        record = _build_record(cid_candidate, props)
+        cache_set(key, True, record)
+        cache_set(("cid", cid_candidate), True, record)
+        return dict(record)
+
+    return _empty_record(cfg.write_not_found_literal)
 
 
 def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str | None]:
@@ -481,6 +707,7 @@ __all__ = [
     "get_all_cid",
     "get_standard_name",
     "get_properties",
+    "resolve_pubchem_record",
     "process_compound",
     "Properties",
 ]

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -12,7 +12,7 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections import ChainMap
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
 
@@ -296,7 +296,11 @@ def attach_parent_molecule_ids(
     return result, stats
 
 
-def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
+def add_pubchem_data(
+    df: pd.DataFrame,
+    cfg: PubChemCfg,
+    resolver: Callable[..., dict[str, str | None]] = pl.resolve_pubchem_record,
+) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -322,60 +326,83 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
 
     result = df.reset_index(drop=True).copy()
 
-    smiles_list = result["canonical_smiles"].fillna("").tolist()
-    # ``dict.fromkeys`` preserves the order of first occurrence while
-    # removing duplicates. This allows progress output to reflect the
-    # deterministic iteration order of SMILES strings.
-    unique_smiles = [s for s in dict.fromkeys(smiles_list) if s]
+    if not getattr(cfg, "enable", True):
+        logger.info("pubchem_disabled")
+        return result
 
     prefer_local = getattr(cfg, "prefer_local_smiles", False)
-    skip_smiles: set[str] = set()
-    if prefer_local:
-        existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
-        if existing_cols:
-            normalised = pd.DataFrame(
-                {col: result[col].astype("string").replace("", pd.NA) for col in existing_cols}
-            )
-            complete_mask = normalised.notna().all(axis=1)
-            canonical = result.loc[complete_mask, "canonical_smiles"].astype("string")
-            skip_smiles = {
-                str(smi)
-                for smi in canonical[canonical.notna() & canonical.ne("")].tolist()
-            }
+    existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
+    skip_mask = pd.Series(False, index=result.index)
+    if prefer_local and existing_cols:
+        normalised = pd.DataFrame(
+            {col: result[col].astype("string").replace("", pd.NA) for col in existing_cols}
+        )
+        skip_mask = normalised.notna().all(axis=1)
 
-    fetch_smiles = [s for s in unique_smiles if s not in skip_smiles]
+    resolver_cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]] = {}
+    molecule_cache: dict[str, dict[str, str | None]] = {}
+    resolved_rows: list[dict[str, str | None] | None] = [None] * len(result)
 
-    total = len(fetch_smiles)
-    if total:
-        logger.info("pubchem_start", total=total)
-    else:
-        logger.info("pubchem_no_smiles")
+    def normalise(value: object) -> str | None:
+        if pd.isna(value):
+            return None
+        text = str(value).strip()
+        return text or None
 
-    def _value_or_na(value: str | None) -> object:
-        return value if value not in (None, "") else pd.NA
+    def not_found_record() -> dict[str, str | None]:
+        record = {field: None for field in PUBCHEM_COLUMNS}
+        if getattr(cfg, "write_not_found_literal", False):
+            record["pubchem_cid"] = "NOT_FOUND"
+        return record
 
-    records: dict[str, dict[str, object]] = {}
-    for idx, smi in enumerate(fetch_smiles, start=1):
-        logger.info("pubchem_progress", current=idx, total=total)
-        cid = pl.get_cid_from_smiles(smi, cfg) or ""
-        first_cid = cid.split("|")[0] if cid else ""
-        if first_cid:
-            props = pl.get_properties(first_cid, cfg)
-            records[smi] = {
-                "pubchem_cid": first_cid,
-                "pubchem_iupac_name": _value_or_na(props.IUPACName),
-                "pubchem_molecular_formula": _value_or_na(props.MolecularFormula),
-                "pubchem_isomeric_smiles": _value_or_na(props.iSMILES),
-                "pubchem_canonical_smiles": _value_or_na(props.cSMILES),
-                "pubchem_inchi": _value_or_na(props.InChI),
-                "pubchem_inchikey": _value_or_na(props.InChIKey),
-            }
-        else:
-            records[smi] = {col: pd.NA for col in PUBCHEM_COLUMNS}
+    for idx, row in result.iterrows():
+        if skip_mask.iloc[idx]:
+            continue
 
-    empty = {col: pd.NA for col in PUBCHEM_COLUMNS}
-    pubchem_rows = [records.get(smi, empty.copy()) for smi in smiles_list]
-    pubchem_df = pd.DataFrame(pubchem_rows, index=result.index).convert_dtypes()
+        molecule_id = normalise(row.get("molecule_chembl_id"))
+        parent_id = normalise(row.get("parent_molecule_chembl_id"))
+
+        if not getattr(cfg, "allow_polymer", False):
+            polymer_flag = row.get("polymer_flag")
+            is_polymer = bool(polymer_flag) if not pd.isna(polymer_flag) else False
+            if is_polymer:
+                record = not_found_record()
+                resolved_rows[idx] = record
+                if molecule_id:
+                    molecule_cache[molecule_id] = dict(record)
+                continue
+
+        if getattr(cfg, "use_parent_for_salts", False) and parent_id:
+            cached_parent = molecule_cache.get(parent_id)
+            if cached_parent is not None:
+                record = dict(cached_parent)
+                resolved_rows[idx] = record
+                if molecule_id:
+                    molecule_cache[molecule_id] = dict(record)
+                continue
+
+        if molecule_id and molecule_id in molecule_cache:
+            record = dict(molecule_cache[molecule_id])
+            resolved_rows[idx] = record
+            continue
+
+        identifiers = {
+            "cid": normalise(row.get("pubchem_cid")),
+            "smiles": normalise(row.get("canonical_smiles")),
+            "inchikey": normalise(row.get("standard_inchi_key")),
+            "inchi": normalise(row.get("standard_inchi")),
+            "pref_name": normalise(row.get("pref_name")),
+        }
+
+        record = resolver(identifiers, cfg, cache=resolver_cache)
+        record = dict(record)
+        resolved_rows[idx] = record
+        if molecule_id:
+            molecule_cache[molecule_id] = dict(record)
+        if getattr(cfg, "use_parent_for_salts", False) and parent_id:
+            molecule_cache[parent_id] = dict(record)
+
+    pubchem_df = pd.DataFrame(resolved_rows, index=result.index)
 
     for col in PUBCHEM_COLUMNS:
         if col not in pubchem_df.columns:
@@ -387,10 +414,15 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
                 existing = result[col]
                 missing_mask = existing.isna() | existing.eq("")
                 result.loc[missing_mask, col] = new_series[missing_mask]
+                result[col] = result[col].astype("string")
             else:
                 result[col] = new_series
         else:
             result[col] = new_series
+
+    for col in PUBCHEM_COLUMNS:
+        if col in result.columns:
+            result[col] = result[col].astype("string")
 
     return result
 
@@ -578,6 +610,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         df = normalize_testitems(df)
         df = add_pipeline_metadata(df)
+        cleanup_columns = {"parent_molecule_chembl_id", "natural_product", "prodrug", "polymer_flag"}
+        empty_cleanup = [
+            column
+            for column in cleanup_columns
+            if column in df.columns and df[column].isna().all()
+        ]
+        if empty_cleanup:
+            df = df.drop(columns=empty_cleanup)
         # Determine column order: schema columns first, followed by
         # additional fields sorted alphabetically.
         schema_cols = list(TestitemsSchema.columns)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -21,9 +21,15 @@ def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> No
     df = pd.DataFrame({"canonical_smiles": ["C"]})
     cfg = pl.PubChemCfg(delay=0)
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+    def fake_resolver(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]],
+    ) -> dict[str, str | None]:
+        return {col: None for col in gtd.PUBCHEM_COLUMNS}
 
-    result = gtd.add_pubchem_data(df, cfg)
+    result = gtd.add_pubchem_data(df, cfg, resolver=fake_resolver)
     pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
     assert pubchem_cols
     assert result[pubchem_cols].isna().all().all()
@@ -45,18 +51,97 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     )
     cfg = pl.PubChemCfg(delay=0, prefer_local_smiles=True)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+    def fail(*_: object, **__: object) -> dict[str, str | None]:  # pragma: no cover - defensive
         raise AssertionError("PubChem lookup should not be called")
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-    monkeypatch.setattr(pl, "get_properties", fail)
-
-    result = gtd.add_pubchem_data(df, cfg)
+    result = gtd.add_pubchem_data(df, cfg, resolver=fail)
 
     expected = df.copy()
     for column in gtd.PUBCHEM_COLUMNS:
         expected[column] = expected[column].astype("string")
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_add_pubchem_data_reuses_cached_resolutions() -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C", "C"]})
+    cfg = pl.PubChemCfg(delay=0)
+
+    computed: list[str] = []
+
+    def fake_resolver(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]],
+    ) -> dict[str, str | None]:
+        key = ("smiles", identifiers.get("smiles") or "")
+        cached = cache.get(key)
+        if cached is not None:
+            found, record = cached
+            assert found
+            assert record is not None
+            return dict(record)
+        computed.append(key[1])
+        record = {col: f"value-{key[1]}" if col == "pubchem_cid" else None for col in gtd.PUBCHEM_COLUMNS}
+        cache[key] = (True, record)
+        cache[("cid", record["pubchem_cid"])] = (True, record)
+        return dict(record)
+
+    result = gtd.add_pubchem_data(df, cfg, resolver=fake_resolver)
+
+    assert computed == ["C"]
+    assert result["pubchem_cid"].tolist() == ["value-C", "value-C"]
+
+
+def test_add_pubchem_data_caches_not_found_failures() -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C", "C"]})
+    cfg = pl.PubChemCfg(delay=0)
+
+    computed: list[str] = []
+
+    def fake_resolver(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]],
+    ) -> dict[str, str | None]:
+        key = ("smiles", identifiers.get("smiles") or "")
+        cached = cache.get(key)
+        if cached is not None:
+            found, _ = cached
+            assert not found
+            return {col: None for col in gtd.PUBCHEM_COLUMNS}
+        computed.append(key[1])
+        cache[key] = (False, None)
+        return {col: None for col in gtd.PUBCHEM_COLUMNS}
+
+    _ = gtd.add_pubchem_data(df, cfg, resolver=fake_resolver)
+
+    assert computed == ["C"]
+
+
+def test_add_pubchem_data_retries_transient_failures() -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C", "C"]})
+    cfg = pl.PubChemCfg(delay=0)
+
+    attempts: list[str] = []
+
+    def fake_resolver(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]],
+    ) -> dict[str, str | None]:
+        key = ("smiles", identifiers.get("smiles") or "")
+        attempts.append(key[1])
+        # Simulate transient error by not touching the cache on first attempt
+        if attempts.count(key[1]) > 1:
+            cache[key] = (False, None)
+        return {col: None for col in gtd.PUBCHEM_COLUMNS}
+
+    _ = gtd.add_pubchem_data(df, cfg, resolver=fake_resolver)
+
+    assert attempts == ["C", "C"]
 
 
 def test_run_chembl_column_order(

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -218,3 +218,101 @@ def test_cache_entry_expires(monkeypatch: pytest.MonkeyPatch) -> None:
     time.sleep(1.1)
     pl.make_request(url, cfg)
     assert calls["n"] == 2  # cache expired
+
+
+def test_resolve_pubchem_record_follows_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = pl.PubChemCfg(delay=0, retries=1, backoff_initial_seconds=0.1)
+
+    calls: list[tuple[str, bool]] = []
+
+    def fake_make_request(
+        url: str,
+        cfg: pl.PubChemCfg,
+        *,
+        deadline: float | None = None,
+        return_status: bool = False,
+    ) -> dict[str, object] | tuple[int | None, dict[str, object] | None] | None:
+        calls.append((url, return_status))
+        if "smiles" in url:
+            if return_status:
+                return 404, None
+            return None
+        if "inchikey" in url:
+            data = {"IdentifierList": {"CID": ["321"]}}
+            if return_status:
+                return 200, data
+            return data
+        if "property" in url:
+            return {"PropertyTable": {"Properties": [{"IUPACName": "foo"}]}}
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr(pl, "make_request", fake_make_request)
+    monkeypatch.setattr(pl, "_CACHE", None)
+
+    cache: dict[tuple[str, str], tuple[bool, dict[str, str | None] | None]] = {}
+    identifiers = {
+        "cid": None,
+        "smiles": "C",
+        "inchikey": "AAA",
+        "inchi": None,
+        "pref_name": None,
+    }
+
+    record = pl.resolve_pubchem_record(identifiers, cfg, cache=cache)
+
+    assert record["pubchem_cid"] == "321"
+    assert record["pubchem_iupac_name"] == "foo"
+    assert calls[0][0].endswith("/smiles/C/cids/JSON")
+    assert calls[1][0].endswith("/inchikey/AAA/cids/JSON")
+    assert cache[("smiles", "C")] == (False, None)
+    found, stored = cache[("inchikey", "AAA")]
+    assert found
+    assert stored is not None
+
+    call_count = len(calls)
+    second = pl.resolve_pubchem_record(identifiers, cfg, cache=cache)
+    assert second == record
+    assert len(calls) == call_count
+
+
+def test_make_request_backoff_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = pl.PubChemCfg(delay=0, retries=2, backoff_initial_seconds=0.25)
+
+    class StubResponse:
+        def __init__(self, status_code: int, payload: dict[str, object] | None = None) -> None:
+            self.status_code = status_code
+            self._payload = payload or {}
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise requests.HTTPError(response=self)
+
+    responses_iter = iter(
+        [
+            StubResponse(429, {}),
+            StubResponse(200, {"IdentifierList": {"CID": [1]}}),
+        ]
+    )
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> StubResponse:
+        return next(responses_iter)
+
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(pl, "sleep", lambda delay: sleeps.append(delay))
+    monkeypatch.setattr(
+        pl,
+        "get_limiter",
+        lambda *a, **k: type("L", (), {"acquire": lambda self: None})(),
+    )
+    monkeypatch.setattr(pl, "_CACHE", None)
+    monkeypatch.setattr(pl._session, "get", fake_get)
+
+    status, data = pl.make_request("https://example.org", cfg, return_status=True)
+
+    assert status == 200
+    assert data == {"IdentifierList": {"CID": [1]}}
+    assert sleeps == [0.25]


### PR DESCRIPTION
## Summary
- extend PubChem configuration/schema to cover resolution order, backoff, and enable switches
- implement a cached PubChem resolver with HTTP status-aware backoff and reuse in get_testitem_data
- add targeted tests for resolver fallbacks, status handling, and new caching behaviour

## Testing
- pytest tests/test_pubchem_library.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d67edb421c8324a98d79db542403c0