### PR TITLE
Align documentation with dictionary subfolder updates

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -126,8 +126,8 @@ The CLI only exposes high-level switches such as `--batch-size` or `--dry-run`; 
 | Key | Default | Description |
 | --- | --- | --- |
 | `enable` | `true` | Master switch for the enrichment stage that derives salt identifiers and catalogue flags. |
-| `sources.molecule_catalog_path` | `dictionary/molecule_catalog.csv` | CSV with `molecule_chembl_id` and the `natural_product`/`prodrug`/`polymer_flag` columns. |
-| `sources.molecule_hierarchy_path` | `dictionary/molecule_hierarchy.csv` | CSV that maps derivatives to their parent molecule (`molecule_chembl_id`, `parent_molecule_chembl_id`). |
+| `sources.molecule_catalog_path` | `dictionary/_testitem/molecule_catalog.csv` | CSV with `molecule_chembl_id` and the `natural_product`/`prodrug`/`polymer_flag` columns. |
+| `sources.molecule_hierarchy_path` | `dictionary/_testitem/molecule_hierarchy.csv` | CSV that maps derivatives to their parent molecule (`molecule_chembl_id`, `parent_molecule_chembl_id`). |
 | `output.salt_as_null_when_absent` | `true` | Emit `null` (or `-` when set to `false`) when the compound is not a salt. |
 | `flags.coerce_to_bool` | `true` | Normalise catalogue values such as `Y/N`, `1/0`, `yes/no` to pandas nullable booleans. |
 | `flags.parent_fallback` | `true` | Reuse parent flag values when the child entry is missing. |
@@ -160,21 +160,21 @@ The CLI only exposes high-level switches such as `--batch-size` or `--dry-run`; 
 | Sub-section | Key | Default | Description |
 | --- | --- | --- | --- |
 | `uniprot` | `column` | `uniprot_id` | Column with UniProt identifiers. |
-|  | `data_dir` | `dictionary/uniprot` | Directory holding cached UniProt JSON files. |
+|  | `data_dir` | `dictionary/_target/_uniprot` | Directory holding cached UniProt JSON files. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
 | `chembl` | `column` | `target_chembl_id` | Column with ChEMBL target identifiers. |
 |  | `chunk_size` | `5` | Batch size for API requests. |
 |  | `timeout` | `30.0` | Request timeout in seconds. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
-| `iuphar` | `target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | Lookup table with IUPHAR target metadata. |
-|  | `family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | Lookup table with IUPHAR family metadata. |
+| `iuphar` | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Lookup table with IUPHAR target metadata. |
+|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Lookup table with IUPHAR family metadata. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
-| `all` | `data_dir` | `dictionary/uniprot` | Directory containing cached UniProt data. |
-|  | `target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target reference data. |
-|  | `family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family reference data. |
+| `all` | `data_dir` | `dictionary/_target/_uniprot` | Directory containing cached UniProt data. |
+|  | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target reference data. |
+|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family reference data. |
 |  | `chunk_size` | `5` | Batch size when combining all sources. |
 |  | `timeout` | `30.0` | Request timeout in seconds. |
-|  | `organism_csv` | `dictionary/_Target/targets_type.csv` | Taxonomy and target type mapping. |
+|  | `organism_csv` | `dictionary/_target/targets_type.csv` | Taxonomy and target type mapping. |
 |  | `uniprot_column` | `uniprot_id` | Column used to join UniProt data. |
 |  | `chembl_out` | `null` | Optional override for the combined ChEMBL output path. |
 |  | `uniprot_out` | `null` | Optional override for the combined UniProt output path. |
@@ -203,11 +203,11 @@ All URLs must comply with the respective service usage policies, including rate 
 | Key | Default | Description |
 | --- | --- | --- |
 | `dictionary_dir` | `dictionary` | Root directory with lookup tables. |
