### PR TITLE
Format codebase with Ruff and fix mypy strict issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -25,15 +25,15 @@ from .document_type_terms import (
 )
 from .logging_setup import Logger, LoggerConfig, configure_logger
 from .organism_classification import (
+    TYPE_MULTICELLULAR,
+    TYPE_UNICELLULAR,
+    TYPE_VIRAL,
     OrganismClassificationRules,
     add_cellularity,
     add_cellularity_smart,
     classify_by_lineage,
     classify_record,
     normalize,
-    TYPE_MULTICELLULAR,
-    TYPE_UNICELLULAR,
-    TYPE_VIRAL,
 )
 from .parser_schema import CSVExportArgs
 from .sidecar import SidecarErrors

--- a/library/activity_action_properties.py
+++ b/library/activity_action_properties.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import json
+from collections.abc import Mapping
 from typing import Any
 
 import pandas as pd
@@ -46,7 +46,7 @@ def _has_value(value: Any) -> bool:
         return False
     if isinstance(value, str):
         return bool(value.strip())
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, list | tuple | set):
         return any(_has_value(item) for item in value)
     if isinstance(value, Mapping):
         return any(_has_value(item) for item in value.values())
@@ -67,7 +67,9 @@ def _clean_structure(data: Any) -> Any:
         }
         return cleaned if cleaned else None
     if isinstance(data, list):
