### PR TITLE
Stream document pipeline exports via chunked deterministic writer

### DIFF
--- a/library/utils/cli_tools/check_determinism.py
+++ b/library/utils/cli_tools/check_determinism.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Verify deterministic CSV output.
 
-This script writes a small test :class:`pandas.DataFrame` twice using
-:func:`library.csv_utils.write_csv_deterministic` and compares the
-SHA-256 hashes of the resulting files. A non-zero exit code is returned if the
-hashes differ.
+This script writes a small test :class:`pandas.DataFrame` using both the
+standard and chunked deterministic CSV writers and compares the SHA-256 hashes
+of the resulting files. A non-zero exit code is returned if any hash differs.
 """
 
 from __future__ import annotations
@@ -28,7 +27,11 @@ except ImportError as exc:  # pragma: no cover - import-time check
     ) from exc
 
 from library.cli import LoggerConfig, configure_logger
-from library.csv_utils import sha256_file, write_csv_deterministic
+from library.csv_utils import (
+    sha256_file,
+    write_csv_chunks_deterministic,
+    write_csv_deterministic,
+)
 from library.log import logger
 from library.timing import log_duration
 
@@ -51,6 +54,7 @@ def run_check(tmp_dir: Path) -> bool:
 
     first = tmp_dir / "first.csv"
     second = tmp_dir / "second.csv"
+    chunked = tmp_dir / "chunked.csv"
 
     # Write the DataFrame twice using the deterministic writer
     key_cols = list(df.columns)
@@ -60,10 +64,26 @@ def run_check(tmp_dir: Path) -> bool:
     write_csv_deterministic(df, second, key_cols=key_cols)
     hash2 = sha256_file(second)
 
+    chunk_iter = [df.copy()]
+    write_csv_chunks_deterministic(
+        chunk_iter,
+        chunked,
+        key_cols=key_cols,
+        col_order=key_cols,
+        chunksize=len(df),
+        merge_chunksize=len(df),
+        sort_chunksize=len(df),
+        sep=",",
+        encoding="utf-8-sig",
+        cfg=None,
+    )
+    hash3 = sha256_file(chunked)
+
     logger.debug("hash", label="first", value=hash1)
     logger.debug("hash", label="second", value=hash2)
+    logger.debug("hash", label="chunked", value=hash3)
 
-    return hash1 == hash2
+    return hash1 == hash2 == hash3
 
 
 def main() -> int:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -45,6 +45,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import document_postprocessing as dp
 from library import io
+from library.csv_utils import write_csv_chunks_deterministic
 from library import openalex_crossref_library as ocl
 from library import pubmed_library as pl
 from library import semantic_scholar_library as ssl
@@ -532,6 +533,31 @@ _EXPORT_SORT_FALLBACK = [
 ]
 
 
+_EXPORT_STREAM_CHUNK_SIZE = 10_000
+
+
+def _iter_export_chunks(df: pd.DataFrame, *, chunk_size: int) -> Iterable[pd.DataFrame]:
+    """Yield export-ready DataFrame chunks from ``df``."""
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    if df.empty:
+        yield build_dataframe([], columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False)
+        return
+
+    total = len(df)
+    for start in range(0, total, chunk_size):
+        stop = start + chunk_size
+        chunk = df.iloc[start:stop]
+        export_chunk = build_dataframe(
+            chunk, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
+        )
+        export_chunk = dataframe_to_strings(
+            export_chunk, skip=_NUMERIC_EXPORT_COLUMNS
+        )
+        yield _prepare_export_frame(export_chunk)
+
+
 def _coalesce_columns(df: pd.DataFrame, columns: Sequence[str]) -> pd.Series:
     """Return the first non-empty value across ``columns`` for each row."""
 
@@ -571,6 +597,7 @@ def _finalise_export(
     *,
     input_csv: Path,
     key_columns: Sequence[str] | None = None,
+    chunk_size: int | None = None,
 ) -> int:
     """Validate ``df`` and write CSV/metadata artefacts."""
 
@@ -617,34 +644,35 @@ def _finalise_export(
     rows_kept = len(validated)
     rows_dropped = rows_total - rows_kept
 
-    export_df = build_dataframe(
-        validated, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
-    )
-    export_df = dataframe_to_strings(export_df, skip=_NUMERIC_EXPORT_COLUMNS)
-    export_df = _prepare_export_frame(export_df)
-
     key_cols: list[str] = []
     if key_columns:
         for column in key_columns:
             mapped = _EXPORT_COLUMN_RENAMES.get(column, column)
-            if mapped in export_df.columns and mapped not in key_cols:
+            if mapped in _EXPORT_COLUMNS and mapped not in key_cols:
                 key_cols.append(mapped)
     if not key_cols:
         for candidate in _EXPORT_SORT_FALLBACK:
-            if candidate in export_df.columns:
+            if candidate in _EXPORT_COLUMNS:
                 key_cols = [candidate]
                 break
     if not key_cols:
         key_cols = [_EXPORT_COLUMNS[0]]
 
     col_order = list(_EXPORT_COLUMNS)
+    stream_chunk = max(1, int(chunk_size or _EXPORT_STREAM_CHUNK_SIZE))
+    export_chunks = _iter_export_chunks(validated, chunk_size=stream_chunk)
     try:
-        csv_path = io.write_csv(
-            export_df,
+        csv_path = write_csv_chunks_deterministic(
+            export_chunks,
             output,
             cfg=cfg,
             key_cols=key_cols,
             col_order=col_order,
+            chunksize=stream_chunk,
+            merge_chunksize=stream_chunk,
+            sort_chunksize=stream_chunk,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
         )
     except OSError as exc:
         logger.error("csv_write_failed", error=str(exc), path=str(output))
@@ -775,6 +803,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
+            chunk_size=cfg.document.pubmed.batch_size,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("pubmed_pipeline_failed", error=str(exc))
@@ -848,6 +877,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
+            chunk_size=cfg.document.chembl.chunk_size,
         )
         return exit_code
 
@@ -932,6 +962,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
+            chunk_size=cfg.document.all.chunk_size,
         )
         return exit_code
 
@@ -979,6 +1010,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         cfg,
         input_csv=Path(args.input_csv),
         key_columns=["document_chembl_id"],
+        chunk_size=cfg.document.all.chunk_size,
     )
     return exit_code
 

--- a/tests/test_csv_determinism_integration.py
+++ b/tests/test_csv_determinism_integration.py
@@ -15,5 +15,5 @@ def test_csv_determinism_integration() -> None:
     )
     records = [json.loads(line) for line in proc.stdout.splitlines()]
     hashes = [r["value"] for r in records if r.get("event") == "hash"]
-    assert len(hashes) == 2
-    assert hashes[0] == hashes[1]
+    assert len(hashes) == 3
+    assert len(set(hashes)) == 1

--- a/tests/test_determinism_script.py
+++ b/tests/test_determinism_script.py
@@ -7,9 +7,9 @@ import sys
 def test_determinism_script_returns_zero() -> None:
     """Run determinism check script and assert a zero exit code.
 
