### PR TITLE
Infer target cellularity without CLI organism CSV

### DIFF
--- a/library/organism_classification.py
+++ b/library/organism_classification.py
@@ -1,0 +1,114 @@
+"""Utilities for deriving organism cellularity information from taxonomy."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+DEFAULT_TYPE = "-"
+VIRAL_SUPERKINGDOMS = {"viruses"}
+UNICELLULAR_SUPERKINGDOMS = {"bacteria", "archaea"}
+VIRAL_KEYWORDS: tuple[str, ...] = ("virus", "phage")
+UNICELLULAR_PHYLUMS = {
+    "amoebozoa",
+    "bacillati",
+    "cryptista",
+    "discoba",
+    "fungi",
+    "haptista",
+    "metamonada",
+    "methanobacteriati",
+    "myzozoa",
+    "pseudomonadati",
+    "sar",
+    "thermotogati",
+}
+
+
+def _normalise_token(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    if pd.isna(value):  # type: ignore[arg-type]
+        return ""
+    return str(value).strip()
+
+
+def _is_viral(genus: str, superkingdom: str) -> bool:
+    if superkingdom.lower() in VIRAL_SUPERKINGDOMS:
+        return True
+    genus_lower = genus.lower()
+    return any(token in genus_lower for token in VIRAL_KEYWORDS)
+
+
+def _is_unicellular(superkingdom: str, phylum: str, lineage_class: str) -> bool:
+    if superkingdom.lower() in UNICELLULAR_SUPERKINGDOMS:
+        return True
+    tokens: Iterable[str] = (phylum.lower(), lineage_class.lower())
+    return any(token in UNICELLULAR_PHYLUMS for token in tokens if token)
+
+
+def add_cellularity_smart(
+    df: pd.DataFrame,
+    *,
+    genus_col: str = "genus",
+    superkingdom_col: str = "superkingdom",
+    phylum_col: str = "phylum",
+    lineage_class_col: str = "lineage_class",
+    taxon_id_col: str = "taxon_id",
+) -> pd.DataFrame:
+    """Return organism cellularity derived from taxonomy hints.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing organism taxonomy columns.
+    genus_col, superkingdom_col, phylum_col, lineage_class_col, taxon_id_col:
+        Column names providing genus and taxonomy attributes. Missing columns
+        are treated as empty strings.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Two-column frame with ``genus`` and the inferred ``type`` suitable for
+        :func:`library.target_postprocessing.finalise_targets`.
+    """
+
+    if genus_col not in df.columns:
+        return pd.DataFrame({"genus": pd.Series(dtype="string"), "type": pd.Series(dtype="string")})
+
+    genus = df[genus_col].astype("string")
+    superkingdom = df.get(superkingdom_col, pd.Series(index=df.index, dtype="string")).astype("string")
+    phylum = df.get(phylum_col, pd.Series(index=df.index, dtype="string")).astype("string")
+    lineage_class = df.get(lineage_class_col, pd.Series(index=df.index, dtype="string")).astype("string")
+
+    records = []
+    for g, sk, ph, lc in zip(genus, superkingdom, phylum, lineage_class, strict=False):
+        g_norm = _normalise_token(g)
+        if not g_norm:
+            continue
+        sk_norm = _normalise_token(sk)
+        ph_norm = _normalise_token(ph)
+        lc_norm = _normalise_token(lc)
+        if _is_viral(g_norm, sk_norm):
+            inferred = "Viruses"
+        elif _is_unicellular(sk_norm, ph_norm, lc_norm):
+            inferred = "Unicellular organism"
+        elif sk_norm:
+            inferred = "Multicellular organism"
+        else:
+            inferred = DEFAULT_TYPE
+        records.append((g_norm, inferred))
+
+    if not records:
+        return pd.DataFrame({"genus": pd.Series(dtype="string"), "type": pd.Series(dtype="string")})
+
+    priority = {"Viruses": 3, "Unicellular organism": 2, "Multicellular organism": 1, DEFAULT_TYPE: 0}
+    df_records = pd.DataFrame(records, columns=["genus", "type"])
+    df_records = df_records.sort_values(by="type", key=lambda s: s.map(priority).fillna(0), ascending=False)
+    deduplicated = df_records.drop_duplicates(subset="genus", keep="first")
+    deduplicated["type"] = deduplicated["type"].astype("string")
+    return deduplicated.reset_index(drop=True)
+

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -28,6 +28,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import io
 from library import iuphar_library as ii
+from library import organism_classification
 from library import target_postprocessing as tp
 from library import protein_classification as pc
 from library import uniprot_library as uu
@@ -348,15 +349,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=30.0,
         help="Timeout in seconds for each HTTP request",
-    )
-    all_cmd.add_argument(
-        "--organism-csv",
-        type=Path,
-        default=None,
-        help=(
-            "CSV mapping 'genus' to organism 'type' for finalisation "
-            "(default: config resources.organism_csv)"
-        ),
     )
     all_cmd.add_argument(
         "--uniprot-column",
@@ -1013,11 +1005,13 @@ def merge_results(
         classifier = pc.classifier_from_config(cfg)
     merged = pc.append_protein_class_predictions(merged, classifier)
     processed = tp.postprocess_targets(merged)
-    organism_df = pd.read_csv(
-        cfg.target.all.organism_csv,
-        sep=cfg.io.csv_sep,
-        encoding=cfg.io.csv_encoding,
-        dtype=str,
+    organism_df = organism_classification.add_cellularity_smart(
+        merged,
+        genus_col="genus",
+        superkingdom_col="superkingdom",
+        phylum_col="phylum",
+        lineage_class_col="lineage_class",
+        taxon_id_col="taxon_id",
     )
     final_df = tp.finalise_targets(processed, organism_df)
     logger.info("merge_results_done", rows=len(final_df))
@@ -1184,7 +1178,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "data_dir": "target.all.data_dir",
                 "target_csv": "target.all.target_csv",
                 "family_csv": "target.all.family_csv",
-                "organism_csv": "target.all.organism_csv",
                 "uniprot_column": "target.all.uniprot_column",
                 "chembl_out": "target.all.chembl_out",
                 "uniprot_out": "target.all.uniprot_out",

--- a/tests/test_get_target_data_all.py
+++ b/tests/test_get_target_data_all.py
@@ -59,14 +59,14 @@ def test_run_all_uses_local_inputs(
     chembl_data = Path("tests/data/chembl_targets_min.csv")
     uniprot_data = Path("tests/data/uniprot_targets_min.csv")
     iuphar_data = Path("tests/data/iuphar_targets_min.csv")
-    organism_csv = Path("tests/data/organism_min.csv")
-
     original_chunk = cfg.target.chembl.chunk_size
     cfg.target.all.chunk_size = original_chunk + 2
-    cfg.target.all.organism_csv = organism_csv
     cfg.target.all.chembl_out = tmp_path / "chembl_out.csv"
     cfg.target.all.uniprot_out = tmp_path / "uniprot_out.csv"
     cfg.target.all.iuphar_out = tmp_path / "iuphar_out.csv"
+    cfg.target.all.target_csv = iuphar_data
+    cfg.target.all.family_csv = tmp_path / "family.csv"
+    cfg.target.all.family_csv.write_text("id,name\n1,Example\n")
 
     # ------------------------------------------------------------------
     # Patch network-dependent functions to use local files
@@ -103,6 +103,23 @@ def test_run_all_uses_local_inputs(
         return orig_finalise(df, organism, **kw)
 
     monkeypatch.setattr(tp, "finalise_targets", patched_finalise)
+    monkeypatch.setattr(gtd.pc, "classifier_from_config", lambda _cfg: object())
+    monkeypatch.setattr(
+        gtd.pc, "append_protein_class_predictions", lambda df, _cls: df
+    )
+
+    def fake_classification(data: pd.DataFrame, **_: object) -> pd.DataFrame:
+        if "genus" not in data:
+            return pd.DataFrame({"genus": [], "type": []})
+        genus_values = (
+            data["genus"].dropna().astype(str).str.strip().replace("", pd.NA).dropna()
+        )
+        unique = genus_values.drop_duplicates().reset_index(drop=True)
+        return pd.DataFrame({"genus": unique, "type": ["-"] * len(unique)})
+
+    monkeypatch.setattr(
+        gtd.organism_classification, "add_cellularity_smart", fake_classification
+    )
 
     # Skip strict schema validation; the goal is to exercise orchestration.
     monkeypatch.setattr(

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -224,13 +224,13 @@ def test_run_all_preserves_reaction_ec_numbers(
     chembl_data = Path("tests/data/chembl_targets_min.csv")
     uniprot_data = Path("tests/data/uniprot_targets_min.csv")
     iuphar_data = Path("tests/data/iuphar_targets_min.csv")
-    organism_csv = Path("tests/data/organism_min.csv")
-
-    cfg.target.all.organism_csv = organism_csv
     cfg.target.all.chembl_out = tmp_path / "chembl_out.csv"
     cfg.target.all.uniprot_out = tmp_path / "uniprot_out.csv"
     cfg.target.all.iuphar_out = tmp_path / "iuphar_out.csv"
     cfg.target.all.uniprot_column = "uniprot_id"
+    cfg.target.all.target_csv = iuphar_data
+    cfg.target.all.family_csv = tmp_path / "family.csv"
+    cfg.target.all.family_csv.write_text("id,name\n1,Example\n")
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         shutil.copy(chembl_data, args.output_csv)
@@ -258,6 +258,23 @@ def test_run_all_preserves_reaction_ec_numbers(
         return original_finalise(df, organism, **kwargs)
 
     monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)
+    monkeypatch.setattr(gtd.pc, "classifier_from_config", lambda _cfg: object())
+    monkeypatch.setattr(
+        gtd.pc, "append_protein_class_predictions", lambda df, _cls: df
+    )
+
+    def fake_classification(data: pd.DataFrame, **_: object) -> pd.DataFrame:
+        if "genus" not in data:
+            return pd.DataFrame({"genus": [], "type": []})
+        genus_values = (
+            data["genus"].dropna().astype(str).str.strip().replace("", pd.NA).dropna()
+        )
+        unique = genus_values.drop_duplicates().reset_index(drop=True)
+        return pd.DataFrame({"genus": unique, "type": ["-"] * len(unique)})
+
+    monkeypatch.setattr(
+        gtd.organism_classification, "add_cellularity_smart", fake_classification
+    )
     monkeypatch.setattr(
         TargetsSchema, "validate", staticmethod(lambda df, lazy=True: df)
     )

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -32,9 +32,10 @@ def test_iuphar_merge_preserves_ec_number(
     monkeypatch.setattr(tp, "finalise_targets", lambda df, org: df)
     monkeypatch.setattr(pc, "classifier_from_config", lambda cfg: None)
     monkeypatch.setattr(pc, "append_protein_class_predictions", lambda df, _cls: df)
-    cfg.target.all.organism_csv = tmp_path / "organism.csv"
-    pd.DataFrame({"genus": [], "type": []}).to_csv(
-        cfg.target.all.organism_csv, index=False
+    monkeypatch.setattr(
+        gtd.organism_classification,
+        "add_cellularity_smart",
+        lambda *_args, **_kwargs: pd.DataFrame({"genus": [], "type": []}),
     )
 
     merged = gtd.merge_results(combined_df, iuphar_df, cfg)

--- a/tests/test_organism_classification.py
+++ b/tests/test_organism_classification.py
@@ -1,0 +1,54 @@
+"""Tests for :mod:`library.organism_classification`."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from library import organism_classification as oc
+
+
+def test_add_cellularity_smart_handles_missing_columns() -> None:
+    df = pd.DataFrame({"something": ["value"]})
+
+    result = oc.add_cellularity_smart(df)
+
+    assert result.empty
+
+
+def test_add_cellularity_smart_detects_viruses() -> None:
+    df = pd.DataFrame({
+        "genus": ["Lentivirus", "Sample"],
+        "superkingdom": ["Viruses", ""],
+    })
+
+    result = oc.add_cellularity_smart(df)
+    row = result[result["genus"] == "Lentivirus"].iloc[0]
+    assert row["type"] == "Viruses"
+
+
+def test_add_cellularity_smart_detects_bacteria() -> None:
+    df = pd.DataFrame(
+        {
+            "genus": ["Escherichia"],
+            "superkingdom": ["Bacteria"],
+            "phylum": ["Pseudomonadati"],
+        }
+    )
+
+    result = oc.add_cellularity_smart(df)
+    assert result.loc[0, "type"] == "Unicellular organism"
+
+
+def test_add_cellularity_smart_distinguishes_eukaryotes() -> None:
+    df = pd.DataFrame(
+        {
+            "genus": ["Homo", "Plasmodium"],
+            "superkingdom": ["Eukaryota", "Eukaryota"],
+            "phylum": ["Chordata", "Sar"],
+        }
+    )
+
+    result = oc.add_cellularity_smart(df)
+    assert result[result["genus"] == "Homo"].iloc[0]["type"] == "Multicellular organism"
+    assert result[result["genus"] == "Plasmodium"].iloc[0]["type"] == "Unicellular organism"
+

