### PR TITLE
Add reusable organism cellularity classification module

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -24,6 +24,17 @@ from .document_type_terms import (
     parse_terms,
 )
 from .logging_setup import Logger, LoggerConfig, configure_logger
+from .organism_classification import (
+    OrganismClassificationRules,
+    add_cellularity,
+    add_cellularity_smart,
+    classify_by_lineage,
+    classify_record,
+    normalize,
+    TYPE_MULTICELLULAR,
+    TYPE_UNICELLULAR,
+    TYPE_VIRAL,
+)
 from .parser_schema import CSVExportArgs
 from .sidecar import SidecarErrors
 from .timing import log_duration
@@ -48,4 +59,13 @@ __all__ = [
     "configure_logger",
     "CSVExportArgs",
     "log_duration",
+    "OrganismClassificationRules",
+    "add_cellularity",
+    "add_cellularity_smart",
+    "classify_by_lineage",
+    "classify_record",
+    "normalize",
+    "TYPE_MULTICELLULAR",
+    "TYPE_UNICELLULAR",
+    "TYPE_VIRAL",
 ]

--- a/library/organism_classification.py
+++ b/library/organism_classification.py
@@ -2,19 +2,43 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Sequence
 
 import pandas as pd
 
-__all__ = ["add_cellularity_smart"]
+__all__ = [
+    "OrganismClassificationRules",
+    "normalize",
+    "classify_by_lineage",
+    "classify_record",
+    "add_cellularity",
+    "add_cellularity_smart",
+    "TYPE_MULTICELLULAR",
+    "TYPE_UNICELLULAR",
+    "TYPE_VIRAL",
+]
 
+# ===== Text labels =====
 TYPE_MULTICELLULAR = "Multicellular organism"
 TYPE_UNICELLULAR = "Unicellular organism"
 TYPE_VIRAL = "Viruses"
 
