### PR TITLE
Document molecule catalog SQLite cache location

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -44,6 +44,7 @@ Sensitive values (API tokens, personal e-mails) should be injected via environme
 | Key | Default | Description |
 | --- | --- | --- |
 | `cache_path` | `data/cache/molecule_parent_catalog.json` | Location of the JSON cache storing molecule parent-child relationships reused by enrichment jobs. |
+| `sqlite_path` | `data/cache/molecule_parent_catalog.sqlite` | Location of the SQLite cache powering parent-child lookups; override via `CHEMBL_DA_MOLECULE_CATALOG_SQLITE`. |
 | `endpoint` | `molecule` | ChEMBL REST resource queried when the cache needs to be refreshed. |
 | `child_field` | `molecule_chembl_id` | JSON field containing the child molecule identifier extracted from API responses. |
 | `parent_field` | `parent_molecule_chembl_id` | JSON field containing the parent molecule identifier extracted from API responses. |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -44,6 +44,7 @@
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
 | `cache_path` | `data/cache/molecule_parent_catalog.json` | Путь к локальному JSON с отношениями родитель→потомок, который переиспользуется конвейерами. |
+| `sqlite_path` | `data/cache/molecule_parent_catalog.sqlite` | Путь к SQLite-кэшу для быстрых запросов по связям; переопределяется переменной `CHEMBL_DA_MOLECULE_CATALOG_SQLITE`. |
 | `endpoint` | `molecule` | Ресурс REST API ChEMBL, из которого подкачиваются данные при обновлении кэша. |
 | `child_field` | `molecule_chembl_id` | Поле ответа API с идентификатором дочерней молекулы. |
 | `parent_field` | `parent_molecule_chembl_id` | Поле ответа API с идентификатором родительской молекулы. |


### PR DESCRIPTION
## Summary
- mention the SQLite cache location and env override in the English configuration reference
- mirror the SQLite cache documentation in the Russian configuration guide

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d6b7d3d1cc83249d9f649a160519ce