### PR TITLE
Improve parent catalog fallback batching

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -6,6 +6,7 @@ import csv
 import json
 import sqlite3
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from time import perf_counter
 from typing import Mapping
@@ -28,6 +29,9 @@ _PARENT_LOOKUP_SINGLE_LIMIT = _DEFAULT_CATALOG_CFG.fallback_single_limit
 _PARENT_LOOKUP_FALLBACK_THRESHOLD = 1
 _PARENT_LOOKUP_SINGLE_ATTEMPTS_MIN = 1
 _SQLITE_VARIABLE_LIMIT = 900
+_PARENT_LOOKUP_SINGLE_CONCURRENCY = 4
+
+_PARENT_CATALOG_LOADING = False
 
 __all__ = [
     "fetch_parent_catalog",
@@ -250,40 +254,92 @@ def _fetch_parent_catalog_via_helper(
         else:
             remaining = list(pending)
 
-        total_remaining = len(remaining)
-        for chembl_id in remaining:
-            if chembl_id in existing or chembl_id in result:
-                continue
-            if single_limit is not None and single_requests >= single_limit:
+        outstanding = [
+            chembl_id
+            for chembl_id in remaining
+            if chembl_id not in existing and chembl_id not in result
+        ]
+        if outstanding and not _PARENT_CATALOG_LOADING:
+            try:
+                load_parent_catalog(
+                    client=client,
+                    api_cfg=api_cfg,
+                    catalog_cfg=cfg,
+                    timeout=timeout,
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "parent_lookup_cache_refresh_failed",
+                    extra={"error": str(exc)},
+                )
+        if outstanding:
+            cache_hits = query_parent_catalog(outstanding, cfg)
+            if cache_hits:
+                result.update(cache_hits)
+                outstanding = [
+                    chembl_id for chembl_id in outstanding if chembl_id not in cache_hits
+                ]
+
+        if outstanding:
+            if single_limit is not None and len(outstanding) > single_limit:
                 logger.warning(
                     "parent_lookup_single_limit_reached",
                     extra={
                         "limit": single_limit,
-                        "remaining": max(total_remaining - single_requests, 0),
+                        "remaining": len(outstanding) - single_limit,
                     },
                 )
-                break
-            single_requests += 1
-            for attempt in range(1, attempts + 1):
-                try:
-                    pair = fetch_parent_for_id(
-                        chembl_id, client=client, api_cfg=api_cfg, timeout=timeout
-                    )
-                except Exception as exc:  # pragma: no cover - defensive logging
-                    if attempt >= attempts:
+                outstanding = outstanding[:single_limit]
+
+        if outstanding:
+            max_workers = max(1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY))
+            single_requests = len(outstanding)
+
+            def _fetch_with_retry(chembl_id: str) -> tuple[str, str] | None:
+                for attempt in range(1, attempts + 1):
+                    try:
+                        pair = fetch_parent_for_id(
+                            chembl_id,
+                            client=client,
+                            api_cfg=api_cfg,
+                            timeout=timeout,
+                        )
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        if attempt >= attempts:
+                            logger.warning(
+                                "parent_lookup_single_failed",
+                                extra={"chembl_id": chembl_id, "error": str(exc)},
+                            )
+                            return None
+                        if delay:
+                            sleep(delay * (2 ** (attempt - 1)))
+                        continue
+                    if pair is None:
+                        return None
+                    return pair
+                return None
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_map = {
+                    executor.submit(_fetch_with_retry, chembl_id): chembl_id
+                    for chembl_id in outstanding
+                }
+                for future in as_completed(future_map):
+                    try:
+                        pair = future.result()
+                    except Exception as exc:  # pragma: no cover - defensive logging
                         logger.warning(
                             "parent_lookup_single_failed",
-                            extra={"chembl_id": chembl_id, "error": str(exc)},
+                            extra={
+                                "chembl_id": future_map[future],
+                                "error": str(exc),
+                            },
                         )
-                        break
-                    if delay:
-                        sleep(delay * (2 ** (attempt - 1)))
-                    continue
-                if pair is None:
-                    break
-                child_id, parent_id = pair
-                result[child_id] = parent_id
-                break
+                        continue
+                    if not pair:
+                        continue
+                    child_id, parent_id = pair
+                    result[child_id] = parent_id
     finally:
         elapsed = perf_counter() - fallback_start
         logger.info(
@@ -673,8 +729,13 @@ def load_parent_catalog(
             _write_parent_catalog_sqlite(items, catalog_cfg, replace=True)
             return cached
 
-    result = fetch_parent_catalog(
-        client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
-    )
+    global _PARENT_CATALOG_LOADING
+    _PARENT_CATALOG_LOADING = True
+    try:
+        result = fetch_parent_catalog(
+            client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
+        )
+    finally:
+        _PARENT_CATALOG_LOADING = False
     write_parent_catalog_cache(result, catalog_cfg)
     return result

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from time import perf_counter, sleep
 from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
 from library import chembl_library as cl
+from library import molecule_catalog
 from library import pubchem_library as pl
+from library.config import ApiCfg, MoleculeCatalogCfg
 from scripts import get_testitem_data
 
 
@@ -61,6 +64,14 @@ def test_get_testitem_parent_catalog(
     def fail_load_parent_catalog(**_: object) -> dict[str, str]:  # pragma: no cover
         pytest.fail("load_parent_catalog should not be triggered for partial coverage")
 
+    original_apply = get_testitem_data.apply_config_overrides
+
+    def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
+        cfg = original_apply(*args, **kwargs)
+        cfg.pubchem.resolve_order = ("cache", "smiles")
+        return cfg
+
+    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
@@ -166,6 +177,14 @@ def test_get_testitem_skips_parent_lookup_when_present(
         fetch_called = True
         return {}
 
+    original_apply = get_testitem_data.apply_config_overrides
+
+    def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
+        cfg = original_apply(*args, **kwargs)
+        cfg.pubchem.resolve_order = ("cache", "smiles")
+        return cfg
+
+    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
@@ -197,3 +216,41 @@ def test_get_testitem_skips_parent_lookup_when_present(
     df = pd.read_csv(output_csv)
     assert list(df["parent_molecule_chembl_id"]) == ["CHEMBL9001", "CHEMBL9002"]
     assert fetch_called is False
+
+
+def test_parent_lookup_fallback_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure fallback requests are executed with bounded parallelism."""
+
+    ids = [f"CHEMBL{i}" for i in range(1, 9)]
+    mapping = {chembl_id: f"{chembl_id}_P" for chembl_id in ids}
+    api_cfg = ApiCfg()
+    catalog_cfg = MoleculeCatalogCfg()
+
+    monkeypatch.setattr(molecule_catalog, "_PARENT_LOOKUP_SINGLE_CONCURRENCY", 8)
+    monkeypatch.setattr(molecule_catalog, "query_parent_catalog", lambda children, catalog_cfg: {})
+    monkeypatch.setattr(molecule_catalog, "load_parent_catalog", lambda **_: {})
+
+    fetch_calls: list[str] = []
+
+    def fake_fetch_parent_for_id(chembl_id: str, **_: object) -> tuple[str, str]:
+        fetch_calls.append(chembl_id)
+        sleep(0.05)
+        return chembl_id, mapping[chembl_id]
+
+    monkeypatch.setattr(molecule_catalog, "fetch_parent_for_id", fake_fetch_parent_for_id)
+
+    start = perf_counter()
+    result = molecule_catalog._fetch_parent_catalog_via_helper(
+        ids,
+        client=SimpleNamespace(),
+        api_cfg=api_cfg,
+        timeout=None,
+        existing={},
+        catalog_cfg=catalog_cfg,
+        allow_rebatch=False,
+    )
+    elapsed = perf_counter() - start
+
+    assert result == mapping
+    assert set(fetch_calls) == set(ids)
+    assert elapsed < 0.3


### PR DESCRIPTION
## Summary
- refresh the parent catalog fallback to reuse the SQLite cache before firing single-ID lookups and fan out the remaining calls through a bounded thread pool
- guard full catalog loads with a re-entrancy flag so cache refreshes can be requested safely from the fallback helper
- extend the smoke tests to stabilise PubChem config overrides and assert that fallback lookups finish quickly even when many IDs need parents

## Testing
- pytest tests/smoke/test_get_testitem_parent.py

------
https://chatgpt.com/codex/tasks/task_e_68d6958cdd388324b8f146fe00d98e47