### PR TITLE
Expand activity standard type validation

### DIFF
--- a/docs/DATA_SCHEMA_EN.md
+++ b/docs/DATA_SCHEMA_EN.md
@@ -68,7 +68,7 @@
 | type | string | ChEMBL `/activity` | Original measurement type returned by the API.|
 | units | string | ChEMBL `/activity` | Original units associated with `value`.|
 | value | string/number | ChEMBL `/activity` | Raw measurement reported by the API.|
-| standard_type | string | ChEMBL `/activity` | Normalized measurement type (restricted to `IC50` or `Ki`).|
+| standard_type | string | ChEMBL `/activity` | Normalized measurement type constrained by configuration (e.g., `IC50`, `EC50`, `Ki`, `KD`).|
 | standard_value | number (float) | ChEMBL `/activity` | Normalized numeric value in molar units; guaranteed non-negative.|
 | standard_lower_value | string/number | ChEMBL `/activity` | Lower bound supplied by ChEMBL when the measurement is a range.|
 | standard_upper_value | string/number | ChEMBL `/activity` | Upper bound supplied by ChEMBL when available.|

--- a/docs/DATA_SCHEMA_RU.md
+++ b/docs/DATA_SCHEMA_RU.md
@@ -68,7 +68,7 @@
 | type | строка | ChEMBL `/activity` | Тип исходного измерения (как в API).|
 | units | строка | ChEMBL `/activity` | Единицы исходного значения `value`.|
 | value | строка/число | ChEMBL `/activity` | Первичное численное значение, как возвращает API.|
-| standard_type | строка | ChEMBL `/activity` | Нормализованный тип (ограничен значениями `IC50` или `Ki`).|
+| standard_type | строка | ChEMBL `/activity` | Нормализованный тип, ограниченный конфигурацией (например, `IC50`, `EC50`, `Ki`, `KD`).|
 | standard_value | число (float) | ChEMBL `/activity` | Нормализованное числовое значение (молярные единицы), гарантированно неотрицательное.|
 | standard_lower_value | строка/число | ChEMBL `/activity` | Нижняя граница диапазона, если ChEMBL возвращает интервал.|
 | standard_upper_value | строка/число | ChEMBL `/activity` | Верхняя граница диапазона, если она указана.|

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -6,10 +6,12 @@ expected structure of activity dataframes.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import cast
 
 import pandera.pandas as pa
 from pandera.dtypes import DataType
+import yaml
 
 PA_ANY = cast(DataType, None)
 
@@ -23,6 +25,48 @@ _ALLOWED_ACTION_TYPES = {
     "triaged",
     "unknown",
 }
+
+
+def _load_standard_type_values() -> tuple[str, ...]:
+    """Return configured standard type values if available."""
+
+    config_path = Path(__file__).resolve().parents[1] / "config.yaml"
+    try:
+        with config_path.open("r", encoding="utf8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except (FileNotFoundError, yaml.YAMLError, TypeError):
+        return ()
+
+    metrics = (
+        config
+        .get("activity_enrichment", {})
+        .get("action_type", {})
+        .get("metrics", {})
+    )
+    if not isinstance(metrics, dict):
+        return ()
+
+    values: set[str] = set()
+    for key in metrics.keys():
+        token = str(key).strip()
+        if not token:
+            continue
+        variants = {
+            token,
+            token.lower(),
+            token.upper(),
+            token.capitalize(),
+        }
+        if token[0].isalpha():
+            variants.add(token[0].upper() + token[1:])
+        values.update(filter(None, variants))
+    return tuple(sorted(values))
+
+
+_STANDARD_TYPE_VALUES = _load_standard_type_values()
+_STANDARD_TYPE_CHECKS: list[pa.Check] = []
+if _STANDARD_TYPE_VALUES:
+    _STANDARD_TYPE_CHECKS.append(pa.Check.isin(sorted(_STANDARD_TYPE_VALUES)))
 
 
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
@@ -53,7 +97,7 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
         "value": pa.Column(object, required=False, nullable=True),
         "standard_type": pa.Column(
             str,
-            pa.Check.isin(["IC50", "Ki"]),
+            checks=_STANDARD_TYPE_CHECKS,
             required=False,
             nullable=True,
         ),

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,6 +47,22 @@ def test_activities_schema_validation() -> None:
         ActivitiesSchema.validate(invalid)
 
 
+def test_activities_schema_accepts_configured_standard_types() -> None:
+    """Configured standard types are permitted by the schema."""
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["1", "2", "3"],
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+            "assay_chembl_id": ["CHEMBL0", "CHEMBL0", "CHEMBL1"],
+            "standard_value": [1.0, 2.0, 3.0],
+            "standard_type": ["IC50", "EC50", "KD"],
+        }
+    )
+
+    ActivitiesSchema.validate(df)
+
+
 def test_activities_schema_accepts_object_dtypes() -> None:
     """``standard_value`` validates with object dtype."""
 


### PR DESCRIPTION
## Summary
- load configured activity standard types from config.yaml and fall back to type-only validation when unavailable
- update the activities schema and docs to reflect the expanded list of acceptable standard types
- add a regression test covering multiple configured measurement types

## Testing
- pytest tests/test_schemas.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ec943c8483248a108ed18845e1ba