### PR TITLE
Restore add_cellularity_smart signature and tighten export writer call

### DIFF
--- a/library/organism_classification.py
+++ b/library/organism_classification.py
@@ -34,6 +34,7 @@ DEFAULT_SUPERKINGDOM_COLUMN = "lineage_superkingdom"
 DEFAULT_PHYLUM_COLUMN = "lineage_phylum"
 DEFAULT_CLASS_COLUMN = "lineage_class"
 DEFAULT_OUTPUT_COLUMN = "type"
+DEFAULT_TAXON_ID_COLUMN = "taxon_id"
 
 DEFAULT_NULL_LITERALS: frozenset[str] = frozenset({"nan", "none", "-", "na"})
 TAXONOMY_SEPARATORS: Sequence[str] = ("|", ";")
@@ -234,9 +235,29 @@ def add_cellularity_smart(
     phylum_col: str = DEFAULT_PHYLUM_COLUMN,
     class_col: str = DEFAULT_CLASS_COLUMN,
     output_col: str = DEFAULT_OUTPUT_COLUMN,
+    taxon_id_col: str = DEFAULT_TAXON_ID_COLUMN,
     rules: OrganismClassificationRules = DEFAULT_RULES,
 ) -> pd.DataFrame:
-    """Backward-compatible wrapper around :func:`add_cellularity`."""
+    """Backward-compatible wrapper around :func:`add_cellularity`.
+
+    Parameters
+    ----------
+    df:
+        Input frame expected to contain the lineage columns used for
+        classification.
+    genus_col, superkingdom_col, phylum_col, class_col:
+        Column names storing taxonomy annotations.
+    output_col:
+        Column receiving the inferred cellularity labels.
+    taxon_id_col:
+        Retained for backwards compatibility with legacy call sites. The
+        identifier is not required for lineage-based inference and therefore
+        ignored.
+    rules:
+        Rule set controlling the inference heuristics.
+    """
+
+    _ = taxon_id_col  # Intentionally ignored; maintained for compatibility.
 
     return add_cellularity(
         df,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -625,17 +625,28 @@ def _write_export_chunks(
 ) -> Path:
     """Stream ``chunks`` to ``path`` using the deterministic CSV writer."""
 
-    kwargs: dict[str, object] = {
-        "col_order": list(_EXPORT_COLUMNS),
-        "key_cols": list(key_cols),
-        "sep": cfg.io.csv_sep,
-        "encoding": cfg.io.csv_encoding,
-        "cfg": cfg,
-    }
     if chunk_size:
-        kwargs["chunksize"] = chunk_size
-        kwargs["merge_chunksize"] = chunk_size
-    return write_csv_chunks_deterministic(chunks, path, **kwargs)
+        return write_csv_chunks_deterministic(
+            chunks,
+            path,
+            col_order=list(_EXPORT_COLUMNS),
+            key_cols=list(key_cols),
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            cfg=cfg,
+            chunksize=chunk_size,
+            merge_chunksize=chunk_size,
+        )
+
+    return write_csv_chunks_deterministic(
+        chunks,
+        path,
+        col_order=list(_EXPORT_COLUMNS),
+        key_cols=list(key_cols),
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+        cfg=cfg,
+    )
 
 
 def _finalise_export(


### PR DESCRIPTION
## Summary
- restore the taxon_id_col parameter on add_cellularity_smart and document its compatibility role
- forward typed keyword arguments directly from _write_export_chunks to the deterministic CSV writer

## Testing
- pytest tests/test_organism_classification.py

------
https://chatgpt.com/codex/tasks/task_e_68d7009943908324aa9a8a61c47b3795