### PR TITLE
Update pyarrow dependency to released version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "requests==2.32.5",
   "PyYAML==6.0.2",
   "openpyxl==3.1.5",
-  "pyarrow==21.0.0",
+  "pyarrow==17.0.0",
   "jsonschema==4.25.1",
   "pandera==0.26.1",
   "cachetools==5.3.2",


### PR DESCRIPTION
## Summary
- replace the unreleased pyarrow pin with the latest stable release compatible with NumPy 2.x

## Testing
- pip install .[dev]

------
https://chatgpt.com/codex/tasks/task_e_68d6e5b352b08324bdc5fa5fbf4196e7