-        cleaned_list = [item for item in (_clean_structure(v) for v in data) if _has_value(item)]
+        cleaned_list = [
+            item for item in (_clean_structure(v) for v in data) if _has_value(item)
+        ]
         return cleaned_list if cleaned_list else None
     if isinstance(data, tuple):
         cleaned_tuple = tuple(
@@ -110,7 +112,9 @@ def _extract_effect_features(record: Mapping[str, Any]) -> dict[str, Any]:
     text = _collect_text(record)
     positive_hits = sorted({kw for kw in _POSITIVE_KEYWORDS if kw in text})
     negative_hits = sorted({kw for kw in _NEGATIVE_KEYWORDS if kw in text})
-    is_allosteric = bool(positive_hits or negative_hits or any(kw in text for kw in _ALLOSTERIC_KEYWORDS))
+    is_allosteric = bool(
+        positive_hits or negative_hits or any(kw in text for kw in _ALLOSTERIC_KEYWORDS)
+    )
     return {
         "allosteric": is_allosteric,
         "positive": bool(positive_hits),
@@ -215,7 +219,7 @@ def annotate_action_properties(df: pd.DataFrame) -> pd.DataFrame:
     action_types: list[str | None] = []
     column_names = tuple(df.columns)
     records_iter = (
-        dict(zip(column_names, row))
+        dict(zip(column_names, row, strict=False))
         for row in df.itertuples(index=False, name=None)
     )
 
@@ -236,4 +240,3 @@ __all__ = [
     "build_activity_properties",
     "infer_action_type",
 ]
-

--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -50,11 +50,7 @@ class ChemblClient:
         api = api or ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)")
         retry = retry or RetryCfg()
         self.session = session or session_with_retry(api, retry)
-        ttl = (
-            chembl.cache_ttl
-            if chembl is not None
-            else ChemblCacheCfg().cache_ttl
-        )
+        ttl = chembl.cache_ttl if chembl is not None else ChemblCacheCfg().cache_ttl
         maxsize = (
             chembl.cache_maxsize
             if chembl is not None

--- a/library/cli/commands/__init__.py
+++ b/library/cli/commands/__init__.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from importlib import import_module
+from types import ModuleType
 from typing import cast
 
 
-def _resolve_module(module: str):
+def _resolve_module(module: str) -> ModuleType:
     """Return the module object for the requested CLI tool."""
 
     if "." in module:
@@ -36,4 +37,4 @@ def _run(module: str, argv: Sequence[str] | None = None) -> int:
     return cast(int, main_func(argv))
 
 
-__all__ = ["_run"]
+__all__: list[str] = ["_run"]

--- a/library/config.py
+++ b/library/config.py
@@ -415,6 +415,7 @@ class InitCfg(_BaseModel):
     all_doc: Path = Path("data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx")
     output_dir: Path = Path("data/output/ChEMBL/processed")
 
+
 class RateCfg(_BaseModel):
     global_rps: int = Field(8, ge=1)
     global_burst: int = Field(8, ge=1)
@@ -538,7 +539,9 @@ class ActivityActionTypeCfg(_BoolModel):
             items = list(value)
         cleaned = [str(item).strip() for item in items if str(item).strip()]
         if not cleaned:
-            raise ValueError("activity_enrichment.action_type field lists must be non-empty")
+            raise ValueError(
+                "activity_enrichment.action_type field lists must be non-empty"
+            )
         return cleaned
 
 
@@ -589,7 +592,9 @@ class ActivityPropertiesCfg(_BoolModel):
     @classmethod
     def _non_empty(cls, v: str) -> str:
         if not v or not str(v).strip():
-            raise ValueError("activity_enrichment.activity_properties fields must be non-empty")
+            raise ValueError(
+                "activity_enrichment.activity_properties fields must be non-empty"
+            )
         return v
 
 
@@ -775,16 +780,12 @@ class ChemblSourceCfg(_BaseModel):
     molecule_catalog: MoleculeCatalogCfg = Field(
         default_factory=lambda: MoleculeCatalogCfg()
     )
-    pipelines: ChemblPipelinesCfg = Field(
-        default_factory=lambda: ChemblPipelinesCfg()
-    )
+    pipelines: ChemblPipelinesCfg = Field(default_factory=lambda: ChemblPipelinesCfg())
 
 
 class UniprotSourceCfg(_BaseModel):
     api: UniprotCfg = Field(default_factory=lambda: UniprotCfg())
-    mapping: UniprotMappingCfg = Field(
-        default_factory=lambda: UniprotMappingCfg()
-    )
+    mapping: UniprotMappingCfg = Field(default_factory=lambda: UniprotMappingCfg())
 
 
 class SourcesCfg(_BaseModel):
@@ -1133,11 +1134,7 @@ def _merge_mapping(dest: dict[str, Any], src: dict[str, Any]) -> None:
     """Recursively merge mapping *src* into *dest*."""
 
     for key, value in src.items():
-        if (
-            key in dest
-            and isinstance(dest[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in dest and isinstance(dest[key], dict) and isinstance(value, dict):
             _merge_mapping(dest[key], value)
         else:
             dest[key] = value
@@ -1207,6 +1204,7 @@ def _upgrade_legacy_config(data: dict[str, Any]) -> None:
     if "doc_type" in data:
         system_cfg.setdefault("doc_type", {})
         _merge_mapping(system_cfg["doc_type"], data.pop("doc_type"))
+
 
 def print_config(cfg: Config) -> None:
     """Print ``cfg`` as YAML masking secret values."""

--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -260,7 +260,9 @@ def write_csv_deterministic(
                 )
                 tmp_paths.append(chunk_path)
 
-            key_indices = [column_names.index(c) for c in sort_cols] if sort_cols else []
+            key_indices = (
+                [column_names.index(c) for c in sort_cols] if sort_cols else []
+            )
             key_funcs: list[Callable[[str], object]] = []
             for col in sort_cols:
                 dtype = work.dtypes[col]
@@ -471,7 +473,9 @@ def write_csv_chunks_deterministic(
         first = next((c for c in current if c is not None), pd.DataFrame())
         columns = list(first.columns)
         dtypes = {col: first.dtypes[col].name for col in columns}
-        resolved_sort_cols = _resolve_sort_columns(first, key_cols_list, emit_warning=False)
+        resolved_sort_cols = _resolve_sort_columns(
+            first, key_cols_list, emit_warning=False
+        )
 
         def _fmt(value: Any) -> Any:
             if pd.isna(value):
@@ -486,7 +490,11 @@ def write_csv_chunks_deterministic(
         for idx, frame in enumerate(current):
             if frame is not None and not frame.empty:
                 row = frame.iloc[0]
-                key = tuple(row[k] for k in resolved_sort_cols) if resolved_sort_cols else tuple()
+                key = (
+                    tuple(row[k] for k in resolved_sort_cols)
+                    if resolved_sort_cols
+                    else tuple()
+                )
                 heapq.heappush(heap, (key, idx, 0))
 
         with out_path.open("w", encoding=encoding, newline="") as fh:

--- a/library/input_initialisation_library.py
+++ b/library/input_initialisation_library.py
@@ -19,12 +19,10 @@ except ImportError as exc:  # pragma: no cover - Python <3.7
 
 import pandas as pd
 
+from . import organism_classification
 from .config import Config
 from .io import write_csv
 from .log import logger
-
-from . import organism_classification
-
 
 EntityName = Literal[
     "activity",
@@ -511,7 +509,6 @@ def process_activity_table(
 
     targets = pd.read_csv(
         targets_path,
-
         usecols=[
             "target_chembl_id",
             "IUPHAR_class",
@@ -538,7 +535,6 @@ def process_activity_table(
             "phylum": "string",
             "taxon_id": "string",
         },
-
     )
 
     df = df.merge(
@@ -555,7 +551,6 @@ def process_activity_table(
                 "taxon_id",
                 "gene_index",
                 "taxon_index",
-                "organism_cellularity",
             ]
         ],
         how="left",
@@ -565,22 +560,39 @@ def process_activity_table(
     # input dataframe already contains some of these fields.
     df = df.loc[:, ~df.columns.duplicated()]
 
+    if "organism_cellularity" not in df.columns:
+        df["organism_cellularity"] = pd.Series(dtype="string")
+
     df["multifunctional_enzyme"] = _safe_to_bool(
         df["multifunctional_enzyme"], "multifunctional_enzyme"
     )
-
 
     df = organism_classification.add_cellularity_smart(
         df,
         genus_col="genus",
         superkingdom_col="superkingdom",
         phylum_col="phylum",
-        taxon_id_col="taxon_id",
-        output_col="unicellular_organism",
+        output_col="organism_cellularity",
     )
 
-    df.drop(columns=["genus", "superkingdom", "phylum", "taxon_id"], inplace=True)
+    unicellular_labels = {
+        organism_classification.TYPE_UNICELLULAR,
+        organism_classification.TYPE_VIRAL,
+    }
+    df["unicellular_organism"] = (
+        df["organism_cellularity"].astype("string").isin(unicellular_labels)
+    ).astype("boolean")
 
+    df.drop(
+        columns=[
+            "genus",
+            "superkingdom",
+            "phylum",
+            "taxon_id",
+            "organism_cellularity",
+        ],
+        inplace=True,
+    )
 
     # --- final ordering ----------------------------------------------------
     final_cols = [
@@ -1586,5 +1598,3 @@ def normalize_pair_columns(df: pd.DataFrame) -> pd.DataFrame:
         elif key == "activityid2":
             rename[col] = "activity_chembl_id2"
     return df.rename(columns=rename)
-
-

--- a/library/io.py
+++ b/library/io.py
@@ -34,8 +34,8 @@ import yaml
 
 from . import validation
 from .config import Config, IoCfg, _serialize_paths
-from .log import logger
 from .git_utils import _git_sha
+from .log import logger
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     import pandera as pa

--- a/library/mapper_library.py
+++ b/library/mapper_library.py
@@ -15,7 +15,6 @@ from .config import UniprotMappingCfg
 from .log import logger
 from .rate_limiter import get_limiter
 
-
 _UNIPROT_MAPPING_CACHE_MAXSIZE = 128
 
 

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import csv
 import json
 import sqlite3
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from time import perf_counter
-from typing import Mapping
 from urllib.parse import urlencode, urljoin
 
 from .chembl_client import ChemblClient, _chunked
@@ -277,7 +276,9 @@ def _fetch_parent_catalog_via_helper(
             if cache_hits:
                 result.update(cache_hits)
                 outstanding = [
-                    chembl_id for chembl_id in outstanding if chembl_id not in cache_hits
+                    chembl_id
+                    for chembl_id in outstanding
+                    if chembl_id not in cache_hits
                 ]
 
         if outstanding:
@@ -292,7 +293,9 @@ def _fetch_parent_catalog_via_helper(
                 outstanding = outstanding[:single_limit]
 
         if outstanding:
-            max_workers = max(1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY))
+            max_workers = max(
+                1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY)
+            )
             single_requests = len(outstanding)
 
             def _fetch_with_retry(chembl_id: str) -> tuple[str, str] | None:
@@ -418,12 +421,16 @@ def fetch_parent_catalog_for(
             continue
         result.update(chunk_result)
         if len(chunk_result) != len(chunk):
-            missing = [chembl_id for chembl_id in chunk if chembl_id not in chunk_result]
+            missing = [
+                chembl_id for chembl_id in chunk if chembl_id not in chunk_result
+            ]
             if missing:
                 fallback_candidates.extend(missing)
 
     if fallback_candidates:
-        ordered = [item for item in dict.fromkeys(fallback_candidates) if item not in result]
+        ordered = [
+            item for item in dict.fromkeys(fallback_candidates) if item not in result
+        ]
         if ordered:
             fallback_result = _fetch_parent_catalog_via_helper(
                 ordered,
@@ -500,7 +507,7 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
                         "missing columns in parent catalog: "
                         + ", ".join(sorted(missing))
                     )
-                result: dict[str, str] = {}
+                parsed: dict[str, str] = {}
                 for row in reader:
                     child = row.get(catalog_cfg.child_field)
                     parent = row.get(catalog_cfg.parent_field)
@@ -511,8 +518,8 @@ def _read_cache(path: Path, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
                         parent_id = _normalise_chembl_id(str(parent))
                     except ValueError:
                         continue
-                    result[child_id] = parent_id
-                return result
+                    parsed[child_id] = parent_id
+                return parsed
         except csv.Error as exc:  # pragma: no cover - defensive
             raise ValueError(f"invalid CSV catalog: {path}: {exc}") from exc
     try:

--- a/library/organism_classification.py
+++ b/library/organism_classification.py
@@ -1,4 +1,3 @@
-
 """Utilities for classifying organism cellularity.
 
 This module provides helpers to derive a ``unicellular_organism`` flag
@@ -7,9 +6,8 @@ from basic taxonomic annotations available in ChEMBL dictionaries.
 
 from __future__ import annotations
 
-
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Iterable, Mapping, Sequence
 
 import pandas as pd
 
@@ -114,7 +112,9 @@ class OrganismClassificationRules:
 DEFAULT_RULES = OrganismClassificationRules()
 
 
-def normalize(value: object | None, *, rules: OrganismClassificationRules = DEFAULT_RULES) -> str:
+def normalize(
+    value: object | None, *, rules: OrganismClassificationRules = DEFAULT_RULES
+) -> str:
     """Return a lowercase normalised taxonomy token."""
 
     if isinstance(value, pd.Series):
@@ -161,7 +161,6 @@ def classify_by_lineage(
     if superkingdom in rules.unicellular_superkingdoms:
         return rules.label_unicellular()
 
-
     if any(token in rules.unicellular_phyla for token in _split_taxonomy(phylum)):
         return rules.label_unicellular()
     if any(token in rules.unicellular_classes for token in _split_taxonomy(klass)):
@@ -199,7 +198,6 @@ def classify_record(
 def add_cellularity(
     df: pd.DataFrame,
     *,
-
     genus_column: str = DEFAULT_GENUS_COLUMN,
     superkingdom_column: str = DEFAULT_SUPERKINGDOM_COLUMN,
     phylum_column: str = DEFAULT_PHYLUM_COLUMN,

--- a/library/pipeline_metadata.py
+++ b/library/pipeline_metadata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import lru_cache
 from importlib import metadata
 from pathlib import Path
@@ -13,7 +13,7 @@ import pandas as pd
 try:  # Python 3.11+
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
 
 _PACKAGE_NAME: Final[str] = "chembl-data-acquisition"
 _DEFAULT_VERSION: Final[str] = "0.0.0"
@@ -30,7 +30,10 @@ def _read_version_from_pyproject() -> str:
     try:
         with _PYPROJECT_PATH.open("rb") as handle:
             data = tomllib.load(handle)
-    except (OSError, tomllib.TOMLDecodeError):  # pragma: no cover - unlikely during tests
+    except (
+        OSError,
+        tomllib.TOMLDecodeError,
+    ):  # pragma: no cover - unlikely during tests
         return _DEFAULT_VERSION
     project = data.get("project")
     if isinstance(project, dict):
@@ -54,7 +57,7 @@ def get_pipeline_version() -> str:
 def get_timestamp_utc() -> str:
     """Return an ISO 8601 timestamp representing the pipeline execution time."""
 
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 @lru_cache(maxsize=1)
@@ -74,7 +77,7 @@ def add_pipeline_metadata(df: pd.DataFrame) -> pd.DataFrame:
         # Preserve dtypes while ensuring the columns exist for empty frames.
         metadata_values = pipeline_metadata()
         result = df.copy()
-        for column, value in metadata_values.items():
+        for column, _value in metadata_values.items():
             result[column] = pd.Series(dtype="string")
         return result
 
@@ -90,4 +93,3 @@ __all__ = [
     "get_timestamp_utc",
     "pipeline_metadata",
 ]
-

--- a/library/protein_classification.py
+++ b/library/protein_classification.py
@@ -30,7 +30,6 @@ _CONFIDENCE_MAP: Mapping[str, str] = {
 
 
 def classifier_from_config(cfg: Config) -> IUPHARClassifier:
-
     data = IUPHARData.from_files(
         target_path=cfg.target.iuphar.target_csv,
         family_path=cfg.target.iuphar.family_csv,
@@ -40,7 +39,6 @@ def classifier_from_config(cfg: Config) -> IUPHARClassifier:
 
 
 def _normalise(value: object | None) -> str:
-
     if value is None:
         return ""
     if isinstance(value, float) and pd.isna(value):
@@ -52,21 +50,16 @@ def _normalise(value: object | None) -> str:
 
 
 def _select_evidence(row: pd.Series, status: str) -> str:
-
     evidence_map: Mapping[str, str] = {
         "target_id": _normalise(
             row.get("target_id")
             or row.get("IUPHAR_target_id")
             or row.get("GuidetoPHARMACOLOGY")
         ),
-        "family_id": _normalise(
-            row.get("IUPHAR_family_id") or row.get("family_id")
-        ),
+        "family_id": _normalise(row.get("IUPHAR_family_id") or row.get("family_id")),
         "ec_number": _normalise(row.get("ec_number")),
         "name": _normalise(
-            row.get("iuphar_name")
-            or row.get("IUPHAR_name")
-            or row.get("pref_name")
+            row.get("iuphar_name") or row.get("IUPHAR_name") or row.get("pref_name")
         ),
         "molecular_function": _normalise(row.get("molecular_function")),
     }
@@ -75,7 +68,6 @@ def _select_evidence(row: pd.Series, status: str) -> str:
 
 @dataclass
 class Prediction:
-
     L1: str
     L2: str
     L3: str
@@ -85,7 +77,6 @@ class Prediction:
 
     @classmethod
     def from_record(cls, record: ClassificationRecord, *, evidence: str) -> Prediction:
-
         status = record.STATUS or "N/A"
         confidence = _CONFIDENCE_MAP.get(status, "low")
         rule_id = status if status not in {"", "N/A"} else "-"
@@ -99,7 +90,6 @@ class Prediction:
         )
 
     def as_dict(self) -> dict[str, str]:
-
         return {
             "protein_class_pred_L1": self.L1 or "-",
             "protein_class_pred_L2": self.L2 or "-",
@@ -113,7 +103,6 @@ class Prediction:
 def append_protein_class_predictions(
     df: pd.DataFrame, classifier: IUPHARClassifier
 ) -> pd.DataFrame:
-
     result = df.copy()
     if result.empty:
         for column in PREDICTION_COLUMNS:
@@ -125,9 +114,7 @@ def append_protein_class_predictions(
         family_id = _normalise(row.get("IUPHAR_family_id") or row.get("family_id"))
         ec_number = _normalise(row.get("ec_number"))
         name = _normalise(
-            row.get("iuphar_name")
-            or row.get("IUPHAR_name")
-            or row.get("pref_name")
+            row.get("iuphar_name") or row.get("IUPHAR_name") or row.get("pref_name")
         )
 
         record = classifier.get(target_id, family_id, ec_number, name)
@@ -142,6 +129,7 @@ def append_protein_class_predictions(
 
     predictions = result.apply(_predict, axis=1)
     for column in PREDICTION_COLUMNS:
-        result[column] = predictions[column].fillna("-").replace("", "-").astype("string")
+        result[column] = (
+            predictions[column].fillna("-").replace("", "-").astype("string")
+        )
     return result
-

--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -6,10 +6,10 @@ The implementation is a Python translation of a PowerQuery script.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Callable, Hashable, Mapping, MutableMapping
 from dataclasses import dataclass
 from time import monotonic
-from typing import Any, Hashable, cast
+from typing import Any, cast
 from urllib.parse import quote
 
 import requests
@@ -172,9 +172,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
 
     for attempt in range(1, attempts + 1):
         if deadline is not None and monotonic() >= deadline:
-            logger.warning(
-                "request_timeout", url=url, attempt=attempt, rps=cfg.rps
-            )
+            logger.warning("request_timeout", url=url, attempt=attempt, rps=cfg.rps)
             logger.info("request_fail", url=url, status=None, rps=cfg.rps)
             return None
         event = "request_start" if attempt == 1 else "request_retry"
@@ -210,7 +208,9 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             logger.info("request_fail", url=url, status=status, rps=cfg.rps)
             return None
         if status == 429 or 500 <= status < 600:
-            event_name = "request_rate_limited" if status == 429 else "request_server_error"
+            event_name = (
+                "request_rate_limited" if status == 429 else "request_server_error"
+            )
             logger.warning(
                 event_name,
                 url=url,
@@ -638,7 +638,11 @@ def process_compound(compound_name: str, cfg: PubChemCfg) -> dict[str, str | Non
     """
     cid = get_cid(compound_name, cfg)
     standard = get_standard_name(cid, cfg) if cid else None
-    props = get_properties(cid, cfg) if cid else Properties(None, None, None, None, None, None)
+    props = (
+        get_properties(cid, cfg)
+        if cid
+        else Properties(None, None, None, None, None, None)
+    )
     return {
         "Name": compound_name,
         "CID": cid,

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -48,9 +48,7 @@ class RateLimiter:
             with self._lock:
                 now = time.monotonic()
                 elapsed = now - self._updated
-                self._tokens = min(
-                    float(self.burst), self._tokens + elapsed * self.rps
-                )
+                self._tokens = min(float(self.burst), self._tokens + elapsed * self.rps)
                 if self._tokens >= 1 or math.isclose(
                     self._tokens, 1.0, rel_tol=0.0, abs_tol=1e-9
                 ):

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -174,7 +174,9 @@ def _pipe_merge_columns(df: pd.DataFrame, columns: Iterable[str]) -> pd.Series:
     if not available:
         return _default_series(df)
 
-    merged = df.apply(lambda row: _pipe_merge([row.get(col) for col in available]), axis=1)
+    merged = df.apply(
+        lambda row: _pipe_merge([row.get(col) for col in available]), axis=1
+    )
     merged = merged.replace("", "-")
     return merged.fillna("-")
 
@@ -187,7 +189,14 @@ def align_target_columns(df: pd.DataFrame) -> pd.DataFrame:
     aligned["target_chembl_id"] = _series_or_default(df, "target_chembl_id")
     aligned["uniprot_id_primary"] = _series_or_default(df, "uniprotkb_Id")
     aligned["uniprot_ids_all"] = _pipe_merge_columns(
-        df, ["uniprotkb_Id", "uniprot_id", "secondary_uniprot_id", "secondaryAccessions", "mapping_uniprot_id"]
+        df,
+        [
+            "uniprotkb_Id",
+            "uniprot_id",
+            "secondary_uniprot_id",
+            "secondaryAccessions",
+            "mapping_uniprot_id",
+        ],
     )
     aligned["isoform_ids"] = _series_or_default(df, "isoform_ids")
     aligned["isoform_names"] = _series_or_default(df, "isoform_names")
@@ -219,7 +228,9 @@ def align_target_columns(df: pd.DataFrame) -> pd.DataFrame:
     aligned["gtop_synonyms"] = _series_or_default(df, "synonyms")
     aligned["gtop_natural_ligands_n"] = _series_or_default(df, "gtop_natural_ligands_n")
     aligned["gtop_interactions_n"] = _series_or_default(df, "gtop_interactions_n")
-    aligned["gtop_function_text_short"] = _series_or_default(df, "gtop_function_text_short")
+    aligned["gtop_function_text_short"] = _series_or_default(
+        df, "gtop_function_text_short"
+    )
     aligned["uniprot_last_update"] = _series_or_default(df, "uniprot_last_update")
     aligned["uniprot_version"] = _series_or_default(df, "uniprot_version")
     aligned["pipeline_version"] = _series_or_default(df, "pipeline_version")
@@ -233,7 +244,9 @@ def align_target_columns(df: pd.DataFrame) -> pd.DataFrame:
     aligned["secondaryAccessions"] = _series_or_default(df, "secondaryAccessions")
     aligned["recommendedName"] = _series_or_default(df, "recommendedName")
     aligned["geneName"] = _series_or_default(df, "geneName")
-    aligned["secondaryAccessionNames"] = _series_or_default(df, "secondaryAccessionNames")
+    aligned["secondaryAccessionNames"] = _series_or_default(
+        df, "secondaryAccessionNames"
+    )
     aligned["molecular_function"] = _series_or_default(df, "molecular_function")
     aligned["cellular_component"] = _series_or_default(df, "cellular_component")
     aligned["subcellular_location"] = _series_or_default(df, "subcellular_location")
@@ -262,7 +275,9 @@ def align_target_columns(df: pd.DataFrame) -> pd.DataFrame:
     aligned["tax_id"] = _series_or_default(df, "tax_id")
     aligned["species_group_flag"] = _series_or_default(df, "species_group_flag")
     aligned["target_components"] = _series_or_default(df, "target_components")
-    aligned["protein_classifications"] = _series_or_default(df, "protein_classifications")
+    aligned["protein_classifications"] = _series_or_default(
+        df, "protein_classifications"
+    )
     aligned["cross_references"] = _series_or_default(df, "cross_references")
     aligned["gene_symbol_list"] = _series_or_default(df, "gene")
     aligned["protein_synonym_list"] = _series_or_default(df, "synonyms")
@@ -271,9 +286,15 @@ def align_target_columns(df: pd.DataFrame) -> pd.DataFrame:
     aligned["protein_class_pred_L1"] = _series_or_default(df, "protein_class_pred_L1")
     aligned["protein_class_pred_L2"] = _series_or_default(df, "protein_class_pred_L2")
     aligned["protein_class_pred_L3"] = _series_or_default(df, "protein_class_pred_L3")
-    aligned["protein_class_pred_rule_id"] = _series_or_default(df, "protein_class_pred_rule_id")
-    aligned["protein_class_pred_evidence"] = _series_or_default(df, "protein_class_pred_evidence")
-    aligned["protein_class_pred_confidence"] = _series_or_default(df, "protein_class_pred_confidence")
+    aligned["protein_class_pred_rule_id"] = _series_or_default(
+        df, "protein_class_pred_rule_id"
+    )
+    aligned["protein_class_pred_evidence"] = _series_or_default(
+        df, "protein_class_pred_evidence"
+    )
+    aligned["protein_class_pred_confidence"] = _series_or_default(
+        df, "protein_class_pred_confidence"
+    )
     aligned["iuphar_target_id"] = _series_or_default(df, "target_id")
     aligned["iuphar_family_id"] = _series_or_default(df, "IUPHAR_family_id")
     aligned["iuphar_type"] = _series_or_default(df, "IUPHAR_type")
@@ -601,6 +622,7 @@ def finalise_targets(
     df = align_target_columns(df)
 
     return df
+
 
 def finalise_file(
     input_path: Path | str,

--- a/library/testitem_enrichment.py
+++ b/library/testitem_enrichment.py
@@ -25,18 +25,13 @@ class _SourceFrames:
 def _read_source(path: Path, *, io_cfg: IoCfg) -> pd.DataFrame:
     """Read a CSV file using the shared I/O configuration."""
 
-    return io.read_csv(path, cfg=io_cfg, dtype="string")
+    return io.read_csv(path, cfg=io_cfg, dtype=pd.StringDtype())
 
 
 def _normalise_ids(series: pd.Series) -> pd.Series:
     """Return ``series`` with whitespace trimmed and converted to upper case."""
 
-    normalised = (
-        series.fillna("")
-        .astype("string")
-        .str.strip()
-        .str.upper()
-    )
+    normalised = series.fillna("").astype("string").str.strip().str.upper()
     return normalised.mask(normalised == "", other=pd.NA)
 
 
@@ -126,7 +121,9 @@ def _prepare_catalog(
 
     if cfg.flags.coerce_to_bool:
         for column in _FLAG_COLUMNS:
-            catalog[column], unknown_values = _coerce_flag_values(catalog[column], column)
+            catalog[column], unknown_values = _coerce_flag_values(
+                catalog[column], column
+            )
             unknown_by_column[column] = unknown_values
     else:
         for column in _FLAG_COLUMNS:
@@ -189,7 +186,9 @@ def enrich(
         hierarchy = hierarchy.drop_duplicates(
             subset=["molecule_chembl_id"], keep="first"
         ).set_index("molecule_chembl_id")
-        parent_from_hierarchy = child_ids.map(hierarchy["parent_molecule_chembl_id"].to_dict())
+        parent_from_hierarchy = child_ids.map(
+            hierarchy["parent_molecule_chembl_id"].to_dict()
+        )
         parent_ids = parent_ids.fillna(parent_from_hierarchy)
 
     parent_ids = parent_ids.astype("string")
@@ -206,13 +205,11 @@ def enrich(
 
     if cfg.logging.warn_missing_molecule and not catalog.empty:
         known_ids = set(catalog.index)
-        missing_children = sorted({value for value in child_ids.dropna() if value not in known_ids})
+        missing_children = sorted(
+            {value for value in child_ids.dropna() if value not in known_ids}
+        )
         missing_parents = sorted(
-            {
-                value
-                for value in parent_ids.dropna()
-                if value not in known_ids
-            }
+            {value for value in parent_ids.dropna() if value not in known_ids}
         )
         if missing_children:
             logger.warning(
@@ -250,9 +247,7 @@ def enrich(
 
         if cfg.logging.warn_inconsistent_flags:
             inconsistent = (
-                child_flag.notna()
-                & parent_flag.notna()
-                & (child_flag != parent_flag)
+                child_flag.notna() & parent_flag.notna() & (child_flag != parent_flag)
             )
             if inconsistent.any():
                 logger.warning(

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -887,7 +887,10 @@ def _fetch_gtop_endpoint(
             return response.json()
     except (json.JSONDecodeError, ValueError) as exc:
         logger.warning(
-            "gtop_json_decode_failed", gtop_id=gtop_id, endpoint=endpoint, error=str(exc)
+            "gtop_json_decode_failed",
+            gtop_id=gtop_id,
+            endpoint=endpoint,
+            error=str(exc),
         )
     except requests.RequestException as exc:  # pragma: no cover - network failures
         logger.warning(
@@ -1251,9 +1254,7 @@ def process(
                 info = collect_info(uid, data_dir, cfg=cfg, gtop_cfg=gtop_cfg)
                 unexpected = sorted(set(info) - expected_columns)
                 if unexpected:
-                    logger.debug(
-                        "uniprot_extra_fields", uid=uid, columns=unexpected
-                    )
+                    logger.debug("uniprot_extra_fields", uid=uid, columns=unexpected)
                 row = {
                     column: ("" if info.get(column) is None else info.get(column))
                     for column in fieldnames

--- a/library/utils/cli_tools/__init__.py
+++ b/library/utils/cli_tools/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__all__ = []
+__all__: list[str] = []

--- a/library/validation.py
+++ b/library/validation.py
@@ -77,7 +77,9 @@ def _combine_failure_cases(cases: list[pd.DataFrame]) -> pd.DataFrame:
 class _SupportsDataFrameValidate(Protocol):
     """Protocol describing the subset of pandera schema API we rely on."""
 
-    def validate(self, dataframe: pd.DataFrame, *args: Any, **kwargs: Any) -> pd.DataFrame:
+    def validate(
+        self, dataframe: pd.DataFrame, *args: Any, **kwargs: Any
+    ) -> pd.DataFrame:
         """Validate *dataframe* and return the cleansed result."""
 
 
@@ -102,7 +104,9 @@ def _validate_with_schema(
         except SchemaErrors as exc:
             failure_cases = exc.failure_cases.copy()
             indices = _unique_indices(
-                failure_cases["index"] if "index" in failure_cases else pd.Series(dtype=object)
+                failure_cases["index"]
+                if "index" in failure_cases
+                else pd.Series(dtype=object)
             )
             if not indices:
                 logger.info(

--- a/library/version.py
+++ b/library/version.py
@@ -36,6 +36,4 @@ def require_python_version(min_version: tuple[int, int] = (3, 12)) -> None:
             required=needed,
             found=current_str,
         )
-        raise RuntimeError(
-            f"Python {needed} or later is required; found {current_str}"
-        )
+        raise RuntimeError(f"Python {needed} or later is required; found {current_str}")

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import cast
 
 import pandera.pandas as pa
-from pandera.dtypes import DataType
 import yaml
+from pandera.dtypes import DataType
 
 PA_ANY = cast(DataType, None)
 
@@ -38,10 +38,7 @@ def _load_standard_type_values() -> tuple[str, ...]:
         return ()
 
     metrics = (
-        config
-        .get("activity_enrichment", {})
-        .get("action_type", {})
-        .get("metrics", {})
+        config.get("activity_enrichment", {}).get("action_type", {}).get("metrics", {})
     )
     if not isinstance(metrics, dict):
         return ()

--- a/schemas/testitems.py
+++ b/schemas/testitems.py
@@ -13,15 +13,11 @@ PA_ANY = cast(DataType, None)
 TestitemsSchema: pa.DataFrameSchema = pa.DataFrameSchema(
     {
         "molecule_chembl_id": pa.Column(str, required=True, nullable=True),
-
-        "parent_molecule_chembl_id": pa.Column(
-            str, required=False, nullable=True
-        ),
+        "parent_molecule_chembl_id": pa.Column(str, required=False, nullable=True),
         "salt_chembl_id": pa.Column(str, required=False, nullable=True),
         "natural_product": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
         "prodrug": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
         "polymer_flag": pa.Column(pd.BooleanDtype(), required=False, nullable=True),
-
         "black_box_warning": pa.Column(PA_ANY, required=False, nullable=True),
         "first_approval": pa.Column(PA_ANY, required=False, nullable=True),
         "max_phase": pa.Column(str, required=False, nullable=True),

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -203,8 +203,10 @@ def _apply_uncertainty_bounds(
         return lower, upper
     lower.loc[mask] = base.loc[mask] - delta.loc[mask]
     upper.loc[mask] = base.loc[mask] + delta.loc[mask]
-    mismatch = mask & std_values.notna() & ~np.isclose(
-        std_values.loc[mask], base.loc[mask], equal_nan=True
+    mismatch = (
+        mask
+        & std_values.notna()
+        & ~np.isclose(std_values.loc[mask], base.loc[mask], equal_nan=True)
     )
     if mismatch.any():
         logger.warning(
@@ -238,12 +240,8 @@ def compute_activity_bounds(
 
     range_mask = std_values.notna() & std_upper.notna()
     if range_mask.any():
-        range_lower = pd.Series(
-            np.minimum(std_values, std_upper), index=result.index
-        )
-        range_upper = pd.Series(
-            np.maximum(std_values, std_upper), index=result.index
-        )
+        range_lower = pd.Series(np.minimum(std_values, std_upper), index=result.index)
+        range_upper = pd.Series(np.maximum(std_values, std_upper), index=result.index)
         lower_fill = range_mask & lower.isna()
         upper_fill = range_mask & upper.isna()
         if lower_fill.any():
@@ -299,10 +297,7 @@ def compute_activity_bounds(
             if upper_needed.any():
                 upper.loc[upper_needed] = between_upper.loc[upper_needed]
 
-        missing_second = (
-            between_mask
-            & (std_values.isna() | std_upper.isna())
-        )
+        missing_second = between_mask & (std_values.isna() | std_upper.isna())
         if missing_second.any():
             logger.warning(
                 "activity_bounds_missing_range_values",
@@ -427,7 +422,7 @@ def _has_value(value: Any) -> bool:
         return False
     if isinstance(value, str):
         return bool(value.strip())
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, list | tuple | set):
         return any(_has_value(item) for item in value)
     if isinstance(value, Mapping):
         return any(_has_value(item) for item in value.values())
@@ -449,12 +444,16 @@ def _clean_structure(data: Any) -> Any:
         return cleaned or None
     if isinstance(data, list):
         cleaned_list = [
-            item for item in (_clean_structure(value) for value in data) if _has_value(item)
+            item
+            for item in (_clean_structure(value) for value in data)
+            if _has_value(item)
         ]
         return cleaned_list or None
     if isinstance(data, tuple):
         cleaned_tuple = tuple(
-            item for item in (_clean_structure(value) for value in data) if _has_value(item)
+            item
+            for item in (_clean_structure(value) for value in data)
+            if _has_value(item)
         )
         return cleaned_tuple or None
     return data
@@ -480,7 +479,9 @@ def _extract_effect_features(record: Mapping[str, Any]) -> dict[str, Any]:
     positive_hits = sorted({kw for kw in _POSITIVE_KEYWORDS if kw in text})
     negative_hits = sorted({kw for kw in _NEGATIVE_KEYWORDS if kw in text})
     is_allosteric = bool(
-        positive_hits or negative_hits or any(keyword in text for keyword in _ALLOSTERIC_KEYWORDS)
+        positive_hits
+        or negative_hits
+        or any(keyword in text for keyword in _ALLOSTERIC_KEYWORDS)
     )
     return {
         "allosteric": is_allosteric,
@@ -678,7 +679,9 @@ def build_activity_properties(
         }
         break
 
-    functionality_value = _first_non_empty(record.get(field) for field in functionality_fields)
+    functionality_value = _first_non_empty(
+        record.get(field) for field in functionality_fields
+    )
     mechanism_value = _first_non_empty(record.get(field) for field in mechanism_fields)
 
     payload = {
@@ -697,7 +700,9 @@ def build_activity_properties(
     if not cleaned:
         return None, None
 
-    json_text = json.dumps(cleaned, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    json_text = json.dumps(
+        cleaned, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
     hash_value = None
     if properties_cfg.hash_column:
         hash_value = sha256(json_text.encode("utf-8")).hexdigest()
@@ -813,7 +818,9 @@ def apply_activity_annotations(
             )
 
     if properties_cfg.enabled:
-        properties_series = pd.Series(property_values, index=result.index, dtype="string")
+        properties_series = pd.Series(
+            property_values, index=result.index, dtype="string"
+        )
         result[properties_cfg.column] = properties_series
         if properties_cfg.log_missing:
             missing = int(properties_series.isna().sum())
@@ -852,6 +859,7 @@ def apply_activity_annotations(
         )
 
     return result
+
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute activity retrieval from the ChEMBL API.
@@ -911,13 +919,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         enrichment_cfg = cfg.activity_enrichment
         extra_columns: list[str] = []
         action_cfg = enrichment_cfg.action_type
-        if (
-            action_cfg.enabled
-            or action_cfg.log_missing
-            or action_cfg.log_distribution
-        ):
+        if action_cfg.enabled or action_cfg.log_missing or action_cfg.log_distribution:
             extra_columns.append(action_cfg.column)
-        properties_cfg = enrichment_cfg.activity_properties
         extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}
 
         try:
@@ -971,7 +974,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             try:
                 validation_result = validate_activities(df, return_result=True)
             except SchemaErrors as exc:
-                failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
+                failure_path = Path(output).with_name(
+                    f"{Path(output).stem}_failure_cases.csv"
+                )
                 errors = SidecarErrors()
                 for row in exc.failure_cases.to_dict("records"):
                     errors.add_error(row)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -100,13 +100,12 @@ def _build_fallback_doi_map(
             for column in (pmid_column, doi_column)
             if column not in frame.columns
         ]
-        raise ValueError(
-            "missing columns in fallback DOI file: "
-            f"{', '.join(missing)}"
-        )
+        raise ValueError(f"missing columns in fallback DOI file: {', '.join(missing)}")
 
     mapping: dict[str, str] = {}
-    for pmid_value, doi_value in frame[[pmid_column, doi_column]].itertuples(index=False):
+    for pmid_value, doi_value in frame[[pmid_column, doi_column]].itertuples(
+        index=False
+    ):
         if pd.isna(pmid_value):
             pmid = ""
         else:
@@ -302,9 +301,7 @@ def fetch_pubmed_records(
         batch_list = _coerce_batch_argument(first, *rest)
 
         try:
-
             with session_with_retry(__cfg.api, __cfg.retry) as session:
-
                 pubmed_limiter.acquire()
                 pubmed_list = pl.fetch_pubmed_batch(
                     session, batch_list, sleep, cfg=pubmed_cfg
@@ -323,7 +320,9 @@ def fetch_pubmed_records(
 
                     # Create a map for easy lookup
                     semsch_map = {
-                        s.get("scholar.PMID"): s for s in semsch_list if s.get("scholar.PMID")
+                        s.get("scholar.PMID"): s
+                        for s in semsch_list
+                        if s.get("scholar.PMID")
                     }
 
                     # Fallback to the single-record endpoint when the batch request fails
@@ -431,7 +430,6 @@ _NUMERIC_EXPORT_COLUMNS = {
 
 
 _EXPORT_COLUMNS = [
-
     "PubMed.PMID",
     "PubMed.DOI",
     "PubMed.ArticleTitle",

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -28,11 +28,11 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import io
 from library import iuphar_library as ii
-from library import target_postprocessing as tp
 from library import protein_classification as pc
+from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.chembl_target import normalize_reaction_ec_numbers
 from library.chembl_client import ChemblClient
+from library.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
     LoggerConfig,
     apply_config_overrides,
@@ -54,8 +54,6 @@ from library.table_quality import analyze_table_quality
 from schemas import TargetsSchema, normalize_targets
 from schemas.targets import TARGETS_COLUMN_ORDER
 
-
-
 TARGETS_REQUIRED_COLUMNS: set[str] = {
     name for name, column in TargetsSchema.columns.items() if column.required
 }
@@ -65,9 +63,10 @@ TARGETS_OPTIONAL_COLUMNS: list[str] = [
 ]
 
 TARGETS_OBJECT_COLUMNS: set[str] = {
-    name for name, column in TargetsSchema.columns.items() if str(column.dtype) == "object"
+    name
+    for name, column in TargetsSchema.columns.items()
+    if str(column.dtype) == "object"
 }
-
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:
@@ -881,9 +880,7 @@ def fetch_iuphar(
         combined_df = combined_df.rename(columns={"uniprot_id_y": "uniprot_id"})
 
     ec_number_columns = [
-        column
-        for column in combined_df.columns
-        if column.startswith("ec_numbers")
+        column for column in combined_df.columns if column.startswith("ec_numbers")
     ]
     if ec_number_columns:
         combined_df["ec_numbers"] = combined_df.apply(
@@ -909,9 +906,7 @@ def fetch_iuphar(
             axis=1,
         )
         extra_reaction_columns = [
-            column
-            for column in reaction_ec_columns
-            if column != "reaction_ec_numbers"
+            column for column in reaction_ec_columns if column != "reaction_ec_numbers"
         ]
         if extra_reaction_columns:
             combined_df = combined_df.drop(

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 # ruff: noqa: E402
 from pathlib import Path
@@ -14,26 +14,18 @@ if __package__ is None:  # running as a script
 
 import argparse
 from collections import ChainMap
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from itertools import islice, tee
-from typing import Any, Callable, NamedTuple
+from typing import Any, NamedTuple
 
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
-from library import io
-from library import molecule_catalog
-from library import testitem_enrichment
+from library import io, molecule_catalog, testitem_enrichment
 from library import pubchem_library as pl
-from library.molecule_catalog import (
-    load_parent_catalog,
-    query_parent_catalog,
-    update_parent_catalog_cache,
-    write_parent_catalog_cache,
-)
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -54,6 +46,12 @@ from library.config import (
 )
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.molecule_catalog import (
+    load_parent_catalog,
+    query_parent_catalog,
+    update_parent_catalog_cache,
+    write_parent_catalog_cache,
+)
 from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -152,10 +150,10 @@ def _load_pubchem_cid_cache(
             except ValueError:
                 updated_at = None
             if updated_at is not None and updated_at.tzinfo is None:
-                updated_at = updated_at.replace(tzinfo=timezone.utc)
+                updated_at = updated_at.replace(tzinfo=UTC)
             if updated_at is not None:
                 expires_at = updated_at + timedelta(hours=ttl_hours)
-                if expires_at <= datetime.now(timezone.utc):
+                if expires_at <= datetime.now(UTC):
                     logger.info("pubchem_cache_expired", path=str(path))
                     return {}
 
@@ -181,7 +179,9 @@ def _load_pubchem_cid_cache(
     return cache
 
 
-def _write_pubchem_cid_cache(path: Path | None, cache: Mapping[str, str | None]) -> None:
+def _write_pubchem_cid_cache(
+    path: Path | None, cache: Mapping[str, str | None]
+) -> None:
     """Persist CID cache mapping to disk."""
 
     if path is None:
@@ -199,7 +199,7 @@ def _write_pubchem_cid_cache(path: Path | None, cache: Mapping[str, str | None])
             payload = {
                 "metadata": {
                     "version": _PUBCHEM_CACHE_SCHEMA_VERSION,
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                    "updated_at": datetime.now(UTC).isoformat(),
                 },
                 "values": serialisable,
             }
@@ -283,7 +283,8 @@ def resolve_pubchem_cid(
     cfg: PubChemCfg,
     *,
     parent_loader: Callable[[str], pd.Series | None] | None = None,
-    resolution_cache: MutableMapping[tuple[str | None, ...], pl.PubChemResolution] | None = None,
+    resolution_cache: MutableMapping[tuple[str | None, ...], pl.PubChemResolution]
+    | None = None,
 ) -> str | None:
     """Resolve PubChem CID for a ChEMBL record."""
 
@@ -400,12 +401,7 @@ def _resolve_catalog_load_source(
 def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
     """Return ``series`` normalised to upper-case ChEMBL identifiers."""
 
-    normalised = (
-        series.fillna("")
-        .astype("string")
-        .str.strip()
-        .str.upper()
-    )
+    normalised = series.fillna("").astype("string").str.strip().str.upper()
     return normalised
 
 
@@ -436,9 +432,7 @@ def attach_parent_molecule_ids(
     """
 
     if "parant_molecule_id" in df.columns:
-        raise ValueError(
-            "Input frame contains unexpected column 'parant_molecule_id'."
-        )
+        raise ValueError("Input frame contains unexpected column 'parant_molecule_id'.")
 
     result = df.copy()
 
@@ -503,11 +497,7 @@ def attach_parent_molecule_ids(
     uncovered_children = 0
 
     if catalog is not None:
-        base_view = {
-            key: catalog[key]
-            for key in unique_children
-            if key in catalog
-        }
+        base_view = {key: catalog[key] for key in unique_children if key in catalog}
         catalog_data = ChainMap({}, base_view)
     else:
         catalog_data = {}
@@ -525,9 +515,7 @@ def attach_parent_molecule_ids(
                     source_resolved = PARENT_LOOKUP_SOURCE_CACHE
 
     parent_map = {
-        key: catalog_data[key]
-        for key in unique_children
-        if key in catalog_data
+        key: catalog_data[key] for key in unique_children if key in catalog_data
     }
     missing_ids = [key for key in unique_children if key not in parent_map]
     uncovered_children = len(missing_ids)
@@ -639,9 +627,8 @@ def add_pubchem_data(
     api_cfg: ApiCfg | None = None,
     timeout: float | None = None,
     cid_cache: MutableMapping[str, str | None] | None = None,
-    resolution_cache: MutableMapping[
-        tuple[str | None, ...], pl.PubChemResolution
-    ] | None = None,
+    resolution_cache: MutableMapping[tuple[str | None, ...], pl.PubChemResolution]
+    | None = None,
     parent_record_cache: MutableMapping[str, pd.Series | None] | None = None,
 ) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
@@ -682,7 +669,10 @@ def add_pubchem_data(
     existing_cols = [col for col in PUBCHEM_COLUMNS if col in result.columns]
     if prefer_local and existing_cols:
         normalised = pd.DataFrame(
-            {col: result[col].astype("string").replace("", pd.NA) for col in existing_cols}
+            {
+                col: result[col].astype("string").replace("", pd.NA)
+                for col in existing_cols
+            }
         )
         complete_mask = normalised.notna().all(axis=1)
     else:
@@ -691,23 +681,16 @@ def add_pubchem_data(
     def _mask_for(series: pd.Series | None, keyword: str) -> pd.Series:
         if series is None:
             return pd.Series(False, index=result.index)
-        normalised = (
-            series.astype("string")
-            .fillna("")
-            .str.strip()
-            .str.casefold()
-        )
+        normalised = series.astype("string").fillna("").str.strip().str.casefold()
         return normalised.str.contains(keyword.casefold(), regex=False, na=False)
 
     molecule_type_series = result.get("molecule_type")
     structure_type_series = result.get("structure_type")
-    polymer_mask = (
-        _mask_for(molecule_type_series, "polymer")
-        | _mask_for(structure_type_series, "polymer")
+    polymer_mask = _mask_for(molecule_type_series, "polymer") | _mask_for(
+        structure_type_series, "polymer"
     )
-    mixture_mask = (
-        _mask_for(molecule_type_series, "mixture")
-        | _mask_for(structure_type_series, "mixture")
+    mixture_mask = _mask_for(molecule_type_series, "mixture") | _mask_for(
+        structure_type_series, "mixture"
     )
 
     polymer_indexes = set(polymer_mask[polymer_mask].index.tolist())
@@ -782,7 +765,7 @@ def add_pubchem_data(
 
     if "molecule_chembl_id" in result.columns and "pubchem_cid" in result.columns:
         for chembl_raw, cid_raw in zip(
-            result["molecule_chembl_id"], result["pubchem_cid"]
+            result["molecule_chembl_id"], result["pubchem_cid"], strict=False
         ):
             chembl_id = _normalise_identifier(chembl_raw, uppercase=True)
             if not chembl_id:
@@ -800,7 +783,11 @@ def add_pubchem_data(
         for idx, row in result.iterrows()
         if idx not in skip_indexes
         and not (
-            (chembl_id := _normalise_identifier(row.get("molecule_chembl_id"), uppercase=True))
+            (
+                chembl_id := _normalise_identifier(
+                    row.get("molecule_chembl_id"), uppercase=True
+                )
+            )
             and chembl_id in cid_cache
             and cid_cache[chembl_id]
         )
@@ -852,7 +839,7 @@ def add_pubchem_data(
         return value if value not in (None, "") else pd.NA
 
     lookup_cids: set[str] = set()
-    for idx, cid in zip(result.index, cid_list):
+    for idx, cid in zip(result.index, cid_list, strict=False):
         if not cid:
             continue
         if idx in skip_indexes:
@@ -866,7 +853,7 @@ def add_pubchem_data(
         properties[cid] = pl.get_properties(cid, cfg)
 
     pubchem_rows: list[dict[str, object]] = []
-    for idx, cid in zip(result.index, cid_list):
+    for idx, cid in zip(result.index, cid_list, strict=False):
         row_data: dict[str, object] = {col: pd.NA for col in PUBCHEM_COLUMNS}
         if idx in skip_indexes:
             for column in PUBCHEM_COLUMNS:
@@ -905,7 +892,9 @@ def add_pubchem_data(
                 missing_mask = existing.isna() | existing.eq("")
                 result.loc[missing_mask, col] = new_series[missing_mask]
             elif prefer_values:
-                incoming = new_series.where(~(new_series.isna() | new_series.eq("")), pd.NA)
+                incoming = new_series.where(
+                    ~(new_series.isna() | new_series.eq("")), pd.NA
+                )
                 combined = incoming.combine_first(existing)
                 result[col] = combined.astype("string")
             else:
@@ -1089,11 +1078,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 error=str(exc),
             )
             return 1
- 
+
         logger.info("parent_lookup_start")
         try:
-            catalog_arg = parent_catalog if parent_catalog else (
-                None if need_lookup else parent_catalog
+            catalog_arg = (
+                parent_catalog
+                if parent_catalog
+                else (None if need_lookup else parent_catalog)
             )
             df, parent_stats = attach_parent_molecule_ids(
                 df,
@@ -1118,9 +1109,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
 
         pubchem_cid_cache: dict[str, str | None] | None = None
-        pubchem_resolution_cache: dict[
-            tuple[str | None, ...], pl.PubChemResolution
-        ] | None = None
+        pubchem_resolution_cache: (
+            dict[tuple[str | None, ...], pl.PubChemResolution] | None
+        ) = None
         pubchem_parent_record_cache: dict[str, pd.Series | None] | None = None
         if getattr(cfg.pubchem, "enable", True):
             pubchem_cid_cache = _load_pubchem_cid_cache(

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -25,8 +25,8 @@ from library.cli import (
 from library.config import Config, ensure_dirs, print_config
 from library.io import default_output_path, read_ids, write_csv
 from library.log import logger
-from library.pipeline_targets import PipelineResult, run_pipeline
 from library.pipeline_metadata import add_pipeline_metadata
+from library.pipeline_targets import PipelineResult, run_pipeline
 
 
 class PipelineConfig(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from library.config import ApiCfg, Config
+from library.config import Config
 
 
 @pytest.fixture()

--- a/tests/smoke/test_activity_action_properties_smoke.py
+++ b/tests/smoke/test_activity_action_properties_smoke.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import pandas as pd
-
 import yaml
 
 from library.config import Config
@@ -42,8 +41,12 @@ def test_activity_action_properties_cli(tmp_path: Path, monkeypatch) -> None:
     )
 
     monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
-    monkeypatch.setattr("scripts.get_activity_data.cl.get_activities", lambda *_, **__: df)
-    monkeypatch.setattr("scripts.get_activity_data.analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        "scripts.get_activity_data.cl.get_activities", lambda *_, **__: df
+    )
+    monkeypatch.setattr(
+        "scripts.get_activity_data.analyze_table_quality", lambda *_, **__: None
+    )
     monkeypatch.setattr("scripts.get_activity_data.write_meta_yaml", lambda **__: None)
     monkeypatch.setattr("scripts.get_activity_data.file_sha256", lambda _: "deadbeef")
 
@@ -78,4 +81,7 @@ def test_activity_action_properties_cli(tmp_path: Path, monkeypatch) -> None:
     payloads = result["activity_properties"].map(json.loads).tolist()
     assert payloads[0]["effect_features"]["positive"] is True
     assert payloads[1]["effect_features"]["negative"] is True
-    assert all(isinstance(value, str) and len(value) == 64 for value in result["properties_hash"].tolist())
+    assert all(
+        isinstance(value, str) and len(value) == 64
+        for value in result["properties_hash"].tolist()
+    )

--- a/tests/smoke/test_activity_bounds_smoke.py
+++ b/tests/smoke/test_activity_bounds_smoke.py
@@ -5,46 +5,57 @@ import pytest
 
 from library.config import ActivityBoundsCfg
 from schemas import normalize_activities
-from scripts.get_activity_data import compute_activity_bounds, logger as activity_logger
+from scripts.get_activity_data import compute_activity_bounds
+from scripts.get_activity_data import logger as activity_logger
 
 
-def _compute(data: list[dict[str, object]], cfg: ActivityBoundsCfg | None = None) -> pd.DataFrame:
+def _compute(
+    data: list[dict[str, object]], cfg: ActivityBoundsCfg | None = None
+) -> pd.DataFrame:
     frame = pd.DataFrame(data)
     normalised = normalize_activities(frame)
     return compute_activity_bounds(normalised, cfg or ActivityBoundsCfg())
 
 
 def test_bounds_equal_relation() -> None:
-    result = _compute([
-        {"standard_value": 5.0, "standard_relation": "="},
-    ])
+    result = _compute(
+        [
+            {"standard_value": 5.0, "standard_relation": "="},
+        ]
+    )
     row = result.iloc[0]
     assert row["lower_value"] == pytest.approx(5.0)
     assert row["upper_value"] == pytest.approx(5.0)
 
 
 def test_bounds_greater_relation() -> None:
-    result = _compute([
-        {"standard_value": 3.0, "standard_relation": ">"},
-    ])
+    result = _compute(
+        [
+            {"standard_value": 3.0, "standard_relation": ">"},
+        ]
+    )
     row = result.iloc[0]
     assert row["lower_value"] == pytest.approx(3.0)
     assert pd.isna(row["upper_value"])
 
 
 def test_bounds_less_relation() -> None:
-    result = _compute([
-        {"standard_value": 4.0, "standard_relation": "<"},
-    ])
+    result = _compute(
+        [
+            {"standard_value": 4.0, "standard_relation": "<"},
+        ]
+    )
     row = result.iloc[0]
     assert pd.isna(row["lower_value"])
     assert row["upper_value"] == pytest.approx(4.0)
 
 
 def test_bounds_range_pair() -> None:
-    result = _compute([
-        {"standard_value": 1.0, "standard_upper_value": 2.0},
-    ])
+    result = _compute(
+        [
+            {"standard_value": 1.0, "standard_upper_value": 2.0},
+        ]
+    )
     row = result.iloc[0]
     assert row["lower_value"] == pytest.approx(1.0)
     assert row["upper_value"] == pytest.approx(2.0)
@@ -57,9 +68,11 @@ def test_bounds_unknown_relation_logs(monkeypatch: pytest.MonkeyPatch) -> None:
         events.append(event)
 
     monkeypatch.setattr(activity_logger, "warning", fake_warning)
-    result = _compute([
-        {"standard_value": 7.0, "standard_relation": "??"},
-    ])
+    result = _compute(
+        [
+            {"standard_value": 7.0, "standard_relation": "??"},
+        ]
+    )
     assert "activity_bounds_unknown_relation" in events
     assert result["lower_value"].isna().all()
     assert result["upper_value"].isna().all()

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, Iterable
 
 import pandas as pd
 import pytest
@@ -52,21 +52,19 @@ def _assert_column_types(
         else:
             checks = tuple(validators)
         if not any(check(series) for check in checks):
-            raise AssertionError(
-                f"unexpected dtype for {column}: {series.dtype!s}"
-            )
+            raise AssertionError(f"unexpected dtype for {column}: {series.dtype!s}")
 
 
-def test_get_activity_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_activity_data_smoke(
+    smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Smoke-test ``get_activity_data`` with bundled identifiers."""
 
     input_csv = Path("data/input-smoke/activity.csv")
     output_csv = smoke_output_dir / "activity.csv"
     _cleanup_output(output_csv)
 
-    def fake_get_activities(
-        ids, cfg, client, chunk_size, timeout, **kwargs
-    ):  # type: ignore[no-untyped-def]
+    def fake_get_activities(ids, cfg, client, chunk_size, timeout, **kwargs):  # type: ignore[no-untyped-def]
         rows: list[dict[str, object]] = []
         for idx, raw_id in enumerate(ids, start=1):
             activity_id = int(str(raw_id))
@@ -83,7 +81,9 @@ def test_get_activity_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.Mon
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_activities", fake_get_activities)
-    monkeypatch.setattr(get_activity_data, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        get_activity_data, "analyze_table_quality", lambda *_, **__: None
+    )
 
     exit_code = get_activity_data.main(
         [
@@ -128,7 +128,9 @@ def test_get_activity_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.Mon
     )
 
 
-def test_get_assay_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_assay_data_smoke(
+    smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Smoke-test ``get_assay_data`` using canned assay identifiers."""
 
     input_csv = Path("data/input-smoke/assay.csv")
@@ -219,7 +221,9 @@ def test_get_document_data_smoke(
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_documents", fake_get_documents)
-    monkeypatch.setattr(get_document_data, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        get_document_data, "analyze_table_quality", lambda *_, **__: None
+    )
 
     exit_code = get_document_data.main(
         [
@@ -261,7 +265,9 @@ def test_get_document_data_smoke(
     )
 
 
-def test_get_target_data_smoke(smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_target_data_smoke(
+    smoke_output_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Smoke-test ``get_target_data`` using the ``chembl`` pipeline."""
 
     input_csv = Path("data/input-smoke/targets.csv")
@@ -395,7 +401,9 @@ def test_get_testitem_data_smoke(
         "load_parent_catalog",
         lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
     )
-    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+    )
 
     original_apply = get_testitem_data.apply_config_overrides
 

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from time import perf_counter, sleep
 from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
 from library import chembl_library as cl
-from library import molecule_catalog
 from library import pubchem_library as pl
-from library.config import ApiCfg, MoleculeCatalogCfg
 from scripts import get_testitem_data
 
 
@@ -76,7 +73,9 @@ def test_get_testitem_parent_catalog(
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
     monkeypatch.setattr(pl, "get_properties", fake_get_properties)
-    monkeypatch.setattr(get_testitem_data, "load_parent_catalog", fail_load_parent_catalog)
+    monkeypatch.setattr(
+        get_testitem_data, "load_parent_catalog", fail_load_parent_catalog
+    )
     monkeypatch.setattr(get_testitem_data, "query_parent_catalog", lambda *_, **__: {})
     fetch_calls: list[list[str]] = []
     mapping = {
@@ -110,8 +109,12 @@ def test_get_testitem_parent_catalog(
         "update_parent_catalog_cache",
         lambda data, cfg: None,
     )
-    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply_config_overrides)
+    monkeypatch.setattr(
+        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+    )
 
     exit_code = get_testitem_data.main(
         [
@@ -197,7 +200,9 @@ def test_get_testitem_skips_parent_lookup_when_present(
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
     monkeypatch.setattr(pl, "get_properties", fake_get_properties)
-    monkeypatch.setattr(get_testitem_data, "load_parent_catalog", fail_load_parent_catalog)
+    monkeypatch.setattr(
+        get_testitem_data, "load_parent_catalog", fail_load_parent_catalog
+    )
     monkeypatch.setattr(
         get_testitem_data.molecule_catalog,
         "fetch_parent_catalog_for",
@@ -210,8 +215,12 @@ def test_get_testitem_skips_parent_lookup_when_present(
         cfg.pubchem.resolve_order = ("smiles",)
         return cfg
 
-    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply_config_overrides)
+    monkeypatch.setattr(
+        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+    )
 
     exit_code = get_testitem_data.main(
         [
@@ -232,7 +241,6 @@ def test_get_testitem_skips_parent_lookup_when_present(
     df = pd.read_csv(output_csv)
     assert list(df["parent_molecule_chembl_id"]) == ["CHEMBL9001", "CHEMBL9002"]
     assert fetch_called is False
-
 
 
 def test_get_testitem_refreshes_outdated_parents(
@@ -301,7 +309,9 @@ def test_get_testitem_refreshes_outdated_parents(
         "update_parent_catalog_cache",
         lambda data, cfg: None,
     )
-    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+    )
     monkeypatch.setattr(get_testitem_data, "query_parent_catalog", lambda *_, **__: {})
 
     def patched_apply_config_overrides(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
@@ -310,7 +320,9 @@ def test_get_testitem_refreshes_outdated_parents(
         cfg.pubchem.resolve_order = ("smiles",)
         return cfg
 
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply_config_overrides)
+    monkeypatch.setattr(
+        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+    )
 
     exit_code = get_testitem_data.main(
         [

--- a/tests/smoke/test_testitem_salt_flags_smoke.py
+++ b/tests/smoke/test_testitem_salt_flags_smoke.py
@@ -104,7 +104,9 @@ def test_testitem_salt_flags_smoke(
             hierarchy=hierarchy, catalog=catalog
         ),
     )
-    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(
+        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+    )
 
     exit_code = get_testitem_data.main(
         [

--- a/tests/test_activity_action_properties.py
+++ b/tests/test_activity_action_properties.py
@@ -3,8 +3,8 @@ import json
 import pandas as pd
 import pytest
 
-from library.config import ActivityActionTypeCfg, ActivityPropertiesCfg
 from library.activity_action_properties import annotate_action_properties
+from library.config import ActivityActionTypeCfg, ActivityPropertiesCfg
 from scripts.get_activity_data import (
     _extract_effect_features,
     _normalise_mapping,
@@ -44,11 +44,7 @@ def test_infer_action_type_metric_precedence() -> None:
     cfg = ActivityActionTypeCfg()
     record = _record(activity_comment="positive allosteric modulator")
     features = _extract_effect_features(record)
-    allowlist = {
-        token
-        for value in cfg.allowlist
-        if (token := value.strip().lower())
-    }
+    allowlist = {token for value in cfg.allowlist if (token := value.strip().lower())}
     result = infer_action_type(
         record,
         cfg,
@@ -67,13 +63,11 @@ def test_infer_action_type_metric_precedence() -> None:
 
 def test_infer_action_type_allosteric_fallback() -> None:
     cfg = ActivityActionTypeCfg()
-    record = _record(standard_type="TGI50", activity_comment="positive allosteric modulator")
+    record = _record(
+        standard_type="TGI50", activity_comment="positive allosteric modulator"
+    )
     features = _extract_effect_features(record)
-    allowlist = {
-        token
-        for value in cfg.allowlist
-        if (token := value.strip().lower())
-    }
+    allowlist = {token for value in cfg.allowlist if (token := value.strip().lower())}
     trackers = _tracker()
     result = infer_action_type(
         record,
@@ -141,16 +135,22 @@ def test_apply_activity_annotations_adds_columns() -> None:
     assert pytest.approx(payload["measurement"]["value"], rel=1e-6) == 1.5
 
 
-def test_annotate_action_properties_streams_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_annotate_action_properties_streams_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     original_to_dict = pd.DataFrame.to_dict
     original_itertuples = pd.DataFrame.itertuples
 
-    def fail_on_records(self: pd.DataFrame, orient: str = "dict", *args: object, **kwargs: object):
+    def fail_on_records(
+        self: pd.DataFrame, orient: str = "dict", *args: object, **kwargs: object
+    ):
         if orient == "records":
             raise AssertionError("to_dict with orient='records' should not be used")
-        return original_to_dict(self, orient=orient, *args, **kwargs)
+        return original_to_dict(self, orient, *args, **kwargs)
 
-    def tracking_itertuples(self: pd.DataFrame, index: bool = False, name: str | None = None):
+    def tracking_itertuples(
+        self: pd.DataFrame, index: bool = False, name: str | None = None
+    ):
         call_count[0] += 1
         iterator = original_itertuples(self, index=index, name=name)
 
@@ -166,13 +166,15 @@ def test_annotate_action_properties_streams_rows(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(pd.DataFrame, "to_dict", fail_on_records)
     monkeypatch.setattr(pd.DataFrame, "itertuples", tracking_itertuples)
 
-    large_frame = pd.DataFrame([
-        _record(
-            activity_comment="positive allosteric modulator",
-            standard_value=index,
-        )
-        for index in range(1000)
-    ])
+    large_frame = pd.DataFrame(
+        [
+            _record(
+                activity_comment="positive allosteric modulator",
+                standard_value=index,
+            )
+            for index in range(1000)
+        ]
+    )
 
     annotated = annotate_action_properties(large_frame)
 

--- a/tests/test_activity_bounds.py
+++ b/tests/test_activity_bounds.py
@@ -5,10 +5,13 @@ import pytest
 
 from library.config import ActivityBoundsCfg
 from schemas import normalize_activities
-from scripts.get_activity_data import compute_activity_bounds, logger as activity_logger
+from scripts.get_activity_data import compute_activity_bounds
+from scripts.get_activity_data import logger as activity_logger
 
 
-def _compute_frame(data: list[dict[str, object]], cfg: ActivityBoundsCfg | None = None) -> pd.DataFrame:
+def _compute_frame(
+    data: list[dict[str, object]], cfg: ActivityBoundsCfg | None = None
+) -> pd.DataFrame:
     frame = pd.DataFrame(data)
     normalised = normalize_activities(frame)
     return compute_activity_bounds(normalised, cfg or ActivityBoundsCfg())
@@ -17,15 +20,27 @@ def _compute_frame(data: list[dict[str, object]], cfg: ActivityBoundsCfg | None 
 def test_compute_activity_bounds_unit_normalization() -> None:
     df = _compute_frame(
         [
-            {"standard_value": 1.0, "standard_relation": "=", "value": 1000.0, "units": "pM"},
-            {"standard_value": 1.0, "standard_relation": "=", "value": 0.001, "units": "uM"},
+            {
+                "standard_value": 1.0,
+                "standard_relation": "=",
+                "value": 1000.0,
+                "units": "pM",
+            },
+            {
+                "standard_value": 1.0,
+                "standard_relation": "=",
+                "value": 0.001,
+                "units": "uM",
+            },
         ]
     )
     assert df["lower_value"].tolist() == pytest.approx([1.0, 1.0])
     assert df["upper_value"].tolist() == pytest.approx([1.0, 1.0])
 
 
-def test_compute_activity_bounds_swaps_conflicts(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_compute_activity_bounds_swaps_conflicts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     events: list[str] = []
 
     def fake_warning(event: str, **_: object) -> None:
@@ -96,7 +111,9 @@ def test_compute_activity_bounds_uncertainty_toggle() -> None:
 def test_compute_activity_bounds_golden_samples() -> None:
     input_df = pd.read_csv("tests/data/activity_bounds_input.csv")
     expected = pd.read_csv("tests/data/activity_bounds_expected.csv")
-    result = compute_activity_bounds(normalize_activities(input_df), ActivityBoundsCfg())
+    result = compute_activity_bounds(
+        normalize_activities(input_df), ActivityBoundsCfg()
+    )
     pd.testing.assert_frame_equal(
         result[["activity_id", "lower_value", "upper_value"]],
         expected,

--- a/tests/test_activity_extraction.py
+++ b/tests/test_activity_extraction.py
@@ -81,9 +81,7 @@ def test_cli_success(
 
     monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
 
-    def fake_get(
-        ids, *, cfg, client, chunk_size, timeout, **kwargs
-    ):  # type: ignore[no-untyped-def]
+    def fake_get(ids, *, cfg, client, chunk_size, timeout, **kwargs):  # type: ignore[no-untyped-def]
         assert list(ids) == ["A1", "A2"]
         return df
 
@@ -139,9 +137,7 @@ def test_cli_validation_failure(
 
     monkeypatch.setattr("scripts.get_activity_data.ChemblClient", DummyChemblClient)
 
-    def fake_get(
-        ids, *, cfg, client, chunk_size, timeout, **kwargs
-    ):  # type: ignore[no-untyped-def]
+    def fake_get(ids, *, cfg, client, chunk_size, timeout, **kwargs):  # type: ignore[no-untyped-def]
         return df
 
     monkeypatch.setattr("scripts.get_activity_data.cl.get_activities", fake_get)

--- a/tests/test_cli_bad_config.py
+++ b/tests/test_cli_bad_config.py
@@ -9,15 +9,15 @@ from pytest import LogCaptureFixture, MonkeyPatch
 
 from library.cli import LoggerConfig, configure_logger
 from library.logging_setup import Logger
+from library.utils.cli_tools import get_document_type as gdoctype
+from library.utils.cli_tools import get_input_initialisation as gii
+from library.utils.cli_tools import mapper_main as mapper
+from library.utils.cli_tools import table_quality_main as tqm
 from scripts import get_activity_data as gad
 from scripts import get_assay_data as gas
 from scripts import get_document_data as gdd
-from library.utils.cli_tools import get_document_type as gdoctype
-from library.utils.cli_tools import get_input_initialisation as gii
 from scripts import get_target_data as gtd
 from scripts import get_testitem_data as gtdt
-from library.utils.cli_tools import mapper_main as mapper
-from library.utils.cli_tools import table_quality_main as tqm
 
 CLIS = [
     (gad.main, [], False),
@@ -174,7 +174,9 @@ def test_doc_type_negative_limit_in_config_exits(
         return orig(cfg, *a, **k)
 
     monkeypatch.setattr("library.cli.configure_logger", _conf)
-    monkeypatch.setattr("library.utils.cli_tools.get_document_type.configure_logger", _conf)
+    monkeypatch.setattr(
+        "library.utils.cli_tools.get_document_type.configure_logger", _conf
+    )
 
     rc = gdoctype.main(
         [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,12 +63,7 @@ def test_schema_file_rejected(tmp_path: Path) -> None:
 def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text(
-        "sources:\n"
-        "  chembl:\n"
-        "    api:\n"
-        "      rps: 1\n"
-        "  openalex:\n"
-        "    rps: 1\n"
+        "sources:\n  chembl:\n    api:\n      rps: 1\n  openalex:\n    rps: 1\n"
     )
     monkeypatch.setenv("CHEMBL_DA__SOURCES__CHEMBL__API__RPS", "3")
     monkeypatch.setenv("CHEMBL_DA__SOURCES__OPENALEX__RPS", "6")
@@ -150,9 +145,7 @@ def test_chembl_cache_maxsize_from_yaml(tmp_path: Path) -> None:
     """Custom ``chembl.cache_maxsize`` should override the default."""
 
     path = tmp_path / "cfg.yaml"
-    path.write_text(
-        "sources:\n  chembl:\n    cache:\n      cache_maxsize: 42\n"
-    )
+    path.write_text("sources:\n  chembl:\n    cache:\n      cache_maxsize: 42\n")
 
     cfg = load_config(path)
 
@@ -256,9 +249,7 @@ def test_schema_negative_value(tmp_path: Path) -> None:
 
 def test_schema_list_item_type(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
-    path.write_text(
-        "system:\n  retry:\n    status_forcelist: [429, '500']\n"
-    )
+    path.write_text("system:\n  retry:\n    status_forcelist: [429, '500']\n")
     with pytest.raises(ValidationError):
         load_config(path)
 
@@ -296,17 +287,9 @@ def test_ensure_dirs_creates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert out.is_dir() and cache.is_dir()
 
 
-
 def test_unknown_key_warning_non_strict(tmp_path: Path) -> None:
-
     path = tmp_path / "cfg.yaml"
-    path.write_text(
-        "unknown: 1\n"
-        "sources:\n"
-        "  chembl:\n"
-        "    api:\n"
-        "      rps: 1\n"
-    )
+    path.write_text("unknown: 1\nsources:\n  chembl:\n    api:\n      rps: 1\n")
     buf = io.StringIO()
     configure_logger(LoggerConfig(stream=buf))
     load_config(path, strict=False)
@@ -345,7 +328,6 @@ def test_default_resource_paths_exist() -> None:
         "iuphar_family_csv",
         "uniprot_data_dir",
         "targets_type_csv",
-
     ):
         resource_path = getattr(resources, field)
         full_path = (
@@ -376,6 +358,8 @@ def test_config_class_default_resources_exist() -> None:
             else project_root / resource_path
         )
         assert resolved.exists(), f"Missing default resource: {resolved}"
+
+
 def test_yaml_error_includes_path(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("sources:\n  chembl:\n    api: [\n")  # malformed YAML
@@ -402,9 +386,7 @@ def test_user_agent_must_include_contact(
     )
     # Ensure the invalid YAML value is used rather than the environment
     # override provided by the autouse fixture.
-    monkeypatch.delenv(
-        "CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False
-    )
+    monkeypatch.delenv("CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False)
     with pytest.raises(ValidationError, match="user_agent"):
         load_config(path)
 
@@ -422,9 +404,7 @@ def test_user_agent_default_and_overrides(
         "  crossref:\n"
         "    mailto: info@example.org\n"
     )
-    monkeypatch.delenv(
-        "CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False
-    )
+    monkeypatch.delenv("CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False)
     cfg = load_config(path)
     assert cfg.api.user_agent == "chembl-da/0.1 (mailto:contact@example.org)"
 
@@ -435,9 +415,7 @@ def test_user_agent_default_and_overrides(
     cfg = load_config(path)
     assert cfg.api.user_agent == "cli-agent/1.0 (mailto:test@example.org)"
 
-    monkeypatch.delenv(
-        "CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False
-    )
+    monkeypatch.delenv("CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False)
     cfg = load_config(
         path,
         cli_overrides={
@@ -462,9 +440,7 @@ def test_openalex_mailto_required(tmp_path: Path) -> None:
 
 def test_crossref_mailto_format(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
-    path.write_text(
-        "sources:\n  crossref:\n    mailto: not-an-email\n"
-    )
+    path.write_text("sources:\n  crossref:\n    mailto: not-an-email\n")
     with pytest.raises(ValidationError, match="crossref.mailto"):
         load_config(path)
 
@@ -585,9 +561,7 @@ def test_target_chembl_defaults_match_cli(
         cfg: object,
         client: object,
         mapping_cfg: object,
-
         chunk_size: object | None = None,
-
         timeout: object,
     ) -> pd.DataFrame:
         return pd.DataFrame({"target_chembl_id": list(ids)})

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -16,9 +16,9 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 
+import library.csv_utils as csv_utils
 import library.git_utils as git_utils
 from library.config import Config
-import library.csv_utils as csv_utils
 from library.csv_utils import sha256_file, write_csv_deterministic
 
 
@@ -150,7 +150,9 @@ def test_write_csv_deterministic_missing_sort_columns(
     content = path.read_text(encoding="utf-8-sig")
     assert content == "value,name\n1,alpha\n2,beta\n"
 
-    fallback_event = [payload for event, payload in events if event == "missing_key_columns"]
+    fallback_event = [
+        payload for event, payload in events if event == "missing_key_columns"
+    ]
     assert fallback_event
     assert fallback_event[0]["fallback"] == ["value", "name"]
 

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -13,9 +13,7 @@ def test_env_file_overrides(tmp_path, monkeypatch) -> None:
     )
 
     env_path = tmp_path / ".env"
-    env_path.write_text(
-        "CHEMBL_DA__SOURCES__CHEMBL__API__RPS=7\n", encoding="utf8"
-    )
+    env_path.write_text("CHEMBL_DA__SOURCES__CHEMBL__API__RPS=7\n", encoding="utf8")
 
     for line in env_path.read_text(encoding="utf8").splitlines():
         key, value = line.split("=", 1)

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -21,8 +21,6 @@ from library.config import (
     PubMedCfg,
     SemanticScholarCfg,
 )
-from library.document_pipeline import DOCUMENT_SCHEMA_COLUMNS
-from schemas import DocumentsSchema
 from scripts import get_document_data as gdd
 
 
@@ -121,9 +119,7 @@ def test_run_all_logs_failing_ids(
     chunk_size = cfg.document.all.chunk_size
     ids = [f"CHEMBL{i}" for i in range(1, chunk_size + 3)]
     input_csv = tmp_path / "docs.csv"
-    input_csv.write_text(
-        "document_chembl_id\n" + "\n".join(ids) + "\n"
-    )
+    input_csv.write_text("document_chembl_id\n" + "\n".join(ids) + "\n")
 
     class DummyClient:
         def __enter__(self) -> DummyClient:
@@ -174,9 +170,7 @@ def test_run_all_passes_generator_to_get_documents(
     cfg = Config()
     ids = [f"CHEMBL{i}" for i in range(1, 4)]
     input_csv = tmp_path / "docs.csv"
-    input_csv.write_text(
-        "document_chembl_id\n" + "\n".join(ids) + "\n"
-    )
+    input_csv.write_text("document_chembl_id\n" + "\n".join(ids) + "\n")
 
     class DummyClient:
         def __enter__(self) -> DummyClient:
@@ -485,7 +479,6 @@ def test_write_csv_column_order(
     assert captured["key_cols"] == ["ChEMBL.document_chembl_id"]
 
 
-
 def test_fetch_pubmed_records_handles_generic_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -531,7 +524,7 @@ def test_fetch_pubmed_records_accepts_config(
     factory_calls: dict[str, Any] = {}
 
     class DummySession:
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> DummySession:
             return self
 
         def __exit__(self, *exc: object) -> None:  # pragma: no cover - no cleanup

--- a/tests/test_get_target_data_all.py
+++ b/tests/test_get_target_data_all.py
@@ -18,8 +18,8 @@ from pytest import MonkeyPatch
 
 from library import protein_classification as pc
 from library.config import Config
-from schemas.targets import TARGETS_COLUMN_ORDER
 from schemas import TargetsSchema
+from schemas.targets import TARGETS_COLUMN_ORDER
 from scripts import get_target_data as gtd
 
 
@@ -39,7 +39,9 @@ class DummyClassifier:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[str, ...]]] = []
 
-    def get(self, target_id: str, family_id: str, ec_number: str, name: str) -> DummyRecord:
+    def get(
+        self, target_id: str, family_id: str, ec_number: str, name: str
+    ) -> DummyRecord:
         self.calls.append(("get", (target_id, family_id, ec_number, name)))
         return DummyRecord()
 
@@ -124,7 +126,9 @@ def test_run_all_uses_local_inputs(
     orig_finalise = gtd.tp.finalise_targets
 
     def patched_finalise(df: pd.DataFrame, **kwargs: object) -> pd.DataFrame:
-        df = df.drop(columns=[col for col in ("type", "target_type") if col in df.columns])
+        df = df.drop(
+            columns=[col for col in ("type", "target_type") if col in df.columns]
+        )
         return orig_finalise(df, **kwargs)
 
     monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -12,8 +12,8 @@ from pytest import MonkeyPatch
 
 from library import protein_classification as pc
 from library.config import Config
-from scripts import get_target_data as gtd
 from schemas import TargetsSchema
+from scripts import get_target_data as gtd
 
 
 class DummyRecord:
@@ -32,7 +32,9 @@ class DummyClassifier:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[str, ...]]] = []
 
-    def get(self, target_id: str, family_id: str, ec_number: str, name: str) -> DummyRecord:
+    def get(
+        self, target_id: str, family_id: str, ec_number: str, name: str
+    ) -> DummyRecord:
         self.calls.append(("get", (target_id, family_id, ec_number, name)))
         return DummyRecord()
 
@@ -152,9 +154,7 @@ def test_run_uniprot_writes_sidecar(
     monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
 ) -> None:
     input_csv = tmp_path / "targets.csv"
-    input_csv.write_text(
-        "uniprot_id\nP12345\nP23456\n", encoding=cfg.io.csv_encoding
-    )
+    input_csv.write_text("uniprot_id\nP12345\nP23456\n", encoding=cfg.io.csv_encoding)
     output_csv = tmp_path / "uniprot.csv"
     cfg.target.uniprot.data_dir = tmp_path
 
@@ -283,7 +283,9 @@ def test_run_all_preserves_reaction_ec_numbers(
     orig_finalise = gtd.tp.finalise_targets
 
     def patched_finalise(df: pd.DataFrame, **kwargs: object) -> pd.DataFrame:
-        df = df.drop(columns=[col for col in ("type", "target_type") if col in df.columns])
+        df = df.drop(
+            columns=[col for col in ("type", "target_type") if col in df.columns]
+        )
         return orig_finalise(df, **kwargs)
 
     monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)
@@ -292,9 +294,7 @@ def test_run_all_preserves_reaction_ec_numbers(
     )
 
     input_csv = tmp_path / "targets.csv"
-    input_csv.write_text(
-        "target_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding
-    )
+    input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding)
     output_csv = tmp_path / "out.csv"
 
     args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -29,7 +29,9 @@ class DummyClassifier:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[str, ...]]] = []
 
-    def get(self, target_id: str, family_id: str, ec_number: str, name: str) -> DummyRecord:
+    def get(
+        self, target_id: str, family_id: str, ec_number: str, name: str
+    ) -> DummyRecord:
         self.calls.append(("get", (target_id, family_id, ec_number, name)))
         return DummyRecord()
 
@@ -72,7 +74,9 @@ def test_iuphar_merge_preserves_ec_number(
     orig_finalise = tp.finalise_targets
 
     def patched_finalise(df: pd.DataFrame, **kwargs: object) -> pd.DataFrame:
-        df = df.drop(columns=[col for col in ("type", "target_type") if col in df.columns])
+        df = df.drop(
+            columns=[col for col in ("type", "target_type") if col in df.columns]
+        )
         return orig_finalise(df, **kwargs)
 
     monkeypatch.setattr(tp, "finalise_targets", patched_finalise)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Callable, Iterable, Mapping
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from datetime import datetime, timedelta, timezone
-from typing import Callable, Iterable, Mapping
 from types import SimpleNamespace
 
 import pandas as pd
@@ -111,7 +111,8 @@ def test_add_pubchem_data_reuses_resolution_cache(
         identifiers: Mapping[str, str | None],
         cfg: pl.PubChemCfg,
         *,
-        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] | None = None,
+        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution]
+        | None = None,
         resolution_key: tuple[str | None, ...] | None = None,
         **kwargs: object,
     ) -> pl.PubChemResolution:
@@ -156,7 +157,9 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
         return pl.PubChemResolution(cid="321", source="cache")
 
     def fail(*_: object, **__: object) -> None:
-        raise AssertionError("get_properties should not be called when prefer_local_smiles is enabled")
+        raise AssertionError(
+            "get_properties should not be called when prefer_local_smiles is enabled"
+        )
 
     monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
     monkeypatch.setattr(pl, "get_properties", fail)
@@ -169,14 +172,11 @@ def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) 
     pd.testing.assert_frame_equal(result, expected)
 
 
-
 def test_add_pubchem_data_preserves_existing_values(
-
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     df = pd.DataFrame(
         {
-
             "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
             "canonical_smiles": ["", "C", "CC"],
             "molecule_type": ["Polymer", "Mixture", "Small molecule"],
@@ -200,7 +200,8 @@ def test_add_pubchem_data_preserves_existing_values(
         cfg: pl.PubChemCfg,
         *,
         parent_loader: Callable[[str], pd.Series | None] | None = None,
-        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] | None = None,
+        resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution]
+        | None = None,
     ) -> str:
         calls.append(row["molecule_chembl_id"])
         return "333"
@@ -230,7 +231,6 @@ def test_add_pubchem_data_preserves_existing_values(
     assert result.loc[1, "pubchem_cid"] == "222"
     assert result.loc[1, "pubchem_iupac_name"] == "mixture"
     assert result.loc[2, "pubchem_cid"] == "333"
- 
 
 
 def test_resolve_pubchem_cid_prefers_inchikey(
@@ -460,7 +460,7 @@ def test_write_pubchem_cid_cache_creates_parent_dir(tmp_path: Path) -> None:
 
 def test_load_pubchem_cid_cache_expires(tmp_path: Path) -> None:
     cache_path = tmp_path / "cid_cache.json"
-    expired_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    expired_at = datetime.now(UTC) - timedelta(hours=2)
     payload = {
         "metadata": {
             "version": gtd._PUBCHEM_CACHE_SCHEMA_VERSION,
@@ -521,7 +521,6 @@ def test_run_chembl_column_order(
         captured_precomputed["data"] = kwargs.get("precomputed")
         captured_precomputed["frame"] = frame.copy()
         return (
-
             frame,
             gtd.ParentLookupStats(
                 source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
@@ -532,7 +531,9 @@ def test_run_chembl_column_order(
             ),
         )
 
-    monkeypatch.setattr(gtd, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids)
+    monkeypatch.setattr(
+        gtd, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids
+    )
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
@@ -561,9 +562,7 @@ def test_run_chembl_column_order(
     assert isinstance(prepared, gtd.ParentLookupPreparedData)
     captured_frame = captured_precomputed["frame"]
     assert isinstance(captured_frame, pd.DataFrame)
-    expected_prepared = prepare_parent_lookup_data(
-        captured_frame, cfg.molecule_catalog
-    )
+    expected_prepared = prepare_parent_lookup_data(captured_frame, cfg.molecule_catalog)
     pd.testing.assert_series_equal(
         prepared.child_ids, expected_prepared.child_ids, check_names=False
     )
@@ -572,7 +571,10 @@ def test_run_chembl_column_order(
         expected_prepared.existing_parent_ids,
         check_names=False,
     )
-    assert prepared.existing_parent_ids.tolist() == expected_prepared.existing_parent_ids.tolist()
+    assert (
+        prepared.existing_parent_ids.tolist()
+        == expected_prepared.existing_parent_ids.tolist()
+    )
     expected_need_lookup = set(
         expected_prepared.child_ids[
             (expected_prepared.child_ids != "")
@@ -623,7 +625,6 @@ def test_run_chembl_initialises_pubchem_session(
             ),
         ),
     )
-
 
     captured: dict[str, object] = {}
 
@@ -745,9 +746,7 @@ def test_run_chembl_calls_pubchem_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
     input_csv = tmp_path / "testitems.csv"
-    input_csv.write_text(
-        "molecule_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding
-    )
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\n", encoding=cfg.io.csv_encoding)
 
     args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
 
@@ -871,7 +870,9 @@ def test_run_chembl_merges_parent_catalog(
         catalog_cfg = kwargs.get("catalog_cfg")
         mapping = captured_catalog or {}
         parent_field = (
-            catalog_cfg.parent_field if catalog_cfg is not None else "parent_molecule_chembl_id"
+            catalog_cfg.parent_field
+            if catalog_cfg is not None
+            else "parent_molecule_chembl_id"
         )
         child_field = (
             catalog_cfg.child_field if catalog_cfg is not None else "molecule_chembl_id"
@@ -884,7 +885,6 @@ def test_run_chembl_merges_parent_catalog(
         )
         return (
             updated,
-
             gtd.ParentLookupStats(
                 source=gtd.PARENT_LOOKUP_SOURCE_SKIPPED,
                 missing=0,
@@ -894,7 +894,9 @@ def test_run_chembl_merges_parent_catalog(
             ),
         )
 
-    monkeypatch.setattr(gtd, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids)
+    monkeypatch.setattr(
+        gtd, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids
+    )
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
@@ -1058,9 +1060,7 @@ def test_attach_parent_ids_preserves_existing_values_when_cache_has_no_matches(
     expected = pd.Series(
         ["CHEMBL1_EXISTING", pd.NA], index=result.index, dtype="string"
     )
-    pd.testing.assert_series_equal(
-        result[parent_field], expected, check_names=False
-    )
+    pd.testing.assert_series_equal(result[parent_field], expected, check_names=False)
     assert stats.missing == 1
     assert stats.attached == 1
 
@@ -1135,7 +1135,6 @@ def test_run_chembl_preserves_existing_parent_value_when_catalog_missing(
 def test_run_chembl_parent_catalog_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
-
     input_csv = tmp_path / "testitems.csv"
     input_csv.write_text("molecule_chembl_id\nCHEMBL1\n")
 
@@ -1479,10 +1478,7 @@ def test_attach_parent_molecule_ids_handles_large_catalog(
     catalog_cfg.cache_path = tmp_path / "catalog.json"
     catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
-    base_catalog = {
-        f"CHEMBL{i}": f"CHEMBL{i}_PARENT"
-        for i in range(1, 5000)
-    }
+    base_catalog = {f"CHEMBL{i}": f"CHEMBL{i}_PARENT" for i in range(1, 5000)}
 
     class TrackingMapping(Mapping[str, str]):
         def __init__(self, data: Mapping[str, str]) -> None:
@@ -1739,7 +1735,6 @@ def test_attach_parent_molecule_ids_fetch_failure(
         lambda **__: {},
     )
 
-
     def failing_fetch(
         ids: list[str],
         *,
@@ -1790,12 +1785,10 @@ def test_attach_parent_molecule_ids_uses_cache_only(
     catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
     catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
 
-
     def unexpected_load_parent_catalog(**_: object) -> dict[str, str]:
         raise AssertionError("load_parent_catalog should not be called")
 
     monkeypatch.setattr(gtd, "load_parent_catalog", unexpected_load_parent_catalog)
-
 
     def unexpected_fetch(
         ids: list[str],
@@ -1830,4 +1823,3 @@ def test_attach_parent_molecule_ids_uses_cache_only(
     assert stats.missing == 0
     assert stats.attached == 1
     assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
-

--- a/tests/test_input_initialisation_library.py
+++ b/tests/test_input_initialisation_library.py
@@ -11,7 +11,7 @@ import pytest
 
 from library import input_initialisation_library as lib
 from library.cli import LoggerConfig, configure_logger
-from library.config import ApiCfg, Config
+from library.config import Config
 from library.input_initialisation_library import (
     TableDict,
     _ensure_openpyxl,
@@ -529,7 +529,6 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
                 "superkingdom",
                 "phylum",
                 "taxon_id",
-
             ]
         )
         + "\n"
@@ -546,7 +545,6 @@ def test_process_activity_table_basic(tmp_path: Path) -> None:
                 "Bacteria",
                 "Pseudomonadota",
                 "511145",
-
             ]
         )
         + "\n"
@@ -650,7 +648,6 @@ def test_process_activity_table_without_nstereo(tmp_path: Path) -> None:
             ]
         )
         + "\nT1,,,,,, ,Homo,Eukaryota,Chordata,9606\n"
-
     )
 
     res = process_activity_table(df, tmp_path)
@@ -718,7 +715,6 @@ def test_process_activity_table_targets_in_subdir(tmp_path: Path) -> None:
             ]
         )
         + "\nT1,ClassB,, , , ,False,,Viruses,,11676\n"
-
     )
 
     res = process_activity_table(df, tmp_path)

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -45,9 +45,7 @@ def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
     data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
     dummy = DummySession()
     monkeypatch.setattr(ii, "_session", dummy)
-    monkeypatch.setattr(
-        ii, "get_limiter", lambda name, rps, burst=None: DummyLimiter()
-    )
+    monkeypatch.setattr(ii, "get_limiter", lambda name, rps, burst=None: DummyLimiter())
 
     cfg = IupharCfg(base="https://example.org/services", rps=10, burst=10)
 

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -32,7 +32,7 @@ class DummyClient:
         try:
             return self._responses.pop(0)
         except IndexError:  # pragma: no cover - defensive
-            raise AssertionError("unexpected request")
+            raise AssertionError("unexpected request") from None
 
 
 @pytest.fixture()
@@ -100,7 +100,9 @@ def test_fetch_parent_catalog_for_returns_only_requested(api_cfg: ApiCfg) -> Non
 
     assert len(client.calls) == 2
     assert "CHEMBL1%2CCHEMBL_MISSING" in client.calls[0]
-    assert client.calls[1].endswith("/molecule/CHEMBL_MISSING.json?format=json&fields=molecule_chembl_id%2Cparent_molecule_chembl_id")
+    assert client.calls[1].endswith(
+        "/molecule/CHEMBL_MISSING.json?format=json&fields=molecule_chembl_id%2Cparent_molecule_chembl_id"
+    )
     assert result == {"CHEMBL1": "CHEMBL10"}
 
 
@@ -159,7 +161,9 @@ def test_fetch_parent_for_id_returns_pair(api_cfg: ApiCfg) -> None:
 def test_fetch_parent_catalog_for_small_batch_uses_single_helper(
     api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("library.molecule_catalog._PARENT_LOOKUP_FALLBACK_THRESHOLD", 10)
+    monkeypatch.setattr(
+        "library.molecule_catalog._PARENT_LOOKUP_FALLBACK_THRESHOLD", 10
+    )
     responses = [
         {
             "molecule": {
@@ -331,12 +335,12 @@ def test_fetch_parent_catalog_for_respects_single_limit(api_cfg: ApiCfg) -> None
     assert "CHEMBL2" not in single_calls[0]
 
 
-def test_load_parent_catalog_reads_existing_cache(tmp_path: Path, api_cfg: ApiCfg) -> None:
+def test_load_parent_catalog_reads_existing_cache(
+    tmp_path: Path, api_cfg: ApiCfg
+) -> None:
     cache = tmp_path / "catalog.json"
     cache.write_text(json.dumps({"chembl10": "chembl99"}), encoding="utf-8")
-    cfg = MoleculeCatalogCfg(
-        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
-    )
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite")
 
     result = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
@@ -351,9 +355,7 @@ def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) ->
         "molecule_chembl_id,parent_molecule_chembl_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(
-        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
-    )
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite")
 
     result = load_parent_catalog(
         client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg
@@ -362,15 +364,15 @@ def test_load_parent_catalog_reads_csv_cache(tmp_path: Path, api_cfg: ApiCfg) ->
     assert result == {"CHEMBL1": "CHEMBL42"}
 
 
-def test_load_parent_catalog_invalid_csv_columns(tmp_path: Path, api_cfg: ApiCfg) -> None:
+def test_load_parent_catalog_invalid_csv_columns(
+    tmp_path: Path, api_cfg: ApiCfg
+) -> None:
     cache = tmp_path / "catalog.csv"
     cache.write_text(
         "molecule_chembl_id,parant_molecule_id\nchembl1,chembl42\n",
         encoding="utf-8",
     )
-    cfg = MoleculeCatalogCfg(
-        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
-    )
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite")
 
     with pytest.raises(ValueError):
         load_parent_catalog(client=DummyClient([]), api_cfg=api_cfg, catalog_cfg=cfg)
@@ -380,9 +382,7 @@ def test_load_parent_catalog_fetches_and_persists(
     tmp_path: Path, api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache = tmp_path / "catalog.json"
-    cfg = MoleculeCatalogCfg(
-        cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite"
-    )
+    cfg = MoleculeCatalogCfg(cache_path=cache, sqlite_path=tmp_path / "catalog.sqlite")
     data = {"CHEMBL50": "CHEMBL60"}
 
     def fake_fetch(

--- a/tests/test_openalex_crossref_library.py
+++ b/tests/test_openalex_crossref_library.py
@@ -3,7 +3,7 @@ import requests
 
 from library import openalex_crossref_library as ocl
 from library import rate_limiter as rl
-from library.config import ApiCfg, Config, CrossRefCfg, OpenAlexCfg
+from library.config import Config
 
 
 def test_fetch_openalex_uses_cfg(monkeypatch) -> None:

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -6,9 +6,9 @@ free of duplicate requirement entries.
 
 from __future__ import annotations
 
+import tomllib
 from collections import defaultdict
 from pathlib import Path
-import tomllib
 
 
 def test_optional_dependencies_are_unique() -> None:
@@ -20,7 +20,9 @@ def test_optional_dependencies_are_unique() -> None:
 
     duplicates: dict[str, set[str]] = defaultdict(set)
 
-    for extra_name, requirements in data.get("project", {}).get("optional-dependencies", {}).items():
+    for extra_name, requirements in (
+        data.get("project", {}).get("optional-dependencies", {}).items()
+    ):
         seen: set[str] = set()
         for requirement in requirements:
             normalized = requirement.strip()
@@ -31,5 +33,7 @@ def test_optional_dependencies_are_unique() -> None:
 
     assert not duplicates, (
         "Duplicate optional dependency entries detected: "
-        + ", ".join(f"{group}: {sorted(values)}" for group, values in sorted(duplicates.items()))
+        + ", ".join(
+            f"{group}: {sorted(values)}" for group, values in sorted(duplicates.items())
+        )
     )

--- a/tests/test_protein_classification.py
+++ b/tests/test_protein_classification.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.iuphar_library import ClassificationRecord
 from library import protein_classification as pc
+from library.iuphar_library import ClassificationRecord
 
 
 class DummyClassifier:
@@ -23,7 +23,9 @@ class DummyClassifier:
     def get(self, *_args: object, **_kwargs: object) -> ClassificationRecord:
         return self.record
 
-    def by_molecular_function(self, *_args: object, **_kwargs: object) -> ClassificationRecord:
+    def by_molecular_function(
+        self, *_args: object, **_kwargs: object
+    ) -> ClassificationRecord:
         return self.fallback
 
 

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -289,7 +289,9 @@ def test_get_properties_returns_none_for_missing() -> None:
         f"{cfg.base.rstrip('/')}/compound/cid/{cid}/property/"
         "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
     )
-    responses.add(responses.GET, url, json={"PropertyTable": {"Properties": [{}]}}, status=200)
+    responses.add(
+        responses.GET, url, json={"PropertyTable": {"Properties": [{}]}}, status=200
+    )
 
     props = pl.get_properties(cid, cfg)
 

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -12,10 +12,7 @@ import requests
 
 from library import rate_limiter as rl
 from library.config import (
-    ApiCfg,
     Config,
-    CrossRefCfg,
-    OpenAlexCfg,
     PubMedCfg,
     SemanticScholarCfg,
 )
@@ -120,7 +117,9 @@ def test_do_request_attempt_count(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pq, "_make_request", fake_make_request)
 
     data, err = pq._do_request(
-        cast(requests.Session, DummySession(DummyResponse(200, text="{}", json_data={}))),
+        cast(
+            requests.Session, DummySession(DummyResponse(200, text="{}", json_data={}))
+        ),
         "http://example.org",
         delay=0,
         retries=2,

--- a/tests/test_target_cli_organism_csv.py
+++ b/tests/test_target_cli_organism_csv.py
@@ -2,117 +2,117 @@
 
 from __future__ import annotations
 
-
-import pytest
 import pandas as pd
+import pytest
 
 from library import protein_classification as pc
 from library.config import Config
 from scripts import get_target_data as gtd
 
 
-
 class DummyRecord:
-  """Lightweight stand-in for :class:`IUPHARClassificationRecord`."""
+    """Lightweight stand-in for :class:`IUPHARClassificationRecord`."""
 
-  def __init__(self, status: str = "target_id") -> None:
-    self.STATUS = status
-    self.IUPHAR_class = "ClassA"
-    self.IUPHAR_subclass = "SubclassA"
-    self.IUPHAR_type = "TypeA"
+    def __init__(self, status: str = "target_id") -> None:
+        self.STATUS = status
+        self.IUPHAR_class = "ClassA"
+        self.IUPHAR_subclass = "SubclassA"
+        self.IUPHAR_type = "TypeA"
 
 
 class DummyClassifier:
-  """Minimal classifier returning deterministic predictions."""
+    """Minimal classifier returning deterministic predictions."""
 
-  def __init__(self) -> None:
-    self.calls: list[tuple[str, tuple[str, ...]]] = []
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
 
-  def get(
-    self,
-    target_id: str,
-    family_id: str,
-    ec_number: str,
-    name: str,
-  ) -> DummyRecord:
-    self.calls.append(("get", (target_id, family_id, ec_number, name)))
-    return DummyRecord()
+    def get(
+        self,
+        target_id: str,
+        family_id: str,
+        ec_number: str,
+        name: str,
+    ) -> DummyRecord:
+        self.calls.append(("get", (target_id, family_id, ec_number, name)))
+        return DummyRecord()
 
-  def by_molecular_function(self, molecular_function: str) -> DummyRecord:
-    self.calls.append(("by_molecular_function", (molecular_function,)))
-    return DummyRecord(status="molecular_function")
+    def by_molecular_function(self, molecular_function: str) -> DummyRecord:
+        self.calls.append(("by_molecular_function", (molecular_function,)))
+        return DummyRecord(status="molecular_function")
 
 
 def test_all_subcommand_rejects_organism_csv() -> None:
-  """The ``all`` sub-command no longer accepts ``--organism-csv``."""
+    """The ``all`` sub-command no longer accepts ``--organism-csv``."""
 
-  parser, _log_cfg = gtd.build_parser()
-  with pytest.raises(SystemExit):
-    parser.parse_args(["all", "--organism-csv", "ignored.csv"])
+    parser, _log_cfg = gtd.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["all", "--organism-csv", "ignored.csv"])
 
 
 def test_merge_results_uses_classifier(
-  monkeypatch: pytest.MonkeyPatch, cfg: Config
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
-  """``merge_results`` loads the classifier when none is provided."""
+    """``merge_results`` loads the classifier when none is provided."""
 
-  combined_df = pd.DataFrame(
-    {
-      "target_chembl_id": ["CHEMBL1"],
-      "uniprot_id": ["P12345"],
-      "uniProtkbId": ["P12345-1"],
-      "pref_name": ["Alpha"],
-      "component_description": ["Alpha component"],
-      "gene": ["GENEA|ALPHA"],
-      "chembl_alternative_name": ["Alt"],
-      "names": ["Name1|Name2"],
-      "secondaryAccessionNames": ["Sec1"],
-      "ec_numbers": ["1.1.1.1"],
-      "reaction_ec_numbers": ["2.2.2.2"],
-      "genus": ["Homo"],
-      "lineage_superkingdom": ["Eukaryota"],
-      "lineage_phylum": ["Chordata"],
-      "lineage_class": ["Mammalia"],
-    }
-  )
-  iuphar_df = pd.DataFrame(
-    {
-      "uniprot_id": ["P12345"],
-      "IUPHAR_class": ["Kinase"],
-      "target_id": ["T1"],
-    }
-  )
+    combined_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P12345"],
+            "uniProtkbId": ["P12345-1"],
+            "pref_name": ["Alpha"],
+            "component_description": ["Alpha component"],
+            "gene": ["GENEA|ALPHA"],
+            "chembl_alternative_name": ["Alt"],
+            "names": ["Name1|Name2"],
+            "secondaryAccessionNames": ["Sec1"],
+            "ec_numbers": ["1.1.1.1"],
+            "reaction_ec_numbers": ["2.2.2.2"],
+            "genus": ["Homo"],
+            "lineage_superkingdom": ["Eukaryota"],
+            "lineage_phylum": ["Chordata"],
+            "lineage_class": ["Mammalia"],
+        }
+    )
+    iuphar_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P12345"],
+            "IUPHAR_class": ["Kinase"],
+            "target_id": ["T1"],
+        }
+    )
 
-  sentinel = DummyClassifier()
-  recorded: dict[str, object] = {}
+    sentinel = DummyClassifier()
+    recorded: dict[str, object] = {}
 
-  def fake_classifier(config: Config) -> DummyClassifier:
-    recorded["config"] = config
-    return sentinel
+    def fake_classifier(config: Config) -> DummyClassifier:
+        recorded["config"] = config
+        return sentinel
 
-  def fake_append(df: pd.DataFrame, classifier: DummyClassifier) -> pd.DataFrame:
-    recorded["classifier"] = classifier
-    df = df.copy()
+    def fake_append(df: pd.DataFrame, classifier: DummyClassifier) -> pd.DataFrame:
+        recorded["classifier"] = classifier
+        df = df.copy()
+        for column in pc.PREDICTION_COLUMNS:
+            df[column] = "ClassA"
+        return df
+
+    monkeypatch.setattr(pc, "classifier_from_config", fake_classifier)
+    monkeypatch.setattr(pc, "append_protein_class_predictions", fake_append)
+
+    orig_finalise = gtd.tp.finalise_targets
+
+    def patched_finalise(df: pd.DataFrame, **kwargs: object) -> pd.DataFrame:
+        df = df.drop(
+            columns=[col for col in ("type", "target_type") if col in df.columns]
+        )
+        return orig_finalise(df, **kwargs)
+
+    monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)
+
+    result = gtd.merge_results(combined_df, iuphar_df, cfg)
+
+    assert recorded["config"] is cfg
+    assert recorded["classifier"] is sentinel
     for column in pc.PREDICTION_COLUMNS:
-      df[column] = "ClassA"
-    return df
-
-  monkeypatch.setattr(pc, "classifier_from_config", fake_classifier)
-  monkeypatch.setattr(pc, "append_protein_class_predictions", fake_append)
-
-  orig_finalise = gtd.tp.finalise_targets
-
-  def patched_finalise(df: pd.DataFrame, **kwargs: object) -> pd.DataFrame:
-    df = df.drop(columns=[col for col in ("type", "target_type") if col in df.columns])
-    return orig_finalise(df, **kwargs)
-
-  monkeypatch.setattr(gtd.tp, "finalise_targets", patched_finalise)
-
-  result = gtd.merge_results(combined_df, iuphar_df, cfg)
-
-  assert recorded["config"] is cfg
-  assert recorded["classifier"] is sentinel
-  for column in pc.PREDICTION_COLUMNS:
-    assert column in result.columns
-  assert result.loc[0, "target_type"] == "Multicellular organism"
-  assert result.loc[0, "protein_class_pred_L1"] == "ClassA"
+        assert column in result.columns
+    assert result.loc[0, "target_type"] == "Multicellular organism"
+    assert result.loc[0, "protein_class_pred_L1"] == "ClassA"

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pandas as pd
 
 from library import target_postprocessing as tp
-from library.config import Config, IoCfg
+from library.config import Config
 from schemas.targets import TARGETS_COLUMN_ORDER
 
 

--- a/tests/test_testitem_enrichment.py
+++ b/tests/test_testitem_enrichment.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from library.config import Config
 from library import testitem_enrichment
+from library.config import Config
 
 
 def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
@@ -14,14 +14,18 @@ def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
     frame.to_csv(path, index=False)
 
 
-def test_enrich_adds_flags_and_salt(
-    tmp_path: Path, cfg: Config
-) -> None:
+def test_enrich_adds_flags_and_salt(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame(
         [
             {"molecule_chembl_id": "CHEMBL100"},
-            {"molecule_chembl_id": "CHEMBL200", "parent_molecule_chembl_id": "CHEMBL0200P"},
-            {"molecule_chembl_id": "CHEMBL300", "parent_molecule_chembl_id": "CHEMBL300"},
+            {
+                "molecule_chembl_id": "CHEMBL200",
+                "parent_molecule_chembl_id": "CHEMBL0200P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL300",
+                "parent_molecule_chembl_id": "CHEMBL300",
+            },
         ]
     )
 
@@ -29,8 +33,14 @@ def test_enrich_adds_flags_and_salt(
     _write_csv(
         hierarchy_path,
         [
-            {"molecule_chembl_id": "CHEMBL100", "parent_molecule_chembl_id": "CHEMBL0100P"},
-            {"molecule_chembl_id": "CHEMBL200", "parent_molecule_chembl_id": "CHEMBL0200P"},
+            {
+                "molecule_chembl_id": "CHEMBL100",
+                "parent_molecule_chembl_id": "CHEMBL0100P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL200",
+                "parent_molecule_chembl_id": "CHEMBL0200P",
+            },
         ],
     )
 
@@ -38,10 +48,30 @@ def test_enrich_adds_flags_and_salt(
     _write_csv(
         catalog_path,
         [
-            {"molecule_chembl_id": "CHEMBL100", "natural_product": "Y", "prodrug": "", "polymer_flag": "0"},
-            {"molecule_chembl_id": "CHEMBL0100P", "natural_product": "", "prodrug": "N", "polymer_flag": ""},
-            {"molecule_chembl_id": "CHEMBL200", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
-            {"molecule_chembl_id": "CHEMBL0200P", "natural_product": "", "prodrug": "Y", "polymer_flag": "0"},
+            {
+                "molecule_chembl_id": "CHEMBL100",
+                "natural_product": "Y",
+                "prodrug": "",
+                "polymer_flag": "0",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL0100P",
+                "natural_product": "",
+                "prodrug": "N",
+                "polymer_flag": "",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL200",
+                "natural_product": "N",
+                "prodrug": "Y",
+                "polymer_flag": "1",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL0200P",
+                "natural_product": "",
+                "prodrug": "Y",
+                "polymer_flag": "0",
+            },
         ],
     )
 
@@ -74,8 +104,14 @@ def test_enrich_logs_missing_and_inconsistent(
 ) -> None:
     df = pd.DataFrame(
         [
-            {"molecule_chembl_id": "CHEMBL500", "parent_molecule_chembl_id": "CHEMBL0500P"},
-            {"molecule_chembl_id": "CHEMBL600", "parent_molecule_chembl_id": "CHEMBL0600P"},
+            {
+                "molecule_chembl_id": "CHEMBL500",
+                "parent_molecule_chembl_id": "CHEMBL0500P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL600",
+                "parent_molecule_chembl_id": "CHEMBL0600P",
+            },
         ]
     )
 
@@ -83,7 +119,10 @@ def test_enrich_logs_missing_and_inconsistent(
     _write_csv(
         hierarchy_path,
         [
-            {"molecule_chembl_id": "CHEMBL500", "parent_molecule_chembl_id": "CHEMBL0500P"},
+            {
+                "molecule_chembl_id": "CHEMBL500",
+                "parent_molecule_chembl_id": "CHEMBL0500P",
+            },
         ],
     )
 
@@ -91,8 +130,18 @@ def test_enrich_logs_missing_and_inconsistent(
     _write_csv(
         catalog_path,
         [
-            {"molecule_chembl_id": "CHEMBL500", "natural_product": "Y", "prodrug": "N", "polymer_flag": "0"},
-            {"molecule_chembl_id": "CHEMBL0500P", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
+            {
+                "molecule_chembl_id": "CHEMBL500",
+                "natural_product": "Y",
+                "prodrug": "N",
+                "polymer_flag": "0",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL0500P",
+                "natural_product": "N",
+                "prodrug": "Y",
+                "polymer_flag": "1",
+            },
         ],
     )
 
@@ -118,14 +167,21 @@ def test_enrich_logs_missing_and_inconsistent(
     assert "testitem_enrichment_missing_parent_flags" in event_names
 
 
-def test_enrich_respects_configuration_options(
-    tmp_path: Path, cfg: Config
-) -> None:
+def test_enrich_respects_configuration_options(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame(
         [
-            {"molecule_chembl_id": "CHEMBL800", "parent_molecule_chembl_id": "CHEMBL0800P"},
-            {"molecule_chembl_id": "CHEMBL810", "parent_molecule_chembl_id": "CHEMBL0810P"},
-            {"molecule_chembl_id": "CHEMBL900", "parent_molecule_chembl_id": "CHEMBL900"},
+            {
+                "molecule_chembl_id": "CHEMBL800",
+                "parent_molecule_chembl_id": "CHEMBL0800P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL810",
+                "parent_molecule_chembl_id": "CHEMBL0810P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL900",
+                "parent_molecule_chembl_id": "CHEMBL900",
+            },
         ]
     )
 
@@ -133,8 +189,14 @@ def test_enrich_respects_configuration_options(
     _write_csv(
         hierarchy_path,
         [
-            {"molecule_chembl_id": "CHEMBL800", "parent_molecule_chembl_id": "CHEMBL0800P"},
-            {"molecule_chembl_id": "CHEMBL810", "parent_molecule_chembl_id": "CHEMBL0810P"},
+            {
+                "molecule_chembl_id": "CHEMBL800",
+                "parent_molecule_chembl_id": "CHEMBL0800P",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL810",
+                "parent_molecule_chembl_id": "CHEMBL0810P",
+            },
         ],
     )
 
@@ -142,9 +204,24 @@ def test_enrich_respects_configuration_options(
     _write_csv(
         catalog_path,
         [
-            {"molecule_chembl_id": "CHEMBL800", "natural_product": "Y", "prodrug": "N", "polymer_flag": "0"},
-            {"molecule_chembl_id": "CHEMBL0800P", "natural_product": "N", "prodrug": "Y", "polymer_flag": "1"},
-            {"molecule_chembl_id": "CHEMBL0810P", "natural_product": "N", "prodrug": "N", "polymer_flag": "0"},
+            {
+                "molecule_chembl_id": "CHEMBL800",
+                "natural_product": "Y",
+                "prodrug": "N",
+                "polymer_flag": "0",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL0800P",
+                "natural_product": "N",
+                "prodrug": "Y",
+                "polymer_flag": "1",
+            },
+            {
+                "molecule_chembl_id": "CHEMBL0810P",
+                "natural_product": "N",
+                "prodrug": "N",
+                "polymer_flag": "0",
+            },
         ],
     )
 

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -120,5 +120,8 @@ def test_collect_info_enriches_gtop(tmp_path: Path) -> None:
 
     assert result["gtop_natural_ligands_n"] == "2"
     assert result["gtop_interactions_n"] == "3"
-    assert result["gtop_function_text_short"] == "Physiological function: Regulates sample process"
+    assert (
+        result["gtop_function_text_short"]
+        == "Physiological function: Regulates sample process"
+    )
     assert len(responses.calls) == 3

--- a/tests/test_uniprot_process_columns.py
+++ b/tests/test_uniprot_process_columns.py
@@ -50,4 +50,3 @@ def test_process_writes_expected_columns(
     row = df.loc[0]
     assert row["uniprot_id"] == "P12345"
     assert row["secondaryAccessions"] == "S1|S2"
-

--- a/tests/test_write_csv_chunks_deterministic.py
+++ b/tests/test_write_csv_chunks_deterministic.py
@@ -56,9 +56,7 @@ def test_write_csv_chunks_deterministic_missing_keys(tmp_path: Path) -> None:
         key_cols=["chembl_id"],
     )
 
-    chunk_iter = (
-        shuffled.iloc[i : i + 2] for i in range(0, len(shuffled), 2)
-    )
+    chunk_iter = (shuffled.iloc[i : i + 2] for i in range(0, len(shuffled), 2))
     write_csv_chunks_deterministic(
         chunk_iter,
         path_chunks,


### PR DESCRIPTION
## Summary
- run Ruff formatting across the repository and add the `ruff-format` hook to pre-commit to keep styling consistent
- tighten typing in CLI dispatch utilities, pipeline metadata, molecule catalog cache handling, and activity enrichment helpers to satisfy `mypy --strict`
- normalise test item enrichment inputs by reading CSV data as pandas strings and computing boolean unicellular flags via organism classification

## Testing
- ruff format --check
- ruff check
- mypy
- pytest tests/test_activity_action_properties.py
- pytest tests/test_molecule_catalog.py::test_fetch_parent_catalog_for_returns_only_requested
- pytest tests/test_input_initialisation_library.py::test_process_activity_table_basic
- pytest tests/test_testitem_enrichment.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f1e5a1c083248d2e65c966e03ab8