### PR TITLE
Support PubChem parent fallback for salts

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1020,6 +1020,12 @@
           "title": "Prefer Local Smiles",
           "type": "boolean"
         },
+        "use_parent_for_salts": {
+          "default": false,
+          "description": "Resolve PubChem CIDs via parent structures when child lookups fail",
+          "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
         "cid_cache_path": {
           "default": null,
           "description": "Optional JSON cache storing PubChem CIDs by molecule_chembl_id",

--- a/config.yaml
+++ b/config.yaml
@@ -136,6 +136,7 @@ sources:
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
     cache_ttl: 3600  # Request cache time-to-live in seconds
+    use_parent_for_salts: false  # Attempt parent structures when salt lookups fail
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)

--- a/library/config.py
+++ b/library/config.py
@@ -268,6 +268,10 @@ class PubChemCfg(_BaseModel):
         default=None,
         description="Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
     )
+    use_parent_for_salts: bool = Field(
+        False,
+        description="Resolve PubChem CIDs via parent structures when child lookups fail",
+    )
 
     @field_validator("base")
     @classmethod

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,7 +16,7 @@ from collections import ChainMap
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
 import requests
@@ -185,13 +185,16 @@ def _select_primary_cid(
     return primary
 
 
-def resolve_pubchem_cid(
-    row: pd.Series, cache: MutableMapping[str, str | None], cfg: PubChemCfg
+def _resolve_cid_from_row(
+    row: pd.Series,
+    cache: MutableMapping[str, str | None],
+    cfg: PubChemCfg,
+    *,
+    chembl_id: str | None,
 ) -> str | None:
-    """Resolve PubChem CID for a ChEMBL record."""
+    """Return a CID for ``row`` using its structure fields."""
 
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    if chembl_id and chembl_id in cache:
+    if chembl_id and chembl_id in cache and cache[chembl_id]:
         return cache[chembl_id]
 
     inchikey = _normalise_identifier(row.get("standard_inchi_key"), uppercase=True)
@@ -256,6 +259,68 @@ def resolve_pubchem_cid(
                 cache[chembl_id] = cid
             return cid
 
+    return None
+
+
+def resolve_pubchem_cid(
+    row: pd.Series,
+    cache: MutableMapping[str, str | None],
+    cfg: PubChemCfg,
+    *,
+    parent_loader: Callable[[str], pd.Series | None] | None = None,
+) -> str | None:
+    """Resolve PubChem CID for a ChEMBL record."""
+
+    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
+    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
+    if cid is not None:
+        return cid
+
+    if not cfg.use_parent_for_salts:
+        if chembl_id and chembl_id not in cache:
+            cache[chembl_id] = None
+        return None
+
+    parent_id = _normalise_identifier(
+        row.get("parent_molecule_chembl_id"), uppercase=True
+    )
+    if not parent_id:
+        if chembl_id and chembl_id not in cache:
+            cache[chembl_id] = None
+        return None
+
+    if parent_loader is None:
+        if chembl_id and chembl_id not in cache:
+            cache[chembl_id] = None
+        return None
+
+    parent_row = parent_loader(parent_id)
+    if parent_row is None:
+        logger.info(
+            "pubchem_parent_structure_missing",
+            child=chembl_id,
+            parent=parent_id,
+            reason="parent_unavailable",
+        )
+        if chembl_id and chembl_id not in cache:
+            cache[chembl_id] = None
+        return None
+
+    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
+    if parent_cid:
+        cache[parent_id] = parent_cid
+        if chembl_id:
+            cache[chembl_id] = parent_cid
+        return parent_cid
+
+    logger.info(
+        "pubchem_parent_structure_missing",
+        child=chembl_id,
+        parent=parent_id,
+        reason="structure_unresolved",
+    )
+    if parent_id and parent_id not in cache:
+        cache[parent_id] = None
     if chembl_id and chembl_id not in cache:
         cache[chembl_id] = None
     return None
@@ -491,7 +556,14 @@ def attach_parent_molecule_ids(
     return result, stats
 
 
-def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
+def add_pubchem_data(
+    df: pd.DataFrame,
+    cfg: PubChemCfg,
+    *,
+    client: ChemblClient | None = None,
+    api_cfg: ApiCfg | None = None,
+    timeout: float | None = None,
+) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
     For each canonical SMILES string in ``df``, the function looks up the
@@ -505,6 +577,12 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
         Data frame returned by :func:`library.chembl_library.get_testitem`.
     cfg:
         PubChem configuration options.
+    client:
+        Optional ChEMBL client reused to fetch parent structures.
+    api_cfg:
+        Optional API configuration required when ``client`` is supplied.
+    timeout:
+        Optional timeout for parent lookups via :func:`cl.get_testitem`.
 
     Returns
     -------
@@ -529,6 +607,51 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
     cache_path = getattr(cfg, "cid_cache_path", None)
     cid_cache = _load_pubchem_cid_cache(cache_path)
     cache_dirty = False
+
+    local_records: dict[str, pd.Series] = {}
+    if "molecule_chembl_id" in result.columns:
+        for index, value in result["molecule_chembl_id"].items():
+            chembl_norm = _normalise_identifier(value, uppercase=True)
+            if chembl_norm and chembl_norm not in local_records:
+                local_records[chembl_norm] = result.loc[index]
+
+    parent_record_cache: dict[str, pd.Series | None] = {}
+
+    def load_parent_record(parent_id: str) -> pd.Series | None:
+        parent_norm = _normalise_identifier(parent_id, uppercase=True)
+        if not parent_norm:
+            return None
+        if parent_norm in parent_record_cache:
+            return parent_record_cache[parent_norm]
+        if parent_norm in local_records:
+            parent_record_cache[parent_norm] = local_records[parent_norm]
+            return parent_record_cache[parent_norm]
+        if client is None or api_cfg is None:
+            parent_record_cache[parent_norm] = None
+            return None
+        try:
+            parent_df = cl.get_testitem(
+                [parent_norm],
+                cfg=api_cfg,
+                client=client,
+                chunk_size=1,
+                timeout=timeout,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning(
+                "pubchem_parent_load_failed",
+                parent=parent_norm,
+                error=str(exc),
+            )
+            parent_record_cache[parent_norm] = None
+            return None
+        if parent_df.empty:
+            parent_record_cache[parent_norm] = None
+            return None
+        parent_row = parent_df.iloc[0]
+        local_records[parent_norm] = parent_row
+        parent_record_cache[parent_norm] = parent_row
+        return parent_row
 
     if "molecule_chembl_id" in result.columns and "pubchem_cid" in result.columns:
         for chembl_raw, cid_raw in zip(
@@ -575,7 +698,12 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
         if lookup_required and total:
             progress += 1
             logger.info("pubchem_progress", current=progress, total=total)
-        cid = resolve_pubchem_cid(row, cid_cache, cfg)
+        cid = resolve_pubchem_cid(
+            row,
+            cid_cache,
+            cfg,
+            parent_loader=load_parent_record,
+        )
         cid_by_index[idx] = cid
         if chembl_id:
             after_present = chembl_id in cid_cache
@@ -786,10 +914,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 parent_catalog.update(fetched)
                 update_parent_catalog_cache(fetched, cfg.molecule_catalog)
                 parent_catalog_source = PARENT_LOOKUP_SOURCE_PARTIAL
-        logger.info("pubchem_augment_start")
-        df = add_pubchem_data(df, cfg.pubchem)
-        logger.info("pubchem_augment_done")
- 
         try:
             ensure_no_parant_column(df)
         except ValueError as exc:
@@ -824,6 +948,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             attached=parent_stats.attached,
             missing=parent_stats.missing,
         )
+
+        logger.info("pubchem_augment_start")
+        df = add_pubchem_data(
+            df,
+            cfg.pubchem,
+            client=client,
+            api_cfg=cfg.api,
+            timeout=cfg.testitem.timeout,
+        )
+        logger.info("pubchem_augment_done")
 
         enrichment_cfg = cfg.testitem_molecule_enrichment
         if enrichment_cfg.enable:

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -196,7 +196,7 @@ def test_testitem_timeout_override(
         return pd.DataFrame({"molecule_chembl_id": data})
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
-    monkeypatch.setattr(gtdt, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(gtdt, "add_pubchem_data", lambda df, cfg, **__: df)
     monkeypatch.setattr(
         gtdt,
         "attach_parent_molecule_ids",

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -99,6 +99,84 @@ def test_resolve_pubchem_cid_prefers_inchikey(
     assert calls == ["inchikey"]
 
 
+def test_resolve_pubchem_cid_uses_parent_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child_row = pd.Series(
+        {
+            "molecule_chembl_id": "CHEMBL2",
+            "parent_molecule_chembl_id": "CHEMBL1",
+            "standard_inchi_key": pd.NA,
+            "standard_inchi": pd.NA,
+            "pref_name": pd.NA,
+            "canonical_smiles": pd.NA,
+        }
+    )
+    parent_row = pd.Series(
+        {
+            "molecule_chembl_id": "CHEMBL1",
+            "standard_inchi_key": "parent-key",
+        }
+    )
+    cache: dict[str, str | None] = {}
+    cfg = pl.PubChemCfg(delay=0, use_parent_for_salts=True)
+
+    calls: list[str] = []
+
+    def record_inchikey(value: str, _: pl.PubChemCfg) -> str:
+        calls.append(value)
+        return "42"
+
+    monkeypatch.setattr(pl, "get_cid_from_inchikey", record_inchikey)
+    monkeypatch.setattr(pl, "get_cid_from_inchi", lambda *_: None)
+    monkeypatch.setattr(pl, "get_cid", lambda *_: None)
+    monkeypatch.setattr(pl, "get_all_cid", lambda *_: None)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+
+    cid = gtd.resolve_pubchem_cid(
+        child_row,
+        cache,
+        cfg,
+        parent_loader=lambda _: parent_row,
+    )
+
+    assert cid == "42"
+    assert cache["CHEMBL1"] == "42"
+    assert cache["CHEMBL2"] == "42"
+    assert calls == ["PARENT-KEY"]
+
+
+def test_resolve_pubchem_cid_logs_when_parent_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = pd.Series(
+        {
+            "molecule_chembl_id": "CHEMBL2",
+            "parent_molecule_chembl_id": "CHEMBL1",
+        }
+    )
+    cache: dict[str, str | None] = {}
+    cfg = pl.PubChemCfg(delay=0, use_parent_for_salts=True)
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, **kwargs: object) -> None:
+        events.append((event, kwargs))
+
+    monkeypatch.setattr(gtd.logger, "info", capture)
+
+    cid = gtd.resolve_pubchem_cid(
+        row,
+        cache,
+        cfg,
+        parent_loader=lambda _: None,
+    )
+
+    assert cid is None
+    assert cache["CHEMBL2"] is None
+    assert any(event == "pubchem_parent_structure_missing" for event, _ in events)
+
+
 def test_add_pubchem_data_uses_disk_cache(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -167,7 +245,7 @@ def test_run_chembl_column_order(
         "fetch_parent_catalog_for",
         lambda *_, **__: {},
     )
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg, **__: df)
     monkeypatch.setattr(
         gtd,
         "attach_parent_molecule_ids",
@@ -225,7 +303,7 @@ def test_run_chembl_initialises_pubchem_session(
         {"molecule_chembl_id": ["CHEMBL1"], "molecule_type": ["Small molecule"]}
     )
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg, **__: frame)
     monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
 
     monkeypatch.setattr(
@@ -302,7 +380,7 @@ def test_run_chembl_merges_parent_catalog(
         return parent_catalog
 
     monkeypatch.setattr(gtd, "query_parent_catalog", fake_query_parent_catalog)
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
     captured_catalog: dict[str, str] | None = None
     captured_source: str | None = None
 
@@ -387,7 +465,7 @@ def test_run_chembl_updates_parent_cache_and_reuses_results(
     source = pd.DataFrame([{child_field: "CHEMBL1", parent_field: pd.NA}])
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: source.copy())
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
 
     cache_path = tmp_path / "parent_catalog.json"
     cache_path.write_text("{}", encoding="utf-8")
@@ -526,7 +604,7 @@ def test_run_chembl_preserves_existing_parent_value_when_catalog_missing(
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: source.copy())
     monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
     monkeypatch.setattr(
         gtd,
         "attach_parent_molecule_ids",
@@ -597,7 +675,7 @@ def test_run_chembl_parent_catalog_error(
             ]
         ),
     )
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
@@ -653,7 +731,7 @@ def test_run_chembl_parent_catalog_request_error(
             ]
         ),
     )
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _: frame)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")


### PR DESCRIPTION
## Summary
- add a `use_parent_for_salts` switch to the PubChem configuration and surface it in the default config
- resolve PubChem CIDs with optional parent lookups, including on-demand parent fetches and logging when parents lack structures
- move PubChem enrichment after parent attachment and update tests to cover the new resolution path

## Testing
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_uses_parent_when_enabled
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_logs_when_parent_missing
- pytest tests/test_get_testitem_data.py::test_run_chembl_column_order
- pytest tests/test_get_testitem_data.py::test_run_chembl_initialises_pubchem_session
- pytest tests/test_get_testitem_data.py::test_run_chembl_merges_parent_catalog

------
https://chatgpt.com/codex/tasks/task_e_68d68a915b4883248524dba5b03f0cfb