-    The script writes a small DataFrame twice using the deterministic CSV writer
-    and compares their SHA-256 hashes. When the output is deterministic the
-    script exits with code ``0``.
+    The script now writes a small DataFrame through both deterministic CSV
+    writers and compares their SHA-256 hashes. When the output is deterministic
+    the script exits with code ``0``.
     """
 
     result = subprocess.run(

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -76,20 +76,17 @@ def test_cli_uses_custom_column(
     monkeypatch.setattr(cl, "get_documents", fake_get_documents)
     monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
 
-    def fake_write_csv(
-        df: pd.DataFrame,
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
-        key_cols: list[str] | None = None,
-        col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        **_: Any,
     ) -> Path:
+        list(chunks)
         return path
 
-    monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
@@ -326,7 +323,7 @@ def test_run_pubmed_uses_keyword_arguments(
     monkeypatch.setattr(
         gdd,
         "_finalise_export",
-        lambda df, output, cfg, input_csv, key_columns: 0,
+        lambda df, output, cfg, input_csv, key_columns, **kwargs: 0,
     )
 
     cfg = Config()
@@ -381,7 +378,7 @@ def test_run_pubmed_uses_fallback_csv(
     monkeypatch.setattr(
         gdd,
         "_finalise_export",
-        lambda df, output, cfg, input_csv, key_columns: 0,
+        lambda df, output, cfg, input_csv, key_columns, **kwargs: 0,
     )
 
     captured: dict[str, Any] = {}
@@ -450,23 +447,22 @@ def test_write_csv_column_order(
 
     captured: dict[str, Any] = {}
 
-    def fake_write_csv(
-        frame: pd.DataFrame,
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
         key_cols: list[str] | None = None,
         col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        **_: Any,
     ) -> Path:
+        frames = list(chunks)
         captured["col_order"] = list(col_order or [])
-        captured["columns"] = list(frame.columns)
+        captured["columns"] = list(frames[0].columns) if frames else []
         captured["key_cols"] = list(key_cols or [])
         return path
 
-    monkeypatch.setattr(lib_io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
@@ -863,21 +859,19 @@ def test_finalise_export_falls_back_to_default_key(
     output = tmp_path / "documents.csv"
     captured: dict[str, Any] = {}
 
-    def fake_write_csv(
-        frame: pd.DataFrame,
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
         path: Path,
         *,
         cfg: Any,
-        sep: str | None = None,
-        encoding: str | None = None,
         key_cols: list[str] | None = None,
-        col_order: list[str] | None = None,
-        chunksize: int | None = None,
+        **_: Any,
     ) -> Path:
+        list(chunks)
         captured["key_cols"] = list(key_cols) if key_cols is not None else None
         return path
 
-    monkeypatch.setattr(gdd.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "hash")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})


### PR DESCRIPTION
## Summary
- stream the document pipeline export through the chunked deterministic writer instead of materialising the full DataFrame
- extend the determinism CLI check to cover the chunked writer and update the integration checks
- align document pipeline unit tests with the new streaming export behaviour

## Testing
- pytest tests/test_get_document_data.py
- pytest tests/test_csv_determinism_integration.py tests/test_determinism_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f2e75b5883249e9206dc86deb889