### PR TITLE
Ensure document data CLI bootstraps project root

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -37,6 +37,10 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
+import bootstrap
+
+bootstrap.ensure_project_root()
+
 from library import chembl_library as cl
 from library import cli
 from library import document_postprocessing as dp


### PR DESCRIPTION
## Summary
- import the scripts.bootstrap helper in `get_document_data.py`
- call `bootstrap.ensure_project_root()` before importing the shared library modules so the CLI works when invoked via `python scripts/get_document_data.py`

## Testing
- python scripts/get_document_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d729aebfd0832488ec7cd118734475