### PR TITLE
Disable adapter retries and document manual retry loops

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -25,7 +25,7 @@ Sensitive values (API tokens, personal e-mails) should be injected via environme
 | `chembl_base` | `https://www.ebi.ac.uk/chembl/api/data` | Base URL for the ChEMBL REST API. |
 | `timeout_connect` | `5` | Connection timeout in seconds. |
 | `timeout_read` | `30` | Read timeout in seconds. |
-| `retries` | `3` | HTTP retry attempts handled by `requests`. |
+| `retries` | `3` | Maximum number of attempts performed by higher-level clients; the shared HTTP adapter does not retry automatically. |
 | `backoff_factor` | `0.5` | Multiplier for exponential backoff between retries. |
 | `rps` | `20` | Allowed requests per second for the rate limiter. |
 | `burst` | `20` | Bucket size used by the token bucket limiter. |
@@ -257,7 +257,7 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | `timeout_connect` | `5` | Connection timeout (seconds) for establishing new HTTP sessions. | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_CONNECT`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_CONNECT` |
 | `timeout_read` | `60` | Read timeout (seconds) waiting for server responses. | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_READ`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_READ` |
 | `timeout_seconds` | `30.0` | Upper bound for a single CID resolution attempt, including retries. | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_SECONDS`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_SECONDS` |
-| `retries` | `3` | Number of automatic retries after transient failures. | `CHEMBL_DA_SOURCES_PUBCHEM_RETRIES`, `CHEMBL_DA__SOURCES__PUBCHEM__RETRIES` |
+| `retries` | `3` | Number of attempts executed by the PubChem retry loop before giving up. | `CHEMBL_DA_SOURCES_PUBCHEM_RETRIES`, `CHEMBL_DA__SOURCES__PUBCHEM__RETRIES` |
 | `rps` | `5` | Per-service request-per-second budget used by the rate limiter. | `CHEMBL_DA_SOURCES_PUBCHEM_RPS`, `CHEMBL_DA__SOURCES__PUBCHEM__RPS` |
 | `burst` | `5` | Token bucket size paired with the `rps` limit. | `CHEMBL_DA_SOURCES_PUBCHEM_BURST`, `CHEMBL_DA__SOURCES__PUBCHEM__BURST` |
 | `delay` | `0.2` | Fixed pause (seconds) inserted between retry attempts. | `CHEMBL_DA_SOURCES_PUBCHEM_DELAY`, `CHEMBL_DA__SOURCES__PUBCHEM__DELAY` |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -25,7 +25,7 @@
 | `chembl_base` | `https://www.ebi.ac.uk/chembl/api/data` | Базовый URL ChEMBL REST API. |
 | `timeout_connect` | `5` | Таймаут установки соединения (сек.). |
 | `timeout_read` | `30` | Таймаут ожидания ответа (сек.). |
-| `retries` | `3` | Количество HTTP-повторов. |
+| `retries` | `3` | Максимум попыток, выполняемых клиентскими обёртками; общий HTTP-адаптер повторы не делает. |
 | `backoff_factor` | `0.5` | Множитель экспоненциального backoff между повторами. |
 | `rps` | `20` | Лимит запросов в секунду для rate limiter. |
 | `burst` | `20` | Размер «ведра» токенов. |
