### PR TITLE
Adjust PubMed logging verbosity and add troubleshooting flag

### DIFF
--- a/library/pubmed/aggregation.py
+++ b/library/pubmed/aggregation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
@@ -30,8 +31,30 @@ def merge_records(*records: Mapping[str, Any]) -> dict[str, Any]:
     return merged
 
 
-def print_results(records: list[dict[str, str]]) -> None:
+def _emit_output(log: Any, level: str, output: str) -> None:
+    """Send ``output`` to ``log`` using ``level`` when possible."""
+
+    method = getattr(log, level.lower(), None)
+    if callable(method):
+        try:
+            method("pubmed_record_dump", dump=output)
+        except TypeError:
+            method(output)
+        return
+
+    log_method = getattr(log, "log", None)
+    if callable(log_method):
+        level_name = level.upper()
+        try:
+            log_method(level_name, "pubmed_record_dump", dump=output)
+        except TypeError:
+            level_no = getattr(logging, level_name, logging.INFO)
+            log_method(level_no, output)
+
+
+def print_results(records: list[dict[str, str]], *, level: str = "DEBUG") -> None:
     """Log result records instead of printing to ``stdout``."""
+
     log = logger
     try:
         from tabulate import tabulate
@@ -60,7 +83,7 @@ def print_results(records: list[dict[str, str]]) -> None:
         output = json.dumps(display_records, ensure_ascii=False, indent=2)
 
     try:
-        log.info(output)
+        _emit_output(log, level, output)
     except UnicodeEncodeError:
         import sys
 

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -77,6 +77,11 @@ def parse_args(
         default=argparse.SUPPRESS,
         help="Input CSV path with PMID column",
     )
+    parser.add_argument(
+        "--keep-verbose-dumps",
+        action="store_true",
+        help="Log combined metadata dumps at INFO level for troubleshooting",
+    )
     args = parser.parse_args(argv)
     return args, parser, log_cfg
 
@@ -131,6 +136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     records: list[dict[str, str]] = []
     batch_size = cfg.document.pubmed.batch_size
+    dump_level = "INFO" if args.keep_verbose_dumps else "DEBUG"
     with session_with_retry(cfg.api, cfg.retry) as session:
         for i in range(0, len(pmids), batch_size):
             batch_pmids = pmids[i : i + batch_size]
@@ -156,7 +162,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
 
                 combined = merge_records(pubmed, semsch, openalex, crossref)
-                print_results([combined])
+                print_results([combined], level=dump_level)
                 records.append(combined)
 
     df = pd.DataFrame.from_records(records)

--- a/tests/test_pubmed_aggregation.py
+++ b/tests/test_pubmed_aggregation.py
@@ -16,12 +16,31 @@ def test_merge_records() -> None:
     assert merged == {"a": 1, "b": 3, "c": 4}
 
 
-def test_print_results(
+def test_print_results_logs_at_debug_by_default(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    fake = logging.getLogger("test")
-    caplog.set_level("INFO", logger="test")
+    fake = logging.getLogger("test.debug")
     monkeypatch.setattr(pa, "logger", fake)
     rec = {"PubMed.ArticleTitle": "Example title"}
-    pa.print_results([rec])
-    assert "Example title" in caplog.text
+
+    with caplog.at_level(logging.INFO, logger="test.debug"):
+        pa.print_results([rec])
+    assert all("Example title" not in record.message for record in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="test.debug"):
+        pa.print_results([rec])
+    assert any("Example title" in record.message for record in caplog.records)
+
+
+def test_print_results_can_log_at_info(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = logging.getLogger("test.info")
+    monkeypatch.setattr(pa, "logger", fake)
+    rec = {"PubMed.ArticleTitle": "Example title"}
+
+    with caplog.at_level(logging.INFO, logger="test.info"):
+        pa.print_results([rec], level="INFO")
+
+    assert any("Example title" in record.message for record in caplog.records)

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -14,6 +14,7 @@ def test_pubmed_library_main_smoke(
     """Run the CLI with stubbed network calls."""
     input_csv = Path("tests/data/pmids.csv")
     output_csv = tmp_path / "out.csv"
+    verbose_output_csv = tmp_path / "out_verbose.csv"
 
     def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None):
         return [
@@ -53,6 +54,13 @@ def test_pubmed_library_main_smoke(
     monkeypatch.setattr(pl, "fetch_crossref", fake_fetch_crossref)
     monkeypatch.setattr(pl, "get_limiter", lambda *args, **kwargs: DummyLimiter())
 
+    levels: list[str] = []
+
+    def fake_print_results(records, *, level: str = "DEBUG") -> None:
+        levels.extend([level] * len(records))
+
+    monkeypatch.setattr(pl, "print_results", fake_print_results)
+
     exit_code = pl.main(
         [
             "--input-csv",
@@ -60,10 +68,29 @@ def test_pubmed_library_main_smoke(
             "--output",
             str(output_csv),
             "--log-level",
-            "ERROR",
+            "INFO",
         ]
     )
     assert exit_code == 0
+    assert levels
+    assert all(level == "DEBUG" for level in levels)
     assert output_csv.exists()
     df = pd.read_csv(output_csv)
     assert not df.empty
+
+    start_idx = len(levels)
+    exit_code_verbose = pl.main(
+        [
+            "--input-csv",
+            str(input_csv),
+            "--output",
+            str(verbose_output_csv),
+            "--log-level",
+            "INFO",
+            "--keep-verbose-dumps",
+        ]
+    )
+    assert exit_code_verbose == 0
+    verbose_levels = levels[start_idx:]
+    assert verbose_levels
+    assert all(level == "INFO" for level in verbose_levels)


### PR DESCRIPTION
## Summary
- log PubMed result dumps at debug level by default and support routing through different logger APIs
- add a CLI flag to keep verbose dumps and ensure the smoke test asserts debug-by-default behaviour
- extend aggregation logging tests to cover both default and verbose logging levels

## Testing
- pytest tests/test_pubmed_aggregation.py tests/test_pubmed_library_main_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d90e49a5388324b1fa38849cdf96ba