### PR TITLE
Add offline stubs and regression tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,25 @@ import pytest
 from library.config import ApiCfg, Config
 
 
+@pytest.fixture(autouse=True)
+def _disable_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent external HTTP requests during tests for determinism."""
+
+    try:
+        import requests
+    except ModuleNotFoundError:  # pragma: no cover - requests optional in env
+        return
+
+    def _deny_request(self, method, url, *args, **kwargs):  # type: ignore[override]
+        msg = (
+            "External HTTP requests are disabled during tests; "
+            f"attempted {method} {url}"
+        )
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("requests.sessions.Session.request", _deny_request)
+
+
 @pytest.fixture()
 def cfg() -> Config:
     """Return a baseline :class:`~library.config.Config` instance for tests.

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,0 +1,25 @@
+"""Regression tests for CLI invocation helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from library.cli.commands import _run
+
+
+def test_run_invokes_module_main(monkeypatch) -> None:
+    """Ensure ``_run`` forwards argv to the resolved module."""
+
+    captured: dict[str, object] = {}
+
+    def fake_import(name: str):
+        captured["module"] = name
+        return SimpleNamespace(main=lambda argv=None: (captured.update(argv=argv) or 5))
+
+    monkeypatch.setattr("library.cli.commands.import_module", fake_import)
+
+    exit_code = _run("scripts.get_activity_data", ["--print-config"])
+
+    assert exit_code == 5
+    assert captured["module"] == "scripts.get_activity_data"
+    assert captured["argv"] == ["--print-config"]

--- a/tests/test_csv_utils_streaming.py
+++ b/tests/test_csv_utils_streaming.py
@@ -1,0 +1,36 @@
+"""Regression tests for streamed CSV exports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.csv_utils import write_csv_deterministic
+
+
+def test_write_csv_deterministic_uses_chunksize(
+    tmp_path: Path, monkeypatch
+) -> None:
+    df = pd.DataFrame({"id": [3, 1, 2], "flag": [True, False, True]})
+
+    recorded: dict[str, object] = {}
+    original = pd.DataFrame.to_csv
+
+    def spy(self, *args, **kwargs):  # type: ignore[override]
+        recorded["chunksize"] = kwargs.get("chunksize")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(pd.DataFrame, "to_csv", spy)
+
+    out_path = tmp_path / "stream.csv"
+    write_csv_deterministic(
+        df,
+        out_path,
+        col_order=["id", "flag"],
+        key_cols=["id"],
+        chunksize=64,
+    )
+
+    assert recorded["chunksize"] == 64
+    assert out_path.exists()

--- a/tests/test_molecule_catalog_cache.py
+++ b/tests/test_molecule_catalog_cache.py
@@ -1,0 +1,57 @@
+"""Regression tests for molecule catalog cache parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.config import MoleculeCatalogCfg
+from library import molecule_catalog as mc
+
+
+def _cfg(cache_path: Path) -> MoleculeCatalogCfg:
+    return MoleculeCatalogCfg().model_copy(
+        update={
+            "cache_path": cache_path,
+            "sqlite_path": cache_path.with_suffix(".sqlite"),
+        }
+    )
+
+
+def test_read_cache_csv_normalises_ids(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "molecule_chembl_id,parent_molecule_chembl_id",
+                " chembl1 , CHEMBL999 ",
+                "CHEMBL2,",  # missing parent skipped
+                ",CHEMBL3",  # missing child skipped
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = mc._read_cache(path, _cfg(path))
+
+    assert result == {"CHEMBL1": "CHEMBL999"}
+
+
+def test_read_cache_invalid_json_logs_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "catalog.json"
+    path.write_text("not-json", encoding="utf-8")
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, *args, extra: dict[str, object] | None = None, **kwargs):
+        events.append((event, extra or {}))
+
+    monkeypatch.setattr(mc.logger, "warning", capture)
+
+    result = mc._read_cache(path, _cfg(path))
+
+    assert result == {}
+    assert any(event == "invalid_catalog_cache" for event, _ in events)


### PR DESCRIPTION
## Summary
- block outbound HTTP calls during pytest runs to ensure deterministic execution
- add regression coverage for molecule parent catalog cache handling
- verify CLI dispatcher forwards arguments and streamed CSV exports honour chunk size

## Testing
- pytest tests/test_molecule_catalog_cache.py tests/test_cli_run.py tests/test_csv_utils_streaming.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f2d0a1888324b4015a025ce306b2