### PR TITLE
Enhance PubChem resolution workflow

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -971,6 +971,32 @@
           "title": "Base",
           "type": "string"
         },
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "resolve_order": {
+          "default": [
+            "cache",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name"
+          ],
+          "items": {
+            "enum": [
+              "cache",
+              "smiles",
+              "inchikey",
+              "inchi",
+              "pref_name"
+            ],
+            "type": "string"
+          },
+          "title": "Resolve Order",
+          "type": "array"
+        },
         "timeout_connect": {
           "default": 5,
           "minimum": 1,
@@ -982,6 +1008,13 @@
           "minimum": 1,
           "title": "Timeout Read",
           "type": "integer"
+        },
+        "timeout_seconds": {
+          "default": 30.0,
+          "description": "Overall timeout applied to resolve_pubchem_record requests",
+          "minimum": 0.0,
+          "title": "Timeout Seconds",
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1007,6 +1040,13 @@
           "title": "Delay",
           "type": "number"
         },
+        "backoff_initial_seconds": {
+          "default": 1.0,
+          "description": "Initial backoff delay for resolve_pubchem_record retries",
+          "minimum": 0.0,
+          "title": "Backoff Initial Seconds",
+          "type": "number"
+        },
         "cache_ttl": {
           "default": 3600,
           "description": "Time-to-live for PubChem request cache in seconds",
@@ -1024,6 +1064,18 @@
           "default": false,
           "description": "Resolve PubChem CIDs via parent structures when child lookups fail",
           "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
+        "allow_polymer": {
+          "default": false,
+          "description": "Resolve PubChem records for polymer molecule types",
+          "title": "Allow Polymer",
+          "type": "boolean"
+        },
+        "write_not_found_literal": {
+          "default": false,
+          "description": "Write 'Not Found' when PubChem returns HTTP 404",
+          "title": "Write Not Found Literal",
           "type": "boolean"
         },
         "cid_cache_path": {

--- a/config.yaml
+++ b/config.yaml
@@ -129,14 +129,25 @@ sources:
     burst: 5  # (env: CHEMBL_DA_IUPHAR_BURST)
   pubchem:
     base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"  # PubChem PUG REST API (env: CHEMBL_DA__SOURCES__PUBCHEM__BASE / CHEMBL_DA_PUBCHEM_BASE)
+    enable: true  # Toggle PubChem lookups entirely (env: CHEMBL_DA_PUBCHEM_ENABLE)
+    resolve_order:
+      - cache
+      - smiles
+      - inchikey
+      - inchi
+      - pref_name
     timeout_connect: 5  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT)
     timeout_read: 60  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_READ)
+    timeout_seconds: 30.0  # Overall timeout for resolve_pubchem_record (env: CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS)
     retries: 3
     rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
+    backoff_initial_seconds: 1.0  # Initial exponential backoff for resolve_pubchem_record (env: CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS)
     cache_ttl: 3600  # Request cache time-to-live in seconds
     use_parent_for_salts: false  # Attempt parent structures when salt lookups fail
+    allow_polymer: false  # Include polymer molecule types when resolving PubChem data
+    write_not_found_literal: false  # Emit "Not Found" for explicit 404 responses
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)

--- a/library/config.py
+++ b/library/config.py
@@ -249,12 +249,30 @@ class IupharCfg(_BaseModel):
 
 class PubChemCfg(_BaseModel):
     base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
+    enable: bool = True
+    resolve_order: tuple[str, ...] = (
+        "cache",
+        "smiles",
+        "inchikey",
+        "inchi",
+        "pref_name",
+    )
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(60, ge=1)
+    timeout_seconds: float = Field(
+        30.0,
+        ge=0,
+        description="Overall timeout applied to resolve_pubchem_record requests",
+    )
     retries: int = Field(3, ge=0)
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(3.0, ge=0)
+    backoff_initial_seconds: float = Field(
+        1.0,
+        ge=0,
+        description="Initial backoff delay for resolve_pubchem_record retries",
+    )
     cache_ttl: int = Field(
         3600,
         ge=0,
@@ -272,6 +290,14 @@ class PubChemCfg(_BaseModel):
         False,
         description="Resolve PubChem CIDs via parent structures when child lookups fail",
     )
+    allow_polymer: bool = Field(
+        False,
+        description="Resolve PubChem records for polymer molecule types",
+    )
+    write_not_found_literal: bool = Field(
+        False,
+        description="Write 'Not Found' when PubChem returns HTTP 404",
+    )
 
     @field_validator("base")
     @classmethod
@@ -279,6 +305,17 @@ class PubChemCfg(_BaseModel):
         if not _valid_url(v):
             raise ValueError("invalid URL")
         return v
