### PR TITLE
Improve CSV identifier encoding fallbacks

### DIFF
--- a/library/io.py
+++ b/library/io.py
@@ -22,6 +22,7 @@ Examples
 from __future__ import annotations
 
 import csv
+import locale
 import sys
 from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
@@ -123,16 +124,35 @@ def read_ids(
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
     marker_set = set(na_markers or cfg.na_markers or ())
+
+    def _append_candidate(values: Sequence[str] | str | None, seen: set[str], out: list[str]) -> None:
+        if values is None:
+            return
+        if isinstance(values, str):
+            iterable: Sequence[str] = (values,)
+        else:
+            iterable = values
+        for value in iterable:
+            if not value:
+                continue
+            key = value.lower()
+            if key in seen:
+                continue
+            out.append(value)
+            seen.add(key)
+
     candidates: list[str] = []
-    if encoding:
-        candidates.append(encoding)
-    fallbacks = list(getattr(cfg, "csv_fallback_encodings", ()) or ())
-    for candidate in fallbacks:
-        if candidate and candidate not in candidates:
-            candidates.append(candidate)
+    seen_candidates: set[str] = set()
+    _append_candidate((encoding,) if encoding else None, seen_candidates, candidates)
+    fallbacks = getattr(cfg, "csv_fallback_encodings", ()) or ()
+    _append_candidate(fallbacks, seen_candidates, candidates)
+
+    locale_encoding = locale.getpreferredencoding(False)
+    _append_candidate(locale_encoding, seen_candidates, candidates)
 
     if not candidates:
         candidates.append("utf-8")
+        seen_candidates.add("utf-8")
 
     path_obj = Path(path)
 
@@ -155,6 +175,14 @@ def read_ids(
                     path=str(path_obj),
                     encoding=exc.encoding,
                     error=str(exc.error),
+                )
+                continue
+            except LookupError as exc:
+                logger.warning(
+                    "csv_encoding_lookup_failed",
+                    path=str(path_obj),
+                    encoding=candidate,
+                    error=str(exc),
                 )
                 continue
         attempted = ", ".join(candidates)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -164,6 +164,22 @@ def test_read_ids_falls_back_to_alternative_encoding(tmp_path: Path) -> None:
     assert ids == ["CHEMBL±1"]
 
 
+def test_read_ids_uses_locale_encoding_when_config_lacks_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locale preferred encoding is appended when custom fallbacks are absent."""
+
+    path = tmp_path / "ids.csv"
+    path.write_bytes("id\nЖ\n".encode("windows-1251"))
+
+    cfg = IoCfg(csv_encoding="utf-8", csv_fallback_encodings=())
+
+    monkeypatch.setattr(io.locale, "getpreferredencoding", lambda _=False: "windows-1251")
+
+    ids = list(io.read_ids(path, column="id", cfg=cfg))
+    assert ids == ["Ж"]
+
+
 def test_read_ids_raises_when_all_encodings_fail(tmp_path: Path) -> None:
     """``read_ids`` surfaces decoding errors after exhausting fallbacks."""
 


### PR DESCRIPTION
## Summary
- add locale-preferred encodings to the CSV identifier reader fallback list and deduplicate candidates
- log unknown encoding lookups and ensure ValueError is raised with helpful context when decoding fails
- cover the new behaviour with a unit test that exercises locale-based fallback decoding

## Testing
- pytest tests/test_io.py

------
https://chatgpt.com/codex/tasks/task_e_68d72bee04088324be8e80d7954f2aeb