### PR TITLE
Clarify molecule catalog cache configuration guidance

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -144,11 +144,8 @@ Test item exports must be reconciled with the ChEMBL parent catalogue to expose 
 used by downstream aggregations. The cache path is configured via
 `sources.chembl.molecule_catalog.cache_path`; keep the JSON file accessible to the runner or adjust the
 location by setting `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for
-`CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) or editing `config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
- 
-[`sources.chembl.molecule_catalog`](./CONFIG_EN.md#sources-chembl-molecule-catalog) (`cache_path`); keep the JSON file accessible to the runner or override the
-location through CLI/environment aliases such as `--sources.chembl.molecule_catalog.cache-path` or
-`CHEMBL_DA_MOLECULE_CATALOG_CACHE`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
+`CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) or editing `config.yaml`. Refer to
+[`sources.chembl.molecule_catalog`](./CONFIG_EN.md#sources-chembl-molecule-catalog) for the full option list.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
  
 
 Use `library.molecule_catalog.load_parent_catalog` in a short Python snippet to initialise or refresh the

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -146,12 +146,8 @@ PubChem-дополнение добавляет детерминированны
 родителей ChEMBL. Путь к локальному JSON задаётся через `sources.chembl.molecule_catalog.cache_path`; убедитесь,
 что файл доступен исполнителю, либо задайте новое расположение переменной окружения
 `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (алиас для `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) или правкой
-`config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
-
-родителей ChEMBL. Путь к локальному JSON задаётся через
-[`sources.chembl.molecule_catalog`](./CONFIG_RU.md#sources-chembl-molecule-catalog) (`cache_path`); убедитесь,
-что файл доступен исполнителю, либо переопределите расположение параметрами CLI (`--sources.chembl.molecule_catalog.cache-path`)
-или переменными окружения (`CHEMBL_DA_MOLECULE_CATALOG_CACHE`).【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
+`config.yaml`. Справочный список параметров см. в разделе
+[`sources.chembl.molecule_catalog`](./CONFIG_RU.md#sources-chembl-molecule-catalog).【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
 
 Для первичного создания либо обновления файла выполните небольшой Python-скрипт с вызовом
 `library.molecule_catalog.load_parent_catalog` — функция считывает готовый кэш и, при его отсутствии,


### PR DESCRIPTION
## Summary
- remove the outdated reference to the `--sources.chembl.molecule_catalog.cache-path` CLI flag in both usage guides
- emphasize the supported overrides via the `CHEMBL_DA_MOLECULE_CATALOG_CACHE` environment variable or editing `config.yaml`
- deduplicate the parent catalogue paragraphs and link back to the configuration reference sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a01bb1148324b0ac4561b92f29f0