### PR TITLE
Implement configurable PubChem resolver with backoff

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -966,6 +966,11 @@
     "PubChemCfg": {
       "additionalProperties": false,
       "properties": {
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
         "base": {
           "default": "https://pubchem.ncbi.nlm.nih.gov/rest/pug",
           "title": "Base",
@@ -982,6 +987,12 @@
           "minimum": 1,
           "title": "Timeout Read",
           "type": "integer"
+        },
+        "timeout_seconds": {
+          "default": 30.0,
+          "minimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1007,6 +1018,33 @@
           "title": "Delay",
           "type": "number"
         },
+        "backoff_initial_seconds": {
+          "default": 0.5,
+          "minimum": 0,
+          "title": "Backoff Initial Seconds",
+          "type": "number"
+        },
+        "resolve_order": {
+          "default": [
+            "cached_cid",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name"
+          ],
+          "items": {
+            "enum": [
+              "cached_cid",
+              "smiles",
+              "inchikey",
+              "inchi",
+              "pref_name"
+            ],
+            "type": "string"
+          },
+          "title": "Resolve Order",
+          "type": "array"
+        },
         "cache_ttl": {
           "default": 3600,
           "description": "Time-to-live for PubChem request cache in seconds",
@@ -1019,6 +1057,24 @@
           "description": "Skip PubChem lookups when local pubchem_* columns are populated",
           "title": "Prefer Local Smiles",
           "type": "boolean"
+        },
+        "use_parent_for_salts": {
+          "default": true,
+          "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
+        "allow_polymer": {
+          "default": false,
+          "title": "Allow Polymer",
+          "type": "boolean"
+        },
+        "write_not_found_literal": {
+          "default": null,
+          "title": "Write Not Found Literal",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "cid_cache_path": {
           "default": null,

--- a/config.yaml
+++ b/config.yaml
@@ -128,14 +128,27 @@ sources:
     rps: 5  # (env: CHEMBL_DA_IUPHAR_RPS)
     burst: 5  # (env: CHEMBL_DA_IUPHAR_BURST)
   pubchem:
+    enable: true  # Toggle PubChem enrichment stage (env: CHEMBL_DA_PUBCHEM_ENABLE)
+    resolve_order:  # Resolution order for PubChem lookups
+      - cached_cid
+      - smiles
+      - inchikey
+      - inchi
+      - pref_name
     base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"  # PubChem PUG REST API (env: CHEMBL_DA__SOURCES__PUBCHEM__BASE / CHEMBL_DA_PUBCHEM_BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT)
     timeout_read: 60  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_READ)
+    timeout_seconds: 30.0  # Overall deadline for a single PubChem resolution attempt
     retries: 3
     rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
+    backoff_initial_seconds: 0.5  # Starting delay for exponential backoff on 429/5xx responses
     cache_ttl: 3600  # Request cache time-to-live in seconds
+    use_parent_for_salts: true  # Reuse parent compound CID when available for salt records
+    allow_polymer: false  # Disable PubChem lookups for polymer records by default
+    prefer_local_smiles: false  # Skip lookups when local pubchem_* columns already populated
+    write_not_found_literal: null  # Optional literal written when PubChem data is unavailable
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)

--- a/library/config.py
+++ b/library/config.py
@@ -247,14 +247,33 @@ class IupharCfg(_BaseModel):
         return v
 
 
+_PUBCHEM_ALLOWED_RESOLVE_STEPS = (
+    "cached_cid",
+    "smiles",
+    "inchikey",
+    "inchi",
+    "pref_name",
+)
+
+
 class PubChemCfg(_BaseModel):
+    enable: bool = True
     base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(60, ge=1)
+    timeout_seconds: float = Field(30.0, ge=0)
     retries: int = Field(3, ge=0)
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    backoff_initial_seconds: float = Field(0.5, ge=0)
+    resolve_order: tuple[str, ...] = (
+        "cached_cid",
+        "smiles",
+        "inchikey",
+        "inchi",
+        "pref_name",
+    )
     cache_ttl: int = Field(
         3600,
         ge=0,
@@ -263,6 +282,18 @@ class PubChemCfg(_BaseModel):
     prefer_local_smiles: bool = Field(
         False,
         description="Skip PubChem lookups when local pubchem_* columns are populated",
+    )
+    use_parent_for_salts: bool = Field(
+        True,
+        description="Attempt to reuse parent molecule lookups for salt records",
+    )
+    allow_polymer: bool = Field(
+        False,
+        description="Perform PubChem lookups for polymer records when True",
+    )
+    write_not_found_literal: str | None = Field(
+        default=None,
+        description="Optional literal written when PubChem data is unavailable",
     )
     cid_cache_path: Path | None = Field(
         default=None,
@@ -275,6 +306,35 @@ class PubChemCfg(_BaseModel):
         if not _valid_url(v):
             raise ValueError("invalid URL")
         return v
+
+    @field_validator("resolve_order", mode="before")
+    @classmethod
+    def _resolve_order(cls, value: Any) -> tuple[str, ...]:
+        if isinstance(value, str):
+            parts = [part.strip() for part in value.split(",") if part.strip()]
+        else:
+            parts = list(value)
+        seen: set[str] = set()
+        order: list[str] = []
+        for item in parts:
+            if item not in _PUBCHEM_ALLOWED_RESOLVE_STEPS:
+                raise ValueError(
+                    "resolve_order entries must be one of: "
+                    + ", ".join(_PUBCHEM_ALLOWED_RESOLVE_STEPS)
+                )
+            if item in seen:
+                continue
+            seen.add(item)
+            order.append(item)
+        if not order:
+            return (
+                "cached_cid",
+                "smiles",
+                "inchikey",
+                "inchi",
+                "pref_name",
+            )
+        return tuple(order)
 
 
 class PubMedCfg(_BaseModel):

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,6 +6,8 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
+import time
+from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import quote
@@ -13,6 +15,8 @@ from urllib.parse import quote
 import requests
 from cachetools import TTLCache
 from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from .config import ApiCfg, PubChemCfg, RetryCfg, session_with_retry
 from .log import logger
@@ -24,7 +28,17 @@ _CACHE: TTLCache[str, dict[str, Any]] | None = None
 
 # Shared session with placeholder user agent; production code should call
 # :func:`init_session` to supply real contact details.
-_session: Session = session_with_retry(
+def _build_session(api: ApiCfg, retry: RetryCfg) -> Session:
+    """Return HTTP session for PubChem requests disabling automatic retries."""
+
+    session = session_with_retry(api, retry)
+    adapter = HTTPAdapter(max_retries=Retry(total=0, allowed_methods=None))
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+_session: Session = _build_session(
     ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
 )
 
@@ -41,7 +55,7 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """
 
     global _session
-    _session = session_with_retry(api, retry)
+    _session = _build_session(api, retry)
 
 
 def url_encode(text: str) -> str:
@@ -64,6 +78,54 @@ def url_encode(text: str) -> str:
 def _cids_from_identifier_list(data: dict[str, Any]) -> list[str]:
     """Extract CIDs from a JSON ``IdentifierList`` structure."""
     return [str(cid) for cid in data.get("IdentifierList", {}).get("CID", [])]
+
+
+def _normalise_identifier(value: Any, *, uppercase: bool = False) -> str | None:
+    """Return ``value`` normalised as a stripped string."""
+
+    if value is None:
+        return None
+    try:
+        if value != value:  # type: ignore[comparison-overlap]
+            return None
+    except Exception:  # pragma: no cover - defensive
+        pass
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.upper() if uppercase else text
+
+
+def _select_primary_cid(
+    candidates: list[str],
+    *,
+    chembl_id: str | None,
+    identifier: str,
+    value: str | None,
+) -> str | None:
+    """Return the first unique CID logging alternatives when present."""
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for cid in candidates:
+        cid_value = cid.strip()
+        if not cid_value or cid_value in seen:
+            continue
+        unique.append(cid_value)
+        seen.add(cid_value)
+    if not unique:
+        return None
+    primary = unique[0]
+    if len(unique) > 1:
+        logger.info(
+            "pubchem_multiple_cid",
+            chembl_id=chembl_id,
+            identifier=identifier,
+            value=value,
+            cid=primary,
+            alternatives=unique[1:],
+        )
+    return primary
 
 
 def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> str | None:
@@ -440,6 +502,362 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
     )
 
 
+@dataclass(frozen=True)
+class PubChemRecord:
+    """Resolution result combining CID and associated properties."""
+
+    cid: str | None
+    properties: Properties
+    resolved_by: str | None
+
+
+def _blank_properties() -> Properties:
+    """Return an empty :class:`Properties` instance."""
+
+    return Properties(None, None, None, None, None, None)
+
+
+def _cache_key(kind: str, value: str) -> str:
+    """Return cache key for *kind* and *value*."""
+
+    return f"{kind}:{value}"
+
+
+def _remaining_time(deadline: float | None) -> float | None:
+    """Return seconds remaining until ``deadline`` or ``None`` when unlimited."""
+
+    if deadline is None:
+        return None
+    return max(0.0, deadline - time.monotonic())
+
+
+def _backoff_delay(delay: float, cfg: PubChemCfg) -> float:
+    """Return the next backoff interval."""
+
+    if delay > 0:
+        return delay
+    if cfg.backoff_initial_seconds > 0:
+        return cfg.backoff_initial_seconds
+    if cfg.delay > 0:
+        return cfg.delay
+    return 0.5
+
+
+def _record_from_cache(
+    cache: MutableMapping[str, PubChemRecord] | None, kind: str, value: str
+) -> PubChemRecord | None:
+    if cache is None:
+        return None
+    return cache.get(_cache_key(kind, value))
+
+
+def _store_record(
+    cache: MutableMapping[str, PubChemRecord] | None,
+    kind: str,
+    value: str,
+    record: PubChemRecord,
+) -> None:
+    if cache is None:
+        return
+    cache[_cache_key(kind, value)] = record
+
+
+def _properties_for_cid(
+    cache: MutableMapping[str, PubChemRecord] | None, cid: str, cfg: PubChemCfg
+) -> Properties:
+    cached = _record_from_cache(cache, "cid", cid)
+    if cached and cached.cid:
+        return cached.properties
+    return get_properties(cid, cfg)
+
+
+def _identifier_urls(kind: str, value: str, base: str) -> list[str]:
+    encoded = url_encode(value)
+    if kind == "smiles":
+        return [f"{base}/compound/smiles/{encoded}/cids/JSON"]
+    if kind == "inchikey":
+        return [f"{base}/compound/inchikey/{encoded}/cids/JSON"]
+    if kind == "inchi":
+        return [f"{base}/compound/inchi/{encoded}/cids/JSON"]
+    if kind == "pref_name":
+        return [
+            f"{base}/compound/name/{encoded}/cids/JSON",
+            f"{base}/compound/name/{encoded}/cids/JSON?name_type=word",
+        ]
+    raise ValueError(f"unsupported resolution step: {kind}")
+
+
+def _request_with_backoff(
+    url: str, cfg: PubChemCfg, *, deadline: float | None
+) -> dict[str, Any] | None:
+    """Return JSON response handling backoff for rate limiting and 5xx errors."""
+
+    global _CACHE
+    if _CACHE is None or _CACHE.ttl != cfg.cache_ttl:
+        _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
+
+    cached = _CACHE.get(url)
+    if cached is not None:
+        logger.info("cache_hit", url=url, rps=cfg.rps, status="hit")
+        return cast(dict[str, Any], cached)
+    logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
+
+    delay = cfg.backoff_initial_seconds
+    attempt = 0
+    while True:
+        attempt += 1
+        event = "request_start" if attempt == 1 else "request_retry"
+        logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
+        get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
+        try:
+            response = _session.get(
+                url, timeout=(cfg.timeout_connect, cfg.timeout_read)
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network
+            remaining = _remaining_time(deadline)
+            logger.warning(
+                "request_error",
+                url=url,
+                error=str(exc),
+                attempt=attempt,
+                rps=cfg.rps,
+            )
+            if remaining is not None and remaining <= 0:
+                logger.info("request_fail", url=url, status=None, rps=cfg.rps)
+                return None
+            wait = _backoff_delay(delay, cfg)
+            if remaining is not None:
+                wait = min(wait, remaining)
+            if wait > 0:
+                logger.info(
+                    "pubchem_retry",
+                    url=url,
+                    status=None,
+                    attempt=attempt,
+                    delay=wait,
+                    rps=cfg.rps,
+                )
+                sleep(wait)
+            delay = wait * 2 if wait > 0 else delay
+            continue
+
+        status = response.status_code
+        if status == 404:
+            logger.info(
+                "request_not_found", url=url, status=status, attempt=attempt, rps=cfg.rps
+            )
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            return None
+        if status == 429 or 500 <= status < 600:
+            remaining = _remaining_time(deadline)
+            if remaining is not None and remaining <= 0:
+                logger.warning(
+                    "pubchem_timeout",
+                    url=url,
+                    status=status,
+                    attempt=attempt,
+                    rps=cfg.rps,
+                )
+                logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+                return None
+            wait = _backoff_delay(delay, cfg)
+            if remaining is not None:
+                wait = min(wait, remaining)
+            if wait > 0:
+                logger.info(
+                    "pubchem_retry",
+                    url=url,
+                    status=status,
+                    attempt=attempt,
+                    delay=wait,
+                    rps=cfg.rps,
+                )
+                sleep(wait)
+            delay = wait * 2 if wait > 0 else delay
+            continue
+        try:
+            response.raise_for_status()
+            data = cast(dict[str, Any], response.json())
+        except requests.HTTPError as exc:  # pragma: no cover - network
+            logger.error(
+                "request_error",
+                url=url,
+                error=str(exc),
+                attempt=attempt,
+                status=status,
+                rps=cfg.rps,
+            )
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            return None
+        except ValueError:
+            logger.warning(
+                "response_not_json",
+                url=url,
+                status=status,
+                rps=cfg.rps,
+            )
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            return None
+
+        logger.info("request_ok", url=url, status=status, rps=cfg.rps)
+        assert _CACHE is not None
+        _CACHE[url] = data
+        logger.info("cache_set", url=url, rps=cfg.rps)
+        return data
+
+
+def _resolve_identifier(
+    kind: str,
+    value: str,
+    cfg: PubChemCfg,
+    *,
+    deadline: float | None,
+    chembl_id: str | None,
+) -> str | None:
+    base = cfg.base.rstrip("/")
+    for url in _identifier_urls(kind, value, base):
+        if deadline is not None and _remaining_time(deadline) == 0:
+            return None
+        data = _request_with_backoff(url, cfg, deadline=deadline)
+        if not data:
+            continue
+        cid = _select_primary_cid(
+            _cids_from_identifier_list(data),
+            chembl_id=chembl_id,
+            identifier=kind,
+            value=value,
+        )
+        if cid:
+            return cid
+    return None
+
+
+def _is_truthy_flag(value: Any) -> bool:
+    text = _normalise_identifier(value) or ""
+    return text.lower() in {"1", "true", "yes", "y", "t"}
+
+
+def resolve_pubchem_record(
+    row: Mapping[str, Any],
+    cfg: PubChemCfg,
+    *,
+    cid_cache: MutableMapping[str, str | None] | None = None,
+    resolution_cache: MutableMapping[str, PubChemRecord] | None = None,
+) -> PubChemRecord:
+    """Resolve PubChem information for ``row`` according to ``cfg``."""
+
+    if not cfg.enable:
+        return PubChemRecord(None, _blank_properties(), None)
+
+    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
+    parent_id = _normalise_identifier(
+        row.get("parent_molecule_chembl_id"), uppercase=True
+    )
+
+    if not cfg.allow_polymer and _is_truthy_flag(row.get("polymer_flag")):
+        if cid_cache is not None and chembl_id:
+            cid_cache.setdefault(chembl_id, None)
+        return PubChemRecord(None, _blank_properties(), None)
+
+    resolution_cache = resolution_cache if resolution_cache is not None else {}
+
+    row_cid = _normalise_identifier(row.get("pubchem_cid"))
+    if row_cid:
+        if cid_cache is not None and chembl_id:
+            cid_cache[chembl_id] = row_cid
+        record = _record_from_cache(resolution_cache, "cid", row_cid)
+        if record and record.cid:
+            return PubChemRecord(record.cid, record.properties, "cached_cid")
+        props = _properties_for_cid(resolution_cache, row_cid, cfg)
+        record = PubChemRecord(row_cid, props, "cached_cid")
+        _store_record(resolution_cache, "cid", row_cid, record)
+        return record
+
+    if chembl_id and cid_cache is not None and chembl_id in cid_cache:
+        cached_cid = cid_cache[chembl_id]
+        if cached_cid:
+            record = _record_from_cache(resolution_cache, "cid", cached_cid)
+            if record and record.cid:
+                return PubChemRecord(record.cid, record.properties, "cached_cid")
+            props = _properties_for_cid(resolution_cache, cached_cid, cfg)
+            record = PubChemRecord(cached_cid, props, "cached_cid")
+            _store_record(resolution_cache, "cid", cached_cid, record)
+            return record
+        return PubChemRecord(None, _blank_properties(), None)
+
+    if cfg.use_parent_for_salts and parent_id and cid_cache is not None:
+        parent_cid = cid_cache.get(parent_id)
+        if parent_cid:
+            record = _record_from_cache(resolution_cache, "cid", parent_cid)
+            if record and record.cid:
+                if chembl_id:
+                    cid_cache[chembl_id] = parent_cid
+                return PubChemRecord(record.cid, record.properties, "cached_cid")
+            props = _properties_for_cid(resolution_cache, parent_cid, cfg)
+            record = PubChemRecord(parent_cid, props, "cached_cid")
+            _store_record(resolution_cache, "cid", parent_cid, record)
+            if chembl_id:
+                cid_cache[chembl_id] = parent_cid
+            return record
+
+    deadline = (
+        time.monotonic() + cfg.timeout_seconds if cfg.timeout_seconds > 0 else None
+    )
+
+    for step in cfg.resolve_order:
+        if step == "cached_cid":
+            continue
+        if step == "smiles":
+            candidate = _normalise_identifier(row.get("canonical_smiles"))
+        elif step == "inchikey":
+            candidate = _normalise_identifier(
+                row.get("standard_inchi_key"), uppercase=True
+            )
+        elif step == "inchi":
+            candidate = _normalise_identifier(row.get("standard_inchi"))
+        elif step == "pref_name":
+            candidate = _normalise_identifier(row.get("pref_name"))
+        else:
+            candidate = None
+        if not candidate:
+            continue
+
+        cached_record = _record_from_cache(resolution_cache, step, candidate)
+        if cached_record is not None:
+            if cached_record.cid and cid_cache is not None and chembl_id:
+                cid_cache[chembl_id] = cached_record.cid
+            resolved_by = step if cached_record.cid else None
+            return PubChemRecord(
+                cached_record.cid, cached_record.properties, resolved_by
+            )
+
+        cid = _resolve_identifier(
+            step, candidate, cfg, deadline=deadline, chembl_id=chembl_id
+        )
+        if not cid:
+            _store_record(
+                resolution_cache,
+                step,
+                candidate,
+                PubChemRecord(None, _blank_properties(), None),
+            )
+            continue
+
+        props = _properties_for_cid(resolution_cache, cid, cfg)
+        record = PubChemRecord(cid, props, step)
+        _store_record(resolution_cache, step, candidate, record)
+        _store_record(resolution_cache, "cid", cid, record)
+        if cid_cache is not None and chembl_id:
+            cid_cache[chembl_id] = cid
+        if cfg.use_parent_for_salts and parent_id and cid_cache is not None:
+            cid_cache.setdefault(parent_id, cid)
+        return record
+
+    if cid_cache is not None and chembl_id:
+        cid_cache.setdefault(chembl_id, None)
+    return PubChemRecord(None, _blank_properties(), None)
+
+
 def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str | None]:
     """Process *compound_name* into a structured record.
 
@@ -481,6 +899,8 @@ __all__ = [
     "get_all_cid",
     "get_standard_name",
     "get_properties",
+    "resolve_pubchem_record",
     "process_compound",
     "Properties",
+    "PubChemRecord",
 ]

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -158,107 +158,16 @@ def _write_pubchem_cid_cache(path: Path | None, cache: Mapping[str, str | None])
         logger.warning("pubchem_cache_write_failed", path=str(path), error=str(exc))
 
 
-def _select_primary_cid(
-    candidates: str | None,
-    *,
-    chembl_id: str | None,
-    identifier: str,
-    value: str | None,
-) -> str | None:
-    """Return the primary CID from a pipe-separated list."""
+def _value_or_na(value: str | None) -> object:
+    """Return ``value`` when present, otherwise :data:`pandas.NA`."""
 
-    if not candidates:
-        return None
-    cid_list = [cid.strip() for cid in str(candidates).split("|") if cid.strip()]
-    if not cid_list:
-        return None
-    primary = cid_list[0]
-    if len(cid_list) > 1:
-        logger.info(
-            "pubchem_multiple_cid",
-            chembl_id=chembl_id,
-            identifier=identifier,
-            value=value,
-            cid=primary,
-            alternatives=cid_list[1:],
-        )
-    return primary
-
-
-def resolve_pubchem_cid(
-    row: pd.Series, cache: MutableMapping[str, str | None], cfg: PubChemCfg
-) -> str | None:
-    """Resolve PubChem CID for a ChEMBL record."""
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    if chembl_id and chembl_id in cache:
-        return cache[chembl_id]
-
-    inchikey = _normalise_identifier(row.get("standard_inchi_key"), uppercase=True)
-    if inchikey:
-        cid = _select_primary_cid(
-            pl.get_cid_from_inchikey(inchikey, cfg),
-            chembl_id=chembl_id,
-            identifier="standard_inchi_key",
-            value=inchikey,
-        )
-        if cid:
-            if chembl_id:
-                cache[chembl_id] = cid
-            return cid
-
-    inchi = _normalise_identifier(row.get("standard_inchi"))
-    if inchi:
-        cid = _select_primary_cid(
-            pl.get_cid_from_inchi(inchi, cfg),
-            chembl_id=chembl_id,
-            identifier="standard_inchi",
-            value=inchi,
-        )
-        if cid:
-            if chembl_id:
-                cache[chembl_id] = cid
-            return cid
-
-    pref_name = _normalise_identifier(row.get("pref_name"))
-    if pref_name:
-        cid = _select_primary_cid(
-            pl.get_cid(pref_name, cfg),
-            chembl_id=chembl_id,
-            identifier="pref_name",
-            value=pref_name,
-        )
-        if cid:
-            if chembl_id:
-                cache[chembl_id] = cid
-            return cid
-        cid = _select_primary_cid(
-            pl.get_all_cid(pref_name, cfg),
-            chembl_id=chembl_id,
-            identifier="pref_name_partial",
-            value=pref_name,
-        )
-        if cid:
-            if chembl_id:
-                cache[chembl_id] = cid
-            return cid
-
-    smiles = _normalise_identifier(row.get("canonical_smiles"))
-    if smiles:
-        cid = _select_primary_cid(
-            pl.get_cid_from_smiles(smiles, cfg),
-            chembl_id=chembl_id,
-            identifier="canonical_smiles",
-            value=smiles,
-        )
-        if cid:
-            if chembl_id:
-                cache[chembl_id] = cid
-            return cid
-
-    if chembl_id and chembl_id not in cache:
-        cache[chembl_id] = None
-    return None
+    if value is None:
+        return pd.NA
+    if isinstance(value, str):
+        return value if value else pd.NA
+    if pd.isna(value):
+        return pd.NA
+    return value
 
 
 @dataclass(frozen=True)
@@ -492,26 +401,8 @@ def attach_parent_molecule_ids(
 
 
 def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
-    """Augment ChEMBL records with PubChem information.
+    """Augment ChEMBL records with PubChem information."""
 
-    For each canonical SMILES string in ``df``, the function looks up the
-    corresponding PubChem CID and basic chemical properties. The PubChem
-    fields are appended to the input frame. If a SMILES string cannot be
-    resolved, empty values are inserted.
-
-    Parameters
-    ----------
-    df:
-        Data frame returned by :func:`library.chembl_library.get_testitem`.
-    cfg:
-        PubChem configuration options.
-
-    Returns
-    -------
-    pandas.DataFrame
-        ``df`` with additional PubChem columns.
-
-    """
     if df.empty:
         return df
 
@@ -545,79 +436,97 @@ def add_pubchem_data(df: pd.DataFrame, cfg: PubChemCfg) -> pd.DataFrame:
             if before is _CID_CACHE_MISSING or before != cid_value:
                 cache_dirty = True
 
-    total = sum(
-        1
-        for idx, row in result.iterrows()
-        if not (
-            (chembl_id := _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True))
-            and chembl_id in cid_cache
-            and cid_cache[chembl_id]
-        )
-    )
-    if total:
-        logger.info("pubchem_start", total=total)
+    if not cfg.enable:
+        logger.info("pubchem_disabled")
+        total = 0
     else:
-        logger.info("pubchem_no_smiles")
+        total = sum(
+            1
+            for idx, row in result.iterrows()
+            if not (prefer_local and bool(complete_mask.loc[idx]))
+            and not (
+                (chembl_id := _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True))
+                and chembl_id in cid_cache
+                and cid_cache[chembl_id]
+            )
+        )
+        if total:
+            logger.info("pubchem_start", total=total)
+        else:
+            logger.info("pubchem_no_smiles")
 
-    cid_by_index: dict[int, str | None] = {}
+    literal = getattr(cfg, "write_not_found_literal", None)
+    resolution_cache: dict[str, pl.PubChemRecord] = {}
+    records_by_index: dict[int, pl.PubChemRecord] = {}
     progress = 0
+
+    def _record_from_row(row: pd.Series) -> pl.PubChemRecord:
+        return pl.PubChemRecord(
+            _normalise_identifier(row.get("pubchem_cid")),
+            pl.Properties(
+                _normalise_identifier(row.get("pubchem_iupac_name")),
+                _normalise_identifier(row.get("pubchem_molecular_formula")),
+                _normalise_identifier(row.get("pubchem_isomeric_smiles")),
+                _normalise_identifier(row.get("pubchem_canonical_smiles")),
+                _normalise_identifier(row.get("pubchem_inchi")),
+                _normalise_identifier(row.get("pubchem_inchikey"), uppercase=True),
+            ),
+            "local",
+        )
+
     for idx, row in result.iterrows():
         if prefer_local and bool(complete_mask.loc[idx]):
-            cid_by_index[idx] = _normalise_identifier(row.get("pubchem_cid"))
+            records_by_index[idx] = _record_from_row(row)
+            continue
+        if not cfg.enable:
+            records_by_index[idx] = _record_from_row(row)
             continue
 
         chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
         lookup_required = not (
             chembl_id and chembl_id in cid_cache and cid_cache[chembl_id]
         )
-        before_present = chembl_id in cid_cache if chembl_id else False
-        before_value = cid_cache[chembl_id] if before_present else _CID_CACHE_MISSING
         if lookup_required and total:
             progress += 1
             logger.info("pubchem_progress", current=progress, total=total)
-        cid = resolve_pubchem_cid(row, cid_cache, cfg)
-        cid_by_index[idx] = cid
+
+        before_present = chembl_id in cid_cache if chembl_id else False
+        before_value = cid_cache[chembl_id] if before_present else _CID_CACHE_MISSING
+
+        record = pl.resolve_pubchem_record(
+            row,
+            cfg,
+            cid_cache=cid_cache,
+            resolution_cache=resolution_cache,
+        )
+        records_by_index[idx] = record
+
         if chembl_id:
             after_present = chembl_id in cid_cache
             after_value = cid_cache[chembl_id] if after_present else _CID_CACHE_MISSING
-            if before_present != after_present or after_value != before_value:
+            if after_present != before_present or after_value != before_value:
                 cache_dirty = True
 
     if cache_dirty:
         _write_pubchem_cid_cache(cache_path, cid_cache)
 
-    cid_list = [cid_by_index.get(idx) for idx in result.index]
-
-    def _value_or_na(value: str | None) -> object:
-        return value if value not in (None, "") else pd.NA
-
-    lookup_cids: set[str] = set()
-    for idx, cid in zip(result.index, cid_list):
-        if not cid:
-            continue
-        if prefer_local and bool(complete_mask.loc[idx]):
-            continue
-        lookup_cids.add(cid)
-
-    properties: dict[str, pl.Properties] = {}
-    for cid in sorted(lookup_cids):
-        properties[cid] = pl.get_properties(cid, cfg)
-
     pubchem_rows: list[dict[str, object]] = []
-    for cid in cid_list:
+    for idx in result.index:
+        record = records_by_index.get(idx)
         row_data: dict[str, object] = {col: pd.NA for col in PUBCHEM_COLUMNS}
-        if cid:
-            row_data["pubchem_cid"] = cid
-            props = properties.get(cid)
-            if props:
-                row_data["pubchem_iupac_name"] = _value_or_na(props.IUPACName)
-                row_data["pubchem_molecular_formula"] = _value_or_na(
-                    props.MolecularFormula
-                )
-                row_data["pubchem_isomeric_smiles"] = _value_or_na(props.iSMILES)
-                row_data["pubchem_canonical_smiles"] = _value_or_na(props.cSMILES)
-                row_data["pubchem_inchi"] = _value_or_na(props.InChI)
-                row_data["pubchem_inchikey"] = _value_or_na(props.InChIKey)
+        if record and record.cid:
+            row_data["pubchem_cid"] = record.cid
+        props = record.properties if record else None
+        if props:
+            row_data["pubchem_iupac_name"] = _value_or_na(props.IUPACName)
+            row_data["pubchem_molecular_formula"] = _value_or_na(props.MolecularFormula)
+            row_data["pubchem_isomeric_smiles"] = _value_or_na(props.iSMILES)
+            row_data["pubchem_canonical_smiles"] = _value_or_na(props.cSMILES)
+            row_data["pubchem_inchi"] = _value_or_na(props.InChI)
+            row_data["pubchem_inchikey"] = _value_or_na(props.InChIKey)
+        if (not record or not record.cid) and literal:
+            for col in PUBCHEM_COLUMNS:
+                row_data[col] = literal
         pubchem_rows.append(row_data)
 
     pubchem_df = pd.DataFrame(pubchem_rows, index=result.index).convert_dtypes()
@@ -969,6 +878,60 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    parser.add_argument(
+        "--pubchem-enable",
+        dest="pubchem_enable",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable PubChem lookups (default taken from configuration)",
+    )
+    parser.add_argument(
+        "--pubchem-resolve-order",
+        dest="pubchem_resolve_order",
+        default=None,
+        help="Comma-separated PubChem resolution order",
+    )
+    parser.add_argument(
+        "--pubchem-timeout",
+        dest="pubchem_timeout_seconds",
+        type=float,
+        default=None,
+        help="Overall timeout in seconds for resolving a record",
+    )
+    parser.add_argument(
+        "--pubchem-backoff",
+        dest="pubchem_backoff_initial_seconds",
+        type=float,
+        default=None,
+        help="Initial delay for PubChem exponential backoff",
+    )
+    parser.add_argument(
+        "--pubchem-prefer-local-smiles",
+        dest="pubchem_prefer_local_smiles",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Prefer existing pubchem_* columns over remote lookups",
+    )
+    parser.add_argument(
+        "--pubchem-parent-for-salts",
+        dest="pubchem_use_parent_for_salts",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Reuse parent molecule CID for salt records when available",
+    )
+    parser.add_argument(
+        "--pubchem-allow-polymer",
+        dest="pubchem_allow_polymer",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Allow PubChem lookups for polymer records",
+    )
+    parser.add_argument(
+        "--pubchem-not-found",
+        dest="pubchem_write_not_found_literal",
+        default=None,
+        help="Literal written when PubChem data is unavailable",
+    )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -992,6 +955,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "column": "testitem.column",
                 "batch_size": "testitem.batch_size",
                 "limit": "testitem.limit",
+                "pubchem_enable": "pubchem.enable",
+                "pubchem_resolve_order": "pubchem.resolve_order",
+                "pubchem_timeout_seconds": "pubchem.timeout_seconds",
+                "pubchem_backoff_initial_seconds": "pubchem.backoff_initial_seconds",
+                "pubchem_prefer_local_smiles": "pubchem.prefer_local_smiles",
+                "pubchem_use_parent_for_salts": "pubchem.use_parent_for_salts",
+                "pubchem_allow_polymer": "pubchem.allow_polymer",
+                "pubchem_write_not_found_literal": "pubchem.write_not_found_literal",
             },
         )
         if args.print_config:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -21,7 +21,16 @@ def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> No
     df = pd.DataFrame({"canonical_smiles": ["C"]})
     cfg = pl.PubChemCfg(delay=0)
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+    empty_record = pl.PubChemRecord(
+        None,
+        pl.Properties(None, None, None, None, None, None),
+        None,
+    )
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *_, **__: empty_record,
+    )
 
     result = gtd.add_pubchem_data(df, cfg)
     pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
@@ -48,8 +57,7 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
         raise AssertionError("PubChem lookup should not be called")
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-    monkeypatch.setattr(pl, "get_properties", fail)
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fail)
 
     result = gtd.add_pubchem_data(df, cfg)
 
@@ -57,46 +65,6 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     for column in gtd.PUBCHEM_COLUMNS:
         expected[column] = expected[column].astype("string")
     pd.testing.assert_frame_equal(result, expected)
-
-
-def test_resolve_pubchem_cid_prefers_inchikey(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    row = pd.Series(
-        {
-            "molecule_chembl_id": "chembl1",
-            "standard_inchi_key": "abc-key",
-            "standard_inchi": "ignored",
-            "pref_name": "ignored",
-            "canonical_smiles": "C",
-        }
-    )
-    cfg = pl.PubChemCfg(delay=0)
-    cache: dict[str, str | None] = {}
-    calls: list[str] = []
-
-    def record_call(name: str) -> None:  # pragma: no cover - helper
-        calls.append(name)
-
-    monkeypatch.setattr(
-        pl,
-        "get_cid_from_inchikey",
-        lambda value, cfg: (record_call("inchikey"), "10|20")[1],
-    )
-
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("unexpected resolver invocation")
-
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-
-    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
-
-    assert cid == "10"
-    assert cache["CHEMBL1"] == "10"
-    assert calls == ["inchikey"]
 
 
 def test_add_pubchem_data_uses_disk_cache(
@@ -113,15 +81,6 @@ def test_add_pubchem_data_uses_disk_cache(
     )
 
     cfg = pl.PubChemCfg(delay=0, cid_cache_path=cache_path)
-
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("PubChem lookup should not be called")
-
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", fail)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
 
     props = pl.Properties("name", "formula", "i", "c", "inchi", "inchikey")
     monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: props)

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -218,3 +218,123 @@ def test_cache_entry_expires(monkeypatch: pytest.MonkeyPatch) -> None:
     time.sleep(1.1)
     pl.make_request(url, cfg)
     assert calls["n"] == 2  # cache expired
+
+
+@responses.activate
+def test_resolve_pubchem_record_fallback_order() -> None:
+    """Resolver should follow the configured order and update caches."""
+
+    cfg = pl.PubChemCfg(
+        base="https://example.org/api",
+        delay=0,
+        timeout_seconds=5.0,
+        backoff_initial_seconds=0.1,
+        resolve_order=("smiles", "pref_name"),
+    )
+    row = {
+        "molecule_chembl_id": "CHEMBL1",
+        "canonical_smiles": "C",
+        "pref_name": "methane",
+    }
+    smiles_url = "https://example.org/api/compound/smiles/C/cids/JSON"
+    name_url = "https://example.org/api/compound/name/methane/cids/JSON"
+    props_url = (
+        "https://example.org/api/compound/cid/10/property/"
+        "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+    responses.add(responses.GET, smiles_url, status=404)
+    responses.add(
+        responses.GET,
+        name_url,
+        json={"IdentifierList": {"CID": [10, 10]}},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        props_url,
+        json={
+            "PropertyTable": {
+                "Properties": [
+                    {
+                        "IUPACName": "Methane",
+                        "MolecularFormula": "CH4",
+                        "IsomericSMILES": "C",
+                        "CanonicalSMILES": "C",
+                        "InChI": "InChI=1S/CH4/h1H4",
+                        "InChIKey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+                    }
+                ]
+            }
+        },
+        status=200,
+    )
+
+    cid_cache: dict[str, str | None] = {}
+    resolution_cache: dict[str, pl.PubChemRecord] = {}
+
+    record = pl.resolve_pubchem_record(
+        row,
+        cfg,
+        cid_cache=cid_cache,
+        resolution_cache=resolution_cache,
+    )
+
+    assert record.cid == "10"
+    assert record.resolved_by == "pref_name"
+    assert cid_cache["CHEMBL1"] == "10"
+    assert responses.calls[0].request.url == smiles_url
+    assert responses.calls[1].request.url.startswith(name_url)
+    assert responses.calls[2].request.url == props_url
+
+
+@responses.activate
+def test_resolve_pubchem_record_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 429/5xx responses should trigger exponential backoff."""
+
+    delays: list[float] = []
+
+    def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(pl, "sleep", fake_sleep)
+    cfg = pl.PubChemCfg(
+        base="https://example.org/api",
+        delay=0,
+        timeout_seconds=10.0,
+        backoff_initial_seconds=0.5,
+        resolve_order=("smiles",),
+    )
+    row = {
+        "molecule_chembl_id": "CHEMBL2",
+        "canonical_smiles": "CC",
+    }
+    smiles_url = "https://example.org/api/compound/smiles/CC/cids/JSON"
+    props_url = (
+        "https://example.org/api/compound/cid/11/property/"
+        "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+    responses.add(responses.GET, smiles_url, status=429)
+    responses.add(responses.GET, smiles_url, status=500)
+    responses.add(
+        responses.GET,
+        smiles_url,
+        json={"IdentifierList": {"CID": [11]}},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        props_url,
+        json={"PropertyTable": {"Properties": [{"IUPACName": "ethane"}]}},
+        status=200,
+    )
+
+    cid_cache: dict[str, str | None] = {}
+    record = pl.resolve_pubchem_record(
+        row,
+        cfg,
+        cid_cache=cid_cache,
+        resolution_cache={},
+    )
+
+    assert record.cid == "11"
+    assert delays == [0.5, 1.0]


### PR DESCRIPTION
## Summary
- add additional PubChem configuration toggles and schema definitions, exposing them via YAML, env overrides, and CLI flags
- implement the new `resolve_pubchem_record` resolver with caching/backoff handling and integrate it into the test-item enrichment pipeline
- expand PubChem-related unit tests to cover fallback ordering, HTTP status handling, and the updated resolver plumbing

## Testing
- pytest tests/test_pubchem_library.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d68abe3eb883249fdd73e72a9b81ef