### PR TITLE
Refine PubChem enrichment caching and add regression test

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -636,6 +636,11 @@ def add_pubchem_data(
     client: ChemblClient | None = None,
     api_cfg: ApiCfg | None = None,
     timeout: float | None = None,
+    cid_cache: MutableMapping[str, str | None] | None = None,
+    resolution_cache: MutableMapping[
+        tuple[str | None, ...], pl.PubChemResolution
+    ] | None = None,
+    parent_record_cache: MutableMapping[str, pd.Series | None] | None = None,
 ) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
@@ -721,9 +726,11 @@ def add_pubchem_data(
 
     cache_path = getattr(cfg, "cid_cache_path", None)
     cache_ttl_hours = getattr(cfg, "cache_ttl_hours", None)
-    cid_cache = _load_pubchem_cid_cache(cache_path, ttl_hours=cache_ttl_hours)
+    if cid_cache is None:
+        cid_cache = _load_pubchem_cid_cache(cache_path, ttl_hours=cache_ttl_hours)
     cache_dirty = False
-    resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] = {}
+    if resolution_cache is None:
+        resolution_cache = {}
 
     local_records: dict[str, pd.Series] = {}
     if "molecule_chembl_id" in result.columns:
@@ -732,7 +739,8 @@ def add_pubchem_data(
             if chembl_norm and chembl_norm not in local_records:
                 local_records[chembl_norm] = result.loc[index]
 
-    parent_record_cache: dict[str, pd.Series | None] = {}
+    if parent_record_cache is None:
+        parent_record_cache = {}
 
     def load_parent_record(parent_id: str) -> pd.Series | None:
         parent_norm = _normalise_identifier(parent_id, uppercase=True)
@@ -1066,11 +1074,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 parent_catalog_source = PARENT_LOOKUP_SOURCE_CACHE
                 need_lookup -= set(fallback_catalog)
 
-        logger.info("pubchem_augment_start")
-        df = add_pubchem_data(df, cfg.pubchem)
-        logger.info("pubchem_augment_done")
- 
-
         try:
             ensure_no_parant_column(df)
         except ValueError as exc:
@@ -1108,6 +1111,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             uncovered=parent_stats.uncovered,
         )
 
+        pubchem_cid_cache: dict[str, str | None] | None = None
+        pubchem_resolution_cache: dict[
+            tuple[str | None, ...], pl.PubChemResolution
+        ] | None = None
+        pubchem_parent_record_cache: dict[str, pd.Series | None] | None = None
+        if getattr(cfg.pubchem, "enable", True):
+            pubchem_cid_cache = _load_pubchem_cid_cache(
+                getattr(cfg.pubchem, "cid_cache_path", None),
+                ttl_hours=getattr(cfg.pubchem, "cache_ttl_hours", None),
+            )
+            pubchem_resolution_cache = {}
+            pubchem_parent_record_cache = {}
+
         logger.info("pubchem_augment_start")
         df = add_pubchem_data(
             df,
@@ -1115,6 +1131,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             client=client,
             api_cfg=cfg.api,
             timeout=cfg.testitem.timeout,
+            cid_cache=pubchem_cid_cache,
+            resolution_cache=pubchem_resolution_cache,
+            parent_record_cache=pubchem_parent_record_cache,
         )
         logger.info("pubchem_augment_done")
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -633,6 +633,85 @@ def test_run_chembl_initialises_pubchem_session(
 
 
 
+def test_run_chembl_calls_pubchem_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text(
+        "molecule_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding
+    )
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1"]))
+
+    df = pd.DataFrame(
+        [
+            {
+                "molecule_chembl_id": "CHEMBL1",
+                "canonical_smiles": "C",
+                "molecule_type": "Small molecule",
+                "parent_molecule_chembl_id": pd.NA,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df.copy())
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *_, **__: {},
+    )
+
+    monkeypatch.setattr(
+        gtd,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+                uncovered=0,
+            ),
+        ),
+    )
+
+    cfg.pubchem.cid_cache_path = tmp_path / "pubchem_cache.json"
+    cfg.pubchem.delay = 0
+
+    resolve_calls: list[Mapping[str, str | None]] = []
+
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        pubchem_cfg: pl.PubChemCfg,
+        **kwargs: object,
+    ) -> pl.PubChemResolution:
+        resolve_calls.append(identifiers)
+        return pl.PubChemResolution(cid="321", source="resolver")
+
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
+
+    props = pl.Properties("name", "formula", "i", "c", "inchi", "inchikey")
+    monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: props)
+    monkeypatch.setattr(gtd.pl, "init_session", lambda api, retry: None)
+    monkeypatch.setattr(
+        io,
+        "write_csv",
+        lambda frame, path, *, cfg, key_cols=None, col_order=None, **__: path,
+    )
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
+
+    rc = gtd.run_chembl(cfg, args)
+
+    assert rc == 0
+    assert len(resolve_calls) == 1
+
+
 def test_run_chembl_merges_parent_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- remove the pre-parent lookup PubChem augmentation and initialise reusable caches for the final enrichment step
- allow `add_pubchem_data` to accept pre-loaded caches so a single run can reuse resolution and parent lookups
- add a regression test covering that the PubChem resolver is invoked only once during `run_chembl`

## Testing
- pytest tests/test_get_testitem_data.py::test_run_chembl_calls_pubchem_once
- pytest tests/test_get_testitem_data.py::test_run_chembl_initialises_pubchem_session

------
https://chatgpt.com/codex/tasks/task_e_68d6dcaa78348324960fa41be2dac963