### PR TITLE
Prefill test item parents from hierarchy dictionary

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -38,6 +38,7 @@ from library.cli import (
 from library.config import (
     ApiCfg,
     Config,
+    IoCfg,
     MoleculeCatalogCfg,
     PubChemCfg,
     _serialize_paths,
@@ -403,6 +404,60 @@ def _normalise_chembl_ids(series: pd.Series) -> pd.Series:
 
     normalised = series.fillna("").astype("string").str.strip().str.upper()
     return normalised
+
+
+def load_molecule_hierarchy_lookup(
+    path: Path | None, *, io_cfg: IoCfg
+) -> dict[str, str]:
+    """Return child → parent mapping loaded from a local hierarchy file."""
+
+    if path is None:
+        return {}
+
+    required = ("molecule_chembl_id", "parent_molecule_chembl_id")
+    try:
+        hierarchy_df = io.read_csv(
+            path,
+            cfg=io_cfg,
+            required_columns=required,
+            dtype="string",
+        )
+    except FileNotFoundError:
+        logger.info("molecule_hierarchy_lookup_missing", path=str(path))
+        return {}
+    except ValueError as exc:
+        raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
+
+    if hierarchy_df.empty:
+        return {}
+
+    trimmed = hierarchy_df.loc[:, required].copy()
+    trimmed["molecule_chembl_id"] = (
+        trimmed["molecule_chembl_id"].fillna("").astype("string").str.strip().str.upper()
+    )
+    trimmed["parent_molecule_chembl_id"] = (
+        trimmed["parent_molecule_chembl_id"]
+        .fillna("")
+        .astype("string")
+        .str.strip()
+        .str.upper()
+    )
+
+    filtered = trimmed[
+        (trimmed["molecule_chembl_id"] != "")
+        & (trimmed["parent_molecule_chembl_id"] != "")
+    ].drop_duplicates(subset=["molecule_chembl_id"], keep="first")
+
+    if filtered.empty:
+        return {}
+
+    lookup = filtered.set_index("molecule_chembl_id")["parent_molecule_chembl_id"].to_dict()
+    logger.info(
+        "molecule_hierarchy_lookup_loaded",
+        path=str(path),
+        rows=len(lookup),
+    )
+    return lookup
 
 
 class ParentLookupPreparedData(NamedTuple):
@@ -1041,6 +1096,40 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             existing_parent = _normalise_chembl_ids(df[parent_column])
         else:
             existing_parent = pd.Series("", index=df.index, dtype="string")
+
+        hierarchy_lookup_path = getattr(
+            cfg.testitem_molecule_enrichment.sources,
+            "molecule_hierarchy_path",
+            None,
+        )
+        try:
+            hierarchy_lookup = load_molecule_hierarchy_lookup(
+                hierarchy_lookup_path,
+                io_cfg=cfg.io,
+            )
+        except ValueError as exc:
+            logger.error(
+                "molecule_hierarchy_lookup_invalid",
+                error=str(exc),
+                path=str(hierarchy_lookup_path),
+            )
+            return 1
+
+        if hierarchy_lookup:
+            hierarchy_series = normalised_ids.map(
+                lambda value: hierarchy_lookup.get(value) if value else None
+            )
+            hierarchy_mask = hierarchy_series.notna()
+            if hierarchy_mask.any():
+                resolved = hierarchy_series[hierarchy_mask].astype("string")
+                if parent_column in df.columns:
+                    df[parent_column] = df[parent_column].astype("string")
+                else:
+                    df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
+                df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
+                existing_parent.loc[hierarchy_mask] = (
+                    resolved.fillna("").astype("string")
+                )
 
         if getattr(cfg.molecule_catalog, "force_refresh_existing", False):
             need_lookup_mask = normalised_ids != ""

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -45,6 +45,52 @@ def prepare_parent_lookup_data(
     )
 
 
+def test_load_molecule_hierarchy_lookup_missing(tmp_path: Path, cfg: Config) -> None:
+    path = tmp_path / "missing.csv"
+
+    result = gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert result == {}
+
+
+def test_load_molecule_hierarchy_lookup_filters_empty_rows(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "hierarchy.csv"
+    path.write_text(
+        "\n".join(
+            [
+                "molecule_chembl_id,parent_molecule_chembl_id",
+                "CHEMBL1,CHEMBL2",
+                "CHEMBL3,",
+                ",CHEMBL4",
+                " chembl5 , chembl6 ",
+                "CHEMBL1,CHEMBL7",
+            ]
+        ),
+        encoding=cfg.io.csv_encoding,
+    )
+
+    result = gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert result == {"CHEMBL1": "CHEMBL2", "CHEMBL5": "CHEMBL6"}
+
+
+def test_load_molecule_hierarchy_lookup_missing_columns(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "hierarchy_invalid.csv"
+    path.write_text(
+        "molecule_chembl_id,parent_id\nCHEMBL1,CHEMBL2\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert "invalid hierarchy lookup" in str(excinfo.value)
+
+
 def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> None:
     df = pd.DataFrame({"canonical_smiles": ["C"]})
     cfg = pl.PubChemCfg(delay=0)
@@ -509,6 +555,7 @@ def test_run_chembl_column_order(
         "fetch_parent_catalog_for",
         lambda *_, **__: {},
     )
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
 
     monkeypatch.setattr(
         gtd,
@@ -610,6 +657,7 @@ def test_run_chembl_initialises_pubchem_session(
         "fetch_parent_catalog_for",
         lambda *_, **__: {},
     )
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
 
     monkeypatch.setattr(
         gtd,
@@ -699,6 +747,7 @@ def test_run_chembl_uses_lazy_identifier_stream(
         "fetch_parent_catalog_for",
         lambda *_, **__: {},
     )
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
     monkeypatch.setattr(
         gtd,
         "attach_parent_molecule_ids",
@@ -770,6 +819,7 @@ def test_run_chembl_calls_pubchem_once(
         "fetch_parent_catalog_for",
         lambda *_, **__: {},
     )
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
 
     monkeypatch.setattr(
         gtd,
@@ -819,6 +869,85 @@ def test_run_chembl_calls_pubchem_once(
     assert len(resolve_calls) == 1
 
 
+def test_run_chembl_prefills_parent_from_hierarchy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding=cfg.io.csv_encoding)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["CHEMBL1", "CHEMBL2"]))
+
+    child_field = cfg.molecule_catalog.child_field
+    parent_field = cfg.molecule_catalog.parent_field
+    source = pd.DataFrame(
+        [
+            {child_field: "CHEMBL1", parent_field: pd.NA},
+            {child_field: "CHEMBL2", parent_field: "CHEMBL2_EXISTING"},
+        ]
+    )
+
+    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: source.copy())
+    monkeypatch.setattr(gtd.pl, "init_session", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **_: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
+    monkeypatch.setattr(gtd, "update_parent_catalog_cache", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "write_parent_catalog_cache", lambda *_, **__: None)
+
+    cfg.molecule_catalog.cache_path = tmp_path / "parent_catalog.json"
+    cfg.molecule_catalog.sqlite_path = tmp_path / "parent_catalog.sqlite"
+    hierarchy_path = tmp_path / "hierarchy.csv"
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = hierarchy_path
+
+    captured_path: Path | None = None
+
+    def fake_lookup(path: Path | None, *, io_cfg: object) -> dict[str, str]:
+        nonlocal captured_path
+        captured_path = path
+        return {"CHEMBL1": "CHEMBL1_PARENT"}
+
+    def fail_query(*_: object, **__: object) -> dict[str, str]:
+        raise AssertionError("query_parent_catalog should not be called")
+
+    def fail_fetch(*_: object, **__: object) -> dict[str, str]:
+        raise AssertionError("fetch_parent_catalog_for should not be called")
+
+    def fail_load(**_: object) -> dict[str, str]:
+        raise AssertionError("load_parent_catalog should not be called")
+
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", fake_lookup)
+    monkeypatch.setattr(gtd, "query_parent_catalog", fail_query)
+    monkeypatch.setattr(gtd.molecule_catalog, "fetch_parent_catalog_for", fail_fetch)
+    monkeypatch.setattr(gtd, "load_parent_catalog", fail_load)
+
+    captured_df: pd.DataFrame | None = None
+
+    def fake_write_csv(
+        df: pd.DataFrame,
+        output: Path,
+        *,
+        cfg: Config,
+        key_cols: list[str] | None = None,
+        col_order: list[str] | None = None,
+        **__: object,
+    ) -> Path:
+        nonlocal captured_df
+        captured_df = df.copy()
+        return output
+
+    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+
+    rc = gtd.run_chembl(cfg, args)
+
+    assert rc == 0
+    assert captured_path == hierarchy_path
+    assert captured_df is not None
+    assert captured_df[parent_field].tolist() == ["CHEMBL1_PARENT", "CHEMBL2_EXISTING"]
+
+
 def test_run_chembl_merges_parent_catalog(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
@@ -857,6 +986,7 @@ def test_run_chembl_merges_parent_catalog(
 
     monkeypatch.setattr(gtd, "query_parent_catalog", fake_query_parent_catalog)
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
     captured_catalog: dict[str, str] | None = None
     captured_source: str | None = None
 
@@ -946,6 +1076,7 @@ def test_run_chembl_updates_parent_cache_and_reuses_results(
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: source.copy())
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
 
     cache_path = tmp_path / "parent_catalog.json"
     cache_path.write_text("{}", encoding="utf-8")
@@ -1089,6 +1220,7 @@ def test_run_chembl_preserves_existing_parent_value_when_catalog_missing(
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: source.copy())
     monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
     monkeypatch.setattr(
         gtd,
         "attach_parent_molecule_ids",
@@ -1160,6 +1292,7 @@ def test_run_chembl_parent_catalog_error(
         ),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
@@ -1216,6 +1349,7 @@ def test_run_chembl_parent_catalog_request_error(
         ),
     )
     monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")


### PR DESCRIPTION
## Summary
- add a helper that loads the local molecule hierarchy mapping via the shared CSV reader
- call the hierarchy loader in `run_chembl` to pre-populate parent IDs and avoid redundant catalogue lookups
- cover the hierarchy loader and the new run_chembl behaviour in unit tests while stubbing the loader in existing scenarios

## Testing
- PYTHONPATH=.:scripts pytest -k "hierarchy" tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d9168cd5f88324911b3bdec7d412dc