+
+    @field_validator("resolve_order")
+    @classmethod
+    def _resolve_order(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        allowed = {"cache", "smiles", "inchikey", "inchi", "pref_name"}
+        invalid = [value for value in values if value not in allowed]
+        if invalid:
+            raise ValueError(
+                "pubchem.resolve_order may only contain: " + ", ".join(sorted(allowed))
+            )
+        return values
 
 
 class PubMedCfg(_BaseModel):
@@ -1255,6 +1292,20 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_UNIPROT_BASE": ["sources", "uniprot", "api", "base"],
     "CHEMBL_DA_IUPHAR_BASE": ["sources", "iuphar", "base"],
     "CHEMBL_DA_PUBCHEM_BASE": ["sources", "pubchem", "base"],
+    "CHEMBL_DA_PUBCHEM_ENABLE": ["sources", "pubchem", "enable"],
+    "CHEMBL_DA_PUBCHEM_RESOLVE_ORDER": ["sources", "pubchem", "resolve_order"],
+    "CHEMBL_DA_PUBCHEM_TIMEOUT_SECONDS": ["sources", "pubchem", "timeout_seconds"],
+    "CHEMBL_DA_PUBCHEM_BACKOFF_INITIAL_SECONDS": [
+        "sources",
+        "pubchem",
+        "backoff_initial_seconds",
+    ],
+    "CHEMBL_DA_PUBCHEM_ALLOW_POLYMER": ["sources", "pubchem", "allow_polymer"],
+    "CHEMBL_DA_PUBCHEM_WRITE_NOT_FOUND_LITERAL": [
+        "sources",
+        "pubchem",
+        "write_not_found_literal",
+    ],
     "CHEMBL_DA_LOG_LEVEL": ["system", "log", "level"],
     "CHEMBL_DA_LOG_FORMAT": ["system", "log", "format"],
     "CHEMBL_DA_LOG_DATEFMT": ["system", "log", "datefmt"],

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -7,7 +7,7 @@ The implementation is a Python translation of a PowerQuery script.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Mapping, cast, Literal
 from urllib.parse import quote
 
 import requests
@@ -27,6 +27,19 @@ _CACHE: TTLCache[str, dict[str, Any]] | None = None
 _session: Session = session_with_retry(
     ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
 )
+
+_RESOLVE_KEYS: frozenset[str] = frozenset({"cache", "smiles", "inchikey", "inchi", "pref_name"})
+
+
+@dataclass(frozen=True)
+class PubChemResolution:
+    """Result of :func:`resolve_pubchem_record`."""
+
+    cid: str | None
+    source: str | None
+    status: Literal["resolved", "not_found", "error", "skipped"]
+    status_code: int | None
+    attempts: tuple[str, ...]
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
@@ -64,6 +77,182 @@ def url_encode(text: str) -> str:
 def _cids_from_identifier_list(data: dict[str, Any]) -> list[str]:
     """Extract CIDs from a JSON ``IdentifierList`` structure."""
     return [str(cid) for cid in data.get("IdentifierList", {}).get("CID", [])]
+
+
+def _primary_cid(value: str | None) -> str | None:
+    """Return the first CID from a pipe-separated string."""
+
+    if not value:
+        return None
+    cids = [part.strip() for part in str(value).split("|") if part.strip()]
+    return cids[0] if cids else None
+
+
+def _request_json(url: str, cfg: PubChemCfg, session: Session) -> tuple[dict[str, Any] | None, int | None]:
+    """Perform a JSON request handling retryable PubChem status codes."""
+
+    attempts = max(1, cfg.retries)
+    backoff = cfg.backoff_initial_seconds
+    status_code: int | None = None
+    for attempt in range(1, attempts + 1):
+        get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
+        try:
+            response = session.get(url, timeout=cfg.timeout_seconds)
+        except requests.RequestException as exc:
+            logger.warning(
+                "pubchem_request_error",
+                url=url,
+                attempt=attempt,
+                error=str(exc),
+            )
+            status_code = None
+        else:
+            status_code = response.status_code
+            if status_code == 200:
+                try:
+                    return cast(dict[str, Any], response.json()), status_code
+                except ValueError:
+                    logger.warning(
+                        "pubchem_response_not_json",
+                        url=url,
+                        status=status_code,
+                    )
+                    return None, status_code
+            if status_code == 404:
+                logger.info("pubchem_not_found", url=url, status=status_code)
+                return None, status_code
+            if status_code == 429 or 500 <= status_code < 600:
+                logger.warning(
+                    "pubchem_retryable_status",
+                    url=url,
+                    status=status_code,
+                    attempt=attempt,
+                )
+            elif 400 <= status_code < 500:
+                logger.warning(
+                    "pubchem_client_error",
+                    url=url,
+                    status=status_code,
+                )
+                return None, status_code
+            else:
+                logger.warning(
+                    "pubchem_unexpected_status",
+                    url=url,
+                    status=status_code,
+                )
+                return None, status_code
+
+        if attempt >= attempts:
+            break
+        if status_code in (429,) or (status_code is not None and status_code >= 500) or status_code is None:
+            delay = backoff if backoff > 0 else cfg.delay
+            if delay > 0:
+                sleep(delay)
+            if backoff > 0:
+                backoff *= 2
+            continue
+        break
+    return None, status_code
+
+
+def _resolve_identifier(
+    kind: str,
+    value: str,
+    cfg: PubChemCfg,
+    session: Session,
+) -> tuple[list[str], int | None]:
+    """Resolve *value* of type *kind* into PubChem CIDs."""
+
+    base = cfg.base.rstrip("/")
+    if kind == "smiles":
+        url = f"{base}/compound/smiles/{url_encode(value)}/cids/JSON"
+    elif kind == "inchikey":
+        url = f"{base}/compound/inchikey/{url_encode(value)}/cids/JSON"
+    elif kind == "inchi":
+        url = f"{base}/compound/inchi/{url_encode(value)}/cids/JSON"
+    else:  # pragma: no cover - defensive programming
+        raise ValueError(f"Unsupported identifier kind: {kind}")
+    data, status = _request_json(url, cfg, session)
+    if not data:
+        return [], status
+    cids = sorted(set(_cids_from_identifier_list(data)))
+    return cids, status
+
+
+def _resolve_pref_name(
+    value: str,
+    cfg: PubChemCfg,
+    session: Session,
+) -> tuple[list[str], int | None]:
+    """Resolve preferred names using exact and partial synonym searches."""
+
+    rdf_base = cfg.base.rstrip("/").rsplit("/", 1)[0] + "/rdf"
+    encoded = url_encode(value)
+    urls = [
+        f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={encoded}",
+        f"{rdf_base}/query?graph=synonym&return=cid&format=json&name={encoded}&contain=true",
+    ]
+    last_status: int | None = None
+    for index, url in enumerate(urls):
+        data, status = _request_json(url, cfg, session)
+        last_status = status
+        if data:
+            bindings = data.get("results", {}).get("bindings", [])
+            cids = sorted(set(_extract_cids(bindings)))
+            if cids:
+                return cids, status
+        if status not in (404, 200):
+            return [], status
+        if index == 0 and status in (200, 404):
+            continue
+        break
+    return [], last_status
+
+
+def resolve_pubchem_record(
+    identifiers: Mapping[str, str | None],
+    cfg: PubChemCfg,
+    *,
+    session: Session | None = None,
+) -> PubChemResolution:
+    """Resolve a PubChem record using configured fallbacks."""
+
+    if not cfg.enable:
+        return PubChemResolution(None, None, "skipped", None, tuple())
+
+    molecule_type = (identifiers.get("molecule_type") or "").strip().lower()
+    if molecule_type == "polymer" and not cfg.allow_polymer:
+        return PubChemResolution(None, None, "skipped", None, tuple())
+
+    session = session or _session
+    attempts: list[str] = []
+    last_status: int | None = None
+    for source in cfg.resolve_order:
+        if source not in _RESOLVE_KEYS:
+            raise ValueError(f"Unsupported resolve step: {source}")
+        attempts.append(source)
+        if source == "cache":
+            cached = identifiers.get("cache")
+            cid = _primary_cid(cached) if cached is not None else None
+            if cid:
+                return PubChemResolution(cid, source, "resolved", None, tuple(attempts))
+            continue
+        value = identifiers.get(source)
+        if not value:
+            continue
+        if source == "pref_name":
+            cids, status = _resolve_pref_name(value, cfg, session)
+        else:
+            cids, status = _resolve_identifier(source, value, cfg, session)
+        last_status = status
+        if cids:
+            return PubChemResolution(cids[0], source, "resolved", status, tuple(attempts))
+        if status in (404, 200):
+            continue
+        return PubChemResolution(None, source, "error", status, tuple(attempts))
+
+    return PubChemResolution(None, None, "not_found", last_status, tuple(attempts))
 
 
 def get_cid_from_smiles(smiles: str, cfg: PubChemCfg) -> str | None:
@@ -482,5 +671,7 @@ __all__ = [
     "get_standard_name",
     "get_properties",
     "process_compound",
+    "resolve_pubchem_record",
+    "PubChemResolution",
     "Properties",
 ]

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -199,76 +199,80 @@ def _resolve_cid_from_row(
     cfg: PubChemCfg,
     *,
     chembl_id: str | None,
-) -> str | None:
-    """Return a CID for ``row`` using its structure fields."""
+    resolver: Callable[[Mapping[str, str | None], PubChemCfg], pl.PubChemResolution],
+    resolution_cache: MutableMapping[tuple[tuple[str, str | None], ...], pl.PubChemResolution],
+) -> pl.PubChemResolution:
+    """Return a resolution for ``row`` using configured identifiers."""
 