-| `iuphar_target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target mapping table. |
-| `iuphar_family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family mapping table. |
-| `uniprot_data_dir` | `dictionary/uniprot` | Cached UniProt JSON responses. |
-| `organism_csv` | `dictionary/_Target/targets_type.csv` | Organism and taxonomy mapping. |
-| `targets_type_csv` | `dictionary/_Target/targets_type.csv` | Target type classification table. |
+| `iuphar_target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target mapping table. |
+| `iuphar_family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family mapping table. |
+| `uniprot_data_dir` | `dictionary/_target/_uniprot` | Cached UniProt JSON responses. |
+| `organism_csv` | `dictionary/_target/targets_type.csv` | Organism and taxonomy mapping. |
+| `targets_type_csv` | `dictionary/_target/targets_type.csv` | Target type classification table. |
 
 ### I/O defaults (`local.io`)
 

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -126,8 +126,8 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
 | `enable` | `true` | Включает стадию расчёта `salt_chembl_id` и флагов из каталога молекул. |
-| `sources.molecule_catalog_path` | `dictionary/molecule_catalog.csv` | CSV со столбцами `molecule_chembl_id`, `natural_product`, `prodrug`, `polymer_flag`. |
-| `sources.molecule_hierarchy_path` | `dictionary/molecule_hierarchy.csv` | CSV с соответствиями дочерней и родительской молекулы. |
+| `sources.molecule_catalog_path` | `dictionary/_testitem/molecule_catalog.csv` | CSV со столбцами `molecule_chembl_id`, `natural_product`, `prodrug`, `polymer_flag`. |
+| `sources.molecule_hierarchy_path` | `dictionary/_testitem/molecule_hierarchy.csv` | CSV с соответствиями дочерней и родительской молекулы. |
 | `output.salt_as_null_when_absent` | `true` | При `true` несолевые соединения дают `null`, при `false` — символ `-`. |
 | `flags.coerce_to_bool` | `true` | Нормализует значения вида `Y/N`, `1/0`, `yes/no` в булев тип pandas. |
 | `flags.parent_fallback` | `true` | Подтягивает флаги из родителя, если у дочерней записи они пусты. |
@@ -160,21 +160,21 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Подсекция | Ключ | Значение | Описание |
 | --- | --- | --- | --- |
 | `uniprot` | `column` | `uniprot_id` | Колонка с UniProt ID. |
-|  | `data_dir` | `dictionary/uniprot` | Каталог с кэшированными JSON UniProt. |
+|  | `data_dir` | `dictionary/_target/_uniprot` | Каталог с кэшированными JSON UniProt. |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
 | `chembl` | `column` | `target_chembl_id` | Колонка с таргетами ChEMBL. |
 |  | `chunk_size` | `5` | Размер батча запросов. |
 |  | `timeout` | `30.0` | Таймаут запроса (сек.). |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
-| `iuphar` | `target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | Справочник таргетов IUPHAR. |
-|  | `family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
+| `iuphar` | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Справочник таргетов IUPHAR. |
+|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
-| `all` | `data_dir` | `dictionary/uniprot` | Каталог с данными UniProt. |
-|  | `target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | Таблица таргетов IUPHAR. |
-|  | `family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | Таблица семейств IUPHAR. |
+| `all` | `data_dir` | `dictionary/_target/_uniprot` | Каталог с данными UniProt. |
+|  | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Таблица таргетов IUPHAR. |
+|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Таблица семейств IUPHAR. |
 |  | `chunk_size` | `5` | Размер батча при объединении источников. |
 |  | `timeout` | `30.0` | Таймаут запроса (сек.). |
-|  | `organism_csv` | `dictionary/_Target/targets_type.csv` | Классификация организмов и типов таргетов. |
+|  | `organism_csv` | `dictionary/_target/targets_type.csv` | Классификация организмов и типов таргетов. |
 |  | `uniprot_column` | `uniprot_id` | Колонка для соединения с UniProt. |
 |  | `chembl_out` | `null` | Индивидуальный путь для объединённых данных ChEMBL. |
 |  | `uniprot_out` | `null` | Индивидуальный путь для объединённых данных UniProt. |
