### PR TITLE
Normalize CLI paths with Windows separators

### DIFF
--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -9,6 +9,7 @@ from .parser import (
     build_root_parser,
     configure_logger,
     create_logger_config,
+    path_argument,
     positive_int,
 )
 
@@ -21,5 +22,6 @@ __all__ = [
     "build_root_parser",
     "configure_logger",
     "create_logger_config",
+    "path_argument",
     "positive_int",
 ]

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import argparse
 import uuid
-from pathlib import Path
+import os
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from pydantic import ValidationError
@@ -74,6 +75,30 @@ def positive_int(value: str) -> int:
     return _positive_int(value)
 
 
+def _path_argument(value: str) -> Path:
+    """Convert CLI ``value`` into a :class:`~pathlib.Path` instance.
+
+    On non-Windows platforms command line inputs may still use Windows path
+    separators (a backslash). This helper normalises such inputs by
+    interpreting them as Windows paths and returning a POSIX-compatible
+    ``Path``. The
+    behaviour preserves regular POSIX paths and defers to :class:`Path` on
+    Windows.
+    """
+
+    stripped = value.strip()
+    if os.name != "nt" and "\\" in stripped:
+        windows_path = PureWindowsPath(stripped)
+        return Path(windows_path.as_posix())
+    return Path(stripped)
+
+
+def path_argument(value: str) -> Path:
+    """Public wrapper around :func:`_path_argument` for CLI validators."""
+
+    return _path_argument(value)
+
+
 def add_common_arguments(
     parser: argparse.ArgumentParser, *, defaults: bool = True
 ) -> argparse.ArgumentParser:
