### PR TITLE
Ensure target data CLI locates project root

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -22,6 +22,10 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from library import chembl_library as cl
 from library import cli
 from library import io


### PR DESCRIPTION
## Summary
- ensure `get_target_data.py` adds the repository root to `sys.path` before importing internal modules so the `library` package resolves when run as a script

## Testing
- python scripts/get_target_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d72770a5c48324807a8e25a4e4a1d6