### PR TITLE
docs: align usage guides with available fixtures

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -23,6 +23,10 @@ arguments with the final values.
 Before any network calls the utilities invoke `library.config.ensure_dirs`, ensuring that `local.io.output_dir` and
 `local.io.cache_dir` exist (subject to `local.io.exist_ok`).
 
+### Sample inputs
+
+The repository includes a few compact fixtures under `tests/data/` for smoke-level experimentation (for example, `tests/data/activity_ids_small.csv` and `tests/data/input-smoke/testitem.csv`). Pipelines without bundled samples require user-provided CSVs that expose the identifier column referenced in `config.yaml` or overridden via `--column`.
+
 ### Monitoring structured logs
 
 All entry points rely on `library.logging_setup.Logger` and emit JSON lines enriched with a unique `run_id` and context such as `status`/`rps`. Key lifecycle events include:
@@ -47,12 +51,13 @@ Adjust verbosity with `--log-level DEBUG` for troubleshooting, or rely on the de
 
 ```bash
 python scripts/get_activity_data.py \
-  --input data/input-smoke/activity.csv \
-  --column activity_chembl_id \
+  --input tests/data/activity_ids_small.csv \
+  --column activity_id \
   --batch-size 25 \
   --timeout 45
 ```
 
+* The repository ships `tests/data/activity_ids_small.csv` for smoke-style runs; override `--column` to the file header (`activity_id`) or rename the column to `activity_chembl_id` to rely on defaults.
 * Reads the column configured at `sources.chembl.pipelines.activity.column` (`activity_chembl_id` by default).
 * Writes the main CSV, `*.meta.yaml`, optional `*_failure_cases.csv` and quality reports.
 * Supports `--limit` to restrict the number of identifiers and `--dry-run` to validate inputs without API calls.
@@ -63,30 +68,30 @@ python scripts/get_activity_data.py \
 
 ```bash
 python scripts/get_assay_data.py \
-  --input data/input-smoke/assay.csv \
+  --input path/to/assay_ids.csv \
   --column assay_chembl_id \
   --batch-size 25
 ```
 
-Fetches assay metadata from ChEMBL using the configured identifier column.
+Fetches assay metadata from ChEMBL using the configured identifier column. Prepare a CSV with a single header named `assay_chembl_id` (or pass `--column` to match your file). The project does not contain a bundled smoke file for assays.
 
 ## Document metadata (`get_document_data.py`)
 
 ```bash
 python scripts/get_document_data.py all \
-  --input data/input-smoke/documents.csv \
+  --input path/to/documents.csv \
   --column document_chembl_id \
   --batch-size 20
 ```
 
-The script merges ChEMBL and PubMed sources. Use the exposed flags (`--batch-size`, `--timeout`, `--limit`, `--dry-run`) for
+The script merges ChEMBL and PubMed sources. Prepare a CSV with the `document_chembl_id` column or override `--column` to match your schema—the repository does not bundle a smoke dataset for this pipeline. Use the exposed flags (`--batch-size`, `--timeout`, `--limit`, `--dry-run`) for
 one-off tweaks. Nested parameters such as the PubMed batch size are managed via configuration or environment variables, for
 example:
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
   python scripts/get_document_data.py \
-    --input data/input-smoke/documents.csv \
+    --input path/to/documents.csv \
     --column document_chembl_id
 ```
 
@@ -98,37 +103,37 @@ allowed switches (for example, `--batch-size` for PubMed batching).
 
 ```bash
 python scripts/get_document_data.py pubmed \
-  --input data/input-smoke/documents.csv \
+  --input path/to/documents.csv \
   --column document_chembl_id \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
-  --fallback-doi-csv data/input-smoke/doi_overrides.csv \
+  --fallback-doi-csv path/to/doi_overrides.csv \
   --fallback-doi-pmid-column pmid_override \
   --fallback-doi-value-column doi_override
 ```
 
 Use the on-demand rate limit switches to try faster OpenAlex or CrossRef lookups without touching the YAML file; the fallback
-CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried.【F:scripts/get_document_data.py†L989-L1041】
+CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried. Provide a CSV with the columns referenced by `--fallback-doi-pmid-column` and `--fallback-doi-value-column` (the default headers are `pmid_override` and `doi_override`).【F:scripts/get_document_data.py†L989-L1041】
  
 ## Target aggregation (`get_target_data.py`)
 
 ```bash
 python scripts/get_target_data.py \