-_VIRAL_SUPERKINGDOMS: frozenset[str] = frozenset({"viruses"})
-_UNICELLULAR_SUPERKINGDOMS: frozenset[str] = frozenset({"bacteria", "archaea"})
-_UNICELLULAR_PHYLUM: frozenset[str] = frozenset(
+# ===== Defaults =====
+DEFAULT_GENUS_COLUMN = "genus"
+DEFAULT_SUPERKINGDOM_COLUMN = "lineage_superkingdom"
+DEFAULT_PHYLUM_COLUMN = "lineage_phylum"
+DEFAULT_CLASS_COLUMN = "lineage_class"
+DEFAULT_OUTPUT_COLUMN = "type"
+
+DEFAULT_NULL_LITERALS: frozenset[str] = frozenset({"nan", "none", "-", "na"})
+TAXONOMY_SEPARATORS: Sequence[str] = ("|", ";")
+EMPTY_VALUE = ""
+
+# ===== Rule lists =====
+DEFAULT_VIRAL_SUPERKINGDOMS: frozenset[str] = frozenset({"viruses"})
+DEFAULT_UNICELLULAR_SUPERKINGDOMS: frozenset[str] = frozenset({"bacteria", "archaea"})
+DEFAULT_UNICELLULAR_PHYLA: frozenset[str] = frozenset(
     {
         "apicomplexa",
         "amoebozoa",
@@ -26,7 +50,7 @@ _UNICELLULAR_PHYLUM: frozenset[str] = frozenset(
         "microsporidia",
     }
 )
-_UNICELLULAR_CLASSES: frozenset[str] = frozenset(
+DEFAULT_UNICELLULAR_CLASSES: frozenset[str] = frozenset(
     {
         "aconoidasida",
         "conoidasida",
@@ -37,7 +61,7 @@ _UNICELLULAR_CLASSES: frozenset[str] = frozenset(
         "chlorophyceae",
     }
 )
-_UNICELLULAR_GENUS: frozenset[str] = frozenset(
+DEFAULT_UNICELLULAR_GENERA: frozenset[str] = frozenset(
     {
         "candida",
         "malassezia",
@@ -47,88 +71,173 @@ _UNICELLULAR_GENUS: frozenset[str] = frozenset(
 )
 
 
-def _normalise(value: object | None) -> str:
+@dataclass(frozen=True)
+class OrganismClassificationRules:
+    """Configuration container for cellularity heuristics."""
+
+    viral_superkingdoms: frozenset[str] = field(
+        default_factory=lambda: DEFAULT_VIRAL_SUPERKINGDOMS
+    )
+    unicellular_superkingdoms: frozenset[str] = field(
+        default_factory=lambda: DEFAULT_UNICELLULAR_SUPERKINGDOMS
+    )
+    unicellular_phyla: frozenset[str] = field(
+        default_factory=lambda: DEFAULT_UNICELLULAR_PHYLA
+    )
+    unicellular_classes: frozenset[str] = field(
+        default_factory=lambda: DEFAULT_UNICELLULAR_CLASSES
+    )
+    unicellular_genera: frozenset[str] = field(
+        default_factory=lambda: DEFAULT_UNICELLULAR_GENERA
+    )
+    labels: Sequence[str] = field(
+        default_factory=lambda: (TYPE_MULTICELLULAR, TYPE_UNICELLULAR, TYPE_VIRAL)
+    )
+    null_literals: frozenset[str] = field(default_factory=lambda: DEFAULT_NULL_LITERALS)
+
+    def label_multicellular(self) -> str:
+        return self.labels[0]
+
+    def label_unicellular(self) -> str:
+        return self.labels[1]
+
+    def label_viral(self) -> str:
+        return self.labels[2]
+
+
+DEFAULT_RULES = OrganismClassificationRules()
+
+
+def normalize(value: object | None, *, rules: OrganismClassificationRules = DEFAULT_RULES) -> str:
+    """Return a lowercase normalised taxonomy token."""
+
+    if isinstance(value, pd.Series):
+        raise TypeError("normalize expects a scalar value")
     if value is None:
-        return ""
-    if isinstance(value, float) and pd.isna(value):
-        return ""
+        return EMPTY_VALUE
+    try:
+        if pd.isna(value):
+            return EMPTY_VALUE
+    except TypeError:
+        pass
+
     text = str(value).strip()
     if not text:
-        return ""
+        return EMPTY_VALUE
     lowered = text.lower()
-    if lowered in {"nan", "none", "-", "na"}:
-        return ""
+    if lowered in rules.null_literals:
+        return EMPTY_VALUE
     return lowered
 
 
-def _tokens(value: str) -> Iterable[str]:
+def _split_taxonomy(value: str) -> Iterable[str]:
     if not value:
         return ()
-    return [token.strip() for token in value.replace(";", "|").split("|") if token.strip()]
+
+    tokens = [value]
+    for separator in TAXONOMY_SEPARATORS:
+        tokens = [token for chunk in tokens for token in chunk.split(separator)]
+    return (token.strip() for token in tokens if token.strip())
 
 
-def _classify_row(
+def classify_by_lineage(
+    *,
     genus: str,
     superkingdom: str,
     phylum: str,
     klass: str,
+    rules: OrganismClassificationRules = DEFAULT_RULES,
 ) -> str:
-    if superkingdom in _VIRAL_SUPERKINGDOMS:
-        return TYPE_VIRAL
-    if superkingdom in _UNICELLULAR_SUPERKINGDOMS:
-        return TYPE_UNICELLULAR
+    """Classify an organism using lineage information."""
 
-    if any(token in _UNICELLULAR_PHYLUM for token in _tokens(phylum)):
-        return TYPE_UNICELLULAR
-    if any(token in _UNICELLULAR_CLASSES for token in _tokens(klass)):
-        return TYPE_UNICELLULAR
-    if genus in _UNICELLULAR_GENUS:
-        return TYPE_UNICELLULAR
-    return TYPE_MULTICELLULAR
+    if superkingdom in rules.viral_superkingdoms:
+        return rules.label_viral()
+    if superkingdom in rules.unicellular_superkingdoms:
+        return rules.label_unicellular()
+
+    if any(token in rules.unicellular_phyla for token in _split_taxonomy(phylum)):
+        return rules.label_unicellular()
+    if any(token in rules.unicellular_classes for token in _split_taxonomy(klass)):
+        return rules.label_unicellular()
+    if genus in rules.unicellular_genera:
+        return rules.label_unicellular()
+
+    return rules.label_multicellular()
+
+
+def classify_record(
+    record: Mapping[str, object],
+    *,
+    genus_column: str = DEFAULT_GENUS_COLUMN,
+    superkingdom_column: str = DEFAULT_SUPERKINGDOM_COLUMN,
+    phylum_column: str = DEFAULT_PHYLUM_COLUMN,
+    class_column: str = DEFAULT_CLASS_COLUMN,
+    rules: OrganismClassificationRules = DEFAULT_RULES,
+) -> str:
+    """Infer the cellularity label for a mapping of lineage fields."""
+
+    genus = normalize(record.get(genus_column), rules=rules)
+    superkingdom = normalize(record.get(superkingdom_column), rules=rules)
+    phylum = normalize(record.get(phylum_column), rules=rules)
+    klass = normalize(record.get(class_column), rules=rules)
+    return classify_by_lineage(
+        genus=genus,
+        superkingdom=superkingdom,
+        phylum=phylum,
+        klass=klass,
+        rules=rules,
+    )
+
+
+def add_cellularity(
+    df: pd.DataFrame,
+    *,
+    genus_column: str = DEFAULT_GENUS_COLUMN,
+    superkingdom_column: str = DEFAULT_SUPERKINGDOM_COLUMN,
+    phylum_column: str = DEFAULT_PHYLUM_COLUMN,
+    class_column: str = DEFAULT_CLASS_COLUMN,
+    output_column: str = DEFAULT_OUTPUT_COLUMN,
+    rules: OrganismClassificationRules = DEFAULT_RULES,
+) -> pd.DataFrame:
+    """Return ``df`` with the inferred cellularity column appended."""
+
+    result = df.copy()
+    if result.empty:
+        result[output_column] = pd.Series(dtype="string")
+        return result
+
+    def _infer(row: pd.Series) -> str:
+        return classify_record(
+            row,
+            genus_column=genus_column,
+            superkingdom_column=superkingdom_column,
+            phylum_column=phylum_column,
+            class_column=class_column,
+            rules=rules,
+        )
+
+    result[output_column] = result.apply(_infer, axis=1).astype("string")
+    return result
 
 
 def add_cellularity_smart(
     df: pd.DataFrame,
     *,
-    genus_col: str = "genus",
-    superkingdom_col: str = "lineage_superkingdom",
-    phylum_col: str = "lineage_phylum",
-    class_col: str = "lineage_class",
-    output_col: str = "type",
+    genus_col: str = DEFAULT_GENUS_COLUMN,
+    superkingdom_col: str = DEFAULT_SUPERKINGDOM_COLUMN,
+    phylum_col: str = DEFAULT_PHYLUM_COLUMN,
+    class_col: str = DEFAULT_CLASS_COLUMN,
+    output_col: str = DEFAULT_OUTPUT_COLUMN,
+    rules: OrganismClassificationRules = DEFAULT_RULES,
 ) -> pd.DataFrame:
-    """Return ``df`` with an inferred organism cellularity column.
+    """Backward-compatible wrapper around :func:`add_cellularity`."""
 
-    The classification relies on UniProt taxonomy fields. Viruses are detected
-    from the superkingdom, bacteria and archaea default to unicellular and a set
-    of unicellular eukaryote phyla/classes cover protozoa, yeasts and algae.
-
-    Parameters
-    ----------
-    df:
-        Input table containing taxonomy information.
-    genus_col, superkingdom_col, phylum_col, class_col:
-        Column names holding genus and taxonomy lineage values.
-    output_col:
-        Name of the created column. Defaults to ``"type"``.
-
-    Returns
-    -------
-    pandas.DataFrame
-        Copy of ``df`` with the ``output_col`` column appended. The column uses
-        string dtype.
-    """
-
-    result = df.copy()
-    if result.empty:
-        result[output_col] = pd.Series(dtype="string")
-        return result
-
-    def _infer(row: pd.Series) -> str:
-        genus = _normalise(row.get(genus_col))
-        superkingdom = _normalise(row.get(superkingdom_col))
-        phylum = _normalise(row.get(phylum_col))
-        klass = _normalise(row.get(class_col))
-        return _classify_row(genus, superkingdom, phylum, klass)
-
-    result[output_col] = result.apply(_infer, axis=1).astype("string")
-    return result
+    return add_cellularity(
+        df,
+        genus_column=genus_col,
+        superkingdom_column=superkingdom_col,
+        phylum_column=phylum_col,
+        class_column=class_col,
+        output_column=output_col,
+        rules=rules,
+    )

--- a/tests/test_organism_classification.py
+++ b/tests/test_organism_classification.py
@@ -1,0 +1,112 @@
+import pandas as pd
+
+from library.organism_classification import (
+    TYPE_MULTICELLULAR,
+    TYPE_UNICELLULAR,
+    TYPE_VIRAL,
+    add_cellularity,
+    add_cellularity_smart,
+    classify_by_lineage,
+    classify_record,
+    normalize,
+)
+
+
+def test_normalize_handles_missing_values():
+    assert normalize(None) == ""
+    assert normalize("  ") == ""
+    assert normalize("NA") == ""
+    assert normalize(float("nan")) == ""
+    assert normalize(pd.NA) == ""
+
+
+def test_classify_by_lineage_prioritises_superkingdom():
+    result = classify_by_lineage(
+        genus="candida",
+        superkingdom="viruses",
+        phylum="",
+        klass="",
+    )
+    assert result == TYPE_VIRAL
+
+
+def test_classify_record_uses_all_lineage_levels():
+    record = {
+        "genus": "Chlamydomonas",
+        "lineage_superkingdom": "Eukaryota",
+        "lineage_phylum": "",
+        "lineage_class": "",
+    }
+    assert classify_record(record) == TYPE_UNICELLULAR
+
+
+def test_classify_by_phylum_and_class():
+    assert (
+        classify_by_lineage(
+            genus=normalize(""),
+            superkingdom=normalize("Eukaryota"),
+            phylum=normalize("Apicomplexa"),
+            klass=normalize(""),
+        )
+        == TYPE_UNICELLULAR
+    )
+    assert (
+        classify_by_lineage(
+            genus=normalize(""),
+            superkingdom=normalize("Eukaryota"),
+            phylum=normalize(""),
+            klass=normalize("Saccharomycetes"),
+        )
+        == TYPE_UNICELLULAR
+    )
+
+
+def test_classify_returns_multicellular_by_default():
+    assert (
+        classify_by_lineage(
+            genus="Homo",
+            superkingdom="Eukaryota".lower(),
+            phylum="Chordata",
+            klass="Mammalia",
+        )
+        == TYPE_MULTICELLULAR
+    )
+
+
+def test_add_cellularity_adds_column_with_string_dtype():
+    df = pd.DataFrame(
+        {
+            "genus": ["Candida", None],
+            "lineage_superkingdom": ["Eukaryota", "Bacteria"],
+            "lineage_phylum": ["", ""],
+            "lineage_class": ["", ""],
+        }
+    )
+
+    result = add_cellularity(df)
+    assert result is not df
+    assert list(result["type"]) == [TYPE_UNICELLULAR, TYPE_UNICELLULAR]
+    assert str(result["type"].dtype) == "string"
+
+
+def test_add_cellularity_smart_allows_custom_columns():
+    df = pd.DataFrame(
+        {
+            "GenusName": ["Homo"],
+            "SuperKingdom": ["Eukaryota"],
+            "PhylumName": ["Chordata"],
+            "ClassName": ["Mammalia"],
+        }
+    )
+
+    result = add_cellularity_smart(
+        df,
+        genus_col="GenusName",
+        superkingdom_col="SuperKingdom",
+        phylum_col="PhylumName",
+        class_col="ClassName",
+        output_col="OrganismType",
+    )
+
+    assert list(result["OrganismType"]) == [TYPE_MULTICELLULAR]
+    assert str(result["OrganismType"].dtype) == "string"


### PR DESCRIPTION
## Summary
- replace the organism classification helper with a configurable rules container and reusable functions
- expose the classification utilities from the package init for downstream importers
- add focused unit tests that cover lineage precedence and missing data handling

## Testing
- pytest tests/test_organism_classification.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a76cbeb08324a7d01b69579f9110