### PR TITLE
Respect CLI overrides in document pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -794,7 +794,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    limit = cfg.document.pubmed.limit
+    limit = args.limit
     if limit is not None and limit < 0:
         logger.error(
             "invalid_limit",
@@ -804,7 +804,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     try:
         pmids_iter = io.read_ids(
-            args.input_csv, column=cfg.document.pubmed.column, cfg=cfg.io
+            args.input_csv, column=args.column, cfg=cfg.io
         )
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
@@ -850,13 +850,13 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         df = fetch_pubmed_records(
             pmids,
             cfg,
-            sleep=cfg.document.pubmed.sleep,
+            sleep=args.sleep,
             pubmed_cfg=cfg.pubmed,
             semantic_scholar_cfg=cfg.semantic_scholar,
             openalex_cfg=cfg.openalex,
             crossref_cfg=cfg.crossref,
-            max_workers=cfg.document.pubmed.workers,
-            batch_size=cfg.document.pubmed.batch_size,
+            max_workers=args.workers,
+            batch_size=args.batch_size,
             fallback_doi_map=fallback_doi_map,
         )
         output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
@@ -867,7 +867,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
-            chunk_size=cfg.document.pubmed.batch_size,
+            chunk_size=args.batch_size,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("pubmed_pipeline_failed", error=str(exc))
@@ -891,7 +891,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    limit = cfg.document.chembl.limit
+    limit = args.limit
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="document.chembl", limit=limit)
         return 1
@@ -900,7 +900,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
         try:
             ids_iter = io.read_ids(
-                args.input_csv, column=cfg.document.chembl.column, cfg=cfg.io
+                args.input_csv, column=args.column, cfg=cfg.io
             )
         except (FileNotFoundError, ValueError) as exc:
             logger.error(
@@ -921,14 +921,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 ids,
                 cfg=cfg.api,
                 client=client,
-                chunk_size=cfg.document.chembl.chunk_size,
-                timeout=cfg.document.chembl.timeout,
+                chunk_size=args.chunk_size,
+                timeout=args.timeout,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.error(
                 "chembl_documents_fetch_failed",
                 error=str(exc),
-                chunk_size=cfg.document.chembl.chunk_size,
+                chunk_size=args.chunk_size,
             )
             return 1
         if "doi" in df.columns:
@@ -941,7 +941,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
-            chunk_size=cfg.document.chembl.chunk_size,
+            chunk_size=args.chunk_size,
         )
         return exit_code
 
@@ -962,7 +962,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         Zero on success, non-zero on failure.
 
     """
-    limit = cfg.document.all.limit
+    limit = args.limit
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="document.all", limit=limit)
         return 1
@@ -970,7 +970,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     # Prepare shared session before performing any API calls
     try:
         ids_iter = io.read_ids(
-            args.input_csv, column=cfg.document.all.column, cfg=cfg.io
+            args.input_csv, column=args.column, cfg=cfg.io
         )
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
@@ -987,7 +987,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("process_limit", limit=len(limited_ids))
 
     iterator = iter(ids_source)
-    sample_size = cfg.document.all.chunk_size
+    sample_size = args.chunk_size
     sample_ids = list(islice(iterator, sample_size))
     ids_for_fetch = chain(sample_ids, iterator)
     try:
@@ -996,15 +996,15 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 ids_for_fetch,
                 cfg=cfg.api,
                 client=client,
-                chunk_size=cfg.document.all.chunk_size,
-                timeout=cfg.document.all.timeout,
+                chunk_size=args.chunk_size,
+                timeout=args.timeout,
             )
     except (requests.RequestException, ValueError) as exc:
         logger.error(
             "chembl_documents_fetch_failed",
             ids=sample_ids,
             error=str(exc),
-            chunk_size=cfg.document.all.chunk_size,
+            chunk_size=args.chunk_size,
         )
         return 1
     output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
@@ -1026,7 +1026,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             cfg,
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
-            chunk_size=cfg.document.all.chunk_size,
+            chunk_size=args.chunk_size,
         )
         return exit_code
 
@@ -1048,12 +1048,12 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     pmids = pubmed_ids.dropna().astype(str).tolist()
     pub_df = fetch_pubmed_records(
         pmids,
-        cfg.document.all.sleep,
+        args.sleep,
         cfg.semantic_scholar,
         cfg.openalex,
         cfg.crossref,
-        cfg.document.all.workers,
-        cfg.document.all.batch_size,
+        args.workers,
+        args.batch_size,
         pubmed_cfg=cfg.pubmed,
         fallback_doi_map=doi_fallback_map or None,
     )
@@ -1074,7 +1074,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         cfg,
         input_csv=Path(args.input_csv),
         key_columns=["document_chembl_id"],
-        chunk_size=cfg.document.all.chunk_size,
+        chunk_size=args.chunk_size,
     )
     return exit_code
 


### PR DESCRIPTION
## Summary
- ensure document CLI uses parsed arguments such as --column, --limit, and chunk sizing when reading inputs and invoking fetchers
- propagate CLI-derived chunk and batch sizing to downstream exports so command-line overrides take effect

## Testing
- python -m py_compile scripts/get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d700ca043c8324bc3589f8dd4fadb7