-  --input data/input-smoke/targets.csv \
+  --input path/to/targets.csv \
   --column target_chembl_id
 ```
 
-Combines ChEMBL, UniProt and IUPHAR sources according to `sources.chembl.pipelines.target.*`.
+Combines ChEMBL, UniProt and IUPHAR sources according to `sources.chembl.pipelines.target.*`. Create a CSV with a `target_chembl_id` header (one identifier per row) to execute the pipeline; no fixture ships with the repository.
 
 ## Test item enrichment (`get_testitem_data.py`)
 
 ```bash
 python scripts/get_testitem_data.py \
-  --input data/input-smoke/testitem.csv \
+  --input tests/data/input-smoke/testitem.csv \
   --column molecule_chembl_id
 ```
 
-Downloads compound-centric annotations for the supplied identifiers.
+Downloads compound-centric annotations for the supplied identifiers. The command can be executed with the bundled smoke dataset in `tests/data/input-smoke/testitem.csv` or any CSV that exposes the required identifier column.
 
 ### Tracking `properties_hash`
 
@@ -161,9 +166,9 @@ The optional `testitem_molecule_enrichment` stage augments `testitem.csv` with
 `salt_chembl_id`, `natural_product`, `prodrug`, and `polymer_flag` using two
 CSV dictionaries:
 
-* `dictionary/_testitem/molecule_hierarchy.csv` (columns `molecule_chembl_id`,
+* `tests/data/input-smoke/molecule_hierarchy.csv` (columns `molecule_chembl_id`,
   `parent_molecule_chembl_id`) maps salts to their parent molecules.
-* `dictionary/_testitem/molecule_catalog.csv` (columns `molecule_chembl_id`,
+* `tests/data/input-smoke/molecule_catalog.csv` (columns `molecule_chembl_id`,
   `natural_product`, `prodrug`, `polymer_flag`) stores boolean attributes.
 
 Missing dictionary rows trigger warnings such as
@@ -181,25 +186,25 @@ raw catalogue tokens.【F:library/testitem_enrichment.py†L17-L216】
 
 ```bash
 python -m library.utils.cli_tools.get_input_initialisation \
-  --same-doc data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx \
-  --all-doc data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx \
-  --out-dir data/output/ChEMBL/processed
+  --same-doc path/to/ChEMBL_same_document.xlsx \
+  --all-doc path/to/ChEMBL_all.xlsx \
+  --out-dir path/to/output
 ```
 
 * Builds pair tables (`pairs_same_document.csv`, `pairs_independent.csv`, `pairs_non_independent.csv`).
 * Produces entity-specific slices (`activity_*`, `assay_*`, `document_*`, `target_*`, `testitem_*`, `system_*`).
-* Creates a `data_validity_report/` folder with quality reports for each exported table.
+* Creates a `data_validity_report/` folder with quality reports for each exported table. Supply the original Excel exports from your ChEMBL workflow—example fixtures are not part of the repository.
 
 ## Table quality profiler (`library/utils/cli_tools/table_quality_main.py`)
 
 ```bash
 python -m library.utils.cli_tools.table_quality_main \
-  --input data/input-smoke/activity.csv \
+  --input tests/data/activities_valid.csv \
   --table-name activity
 ```
 
 Generates `<table-name>_quality_report_table.csv` and `<table-name>_data_correlation_report_table.csv` using the CSV defaults from
-`local.io`.
+`local.io`. Replace the sample file with your own extracts to analyse custom tables.
 
 ## Runtime configuration overrides
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -23,6 +23,10 @@
 Перед сетевыми вызовами выполняется `library.config.ensure_dirs`, чтобы `local.io.output_dir` и `local.io.cache_dir` существовали
 (если `local.io.exist_ok=true`, каталоги создаются автоматически).
 
+### Примерные входные файлы
+
+В репозитории есть несколько компактных наборов в `tests/data/` для быстрой проверки пайплайнов (например, `tests/data/activity_ids_small.csv` и `tests/data/input-smoke/testitem.csv`). Пайплайны без готовых примеров требуют пользовательских CSV с колонкой идентификатора из `config.yaml` или переданной через `--column`.
+
 ### Мониторинг структурированных логов
 
 Все утилиты используют `library.logging_setup.Logger` и пишут JSON-строки с уникальным `run_id` и дополнительными полями (`status`, `rps` и др.). Основные события:
@@ -47,12 +51,13 @@ python scripts/get_document_data.py all --input documents.csv --column document_
 
 ```bash
 python scripts/get_activity_data.py \
