### PR TITLE
Gate PubMed batches on rate limiter

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -305,6 +305,7 @@ def fetch_pubmed_records(
 
             with session_with_retry(__cfg.api, __cfg.retry) as session:
 
+                pubmed_limiter.acquire()
                 pubmed_list = pl.fetch_pubmed_batch(
                     session, batch_list, sleep, cfg=pubmed_cfg
                 )

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -612,9 +612,11 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
     class TrackingLimiter:
         def __init__(self) -> None:
             self.acquisitions = 0
+            self.history: list[int] = []
 
         def acquire(self) -> None:
             self.acquisitions += 1
+            self.history.append(self.acquisitions)
 
     tracking_limiter = TrackingLimiter()
     batches_seen: list[list[str]] = []
@@ -631,8 +633,9 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
     def fake_pubmed_batch(
         session: Any, batch: list[str], sleep: float, cfg: Any | None = None
     ) -> list[dict[str, str]]:
+        acquisition_count = tracking_limiter.acquisitions
         batches_seen.append(list(batch))
-        assert tracking_limiter.acquisitions == len(batches_seen)
+        assert acquisition_count == len(batches_seen)
         return [{"PubMed.PMID": pmid} for pmid in batch]
 
     def fake_semantic_batch(
@@ -667,6 +670,7 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
 
     assert batches_seen == [["1"], ["2"]]
     assert tracking_limiter.acquisitions == len(batches_seen)
+    assert tracking_limiter.history == [1, 2]
     assert list(df["PubMed.PMID"]) == ["1", "2"]
 
 


### PR DESCRIPTION
## Summary
- acquire the PubMed rate limiter before invoking the batch fetcher
- extend the limiter test to assert the number of acquisitions per batch

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_acquires_pubmed_limiter
- python scripts/get_document_data.py pubmed --input tests/data/pmids.csv --output /tmp/documents.csv --config config.yaml --workers 2 --batch-size 2 --limit 4 --log-level INFO

------
https://chatgpt.com/codex/tasks/task_e_68d6e64aabe48324a8fd14d82d21e5bb