@@ -111,14 +136,14 @@ def add_common_arguments(
     parser.add_argument(
         "--input",
         dest="input_csv",
-        type=Path,
+        type=path_argument,
         default=input_default,
         help="Input CSV file",
     )
     parser.add_argument(
         "--output",
         dest="output_csv",
-        type=Path,
+        type=path_argument,
         default=output_default,
         help="Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)",
     )
@@ -176,7 +201,7 @@ def build_parser(
     parser.add_argument(
         "--config",
         dest="config",
-        type=Path,
+        type=path_argument,
         default=Path("config.yaml"),
         help="YAML configuration file",
     )
@@ -216,7 +241,7 @@ def build_root_parser() -> tuple[
     root.add_argument(
         "--config",
         dest="config",
-        type=Path,
+        type=path_argument,
         default=Path("config.yaml"),
         help="YAML configuration file",
     )
@@ -231,7 +256,7 @@ def build_root_parser() -> tuple[
     shared.add_argument(
         "--config",
         dest="config",
-        type=Path,
+        type=path_argument,
         default=argparse.SUPPRESS,
         help="YAML configuration file",
     )

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pandas as pd
 
 from . import cli
-from .cli import LoggerConfig, configure_logger
+from .cli import LoggerConfig, configure_logger, path_argument
 from .cli import build_parser as base_parser
 from .config import Config, ensure_dirs, print_config, session_with_retry
 from .csv_utils import write_csv_deterministic
@@ -73,7 +73,7 @@ def parse_args(
     parser.add_argument(
         "--input-csv",
         dest="input_csv",
-        type=Path,
+        type=path_argument,
         default=argparse.SUPPRESS,
         help="Input CSV path with PMID column",
     )

--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from library.chunk_io import process_csv_chunks
-from library.cli import LoggerConfig, add_common_arguments, configure_logger
+from library.cli import (
+    LoggerConfig,
+    add_common_arguments,
+    configure_logger,
+    path_argument,
+)
 from library.config import Config, ensure_dirs
 from library.io import default_output_path
 from library.log import logger
@@ -34,7 +38,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     parser.add_argument(
         "--checkpoint",
-        type=Path,
+        type=path_argument,
         default=Path("checkpoint.json"),
         help="Path to checkpoint file",
     )

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -16,16 +16,16 @@ matching suffixes, for example ``activity_independent.csv`` or
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from library import cli
 from library import input_initialisation_library as lib
 from library.cli import (
     LoggerConfig,
     configure_logger,
+    path_argument,
 )
 from library.cli import (
     build_parser as base_parser,
@@ -122,17 +122,17 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     parser, log_cfg = base_parser(__doc__ or "Input initialisation", column="chembl_id")
     parser.add_argument(
         "--same-doc",
-        type=Path,
+        type=path_argument,
         help="Path to same document workbook (default: config init.same_doc)",
     )
     parser.add_argument(
         "--all-doc",
-        type=Path,
+        type=path_argument,
         help="Path to all document workbook (default: config init.all_doc)",
     )
     parser.add_argument(
         "--dictionary-dir",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Directory with _Target/targets_type.csv and _Curation/citation_fraction.csv "
@@ -141,7 +141,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     parser.add_argument(
         "--out-dir",
-        type=Path,
+        type=path_argument,
         help="Output directory (default: config init.output_dir)",
     )
     parser.add_argument(

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -54,6 +54,7 @@ from library.cli import (
     LoggerConfig,
     build_root_parser,
     configure_logger,
+    path_argument,
     positive_int,
 )
 from library.config import (
@@ -1147,7 +1148,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     pubmed.add_argument(
         "--fallback-doi-csv",
-        type=Path,
+        type=path_argument,
         default=None,
         help="Optional CSV file providing PMID to DOI overrides",
     )

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -39,6 +39,7 @@ from library.cli import (
     LoggerConfig,
     build_root_parser,
     configure_logger,
+    path_argument,
     positive_int,
 )
 from library.config import (
@@ -208,7 +209,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     uniprot.add_argument(
         "--data-dir",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Directory containing '<uniprot_id>.json' files "
@@ -266,7 +267,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     iuphar.add_argument(
         "--target-csv",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Path to the _IUPHAR_target.csv file "
@@ -275,7 +276,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     iuphar.add_argument(
         "--family-csv",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Path to the _IUPHAR_family.csv file "
@@ -301,24 +302,24 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     all_cmd.add_argument(
         "--chembl-out",
         dest="chembl_out",
-        type=Path,
+        type=path_argument,
         help="Optional path to save intermediate ChEMBL data",
     )
     all_cmd.add_argument(
         "--uniprot-out",
         dest="uniprot_out",
-        type=Path,
+        type=path_argument,
         help="Optional path to save intermediate UniProt data",
     )
     all_cmd.add_argument(
         "--iuphar-out",
         dest="iuphar_out",
-        type=Path,
+        type=path_argument,
         help="Optional path to save intermediate IUPHAR data",
     )
     all_cmd.add_argument(
         "--data-dir",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Directory containing '<uniprot_id>.json' files "
@@ -327,7 +328,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     all_cmd.add_argument(
         "--target-csv",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Path to the _IUPHAR_target.csv file "
@@ -336,7 +337,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     )
     all_cmd.add_argument(
         "--family-csv",
-        type=Path,
+        type=path_argument,
         default=None,
         help=(
             "Path to the _IUPHAR_family.csv file "

--- a/tests/test_cli_common_args.py
+++ b/tests/test_cli_common_args.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 
 from library import cli
-from library.cli import add_common_arguments
+from library.cli import add_common_arguments, path_argument
 
 
 def _write_config(tmp_path: Path) -> Path:
@@ -18,7 +18,7 @@ def test_config_defaults_applied(tmp_path: Path) -> None:
     cfg_path = _write_config(tmp_path)
     parser = argparse.ArgumentParser()
     add_common_arguments(parser)
-    parser.add_argument("--config", default=cfg_path, type=Path)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
     args = parser.parse_args(["--config", str(cfg_path)])
     cfg = cli.apply_config_overrides(args, parser, args.config)
     assert args.sep == "|"
@@ -31,7 +31,7 @@ def test_cli_overrides_config(tmp_path: Path) -> None:
     cfg_path = _write_config(tmp_path)
     parser = argparse.ArgumentParser()
     add_common_arguments(parser)
-    parser.add_argument("--config", default=cfg_path, type=Path)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
     args = parser.parse_args(
         [
             "--config",
@@ -48,3 +48,12 @@ def test_cli_overrides_config(tmp_path: Path) -> None:
     assert cfg.io.csv_sep == ";"
     assert cfg.io.csv_encoding == "utf16"
     assert cfg.log.level == "DEBUG"
+
+
+def test_path_argument_normalises_windows_style(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path)
+    parser = argparse.ArgumentParser()
+    add_common_arguments(parser)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
+    args = parser.parse_args(["--config", str(cfg_path), "--input", "data\\input\\file.csv"])
+    assert args.input_csv == Path("data/input/file.csv")

--- a/tests/test_cli_limit.py
+++ b/tests/test_cli_limit.py
@@ -4,13 +4,14 @@ import argparse
 from pathlib import Path
 
 from library import cli
+from library.cli import path_argument
 
 
 def test_cli_limit_override(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text("")
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default=cfg_path, type=Path)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
     parser.add_argument("--limit", type=int, default=None)
     args = parser.parse_args(["--config", str(cfg_path), "--limit", "5"])
     cfg = cli.apply_config_overrides(


### PR DESCRIPTION
## Summary
- add a shared `path_argument` helper that normalises Windows-style CLI paths on POSIX systems and export it via `library.cli`
- update CLI entry points to use the new path parser for file and directory options to avoid backslash-related write failures
- extend the CLI tests to cover the Windows-style path handling

## Testing
- pytest tests/test_cli_common_args.py tests/test_cli_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68d7351b4f74832492dbfeafc902802d