### PR TITLE
Ensure PubChem CID cache writer creates directories

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -184,7 +184,7 @@ def _write_pubchem_cid_cache(path: Path | None, cache: Mapping[str, str | None])
 
     if path is None:
         return
-    ensure_dirs(path.parent)
+    path.parent.mkdir(parents=True, exist_ok=True)
     serialisable: dict[str, str] = {}
     for key, value in cache.items():
         if not key:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -444,6 +444,19 @@ def test_add_pubchem_data_uses_disk_cache(
         assert cache_data == {"CHEMBL1": "321"}
 
 
+def test_write_pubchem_cid_cache_creates_parent_dir(tmp_path: Path) -> None:
+    cache_path = tmp_path / "nested" / "cid_cache.json"
+
+    assert not cache_path.parent.exists()
+
+    gtd._write_pubchem_cid_cache(cache_path, {"CHEMBL1": "321"})
+
+    assert cache_path.exists()
+    payload = json.loads(cache_path.read_text())
+    assert payload["values"] == {"CHEMBL1": "321"}
+    assert payload["metadata"]["version"] == gtd._PUBCHEM_CACHE_SCHEMA_VERSION
+
+
 def test_load_pubchem_cid_cache_expires(tmp_path: Path) -> None:
     cache_path = tmp_path / "cid_cache.json"
     expired_at = datetime.now(timezone.utc) - timedelta(hours=2)


### PR DESCRIPTION
## Summary
- ensure the PubChem CID cache writer creates its parent directory before writing
- add a regression test that verifies the cache file is created in a new directory

## Testing
- pytest tests/test_get_testitem_data.py -k write_pubchem_cid_cache_creates_parent_dir

------
https://chatgpt.com/codex/tasks/task_e_68d6dc9b77c88324a0044c753d6eec83