### PR TITLE
Document activity enrichment configuration details

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -75,13 +75,54 @@ Each sub-section below defines defaults for the respective CLI utility. CLI argu
 
 #### Activity enrichment (`activity_enrichment`)
 
+This block controls derived annotations appended to every activity row. It works alongside the separate
+`activity_bounds` configuration (documented below) that is responsible solely for calculating numerical limits.
+`activity_enrichment` itself is divided into two independent sub-sections that can be toggled individually.
+
+##### Action type labelling (`activity_enrichment.action_type`)
+
+* `enabled` — master switch (`true` by default).【F:config.yaml†L192-L193】
+* `column` — name of the output column that stores the resolved label (`action_type`).【F:config.yaml†L194-L194】
+* Logging flags control diagnostics when the source data does not produce a value:
+  * `log_missing` emits a warning when the label cannot be determined (`true`).【F:config.yaml†L195-L195】
+  * `log_distribution` prints summary statistics after enrichment (`true`).【F:config.yaml†L196-L196】
+* `metrics` maps activity measurements (IC50, EC50, etc.) to default labels such as `inhibition` or `activation`. Extend the
+  mapping to support additional metrics.【F:config.yaml†L197-L202】
+* `triages`, `functionality` and `mechanism` are optional overrides for explicit text matches. The defaults keep `triages` and
+  `mechanism` empty while normalising common functional annotations (agonist, antagonist, etc.).【F:config.yaml†L203-L210】
+* The helper field lists (`triage_fields`, `functionality_fields`, `mechanism_fields`) decide which columns are scanned for
+  keywords or manual labels before applying metric defaults.【F:config.yaml†L211-L219】
+* `allowlist` enumerates labels allowed in the output. Values not present in the list fall back to `fallback` after logging the
+  anomaly.【F:config.yaml†L220-L227】
+* `positive_label` and `negative_label` define human-readable aliases used when the data represents positive/negative modulators
+  (`PAM`/`NAM`). The neutral fallback is `unknown`.【F:config.yaml†L228-L230】
+
+##### Activity properties flattening (`activity_enrichment.activity_properties`)
+
+* `enabled` — feature switch (`true`).【F:config.yaml†L231-L233】
+* `column` — name of the raw JSON-like source column (`activity_properties`).【F:config.yaml†L233-L233】
+* `summary_column` — destination column for the rendered text summary (`activity_property_summary`).【F:config.yaml†L234-L234】
+* `name_field`, `value_field`, `units_field` identify keys within each property record (`type`, `value`, `units`).【F:config.yaml†L235-L237】
+* `separator` and `pair_separator` control formatting when properties are concatenated (`"; "` between pairs,
+  `"="` between name and value).【F:config.yaml†L238-L239】
+* `drop_source_column` removes the original structured column after summarisation (`true`).【F:config.yaml†L240-L240】
+* Logging flags default to `false`, muting missing/distribution reports unless troubleshooting is required.【F:config.yaml†L241-L242】
+* `allowlist` restricts which property groups are retained (measurement, assay, comments, effect_features, triage, mechanism,
+  functionality).【F:config.yaml†L243-L250】
+* `hash_column` stores a deterministic fingerprint of the preserved properties (`properties_hash`), enabling change detection in
+  downstream jobs.【F:config.yaml†L251-L251】
+
+##### Activity bounds (`activity_bounds`)
+
 The activity pipeline enriches raw ChEMBL payloads with canonical lower/upper bounds using the rules implemented by
-`compute_activity_bounds` in `scripts/get_activity_data.py`. Configuration for the feature is stored in the `activity_bounds`
-block and controls the following deterministic stages (executed in order for every row):【F:scripts/get_activity_data.py†L212-L353】【F:library/config.py†L371-L388】
+`compute_activity_bounds` in `scripts/get_activity_data.py`. Configuration for this feature is stored in the
+`activity_bounds` block (separate from `activity_enrichment`) and controls the following deterministic stages (executed
+in order for every row):【F:scripts/get_activity_data.py†L212-L353】【F:library/config.py†L371-L388】
 
 1. Use `standard_lower_value`/`standard_upper_value` when both are populated.
 2. Combine `standard_value` with the opposite explicit limit (for example `standard_upper_value`) and fill the missing bound.
-3. Inspect `standard_relation` when `enable_from_relation` is `true`, mapping operators such as `=`, `≈`, `>=`, `<=`, `between` and `range` to appropriate bounds.
+3. Inspect `standard_relation` when `enable_from_relation` is `true`, mapping operators such as `=`, `≈`, `>=`, `<=`, `between`
+   and `range` to appropriate bounds.
 4. Parse `±` expressions from `standard_text_value` when `enable_from_uncertainty` is enabled.
 
 Each completed step locks in previously derived numbers; disabling a stage simply skips it without mutating earlier results.

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -75,9 +75,45 @@
 
 #### Обогащение активностей (`activity_enrichment`)
 
