### PR TITLE
Stream document exports via chunked deterministic writer

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -834,6 +834,12 @@
           "title": "Csv Encoding",
           "type": "string"
         },
+        "csv_chunksize": {
+          "default": 10000,
+          "minimum": 1,
+          "title": "Csv Chunksize",
+          "type": "integer"
+        },
         "na_markers": {
           "anyOf": [
             {

--- a/config.yaml
+++ b/config.yaml
@@ -176,6 +176,7 @@ local:
     cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA_CACHE_DIR)
     csv_sep: ","  # CSV field separator
     csv_encoding: "utf-8-sig"  # Encoding for CSV files
+    csv_chunksize: 10000  # Rows per batch when streaming deterministic CSV exports
     na_markers:
       - "#N/A"
     exist_ok: true  # Create directories with ensure_dirs if missing

--- a/library/config.py
+++ b/library/config.py
@@ -383,6 +383,7 @@ class IoCfg(_BoolModel):
     csv_sep: str = ","
     csv_encoding: str = "utf-8-sig"
     na_markers: Sequence[str] | None = ("#N/A",)
+    csv_chunksize: int = Field(10000, ge=1)
     exist_ok: bool = True
 
     @field_validator("exist_ok", mode="before")

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -45,6 +45,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import document_postprocessing as dp
 from library import io
+from library.csv_utils import write_csv_chunks_deterministic
 from library import openalex_crossref_library as ocl
 from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
@@ -564,6 +565,61 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
     return frame[_EXPORT_COLUMNS]
 
 
+def _iter_export_chunks(
+    df: pd.DataFrame,
+    *,
+    chunk_size: int | None,
+) -> Iterable[pd.DataFrame]:
+    """Yield export-ready chunks with deterministic column ordering."""
+
+    total_rows = len(df)
+    if total_rows == 0:
+        empty = dataframe_to_strings(df.copy(), skip=_NUMERIC_EXPORT_COLUMNS)
+        yield _prepare_export_frame(empty)
+        return
+
+    effective_size = chunk_size if chunk_size and chunk_size > 0 else total_rows
+    for start in range(0, total_rows, effective_size):
+        stop = start + effective_size
+        chunk = df.iloc[start:stop].copy()
+        chunk = dataframe_to_strings(chunk, skip=_NUMERIC_EXPORT_COLUMNS)
+        yield _prepare_export_frame(chunk)
+
+
+def _resolve_chunk_size(value: int | None) -> int | None:
+    """Return ``value`` when positive, otherwise ``None``."""
+
+    if value is None:
+        return None
+    if value <= 0:
+        logger.warning("invalid_csv_chunksize", value=value)
+        return None
+    return value
+
+
+def _write_export_chunks(
+    chunks: Iterable[pd.DataFrame],
+    path: Path,
+    *,
+    cfg: Config,
+    key_cols: Sequence[str],
+    chunk_size: int | None,
+) -> Path:
+    """Stream ``chunks`` to ``path`` using the deterministic CSV writer."""
+
+    kwargs: dict[str, object] = {
+        "col_order": list(_EXPORT_COLUMNS),
+        "key_cols": list(key_cols),
+        "sep": cfg.io.csv_sep,
+        "encoding": cfg.io.csv_encoding,
+        "cfg": cfg,
+    }
+    if chunk_size:
+        kwargs["chunksize"] = chunk_size
+        kwargs["merge_chunksize"] = chunk_size
+    return write_csv_chunks_deterministic(chunks, path, **kwargs)
+
+
 def _finalise_export(
     df: pd.DataFrame,
     output: Path,
@@ -574,8 +630,10 @@ def _finalise_export(
 ) -> int:
     """Validate ``df`` and write CSV/metadata artefacts."""
 
-    df = add_pipeline_metadata(df)
-    ordered = build_dataframe(df, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False)
+    df_with_metadata = add_pipeline_metadata(df)
+    ordered = build_dataframe(
+        df_with_metadata, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
+    )
     rows_total = len(ordered)
     exit_code = 0
     required_cols = {
@@ -617,34 +675,40 @@ def _finalise_export(
     rows_kept = len(validated)
     rows_dropped = rows_total - rows_kept
 
-    export_df = build_dataframe(
+    export_ready = build_dataframe(
         validated, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
     )
-    export_df = dataframe_to_strings(export_df, skip=_NUMERIC_EXPORT_COLUMNS)
-    export_df = _prepare_export_frame(export_df)
+
+    renamed_columns = {
+        column: _EXPORT_COLUMN_RENAMES.get(column, column)
+        for column in export_ready.columns
+    }
+    final_column_names = set(renamed_columns.values())
 
     key_cols: list[str] = []
     if key_columns:
         for column in key_columns:
             mapped = _EXPORT_COLUMN_RENAMES.get(column, column)
-            if mapped in export_df.columns and mapped not in key_cols:
+            if mapped in final_column_names and mapped not in key_cols:
                 key_cols.append(mapped)
     if not key_cols:
         for candidate in _EXPORT_SORT_FALLBACK:
-            if candidate in export_df.columns:
+            if candidate in final_column_names:
                 key_cols = [candidate]
                 break
     if not key_cols:
         key_cols = [_EXPORT_COLUMNS[0]]
 
-    col_order = list(_EXPORT_COLUMNS)
+    chunk_size = _resolve_chunk_size(getattr(cfg.io, "csv_chunksize", None))
+    chunks = _iter_export_chunks(export_ready, chunk_size=chunk_size)
+
     try:
-        csv_path = io.write_csv(
-            export_df,
+        csv_path = _write_export_chunks(
+            chunks,
             output,
             cfg=cfg,
             key_cols=key_cols,
-            col_order=col_order,
+            chunk_size=chunk_size,
         )
     except OSError as exc:
         logger.error("csv_write_failed", error=str(exc), path=str(output))
@@ -668,7 +732,7 @@ def _finalise_export(
 
     quality_path = csv_path.with_suffix(".quality.json")
     try:
-        report = build_quality_report(validated)
+        report = build_quality_report(export_ready)
         save_quality_report(report, quality_path)
     except (OSError, TypeError, ValueError) as exc:
         logger.error(
@@ -679,7 +743,7 @@ def _finalise_export(
         return 1
 
     try:
-        analyze_table_quality(validated, table_name=str(csv_path.with_suffix("")))
+        analyze_table_quality(export_ready, table_name=str(csv_path.with_suffix("")))
     except ValueError as exc:
         logger.error("quality_report_generation_failed", error=str(exc))
         return 1

--- a/tests/test_determinism_script.py
+++ b/tests/test_determinism_script.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
 
 
 def test_determinism_script_returns_zero() -> None:
@@ -19,3 +23,33 @@ def test_determinism_script_returns_zero() -> None:
         check=False,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_determinism_script_reports_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The script should exit with ``1`` when hashes differ."""
+
+    from scripts import check_determinism as script
+    from library.utils.cli_tools import check_determinism as impl
+
+    def fake_write_csv_deterministic(
+        df: pd.DataFrame,
+        path: Path,
+        **_: object,
+    ) -> Path:
+        target = Path(path)
+        content = "first" if "first" in target.name else "second"
+        target.write_text(content, encoding="utf-8")
+        return target
+
+    monkeypatch.setattr(impl, "write_csv_deterministic", fake_write_csv_deterministic)
+    monkeypatch.setattr(
+        impl,
+        "sha256_file",
+        lambda p: "hash1" if "first" in str(p) else "hash2",
+    )
+    monkeypatch.setattr(sys, "argv", ["check_determinism", "--log-level", "DEBUG"])
+
+    rc = script.main()
+    assert rc == 1

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -4,7 +4,7 @@ import argparse
 import io
 import json
 import sys
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -76,20 +76,18 @@ def test_cli_uses_custom_column(
     monkeypatch.setattr(cl, "get_documents", fake_get_documents)
     monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
 
-    def fake_write_csv(
-        df: pd.DataFrame,
+    def fake_write_export_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
-        key_cols: list[str] | None = None,
-        col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        key_cols: Sequence[str],
+        chunk_size: int | None,
     ) -> Path:
+        list(chunks)
         return path
 
-    monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "_write_export_chunks", fake_write_export_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
@@ -450,23 +448,20 @@ def test_write_csv_column_order(
 
     captured: dict[str, Any] = {}
 
-    def fake_write_csv(
-        frame: pd.DataFrame,
+    def fake_write_export_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
-        key_cols: list[str] | None = None,
-        col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        key_cols: Sequence[str],
+        chunk_size: int | None,
     ) -> Path:
-        captured["col_order"] = list(col_order or [])
-        captured["columns"] = list(frame.columns)
-        captured["key_cols"] = list(key_cols or [])
+        frames = list(chunks)
+        captured["columns"] = list(frames[0].columns) if frames else []
+        captured["key_cols"] = list(key_cols)
         return path
 
-    monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "_write_export_chunks", fake_write_export_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
@@ -480,7 +475,6 @@ def test_write_csv_column_order(
     )
     rc = gdd.run_chembl(cfg, args)
     assert rc == 0
-    assert captured["col_order"] == gdd._EXPORT_COLUMNS
     assert captured["columns"] == gdd._EXPORT_COLUMNS
     assert captured["key_cols"] == ["ChEMBL.document_chembl_id"]
 
@@ -863,21 +857,19 @@ def test_finalise_export_falls_back_to_default_key(
     output = tmp_path / "documents.csv"
     captured: dict[str, Any] = {}
 
-    def fake_write_csv(
-        frame: pd.DataFrame,
+    def fake_write_export_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
-        key_cols: list[str] | None = None,
-        col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        key_cols: Sequence[str],
+        chunk_size: int | None,
     ) -> Path:
-        captured["key_cols"] = list(key_cols) if key_cols is not None else None
+        list(chunks)
+        captured["key_cols"] = list(key_cols)
         return path
 
-    monkeypatch.setattr(gdd.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "_write_export_chunks", fake_write_export_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "hash")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})


### PR DESCRIPTION
## Summary
- add a configurable csv chunk size to the IO configuration so document exports can be streamed deterministically
- refactor document export finalisation to stream chunks through the deterministic writer while preserving key column fallbacks
- update document pipeline and determinism tests to use the new writer helper and cover hash mismatch handling

## Testing
- pytest tests/test_get_document_data.py::test_finalise_export_falls_back_to_default_key tests/test_get_document_data.py::test_write_csv_column_order tests/test_determinism_script.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6f207acb4832491343476c0fe5ffb