### PR TITLE
Ensure CLI scripts resolve library imports when run directly

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -1,0 +1,20 @@
+"""Runtime helpers for script execution.
+
+This module ensures that executing a script via ``python scripts/foo.py``
+behaves the same as ``python -m scripts.foo`` by pre-pending the project
+root to :mod:`sys.path`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def ensure_project_root() -> None:
+  """Insert the project root into :data:`sys.path` if missing."""
+  project_root = str(_PROJECT_ROOT)
+  if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -9,8 +9,11 @@ import argparse
 from collections.abc import Sequence
 from itertools import islice
 
+import bootstrap
 import requests
 from pandera.errors import SchemaErrors
+
+bootstrap.ensure_project_root()
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl


### PR DESCRIPTION
## Summary
- add a bootstrap helper that prepends the project root to `sys.path`
- call the bootstrapper from `get_assay_data.py` so `python scripts/get_assay_data.py` works without installation

## Testing
- `python scripts/get_assay_data.py -h`

------
https://chatgpt.com/codex/tasks/task_e_68d7232a8d748324ab988545473feef1