### PR TITLE
Improve environment override validation errors

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -22,7 +22,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, ValidationError, field_validator
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -981,8 +981,9 @@ def _set_by_path(data: dict[str, Any], path: list[str], value: Any) -> None:
     cur[path[-1]] = value
 
 
-def _apply_env_overrides(data: dict[str, Any]) -> None:
+def _apply_env_overrides(data: dict[str, Any]) -> dict[tuple[str, ...], str]:
     prefix = "CHEMBL_DA"
+    overrides: dict[tuple[str, ...], str] = {}
     for env_key, env_val in os.environ.items():
         key = env_key.upper()
         if key in _ALIAS_MAP:
@@ -995,7 +996,89 @@ def _apply_env_overrides(data: dict[str, Any]) -> None:
         if not _is_valid_path(parts):
             logger.warning(f"Environment variable {key} ignored")
             continue
-        _set_by_path(data, parts, env_val)
+        value = _parse_env_value(key, env_val)
+        _set_by_path(data, parts, value)
+        overrides[tuple(parts)] = key
+    return overrides
+
+
+def _parse_env_value(env_key: str, raw_value: str) -> Any:
+    """Normalize *raw_value* from environment variable *env_key*.
+
+    Empty strings are returned unchanged to avoid coercing intentional blanks to
+    ``None``. Other values are parsed using :func:`yaml.safe_load` so that
+    numbers, booleans, lists, and mappings are deserialized before validation.
+    """
+
+    if raw_value == "":
+        return ""
+    if raw_value and raw_value.strip() == "":
+        return raw_value
+    try:
+        return yaml.safe_load(raw_value)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{env_key} could not be parsed: {exc}") from exc
+
+
+def _normalize_env_errors(
+    errors: list[dict[str, Any]], overrides: dict[tuple[str, ...], str]
+) -> tuple[list[str], int]:
+    """Return formatted messages for validation *errors* caused by overrides."""
+
+    messages: list[str] = []
+    handled = 0
+    for error in errors:
+        loc = error.get("loc", ())
+        if not isinstance(loc, tuple):
+            continue
+        path = tuple(str(part).lower() for part in loc if isinstance(part, str))
+        env_key = overrides.get(path)
+        if not env_key:
+            continue
+        messages.append(_format_env_error(env_key, error))
+        handled += 1
+    return messages, handled
+
+
+def _format_env_error(env_key: str, error: dict[str, Any]) -> str:
+    """Return a human readable error string for *env_key* based on *error*."""
+
+    message = _format_env_error_message(error)
+    return f"{env_key} {message}".strip()
+
+
+def _format_env_error_message(error: dict[str, Any]) -> str:
+    """Convert a Pydantic error dictionary into a concise human message."""
+
+    error_type = error.get("type")
+    ctx: dict[str, Any] = error.get("ctx") or {}
+    if error_type == "greater_than_equal" and "ge" in ctx:
+        return f"must be ≥{ctx['ge']}"
+    if error_type == "greater_than" and "gt" in ctx:
+        return f"must be >{ctx['gt']}"
+    if error_type == "less_than_equal" and "le" in ctx:
+        return f"must be ≤{ctx['le']}"
+    if error_type == "less_than" and "lt" in ctx:
+        return f"must be <{ctx['lt']}"
+    if error_type == "int_parsing":
+        return "must be an integer"
+    if error_type == "float_parsing":
+        return "must be a number"
+    if error_type == "bool_parsing":
+        return "must be a boolean"
+    if error_type in {"string_type", "string_parsing"}:
+        return "must be a string"
+    if error_type == "list_type":
+        return "must be a list"
+    if error_type == "dict_type":
+        return "must be a mapping"
+    if error_type in {"enum", "literal_error"} and "expected" in ctx:
+        expected = ", ".join(map(str, ctx["expected"]))
+        return f"must be one of {expected}"
+    message = error.get("msg", "is invalid")
+    if message.startswith("Input should be "):
+        return "must be " + message[len("Input should be ") :]
+    return message
 
 
 def _is_valid_path(path: list[str]) -> bool:
