### PR TITLE
Tighten PubMed CLI logging verbosity controls

### DIFF
--- a/library/pubmed/aggregation.py
+++ b/library/pubmed/aggregation.py
@@ -8,6 +8,9 @@ from typing import Any
 
 from ..log import logger
 
+TITLE_PREVIEW_LIMIT = 80
+TITLE_SUFFIX = "..."
+
 __all__ = ["merge_records", "print_results"]
 
 
@@ -52,6 +55,28 @@ def _emit_output(log: Any, level: str, output: str) -> None:
             log_method(level_no, output)
 
 
+def _first_non_empty(record: Mapping[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty string value from ``record`` keyed by ``keys``."""
+
+    for key in keys:
+        value = record.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _shorten_title(title: str) -> str:
+    """Return a shortened representation of ``title`` suitable for logs."""
+
+    clean = title.strip()
+    if len(clean) <= TITLE_PREVIEW_LIMIT:
+        return clean
+    return clean[: TITLE_PREVIEW_LIMIT - len(TITLE_SUFFIX)] + TITLE_SUFFIX
+
+
 def print_results(records: list[dict[str, str]], *, level: str = "DEBUG") -> None:
     """Log result records instead of printing to ``stdout``."""
 
@@ -65,15 +90,34 @@ def print_results(records: list[dict[str, str]], *, level: str = "DEBUG") -> Non
 
     display_records = []
     for rec in records:
-        d = rec.copy()
-        title = (
-            d.get("PubMed.ArticleTitle")
-            or d.get("crossref.Title")
-            or d.get("Title")
-            or ""
+        pmid = _first_non_empty(
+            rec,
+            (
+                "PubMed.PMID",
+                "scholar.PMID",
+                "PMID",
+            ),
         )
-        d["Title"] = title[:77] + "..." if len(title) > 80 else title
-        display_records.append(d)
+        doi = _first_non_empty(
+            rec,
+            (
+                "PubMed.DOI",
+                "scholar.DOI",
+                "crossref.DOI",
+                "DOI",
+            ),
+        )
+        title = _shorten_title(
+            _first_non_empty(
+                rec,
+                (
+                    "PubMed.ArticleTitle",
+                    "crossref.Title",
+                    "Title",
+                ),
+            )
+        )
+        display_records.append({"PMID": pmid, "DOI": doi, "Title": title})
 
     if use_tabulate:
         output = tabulate(display_records, headers="keys")

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -78,9 +78,9 @@ def parse_args(
         help="Input CSV path with PMID column",
     )
     parser.add_argument(
-        "--keep-verbose-dumps",
+        "--verbose",
         action="store_true",
-        help="Log combined metadata dumps at INFO level for troubleshooting",
+        help="Log compact metadata dumps at INFO level for troubleshooting",
     )
     args = parser.parse_args(argv)
     return args, parser, log_cfg
@@ -136,7 +136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     records: list[dict[str, str]] = []
     batch_size = cfg.document.pubmed.batch_size
-    dump_level = "INFO" if args.keep_verbose_dumps else "DEBUG"
+    dump_level = "INFO" if args.verbose else "DEBUG"
     with session_with_retry(cfg.api, cfg.retry) as session:
         for i in range(0, len(pmids), batch_size):
             batch_pmids = pmids[i : i + batch_size]

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from library import pubmed_library as pl
+from library.pubmed import aggregation as pa
 
 
 def test_pubmed_library_main_smoke(
@@ -55,11 +56,13 @@ def test_pubmed_library_main_smoke(
     monkeypatch.setattr(pl, "get_limiter", lambda *args, **kwargs: DummyLimiter())
 
     levels: list[str] = []
+    dumps: list[str] = []
 
-    def fake_print_results(records, *, level: str = "DEBUG") -> None:
-        levels.extend([level] * len(records))
+    def fake_emit_output(log, level: str, output: str) -> None:
+        levels.append(level)
+        dumps.append(output)
 
-    monkeypatch.setattr(pl, "print_results", fake_print_results)
+    monkeypatch.setattr(pa, "_emit_output", fake_emit_output)
 
     exit_code = pl.main(
         [
@@ -73,12 +76,17 @@ def test_pubmed_library_main_smoke(
     )
     assert exit_code == 0
     assert levels
-    assert all(level == "DEBUG" for level in levels)
+    default_levels = levels.copy()
+    default_dumps = dumps.copy()
+    assert all(level == "DEBUG" for level in default_levels)
+    assert default_dumps
+    assert all(len(dump) < 200 for dump in default_dumps)
     assert output_csv.exists()
     df = pd.read_csv(output_csv)
     assert not df.empty
 
     start_idx = len(levels)
+    start_dump_idx = len(dumps)
     exit_code_verbose = pl.main(
         [
             "--input-csv",
@@ -87,10 +95,18 @@ def test_pubmed_library_main_smoke(
             str(verbose_output_csv),
             "--log-level",
             "INFO",
-            "--keep-verbose-dumps",
+            "--verbose",
         ]
     )
     assert exit_code_verbose == 0
     verbose_levels = levels[start_idx:]
+    verbose_dumps = dumps[start_dump_idx:]
     assert verbose_levels
     assert all(level == "INFO" for level in verbose_levels)
+    assert verbose_dumps
+    for dump in verbose_dumps:
+        assert "PMID" in dump
+        assert "DOI" in dump
+        assert "Title" in dump
+        assert "PubMed.PMID" not in dump
+        assert len(dump) < 200


### PR DESCRIPTION
## Summary
- add a `--verbose` switch to the PubMed CLI to explicitly enable metadata dump logs
- reduce logged record content to compact PMID/DOI/title snippets that default to DEBUG
- extend the smoke test to assert both verbosity selection and dump compactness

## Testing
- pytest tests/test_pubmed_aggregation.py tests/test_pubmed_library_main_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d9139f25d08324a4bf4a2b7b64f6dd