### PR TITLE
Ensure chunk CSV readers close handles during merge

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -13,7 +13,7 @@ import hashlib
 import heapq
 import os
 import tempfile
-from contextlib import ExitStack, closing
+from contextlib import ExitStack
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
@@ -458,16 +458,18 @@ def write_csv_chunks_deterministic(
             )
 
         with ExitStack() as stack:
-            readers = [
-                stack.enter_context(
-                    closing(
-                        pd.read_csv(
-                            p, sep=sep, encoding=encoding, chunksize=merge_chunksize
-                        )
-                    )
+            readers = []
+            for tmp_path in tmp_paths:
+                handle = stack.enter_context(
+                    tmp_path.open("r", encoding=encoding, newline="")
                 )
-                for p in tmp_paths
-            ]
+                reader = pd.read_csv(
+                    handle,
+                    sep=sep,
+                    chunksize=merge_chunksize,
+                )
+                stack.callback(reader.close)
+                readers.append(reader)
             current: list[pd.DataFrame | None] = []
             for r in readers:
                 try:


### PR DESCRIPTION
## Summary
- open temporary chunk files through ExitStack-managed handles before pandas reads them
- register explicit reader closures to release Windows file handles during deterministic CSV merges

## Testing
- python -m compileall library/csv_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d72ee8e504832482c49833f15506b5