### PR TITLE
Remove duplicate dev dependency entry and guard against regressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dev = [
   "psutil==7.0.0",
   "pytest==8.4.2",
   "pytest-cov==6.0.0",
-  "hypothesis==6.138.15",
   "responses==0.25.8",
   "ruff==0.13.0",
   "types-cachetools==6.2.0.20250827",

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,35 @@
+"""Tests for optional dependency configuration.
+
+Ensures each optional dependency list in the project metadata remains
+free of duplicate requirement entries.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+import tomllib
+
+
+def test_optional_dependencies_are_unique() -> None:
+    """Verify that optional dependency groups contain unique entries."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    pyproject_path = project_root / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    duplicates: dict[str, set[str]] = defaultdict(set)
+
+    for extra_name, requirements in data.get("project", {}).get("optional-dependencies", {}).items():
+        seen: set[str] = set()
+        for requirement in requirements:
+            normalized = requirement.strip()
+            if normalized in seen:
+                duplicates[extra_name].add(normalized)
+            else:
+                seen.add(normalized)
+
+    assert not duplicates, (
+        "Duplicate optional dependency entries detected: "
+        + ", ".join(f"{group}: {sorted(values)}" for group, values in sorted(duplicates.items()))
+    )


### PR DESCRIPTION
## Summary
- remove the duplicate hypothesis entry from the dev optional dependency group
- add a regression test that validates optional dependency groups contain unique requirements

## Testing
- pip install .[dev]
- pytest tests/test_optional_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e6817cc483249f8b8c01a5967832