### PR TITLE
Handle PubChem request timeout

### DIFF
--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
+from time import monotonic
 from typing import Any, Hashable, cast
 from urllib.parse import quote
 
@@ -165,8 +166,17 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
 
     attempts = max(cfg.retries, 1)
     backoff_delay = cfg.backoff_initial_seconds
+    deadline: float | None = None
+    if cfg.timeout_seconds > 0:
+        deadline = monotonic() + cfg.timeout_seconds
 
     for attempt in range(1, attempts + 1):
+        if deadline is not None and monotonic() >= deadline:
+            logger.warning(
+                "request_timeout", url=url, attempt=attempt, rps=cfg.rps
+            )
+            logger.info("request_fail", url=url, status=None, rps=cfg.rps)
+            return None
         event = "request_start" if attempt == 1 else "request_retry"
         logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -161,6 +161,57 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
     assert attempts["n"] == 2
 
 
+def test_make_request_aborts_when_timeout_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``make_request`` stops retrying when the overall timeout is exceeded."""
+
+    class FakeMonotonic:
+        def __init__(self) -> None:
+            self.values = iter([0.0, 0.0, 6.0])
+
+        def __call__(self) -> float:
+            try:
+                return next(self.values)
+            except StopIteration:
+                return 6.0
+
+    class Limiter:
+        def acquire(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    attempts = {"n": 0}
+    warnings: list[str] = []
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> None:
+        attempts["n"] += 1
+        raise requests.Timeout("hanging request")
+
+    monkeypatch.setattr(pl, "monotonic", FakeMonotonic())
+    monkeypatch.setattr(pl, "get_limiter", lambda *args, **kwargs: Limiter())
+    monkeypatch.setattr(pl._session, "get", fake_get)
+    monkeypatch.setattr(pl, "sleep", lambda *_: None)
+    monkeypatch.setattr(
+        pl.logger,
+        "warning",
+        lambda event, *args, **kwargs: warnings.append(event),
+    )
+    pl._CACHE = None
+
+    cfg = pl.PubChemCfg(
+        retries=5,
+        delay=0,
+        backoff_initial_seconds=0,
+        timeout_seconds=5,
+    )
+
+    result = pl.make_request("https://example.org", cfg)
+
+    assert result is None
+    assert attempts["n"] == 1
+    assert "request_timeout" in warnings
+
+
 @responses.activate
 def test_resolve_pubchem_record_falls_back_to_inchikey(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- stop PubChem request retries once the configured timeout is exceeded and log the timeout event
- return `None` after a timed out request to let callers degrade cleanly
- add a unit test that simulates a hanging request to confirm the timeout handling

## Testing
- pytest tests/test_pubchem_library.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e652a0a88324a8429d059221cb0c