### PR TITLE
feat(pubchem): make CID resolution order configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1007,6 +1007,26 @@
           "title": "Delay",
           "type": "number"
         },
+        "resolve_order": {
+          "default": [
+            "cache",
+            "inchikey",
+            "name",
+            "smiles"
+          ],
+          "description": "Resolution order for PubChem CID lookups",
+          "items": {
+            "enum": [
+              "cache",
+              "inchikey",
+              "name",
+              "smiles"
+            ],
+            "type": "string"
+          },
+          "title": "Resolve Order",
+          "type": "array"
+        },
         "cache_ttl": {
           "default": 3600,
           "description": "Time-to-live for PubChem request cache in seconds",

--- a/library/config.py
+++ b/library/config.py
@@ -255,6 +255,10 @@ class PubChemCfg(_BaseModel):
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    resolve_order: list[str] = Field(
+        default_factory=lambda: ["cache", "inchikey", "name", "smiles"],
+        description="Resolution order for PubChem CID lookups",
+    )
     cache_ttl: int = Field(
         3600,
         ge=0,
@@ -275,6 +279,15 @@ class PubChemCfg(_BaseModel):
         if not _valid_url(v):
             raise ValueError("invalid URL")
         return v
+
+    @field_validator("resolve_order")
+    @classmethod
+    def _validate_resolve_order(cls, value: list[str]) -> list[str]:
+        allowed = {"cache", "inchikey", "name", "smiles"}
+        invalid = [item for item in value if item not in allowed]
+        if invalid:
+            raise ValueError(f"invalid resolve order entries: {invalid}")
+        return value
 
 
 class PubMedCfg(_BaseModel):

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -191,19 +191,25 @@ def resolve_pubchem_cid(
     """Resolve PubChem CID for a ChEMBL record."""
 
     chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    if chembl_id and chembl_id in cache:
-        return cache[chembl_id]
-
-    def _store(value: str | None) -> str | None:
-        if chembl_id:
-            cache[chembl_id] = value
-        return value
+    candidates: dict[str, str | None] = {
+        "standard_inchi_key": _normalise_identifier(
+            row.get("standard_inchi_key"), uppercase=True
+        ),
+        "pubchem_inchikey": _normalise_identifier(
+            row.get("pubchem_inchikey"), uppercase=True
+        ),
+        "standard_inchi": _normalise_identifier(row.get("standard_inchi")),
+        "pubchem_inchi": _normalise_identifier(row.get("pubchem_inchi")),
+        "pref_name": _normalise_identifier(row.get("pref_name")),
+        "canonical_smiles": _normalise_identifier(row.get("canonical_smiles")),
+    }
 
     def _attempt(
         identifier: str,
-        value: str | None,
+        candidate_key: str,
         resolver: Callable[[str, PubChemCfg], str | None],
     ) -> str | None:
+        value = candidates.get(candidate_key)
         if not value:
             return None
         resolved = resolver(value, cfg)
@@ -214,28 +220,33 @@ def resolve_pubchem_cid(
             value=value,
         )
 
-    inchikey = _normalise_identifier(row.get("standard_inchi_key"), uppercase=True)
-    cid = _attempt("standard_inchi_key", inchikey, pl.get_cid_from_inchikey)
-    if cid:
-        return _store(cid)
+    pipeline: dict[str, list[tuple[str, str, Callable[[str, PubChemCfg], str | None]]]] = {
+        "inchikey": [
+            ("standard_inchi_key", "standard_inchi_key", pl.get_cid_from_inchikey),
+            ("pubchem_inchikey", "pubchem_inchikey", pl.get_cid_from_inchikey),
+            ("standard_inchi", "standard_inchi", pl.get_cid_from_inchi),
+            ("pubchem_inchi", "pubchem_inchi", pl.get_cid_from_inchi),
+        ],
+        "name": [
+            ("pref_name", "pref_name", pl.get_cid),
+            ("pref_name_partial", "pref_name", pl.get_all_cid),
+        ],
+        "smiles": [
+            ("canonical_smiles", "canonical_smiles", pl.get_cid_from_smiles),
+        ],
+    }
 
-    inchi = _normalise_identifier(row.get("standard_inchi"))
-    cid = _attempt("standard_inchi", inchi, pl.get_cid_from_inchi)
-    if cid:
-        return _store(cid)
-
-    pref_name = _normalise_identifier(row.get("pref_name"))
-    cid = _attempt("pref_name", pref_name, pl.get_cid)
-    if cid:
-        return _store(cid)
-    cid = _attempt("pref_name_partial", pref_name, pl.get_all_cid)
-    if cid:
-        return _store(cid)
-
-    smiles = _normalise_identifier(row.get("canonical_smiles"))
-    cid = _attempt("canonical_smiles", smiles, pl.get_cid_from_smiles)
-    if cid:
-        return _store(cid)
+    for step in getattr(cfg, "resolve_order", ["cache", "inchikey", "name", "smiles"]):
+        if step == "cache":
+            if chembl_id and chembl_id in cache:
+                return cache[chembl_id]
+            continue
+        for identifier, candidate_key, resolver in pipeline.get(step, []):
+            cid = _attempt(identifier, candidate_key, resolver)
+            if cid:
+                if chembl_id:
+                    cache[chembl_id] = cid
+                return cid
 
     if chembl_id and chembl_id not in cache:
         cache[chembl_id] = None

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -99,6 +99,40 @@ def test_resolve_pubchem_cid_prefers_inchikey(
     assert calls == ["inchikey"]
 
 
+def test_resolve_pubchem_cid_uses_pubchem_inchikey_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = pd.Series(
+        {
+            "molecule_chembl_id": "chembl1",
+            "pubchem_inchikey": "pubchem-key",
+            "pref_name": "should-not-trigger",
+            "canonical_smiles": "C",
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0)
+    cache: dict[str, str | None] = {}
+
+    monkeypatch.setattr(
+        pl,
+        "get_cid_from_inchikey",
+        lambda value, cfg: "42" if value == "PUBCHEM-KEY" else None,
+    )
+
+    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("unexpected resolver invocation")
+
+    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
+    monkeypatch.setattr(pl, "get_cid", fail)
+    monkeypatch.setattr(pl, "get_all_cid", fail)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
+
+    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
+
+    assert cid == "42"
+    assert cache["CHEMBL1"] == "42"
+
+
 def test_add_pubchem_data_uses_disk_cache(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add a configurable `resolve_order` to the PubChem CID lookup configuration with validation
- refactor CID resolution to collect identifier candidates upfront and resolve according to the configured order
- extend the JSON schema and add coverage for resolving via `pubchem_inchikey` without falling back to name lookups

## Testing
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_prefers_inchikey tests/test_get_testitem_data.py::test_resolve_pubchem_cid_uses_pubchem_inchikey_first -q

------
https://chatgpt.com/codex/tasks/task_e_68d68e73b4808324afa9ce675cd94098