### PR TITLE
Improve UniProt retry handling

### DIFF
--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import csv
 import json
+import random
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
@@ -54,13 +55,15 @@ _DEFAULT_UNIPROT_DATA_DIR = Path("uniprot")
 _session: Session = session_with_retry(
     ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
 )
+_retry_cfg: RetryCfg = RetryCfg()
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session."""
 
-    global _session
+    global _session, _retry_cfg
     _session = session_with_retry(api, retry)
+    _retry_cfg = retry
 
 
 __all__ = [
@@ -145,6 +148,24 @@ class UniProtFetchError(RuntimeError):
     """Raised when a UniProt record cannot be retrieved or decoded."""
 
 
+def _should_retry(status: int | None) -> bool:
+    """Return ``True`` when ``status`` indicates a retryable condition."""
+
+    if status is None:
+        return True
+    return status in _retry_cfg.status_forcelist
+
+
+def _sleep_with_backoff(attempt: int) -> None:
+    """Sleep using exponential backoff with jitter for the given attempt."""
+
+    base_delay = _retry_cfg.backoff_factor * (2 ** (attempt - 1))
+    if base_delay <= 0:
+        return
+    jitter = random.uniform(0.0, base_delay)
+    sleep(base_delay + jitter)
+
+
 def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
     """Fetch a UniProt JSON record from the public REST API.
 
@@ -167,25 +188,62 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
 
     """
     limiter = get_limiter("uniprot", cfg.rps, cfg.burst)
-    if cfg.delay:
-        sleep(cfg.delay)
-    limiter.acquire()
     base = cfg.base.rstrip("/")
     url = f"{base}/uniprotkb/{uniprot_id}.json"
     timeout = (cfg.timeout_connect, cfg.timeout_read)
-    try:
-        with _session.get(url, timeout=timeout) as resp:
-            resp.raise_for_status()
-            try:
-                return cast(dict[str, Any], resp.json())
-            except json.JSONDecodeError as exc:  # pragma: no cover - malformed JSON
-                raise UniProtFetchError(
-                    f"Failed to decode JSON for UniProt {uniprot_id}: {exc}"
-                ) from exc
-    except requests.RequestException as exc:  # pragma: no cover - network
-        raise UniProtFetchError(
-            f"UniProt request failed for {uniprot_id}: {exc}"
-        ) from exc
+
+    for attempt in range(1, _retry_cfg.max_attempts + 1):
+        if cfg.delay:
+            sleep(cfg.delay)
+        limiter.acquire()
+        try:
+            with _session.get(url, timeout=timeout) as resp:
+                status = resp.status_code
+                try:
+                    resp.raise_for_status()
+                except requests.HTTPError as exc:
+                    if _should_retry(status) and attempt < _retry_cfg.max_attempts:
+                        logger.warning(
+                            "uniprot_request_retry",
+                            url=url,
+                            attempt=attempt,
+                            max_attempts=_retry_cfg.max_attempts,
+                            status=status,
+                            rps=cfg.rps,
+                            error=str(exc),
+                        )
+                        _sleep_with_backoff(attempt)
+                        continue
+                    raise UniProtFetchError(
+                        f"UniProt request failed for {uniprot_id}: {exc}"
+                    ) from exc
+                try:
+                    return cast(dict[str, Any], resp.json())
+                except json.JSONDecodeError as exc:  # pragma: no cover - malformed JSON
+                    raise UniProtFetchError(
+                        f"Failed to decode JSON for UniProt {uniprot_id}: {exc}"
+                    ) from exc
+        except requests.RequestException as exc:  # pragma: no cover - network
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if _should_retry(status) and attempt < _retry_cfg.max_attempts:
+                logger.warning(
+                    "uniprot_request_retry",
+                    url=url,
+                    attempt=attempt,
+                    max_attempts=_retry_cfg.max_attempts,
+                    status=status,
+                    rps=cfg.rps,
+                    error=str(exc),
+                )
+                _sleep_with_backoff(attempt)
+                continue
+            raise UniProtFetchError(
+                f"UniProt request failed for {uniprot_id}: {exc}"
+            ) from exc
+
+    raise UniProtFetchError(
+        f"UniProt request failed for {uniprot_id}: exceeded retry attempts"
+    )
 
 
 def _collect_name_fields(name_obj: dict[str, Any]) -> Iterable[str]:

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -12,7 +12,7 @@ requests = pytest.importorskip("requests")
 responses = pytest.importorskip("responses")
 
 from library import uniprot_library as ul  # noqa: E402
-from library.config import IupharCfg, UniprotCfg  # noqa: E402
+from library.config import IupharCfg, RetryCfg, UniprotCfg  # noqa: E402
 
 
 def test_extract_names() -> None:
@@ -28,8 +28,9 @@ def test_extract_names() -> None:
 
 
 @responses.activate
-def test_fetch_uniprot_network_error() -> None:
+def test_fetch_uniprot_network_error(monkeypatch) -> None:
     cfg = UniprotCfg(base="https://example.org", delay=0)
+    monkeypatch.setattr(ul, "_retry_cfg", RetryCfg(max_attempts=1))
     responses.add(
         responses.GET,
         "https://example.org/uniprotkb/P12345.json",
@@ -79,6 +80,46 @@ def test_fetch_uniprot_uses_cfg(monkeypatch) -> None:
     assert called["url"] == "https://example.org/api/uniprotkb/P12345.json"
     assert called["timeout"] == (1, 2)
     assert sleeps and sleeps[0] == pytest.approx(0.5)
+
+
+@responses.activate
+def test_fetch_uniprot_retries_transient_error(monkeypatch) -> None:
+    cfg = UniprotCfg(base="https://example.org", delay=0)
+    monkeypatch.setattr(
+        ul,
+        "_retry_cfg",
+        RetryCfg(max_attempts=3, backoff_factor=0.5, status_forcelist=[500]),
+    )
+    url = "https://example.org/uniprotkb/P12345.json"
+
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, json={"status": "ok"})
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(ul, "sleep", lambda delay: sleeps.append(delay))
+    monkeypatch.setattr(ul.random, "uniform", lambda _a, b: b)
+
+    records: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, **payload: object) -> None:
+        records.append((event, payload))
+
+    monkeypatch.setattr(ul.logger, "warning", capture)
+
+    result = ul.fetch_uniprot("P12345", cfg=cfg)
+
+    assert result == {"status": "ok"}
+    assert len(responses.calls) == 2
+    assert sleeps == [pytest.approx(1.0)]
+    assert len(records) == 1
+    event, payload = records[0]
+    assert event == "uniprot_request_retry"
+    assert payload["url"] == url
+    assert payload["attempt"] == 1
+    assert payload["max_attempts"] == 3
+    assert payload["status"] == 500
+    assert payload["rps"] == cfg.rps
+    assert "500" in str(payload["error"])
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- persist the UniProt retry configuration during session initialisation
- apply explicit retry handling with exponential backoff and structured logging for fetch_uniprot
- extend unit tests to cover transient failures and verify retry behaviour and logging

## Testing
- pytest tests/test_uniprot_library.py

------
https://chatgpt.com/codex/tasks/task_e_68d9137985f08324966a283ff135c4bb