### PR TITLE
Fix ChemblClient retry loop and parent fallback fan-out

### DIFF
--- a/library/chembl_client.py
+++ b/library/chembl_client.py
@@ -137,9 +137,9 @@ class ChemblClient:
             )
 
         last_exc: requests.RequestException | ValueError | None = None
-        attempts = max(1, cfg.retries)
+        total_attempts = cfg.retries + 1
 
-        for attempt in range(1, attempts + 1):
+        for attempt in range(1, total_attempts + 1):
             limiter.acquire()
             event = "request_start" if attempt == 1 else "request_retry"
             logger.info(event, extra={"url": url, "attempt": attempt, "rps": cfg.rps})
@@ -172,7 +172,7 @@ class ChemblClient:
                         return data
             except (requests.RequestException, ValueError) as exc:
                 last_exc = exc
-                if attempt >= attempts:
+                if attempt >= total_attempts:
                     logger.exception(
                         "request_fail",
                         extra={"url": url, "status": None, "rps": cfg.rps},

--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -26,6 +26,7 @@ _PARENT_LOOKUP_PARENT_FIELD = _DEFAULT_CATALOG_CFG.parent_field
 _PARENT_LOOKUP_CHUNK_SIZE = _DEFAULT_CATALOG_CFG.page_size
 _PARENT_LOOKUP_SINGLE_LIMIT = _DEFAULT_CATALOG_CFG.fallback_single_limit
 _PARENT_LOOKUP_FALLBACK_THRESHOLD = 1
+_PARENT_LOOKUP_RETRY_THRESHOLD = 10
 _PARENT_LOOKUP_SINGLE_ATTEMPTS_MIN = 1
 _SQLITE_VARIABLE_LIMIT = 900
 _PARENT_LOOKUP_SINGLE_CONCURRENCY = 4
@@ -210,7 +211,7 @@ def _fetch_parent_catalog_via_helper(
     if not pending:
         return {}
 
-    attempts = max(_PARENT_LOOKUP_SINGLE_ATTEMPTS_MIN, api_cfg.retries)
+    attempts = max(_PARENT_LOOKUP_SINGLE_ATTEMPTS_MIN, api_cfg.retries + 1)
     delay = api_cfg.backoff_factor
     single_limit = cfg.fallback_single_limit
     result: dict[str, str] = {}
@@ -220,7 +221,7 @@ def _fetch_parent_catalog_via_helper(
 
     try:
         retry_chunk_size = 0
-        if allow_rebatch:
+        if allow_rebatch and len(pending) >= _PARENT_LOOKUP_RETRY_THRESHOLD:
             base_chunk_size = max(1, cfg.page_size)
             retry_chunk_size = base_chunk_size // 2
             if retry_chunk_size < 2:
@@ -251,13 +252,23 @@ def _fetch_parent_catalog_via_helper(
                 if missing:
                     remaining.extend(missing)
         else:
-            remaining = list(pending)
+            remaining = [
+                chembl_id for chembl_id in pending if chembl_id not in existing
+            ]
 
-        outstanding = [
-            chembl_id
-            for chembl_id in remaining
-            if chembl_id not in existing and chembl_id not in result
-        ]
+        outstanding_pool = {
+            chembl_id for chembl_id in remaining if chembl_id not in existing
+        }
+        outstanding: list[str] = []
+        if outstanding_pool:
+            seen_outstanding: set[str] = set()
+            for chembl_id in pending:
+                if chembl_id not in outstanding_pool:
+                    continue
+                if chembl_id in result or chembl_id in seen_outstanding:
+                    continue
+                seen_outstanding.add(chembl_id)
+                outstanding.append(chembl_id)
         if outstanding and not _PARENT_CATALOG_LOADING:
             try:
                 load_parent_catalog(
@@ -293,10 +304,13 @@ def _fetch_parent_catalog_via_helper(
                 outstanding = outstanding[:single_limit]
 
         if outstanding:
-            max_workers = max(
-                1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY)
-            )
             single_requests = len(outstanding)
+            if retry_chunk_size:
+                max_workers = max(
+                    1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY)
+                )
+            else:
+                max_workers = 1
 
             def _fetch_with_retry(chembl_id: str) -> tuple[str, str] | None:
                 for attempt in range(1, attempts + 1):

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from .cli import LoggerConfig, apply_config_overrides, configure_logger
+from . import cli
+from .cli import LoggerConfig, configure_logger
 from .cli import build_parser as base_parser
 from .config import Config, ensure_dirs, print_config, session_with_retry
 from .csv_utils import write_csv_deterministic
@@ -87,7 +88,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg = apply_config_overrides(
+        cfg = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/library/utils/cli_tools/get_document_type.py
+++ b/library/utils/cli_tools/get_document_type.py
@@ -11,9 +11,9 @@ from collections.abc import Iterable, Mapping, Sequence
 
 import pandas as pd
 
+from library import cli
 from library import io
 from library.cli import (
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -139,7 +139,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger_inst.info("pipeline_start", run_id=log_cfg.run_id)
 
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -21,10 +21,10 @@ from pathlib import Path
 import argparse
 from collections.abc import Sequence
 
+from library import cli
 from library import input_initialisation_library as lib
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -160,7 +160,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/library/utils/cli_tools/mapper_batch_main.py
+++ b/library/utils/cli_tools/mapper_batch_main.py
@@ -7,10 +7,10 @@ from collections.abc import Callable, Sequence
 
 import pandas as pd
 
+from library import cli
 from library import io
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import build_parser as base_parser
@@ -113,7 +113,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg = cli.apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     print_config(cfg)
     func: Callable[[Config, argparse.Namespace], int] = args.func

--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -8,10 +8,10 @@ from urllib.error import URLError
 
 import pandas as pd
 
+from library import cli
 from library import io
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -120,7 +120,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = cli.apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -10,9 +10,9 @@ from collections.abc import Sequence
 
 import pandas as pd
 
+from library import cli
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -85,7 +85,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(args, parser, args.config)
+        cfg: Config = cli.apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -19,11 +19,11 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
+from library import cli
 from library import io
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -1092,7 +1092,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -14,11 +14,11 @@ from pandera.errors import SchemaErrors
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
+from library import cli
 from library import io
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import build_parser as base_parser
@@ -243,7 +243,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -38,6 +38,7 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
+from library import cli
 from library import document_postprocessing as dp
 from library import io
 from library.csv_utils import write_csv_chunks_deterministic
@@ -47,7 +48,6 @@ from library import semantic_scholar_library as ssl
 from library.chembl_client import ChemblClient, _chunked
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     build_root_parser,
     configure_logger,
     positive_int,
@@ -1282,7 +1282,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             }
         )
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             subparser,
             args.config,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -23,6 +23,7 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
+from library import cli
 from library import io
 from library import iuphar_library as ii
 from library import protein_classification as pc
@@ -32,7 +33,6 @@ from library.chembl_client import ChemblClient
 from library.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     build_root_parser,
     configure_logger,
     positive_int,
@@ -1167,7 +1167,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "iuphar_out": "target.all.iuphar_out",
                 "limit": "target.all.limit",
             }
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args, subparser, args.config, mapping=mapping, base_parser=parser
         )
         if args.print_config:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -21,12 +21,12 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
+from library import cli
 from library import io, molecule_catalog, testitem_enrichment
 from library import pubchem_library as pl
 from library.chembl_client import ChemblClient
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     configure_logger,
 )
 from library.cli import (
@@ -1289,7 +1289,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = apply_config_overrides(
+        cfg: Config = cli.apply_config_overrides(
             args,
             parser,
             args.config,

--- a/scripts/pipeline_targets_main.py
+++ b/scripts/pipeline_targets_main.py
@@ -12,10 +12,10 @@ from pathlib import Path
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from library import cli
 from library.chembl_client import _chunked
 from library.cli import (
     LoggerConfig,
-    apply_config_overrides,
     build_root_parser,
     configure_logger,
 )
@@ -170,7 +170,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger_inst = configure_logger(log_cfg)
     pipeline_logger = logger_inst.bind(stage="pipeline")
     pipeline_logger.info("pipeline_start")
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg = cli.apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
     print_config(cfg)
     if args.print_config:

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -405,14 +405,16 @@ def test_get_testitem_data_smoke(
         get_testitem_data, "analyze_table_quality", lambda *_, **__: None
     )
 
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = get_testitem_data.cli.apply_config_overrides
 
     def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
         cfg.pubchem.allow_polymer = False
         return cfg
 
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)
+    monkeypatch.setattr(
+        get_testitem_data.cli, "apply_config_overrides", patched_apply
+    )
 
     smiles_calls: list[str] = []
     warning_events: list[tuple[str, dict[str, object]]] = []

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -7,7 +7,10 @@ import pandas as pd
 import pytest
 
 from library import chembl_library as cl
+from library import cli as base_cli
 from library import pubchem_library as pl
+
+_ORIGINAL_APPLY = base_cli.apply_config_overrides
 from scripts import get_testitem_data
 
 
@@ -61,14 +64,16 @@ def test_get_testitem_parent_catalog(
     def fail_load_parent_catalog(**_: object) -> dict[str, str]:  # pragma: no cover
         pytest.fail("load_parent_catalog should not be triggered for partial coverage")
 
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = _ORIGINAL_APPLY
 
     def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
         cfg.pubchem.resolve_order = ("cache", "smiles")
         return cfg
 
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)
+    monkeypatch.setattr(
+        get_testitem_data.cli, "apply_config_overrides", patched_apply
+    )
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
@@ -92,7 +97,7 @@ def test_get_testitem_parent_catalog(
         "fetch_parent_catalog_for",
         fake_fetch_parent_catalog_for,
     )
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = _ORIGINAL_APPLY
 
     def patched_apply_config_overrides(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
@@ -113,7 +118,9 @@ def test_get_testitem_parent_catalog(
         get_testitem_data, "analyze_table_quality", lambda *_, **__: None
     )
     monkeypatch.setattr(
-        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+        get_testitem_data.cli,
+        "apply_config_overrides",
+        patched_apply_config_overrides,
     )
 
     exit_code = get_testitem_data.main(
@@ -188,14 +195,16 @@ def test_get_testitem_skips_parent_lookup_when_present(
         fetch_called = True
         return {}
 
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = _ORIGINAL_APPLY
 
     def patched_apply(*args, **kwargs):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
         cfg.pubchem.resolve_order = ("cache", "smiles")
         return cfg
 
-    monkeypatch.setattr(get_testitem_data, "apply_config_overrides", patched_apply)
+    monkeypatch.setattr(
+        get_testitem_data.cli, "apply_config_overrides", patched_apply
+    )
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
     monkeypatch.setattr(pl, "get_cid_from_smiles", fake_get_cid)
@@ -208,7 +217,7 @@ def test_get_testitem_skips_parent_lookup_when_present(
         "fetch_parent_catalog_for",
         fake_fetch_parent_catalog_for,
     )
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = _ORIGINAL_APPLY
 
     def patched_apply_config_overrides(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
         cfg = original_apply(*args, **kwargs)
@@ -219,7 +228,9 @@ def test_get_testitem_skips_parent_lookup_when_present(
         get_testitem_data, "analyze_table_quality", lambda *_, **__: None
     )
     monkeypatch.setattr(
-        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+        get_testitem_data.cli,
+        "apply_config_overrides",
+        patched_apply_config_overrides,
     )
 
     exit_code = get_testitem_data.main(
@@ -288,7 +299,7 @@ def test_get_testitem_refreshes_outdated_parents(
         fetch_calls.append(list(ids))
         return {key: mapping[key] for key in ids if key in mapping}
 
-    original_apply = get_testitem_data.apply_config_overrides
+    original_apply = _ORIGINAL_APPLY
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
     monkeypatch.setattr(pl, "init_session", lambda *_, **__: None)
@@ -321,7 +332,9 @@ def test_get_testitem_refreshes_outdated_parents(
         return cfg
 
     monkeypatch.setattr(
-        get_testitem_data, "apply_config_overrides", patched_apply_config_overrides
+        get_testitem_data.cli,
+        "apply_config_overrides",
+        patched_apply_config_overrides,
     )
 
     exit_code = get_testitem_data.main(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from library.cli import apply_config_overrides
+from library import cli
 
 
 def test_apply_config_overrides_missing_config(
@@ -13,6 +13,6 @@ def test_apply_config_overrides_missing_config(
     parser.add_argument("--config", default="config.yaml")
     args = parser.parse_args(["--config", str(tmp_path / "missing.yaml")])
     with pytest.raises(SystemExit) as excinfo:
-        apply_config_overrides(args, parser, args.config)
+        cli.apply_config_overrides(args, parser, args.config)
     assert excinfo.value.code == 2
     assert "configuration file not found" in capsys.readouterr().err

--- a/tests/test_cli_common_args.py
+++ b/tests/test_cli_common_args.py
@@ -1,7 +1,8 @@
 import argparse
 from pathlib import Path
 
-from library.cli import add_common_arguments, apply_config_overrides
+from library import cli
+from library.cli import add_common_arguments
 
 
 def _write_config(tmp_path: Path) -> Path:
@@ -19,7 +20,7 @@ def test_config_defaults_applied(tmp_path: Path) -> None:
     add_common_arguments(parser)
     parser.add_argument("--config", default=cfg_path, type=Path)
     args = parser.parse_args(["--config", str(cfg_path)])
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg = cli.apply_config_overrides(args, parser, args.config)
     assert args.sep == "|"
     assert args.encoding == "latin1"
     assert cfg.io.csv_sep == "|"
@@ -43,7 +44,7 @@ def test_cli_overrides_config(tmp_path: Path) -> None:
             "DEBUG",
         ]
     )
-    cfg = apply_config_overrides(args, parser, args.config)
+    cfg = cli.apply_config_overrides(args, parser, args.config)
     assert cfg.io.csv_sep == ";"
     assert cfg.io.csv_encoding == "utf16"
     assert cfg.log.level == "DEBUG"

--- a/tests/test_cli_limit.py
+++ b/tests/test_cli_limit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from library.cli import apply_config_overrides
+from library import cli
 
 
 def test_cli_limit_override(tmp_path: Path) -> None:
@@ -13,7 +13,7 @@ def test_cli_limit_override(tmp_path: Path) -> None:
     parser.add_argument("--config", default=cfg_path, type=Path)
     parser.add_argument("--limit", type=int, default=None)
     args = parser.parse_args(["--config", str(cfg_path), "--limit", "5"])
-    cfg = apply_config_overrides(
+    cfg = cli.apply_config_overrides(
         args, parser, args.config, mapping={"limit": "activity.limit"}
     )
     assert cfg.activity.limit == 5

--- a/tests/test_cli_option_order.py
+++ b/tests/test_cli_option_order.py
@@ -36,7 +36,7 @@ def test_target_input_before_subcommand(
         captured["input_csv"] = Path(args.input_csv)
         return 0
 
-    monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(gtd.cli, "apply_config_overrides", fake_apply)
     monkeypatch.setattr(gtd, "run_all", fake_run_all)
 
     rc = gtd.main(["--config", str(config_yaml), "--input", str(input_csv), "all"])
@@ -68,7 +68,7 @@ def test_document_input_before_subcommand(
         captured["input_csv"] = Path(args.input_csv)
         return 0
 
-    monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(gdd.cli, "apply_config_overrides", fake_apply)
     monkeypatch.setattr(gdd, "run_chembl", fake_run)
 
     rc = gdd.main(["--config", str(config_yaml), "--input", str(input_csv), "chembl"])

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -64,7 +64,7 @@ def test_assay_timeout_override(
         cfg.assay.timeout = float(a.timeout)
         return cfg
 
-    monkeypatch.setattr(gas, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(gas.cli, "apply_config_overrides", fake_apply)
 
     def fake_get_assays(
         ids: Sequence[str],
@@ -124,7 +124,7 @@ def test_document_timeout_override(
         cfg.api.user_agent = "test/0.1 (mailto:test@example.com)"
         return cfg
 
-    monkeypatch.setattr(gdd, "apply_config_overrides", fake_apply_doc)
+    monkeypatch.setattr(gdd.cli, "apply_config_overrides", fake_apply_doc)
 
     def fake_get_documents(
         ids: Sequence[str],
@@ -181,7 +181,7 @@ def test_testitem_timeout_override(
         cfg.testitem.timeout = float(a.timeout)
         return cfg
 
-    monkeypatch.setattr(gtdt, "apply_config_overrides", fake_apply_test)
+    monkeypatch.setattr(gtdt.cli, "apply_config_overrides", fake_apply_test)
 
     def fake_get_testitem(
         ids: Sequence[str],
@@ -254,7 +254,7 @@ def test_target_timeout_override(
         cfg.target.chembl.timeout = float(a.timeout)
         return cfg
 
-    monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply_target)
+    monkeypatch.setattr(gtd.cli, "apply_config_overrides", fake_apply_target)
 
     def fake_get_targets(
         ids: Sequence[str],
@@ -314,7 +314,7 @@ def test_target_chunk_size_override(
         cfg.target.chembl.chunk_size = int(a.chunk_size)
         return cfg
 
-    monkeypatch.setattr(gtd, "apply_config_overrides", fake_apply_chunk)
+    monkeypatch.setattr(gtd.cli, "apply_config_overrides", fake_apply_chunk)
 
     def fake_get_targets(
         ids: Sequence[str],

--- a/tests/test_mapper_batch_main.py
+++ b/tests/test_mapper_batch_main.py
@@ -26,7 +26,7 @@ def test_main_invokes_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
 
     cfg = Config()
     cfg.api.user_agent = "test@example.org"
-    monkeypatch.setattr(cli, "apply_config_overrides", lambda *_, **__: cfg)
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *_, **__: cfg)
     monkeypatch.setattr(cli, "ensure_dirs", lambda *_: None)
 
     printed: dict[str, Config] = {}

--- a/tests/test_molecule_catalog.py
+++ b/tests/test_molecule_catalog.py
@@ -165,6 +165,12 @@ def test_fetch_parent_catalog_for_small_batch_uses_single_helper(
     monkeypatch.setattr(
         "library.molecule_catalog._PARENT_LOOKUP_FALLBACK_THRESHOLD", 10
     )
+    monkeypatch.setattr(
+        "library.molecule_catalog.load_parent_catalog", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "library.molecule_catalog.query_parent_catalog", lambda *_, **__: {}
+    )
     responses = [
         {
             "molecule": {
@@ -194,6 +200,12 @@ def test_fetch_parent_catalog_for_falls_back_on_bulk_error(
 ) -> None:
     api_cfg = api_cfg.model_copy(update={"backoff_factor": 0})
     monkeypatch.setattr("library.molecule_catalog._PARENT_LOOKUP_FALLBACK_THRESHOLD", 1)
+    monkeypatch.setattr(
+        "library.molecule_catalog.load_parent_catalog", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "library.molecule_catalog.query_parent_catalog", lambda *_, **__: {}
+    )
 
     class FallbackClient(DummyClient):
         def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None = None):
@@ -218,7 +230,7 @@ def test_fetch_parent_catalog_for_falls_back_on_bulk_error(
 
     assert result == {"CHEMBL1": "CHEMBL10"}
     fallback_calls = [call for call in client.calls if "/molecule/" in call]
-    assert len(fallback_calls) == api_cfg.retries + 1
+    assert len(fallback_calls) == api_cfg.retries + 2
     assert any("CHEMBL1" in call for call in fallback_calls)
 
 
@@ -258,10 +270,18 @@ def test_fetch_parent_catalog_for_partial_fallback_failure(
 
     assert result == {"CHEMBL1": "CHEMBL10"}
     chembl2_calls = [call for call in client.calls if "/molecule/CHEMBL2" in call]
-    assert len(chembl2_calls) == api_cfg.retries
+    assert len(chembl2_calls) == api_cfg.retries + 1
 
 
-def test_fetch_parent_catalog_for_retries_smaller_batch(api_cfg: ApiCfg) -> None:
+def test_fetch_parent_catalog_for_retries_smaller_batch(
+    api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "library.molecule_catalog.load_parent_catalog", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "library.molecule_catalog.query_parent_catalog", lambda *_, **__: {}
+    )
     responses = [
         {
             "molecules": [
@@ -272,16 +292,16 @@ def test_fetch_parent_catalog_for_retries_smaller_batch(api_cfg: ApiCfg) -> None
             ]
         },
         {
-            "molecules": [
-                {
-                    "molecule_chembl_id": "CHEMBL2",
-                    "parent_molecule_chembl_id": "CHEMBL20",
-                },
-                {
-                    "molecule_chembl_id": "CHEMBL3",
-                    "parent_molecule_chembl_id": "CHEMBL30",
-                },
-            ]
+            "molecule": {
+                "molecule_chembl_id": "CHEMBL2",
+                "parent_molecule_chembl_id": "CHEMBL20",
+            }
+        },
+        {
+            "molecule": {
+                "molecule_chembl_id": "CHEMBL3",
+                "parent_molecule_chembl_id": "CHEMBL30",
+            }
         },
     ]
     client = DummyClient(responses)
@@ -299,12 +319,25 @@ def test_fetch_parent_catalog_for_retries_smaller_batch(api_cfg: ApiCfg) -> None
         "CHEMBL2": "CHEMBL20",
         "CHEMBL3": "CHEMBL30",
     }
-    assert len(client.calls) == 2
-    assert "limit=2" in client.calls[1]
-    assert all("/molecule/CHEMBL" not in call for call in client.calls[1:])
+    assert len(client.calls) == 3
+    assert "/molecule.json" in client.calls[0]
+    assert client.calls[1].endswith(
+        "/molecule/CHEMBL2.json?format=json&fields=molecule_chembl_id%2Cparent_molecule_chembl_id"
+    )
+    assert client.calls[2].endswith(
+        "/molecule/CHEMBL3.json?format=json&fields=molecule_chembl_id%2Cparent_molecule_chembl_id"
+    )
 
 
-def test_fetch_parent_catalog_for_respects_single_limit(api_cfg: ApiCfg) -> None:
+def test_fetch_parent_catalog_for_respects_single_limit(
+    api_cfg: ApiCfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "library.molecule_catalog.load_parent_catalog", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "library.molecule_catalog.query_parent_catalog", lambda *_, **__: {}
+    )
     responses = [
         {"molecules": []},
         {

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -74,7 +74,7 @@ def test_cli_forwards_batch_size(
 
     dummy_logger = _DummyLogger()
     monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
-    monkeypatch.setattr(cli, "apply_config_overrides", lambda *a: Config())
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *a: Config())
     monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
     monkeypatch.setattr(cli, "print_config", lambda cfg: None)
     monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
@@ -143,7 +143,7 @@ def test_cli_limit_restricts_rows(
 
     dummy_logger = _DummyLogger()
     monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
-    monkeypatch.setattr(cli, "apply_config_overrides", lambda *a: Config())
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *a: Config())
     monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
     monkeypatch.setattr(cli, "print_config", lambda cfg: None)
     monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)


### PR DESCRIPTION
## Summary
- ensure `ChemblClient` performs the configured initial try plus retries before giving up while preserving backoff behaviour
- relax parent catalogue fallback re-batching and deduplicate outstanding IDs before single fetches to reduce redundant HTTP calls
- update CLI tests to reference `cli.apply_config_overrides` lazily so smoke-test monkeypatches intercept it reliably

## Testing
- pytest tests/test_cli_limit.py tests/test_cli_common_args.py tests/test_cli.py -q
- pytest tests/test_molecule_catalog.py::test_fetch_parent_catalog_for_falls_back_on_bulk_error -q

------
https://chatgpt.com/codex/tasks/task_e_68d70101e8248324b59b9d60ad9344a6