@@ -203,11 +203,11 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
 | `dictionary_dir` | `dictionary` | Корневая папка словарей. |
-| `iuphar_target_csv` | `dictionary/_IUPHAR/_IUPHAR_target.csv` | Соответствия таргетов IUPHAR. |
-| `iuphar_family_csv` | `dictionary/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
-| `uniprot_data_dir` | `dictionary/uniprot` | Кэшированные ответы UniProt. |
-| `organism_csv` | `dictionary/_Target/targets_type.csv` | Классификация организмов. |
-| `targets_type_csv` | `dictionary/_Target/targets_type.csv` | Классификация типов таргетов. |
+| `iuphar_target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Соответствия таргетов IUPHAR. |
+| `iuphar_family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
+| `uniprot_data_dir` | `dictionary/_target/_uniprot` | Кэшированные ответы UniProt. |
+| `organism_csv` | `dictionary/_target/targets_type.csv` | Классификация организмов. |
+| `targets_type_csv` | `dictionary/_target/targets_type.csv` | Классификация типов таргетов. |
 
 ### Настройки ввода-вывода (`local.io`)
 

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -126,8 +126,8 @@ Before distributing the export, join it with the parent molecule catalogue to ex
 `sources.chembl.molecule_catalog.cache_path` and loaded via
 `library.molecule_catalog.load_parent_catalog`, which refreshes the cache from the ChEMBL API when needed.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
 
-An additional enrichment stage reads `dictionary/molecule_hierarchy.csv` and
-`dictionary/molecule_catalog.csv` to populate the salt identifier and the
+An additional enrichment stage reads `dictionary/_testitem/molecule_hierarchy.csv` and
+`dictionary/_testitem/molecule_catalog.csv` to populate the salt identifier and the
 `natural_product`, `prodrug`, `polymer_flag` booleans before validation. The
 pipeline detects salts when `parent_molecule_chembl_id` differs from
 `molecule_chembl_id`, fills `salt_chembl_id` with the child identifier, and

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -115,8 +115,8 @@ JSON-файл содержит:
 `sources.chembl.molecule_catalog.cache_path` и загружается функцией
 `library.molecule_catalog.load_parent_catalog`, которая при необходимости обновляет кэш через API ChEMBL.【F:config.yaml†L25-L33】【F:library/molecule_catalog.py†L43-L136】
 
-Дополнительный этап обогащения использует `dictionary/molecule_hierarchy.csv` и
-`dictionary/molecule_catalog.csv`, чтобы до валидации заполнить `salt_chembl_id`
+Дополнительный этап обогащения использует `dictionary/_testitem/molecule_hierarchy.csv` и
+`dictionary/_testitem/molecule_catalog.csv`, чтобы до валидации заполнить `salt_chembl_id`
 и булевы признаки `natural_product`, `prodrug`, `polymer_flag`. Соль
 распознаётся, когда `parent_molecule_chembl_id` отличается от
 `molecule_chembl_id`, после чего в `salt_chembl_id` попадает идентификатор

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -142,13 +142,11 @@ row count stays constant.
 
 Test item exports must be reconciled with the ChEMBL parent catalogue to expose `parent_molecule_chembl_id`
 used by downstream aggregations. The cache path is configured via
-`sources.chembl.molecule_catalog.cache_path`; keep the JSON file accessible to the runner or adjust the
-location by setting `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for
-`CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) or editing `config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
- 
-[`sources.chembl.molecule_catalog`](./CONFIG_EN.md#sources-chembl-molecule-catalog) (`cache_path`); keep the JSON file accessible to the runner or override the
-location through CLI/environment aliases such as `--sources.chembl.molecule_catalog.cache-path` or
-`CHEMBL_DA_MOLECULE_CATALOG_CACHE`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
+[`sources.chembl.molecule_catalog.cache_path`](./CONFIG_EN.md#sources-chembl-molecule-catalog);
+keep the JSON file accessible to the runner or adjust the location by setting
+`CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for
+`CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) or editing
+`config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
  
 
 Use `library.molecule_catalog.load_parent_catalog` in a short Python snippet to initialise or refresh the
@@ -161,9 +159,9 @@ The optional `testitem_molecule_enrichment` stage augments `testitem.csv` with
 `salt_chembl_id`, `natural_product`, `prodrug`, and `polymer_flag` using two
 CSV dictionaries:
 
-* `dictionary/molecule_hierarchy.csv` (columns `molecule_chembl_id`,
+* `dictionary/_testitem/molecule_hierarchy.csv` (columns `molecule_chembl_id`,
   `parent_molecule_chembl_id`) maps salts to their parent molecules.
-* `dictionary/molecule_catalog.csv` (columns `molecule_chembl_id`,
+* `dictionary/_testitem/molecule_catalog.csv` (columns `molecule_chembl_id`,
   `natural_product`, `prodrug`, `polymer_flag`) stores boolean attributes.
 
 Missing dictionary rows trigger warnings such as

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -143,15 +143,11 @@ PubChem-дополнение добавляет детерминированны
 ### Требования к каталогу родительских молекул
 
 Чтобы получить `parent_molecule_chembl_id` для агрегаций, выгрузку необходимо объединить с каталогом
-родителей ChEMBL. Путь к локальному JSON задаётся через `sources.chembl.molecule_catalog.cache_path`; убедитесь,
+родителей ChEMBL. Путь к локальному JSON задаётся через
+[`sources.chembl.molecule_catalog.cache_path`](./CONFIG_RU.md#sources-chembl-molecule-catalog); убедитесь,
 что файл доступен исполнителю, либо задайте новое расположение переменной окружения
 `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (алиас для `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`) или правкой
 `config.yaml`.【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
-
-родителей ChEMBL. Путь к локальному JSON задаётся через
-[`sources.chembl.molecule_catalog`](./CONFIG_RU.md#sources-chembl-molecule-catalog) (`cache_path`); убедитесь,
-что файл доступен исполнителю, либо переопределите расположение параметрами CLI (`--sources.chembl.molecule_catalog.cache-path`)
-или переменными окружения (`CHEMBL_DA_MOLECULE_CATALOG_CACHE`).【F:config.yaml†L25-L33】【F:library/config.py†L487-L551】
 
 Для первичного создания либо обновления файла выполните небольшой Python-скрипт с вызовом
 `library.molecule_catalog.load_parent_catalog` — функция считывает готовый кэш и, при его отсутствии,
@@ -163,9 +159,9 @@ PubChem-дополнение добавляет детерминированны
 столбцы `salt_chembl_id`, `natural_product`, `prodrug`, `polymer_flag` на
 основе двух CSV-словарей:
 
-* `dictionary/molecule_hierarchy.csv` со столбцами `molecule_chembl_id`,
+* `dictionary/_testitem/molecule_hierarchy.csv` со столбцами `molecule_chembl_id`,
   `parent_molecule_chembl_id` описывает связи соли и родителя.
-* `dictionary/molecule_catalog.csv` со столбцами `molecule_chembl_id`,
+* `dictionary/_testitem/molecule_catalog.csv` со столбцами `molecule_chembl_id`,
   `natural_product`, `prodrug`, `polymer_flag` содержит булевы признаки.
 
 Если молекулы нет в словарях, в лог попадают предупреждения


### PR DESCRIPTION
## Summary
- update configuration reference tables to point at the `_testitem` and `_target` dictionary assets that back the pipelines
- sync English and Russian usage/output guides with the new folder prefixes and remove duplicated parent catalogue guidance

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6a02199a48324918c7cd0a19726ce