### PR TITLE
Ensure get_testitem_data can import project modules

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,9 +16,12 @@ from dataclasses import dataclass
 from itertools import islice, tee
 from typing import Any, NamedTuple
 
+import bootstrap
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
+
+bootstrap.ensure_project_root()
 
 from library import chembl_library as cl
 from library import cli


### PR DESCRIPTION
## Summary
- ensure the project root is added to `sys.path` when running `get_testitem_data.py`
- reuse the shared bootstrap helper so module imports succeed when the script is executed directly

## Testing
- python scripts/get_testitem_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d7296a63bc83248139eb9497540730