### PR TITLE
Pass lazy identifier stream to Chembl test item fetch

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,7 +16,7 @@ import argparse
 from collections import ChainMap
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
-from itertools import islice
+from itertools import islice, tee
 from typing import Any, Callable, NamedTuple
 
 import pandas as pd
@@ -91,6 +91,8 @@ PUBCHEM_COLUMNS = [
 
 _PUBCHEM_CID_CACHE_ENCODING = "utf-8"
 _CID_CACHE_MISSING = object()
+
+_FETCH_ERROR_SAMPLE_SIZE = 10
 
 
 def _normalise_identifier(value: Any, *, uppercase: bool = False) -> str | None:
@@ -942,15 +944,15 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         uncovered=0,
     )
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+        sample_ids: tuple[str, ...] = ()
         try:
             ids_iter = io.read_ids(
                 args.input_csv, column=cfg.testitem.column, cfg=cfg.io
             )
             if limit is not None:
-                ids = list(islice(ids_iter, limit))
-                logger.info("process_limit", limit=len(ids))
-            else:
-                ids = list(ids_iter)
+                ids_iter = islice(ids_iter, limit)
+            ids_iter, sample_iter = tee(ids_iter)
+            sample_ids = tuple(islice(sample_iter, _FETCH_ERROR_SAMPLE_SIZE))
         except (FileNotFoundError, ValueError) as exc:
             logger.error(
                 "read_fail",
@@ -959,12 +961,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
-        logger.info("identifiers_retrieved", count=len(ids))
         logger.info("chembl_fetch_start", batch_size=cfg.testitem.batch_size)
 
         try:
             df = cl.get_testitem(
-                ids,
+                ids_iter,
                 cfg=cfg.api,
                 client=client,
                 chunk_size=cfg.testitem.batch_size,
@@ -976,9 +977,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 error=str(exc),
                 batch_size=cfg.testitem.batch_size,
                 timeout=cfg.testitem.timeout,
+                sample_ids=list(sample_ids),
             )
             return 1
-        logger.info("chembl_fetch_done", rows=len(df))
+        rows = len(df)
+        logger.info("chembl_fetch_done", rows=rows)
+        logger.info("identifiers_retrieved", count=rows)
+        if limit is not None:
+            logger.info("process_limit", limit=min(limit, rows))
         parent_column = cfg.molecule_catalog.parent_field
         child_column = cfg.molecule_catalog.child_field
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Iterable, Mapping
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -631,6 +632,100 @@ def test_run_chembl_initialises_pubchem_session(
     assert rc == 0
     assert captured["init"] == (cfg.api, cfg.retry)
 
+
+def test_run_chembl_uses_lazy_identifier_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text(
+        "molecule_chembl_id\nCHEMBL1\nCHEMBL2\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    class SingleUseIterable:
+        def __init__(self, values: list[str]) -> None:
+            self._values = values
+            self.iterations = 0
+
+        def __iter__(self):
+            if self.iterations:
+                raise AssertionError("identifiers iterator consumed multiple times")
+            self.iterations += 1
+            yield from self._values
+
+    ids_source = SingleUseIterable(["CHEMBL1", "CHEMBL2"])
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: ids_source)
+
+    received_ids: object | None = None
+
+    def fake_get_testitem(ids, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal received_ids
+        received_ids = ids
+        values = list(ids)
+        return pd.DataFrame(
+            [
+                {
+                    cfg.molecule_catalog.child_field: value,
+                    cfg.molecule_catalog.parent_field: pd.NA,
+                }
+                for value in values
+            ]
+        )
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+    monkeypatch.setattr(gtd.pl, "init_session", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, *args, **__: frame)
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+    monkeypatch.setattr(gtd, "query_parent_catalog", lambda *_, **__: {})
+    monkeypatch.setattr(
+        gtd.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *_, **__: {},
+    )
+    monkeypatch.setattr(
+        gtd,
+        "attach_parent_molecule_ids",
+        lambda frame, **kwargs: (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
+                missing=0,
+                unique=0,
+                attached=0,
+                uncovered=0,
+            ),
+        ),
+    )
+    monkeypatch.setattr(gtd, "normalize_testitems", lambda frame: frame)
+    monkeypatch.setattr(gtd, "add_pipeline_metadata", lambda frame: frame)
+    monkeypatch.setattr(
+        gtd,
+        "validate_testitems",
+        lambda frame, return_result=True: SimpleNamespace(
+            data=frame,
+            failure_cases=pd.DataFrame(),
+        ),
+    )
+    monkeypatch.setattr(
+        io,
+        "write_csv",
+        lambda df, path, *, cfg, key_cols=None, col_order=None, **__: path,
+    )
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "update_parent_catalog_cache", lambda *_, **__: None)
+
+    rc = gtd.run_chembl(cfg, args)
+
+    assert rc == 0
+    assert ids_source.iterations == 1
+    assert received_ids is not None
+    assert not isinstance(received_ids, list)
+    assert received_ids.__class__.__name__ == "_tee"
 
 
 def test_run_chembl_merges_parent_catalog(


### PR DESCRIPTION
## Summary
- pass the streamed identifier iterator directly into the Chembl test item fetch and log counts from the resulting dataframe
- capture only a small identifier sample for diagnostics on fetch errors and cover the behaviour with a regression test

## Testing
- pytest tests/test_get_testitem_data.py::test_run_chembl_uses_lazy_identifier_stream

------
https://chatgpt.com/codex/tasks/task_e_68d6dca585a88324a2e602f13317f7f3