-
-    if chembl_id and chembl_id in cache and cache[chembl_id]:
-        return cache[chembl_id]
- 
-
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
- 
-
+    cache_value: str | None = None
     if chembl_id:
-        cached = cache.get(chembl_id, _CID_CACHE_MISSING)
-        if cached is not _CID_CACHE_MISSING:
-            cid = _select_primary_cid(
-                cached,
-                chembl_id=chembl_id,
-                identifier="cache",
-                value=cached,
-            )
-            if chembl_id not in cache or cid != cached:
-                cache[chembl_id] = cid
-            return cid
+        cached_entry = cache.get(chembl_id, _CID_CACHE_MISSING)
+        if cached_entry is not _CID_CACHE_MISSING:
+            cache_value = cached_entry if cached_entry is not None else None
+    if cache_value is None:
+        existing = _normalise_identifier(row.get("pubchem_cid"))
+        if existing:
+            cache_value = existing
 
-
-    def _store(value: str | None) -> str | None:
-        if chembl_id:
-            cache[chembl_id] = value
-        return value
-
-    def _attempt(
-        identifier: str,
-        value: str | None,
-        resolver: Callable[[str, PubChemCfg], str | None],
-    ) -> str | None:
-        if not value:
-            return None
-        resolved = resolver(value, cfg)
-        return _select_primary_cid(
-            resolved,
+    if cache_value:
+        primary = _select_primary_cid(
+            cache_value,
             chembl_id=chembl_id,
-            identifier=identifier,
-            value=value,
+            identifier="cache",
+            value=cache_value,
         )
+        if primary:
+            if chembl_id:
+                cache[chembl_id] = primary
+            return pl.PubChemResolution(
+                cid=primary,
+                source="cache",
+                status="resolved",
+                status_code=None,
+                attempts=("cache",),
+            )
 
     inchikey = _normalise_identifier(row.get("standard_inchi_key"), uppercase=True)
-    cid = _attempt("standard_inchi_key", inchikey, pl.get_cid_from_inchikey)
-    if cid:
-        return _store(cid)
-
     inchi = _normalise_identifier(row.get("standard_inchi"))
-    cid = _attempt("standard_inchi", inchi, pl.get_cid_from_inchi)
-    if cid:
-        return _store(cid)
-
     pref_name = _normalise_identifier(row.get("pref_name"))
-    cid = _attempt("pref_name", pref_name, pl.get_cid)
-    if cid:
-        return _store(cid)
-    cid = _attempt("pref_name_partial", pref_name, pl.get_all_cid)
-    if cid:
-        return _store(cid)
-
     smiles = _normalise_identifier(row.get("canonical_smiles"))
-    cid = _attempt("canonical_smiles", smiles, pl.get_cid_from_smiles)
-    if cid:
-        return _store(cid)
+    molecule_type_raw = row.get("molecule_type")
+    molecule_type = None if pd.isna(molecule_type_raw) else str(molecule_type_raw)
 
-    return None
+    identifiers: dict[str, str | None] = {
+        "cache": cache_value,
+        "smiles": smiles,
+        "inchikey": inchikey,
+        "inchi": inchi,
+        "pref_name": pref_name,
+        "molecule_type": molecule_type,
+    }
+
+    key_parts: list[tuple[str, str | None]] = [
+        (token, identifiers.get(token))
+        for token in cfg.resolve_order
+        if token != "cache"
+    ]
+    key_parts.append(("molecule_type", molecule_type))
+    cache_key = tuple(key_parts)
+
+    if cache_key and cache_key in resolution_cache:
+        resolution = resolution_cache[cache_key]
+    else:
+        resolution = resolver(identifiers, cfg)
+        if cache_key:
+            resolution_cache[cache_key] = resolution
+
+    if resolution.cid and chembl_id:
+        cache[chembl_id] = resolution.cid
+    elif (
+        resolution.status == "not_found"
+        and chembl_id
+        and chembl_id not in cache
+    ):
+        cache[chembl_id] = None
+
+    return resolution
 
 
 def resolve_pubchem_cid(
@@ -277,31 +281,41 @@ def resolve_pubchem_cid(
     cfg: PubChemCfg,
     *,
     parent_loader: Callable[[str], pd.Series | None] | None = None,
-) -> str | None:
+    resolution_cache: MutableMapping[
+        tuple[tuple[str, str | None], ...], pl.PubChemResolution
+    ] | None = None,
+    resolver: Callable[[Mapping[str, str | None], PubChemCfg], pl.PubChemResolution]
+    | None = None,
+) -> pl.PubChemResolution:
     """Resolve PubChem CID for a ChEMBL record."""
 
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
-    if cid is not None:
-        return cid
+    if resolution_cache is None:
+        resolution_cache = {}
+    resolver = resolver or pl.resolve_pubchem_record
 
-    if not cfg.use_parent_for_salts:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
+    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
+    resolution = _resolve_cid_from_row(
+        row,
+        cache,
+        cfg,
+        chembl_id=chembl_id,
+        resolver=resolver,
+        resolution_cache=resolution_cache,
+    )
+    if resolution.cid is not None or not cfg.use_parent_for_salts:
+        return resolution
 
     parent_id = _normalise_identifier(
         row.get("parent_molecule_chembl_id"), uppercase=True
     )
-    if not parent_id:
-        if chembl_id and chembl_id not in cache:
+    if not parent_id or parent_loader is None:
+        if (
+            resolution.status == "not_found"
+            and chembl_id
+            and chembl_id not in cache
+        ):
             cache[chembl_id] = None
-        return None
-
-    if parent_loader is None:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
+        return resolution
 
     parent_row = parent_loader(parent_id)
     if parent_row is None:
@@ -311,71 +325,27 @@ def resolve_pubchem_cid(
             parent=parent_id,
             reason="parent_unavailable",
         )
-        if chembl_id and chembl_id not in cache:
+        if (
+            resolution.status == "not_found"
+            and chembl_id
+            and chembl_id not in cache
+        ):
             cache[chembl_id] = None
-        return None
+        return resolution
 
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
-    if parent_cid:
-        cache[parent_id] = parent_cid
-        if chembl_id:
-            cache[chembl_id] = parent_cid
-        return parent_cid
-
-
-    return None
-
-
-def resolve_pubchem_cid(
-    row: pd.Series,
-    cache: MutableMapping[str, str | None],
-    cfg: PubChemCfg,
-    *,
-    parent_loader: Callable[[str], pd.Series | None] | None = None,
-) -> str | None:
-    """Resolve PubChem CID for a ChEMBL record."""
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
-    if cid is not None:
-        return cid
-
-    if not cfg.use_parent_for_salts:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_id = _normalise_identifier(
-        row.get("parent_molecule_chembl_id"), uppercase=True
+    parent_resolution = _resolve_cid_from_row(
+        parent_row,
+        cache,
+        cfg,
+        chembl_id=parent_id,
+        resolver=resolver,
+        resolution_cache=resolution_cache,
     )
-    if not parent_id:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    if parent_loader is None:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_row = parent_loader(parent_id)
-    if parent_row is None:
-        logger.info(
-            "pubchem_parent_structure_missing",
-            child=chembl_id,
-            parent=parent_id,
-            reason="parent_unavailable",
-        )
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
-    if parent_cid:
-        cache[parent_id] = parent_cid
+    if parent_resolution.cid:
+        cache[parent_id] = parent_resolution.cid
         if chembl_id:
-            cache[chembl_id] = parent_cid
-        return parent_cid
+            cache[chembl_id] = parent_resolution.cid
+        return parent_resolution
 
     logger.info(
         "pubchem_parent_structure_missing",
@@ -383,11 +353,19 @@ def resolve_pubchem_cid(
         parent=parent_id,
         reason="structure_unresolved",
     )
-    if parent_id and parent_id not in cache:
+    if (
+        parent_resolution.status == "not_found"
+        and parent_id
+        and parent_id not in cache
+    ):
         cache[parent_id] = None
-    if chembl_id and chembl_id not in cache:
+    if (
+        parent_resolution.status == "not_found"
+        and chembl_id
+        and chembl_id not in cache
+    ):
         cache[chembl_id] = None
-    return None
+    return parent_resolution
 
 
 @dataclass(frozen=True)
@@ -627,6 +605,8 @@ def add_pubchem_data(
     client: ChemblClient | None = None,
     api_cfg: ApiCfg | None = None,
     timeout: float | None = None,
+    resolver: Callable[[Mapping[str, str | None], PubChemCfg], pl.PubChemResolution]
+    | None = None,
 ) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
@@ -647,6 +627,9 @@ def add_pubchem_data(
         Optional API configuration required when ``client`` is supplied.
     timeout:
         Optional timeout for parent lookups via :func:`cl.get_testitem`.
+    resolver:
+        Callable used to resolve PubChem records. Defaults to
+        :func:`library.pubchem_library.resolve_pubchem_record`.
 
     Returns
     -------
@@ -657,7 +640,18 @@ def add_pubchem_data(
     if df.empty:
         return df
 
+    resolver = resolver or pl.resolve_pubchem_record
+
     result = df.reset_index(drop=True).copy()
+
+    if not cfg.enable:
+        logger.info("pubchem_disabled")
+        for column in PUBCHEM_COLUMNS:
+            if column not in result.columns:
+                result[column] = pd.Series(pd.NA, index=result.index, dtype="string")
+            else:
+                result[column] = result[column].astype("string")
+        return result
     prefer_local = getattr(cfg, "prefer_local_smiles", False)
     existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
     if prefer_local and existing_cols:
@@ -671,6 +665,9 @@ def add_pubchem_data(
     cache_path = getattr(cfg, "cid_cache_path", None)
     cid_cache = _load_pubchem_cid_cache(cache_path)
     cache_dirty = False
+    resolution_cache: dict[
+        tuple[tuple[str, str | None], ...], pl.PubChemResolution
+    ] = {}
 
     local_records: dict[str, pd.Series] = {}
     if "molecule_chembl_id" in result.columns:
@@ -747,10 +744,19 @@ def add_pubchem_data(
         logger.info("pubchem_no_smiles")
 
     cid_by_index: dict[int, str | None] = {}
+    resolution_by_index: dict[int, pl.PubChemResolution] = {}
     progress = 0
     for idx, row in result.iterrows():
         if prefer_local and bool(complete_mask.loc[idx]):
-            cid_by_index[idx] = _normalise_identifier(row.get("pubchem_cid"))
+            cid_value = _normalise_identifier(row.get("pubchem_cid"))
+            cid_by_index[idx] = cid_value
+            resolution_by_index[idx] = pl.PubChemResolution(
+                cid=cid_value,
+                source="local",
+                status="resolved" if cid_value else "skipped",
+                status_code=None,
+                attempts=("cache",),
+            )
             continue
 
         chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
@@ -762,13 +768,16 @@ def add_pubchem_data(
         if lookup_required and total:
             progress += 1
             logger.info("pubchem_progress", current=progress, total=total)
-        cid = resolve_pubchem_cid(
+        resolution = resolve_pubchem_cid(
             row,
             cid_cache,
             cfg,
             parent_loader=load_parent_record,
+            resolution_cache=resolution_cache,
+            resolver=resolver,
         )
-        cid_by_index[idx] = cid
+        cid_by_index[idx] = resolution.cid
+        resolution_by_index[idx] = resolution
         if chembl_id:
             after_present = chembl_id in cid_cache
             after_value = cid_cache[chembl_id] if after_present else _CID_CACHE_MISSING
@@ -796,9 +805,17 @@ def add_pubchem_data(
         properties[cid] = pl.get_properties(cid, cfg)
 
     pubchem_rows: list[dict[str, object]] = []
-    for cid in cid_list:
+    for idx, cid in zip(result.index, cid_list):
+        resolution = resolution_by_index.get(idx)
         row_data: dict[str, object] = {col: pd.NA for col in PUBCHEM_COLUMNS}
-        if cid:
+        if (
+            resolution
+            and resolution.status == "not_found"
+            and cfg.write_not_found_literal
+        ):
+            for column in PUBCHEM_COLUMNS:
+                row_data[column] = "Not Found"
+        elif cid:
             row_data["pubchem_cid"] = cid
             props = properties.get(cid)
             if props:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -17,13 +17,22 @@ from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
 
 
-def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_add_pubchem_data_missing_uses_na() -> None:
     df = pd.DataFrame({"canonical_smiles": ["C"]})
     cfg = pl.PubChemCfg(delay=0)
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], cfg: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        return pl.PubChemResolution(
+            cid=None,
+            source="smiles",
+            status="not_found",
+            status_code=404,
+            attempts=("smiles",),
+        )
 
-    result = gtd.add_pubchem_data(df, cfg)
+    result = gtd.add_pubchem_data(df, cfg, resolver=resolver_stub)
     pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
     assert pubchem_cols
     assert result[pubchem_cols].isna().all().all()
@@ -45,13 +54,12 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     )
     cfg = pl.PubChemCfg(delay=0, prefer_local_smiles=True)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+    def fail_resolver(*_: object, **__: object) -> pl.PubChemResolution:  # pragma: no cover
         raise AssertionError("PubChem lookup should not be called")
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-    monkeypatch.setattr(pl, "get_properties", fail)
+    monkeypatch.setattr(pl, "get_properties", lambda *_: None)
 
-    result = gtd.add_pubchem_data(df, cfg)
+    result = gtd.add_pubchem_data(df, cfg, resolver=fail_resolver)
 
     expected = df.copy()
     for column in gtd.PUBCHEM_COLUMNS:
@@ -59,9 +67,55 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_resolve_pubchem_cid_prefers_inchikey(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_add_pubchem_data_writes_not_found_literal() -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    cfg = pl.PubChemCfg(delay=0, write_not_found_literal=True)
+
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], cfg: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        return pl.PubChemResolution(
+            cid=None,
+            source="smiles",
+            status="not_found",
+            status_code=404,
+            attempts=("smiles",),
+        )
+
+    result = gtd.add_pubchem_data(df, cfg, resolver=resolver_stub)
+
+    for column in gtd.PUBCHEM_COLUMNS:
+        assert (result[column] == "Not Found").all()
+
+
+def test_add_pubchem_data_reuses_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C", "C"]})
+    cfg = pl.PubChemCfg(delay=0)
+
+    calls = {"count": 0}
+
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], cfg: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        calls["count"] += 1
+        return pl.PubChemResolution(
+            cid="10",
+            source="smiles",
+            status="resolved",
+            status_code=200,
+            attempts=("smiles",),
+        )
+
+    props = pl.Properties("name", "formula", "i", "c", "inchi", "inchikey")
+    monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: props)
+
+    result = gtd.add_pubchem_data(df, cfg, resolver=resolver_stub)
+
+    assert calls["count"] == 1
+    assert (result["pubchem_cid"] == "10").all()
+
+
+def test_resolve_pubchem_cid_prefers_inchikey() -> None:
     row = pd.Series(
         {
             "molecule_chembl_id": "chembl1",
@@ -73,35 +127,30 @@ def test_resolve_pubchem_cid_prefers_inchikey(
     )
     cfg = pl.PubChemCfg(delay=0)
     cache: dict[str, str | None] = {}
-    calls: list[str] = []
+    calls: list[Mapping[str, str | None]] = []
 
-    def record_call(name: str) -> None:  # pragma: no cover - helper
-        calls.append(name)
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], _: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        calls.append(identifiers)
+        assert identifiers["inchikey"] == "ABC-KEY"
+        return pl.PubChemResolution(
+            cid="10",
+            source="inchikey",
+            status="resolved",
+            status_code=200,
+            attempts=("inchikey",),
+        )
 
-    monkeypatch.setattr(
-        pl,
-        "get_cid_from_inchikey",
-        lambda value, cfg: (record_call("inchikey"), "10|20")[1],
-    )
+    resolution = gtd.resolve_pubchem_cid(row, cache, cfg, resolver=resolver_stub)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("unexpected resolver invocation")
-
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-
-    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
-
-    assert cid == "10"
+    assert resolution.cid == "10"
+    assert resolution.source == "inchikey"
     assert cache["CHEMBL1"] == "10"
-    assert calls == ["inchikey"]
+    assert len(calls) == 1
 
 
-def test_resolve_pubchem_cid_uses_parent_when_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_resolve_pubchem_cid_uses_parent_when_enabled() -> None:
     child_row = pd.Series(
         {
             "molecule_chembl_id": "CHEMBL2",
@@ -121,29 +170,41 @@ def test_resolve_pubchem_cid_uses_parent_when_enabled(
     cache: dict[str, str | None] = {}
     cfg = pl.PubChemCfg(delay=0, use_parent_for_salts=True)
 
-    calls: list[str] = []
+    calls: list[Mapping[str, str | None]] = []
 
-    def record_inchikey(value: str, _: pl.PubChemCfg) -> str:
-        calls.append(value)
-        return "42"
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], _: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        calls.append(identifiers)
+        if identifiers.get("inchikey") == "PARENT-KEY":
+            return pl.PubChemResolution(
+                cid="42",
+                source="inchikey",
+                status="resolved",
+                status_code=200,
+                attempts=("inchikey",),
+            )
+        return pl.PubChemResolution(
+            cid=None,
+            source="inchikey",
+            status="not_found",
+            status_code=404,
+            attempts=("inchikey",),
+        )
 
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", record_inchikey)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", lambda *_: None)
-    monkeypatch.setattr(pl, "get_cid", lambda *_: None)
-    monkeypatch.setattr(pl, "get_all_cid", lambda *_: None)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
-
-    cid = gtd.resolve_pubchem_cid(
+    resolution = gtd.resolve_pubchem_cid(
         child_row,
         cache,
         cfg,
         parent_loader=lambda _: parent_row,
+        resolver=resolver_stub,
     )
 
-    assert cid == "42"
+    assert resolution.cid == "42"
+    assert resolution.source == "inchikey"
     assert cache["CHEMBL1"] == "42"
     assert cache["CHEMBL2"] == "42"
-    assert calls == ["PARENT-KEY"]
+    assert any(call.get("inchikey") == "PARENT-KEY" for call in calls)
 
 
 def test_resolve_pubchem_cid_logs_when_parent_missing(
@@ -165,14 +226,26 @@ def test_resolve_pubchem_cid_logs_when_parent_missing(
 
     monkeypatch.setattr(gtd.logger, "info", capture)
 
-    cid = gtd.resolve_pubchem_cid(
+    def resolver_stub(
+        identifiers: Mapping[str, str | None], _: pl.PubChemCfg
+    ) -> pl.PubChemResolution:
+        return pl.PubChemResolution(
+            cid=None,
+            source="smiles",
+            status="not_found",
+            status_code=404,
+            attempts=("smiles",),
+        )
+
+    resolution = gtd.resolve_pubchem_cid(
         row,
         cache,
         cfg,
         parent_loader=lambda _: None,
+        resolver=resolver_stub,
     )
 
-    assert cid is None
+    assert resolution.cid is None
     assert cache["CHEMBL2"] is None
     assert any(event == "pubchem_parent_structure_missing" for event, _ in events)
 
@@ -192,19 +265,13 @@ def test_add_pubchem_data_uses_disk_cache(
 
     cfg = pl.PubChemCfg(delay=0, cid_cache_path=cache_path)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+    def fail_resolver(*_: object, **__: object) -> pl.PubChemResolution:  # pragma: no cover
         raise AssertionError("PubChem lookup should not be called")
-
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", fail)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
 
     props = pl.Properties("name", "formula", "i", "c", "inchi", "inchikey")
     monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: props)
 
-    result = gtd.add_pubchem_data(df, cfg)
+    result = gtd.add_pubchem_data(df, cfg, resolver=fail_resolver)
 
     assert result.loc[0, "pubchem_cid"] == "321"
     assert result.loc[0, "pubchem_iupac_name"] == "name"

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -161,6 +161,97 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
 
 
 @responses.activate
+def test_resolve_pubchem_record_respects_order() -> None:
+    """Resolution follows configured identifier order."""
+
+    cfg = pl.PubChemCfg(delay=0, backoff_initial_seconds=0, timeout_seconds=1.0)
+    identifiers = {
+        "cache": None,
+        "smiles": "C",
+        "inchikey": "VNWKTOKETHGBQD-UHFFFAOYSA-N",
+        "inchi": None,
+        "pref_name": "methane",
+    }
+
+    smiles_url = f"{cfg.base.rstrip('/')}/compound/smiles/C/cids/JSON"
+    inchikey_url = (
+        f"{cfg.base.rstrip('/')}/compound/inchikey/"
+        "VNWKTOKETHGBQD-UHFFFAOYSA-N/cids/JSON"
+    )
+    responses.add(responses.GET, smiles_url, status=404)
+    responses.add(
+        responses.GET,
+        inchikey_url,
+        json={"IdentifierList": {"CID": [123]}},
+        status=200,
+    )
+
+    resolution = pl.resolve_pubchem_record(identifiers, cfg)
+
+    assert resolution.cid == "123"
+    assert resolution.source == "inchikey"
+    assert resolution.status == "resolved"
+    assert [call.request.url for call in responses.calls] == [smiles_url, inchikey_url]
+
+
+@responses.activate
+def test_resolve_pubchem_record_applies_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 429/5xx statuses trigger exponential backoff."""
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(pl, "sleep", lambda delay: sleeps.append(delay))
+
+    cfg = pl.PubChemCfg(
+        delay=0,
+        backoff_initial_seconds=0.5,
+        timeout_seconds=1.0,
+        retries=3,
+        resolve_order=("smiles",),
+    )
+    url = f"{cfg.base.rstrip('/')}/compound/smiles/C/cids/JSON"
+    responses.add(responses.GET, url, status=429)
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, json={"IdentifierList": {"CID": [77]}}, status=200)
+
+    identifiers = {
+        "cache": None,
+        "smiles": "C",
+        "inchikey": None,
+        "inchi": None,
+        "pref_name": None,
+    }
+
+    resolution = pl.resolve_pubchem_record(identifiers, cfg)
+
+    assert resolution.cid == "77"
+    assert resolution.status == "resolved"
+    assert sleeps == [0.5, 1.0]
+
+
+@responses.activate
+def test_resolve_pubchem_record_reports_not_found() -> None:
+    """404 responses should surface as ``not_found`` status."""
+
+    cfg = pl.PubChemCfg(delay=0, backoff_initial_seconds=0, timeout_seconds=1.0)
+    url = f"{cfg.base.rstrip('/')}/compound/smiles/C/cids/JSON"
+    responses.add(responses.GET, url, status=404)
+
+    identifiers = {
+        "cache": None,
+        "smiles": "C",
+        "inchikey": None,
+        "inchi": None,
+        "pref_name": None,
+    }
+
+    resolution = pl.resolve_pubchem_record(identifiers, cfg)
+
+    assert resolution.cid is None
+    assert resolution.status == "not_found"
+    assert resolution.status_code == 404
+
+
+@responses.activate
 def test_get_properties_returns_none_for_missing() -> None:
     """Missing PubChem fields should be returned as ``None``."""
 


### PR DESCRIPTION
## Summary
- extend the PubChem configuration with enable toggles, backoff controls, and schema/YAML updates
- add a dedicated `resolve_pubchem_record` implementation with retry handling and integrate it into the test-item pipeline
- expand the PubChem tests to cover resolution order, HTTP status handling, and caching/not-found scenarios

## Testing
- pytest tests/test_get_testitem_data.py::test_add_pubchem_data_missing_uses_na -vv

------
https://chatgpt.com/codex/tasks/task_e_68d69047329083249d289b4bc1408c13