### PR TITLE
Avoid materialising document IDs before ChEMBL fetch

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -35,7 +35,7 @@ if __package__ is None:  # running as a script
 import argparse
 from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from itertools import islice
+from itertools import chain, islice
 from typing import cast
 
 import pandas as pd
@@ -882,12 +882,14 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         ids_source = limited_ids
         logger.info("process_limit", limit=len(limited_ids))
 
-    chunk_ids: list[str] = []
+    iterator = iter(ids_source)
+    sample_size = cfg.document.all.chunk_size
+    sample_ids = list(islice(iterator, sample_size))
+    ids_for_fetch = chain(sample_ids, iterator)
     try:
         with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-            chunk_ids = list(ids_source)  # capture IDs for logging on failure
             doc_df = cl.get_documents(
-                chunk_ids,
+                ids_for_fetch,
                 cfg=cfg.api,
                 client=client,
                 chunk_size=cfg.document.all.chunk_size,
@@ -896,7 +898,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     except (requests.RequestException, ValueError) as exc:
         logger.error(
             "chembl_documents_fetch_failed",
-            ids=chunk_ids,
+            ids=sample_ids,
             error=str(exc),
             chunk_size=cfg.document.all.chunk_size,
         )

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -4,7 +4,7 @@ import argparse
 import io
 import json
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -116,8 +116,14 @@ def test_run_all_logs_failing_ids(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Log message should include IDs when document retrieval fails."""
+
+    cfg = Config()
+    chunk_size = cfg.document.all.chunk_size
+    ids = [f"CHEMBL{i}" for i in range(1, chunk_size + 3)]
     input_csv = tmp_path / "docs.csv"
-    input_csv.write_text("document_chembl_id\nCHEMBL1\nCHEMBL2\n")
+    input_csv.write_text(
+        "document_chembl_id\n" + "\n".join(ids) + "\n"
+    )
 
     class DummyClient:
         def __enter__(self) -> DummyClient:
@@ -141,7 +147,6 @@ def test_run_all_logs_failing_ids(
 
     buffer = io.StringIO()
     configure_logger(LoggerConfig(level="ERROR", stream=buffer))
-    cfg = Config()
     args = argparse.Namespace(
         input_csv=input_csv,
         output_csv=tmp_path / "out.csv",
@@ -156,9 +161,72 @@ def test_run_all_logs_failing_ids(
     records = [json.loads(line) for line in log_output.splitlines() if line.strip()]
     assert any(
         record.get("event") == "chembl_documents_fetch_failed"
-        and record.get("ids") == ["CHEMBL1", "CHEMBL2"]
+        and record.get("ids") == ids[:chunk_size]
         for record in records
     )
+
+
+def test_run_all_passes_generator_to_get_documents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``run_all`` should pass a generator into ``get_documents``."""
+
+    cfg = Config()
+    ids = [f"CHEMBL{i}" for i in range(1, 4)]
+    input_csv = tmp_path / "docs.csv"
+    input_csv.write_text(
+        "document_chembl_id\n" + "\n".join(ids) + "\n"
+    )
+
+    class DummyClient:
+        def __enter__(self) -> DummyClient:
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - no cleanup
+            return None
+
+    monkeypatch.setattr(gdd, "ChemblClient", lambda *_, **__: DummyClient())
+
+    captured: dict[str, object] = {}
+
+    def fake_get_documents(
+        ids_iter: Iterable[str],
+        cfg: Any,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
+        assert not isinstance(ids_iter, list)
+        assert isinstance(ids_iter, Iterator)
+        values = list(ids_iter)
+        captured["values"] = values
+        return pd.DataFrame({"document_chembl_id": values})
+
+    monkeypatch.setattr(cl, "get_documents", fake_get_documents)
+    monkeypatch.setattr(gdd.dp, "postprocess_documents", lambda df: df)
+    monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
+
+    def fake_finalise_export(*args: Any, **kwargs: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(gdd, "_finalise_export", fake_finalise_export)
+    monkeypatch.setattr(
+        gdd,
+        "fetch_pubmed_records",
+        lambda *args, **kwargs: pytest.fail("unexpected call"),
+    )
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "out.csv",
+        fallback_doi_csv=None,
+        fallback_doi_pmid_column="PMID",
+        fallback_doi_value_column="DOI",
+    )
+
+    rc = gdd.run_all(cfg, args)
+    assert rc == 0
+    assert captured["values"] == ids
 
 
 def test_pubmed_cli_rejects_non_positive_batch_size(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stream the combined document pipeline so `run_all` passes a generator directly to `cl.get_documents`
- capture only a chunk-sized sample of identifiers when logging failures
- extend document pipeline tests to cover generator handling and bounded failure logging

## Testing
- pytest tests/test_get_document_data.py::test_run_all_logs_failing_ids tests/test_get_document_data.py::test_run_all_passes_generator_to_get_documents

------
https://chatgpt.com/codex/tasks/task_e_68d6dca785308324a718403cb250ade8