-  --input data/input-smoke/activity.csv \
-  --column activity_chembl_id \
+  --input tests/data/activity_ids_small.csv \
+  --column activity_id \
   --batch-size 25 \
   --timeout 45
 ```
 
+* В репозитории доступен файл `tests/data/activity_ids_small.csv`; задайте `--column activity_id` (либо переименуйте колонку в `activity_chembl_id`, чтобы использовать настройки по умолчанию).
 * Использует колонку `sources.chembl.pipelines.activity.column` (по умолчанию `activity_chembl_id`).
 * Создаёт основной CSV, sidecar `*.meta.yaml`, при необходимости `*_failure_cases.csv` и отчёты качества.
 * Поддерживает `--limit` (ограничение по количеству ID) и `--dry-run` (проверка входных данных без запросов к API).
@@ -63,31 +68,31 @@ python scripts/get_activity_data.py \
 
 ```bash
 python scripts/get_assay_data.py \
-  --input data/input-smoke/assay.csv \
+  --input path/to/assay_ids.csv \
   --column assay_chembl_id \
   --batch-size 25
 ```
 
-Загружает метаданные ассайев ChEMBL для указанных идентификаторов.
+Загружает метаданные ассайев ChEMBL для указанных идентификаторов. Подготовьте CSV с заголовком `assay_chembl_id` (либо передайте своё имя колонки через `--column`) — готового smoke-файла в репозитории нет.
 
 ## Метаданные документов (`get_document_data.py`)
 
 ```bash
 python scripts/get_document_data.py all \
-  --input data/input-smoke/documents.csv \
+  --input path/to/documents.csv \
   --column document_chembl_id \
   --batch-size 20
 ```
 
 
-Команда объединяет данные ChEMBL и PubMed. Для разовых корректировок доступны флаги `--batch-size`, `--timeout`, `--limit`,
+Команда объединяет данные ChEMBL и PubMed. Подготовьте CSV с колонкой `document_chembl_id` или передайте имя своей колонки через `--column` — smoke-набор для пайплайна в репозитории отсутствует. Для разовых корректировок доступны флаги `--batch-size`, `--timeout`, `--limit`,
 `--dry-run`. Вложенные параметры (например `sources.chembl.pipelines.document.pubmed.batch_size`) меняются через конфигурацию
 или переменные окружения, например:
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
   python scripts/get_document_data.py \
-    --input data/input-smoke/documents.csv \
+    --input path/to/documents.csv \
     --column document_chembl_id
 ```
 
@@ -100,38 +105,38 @@ CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
 
 ```bash
 python scripts/get_document_data.py pubmed \
-  --input data/input-smoke/documents.csv \
+  --input path/to/documents.csv \
   --column document_chembl_id \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
-  --fallback-doi-csv data/input-smoke/doi_overrides.csv \
+  --fallback-doi-csv path/to/doi_overrides.csv \
   --fallback-doi-pmid-column pmid_override \
   --fallback-doi-value-column doi_override
 ```
 
 Флаги `--openalex-rps` и `--crossref-rps` позволяют временно изменить лимиты без правки YAML, а параметры `--fallback-doi-*`
-подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам.【F:scripts/get_document_data.py†L989-L1041】
+подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам. Подготовьте файл с колонками из аргументов `--fallback-doi-pmid-column` и `--fallback-doi-value-column` (по умолчанию `pmid_override` и `doi_override`).【F:scripts/get_document_data.py†L989-L1041】
 
 
 ## Агрегация таргетов (`get_target_data.py`)
 
 ```bash
 python scripts/get_target_data.py \
-  --input data/input-smoke/targets.csv \
+  --input path/to/targets.csv \
   --column target_chembl_id
 ```
 
