### PR TITLE
Rate limit PubMed batch fetches in document pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -251,6 +251,7 @@ def fetch_pubmed_records(
     rate_cfg = settings.rate
     if pubmed_cfg is None:
         pubmed_cfg = settings.pubmed
+    pubmed_limiter = get_limiter("pubmed", rate_cfg.global_rps, rate_cfg.global_burst)
     semantic_limiter = get_limiter(
         "semantic_scholar", rate_cfg.global_rps, rate_cfg.global_burst
     )
@@ -296,6 +297,7 @@ def fetch_pubmed_records(
 
         try:
             with requests.Session() as session:
+                pubmed_limiter.acquire()
                 pubmed_list = pl.fetch_pubmed_batch(
                     session, batch_list, sleep, cfg=pubmed_cfg
                 )

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -530,6 +530,72 @@ def test_fetch_pubmed_records_accepts_config(
     assert df.loc[0, "PubMed.PMID"] == "1"
 
 
+def test_fetch_pubmed_records_acquires_pubmed_limiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PubMed batch requests should acquire the shared rate limiter."""
+
+    class TrackingLimiter:
+        def __init__(self) -> None:
+            self.acquisitions = 0
+
+        def acquire(self) -> None:
+            self.acquisitions += 1
+
+    tracking_limiter = TrackingLimiter()
+    batches_seen: list[list[str]] = []
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd.requests, "Session", lambda: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any, batch: list[str], sleep: float, cfg: Any | None = None
+    ) -> list[dict[str, str]]:
+        batches_seen.append(list(batch))
+        assert tracking_limiter.acquisitions == len(batches_seen)
+        return [{"PubMed.PMID": pmid} for pmid in batch]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"scholar.PMID": pmid} for pmid in pmids]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+
+    def fake_get_limiter(name: str, *_, **__) -> Any:
+        if name == "pubmed":
+            return tracking_limiter
+        return DummyLimiter()
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    df = gdd.fetch_pubmed_records(
+        ["1", "2"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert batches_seen == [["1"], ["2"]]
+    assert tracking_limiter.acquisitions == len(batches_seen)
+    assert list(df["PubMed.PMID"]) == ["1", "2"]
+
+
 def test_fetch_pubmed_records_uses_explicit_pubmed_cfg(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- create a shared PubMed rate limiter alongside the existing Semantic Scholar limiter
- acquire the PubMed limiter before fetching each batch of records
- extend get_document_data tests to assert the PubMed limiter is consulted

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_acquires_pubmed_limiter

------
https://chatgpt.com/codex/tasks/task_e_68d6dc9cfa78832496eba7dc8306e97a