### PR TITLE
Update README Quick Start CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ pre-commit run --all-files
    files, run one of the data pipelines, for example:
 
   ```bash
-  python -m library.utils.cli_tools.mapper_main --input tests/data/assays.csv \
-      --output out/mapped.csv --log-level DEBUG
-  python -m library.utils.cli_tools.table_quality_main --input tests/data/assays.csv \
-      --output out/report.csv --log-level INFO
+  python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
+      --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
+  python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
+      --output out/quality --table-name chembl_targets --log-level INFO
   ```
+
+  Во втором примере аргумент `--output` должен указывать на каталог, в котором
+  будут созданы файлы отчёта.
 
 4. **Run the tests** – see [Тесты](#тесты).
 


### PR DESCRIPTION
## Summary
- refresh the Quick Start mapper example to use the bundled chembl_targets_min dataset and specify the target column
- correct the table_quality command to point at existing input data, an output directory, and the required table name
- clarify that the table quality output parameter expects a directory for generated reports

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d6b4724918832490aa4e53d6a8073c