### PR TITLE
Add CSV encoding fallbacks for identifier imports

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -383,6 +383,9 @@ class IoCfg(_BoolModel):
     cache_dir: Path = Path(".cache")
     csv_sep: str = ","
     csv_encoding: str = "utf-8-sig"
+    csv_fallback_encodings: Sequence[str] | None = Field(
+        default_factory=lambda: ("utf-8", "cp1252", "windows-1251", "latin-1")
+    )
     na_markers: Sequence[str] | None = ("#N/A",)
     csv_chunksize: int = Field(10000, ge=1)
     exist_ok: bool = True

--- a/library/io.py
+++ b/library/io.py
@@ -37,6 +37,40 @@ from .config import Config, IoCfg, _serialize_paths
 from .git_utils import _git_sha
 from .log import logger
 
+
+class _EncodingDecodeError(Exception):
+    """Wrap :class:`UnicodeDecodeError` with the attempted encoding."""
+
+    def __init__(self, encoding: str, error: UnicodeDecodeError) -> None:
+        super().__init__(str(error))
+        self.encoding = encoding
+        self.error = error
+
+
+def _stream_ids_with_encoding(
+    path: Path,
+    *,
+    column: str,
+    sep: str,
+    encoding: str,
+    marker_set: set[str],
+) -> Iterator[str]:
+    """Yield identifier values using a specific ``encoding``."""
+
+    try:
+        with path.open("r", encoding=encoding, newline="") as fh:
+            reader = csv.DictReader(fh, delimiter=sep)
+            if reader.fieldnames is None or column not in reader.fieldnames:
+                raise ValueError(
+                    f"column '{column}' not found in {path}; available columns: {reader.fieldnames}"
+                )
+            for row in reader:
+                value = (row.get(column) or "").strip()
+                if value and value not in marker_set:
+                    yield value
+    except UnicodeDecodeError as exc:  # pragma: no cover - exercised via fallback tests
+        raise _EncodingDecodeError(encoding, exc) from exc
+
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     import pandera as pa
 else:  # pragma: no cover - exercised in tests via monkeypatch
@@ -89,17 +123,49 @@ def read_ids(
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
     marker_set = set(na_markers or cfg.na_markers or ())
-    try:
-        with Path(path).open("r", encoding=encoding, newline="") as fh:
-            reader = csv.DictReader(fh, delimiter=sep)
-            if reader.fieldnames is None or column not in reader.fieldnames:
-                raise ValueError(
-                    f"column '{column}' not found in {path}; available columns: {reader.fieldnames}"
+    candidates: list[str] = []
+    if encoding:
+        candidates.append(encoding)
+    fallbacks = list(getattr(cfg, "csv_fallback_encodings", ()) or ())
+    for candidate in fallbacks:
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    if not candidates:
+        candidates.append("utf-8")
+
+    path_obj = Path(path)
+
+    def _iter_candidates() -> Iterator[str]:
+        last_error: UnicodeDecodeError | None = None
+        for candidate in candidates:
+            try:
+                yield from _stream_ids_with_encoding(
+                    path_obj,
+                    column=column,
+                    sep=sep,
+                    encoding=candidate,
+                    marker_set=marker_set,
                 )
-            for row in reader:
-                value = (row.get(column) or "").strip()
-                if value and value not in marker_set:
-                    yield value
+                return
+            except _EncodingDecodeError as exc:
+                last_error = exc.error
+                logger.warning(
+                    "csv_decode_failed",
+                    path=str(path_obj),
+                    encoding=exc.encoding,
+                    error=str(exc.error),
+                )
+                continue
+        attempted = ", ".join(candidates)
+        message = (
+            f"failed to decode CSV {path_obj} with encodings: {attempted}. "
+            "Update 'io.csv_encoding' or 'io.csv_fallback_encodings' in the configuration."
+        )
+        raise ValueError(message) from last_error
+
+    try:
+        yield from _iter_candidates()
     except FileNotFoundError:
         raise
     except csv.Error as exc:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -153,6 +153,29 @@ def test_read_ids_custom_na_marker(tmp_path: Path) -> None:
     assert ids == ["1", "2"]
 
 
+def test_read_ids_falls_back_to_alternative_encoding(tmp_path: Path) -> None:
+    """``read_ids`` retries with configured fallback encodings."""
+
+    path = tmp_path / "ids.csv"
+    path.write_bytes("id\nCHEMBL±1\n".encode("windows-1251"))
+
+    cfg = IoCfg(csv_encoding="utf-8-sig")
+    ids = list(io.read_ids(path, column="id", cfg=cfg))
+    assert ids == ["CHEMBL±1"]
+
+
+def test_read_ids_raises_when_all_encodings_fail(tmp_path: Path) -> None:
+    """``read_ids`` surfaces decoding errors after exhausting fallbacks."""
+
+    path = tmp_path / "ids.csv"
+    path.write_bytes("id\n1\n".encode("utf-16"))
+
+    cfg = IoCfg(csv_encoding="utf-8", csv_fallback_encodings=())
+    with pytest.raises(ValueError) as exc:
+        list(io.read_ids(path, column="id", cfg=cfg))
+    assert "failed to decode CSV" in str(exc.value)
+
+
 def test_write_csv_missing_key_column(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1], "b": [2]})
     path = tmp_path / "out.csv"


### PR DESCRIPTION
## Summary
- add fallback encoding handling to `library.io.read_ids` so Windows CSVs decode reliably
- expose configurable CSV fallback encodings through `IoCfg`
- cover the new behaviour with unit tests

## Testing
- pytest tests/test_io.py

------
https://chatgpt.com/codex/tasks/task_e_68d72a81dc508324bc1b6a0f249d5300