-Комбинирует данные ChEMBL, UniProt и IUPHAR согласно разделу `sources.chembl.pipelines.target.*`.
+Комбинирует данные ChEMBL, UniProt и IUPHAR согласно разделу `sources.chembl.pipelines.target.*`. Соберите CSV с колонкой `target_chembl_id` (по одной записи в строке); готовый smoke-набор отсутствует.
 
 ## Обогащение тест-объектов (`get_testitem_data.py`)
 
 ```bash
 python scripts/get_testitem_data.py \
-  --input data/input-smoke/testitem.csv \
+  --input tests/data/input-smoke/testitem.csv \
   --column molecule_chembl_id
 ```
 
-Выгружает дополнительную информацию о соединениях.
+Выгружает дополнительную информацию о соединениях. Можно использовать комплект `tests/data/input-smoke/testitem.csv` или собственный CSV с нужной колонкой идентификаторов.
 
 ### Контроль `properties_hash`
 
@@ -161,9 +166,9 @@ PubChem-дополнение добавляет детерминированны
 столбцы `salt_chembl_id`, `natural_product`, `prodrug`, `polymer_flag` на
 основе двух CSV-словарей:
 
-* `dictionary/_testitem/molecule_hierarchy.csv` со столбцами `molecule_chembl_id`,
+* `tests/data/input-smoke/molecule_hierarchy.csv` со столбцами `molecule_chembl_id`,
   `parent_molecule_chembl_id` описывает связи соли и родителя.
-* `dictionary/_testitem/molecule_catalog.csv` со столбцами `molecule_chembl_id`,
+* `tests/data/input-smoke/molecule_catalog.csv` со столбцами `molecule_chembl_id`,
   `natural_product`, `prodrug`, `polymer_flag` содержит булевы признаки.
 
 Если молекулы нет в словарях, в лог попадают предупреждения
@@ -180,24 +185,24 @@ PubChem-дополнение добавляет детерминированны
 
 ```bash
 python -m library.utils.cli_tools.get_input_initialisation \
-  --same-doc data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx \
-  --all-doc data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx \
-  --out-dir data/output/ChEMBL/processed
+  --same-doc path/to/ChEMBL_same_document.xlsx \
+  --all-doc path/to/ChEMBL_all.xlsx \
+  --out-dir path/to/output
 ```
 
 * Формирует таблицы пар (`pairs_same_document.csv`, `pairs_independent.csv`, `pairs_non_independent.csv`).
 * Создаёт срезы по сущностям (`activity_*`, `assay_*`, `document_*`, `target_*`, `testitem_*`, `system_*`).
-* Добавляет папку `data_validity_report/` с отчётами качества для каждого файла.
+* Добавляет папку `data_validity_report/` с отчётами качества для каждого файла. Используйте исходные Excel-выгрузки вашего процесса ChEMBL — демонстрационные файлы в репозитории не поставляются.
 
 ## Профайлер качества таблиц (`library/utils/cli_tools/table_quality_main.py`)
 
 ```bash
 python -m library.utils.cli_tools.table_quality_main \
-  --input data/input-smoke/activity.csv \
+  --input tests/data/activities_valid.csv \
   --table-name activity
 ```
 
-Генерирует `<table-name>_quality_report_table.csv` и `<table-name>_data_correlation_report_table.csv`, используя настройки `local.io`.
+Генерирует `<table-name>_quality_report_table.csv` и `<table-name>_data_correlation_report_table.csv`, используя настройки `local.io`. При необходимости подставьте собственные CSV.
 
 ## Переопределения конфигурации во время запуска
 


### PR DESCRIPTION
## Summary
- reference the actual smoke-style fixtures shipped under tests/data in both English and Russian usage guides
- instruct users how to prepare custom CSV inputs where bundled samples are unavailable and clarify fallback DOI expectations
- highlight that some pipelines require user-provided files when the repository does not include ready-made smoke datasets

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d6b486e46c8324a32898be0f69be48