### PR TITLE
Refine unicellular classification for target metadata

### DIFF
--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -22,6 +22,7 @@ import pandas as pd
 from .config import Config
 from .io import write_csv
 from .log import logger
+from . import organism_classification
 
 EntityName = Literal[
     "activity",
@@ -477,6 +478,19 @@ def process_activity_table(
 
     targets = pd.read_csv(
         targets_path,
+        usecols=[
+            "target_chembl_id",
+            "IUPHAR_class",
+            "IUPHAR_subclass",
+            "gene_index",
+            "taxon_index",
+            "target_sort_order",
+            "multifunctional_enzyme",
+            "genus",
+            "superkingdom",
+            "phylum",
+            "taxon_id",
+        ],
         dtype={
             "target_chembl_id": "string",
             "IUPHAR_class": "string",
@@ -485,7 +499,10 @@ def process_activity_table(
             "gene_index": "string",
             "target_sort_order": "string",
             "multifunctional_enzyme": "string",
-            "organism_type": "string",
+            "genus": "string",
+            "superkingdom": "string",
+            "phylum": "string",
+            "taxon_id": "string",
         },
     )
 
@@ -497,9 +514,10 @@ def process_activity_table(
                 "multifunctional_enzyme",
                 "IUPHAR_class",
                 "IUPHAR_subclass",
-                "organism_type",
-                "IUPHAR_class",
-                "IUPHAR_subclass",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
                 "gene_index",
                 "taxon_index",
             ]
@@ -515,16 +533,16 @@ def process_activity_table(
         df["multifunctional_enzyme"], "multifunctional_enzyme"
     )
 
-    mapping = {
-        "Multicellular organism": False,
-        "Viruses": True,
-        "Unicellular organism": True,
-    }
-    df["unicellular_organism"] = _safe_to_bool(
-        df["organism_type"].map(mapping), "unicellular_organism"
-    ).fillna(False)
+    df = organism_classification.add_cellularity_smart(
+        df,
+        genus_col="genus",
+        superkingdom_col="superkingdom",
+        phylum_col="phylum",
+        taxon_id_col="taxon_id",
+        output_col="unicellular_organism",
+    )
 
-    df.drop(columns=["organism_type"], inplace=True)
+    df.drop(columns=["genus", "superkingdom", "phylum", "taxon_id"], inplace=True)
 
     # --- final ordering ----------------------------------------------------
     final_cols = [

--- a/library/organism_classification.py
+++ b/library/organism_classification.py
@@ -1,0 +1,110 @@
+"""Utilities for classifying organism cellularity.
+
+This module provides helpers to derive a ``unicellular_organism`` flag
+from basic taxonomic annotations available in ChEMBL dictionaries.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+# Known taxonomic groups that are predominantly unicellular.  The values are
+# stored in lower case to simplify string normalisation via ``str.casefold``.
+_UNICELLULAR_SUPERKINGDOMS: set[str] = {
+    "bacteria",
+    "archaea",
+    "viruses",
+}
+
+_UNICELLULAR_EUKARYOTIC_PHYLA: set[str] = {
+    "sar",
+    "discoba",
+}
+
+_UNICELLULAR_EUKARYOTIC_GENERA: set[str] = {
+    "candida",
+    "chlamydomonas",
+    "crithidia",
+    "cryptosporidium",
+    "eimeria",
+    "leishmania",
+    "malassezia",
+    "plasmodium (laverania)",
+    "plasmodium (plasmodium)",
+    "pneumocystis",
+    "schizotrypanum",
+    "toxoplasma",
+    "trypanosoma",
+}
+
+_VIRUS_TAXON_IDS: set[str] = {
+    "10246",
+    "11082",
+    "11676",
+    "11709",
+    "11908",
+    "11926",
+    "169066",
+    "211044",
+    "266827",
+    "2697049",
+    "3052230",
+    "31647",
+    "343983",
+    "365124",
+    "382835",
+    "64320",
+    "648213",
+    "694009",
+}
+
+
+def _normalise(series: pd.Series) -> pd.Series:
+    """Strip and case-fold string values for robust comparisons."""
+
+    return (
+        series.astype("string")
+        .str.strip()
+        .str.replace("\\s+", " ", regex=True)
+        .str.casefold()
+    )
+
+
+def _any_in(values: pd.Series, options: Iterable[str]) -> pd.Series:
+    """Check whether entries belong to a predefined set."""
+
+    return values.isin(set(options))
+
+
+def add_cellularity_smart(
+    df: pd.DataFrame,
+    *,
+    genus_col: str,
+    superkingdom_col: str,
+    phylum_col: str,
+    taxon_id_col: str | None = None,
+    output_col: str = "unicellular_organism",
+) -> pd.DataFrame:
+    """Annotate unicellular organisms based on taxonomic context."""
+
+    genus = _normalise(df.get(genus_col, pd.Series(dtype="string")))
+    superkingdom = _normalise(df.get(superkingdom_col, pd.Series(dtype="string")))
+    phylum = _normalise(df.get(phylum_col, pd.Series(dtype="string")))
+    if taxon_id_col:
+        taxon_id = _normalise(df.get(taxon_id_col, pd.Series(dtype="string")))
+    else:
+        taxon_id = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    unicellular = pd.Series(False, index=df.index, dtype="boolean")
+
+    unicellular |= _any_in(superkingdom, _UNICELLULAR_SUPERKINGDOMS)
+    unicellular |= _any_in(taxon_id, _VIRUS_TAXON_IDS)
+
+    eukaryotic = superkingdom == "eukaryota"
+    unicellular |= eukaryotic & _any_in(phylum, _UNICELLULAR_EUKARYOTIC_PHYLA)
+    unicellular |= eukaryotic & _any_in(genus, _UNICELLULAR_EUKARYOTIC_GENERA)
+
+    df[output_col] = unicellular.fillna(False)
+    return df

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -525,7 +525,10 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
                 "taxon_index",
                 "target_sort_order",
                 "multifunctional_enzyme",
-                "organism_type",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
             ]
         )
         + "\n"
@@ -538,7 +541,10 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
                 "",
                 "",
                 "True",
-                "Unicellular organism",
+                "Escherichia",
+                "Bacteria",
+                "Pseudomonadota",
+                "511145",
             ]
         )
         + "\n"
@@ -635,10 +641,13 @@ def test_process_activity_table_without_nstereo(tmp_path: Path) -> None:
                 "taxon_index",
                 "target_sort_order",
                 "multifunctional_enzyme",
-                "organism_type",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
             ]
         )
-        + "\nT1,,,,,, ,Multicellular organism\n"
+        + "\nT1,,,,,, ,Homo,Eukaryota,Chordata,9606\n"
     )
 
     res = process_activity_table(df, tmp_path)
@@ -699,10 +708,13 @@ def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
                 "taxon_index",
                 "target_sort_order",
                 "multifunctional_enzyme",
-                "organism_type",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
             ]
         )
-        + "\nT1,ClassB,, , , ,False,Viruses\n"
+        + "\nT1,ClassB,, , , ,False,,Viruses,,11676\n"
     )
 
     res = process_activity_table(df, tmp_path)


### PR DESCRIPTION
## Summary
- limit `targets_type.csv` ingestion to the taxonomy/service columns that are used during activity initialisation
- derive the `unicellular_organism` flag with the new `organism_classification.add_cellularity_smart` helper based on taxonomy
- adjust the activity initialisation tests to reflect the taxonomy-driven classification logic

## Testing
- pytest tests/test_input_initialisation_library.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6a1756f90832489bdf8d1c76f0bc2