@@ -249,7 +249,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `timeout_connect` | `5` | Таймаут установления соединения (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_CONNECT`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_CONNECT` |
 | `timeout_read` | `60` | Таймаут ожидания ответа (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_READ`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_READ` |
 | `timeout_seconds` | `30.0` | Максимальная длительность одной попытки разрешения CID с учётом повторов. | `CHEMBL_DA_SOURCES_PUBCHEM_TIMEOUT_SECONDS`, `CHEMBL_DA__SOURCES__PUBCHEM__TIMEOUT_SECONDS` |
-| `retries` | `3` | Число повторов при временных сбоях. | `CHEMBL_DA_SOURCES_PUBCHEM_RETRIES`, `CHEMBL_DA__SOURCES__PUBCHEM__RETRIES` |
+| `retries` | `3` | Число попыток, которое выполнит цикл повторов PubChem, прежде чем сдаться. | `CHEMBL_DA_SOURCES_PUBCHEM_RETRIES`, `CHEMBL_DA__SOURCES__PUBCHEM__RETRIES` |
 | `rps` | `5` | Локальный лимит запросов в секунду. | `CHEMBL_DA_SOURCES_PUBCHEM_RPS`, `CHEMBL_DA__SOURCES__PUBCHEM__RPS` |
 | `burst` | `5` | Ёмкость токен-бакета, связанного с `rps`. | `CHEMBL_DA_SOURCES_PUBCHEM_BURST`, `CHEMBL_DA__SOURCES__PUBCHEM__BURST` |
 | `delay` | `0.2` | Пауза между повторами (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_DELAY`, `CHEMBL_DA__SOURCES__PUBCHEM__DELAY` |

--- a/library/config.py
+++ b/library/config.py
@@ -954,7 +954,9 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
 
     session = Session()
     retry_cfg = Retry(
-        total=retry.max_attempts,
+        # Automatic retries are disabled to avoid double retry loops; HTTP
+        # clients implement their own attempt counters using ``retry``.
+        total=0,
         backoff_factor=retry.backoff_factor,
         status_forcelist=retry.status_forcelist,
         # ``None`` disables method filtering and retries all HTTP methods.

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -135,6 +135,7 @@ def test_request_json_backoff_grows(monkeypatch) -> None:
     client.request_json("http://example.com", cfg=cfg)
 
     assert sleep_times == [1.0, 2.0]
+    assert len(session.calls) == 3
 
 
 def test_request_json_respects_zero_retries() -> None:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -12,8 +12,8 @@ USER_AGENT = "test-agent/1.0 (mailto:test@example.org)"
 
 
 @responses.activate
-def test_session_with_retry_retries_post() -> None:
-    """Ensure POST requests are retried when configured."""
+def test_session_with_retry_makes_single_attempt() -> None:
+    """The HTTP adapter leaves retry attempts to higher-level clients."""
 
     url = "http://example.com/post"
     responses.add(responses.POST, url, status=500)
@@ -25,5 +25,5 @@ def test_session_with_retry_retries_post() -> None:
     )
     response = session.post(url)
 
-    assert response.status_code == 200
-    assert len(responses.calls) == 2
+    assert response.status_code == 500
+    assert len(responses.calls) == 1

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -158,6 +158,7 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
     pl.make_request("https://example.org", cfg)
 
     assert sleeps == [1]
+    assert attempts["n"] == 2
 
 
 @responses.activate

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -103,6 +103,34 @@ def test_do_request_404() -> None:
     assert err == "PMID not found"
 
 
+def test_do_request_attempt_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry loop performs ``retries + 1`` total attempts."""
+
+    statuses = [500, 500, 200]
+    calls: list[int] = []
+
+    def fake_make_request(*args: Any, **kwargs: Any) -> tuple[int, str, Any, str]:
+        idx = len(calls)
+        calls.append(idx)
+        status = statuses[idx]
+        if status >= 500:
+            return status, "error", None, ""
+        return status, "{}", {"ok": True}, ""
+
+    monkeypatch.setattr(pq, "_make_request", fake_make_request)
+
+    data, err = pq._do_request(
+        cast(requests.Session, DummySession(DummyResponse(200, text="{}", json_data={}))),
+        "http://example.org",
+        delay=0,
+        retries=2,
+    )
+
+    assert data == {"ok": True}
+    assert err == ""
+    assert len(calls) == 3
+
+
 def test_handle_response_retryable() -> None:
     """500 response triggers a retry on non-final attempts."""
     data, err, retry = pq._handle_response(


### PR DESCRIPTION
## Summary
- disable automatic retries on the shared requests session to avoid double retry loops
- document that retry counts are enforced in client code and clarify PubChem settings
- extend HTTP/client tests to assert the expected number of attempts per configuration

## Testing
- pytest tests/test_http_client.py tests/test_chembl_client.py tests/test_pubchem_library.py tests/test_pubmed_query.py


------
https://chatgpt.com/codex/tasks/task_e_68d6dca005588324b993cd9334a34e72