### PR TITLE
Ensure parent records cached for PubChem enrichment

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -747,7 +747,7 @@ def add_pubchem_data(
             else:
                 continue
             local_records[chembl_norm] = record
-            parent_record_cache.setdefault(chembl_norm, record)
+            parent_record_cache[chembl_norm] = record
 
 
     def load_parent_record(parent_id: str) -> pd.Series | None:


### PR DESCRIPTION
## Summary
- populate the parent record cache with locally available ChEMBL rows so parent lookups can reuse cached data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fd114e38832488d4e3f74c241607