### PR TITLE
Refine PubChem lookup progress tracking

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -830,12 +830,8 @@ def add_pubchem_data(
         return bool(chembl_id and cid_cache.get(chembl_id))
 
     cached_mask = chembl_norm.map(_is_cached)
-    needs_lookup_mask = (
-        chembl_norm.notna()
-        & ~skip_mask
-        & ~prefer_local_mask
-        & ~cached_mask
-    )
+    has_chembl_id_mask = chembl_norm.notna()
+    needs_lookup_mask = has_chembl_id_mask & ~skip_mask & ~prefer_local_mask & ~cached_mask
 
     total = int(needs_lookup_mask.sum())
     if total:
@@ -851,9 +847,9 @@ def add_pubchem_data(
             cid_series.loc[idx] = cached_value
             lookup_cids.add(cached_value)
 
-    for progress, row in enumerate(
-        result.loc[needs_lookup_mask].itertuples(), start=1
-    ):
+    progress = 0
+    for row in result.loc[needs_lookup_mask].itertuples():
+        progress += 1
         logger.info("pubchem_progress", current=progress, total=total)
         idx = row.Index
         chembl_id = chembl_norm.loc[idx]


### PR DESCRIPTION
## Summary
- derive the PubChem lookup mask from the prepared boolean series
- log lookup progress directly within the iteration over matching rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8fd136dec8324be7471ce01117125