### PR TITLE
Update CLI usage examples to reference scripts module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ pre-commit run --all-files
    and ``--encoding`` for file encoding. For end-to-end exports that create
    files, run one of the data pipelines, for example:
 
-   ```bash
-   python mapper_main.py --input tests/data/assays.csv \
-       --output out/mapped.csv --log-level DEBUG
-   python table_quality_main.py --input tests/data/assays.csv \
-       --output out/report.csv --log-level INFO
-   ```
+  ```bash
+  python scripts/mapper_main.py --input tests/data/assays.csv \
+      --output out/mapped.csv --log-level DEBUG
+  python scripts/table_quality_main.py --input tests/data/assays.csv \
+      --output out/report.csv --log-level INFO
+  ```
 
 4. **Run the tests** – see [Тесты](#тесты).
 
@@ -491,7 +491,7 @@ An overview of the output directory layout and metadata sidecars is available in
 
 ### Table quality analysis
 
-``table_quality_main.py`` profiles arbitrary CSV files and reports column
+``scripts/table_quality_main.py`` profiles arbitrary CSV files and reports column
 statistics along with correlations between numeric fields. Example usage:
 
 ```python
@@ -505,7 +505,7 @@ quality, corr = analyze_table_quality(df, table_name="data")
 Running the CLI saves ``data_quality_report_table.csv`` and
 ``data_data_correlation_report_table.csv`` in the current working directory::
 
-    python table_quality_main.py --input data.csv --table-name data
+    python scripts/table_quality_main.py --input data.csv --table-name data
 
 All scripts share a common set of flags:
 
@@ -593,9 +593,9 @@ workbook paths are exposed as :class:`pathlib.Path` objects. String values in
 ``config.yaml`` or overrides from the environment and command line are
 automatically converted.
  
-
+```bash
 # профилирование качества таблицы
-python table_quality_main.py \
+python scripts/table_quality_main.py \
     --input tests/data/activity.csv \
     --table-name activity
 ```

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -190,10 +190,10 @@ python scripts/get_input_initialisation.py \
 * Produces entity-specific slices (`activity_*`, `assay_*`, `document_*`, `target_*`, `testitem_*`, `system_*`).
 * Creates a `data_validity_report/` folder with quality reports for each exported table.
 
-## Table quality profiler (`table_quality_main.py`)
+## Table quality profiler (`scripts/table_quality_main.py`)
 
 ```bash
-python table_quality_main.py \
+python scripts/table_quality_main.py \
   --input data/input-smoke/activity.csv \
   --table-name activity
 ```

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -191,10 +191,10 @@ python scripts/get_input_initialisation.py \
 * Создаёт срезы по сущностям (`activity_*`, `assay_*`, `document_*`, `target_*`, `testitem_*`, `system_*`).
 * Добавляет папку `data_validity_report/` с отчётами качества для каждого файла.
 
-## Профайлер качества таблиц (`table_quality_main.py`)
+## Профайлер качества таблиц (`scripts/table_quality_main.py`)
 
 ```bash
-python table_quality_main.py \
+python scripts/table_quality_main.py \
   --input data/input-smoke/activity.csv \
   --table-name activity
 ```


### PR DESCRIPTION
## Summary
- update README usage examples to call mapper and table quality scripts via the scripts package
- refresh English and Russian usage guides to reference scripts/table_quality_main.py
- run codespell to ensure the updated sections remain typo-free

## Testing
- codespell README.md docs/USAGE_EN.md docs/USAGE_RU.md

------
https://chatgpt.com/codex/tasks/task_e_68d6a01a44608324a9099cb4e2dd0974