--- a/tests/test_target_cli_organism_csv.py
+++ b/tests/test_target_cli_organism_csv.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from scripts import get_target_data as gtd
 
 
-def test_organism_csv_default_from_config(tmp_path, monkeypatch) -> None:
-    """``organism_csv`` argument should default to the config value."""
+def test_organism_csv_argument_removed(tmp_path, monkeypatch) -> None:
+    """CLI should no longer expose ``--organism-csv`` for the ``all`` command."""
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
         "sources:\n"
@@ -30,13 +28,10 @@ def test_organism_csv_default_from_config(tmp_path, monkeypatch) -> None:
         "  log:\n"
         "    level: INFO\n"
     )
-    captured: dict[str, Path] = {}
-
     def fake_run_all(cfg, args) -> int:  # type: ignore[unused-argument]
-        captured["organism_csv"] = args.organism_csv
+        assert not hasattr(args, "organism_csv")
         return 0
 
     monkeypatch.setattr(gtd, "run_all", fake_run_all)
     rc = gtd.main(["all", "--config", str(cfg_path)])
     assert rc == 0
-    assert captured["organism_csv"] == Path("dictionary/organism.csv")


### PR DESCRIPTION
## Summary
- remove the `--organism-csv` argument from the target CLI and stop wiring config overrides for it
- infer organism cellularity during result merging via a new `organism_classification.add_cellularity_smart` helper
- refresh target pipeline tests to stub the new behaviour and add dedicated coverage for the classifier

## Testing
- pytest tests/test_organism_classification.py tests/test_get_target_data_all.py tests/test_get_target_data_merge.py tests/test_get_target_data_fetch.py tests/test_target_cli_organism_csv.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a14dbcfc8324b9c3e7d6f722d015