### PR TITLE
docs: remove raw publication type columns

### DIFF
--- a/docs/DATA_SCHEMA_EN.md
+++ b/docs/DATA_SCHEMA_EN.md
@@ -147,7 +147,6 @@
 | PubMed.Issue | number/string | PubMed API | Issue reported by PubMed.|
 | PubMed.StartPage | number/string | PubMed API | First page according to PubMed.|
 | PubMed.EndPage | number/string | PubMed API | Last page according to PubMed.|
-| PubMed.PublicationType | string | PubMed API | Raw publication-type terms.|
 | PubMed.MeSH_Descriptors | string | PubMed API | MeSH descriptors linked to the record.|
 | PubMed.MeSH_Qualifiers | string | PubMed API | MeSH qualifiers associated with the record.|
 | PubMed.ChemicalList | string | PubMed API | List of chemical entities mentioned.|
@@ -161,12 +160,10 @@
 | PubMed.ISSN | string | PubMed API | Journal ISSN as reported by PubMed.|
 | scholar.PMID | number/string | Semantic Scholar | PubMed ID linked by Semantic Scholar.|
 | scholar.Venue | string | Semantic Scholar | Publication venue recorded by Semantic Scholar.|
-| scholar.PublicationTypes | string | Semantic Scholar | Publication-type terms from Semantic Scholar.|
 | scholar.SemanticScholarId | string | Semantic Scholar | Semantic Scholar internal identifier.|
 | scholar.ExternalIds | string | Semantic Scholar | External identifiers serialized as JSON.|
 | scholar.DOI | string | Semantic Scholar | DOI value returned by Semantic Scholar.|
 | scholar.Error | string | Semantic Scholar | Error diagnostics from the Semantic Scholar API.|
-| OpenAlex.PublicationTypes | string | OpenAlex | Publication-type list returned by OpenAlex.|
 | OpenAlex.TypeCrossref | string | OpenAlex/Crossref | Crossref type relayed by OpenAlex.|
 | OpenAlex.Genre | string | OpenAlex | OpenAlex genre classification.|
 | OpenAlex.Id | string | OpenAlex | OpenAlex record identifier.|
@@ -187,6 +184,8 @@
 | OpenAlex.is_review | boolean/string | Post-processing | Review flag derived from OpenAlex metadata.|
 | pipeline_version | string | Pipeline metadata | `chembl-data-acquisition` package version.|
 | timestamp_utc | ISO 8601 string | Pipeline metadata | Export timestamp in UTC.|
+
+> **Note:** Raw publication-type arrays are normalized into the boolean `*.is_review` flags, which provide the canonical review detection signal across sources.
 
 ### target.csv (final export)
 - **Purpose:** unified target table combining ChEMBL, UniProt and IUPHAR attributes while preserving the deterministic column order expected by downstream BI processes.

--- a/docs/DATA_SCHEMA_RU.md
+++ b/docs/DATA_SCHEMA_RU.md
@@ -147,7 +147,6 @@
 | PubMed.Issue | число/строка | PubMed API | Номер выпуска из PubMed.|
 | PubMed.StartPage | число/строка | PubMed API | Стартовая страница.|
 | PubMed.EndPage | число/строка | PubMed API | Конечная страница.|
-| PubMed.PublicationType | строка | PubMed API | Сырые термины типов публикаций.|
 | PubMed.MeSH_Descriptors | строка | PubMed API | Перечень MeSH-дескрипторов.|
 | PubMed.MeSH_Qualifiers | строка | PubMed API | Перечень MeSH-квалификаторов.|
 | PubMed.ChemicalList | строка | PubMed API | Перечень химических сущностей.|
@@ -161,12 +160,10 @@
 | PubMed.ISSN | строка | PubMed API | ISSN журнала.|
 | scholar.PMID | число/строка | Semantic Scholar | Привязанный PubMed ID.|
 | scholar.Venue | строка | Semantic Scholar | Площадка/журнал в Semantic Scholar.|
-| scholar.PublicationTypes | строка | Semantic Scholar | Типы публикаций.|
 | scholar.SemanticScholarId | строка | Semantic Scholar | Внутренний ID Semantic Scholar.|
 | scholar.ExternalIds | строка | Semantic Scholar | Внешние идентификаторы (JSON).|
 | scholar.DOI | строка | Semantic Scholar | DOI из Semantic Scholar.|
 | scholar.Error | строка | Semantic Scholar | Диагностика ошибок вызова.|
-| OpenAlex.PublicationTypes | строка | OpenAlex | Типы публикаций (список).|
 | OpenAlex.TypeCrossref | строка | OpenAlex/Crossref | Классификация Crossref, возвращаемая OpenAlex.|
 | OpenAlex.Genre | строка | OpenAlex | Жанр публикации.|
 | OpenAlex.Id | строка | OpenAlex | Идентификатор записи OpenAlex.|
@@ -187,6 +184,8 @@
 | OpenAlex.is_review | булево/строка | Постобработка | Флаг «обзор» по данным OpenAlex.|
 | pipeline_version | строка | Пайплайн | Версия пакета `chembl-data-acquisition`.|
 | timestamp_utc | строка (ISO 8601) | Пайплайн | Время формирования выгрузки.|
+
+> **Примечание:** Сырые списки типов публикаций нормализуются в булевые поля `*.is_review`, которые дают каноничный признак обзора для всех источников.
 
 ### target.csv (финализированный экспорт)
 - **Назначение:** унифицированная таблица белковых мишеней с объединением атрибутов ChEMBL, UniProt и IUPHAR, приведённая к детерминированному порядку колонок и форматам, совместимым с исходной BI-процессингом.


### PR DESCRIPTION
## Summary
- remove the documentation rows for the raw publication-type arrays in both English and Russian schema guides
- add a short note that review detection is handled via the normalized `*.is_review` booleans

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d90adbfa1c83248acbbcf7a551092c