### PR TITLE
Enable persisted PubChem CID cache by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/output/ChEMBL/processed/pairs_same_document.csv
 .cache/
 data/output/
 data/output-smoke/
+data/cache/pubchem_cid_cache.json
 uniprot/
 **/__pycache__/
 .hypothesis/

--- a/config.schema.json
+++ b/config.schema.json
@@ -1085,7 +1085,7 @@
           ]
         },
         "cid_cache_path": {
-          "default": null,
+          "default": "data/cache/pubchem_cid_cache.json",
           "description": "Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
           "title": "Cid Cache Path",
           "type": [

--- a/config.yaml
+++ b/config.yaml
@@ -145,7 +145,7 @@ sources:
       - pref_name
     cache_ttl: 3600  # Request cache time-to-live in seconds
     cache_ttl_hours: null  # Persisted CID cache TTL in hours; null disables expiry
-    cid_cache_path: null
+    cid_cache_path: "data/cache/pubchem_cid_cache.json"
     batch_size: 50
     prefer_local_smiles: false
     prefer_local_values: true

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -269,7 +269,7 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | `resolve_order` | `cache → smiles → inchikey → inchi → pref_name` | Order in which lookup strategies are attempted when resolving PubChem CIDs. | `CHEMBL_DA_SOURCES_PUBCHEM_RESOLVE_ORDER`, `CHEMBL_DA__SOURCES__PUBCHEM__RESOLVE_ORDER` |
 | `cache_ttl` | `3600` | Lifespan (seconds) of the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_ttl_hours` | `null` | Optional expiry (hours) for the persisted CID cache; `null` keeps entries indefinitely. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
-| `cid_cache_path` | `null` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
+| `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
 | `batch_size` | `50` | Number of rows processed per PubChem batch request. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Skip remote lookups when local SMILES/InChIKey columns are already populated. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Preserve existing `pubchem_*` columns when lookups return empty payloads. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -261,7 +261,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `resolve_order` | `cache → smiles → inchikey → inchi → pref_name` | Очерёдность стратегий при поиске PubChem CID. | `CHEMBL_DA_SOURCES_PUBCHEM_RESOLVE_ORDER`, `CHEMBL_DA__SOURCES__PUBCHEM__RESOLVE_ORDER` |
 | `cache_ttl` | `3600` | Время жизни in-memory кэша HTTP (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_ttl_hours` | `null` | TTL (часы) для постоянного CID-кэша; `null` отключает истечение. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
-| `cid_cache_path` | `null` | Путь к JSON с сохранёнными CID для повторного использования. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
+| `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Путь к JSON с сохранёнными CID для повторного использования. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
 | `batch_size` | `50` | Размер батча для обработчика PubChem. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Пропускать запросы, если локальные SMILES/InChIKey уже заполнены. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Сохранять существующие колонки `pubchem_*`, если ответ пуст. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |

--- a/library/config.py
+++ b/library/config.py
@@ -299,7 +299,7 @@ class PubChemCfg(_BaseModel):
         description="Optional TTL for the persisted CID cache in hours",
     )
     cid_cache_path: Path | None = Field(
-        default=None,
+        default=Path("data/cache/pubchem_cid_cache.json"),
         description="Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
     )
     batch_size: int = Field(50, ge=1)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -60,6 +60,8 @@ from schemas import TestitemsSchema, normalize_testitems
 
 _TYPO_PARENT_COLUMN = "parant_molecule_id"
 
+UTC = timezone.utc
+
 
 def ensure_no_parant_column(df: pd.DataFrame) -> None:
     """Raise a :class:`ValueError` if the legacy typo column is present."""


### PR DESCRIPTION
## Summary
- default the PubChem CID cache location to `data/cache/pubchem_cid_cache.json` and document the change in the schema and configuration guides
- define a shared UTC constant for cache metadata timestamps and ignore the generated cache file in Git

## Testing
- python scripts/get_testitem_data.py --input data/input-smoke/testitem.csv --output /tmp/testitem_post.csv
- python scripts/get_testitem_data.py --input data/input-smoke/testitem.csv --output /tmp/testitem_post_cached.csv
- python - <<'PY'
import pandas as pd
pre = pd.read_csv('/tmp/testitem_pre.csv').drop(columns=['timestamp_utc'])
post = pd.read_csv('/tmp/testitem_post.csv').drop(columns=['timestamp_utc'])
pd.testing.assert_frame_equal(pre, post, check_dtype=False)
print('frames_equal_without_timestamp')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d91690db608324bdc6d61dfd26661b