### PR TITLE
Optimize parent lookup filtering for cached parents

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -592,9 +592,23 @@ def attach_parent_molecule_ids(
             .astype("string")
             .copy()
         )
+        existing_parent = (
+            precomputed.existing_parent_ids.reindex(result.index)
+            .astype("string")
+            .copy()
+        )
+        lookup_mask = normalised_child.isin(precomputed.need_lookup)
     else:
         normalised_child = _normalise_chembl_ids(result[child_column])
-    unique_children = normalised_child[normalised_child != ""].unique()
+        if parent_column in result.columns:
+            existing_parent = result[parent_column].astype("string").copy()
+        else:
+            existing_parent = pd.Series(pd.NA, index=result.index, dtype="string")
+        lookup_mask = (normalised_child != "") & (
+            existing_parent.isna() | existing_parent.eq("")
+        )
+
+    unique_children = tuple(normalised_child[lookup_mask].unique().tolist())
     catalog_data: MutableMapping[str, str]
     used_partial_cache = False
     needs_full_sync = False
@@ -684,24 +698,13 @@ def attach_parent_molecule_ids(
 
     parent_series = normalised_child.map(parent_map).astype("string")
 
-    if precomputed is not None:
-        existing_parent = (
-            precomputed.existing_parent_ids.reindex(result.index)
-            .astype("string")
-            .copy()
-        )
-    elif parent_column in result.columns:
-        existing_parent = result[parent_column].astype("string")
-    else:
-        existing_parent = pd.Series(pd.NA, index=result.index, dtype="string")
-
     combined_parent = existing_parent.copy()
     update_mask = combined_parent.isna() | combined_parent.eq("")
     combined_parent.loc[update_mask] = parent_series.loc[update_mask]
     result[parent_column] = combined_parent.astype("string")
 
     missing = int(combined_parent.isna().sum())
-    attached = len(result) - missing
+    attached = int(combined_parent.notna().sum())
 
     final_source = source_resolved
     if full_sync_used:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1030,6 +1030,76 @@ def test_attach_parent_molecule_ids_fetches_missing(
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])
+def test_attach_parent_molecule_ids_skips_filled_children(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: Config,
+    use_precomputed: bool,
+) -> None:
+    child_field = cfg.sources.chembl.molecule_catalog.child_field
+    parent_field = cfg.sources.chembl.molecule_catalog.parent_field
+    df = pd.DataFrame(
+        {
+            child_field: ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+            parent_field: ["CHEMBL1_PARENT", pd.NA, "CHEMBL3_PARENT"],
+        }
+    )
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    query_calls: list[tuple[str, ...]] = []
+    fetch_calls: list[list[str]] = []
+
+    def fake_query(children: Iterable[str], catalog_cfg: object) -> dict[str, str]:
+        captured = tuple(str(child) for child in children)
+        query_calls.append(captured)
+        return {}
+
+    def fake_fetch(
+        ids: Iterable[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+    ) -> dict[str, str]:
+        ordered = [str(child) for child in ids]
+        fetch_calls.append(ordered)
+        return {value: f"{value}_PARENT" for value in ordered}
+
+    monkeypatch.setattr(gtd, "query_parent_catalog", fake_query)
+    monkeypatch.setattr(gtd.molecule_catalog, "fetch_parent_catalog_for", fake_fetch)
+    monkeypatch.setattr(gtd, "write_parent_catalog_cache", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "update_parent_catalog_cache", lambda *_, **__: None)
+
+    precomputed = (
+        prepare_parent_lookup_data(df, catalog_cfg) if use_precomputed else None
+    )
+    result, stats = gtd.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+        precomputed=precomputed,
+    )
+
+    expected_lookup = ("CHEMBL2",)
+    assert query_calls == [expected_lookup]
+    assert fetch_calls == [["CHEMBL2"]]
+    assert result[parent_field].tolist() == [
+        "CHEMBL1_PARENT",
+        "CHEMBL2_PARENT",
+        "CHEMBL3_PARENT",
+    ]
+    assert stats.unique == 1
+    assert stats.attached == 3
+    assert stats.missing == 0
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_PARTIAL
+
+
+@pytest.mark.parametrize("use_precomputed", [False, True])
 def test_attach_parent_molecule_ids_prefers_partial_fetch_when_complete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- ensure attach_parent_molecule_ids filters lookup IDs based on precomputed metadata or existing parent values before querying caches or the API
- keep parent lookup statistics aligned with the filtered set and reuse the prepared existing parent data
- add a regression test that verifies only missing parent identifiers trigger catalog lookups when some parents are already populated

## Testing
- pytest tests/test_get_testitem_data.py -k "attach_parent_molecule_ids" -q *(fails: SyntaxError in existing test definitions prevents collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d6956e8ebc8324b853abc611b62596