### PR TITLE
Fix get_activity_data bootstrap import for script execution

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -18,6 +18,17 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+    import bootstrap  # type: ignore[import-not-found]
+else:
+    from . import bootstrap  # type: ignore[import-not-found]
+
+bootstrap.ensure_project_root()
+
 from library import chembl_library as cl
 from library import cli
 from library import io


### PR DESCRIPTION
## Summary
- ensure `scripts/get_activity_data.py` can locate the project bootstrap helper when executed as a script
- invoke `bootstrap.ensure_project_root()` so the CLI shares the same import environment as module execution

## Testing
- pytest tests/test_get_activity_data_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d725738dc083249e40b1594695a2d4