### PR TITLE
Clarify fallback DOI CSV defaults in usage docs

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -113,7 +113,7 @@ python scripts/get_document_data.py pubmed \
 ```
 
 Use the on-demand rate limit switches to try faster OpenAlex or CrossRef lookups without touching the YAML file; the fallback
-CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried. Provide a CSV with the columns referenced by `--fallback-doi-pmid-column` and `--fallback-doi-value-column` (the default headers are `pmid_override` and `doi_override`).【F:scripts/get_document_data.py†L989-L1041】
+CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried. Provide a CSV with the columns referenced by `--fallback-doi-pmid-column` and `--fallback-doi-value-column`; when left unspecified the CLI expects `PMID` and `DOI`, while the example above demonstrates custom headers via explicit overrides.【F:scripts/get_document_data.py†L989-L1041】
  
 ## Target aggregation (`get_target_data.py`)
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -115,7 +115,7 @@ python scripts/get_document_data.py pubmed \
 ```
 
 Флаги `--openalex-rps` и `--crossref-rps` позволяют временно изменить лимиты без правки YAML, а параметры `--fallback-doi-*`
-подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам. Подготовьте файл с колонками из аргументов `--fallback-doi-pmid-column` и `--fallback-doi-value-column` (по умолчанию `pmid_override` и `doi_override`).【F:scripts/get_document_data.py†L989-L1041】
+подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам. Подготовьте файл с колонками из аргументов `--fallback-doi-pmid-column` и `--fallback-doi-value-column`; если не задавать их явно, CLI ожидает заголовки `PMID` и `DOI`, а в примере выше показано переименование через явные параметры.【F:scripts/get_document_data.py†L989-L1041】
 
 
 ## Агрегация таргетов (`get_target_data.py`)


### PR DESCRIPTION
## Summary
- clarify that the fallback DOI CSV defaults to PMID and DOI headers in the English usage guide
- mirror the same clarification in the Russian usage guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b7ce0388832492e91516373d559c