### PR TITLE
Adjust parent lookup precomputation and logging

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -71,6 +71,7 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
 
 
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
+PARENT_LOOKUP_SOURCE_LOOKUP = "lookup"
 PARENT_LOOKUP_SOURCE_PARTIAL = "partial"
 PARENT_LOOKUP_SOURCE_SYNC = "sync"
 PARENT_LOOKUP_SOURCE_SKIPPED = "skipped"
@@ -588,6 +589,9 @@ def attach_parent_molecule_ids(
     attached = int(combined_parent.notna().sum())
 
     final_source = source_resolved
+    if catalog is not None and not missing_ids:
+        if final_source in (None, PARENT_LOOKUP_SOURCE_CACHE, PARENT_LOOKUP_SOURCE_SKIPPED):
+            final_source = PARENT_LOOKUP_SOURCE_LOOKUP
     if full_sync_used:
         final_source = PARENT_LOOKUP_SOURCE_SYNC
     elif partial_fetch_used:
@@ -1046,13 +1050,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             need_lookup_mask = normalised_ids != ""
         else:
             need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
-        need_lookup = set(normalised_ids[need_lookup_mask])
-        prepared_need_lookup = set(need_lookup)
-        parent_lookup_data = ParentLookupPreparedData(
-            child_ids=normalised_ids,
-            existing_parent_ids=existing_parent,
-            need_lookup=prepared_need_lookup,
-        )
+        initial_need_lookup = set(normalised_ids[need_lookup_mask])
+        need_lookup = set(initial_need_lookup)
 
         cache_before = _cache_state(cfg.molecule_catalog.cache_path)
         cache_after = cache_before
@@ -1115,6 +1114,20 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 parent_catalog.update(fallback_catalog)
                 parent_catalog_source = PARENT_LOOKUP_SOURCE_CACHE
                 need_lookup -= set(fallback_catalog)
+
+        lookup_resolved = initial_need_lookup - need_lookup
+        parent_lookup_data = ParentLookupPreparedData(
+            child_ids=normalised_ids,
+            existing_parent_ids=existing_parent,
+            need_lookup=set(need_lookup),
+        )
+        if (
+            lookup_resolved
+            and not need_lookup
+            and parent_catalog_source
+            not in (PARENT_LOOKUP_SOURCE_PARTIAL, PARENT_LOOKUP_SOURCE_SYNC)
+        ):
+            parent_catalog_source = PARENT_LOOKUP_SOURCE_LOOKUP
 
         try:
             ensure_no_parant_column(df)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -589,6 +589,74 @@ def test_run_chembl_column_order(
     assert captured["col_order"] == expected_head + expected_tail
 
 
+def test_run_chembl_parent_lookup_precomputed_excludes_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\nCHEMBL2\n")
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(
+        io, "read_ids", lambda *_, **__: iter(["CHEMBL1", "CHEMBL2"])
+    )
+
+    df = pd.DataFrame(
+        [
+            {"molecule_chembl_id": "CHEMBL1", "parent_molecule_id": pd.NA},
+            {"molecule_chembl_id": "CHEMBL2", "parent_molecule_id": pd.NA},
+        ]
+    )
+
+    monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df.copy())
+    monkeypatch.setattr(gtd, "add_pubchem_data", lambda frame, _, **__: frame)
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: {})
+
+    cache_path = tmp_path / "parent_catalog.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    cfg.molecule_catalog.cache_path = cache_path
+    cfg.molecule_catalog.sqlite_path = tmp_path / "parent_catalog.sqlite"
+
+    parent_catalog = {"CHEMBL1": "CHEMBL1_PARENT"}
+
+    monkeypatch.setattr(gtd, "query_parent_catalog", lambda *_, **__: parent_catalog)
+    monkeypatch.setattr(
+        gtd.molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
+    )
+
+    captured_precomputed: dict[str, object] = {}
+
+    def fake_attach(frame: pd.DataFrame, **kwargs: object):
+        captured_precomputed["data"] = kwargs.get("precomputed")
+        return (
+            frame,
+            gtd.ParentLookupStats(
+                source=gtd.PARENT_LOOKUP_SOURCE_CACHE,
+                missing=0,
+                unique=0,
+                attached=len(frame),
+                uncovered=0,
+            ),
+        )
+
+    monkeypatch.setattr(gtd, "attach_parent_molecule_ids", fake_attach)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
+    monkeypatch.setattr(gtd, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gtd, "file_sha256", lambda path: "deadbeef")
+    monkeypatch.setattr(
+        io,
+        "write_csv",
+        lambda df, path, *, cfg, key_cols=None, col_order=None, **__: path,
+    )
+
+    rc = gtd.run_chembl(cfg, args)
+    assert rc == 0
+
+    prepared = captured_precomputed.get("data")
+    assert isinstance(prepared, gtd.ParentLookupPreparedData)
+    assert prepared.need_lookup == {"CHEMBL2"}
+
+
 def test_run_chembl_initialises_pubchem_session(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
@@ -927,7 +995,7 @@ def test_run_chembl_merges_parent_catalog(
     ]
     assert query_calls == 1
     assert captured_catalog is parent_catalog
-    assert captured_source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+    assert captured_source == gtd.PARENT_LOOKUP_SOURCE_LOOKUP
 
 
 def test_run_chembl_updates_parent_cache_and_reuses_results(
@@ -1021,7 +1089,7 @@ def test_run_chembl_updates_parent_cache_and_reuses_results(
     assert update_calls == [{"CHEMBL1": "CHEMBL1_PARENT"}]
     assert [source for _, source in attach_calls] == [
         gtd.PARENT_LOOKUP_SOURCE_PARTIAL,
-        gtd.PARENT_LOOKUP_SOURCE_CACHE,
+        gtd.PARENT_LOOKUP_SOURCE_LOOKUP,
     ]
 
 
@@ -1521,7 +1589,7 @@ def test_attach_parent_molecule_ids_handles_large_catalog(
     assert stats.unique == 3
     assert stats.attached == 3
     assert stats.missing == 0
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_LOOKUP
     assert tracking_catalog.iterations == 0
     assert set(tracking_catalog.lookups) == {"CHEMBL1", "CHEMBL2", "CHEMBL3"}
 
@@ -1822,4 +1890,4 @@ def test_attach_parent_molecule_ids_uses_cache_only(
     assert result[catalog_cfg.parent_field].tolist() == ["CHEMBL1_PARENT"]
     assert stats.missing == 0
     assert stats.attached == 1
-    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_CACHE
+    assert stats.source == gtd.PARENT_LOOKUP_SOURCE_LOOKUP


### PR DESCRIPTION
## Summary
- exclude lookup-resolved identifiers from ParentLookupPreparedData before invoking the parent enrichment
- record parent lookup runs resolved solely from lookup data with a dedicated source flag
- extend the test suite to cover the reduced lookup set and update expectations for lookup-only paths

## Testing
- PYTHONPATH=".:scripts" pytest tests/test_get_testitem_data.py::test_run_chembl_parent_lookup_precomputed_excludes_resolved
- PYTHONPATH=".:scripts" pytest tests/test_get_testitem_data.py::test_run_chembl_merges_parent_catalog
- PYTHONPATH=".:scripts" pytest tests/test_get_testitem_data.py::test_run_chembl_updates_parent_cache_and_reuses_results
- PYTHONPATH=".:scripts" pytest tests/test_get_testitem_data.py::test_attach_parent_molecule_ids_handles_large_catalog
- PYTHONPATH=".:scripts" pytest tests/test_get_testitem_data.py::test_attach_parent_molecule_ids_uses_cache_only

------
https://chatgpt.com/codex/tasks/task_e_68d9168e71448324ade3c752122546cc