@@ -1062,7 +1145,7 @@ def load_config(
             "provide an application config file such as config.yaml."
         )
 
-    _apply_env_overrides(data)
+    env_overrides = _apply_env_overrides(data)
     _upgrade_legacy_config(data)
 
     if cli_overrides:
@@ -1076,7 +1159,16 @@ def load_config(
             raise ValueError(msg)
         logger.warning(msg)
 
-    cfg = Config.model_validate(data)
+    try:
+        cfg = Config.model_validate(data)
+    except ValidationError as exc:
+        env_messages, handled = _normalize_env_errors(exc.errors(), env_overrides)
+        if env_messages:
+            message = "; ".join(env_messages)
+            if handled < len(exc.errors()):
+                message = f"{message}; additional validation errors: {exc}"
+            raise ConfigError(message) from exc
+        raise
 
     if not cfg.io.exist_ok:
         for p in (cfg.io.output_dir, cfg.io.cache_dir):

--- a/tests/test_config_property.py
+++ b/tests/test_config_property.py
@@ -36,7 +36,7 @@ _VALID_ENV_PATHS: dict[str, list[str]] = {
 
 @given(
     item=st.sampled_from(list(_VALID_ENV_PATHS.items())),
-    value=st.text(alphabet=string.ascii_letters + string.digits),
+    value=st.integers(min_value=1, max_value=10_000).map(str),
 )
 def test_apply_env_overrides_valid(item: tuple[str, list[str]], value: str) -> None:
     """Valid environment variables override configuration values."""
@@ -45,9 +45,10 @@ def test_apply_env_overrides_valid(item: tuple[str, list[str]], value: str) -> N
     data: dict[str, Any] = {}
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setenv(env_key, value)
-        config._apply_env_overrides(data)
+        overrides = config._apply_env_overrides(data)
 
-    assert _get_by_path(data, path) == value
+    assert _get_by_path(data, path) == int(value)
+    assert overrides[tuple(path)] == env_key
 
 
 @given(
@@ -75,7 +76,8 @@ def test_apply_env_overrides_invalid(parts: list[str], value: str) -> None:
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setenv(env_key, value)
         monkeypatch.setattr(logger, "warning", fake_warning)
-        config._apply_env_overrides(data)
+        overrides = config._apply_env_overrides(data)
 
     assert data == {}
+    assert overrides == {}
     assert any(env_key in msg for msg in warnings)

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from library.config import load_config
+import pytest
+
+from library.config import ConfigError, load_config
 
 
 def test_env_file_overrides(tmp_path, monkeypatch) -> None:
@@ -27,3 +29,23 @@ def test_env_file_overrides(tmp_path, monkeypatch) -> None:
 
     cfg = load_config(cfg_path)
     assert cfg.api.rps == 7
+
+
+def test_env_override_invalid_value(tmp_path, monkeypatch) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("", encoding="utf8")
+
+    monkeypatch.setenv("CHEMBL_DA_RPS", "0")
+
+    with pytest.raises(ConfigError, match="CHEMBL_DA_RPS must be ≥1"):
+        load_config(cfg_path)
+
+
+def test_env_override_invalid_yaml(tmp_path, monkeypatch) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("", encoding="utf8")
+
+    monkeypatch.setenv("CHEMBL_DA_RPS", "[1, 2")
+
+    with pytest.raises(ConfigError, match="CHEMBL_DA_RPS could not be parsed"):
+        load_config(cfg_path)


### PR DESCRIPTION
## Summary
- normalize environment-derived overrides before invoking the Pydantic config model so that validation errors can be mapped back to the originating variables with clear guidance
- add targeted tests covering environment override normalization, invalid values, and malformed YAML inputs

## Testing
- pytest tests/test_env_loading.py tests/test_config_property.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f26b7b6c832480396f94ae3f8601