### PR TITLE
Add proxy scripts for CLI tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,26 @@ check-determinism = "library.utils.cli_tools.check_determinism:main"
 
 [tool.setuptools]
 py-modules = [
+  "scripts.check_determinism",
+  "scripts.chunk_io",
+  "scripts.chunk_io_main",
+  "scripts.csv_utils",
+  "scripts.csv_utils_main",
+  "scripts.dtype_inspector",
+  "scripts.dtype_inspector_main",
+  "scripts.get_activities",
   "scripts.get_activity_data",
   "scripts.get_assay_data",
-  "scripts.get_target_data",
   "scripts.get_document_data",
+  "scripts.get_document_type",
+  "scripts.get_input_initialisation",
+  "scripts.get_target_data",
   "scripts.get_testitem_data",
+  "scripts.mapper",
+  "scripts.mapper_batch_main",
+  "scripts.mapper_main",
+  "scripts.table_quality",
+  "scripts.table_quality_main",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -1,0 +1,23 @@
+"""Proxy module for :mod:`library.utils.cli_tools.check_determinism`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from inspect import signature
+
+from library.utils.cli_tools import check_determinism as _impl
+
+_IMPL_MAIN = _impl.main
+_HAS_ARGS = len(signature(_IMPL_MAIN).parameters) > 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.check_determinism.main`."""
+
+    if _HAS_ARGS:
+        return _IMPL_MAIN(argv)
+    return _IMPL_MAIN()
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/chunk_io.py
+++ b/scripts/chunk_io.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.chunk_io_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import chunk_io_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.chunk_io_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/chunk_io_main.py
+++ b/scripts/chunk_io_main.py
@@ -1,0 +1,11 @@
+"""Convenience wrapper matching :mod:`scripts.chunk_io`."""
+
+from __future__ import annotations
+
+from .chunk_io import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/csv_utils.py
+++ b/scripts/csv_utils.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.csv_utils_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import csv_utils_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.csv_utils_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/csv_utils_main.py
+++ b/scripts/csv_utils_main.py
@@ -1,0 +1,11 @@
+"""Convenience wrapper matching :mod:`scripts.csv_utils`."""
+
+from __future__ import annotations
+
+from .csv_utils import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/dtype_inspector.py
+++ b/scripts/dtype_inspector.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.dtype_inspector_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import dtype_inspector_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.dtype_inspector_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/dtype_inspector_main.py
+++ b/scripts/dtype_inspector_main.py
@@ -1,0 +1,11 @@
+"""Convenience wrapper matching :mod:`scripts.dtype_inspector`."""
+
+from __future__ import annotations
+
+from .dtype_inspector import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/get_activities.py
+++ b/scripts/get_activities.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.get_activities`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import get_activities as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.get_activities.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/get_document_type.py
+++ b/scripts/get_document_type.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.get_document_type`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import get_document_type as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.get_document_type.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/get_input_initialisation.py
+++ b/scripts/get_input_initialisation.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.get_input_initialisation`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import get_input_initialisation as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.get_input_initialisation.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/mapper.py
+++ b/scripts/mapper.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.mapper_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import mapper_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.mapper_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/mapper_batch_main.py
+++ b/scripts/mapper_batch_main.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.mapper_batch_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import mapper_batch_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.mapper_batch_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/mapper_main.py
+++ b/scripts/mapper_main.py
@@ -1,0 +1,11 @@
+"""Convenience wrapper matching :mod:`scripts.mapper`."""
+
+from __future__ import annotations
+
+from .mapper import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/table_quality.py
+++ b/scripts/table_quality.py
@@ -1,0 +1,17 @@
+"""Proxy module for :mod:`library.utils.cli_tools.table_quality_main`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from library.utils.cli_tools import table_quality_main as _impl
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate execution to :func:`library.utils.cli_tools.table_quality_main.main`."""
+
+    return _impl.main(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/scripts/table_quality_main.py
+++ b/scripts/table_quality_main.py
@@ -1,0 +1,11 @@
+"""Convenience wrapper matching :mod:`scripts.table_quality`."""
+
+from __future__ import annotations
+
+from .table_quality import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    raise SystemExit(main())

--- a/tests/smoke/test_cli_tools_scripts.py
+++ b/tests/smoke/test_cli_tools_scripts.py
@@ -1,0 +1,21 @@
+"""Smoke tests for thin CLI proxy modules in :mod:`scripts`."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_scripts_check_determinism_importable() -> None:
+    """Running ``python -m scripts.check_determinism`` should succeed."""
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.check_determinism",
+            "--log-level",
+            "INFO",
+        ],
+        check=True,
+    )


### PR DESCRIPTION
## Summary
- add thin proxy modules under `scripts/` that delegate to the implementations in `library.utils.cli_tools`
- register the proxy modules with setuptools so they are included in distributions
- add a smoke test that runs `python -m scripts.check_determinism`

## Testing
- pytest tests/smoke/test_cli_tools_scripts.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e5be99688324ae1d7a93b7d0dfa8