### PR TITLE
Expand PubChem configuration and resolver workflow

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -979,6 +979,12 @@
     "PubChemCfg": {
       "additionalProperties": false,
       "properties": {
+        "enable": {
+          "default": true,
+          "description": "Enable PubChem augmentation for test item data",
+          "title": "Enable",
+          "type": "boolean"
+        },
         "base": {
           "default": "https://pubchem.ncbi.nlm.nih.gov/rest/pug",
           "title": "Base",
@@ -995,6 +1001,13 @@
           "minimum": 1,
           "title": "Timeout Read",
           "type": "integer"
+        },
+        "timeout_seconds": {
+          "default": 30.0,
+          "description": "Overall timeout applied to individual PubChem lookups",
+          "minimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1015,19 +1028,28 @@
           "type": "integer"
         },
         "delay": {
-          "default": 3.0,
+          "default": 0.2,
+          "description": "Base delay between retries for network errors",
           "minimum": 0,
           "title": "Delay",
+          "type": "number"
+        },
+        "backoff_initial_seconds": {
+          "default": 0.5,
+          "description": "Initial delay when backing off after 429/5xx responses",
+          "minimum": 0,
+          "title": "Backoff Initial Seconds",
           "type": "number"
         },
         "resolve_order": {
           "default": [
             "cache",
+            "smiles",
             "inchikey",
-            "name",
-            "smiles"
+            "inchi",
+            "pref_name"
           ],
-          "description": "Order of PubChem CID resolvers",
+          "description": "Ordered list of lookup strategies when resolving PubChem CIDs",
           "items": {
             "type": "string"
           },
@@ -1036,70 +1058,14 @@
         },
         "cache_ttl": {
           "default": 3600,
-          "description": "Time-to-live for PubChem request cache in seconds",
+          "description": "Time-to-live for the in-memory PubChem request cache in seconds",
           "minimum": 0,
           "title": "Cache Ttl",
           "type": "integer"
         },
-        "prefer_local_smiles": {
-          "default": false,
-          "description": "Skip PubChem lookups when local pubchem_* columns are populated",
-          "title": "Prefer Local Smiles",
-          "type": "boolean"
-        },
- 
-        "skip_polymers": {
-          "default": false,
-          "description": "Skip PubChem lookups for polymer or mixture records",
-          "title": "Skip Polymers",
-          "type": "boolean"
-        },
- 
-
-        "prefer_local_values": {
-          "default": true,
-          "description": "Retain pre-existing pubchem_* values when PubChem responses are empty",
-          "title": "Prefer Local Values",
-          "type": "boolean"
-        },
-        "resolve_order": {
-          "default": [
-            "standard_inchi_key",
-            "standard_inchi",
-            "pref_name",
-            "pref_name_partial",
-            "canonical_smiles"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "title": "Resolve Order",
-          "type": "array"
-        },
-        "use_parent_for_salts": {
-          "default": true,
-          "title": "Use Parent For Salts",
-          "type": "boolean"
-        },
-        "skip_polymers": {
-          "default": true,
-          "title": "Skip Polymers",
-          "type": "boolean"
-        },
-        "write_not_found_literal": {
-          "default": false,
-          "title": "Write Not Found Literal",
-          "type": "boolean"
-        },
-        "batch_size": {
-          "default": 50,
-          "minimum": 1,
-          "title": "Batch Size",
-          "type": "integer"
-        },
         "cache_ttl_hours": {
           "default": null,
-          "description": "Optional TTL for the persisted CID cache, in hours",
+          "description": "Optional TTL for the persisted CID cache in hours",
           "minimum": 0,
           "title": "Cache Ttl Hours",
           "type": [
@@ -1107,29 +1073,6 @@
             "null"
           ]
         },
-        "timeout_seconds": {
-          "default": 30.0,
-          "minimum": 0,
-          "title": "Timeout Seconds",
-          "type": "number"
-        },
-        "backoff_initial_seconds": {
-          "default": 0.5,
-          "minimum": 0,
-          "title": "Backoff Initial Seconds",
-          "type": "number"
-        },
-
- 
-        "use_parent_for_salts": {
-          "default": false,
-          "description": "Resolve PubChem CIDs via parent structures when child lookups fail",
-          "title": "Use Parent For Salts",
-          "type": "boolean"
-        },
- 
-
- 
         "cid_cache_path": {
           "default": null,
           "description": "Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
@@ -1138,6 +1081,42 @@
             "string",
             "null"
           ]
+        },
+        "batch_size": {
+          "default": 50,
+          "minimum": 1,
+          "title": "Batch Size",
+          "type": "integer"
+        },
+        "prefer_local_smiles": {
+          "default": false,
+          "description": "Skip PubChem lookups when existing pubchem_* columns are complete",
+          "title": "Prefer Local Smiles",
+          "type": "boolean"
+        },
+        "prefer_local_values": {
+          "default": true,
+          "description": "Retain existing pubchem_* values when lookups return empty results",
+          "title": "Prefer Local Values",
+          "type": "boolean"
+        },
+        "use_parent_for_salts": {
+          "default": true,
+          "description": "Resolve PubChem CIDs via parent structures when child lookups fail",
+          "title": "Use Parent For Salts",
+          "type": "boolean"
+        },
+        "allow_polymer": {
+          "default": false,
+          "description": "Allow PubChem lookups for polymer or mixture records",
+          "title": "Allow Polymer",
+          "type": "boolean"
+        },
+        "write_not_found_literal": {
+          "default": false,
+          "description": "Write 'Not Found' when PubChem lookups fail",
+          "title": "Write Not Found Literal",
+          "type": "boolean"
         }
       },
       "title": "PubChemCfg",

--- a/config.yaml
+++ b/config.yaml
@@ -128,33 +128,31 @@ sources:
     rps: 5  # (env: CHEMBL_DA_IUPHAR_RPS)
     burst: 5  # (env: CHEMBL_DA_IUPHAR_BURST)
   pubchem:
+    enable: true  # Toggle PubChem augmentation (env: CHEMBL_DA_PUBCHEM_ENABLE)
     base: "https://pubchem.ncbi.nlm.nih.gov/rest/pug"  # PubChem PUG REST API (env: CHEMBL_DA__SOURCES__PUBCHEM__BASE / CHEMBL_DA_PUBCHEM_BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_CONNECT)
     timeout_read: 60  # (env: CHEMBL_DA_PUBCHEM_TIMEOUT_READ)
+    timeout_seconds: 30.0
     retries: 3
     rps: 5  # (env: CHEMBL_DA_PUBCHEM_RPS)
     burst: 5  # (env: CHEMBL_DA_PUBCHEM_BURST)
     delay: 0.2  # Delay between requests in seconds; must be a float for strict type validation
+    backoff_initial_seconds: 0.5
+    resolve_order:
+      - cache
+      - smiles
+      - inchikey
+      - inchi
+      - pref_name
     cache_ttl: 3600  # Request cache time-to-live in seconds
-
+    cache_ttl_hours: null  # Persisted CID cache TTL in hours; null disables expiry
+    cid_cache_path: null
+    batch_size: 50
     prefer_local_smiles: false
     prefer_local_values: true
-    resolve_order:
-      - standard_inchi_key
-      - standard_inchi
-      - pref_name
-      - pref_name_partial
-      - canonical_smiles
     use_parent_for_salts: true
-    skip_polymers: true
+    allow_polymer: false
     write_not_found_literal: false
-    batch_size: 50
-    cache_ttl_hours: null  # Persisted CID cache TTL in hours; null disables expiry
-    timeout_seconds: 30.0
-    backoff_initial_seconds: 0.5
-
- 
-    use_parent_for_salts: false  # Attempt parent structures when salt lookups fail
 
   pubmed:
     base: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"  # PubMed API root (env: CHEMBL_DA__SOURCES__PUBMED__BASE)

--- a/library/config.py
+++ b/library/config.py
@@ -249,65 +249,77 @@ class IupharCfg(_BaseModel):
 
 
 class PubChemCfg(_BaseModel):
+    """Settings for resolving PubChem data."""
+
+    enable: bool = Field(
+        True,
+        description="Enable PubChem augmentation for test item data",
+    )
     base: str = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(60, ge=1)
+    timeout_seconds: float = Field(
+        30.0,
+        ge=0,
+        description="Overall timeout applied to individual PubChem lookups",
+    )
     retries: int = Field(3, ge=0)
     rps: int = Field(3, ge=1)
     burst: int = Field(5, ge=1)
-    delay: float = Field(3.0, ge=0)
-    resolve_order: list[str] = Field(
-        default_factory=lambda: ["cache", "inchikey", "name", "smiles"],
-        description="Order of PubChem CID resolvers",
+    delay: float = Field(
+        0.2,
+        ge=0,
+        description="Base delay between retries for network errors",
+    )
+    backoff_initial_seconds: float = Field(
+        0.5,
+        ge=0,
+        description="Initial delay when backing off after 429/5xx responses",
+    )
+    resolve_order: tuple[str, ...] = Field(
+        (
+            "cache",
+            "smiles",
+            "inchikey",
+            "inchi",
+            "pref_name",
+        ),
+        description="Ordered list of lookup strategies when resolving PubChem CIDs",
     )
     cache_ttl: int = Field(
         3600,
         ge=0,
-        description="Time-to-live for PubChem request cache in seconds",
+        description="Time-to-live for the in-memory PubChem request cache in seconds",
     )
-    prefer_local_smiles: bool = Field(
-        False,
-        description="Skip PubChem lookups when local pubchem_* columns are populated",
-    )
- 
-    skip_polymers: bool = Field(
-        False,
-        description=(
-            "Skip PubChem lookups for polymer or mixture records, retaining existing"
-            " pubchem_* values"
-        ),
-    )
- 
-    prefer_local_values: bool = Field(
-        True,
-        description="Retain pre-existing pubchem_* values when lookups return empty results",
-    )
-    resolve_order: tuple[str, ...] = (
-        "standard_inchi_key",
-        "standard_inchi",
-        "pref_name",
-        "pref_name_partial",
-        "canonical_smiles",
-    )
-    use_parent_for_salts: bool = True
-    skip_polymers: bool = True
-    write_not_found_literal: bool = False
-    batch_size: int = Field(50, ge=1)
     cache_ttl_hours: float | None = Field(
         None,
         ge=0,
-        description="Optional TTL for the persisted CID cache, expressed in hours",
+        description="Optional TTL for the persisted CID cache in hours",
     )
-    timeout_seconds: float = Field(30.0, ge=0)
-    backoff_initial_seconds: float = Field(0.5, ge=0)
- 
     cid_cache_path: Path | None = Field(
         default=None,
         description="Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
     )
-    use_parent_for_salts: bool = Field(
+    batch_size: int = Field(50, ge=1)
+    prefer_local_smiles: bool = Field(
         False,
+        description="Skip PubChem lookups when existing pubchem_* columns are complete",
+    )
+    prefer_local_values: bool = Field(
+        True,
+        description="Retain existing pubchem_* values when lookups return empty results",
+    )
+    use_parent_for_salts: bool = Field(
+        True,
         description="Resolve PubChem CIDs via parent structures when child lookups fail",
+    )
+    allow_polymer: bool = Field(
+        False,
+        description="Allow PubChem lookups for polymer or mixture records",
+    )
+    write_not_found_literal: bool = Field(
+        False,
+        description="Write 'Not Found' when PubChem lookups fail",
     )
 
     @field_validator("base")

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,8 +6,9 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Hashable, cast
 from urllib.parse import quote
 
 import requests
@@ -150,25 +151,10 @@ def get_cid_from_inchikey(inchikey: str, cfg: PubChemCfg) -> str | None:
 
 
 def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
-    """Make an HTTP GET request and return parsed JSON.
+    """Make an HTTP GET request and return parsed JSON."""
 
-    Parameters
-    ----------
-    url: str
-        Endpoint to query.
-    cfg: PubChemCfg
-        API configuration. ``cfg.delay`` specifies the pause between retry
-        attempts.
-
-    Returns
-    -------
-    dict[str, Any] or None
-        Parsed JSON response on success, otherwise ``None`` when all retries
-        are exhausted or a non-recoverable error occurs.
-    """
     global _CACHE
     if _CACHE is None or _CACHE.ttl != cfg.cache_ttl:
-        # Initialise or refresh the cache with the configured TTL.
         _CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
 
     cached = _CACHE.get(url)
@@ -177,7 +163,10 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         return cast(dict[str, Any], cached)
     logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
 
-    for attempt in range(1, cfg.retries + 1):
+    attempts = max(cfg.retries, 1)
+    backoff_delay = cfg.backoff_initial_seconds
+
+    for attempt in range(1, attempts + 1):
         event = "request_start" if attempt == 1 else "request_retry"
         logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
@@ -186,7 +175,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)
             )
         except requests.RequestException as exc:  # pragma: no cover - network
-            if attempt >= cfg.retries:
+            if attempt >= attempts:
                 logger.error(
                     "request_error",
                     url=url,
@@ -201,28 +190,47 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     rps=cfg.rps,
                 )
                 return None
-            sleep(cfg.delay)
+            if cfg.delay > 0:
+                sleep(cfg.delay)
             continue
 
-        if response.status_code in (404, 400):
+        status = response.status_code
+        if status == 404:
+            logger.info("request_not_found", url=url, status=status, rps=cfg.rps)
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            return None
+        if status == 429 or 500 <= status < 600:
+            event_name = "request_rate_limited" if status == 429 else "request_server_error"
+            logger.warning(
+                event_name,
+                url=url,
+                status=status,
+                attempt=attempt,
+                rps=cfg.rps,
+            )
+            if attempt >= attempts:
+                logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+                return None
+            delay = backoff_delay if backoff_delay > 0 else cfg.delay
+            if delay > 0:
+                sleep(delay)
+                backoff_delay = delay * 2
+            continue
+        if status >= 400:
             logger.warning(
                 "request_unexpected_status",
                 url=url,
-                status=response.status_code,
+                status=status,
                 rps=cfg.rps,
             )
-            logger.info(
-                "request_fail",
-                url=url,
-                status=response.status_code,
-                rps=cfg.rps,
-            )
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
             return None
+
         try:
             response.raise_for_status()
             data = cast(dict[str, Any], response.json())
         except requests.RequestException as exc:  # pragma: no cover - network
-            if attempt >= cfg.retries:
+            if attempt >= attempts:
                 logger.error(
                     "request_error",
                     url=url,
@@ -230,40 +238,32 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     attempt=attempt,
                     rps=cfg.rps,
                 )
-                logger.info(
-                    "request_fail",
-                    url=url,
-                    status=response.status_code,
-                    rps=cfg.rps,
-                )
+                logger.info("request_fail", url=url, status=status, rps=cfg.rps)
                 return None
-            sleep(cfg.delay)
+            if cfg.delay > 0:
+                sleep(cfg.delay)
             continue
         except ValueError:
             logger.warning(
                 "response_not_json",
                 url=url,
-                status=response.status_code,
+                status=status,
                 rps=cfg.rps,
             )
-            logger.info(
-                "request_fail",
-                url=url,
-                status=response.status_code,
-                rps=cfg.rps,
-            )
+            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
             return None
 
         logger.info(
             "request_ok",
             url=url,
-            status=response.status_code,
+            status=status,
             rps=cfg.rps,
         )
-        assert _CACHE is not None  # for type checker; cache initialised above
+        assert _CACHE is not None
         _CACHE[url] = data
         logger.info("cache_set", url=url, rps=cfg.rps)
         return data
+
     return None
 
 
@@ -285,6 +285,33 @@ def validate_cid(cid: str) -> str | None:
     if cid in {"", "0", "-1"}:
         return None
     return cid
+
+
+def _select_primary_cid(
+    candidates: str | None,
+    *,
+    cache_key: str | None,
+    identifier: str,
+    value: str | None,
+) -> str | None:
+    """Return the first CID from ``candidates`` logging alternatives."""
+
+    if not candidates:
+        return None
+    cid_list = [cid.strip() for cid in str(candidates).split("|") if cid.strip()]
+    if not cid_list:
+        return None
+    primary = cid_list[0]
+    if len(cid_list) > 1:
+        logger.info(
+            "pubchem_multiple_cid",
+            chembl_id=cache_key,
+            identifier=identifier,
+            value=value,
+            cid=primary,
+            alternatives=cid_list[1:],
+        )
+    return primary
 
 
 def _extract_cids(bindings: list[dict[str, Any]]) -> list[str]:
@@ -400,6 +427,15 @@ class Properties:
     InChIKey: str | None
 
 
+@dataclass(frozen=True)
+class PubChemResolution:
+    """Result of resolving a PubChem record."""
+
+    cid: str | None
+    source: str | None
+    status: int | None = None
+
+
 def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
     """Retrieve chemical properties for a compound by CID.
 
@@ -438,6 +474,140 @@ def get_properties(cid: str, cfg: PubChemCfg) -> Properties:
         cast(str | None, item.get("InChI")),
         cast(str | None, item.get("InChIKey")),
     )
+
+
+def resolve_pubchem_record(
+    identifiers: Mapping[str, str | None],
+    cfg: PubChemCfg,
+    *,
+    cid_cache: MutableMapping[str, str | None] | None = None,
+    cache_key: str | None = None,
+    resolution_cache: MutableMapping[Hashable, PubChemResolution] | None = None,
+    resolution_key: Hashable | None = None,
+) -> PubChemResolution:
+    """Resolve a PubChem CID according to ``cfg.resolve_order``."""
+
+    if resolution_cache is not None and resolution_key is not None:
+        cached_resolution = resolution_cache.get(resolution_key)
+        if cached_resolution is not None:
+            return cached_resolution
+
+    def _remember(resolution: PubChemResolution) -> PubChemResolution:
+        if resolution_cache is not None and resolution_key is not None:
+            resolution_cache[resolution_key] = resolution
+        if resolution.cid and cid_cache is not None and cache_key:
+            existing = cid_cache.get(cache_key)
+            if existing != resolution.cid:
+                cid_cache[cache_key] = resolution.cid
+        return resolution
+
+    def _resolve_cache() -> PubChemResolution | None:
+        if cid_cache is not None and cache_key:
+            cached_value = cid_cache.get(cache_key)
+            if isinstance(cached_value, str) and cached_value:
+                cid = _select_primary_cid(
+                    cached_value,
+                    cache_key=cache_key,
+                    identifier="cache",
+                    value=cached_value,
+                )
+                if cid:
+                    if cached_value != cid:
+                        cid_cache[cache_key] = cid
+                    return PubChemResolution(cid=cid, source="cache")
+        existing_cid = identifiers.get("pubchem_cid")
+        if existing_cid:
+            cid = _select_primary_cid(
+                existing_cid,
+                cache_key=cache_key,
+                identifier="pubchem_cid",
+                value=existing_cid,
+            )
+            if cid:
+                return PubChemResolution(cid=cid, source="pubchem_cid")
+        return None
+
+    def _attempt_candidates(
+        resolver: Callable[[str, PubChemCfg], str | None],
+        candidates: tuple[tuple[str, str | None], ...],
+    ) -> PubChemResolution | None:
+        for identifier, value in candidates:
+            if not value:
+                continue
+            resolved = resolver(value, cfg)
+            cid = _select_primary_cid(
+                resolved,
+                cache_key=cache_key,
+                identifier=identifier,
+                value=value,
+            )
+            if cid:
+                return PubChemResolution(cid=cid, source=identifier)
+        return None
+
+    def _resolve_smiles() -> PubChemResolution | None:
+        candidates = (
+            ("canonical_smiles", identifiers.get("canonical_smiles")),
+            ("pubchem_canonical_smiles", identifiers.get("pubchem_canonical_smiles")),
+            ("isomeric_smiles", identifiers.get("isomeric_smiles")),
+            ("pubchem_isomeric_smiles", identifiers.get("pubchem_isomeric_smiles")),
+        )
+        return _attempt_candidates(get_cid_from_smiles, candidates)
+
+    def _resolve_inchikey() -> PubChemResolution | None:
+        candidates = (
+            ("standard_inchi_key", identifiers.get("standard_inchi_key")),
+            ("pubchem_inchikey", identifiers.get("pubchem_inchikey")),
+        )
+        return _attempt_candidates(get_cid_from_inchikey, candidates)
+
+    def _resolve_inchi() -> PubChemResolution | None:
+        candidates = (
+            ("standard_inchi", identifiers.get("standard_inchi")),
+            ("pubchem_inchi", identifiers.get("pubchem_inchi")),
+        )
+        return _attempt_candidates(get_cid_from_inchi, candidates)
+
+    def _resolve_name() -> PubChemResolution | None:
+        name_value = identifiers.get("pref_name")
+        if not name_value:
+            return None
+        for identifier, resolver in (
+            ("pref_name", get_cid),
+            ("pref_name_partial", get_all_cid),
+        ):
+            resolved = resolver(name_value, cfg)
+            cid = _select_primary_cid(
+                resolved,
+                cache_key=cache_key,
+                identifier=identifier,
+                value=name_value,
+            )
+            if cid:
+                return PubChemResolution(cid=cid, source=identifier)
+        return None
+
+    handlers: dict[str, Callable[[], PubChemResolution | None]] = {
+        "cache": _resolve_cache,
+        "smiles": _resolve_smiles,
+        "inchikey": _resolve_inchikey,
+        "inchi": _resolve_inchi,
+        "pref_name": _resolve_name,
+        "name": _resolve_name,
+    }
+
+    for stage in cfg.resolve_order:
+        handler = handlers.get(stage.lower())
+        if handler is None:
+            raise ValueError(f"Unknown PubChem resolve order entry: {stage!r}")
+        resolution = handler()
+        if resolution and resolution.cid:
+            return _remember(resolution)
+
+    final = PubChemResolution(cid=None, source=None)
+    if resolution_cache is not None and resolution_key is not None:
+        resolution_cache[resolution_key] = final
+    return final
 
 
 def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str | None]:
@@ -481,6 +651,8 @@ __all__ = [
     "get_all_cid",
     "get_standard_name",
     "get_properties",
+    "resolve_pubchem_record",
     "process_compound",
     "Properties",
+    "PubChemResolution",
 ]

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -233,22 +233,19 @@ def _select_primary_cid(
     return primary
 
 
-def _resolve_cid_from_row(
-    row: pd.Series,
-    cache: MutableMapping[str, str | None],
-    cfg: PubChemCfg,
-    *,
-    chembl_id: str | None,
-) -> str | None:
-    """Return a CID for ``row`` using its structure fields."""
+def _pubchem_identifiers(row: pd.Series) -> dict[str, str | None]:
+    """Return mapping of identifier names to normalised values."""
 
-    chembl_norm = (
-        _normalise_identifier(chembl_id, uppercase=True)
-        if chembl_id
-        else _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    )
-
-    candidates = {
+    return {
+        "pubchem_cid": _normalise_identifier(row.get("pubchem_cid")),
+        "canonical_smiles": _normalise_identifier(row.get("canonical_smiles")),
+        "pubchem_canonical_smiles": _normalise_identifier(
+            row.get("pubchem_canonical_smiles")
+        ),
+        "isomeric_smiles": _normalise_identifier(row.get("isomeric_smiles")),
+        "pubchem_isomeric_smiles": _normalise_identifier(
+            row.get("pubchem_isomeric_smiles")
+        ),
         "standard_inchi_key": _normalise_identifier(
             row.get("standard_inchi_key"), uppercase=True
         ),
@@ -258,100 +255,24 @@ def _resolve_cid_from_row(
         "standard_inchi": _normalise_identifier(row.get("standard_inchi")),
         "pubchem_inchi": _normalise_identifier(row.get("pubchem_inchi")),
         "pref_name": _normalise_identifier(row.get("pref_name")),
-        "canonical_smiles": _normalise_identifier(row.get("canonical_smiles")),
     }
 
-    def _store(value: str) -> str:
-        if chembl_norm:
-            cached_value = cache.get(chembl_norm, _CID_CACHE_MISSING)
-            if cached_value in (_CID_CACHE_MISSING, None) or cached_value != value:
-                cache[chembl_norm] = value
-        return value
 
-    def _attempt(
-        identifier: str,
-        value: str | None,
-        resolver: Callable[[str, PubChemCfg], str | None],
-    ) -> str | None:
-        if not value:
-            return None
-        resolved = resolver(value, cfg)
-        return _select_primary_cid(
-            resolved,
-            chembl_id=chembl_norm,
-            identifier=identifier,
-            value=value,
-        )
+def _pubchem_resolution_key(row: pd.Series) -> tuple[str | None, ...]:
+    """Return a hashable key describing identifiers used for PubChem lookup."""
 
-    def _resolve_cached() -> str | None:
-        if not chembl_norm:
-            return None
-        cached_value = cache.get(chembl_norm, _CID_CACHE_MISSING)
-        if cached_value in (_CID_CACHE_MISSING, None):
-            return None
-        cid_primary = _select_primary_cid(
-            cached_value,
-            chembl_id=chembl_norm,
-            identifier="cache",
-            value=cached_value,
-        )
-        if cid_primary and cached_value != cid_primary:
-            cache[chembl_norm] = cid_primary
-        return cid_primary
-
-    resolver_groups: Mapping[str, Sequence[tuple[str, str | None, Callable[[str, PubChemCfg], str | None]]]] = {
-        "inchikey": (
-            (
-                "standard_inchi_key",
-                candidates["standard_inchi_key"],
-                pl.get_cid_from_inchikey,
-            ),
-            (
-                "pubchem_inchikey",
-                candidates["pubchem_inchikey"],
-                pl.get_cid_from_inchikey,
-            ),
-        ),
-        "inchi": (
-            (
-                "standard_inchi",
-                candidates["standard_inchi"],
-                pl.get_cid_from_inchi,
-            ),
-            (
-                "pubchem_inchi",
-                candidates["pubchem_inchi"],
-                pl.get_cid_from_inchi,
-            ),
-        ),
-        "name": (
-            ("pref_name", candidates["pref_name"], pl.get_cid),
-            ("pref_name_partial", candidates["pref_name"], pl.get_all_cid),
-        ),
-        "smiles": (
-            (
-                "canonical_smiles",
-                candidates["canonical_smiles"],
-                pl.get_cid_from_smiles,
-            ),
-        ),
-    }
-
-    for stage in cfg.resolve_order:
-        if stage == "cache":
-            cached_cid = _resolve_cached()
-            if cached_cid:
-                return cached_cid
-            continue
-        resolvers = resolver_groups.get(stage)
-        if resolvers is None:
-            raise ValueError(f"Unknown PubChem resolve order entry: {stage!r}")
-        for identifier, value, resolver in resolvers:
-            cid = _attempt(identifier, value, resolver)
-            if cid:
-                return _store(cid)
-
-    return None
+    identifiers = _pubchem_identifiers(row)
+    return (
+        identifiers.get("canonical_smiles"),
+        identifiers.get("pubchem_canonical_smiles"),
+        identifiers.get("isomeric_smiles"),
+        identifiers.get("pubchem_isomeric_smiles"),
+        identifiers.get("standard_inchi_key"),
+        identifiers.get("pubchem_inchikey"),
+        identifiers.get("standard_inchi"),
+        identifiers.get("pubchem_inchi"),
+        identifiers.get("pref_name"),
+    )
 
 
 def resolve_pubchem_cid(
@@ -360,11 +281,23 @@ def resolve_pubchem_cid(
     cfg: PubChemCfg,
     *,
     parent_loader: Callable[[str], pd.Series | None] | None = None,
+    resolution_cache: MutableMapping[tuple[str | None, ...], pl.PubChemResolution] | None = None,
 ) -> str | None:
     """Resolve PubChem CID for a ChEMBL record."""
 
     chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
+    identifiers = _pubchem_identifiers(row)
+    resolution_key = _pubchem_resolution_key(row)
+
+    resolution = pl.resolve_pubchem_record(
+        identifiers,
+        cfg,
+        cid_cache=cache,
+        cache_key=chembl_id,
+        resolution_cache=resolution_cache,
+        resolution_key=resolution_key,
+    )
+    cid = resolution.cid
     if cid is not None:
         return cid
 
@@ -398,62 +331,13 @@ def resolve_pubchem_cid(
             cache[chembl_id] = None
         return None
 
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
-    if parent_cid:
-        cache[parent_id] = parent_cid
-        if chembl_id:
-            cache[chembl_id] = parent_cid
-        return parent_cid
-
-
-    return None
-
-
-def resolve_pubchem_cid(
-    row: pd.Series,
-    cache: MutableMapping[str, str | None],
-    cfg: PubChemCfg,
-    *,
-    parent_loader: Callable[[str], pd.Series | None] | None = None,
-) -> str | None:
-    """Resolve PubChem CID for a ChEMBL record."""
-
-    chembl_id = _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True)
-    cid = _resolve_cid_from_row(row, cache, cfg, chembl_id=chembl_id)
-    if cid is not None:
-        return cid
-
-    if not cfg.use_parent_for_salts:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_id = _normalise_identifier(
-        row.get("parent_molecule_chembl_id"), uppercase=True
+    parent_cid = resolve_pubchem_cid(
+        parent_row,
+        cache,
+        cfg,
+        parent_loader=parent_loader,
+        resolution_cache=resolution_cache,
     )
-    if not parent_id:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    if parent_loader is None:
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_row = parent_loader(parent_id)
-    if parent_row is None:
-        logger.info(
-            "pubchem_parent_structure_missing",
-            child=chembl_id,
-            parent=parent_id,
-            reason="parent_unavailable",
-        )
-        if chembl_id and chembl_id not in cache:
-            cache[chembl_id] = None
-        return None
-
-    parent_cid = _resolve_cid_from_row(parent_row, cache, cfg, chembl_id=parent_id)
     if parent_cid:
         cache[parent_id] = parent_cid
         if chembl_id:
@@ -775,6 +659,10 @@ def add_pubchem_data(
     if df.empty:
         return df
 
+    if not getattr(cfg, "enable", True):
+        logger.info("pubchem_disabled")
+        return df
+
     result = df.reset_index(drop=True).copy()
     prefer_local = getattr(cfg, "prefer_local_smiles", False)
     existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
@@ -812,8 +700,8 @@ def add_pubchem_data(
     mixture_indexes = set(mixture_mask[mixture_mask].index.tolist())
 
     skip_indexes: set[int] = set()
-    skip_polymers = getattr(cfg, "skip_polymers", False)
-    if skip_polymers:
+    allow_polymer = getattr(cfg, "allow_polymer", False)
+    if not allow_polymer:
         skip_indexes = polymer_indexes | mixture_indexes
         if skip_indexes:
             logger.warning(
@@ -828,6 +716,7 @@ def add_pubchem_data(
     cache_ttl_hours = getattr(cfg, "cache_ttl_hours", None)
     cid_cache = _load_pubchem_cid_cache(cache_path, ttl_hours=cache_ttl_hours)
     cache_dirty = False
+    resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] = {}
 
     local_records: dict[str, pd.Series] = {}
     if "molecule_chembl_id" in result.columns:
@@ -928,6 +817,7 @@ def add_pubchem_data(
             cid_cache,
             cfg,
             parent_loader=load_parent_record,
+            resolution_cache=resolution_cache,
         )
         cid_by_index[idx] = cid
         if chembl_id:
@@ -979,6 +869,8 @@ def add_pubchem_data(
                 row_data["pubchem_canonical_smiles"] = _value_or_na(props.cSMILES)
                 row_data["pubchem_inchi"] = _value_or_na(props.InChI)
                 row_data["pubchem_inchikey"] = _value_or_na(props.InChIKey)
+        elif getattr(cfg, "write_not_found_literal", False):
+            row_data["pubchem_cid"] = "Not Found"
         pubchem_rows.append(row_data)
 
     pubchem_df = pd.DataFrame(pubchem_rows, index=result.index).convert_dtypes()

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -401,7 +401,7 @@ def test_get_testitem_data_smoke(
 
     def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
-        cfg.pubchem.skip_polymers = True
+        cfg.pubchem.allow_polymer = False
         return cfg
 
     monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Iterable, Mapping
+from typing import Callable, Iterable, Mapping
 
 import pandas as pd
 import pytest
@@ -48,13 +48,92 @@ def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> No
     df = pd.DataFrame({"canonical_smiles": ["C"]})
     cfg = pl.PubChemCfg(delay=0)
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
+    )
 
     result = gtd.add_pubchem_data(df, cfg)
     pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
     assert pubchem_cols
     assert result[pubchem_cols].isna().all().all()
     assert not (result[pubchem_cols] == "Not Found").any().any()
+
+
+def test_add_pubchem_data_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    cfg = pl.PubChemCfg(delay=0, enable=False)
+
+    calls: list[tuple[tuple, dict]] = []
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = gtd.add_pubchem_data(df, cfg)
+
+    assert calls == []
+    assert list(result.columns) == list(df.columns)
+
+
+def test_add_pubchem_data_not_found_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    cfg = pl.PubChemCfg(delay=0, write_not_found_literal=True)
+
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
+    )
+
+    result = gtd.add_pubchem_data(df, cfg)
+
+    assert result.loc[0, "pubchem_cid"] == "Not Found"
+
+
+def test_add_pubchem_data_reuses_resolution_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "canonical_smiles": ["C", "C"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0)
+
+    calls: list[tuple[str | None, ...]] = []
+
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] | None = None,
+        resolution_key: tuple[str | None, ...] | None = None,
+        **kwargs: object,
+    ) -> pl.PubChemResolution:
+        if resolution_cache is not None and resolution_key is not None:
+            if resolution_key in resolution_cache:
+                return resolution_cache[resolution_key]
+            calls.append(resolution_key)
+            result = pl.PubChemResolution(cid="123", source="canonical_smiles")
+            resolution_cache[resolution_key] = result
+            return result
+        raise AssertionError("resolution_cache should be provided")
+
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, cfg: pl.Properties(None, None, None, None, None, None),
+    )
+
+    result = gtd.add_pubchem_data(df, cfg)
+
+    assert len(calls) == 1
+    assert result["pubchem_cid"].tolist() == ["123", "123"]
 
 
 def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -72,10 +151,13 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     )
     cfg = pl.PubChemCfg(delay=0, prefer_local_smiles=True)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("PubChem lookup should not be called")
+    def fake_resolve(*_: object, **__: object) -> pl.PubChemResolution:
+        return pl.PubChemResolution(cid="321", source="cache")
 
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
+    def fail(*_: object, **__: object) -> None:
+        raise AssertionError("get_properties should not be called when prefer_local_smiles is enabled")
+
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
     monkeypatch.setattr(pl, "get_properties", fail)
 
     result = gtd.add_pubchem_data(df, cfg)
@@ -88,7 +170,7 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_add_pubchem_data_preserves_existing_values(
- 
+
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     df = pd.DataFrame(
@@ -101,12 +183,24 @@ def test_add_pubchem_data_preserves_existing_values(
             "pubchem_iupac_name": ["existing", "mixture", ""],
         }
     )
-    cfg = pl.PubChemCfg(delay=0, skip_polymers=True)
+    cfg = pl.PubChemCfg(
+        delay=0,
+        allow_polymer=False,
+        prefer_local_smiles=False,
+        prefer_local_values=True,
+    )
 
     calls: list[str] = []
     warnings: list[tuple[str, dict[str, object]]] = []
 
-    def fake_resolve(row: pd.Series, cache: dict[str, str | None], cfg: pl.PubChemCfg) -> str:
+    def fake_resolve(
+        row: pd.Series,
+        cache: dict[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        parent_loader: Callable[[str], pd.Series | None] | None = None,
+        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] | None = None,
+    ) -> str:
         calls.append(row["molecule_chembl_id"])
         return "333"
 
@@ -116,23 +210,10 @@ def test_add_pubchem_data_preserves_existing_values(
         gtd.logger,
         "warning",
         lambda event, **kwargs: warnings.append((event, kwargs)),
- 
-            "canonical_smiles": ["C"],
-            "pubchem_cid": ["LOCAL"],
-            "pubchem_iupac_name": ["local"],
-        }
-    )
-    cfg = pl.PubChemCfg(delay=0, prefer_local_smiles=False, prefer_local_values=True)
-
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
-    monkeypatch.setattr(
-        pl, "get_properties", lambda *_: pl.Properties(None, None, None, None, None, None)
- 
     )
 
     result = gtd.add_pubchem_data(df, cfg)
 
- 
     assert calls == ["CHEMBL3"]
     assert any(
         event == "pubchem_skip_polymers"
@@ -165,30 +246,29 @@ def test_resolve_pubchem_cid_prefers_inchikey(
     )
     cfg = pl.PubChemCfg(delay=0)
     cache: dict[str, str | None] = {}
-    calls: list[str] = []
+    captured: dict[str, str | None] = {}
 
-    def record_call(name: str) -> None:  # pragma: no cover - helper
-        calls.append(name)
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cid_cache: Mapping[str, str | None] | None = None,
+        cache_key: str | None,
+        **kwargs: object,
+    ) -> pl.PubChemResolution:
+        captured.update(identifiers)
+        assert cache_key == "CHEMBL1"
+        if isinstance(cid_cache, dict) and cache_key:
+            cid_cache[cache_key] = "10"
+        return pl.PubChemResolution(cid="10", source="standard_inchi_key")
 
-    monkeypatch.setattr(
-        pl,
-        "get_cid_from_inchikey",
-        lambda value, cfg: (record_call("inchikey"), "10|20")[1],
-    )
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("unexpected resolver invocation")
-
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-
-    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
+    cid = gtd.resolve_pubchem_cid(row, cache, cfg, resolution_cache={})
 
     assert cid == "10"
     assert cache["CHEMBL1"] == "10"
-    assert calls == ["inchikey"]
+    assert captured["standard_inchi_key"] == "ABC-KEY"
 
 
 def test_resolve_pubchem_cid_uses_pubchem_inchikey(
@@ -205,26 +285,29 @@ def test_resolve_pubchem_cid_uses_pubchem_inchikey(
     )
     cfg = pl.PubChemCfg(delay=0)
     cache: dict[str, str | None] = {}
-    calls: list[str] = []
+    captured: dict[str, str | None] = {}
 
-    def record_inchikey(value: str, _: pl.PubChemCfg) -> str:
-        calls.append(value)
-        return "77"
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cid_cache: Mapping[str, str | None] | None = None,
+        cache_key: str | None,
+        **kwargs: object,
+    ) -> pl.PubChemResolution:
+        captured.update(identifiers)
+        assert cache_key == "CHEMBL1"
+        if isinstance(cid_cache, dict) and cache_key:
+            cid_cache[cache_key] = "77"
+        return pl.PubChemResolution(cid="77", source="pubchem_inchikey")
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("unexpected resolver invocation")
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
 
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", record_inchikey)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
-
-    cid = gtd.resolve_pubchem_cid(row, cache, cfg)
+    cid = gtd.resolve_pubchem_cid(row, cache, cfg, resolution_cache={})
 
     assert cid == "77"
     assert cache["CHEMBL1"] == "77"
-    assert calls == ["XYZ-KEY"]
+    assert captured["pubchem_inchikey"] == "XYZ-KEY"
 
 
 def test_resolve_pubchem_cid_uses_parent_when_enabled(
@@ -251,27 +334,33 @@ def test_resolve_pubchem_cid_uses_parent_when_enabled(
 
     calls: list[str] = []
 
-    def record_inchikey(value: str, _: pl.PubChemCfg) -> str:
-        calls.append(value)
-        return "42"
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cid_cache: Mapping[str, str | None] | None = None,
+        cache_key: str | None,
+        **kwargs: object,
+    ) -> pl.PubChemResolution:
+        calls.append(cache_key or "")
+        if cache_key == "CHEMBL1":
+            return pl.PubChemResolution(cid="42", source="standard_inchi_key")
+        return pl.PubChemResolution(cid=None, source=None)
 
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", record_inchikey)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", lambda *_: None)
-    monkeypatch.setattr(pl, "get_cid", lambda *_: None)
-    monkeypatch.setattr(pl, "get_all_cid", lambda *_: None)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", lambda *_: None)
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
 
     cid = gtd.resolve_pubchem_cid(
         child_row,
         cache,
         cfg,
         parent_loader=lambda _: parent_row,
+        resolution_cache={},
     )
 
     assert cid == "42"
     assert cache["CHEMBL1"] == "42"
     assert cache["CHEMBL2"] == "42"
-    assert calls == ["PARENT-KEY"]
+    assert calls == ["CHEMBL2", "CHEMBL1"]
 
 
 def test_resolve_pubchem_cid_logs_when_parent_missing(
@@ -292,12 +381,18 @@ def test_resolve_pubchem_cid_logs_when_parent_missing(
         events.append((event, kwargs))
 
     monkeypatch.setattr(gtd.logger, "info", capture)
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
+    )
 
     cid = gtd.resolve_pubchem_cid(
         row,
         cache,
         cfg,
         parent_loader=lambda _: None,
+        resolution_cache={},
     )
 
     assert cid is None
@@ -320,14 +415,19 @@ def test_add_pubchem_data_uses_disk_cache(
 
     cfg = pl.PubChemCfg(delay=0, cid_cache_path=cache_path)
 
-    def fail(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("PubChem lookup should not be called")
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cid_cache: Mapping[str, str | None] | None = None,
+        cache_key: str | None = None,
+        **__: object,
+    ) -> pl.PubChemResolution:
+        assert cache_key == "CHEMBL1"
+        assert cid_cache is not None and cid_cache.get("CHEMBL1") == "321"
+        return pl.PubChemResolution(cid="321", source="cache")
 
-    monkeypatch.setattr(pl, "get_cid_from_inchikey", fail)
-    monkeypatch.setattr(pl, "get_cid_from_inchi", fail)
-    monkeypatch.setattr(pl, "get_cid", fail)
-    monkeypatch.setattr(pl, "get_all_cid", fail)
-    monkeypatch.setattr(pl, "get_cid_from_smiles", fail)
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
 
     props = pl.Properties("name", "formula", "i", "c", "inchi", "inchikey")
     monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: props)
@@ -396,7 +496,11 @@ def test_run_chembl_column_order(
         lambda *_, **__: {},
     )
 
-    monkeypatch.setattr(gtd, "add_pubchem_data", lambda df, cfg: df)
+    monkeypatch.setattr(
+        gtd,
+        "add_pubchem_data",
+        lambda df, cfg, **__: df,
+    )
     captured_precomputed: dict[str, object] = {"data": None, "frame": None}
 
     def fake_attach_parent_molecule_ids(frame: pd.DataFrame, **kwargs: object):
@@ -485,6 +589,11 @@ def test_run_chembl_initialises_pubchem_session(
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, pubchem_cfg, **__: frame)
     monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *_, **__: {},
+    )
 
     monkeypatch.setattr(
         gtd,
@@ -657,7 +766,12 @@ def test_run_chembl_updates_parent_cache_and_reuses_results(
     fetch_calls: list[list[str]] = []
 
     def fake_fetch(
-        ids: Iterable[str], *, client: object, api_cfg: object, timeout: float | None
+        ids: Iterable[str],
+        *,
+        client: object,
+        api_cfg: object,
+        timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         normalised = sorted(ids)
         fetch_calls.append(normalised)
@@ -996,6 +1110,7 @@ def test_attach_parent_molecule_ids_fetches_missing(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         captured_ids["ids"] = list(ids)
         return fetched
@@ -1063,6 +1178,7 @@ def test_attach_parent_molecule_ids_skips_filled_children(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         ordered = [str(child) for child in ids]
         fetch_calls.append(ordered)
@@ -1122,6 +1238,7 @@ def test_attach_parent_molecule_ids_prefers_partial_fetch_when_complete(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         ordered = sorted(ids)
         fetch_calls.append(ordered)
@@ -1249,6 +1366,7 @@ def test_attach_parent_molecule_ids_handles_partial_remote_success(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         assert ids == ["CHEMBL1", "CHEMBL2"]
         return remote_result
@@ -1300,6 +1418,7 @@ def test_attach_parent_molecule_ids_updates_cache_for_reuse(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         fetch_calls.append(list(ids))
         return {"CHEMBL2": "CHEMBL2_PARENT"}
@@ -1440,6 +1559,7 @@ def test_attach_parent_molecule_ids_fetch_failure(
         client: object,
         api_cfg: object,
         timeout: float | None,
+        catalog_cfg: object | None = None,
     ) -> dict[str, str]:
         raise requests.RequestException("boom")
 

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -161,6 +161,73 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
 
 
 @responses.activate
+def test_resolve_pubchem_record_falls_back_to_inchikey(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolver should try subsequent identifiers when earlier ones fail."""
+
+    cfg = pl.PubChemCfg(delay=0, backoff_initial_seconds=0, retries=3)
+    monkeypatch.setattr(
+        pl,
+        "get_limiter",
+        lambda *args, **kwargs: type("L", (), {"acquire": lambda self: None})(),
+    )
+
+    identifiers = {
+        "canonical_smiles": "C",
+        "standard_inchi_key": "AAA",
+    }
+
+    smiles_url = f"{cfg.base.rstrip('/')}/compound/smiles/C/cids/JSON"
+    inchikey_url = f"{cfg.base.rstrip('/')}/compound/inchikey/AAA/cids/JSON"
+    responses.add(responses.GET, smiles_url, status=404)
+    responses.add(
+        responses.GET,
+        inchikey_url,
+        json={"IdentifierList": {"CID": [321]}},
+        status=200,
+    )
+
+    resolution = pl.resolve_pubchem_record(identifiers, cfg)
+
+    assert resolution.cid == "321"
+    assert resolution.source == "standard_inchi_key"
+
+
+@responses.activate
+def test_resolve_pubchem_record_backoff_on_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """429/5xx responses should trigger exponential backoff."""
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(pl, "sleep", lambda delay: sleeps.append(delay))
+    monkeypatch.setattr(
+        pl,
+        "get_limiter",
+        lambda *args, **kwargs: type("L", (), {"acquire": lambda self: None})(),
+    )
+
+    cfg = pl.PubChemCfg(delay=0, backoff_initial_seconds=0.1, retries=3)
+    identifiers = {"canonical_smiles": "C"}
+    url = f"{cfg.base.rstrip('/')}/compound/smiles/C/cids/JSON"
+
+    responses.add(responses.GET, url, status=429)
+    responses.add(responses.GET, url, status=503)
+    responses.add(
+        responses.GET,
+        url,
+        json={"IdentifierList": {"CID": [111]}},
+        status=200,
+    )
+
+    resolution = pl.resolve_pubchem_record(identifiers, cfg)
+
+    assert resolution.cid == "111"
+    assert sleeps == [0.1, 0.2]
+
+
+@responses.activate
 def test_get_properties_returns_none_for_missing() -> None:
     """Missing PubChem fields should be returned as ``None``."""
 


### PR DESCRIPTION
## Summary
- extend the PubChem configuration schema with toggles for enablement, lookup order, timing, and output preferences
- rework the PubChem resolver to respect the configured lookup order, apply exponential backoff, and reuse cached results inside `get_testitem_data`
- update CLI/config plumbing and tests to cover the new behaviour, including caching, disablement, and status-aware fallbacks

## Testing
- pytest tests/test_pubchem_library.py tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d697a2d23c83249b2027190b62cd6e