### PR TITLE
Add parent-backed PubChem CID resolution for salts

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -276,7 +276,8 @@ def resolve_pubchem_cid(
     cache: MutableMapping[str, str | None],
     cfg: PubChemCfg,
     *,
-    parent_loader: Callable[[str], pd.Series | None] | None = None,
+    parent_loader: Callable[[str], ParentContext | None] | None = None,
+    parent_data: Mapping[str, ParentContext] | None = None,
 ) -> str | None:
     """Resolve PubChem CID for a ChEMBL record."""
 
@@ -298,79 +299,27 @@ def resolve_pubchem_cid(
             cache[chembl_id] = None
         return None
 
-    if parent_loader is None:
+    parent_context: ParentContext | None = None
+    if parent_data is not None:
+        parent_context = parent_data.get(parent_id)
+
+    if parent_context is None and parent_loader is not None:
+        parent_context = parent_loader(parent_id)
+
+    if parent_context is None:
         if chembl_id and chembl_id not in cache:
             cache[chembl_id] = None
-        return None
-
-    parent_row = parent_loader(parent_id)
-    if parent_row is None:
         logger.info(
             "pubchem_parent_structure_missing",
             child=chembl_id,
             parent=parent_id,
             reason="parent_unavailable",
         )
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
         return None
 
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
-    if parent_cid:
-        cache[parent_id] = parent_cid
-        if chembl_id:
-            cache[chembl_id] = parent_cid
-        return parent_cid
-
-
-    return None
-
-
-def resolve_pubchem_cid(
-    row: pd.Series,
-    cache: MutableMapping[str, str | None],
-    cfg: PubChemCfg,
-    *,
-    parent_loader: Callable[[str], pd.Series | None] | None = None,
-) -> str | None:
-    """Resolve PubChem CID for a ChEMBL record."""
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
-    if cid is not None:
-        return cid
-
-    if not cfg.use_parent_for_salts:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_id = _normalise_identifier(
-        row.get("parent_molecule_chembl_id"), uppercase=True
+    parent_cid = _resolve_cid_from_row(
+        parent_context.row, cache, cfg, chembl_id=parent_id
     )
-    if not parent_id:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    if parent_loader is None:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_row = parent_loader(parent_id)
-    if parent_row is None:
-        logger.info(
-            "pubchem_parent_structure_missing",
-            child=chembl_id,
-            parent=parent_id,
-            reason="parent_unavailable",
-        )
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
     if parent_cid:
         cache[parent_id] = parent_cid
         if chembl_id:
@@ -388,6 +337,14 @@ def resolve_pubchem_cid(
     if chembl_id and chembl_id not in cache:
         cache[chembl_id] = None
     return None
+
+
+@dataclass(frozen=True)
+class ParentContext:
+    """Container storing a parent record for PubChem enrichment."""
+
+    row: pd.Series
+    index: int | None = None
 
 
 @dataclass(frozen=True)
@@ -673,23 +630,24 @@ def add_pubchem_data(
     cid_cache = _load_pubchem_cid_cache(cache_path)
     cache_dirty = False
 
-    local_records: dict[str, pd.Series] = {}
+    parent_data_map: dict[str, ParentContext] = {}
     if "molecule_chembl_id" in result.columns:
-        for index, value in result["molecule_chembl_id"].items():
-            chembl_norm = _normalise_identifier(value, uppercase=True)
-            if chembl_norm and chembl_norm not in local_records:
-                local_records[chembl_norm] = result.loc[index]
+        for index in result.index:
+            row = result.loc[index]
+            chembl_norm = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
+            if chembl_norm and chembl_norm not in parent_data_map:
+                parent_data_map[chembl_norm] = ParentContext(row=row.copy(), index=index)
 
-    parent_record_cache: dict[str, pd.Series | None] = {}
+    parent_record_cache: dict[str, ParentContext | None] = {}
 
-    def load_parent_record(parent_id: str) -> pd.Series | None:
+    def load_parent_record(parent_id: str) -> ParentContext | None:
         parent_norm = _normalise_identifier(parent_id, uppercase=True)
         if not parent_norm:
             return None
         if parent_norm in parent_record_cache:
             return parent_record_cache[parent_norm]
-        if parent_norm in local_records:
-            parent_record_cache[parent_norm] = local_records[parent_norm]
+        if parent_norm in parent_data_map:
+            parent_record_cache[parent_norm] = parent_data_map[parent_norm]
             return parent_record_cache[parent_norm]
         if client is None or api_cfg is None:
             parent_record_cache[parent_norm] = None
@@ -714,9 +672,10 @@ def add_pubchem_data(
             parent_record_cache[parent_norm] = None
             return None
         parent_row = parent_df.iloc[0]
-        local_records[parent_norm] = parent_row
-        parent_record_cache[parent_norm] = parent_row
-        return parent_row
+        context = ParentContext(row=parent_row, index=None)
+        parent_data_map[parent_norm] = context
+        parent_record_cache[parent_norm] = context
+        return context
 
     if "molecule_chembl_id" in result.columns and "pubchem_cid" in result.columns:
         for chembl_raw, cid_raw in zip(
@@ -768,6 +727,7 @@ def add_pubchem_data(
             cid_cache,
             cfg,
             parent_loader=load_parent_record,
+            parent_data=parent_data_map,
         )
         cid_by_index[idx] = cid
         if chembl_id:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -59,6 +59,38 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     pd.testing.assert_frame_equal(result, expected)
 
 
+def test_add_pubchem_data_uses_parent_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL_CHILD", "CHEMBL_PARENT"],
+            "parent_molecule_chembl_id": ["CHEMBL_PARENT", pd.NA],
+            "canonical_smiles": [pd.NA, "C"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0, use_parent_for_salts=True)
+
+    smiles_calls: list[str] = []
+
+    def record_smiles(value: str, _: pl.PubChemCfg) -> str | None:
+        smiles_calls.append(value)
+        return "111" if value == "C" else None
+
+    monkeypatch.setattr(pl, "get_cid_from_inchikey", lambda *_: None)
+    monkeypatch.setattr(pl, "get_cid_from_inchi", lambda *_: None)
+    monkeypatch.setattr(pl, "get_cid", lambda *_: None)
+    monkeypatch.setattr(pl, "get_all_cid", lambda *_: None)
+    monkeypatch.setattr(pl, "get_cid_from_smiles", record_smiles)
+
+    props = pl.Properties("iupac", "formula", "ismiles", "csmiles", "inchi", "inchikey")
+    monkeypatch.setattr(pl, "get_properties", lambda cid, _: props if cid == "111" else None)
+
+    result = gtd.add_pubchem_data(df, cfg)
+
+    assert list(result["pubchem_cid"]) == ["111", "111"]
+    assert result.loc[0, "pubchem_iupac_name"] == "iupac"
+    assert smiles_calls == ["C"]
+
+
 def test_resolve_pubchem_cid_prefers_inchikey(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -133,11 +165,14 @@ def test_resolve_pubchem_cid_uses_parent_when_enabled(
     monkeypatch.setattr(pl, "get_all_cid", lambda *_: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
 
+    parent_context = gtd.ParentContext(row=parent_row)
+
     cid = gtd.resolve_pubchem_cid(
         child_row,
         cache,
         cfg,
-        parent_loader=lambda _: parent_row,
+        parent_loader=lambda _: parent_context,
+        parent_data={"CHEMBL1": parent_context},
     )
 
     assert cid == "42"


### PR DESCRIPTION
## Summary
- add a reusable ParentContext cache in `add_pubchem_data` so parent rows can back-fill salt lookups
- extend `resolve_pubchem_cid` to accept parent data and share resolved IDs between parent and child molecules
- cover the salt fallback path with a smoke test that reuses the parent's PubChem properties

## Testing
- pytest tests/test_get_testitem_data.py::test_add_pubchem_data_uses_parent_fallback -q
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_uses_parent_when_enabled -q

------
https://chatgpt.com/codex/tasks/task_e_68d691925eec83248b7f5f019c3624c9