### PR TITLE
Add configurable PubChem resolver order

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1007,6 +1007,20 @@
           "title": "Delay",
           "type": "number"
         },
+        "resolve_order": {
+          "default": [
+            "cache",
+            "inchikey",
+            "name",
+            "smiles"
+          ],
+          "description": "Order of PubChem CID resolvers",
+          "items": {
+            "type": "string"
+          },
+          "title": "Resolve Order",
+          "type": "array"
+        },
         "cache_ttl": {
           "default": 3600,
           "description": "Time-to-live for PubChem request cache in seconds",

--- a/library/config.py
+++ b/library/config.py
@@ -255,6 +255,10 @@ class PubChemCfg(_BaseModel):
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    resolve_order: list[str] = Field(
+        default_factory=lambda: ["cache", "inchikey", "name", "smiles"],
+        description="Order of PubChem CID resolvers",
+    )
     cache_ttl: int = Field(
         3600,
         ge=0,

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -202,32 +202,30 @@ def _resolve_cid_from_row(
 ) -> str | None:
     """Return a CID for ``row`` using its structure fields."""
 
+    chembl_norm = (
+        _normalise_identifier(chembl_id, uppercase=True)
+        if chembl_id
+        else _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
+    )
 
-    if chembl_id and chembl_id in cache and cache[chembl_id]:
-        return cache[chembl_id]
- 
+    candidates = {
+        "standard_inchi_key": _normalise_identifier(
+            row.get("standard_inchi_key"), uppercase=True
+        ),
+        "pubchem_inchikey": _normalise_identifier(
+            row.get("pubchem_inchikey"), uppercase=True
+        ),
+        "standard_inchi": _normalise_identifier(row.get("standard_inchi")),
+        "pubchem_inchi": _normalise_identifier(row.get("pubchem_inchi")),
+        "pref_name": _normalise_identifier(row.get("pref_name")),
+        "canonical_smiles": _normalise_identifier(row.get("canonical_smiles")),
+    }
 
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
- 
-
-    if chembl_id:
-        cached = cache.get(chembl_id, _CID_CACHE_MISSING)
-        if cached is not _CID_CACHE_MISSING:
-            cid = _select_primary_cid(
-                cached,
-                chembl_id=chembl_id,
-                identifier="cache",
-                value=cached,
-            )
-            if chembl_id not in cache or cid != cached:
-                cache[chembl_id] = cid
-            return cid
-
-
-    def _store(value: str | None) -> str | None:
-        if chembl_id:
-            cache[chembl_id] = value
+    def _store(value: str) -> str:
+        if chembl_norm:
+            cached_value = cache.get(chembl_norm, _CID_CACHE_MISSING)
+            if cached_value in (_CID_CACHE_MISSING, None) or cached_value != value:
+                cache[chembl_norm] = value
         return value
 
     def _attempt(
@@ -240,33 +238,78 @@ def _resolve_cid_from_row(
         resolved = resolver(value, cfg)
         return _select_primary_cid(
             resolved,
-            chembl_id=chembl_id,
+            chembl_id=chembl_norm,
             identifier=identifier,
             value=value,
         )
 
-    inchikey = _normalise_identifier(row.get("standard_inchi_key"), uppercase=True)
-    cid = _attempt("standard_inchi_key", inchikey, pl.get_cid_from_inchikey)
-    if cid:
-        return _store(cid)
+    def _resolve_cached() -> str | None:
+        if not chembl_norm:
+            return None
+        cached_value = cache.get(chembl_norm, _CID_CACHE_MISSING)
+        if cached_value in (_CID_CACHE_MISSING, None):
+            return None
+        cid_primary = _select_primary_cid(
+            cached_value,
+            chembl_id=chembl_norm,
+            identifier="cache",
+            value=cached_value,
+        )
+        if cid_primary and cached_value != cid_primary:
+            cache[chembl_norm] = cid_primary
+        return cid_primary
 
-    inchi = _normalise_identifier(row.get("standard_inchi"))
-    cid = _attempt("standard_inchi", inchi, pl.get_cid_from_inchi)
-    if cid:
-        return _store(cid)
+    resolver_groups: Mapping[str, Sequence[tuple[str, str | None, Callable[[str, PubChemCfg], str | None]]]] = {
+        "inchikey": (
+            (
+                "standard_inchi_key",
+                candidates["standard_inchi_key"],
+                pl.get_cid_from_inchikey,
+            ),
+            (
+                "pubchem_inchikey",
+                candidates["pubchem_inchikey"],
+                pl.get_cid_from_inchikey,
+            ),
+        ),
+        "inchi": (
+            (
+                "standard_inchi",
+                candidates["standard_inchi"],
+                pl.get_cid_from_inchi,
+            ),
+            (
+                "pubchem_inchi",
+                candidates["pubchem_inchi"],
+                pl.get_cid_from_inchi,
+            ),
+        ),
+        "name": (
+            ("pref_name", candidates["pref_name"], pl.get_cid),
+            ("pref_name_partial", candidates["pref_name"], pl.get_all_cid),
+        ),
+        "smiles": (
+            (
+                "canonical_smiles",
+                candidates["canonical_smiles"],
+                pl.get_cid_from_smiles,
+            ),
+        ),
+    }
 
-    pref_name = _normalise_identifier(row.get("pref_name"))
-    cid = _attempt("pref_name", pref_name, pl.get_cid)
-    if cid:
-        return _store(cid)
-    cid = _attempt("pref_name_partial", pref_name, pl.get_all_cid)
-    if cid:
-        return _store(cid)
-
-    smiles = _normalise_identifier(row.get("canonical_smiles"))
-    cid = _attempt("canonical_smiles", smiles, pl.get_cid_from_smiles)
-    if cid:
-        return _store(cid)
+    for stage in cfg.resolve_order:
+        if stage == "cache":
+            cached_cid = _resolve_cached()
+            if cached_cid:
+                return cached_cid
+            continue
+        resolvers = resolver_groups.get(stage)
+        if resolvers is None:
+            raise ValueError(f"Unknown PubChem resolve order entry: {stage!r}")
+        for identifier, value, resolver in resolvers:
+            cid = _attempt(identifier, value, resolver)
+            if cid:
+                return _store(cid)
 
     return None
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -99,6 +99,42 @@ def test_resolve_pubchem_cid_prefers_inchikey(
     assert calls == ["inchikey"]
 
 
+def test_resolve_pubchem_cid_uses_pubchem_inchikey(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = pd.Series(
+        {
+            "molecule_chembl_id": "chembl1",
+            "standard_inchi_key": pd.NA,
+            "pubchem_inchikey": "xyz-key",
+            "pref_name": "ignored",
+            "canonical_smiles": "C",
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0)
+    cache: dict[str, str | None] = {}
+    calls: list[str] = []
+
+    def record_inchikey(value: str, _: pl.PubChemCfg) -> str:
+        calls.append(value)
+        return "77"
+
+    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("unexpected resolver invocation")
+
+    monkeypatch.setattr(pl, "get_cid_from_inchikey", record_inchikey)
+    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
+    monkeypatch.setattr(pl, "get_cid", fail)
+    monkeypatch.setattr(pl, "get_all_cid", fail)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
+
+    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
+
+    assert cid == "77"
+    assert cache["CHEMBL1"] == "77"
+    assert calls == ["XYZ-KEY"]
+
+
 def test_resolve_pubchem_cid_uses_parent_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a configurable `resolve_order` to `PubChemCfg` and expose it in the schema
- resolve PubChem CIDs by iterating resolvers in the configured order while reusing cached candidates
- cover pubchem inchikey resolution with a regression unit test

## Testing
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_uses_pubchem_inchikey


------
https://chatgpt.com/codex/tasks/task_e_68d691292de883249d63250741414853