+Блок отвечает за дополнительные атрибуты, которые записываются в каждую строку активностей. Он работает совместно с
+отдельной конфигурацией `activity_bounds` (описана ниже), отвечающей только за расчёт числовых границ.
+`activity_enrichment` состоит из двух независимых подсекций, каждая включается собственным флагом.
+
+##### Маркировка типа действия (`activity_enrichment.action_type`)
+
+* `enabled` — главный переключатель (по умолчанию `true`).【F:config.yaml†L192-L193】
+* `column` — название выходной колонки с итоговой меткой (`action_type`).【F:config.yaml†L194-L194】
+* Флаги логирования помогают отслеживать диагностические случаи:
+  * `log_missing` выводит предупреждение, если метка не определена (`true`).【F:config.yaml†L195-L195】
+  * `log_distribution` печатает итоговую статистику распределения (`true`).【F:config.yaml†L196-L196】
+* `metrics` сопоставляет типы измерений (IC50, EC50 и т.д.) с базовыми метками (`inhibition`, `activation`, `binding`). Список
+  расширяется при необходимости.【F:config.yaml†L197-L202】
+* `triages`, `functionality`, `mechanism` — словари переопределений для текстовых совпадений. По умолчанию заполнены только
+  типичные функциональные роли (agonist, antagonist и пр.).【F:config.yaml†L203-L210】
+* Списки `triage_fields`, `functionality_fields`, `mechanism_fields` задают, какие исходные колонки просматриваются перед применением
+  значений по метрикам.【F:config.yaml†L211-L219】
+* `allowlist` ограничивает допустимые метки; значения вне списка заменяются на `fallback` после логирования отклонения.【F:config.yaml†L220-L227】
+* `positive_label` и `negative_label` задают читаемые ярлыки для положительных/отрицательных модуляторов (`PAM`/`NAM`), а
+  `fallback` равен `unknown`.【F:config.yaml†L228-L230】
+
+##### Сводка свойств активности (`activity_enrichment.activity_properties`)
+
+* `enabled` — флаг включения (`true`).【F:config.yaml†L231-L233】
+* `column` — исходная колонка со структурированными свойствами (`activity_properties`).【F:config.yaml†L233-L233】
+* `summary_column` — колонка для текстового резюме (`activity_property_summary`).【F:config.yaml†L234-L234】
+* `name_field`, `value_field`, `units_field` задают имена ключей внутри записей (`type`, `value`, `units`).【F:config.yaml†L235-L237】
+* `separator` и `pair_separator` управляют форматированием списка свойств (`"; "` между парами и `"="` между названием и значением).【F:config.yaml†L238-L239】
+* `drop_source_column` удаляет исходную структурированную колонку после агрегации (`true`).【F:config.yaml†L240-L240】
+* Флаги логирования по умолчанию выключены (`log_missing=false`, `log_distribution=false`).【F:config.yaml†L241-L242】
+* `allowlist` ограничивает перечень сохраняемых групп (measurement, assay, comments, effect_features, triage, mechanism,
+  functionality).【F:config.yaml†L243-L250】
+* `hash_column` хранит детерминированный отпечаток итоговых свойств (`properties_hash`) для отслеживания изменений далее по цепочке.【F:config.yaml†L251-L251】
+
+##### Границы активности (`activity_bounds`)
+
 Пайплайн активностей дополняет выгрузку нормализованными границами с помощью `compute_activity_bounds` в
-`scripts/get_activity_data.py`. Настройки собраны в блоке `activity_bounds` и управляют последовательностью детерминированных
-шагов, которые выполняются для каждой строки в следующем порядке：【F:scripts/get_activity_data.py†L212-L353】【F:library/config.py†L371-L388】
+`scripts/get_activity_data.py`. Настройки собраны в отдельном блоке `activity_bounds` (вне `activity_enrichment`) и управляют
+последовательностью детерминированных шагов, которые выполняются для каждой строки в следующем порядке：【F:scripts/get_activity_data.py†L212-L353】【F:library/config.py†L371-L388】
 
 1. Использовать готовые `standard_lower_value`/`standard_upper_value`, если обе границы заданы.
 2. Скомбинировать `standard_value` с противоположной границей и заполнить пропущенное значение.


### PR DESCRIPTION
## Summary
- expand the English configuration guide with detailed documentation for the `activity_enrichment.action_type` and `activity_enrichment.activity_properties` settings, clarifying how they coexist with `activity_bounds`
- mirror the same explanations in the Russian configuration guide to keep terminology and defaults aligned across languages

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a01e2f6483249a10767d796e3b6f