### PR TITLE
Fix document CLI usage examples

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -90,7 +90,7 @@ example:
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
-  python scripts/get_document_data.py \
+  python scripts/get_document_data.py all \
     --input path/to/documents.csv \
     --column document_chembl_id
 ```
@@ -104,7 +104,7 @@ allowed switches (for example, `--batch-size` for PubMed batching).
 ```bash
 python scripts/get_document_data.py pubmed \
   --input path/to/documents.csv \
-  --column document_chembl_id \
+  --column PMID \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -113,7 +113,7 @@ python scripts/get_document_data.py pubmed \
 ```
 
 Use the on-demand rate limit switches to try faster OpenAlex or CrossRef lookups without touching the YAML file; the fallback
-CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried. Provide a CSV with the columns referenced by `--fallback-doi-pmid-column` and `--fallback-doi-value-column`; when left unspecified the CLI expects `PMID` and `DOI`, while the example above demonstrates custom headers via explicit overrides.【F:scripts/get_document_data.py†L989-L1041】
+CSV parameters plug in a minimal PMID→DOI mapping before the remote services are queried. Provide a CSV with the columns referenced by `--fallback-doi-pmid-column` and `--fallback-doi-value-column`; when left unspecified the CLI expects `PMID` and `DOI`, while the example above demonstrates custom headers via explicit overrides. The PubMed sub-command defaults to the `PMID` identifier column, so omit `--column` when the source CSV already uses that header.【F:scripts/get_document_data.py†L989-L1041】
  
 ## Target aggregation (`get_target_data.py`)
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -94,7 +94,7 @@ python scripts/get_document_data.py all \
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
-  python scripts/get_document_data.py \
+  python scripts/get_document_data.py all \
     --input path/to/documents.csv \
     --column document_chembl_id
 ```
@@ -109,7 +109,7 @@ CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
 ```bash
 python scripts/get_document_data.py pubmed \
   --input path/to/documents.csv \
-  --column document_chembl_id \
+  --column PMID \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -118,7 +118,7 @@ python scripts/get_document_data.py pubmed \
 ```
 
 Флаги `--openalex-rps` и `--crossref-rps` позволяют временно изменить лимиты без правки YAML, а параметры `--fallback-doi-*`
-подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам. Подготовьте файл с колонками из аргументов `--fallback-doi-pmid-column` и `--fallback-doi-value-column`; если не задавать их явно, CLI ожидает заголовки `PMID` и `DOI`, а в примере выше показано переименование через явные параметры.【F:scripts/get_document_data.py†L989-L1041】
+подключают лёгкий CSV с соответствиями PMID→DOI до обращения к внешним сервисам. Подготовьте файл с колонками из аргументов `--fallback-doi-pmid-column` и `--fallback-doi-value-column`; если не задавать их явно, CLI ожидает заголовки `PMID` и `DOI`, а в примере выше показано переименование через явные параметры. Подкоманда PubMed по умолчанию ожидает колонку `PMID`, поэтому флаг `--column` можно опустить, если CSV уже использует это имя.【F:scripts/get_document_data.py†L989-L1041】
 
 
 ## Агрегация таргетов (`get_target_data.py`)


### PR DESCRIPTION
## Summary
- include the appropriate sub-command in the `get_document_data.py` environment-variable example
- update the PubMed example to rely on the default PMID column and note the implicit default in both EN and RU guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f0b246f88324b9f65fa4b70d1cf7