### PR TITLE
Refine PubChem parent cache preparation

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -924,34 +924,32 @@ def add_pubchem_data(
     if parent_record_cache is None:
         parent_record_cache = {}
 
-    local_records: dict[str, pd.Series] = {}
+    local_records: pd.DataFrame | None = None
     if "molecule_chembl_id" in result.columns:
-        local_record_data = (
-            result.loc[:, ["molecule_chembl_id"]]
-            .assign(__row=lambda df: df.index)
-            .dropna()
-            .astype({"molecule_chembl_id": "string"})
-            .assign(
-                molecule_chembl_id=lambda df: df[
+        prepared_local_records = (
+            result.assign(
+                __local_molecule=lambda frame: frame[
                     "molecule_chembl_id"
-                ].str.strip().str.upper()
+                ]
+                .astype("string")
+                .str.strip()
+                .str.upper()
             )
-            .drop_duplicates("molecule_chembl_id")
-            .set_index("molecule_chembl_id")["__row"]
-            .map(result.to_dict("index"))
+            .dropna(subset=["__local_molecule"])
         )
-        for chembl_id, row_data in local_record_data.items():
-            chembl_norm = _normalise_identifier(chembl_id, uppercase=True)
-            if not chembl_norm or chembl_norm in local_records:
-                continue
-            if isinstance(row_data, pd.Series):
-                record = row_data
-            elif isinstance(row_data, Mapping):
-                record = pd.Series(row_data).reindex(result.columns, copy=False)
-            else:
-                continue
-            local_records[chembl_norm] = record
-            parent_record_cache[chembl_norm] = record
+        if not prepared_local_records.empty:
+            local_records = (
+                prepared_local_records.drop_duplicates("__local_molecule")
+                .set_index("__local_molecule")
+                .rename_axis("molecule_chembl_id")
+                .reindex(columns=result.columns)
+            )
+            for chembl_norm in local_records.index:
+                try:
+                    record = local_records.loc[chembl_norm]
+                except KeyError:  # pragma: no cover - defensive
+                    continue
+                parent_record_cache[chembl_norm] = record.copy()
 
     pending_parent_ids: list[str] = []
     seen_parent_ids: set[str] = set()
@@ -960,7 +958,9 @@ def add_pubchem_data(
             parent_norm = _normalise_identifier(parent_value, uppercase=True)
             if not parent_norm:
                 continue
-            if parent_norm in parent_record_cache or parent_norm in local_records:
+            if parent_norm in parent_record_cache or (
+                local_records is not None and parent_norm in local_records.index
+            ):
                 continue
             if parent_norm in seen_parent_ids:
                 continue
@@ -1019,6 +1019,11 @@ def add_pubchem_data(
         parent_norm = _normalise_identifier(parent_id, uppercase=True)
         if not parent_norm:
             return None
+        if local_records is not None:
+            try:
+                return local_records.loc[parent_norm]
+            except KeyError:
+                pass
         return parent_record_cache.get(parent_norm)
 
     if "molecule_chembl_id" in result.columns and "pubchem_cid" in result.columns:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -495,6 +495,66 @@ def test_add_pubchem_data_prefetches_parent_records(
     assert result.loc[0, "pubchem_cid"] == "321"
 
 
+def test_add_pubchem_data_primes_parent_cache_with_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL1", "CHEMBL2"],
+            "parent_molecule_chembl_id": [pd.NA, pd.NA, "CHEMBL1"],
+            "canonical_smiles": ["C", "N", "CN"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0)
+    api_cfg = ApiCfg()
+    cid_cache: dict[str, str | None] = {}
+    resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] = {}
+    parent_record_cache: dict[str, pd.Series | None] = {}
+
+    def fail_fetch(*args: object, **kwargs: object) -> pd.DataFrame:  # pragma: no cover
+        raise AssertionError("parent records should not be fetched remotely")
+
+    monkeypatch.setattr(cl, "get_testitem", fail_fetch)
+
+    def fake_resolve(
+        identifiers: Mapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        *,
+        cache_key: str | None = None,
+        **_: object,
+    ) -> pl.PubChemResolution:
+        if cache_key == "CHEMBL1":
+            return pl.PubChemResolution(cid="111", source="local")
+        return pl.PubChemResolution(cid=None, source=None)
+
+    monkeypatch.setattr(pl, "resolve_pubchem_record", fake_resolve)
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, cfg: pl.Properties(None, None, None, None, None, None),
+    )
+
+    result = gtd.add_pubchem_data(
+        df,
+        cfg,
+        client=object(),
+        api_cfg=api_cfg,
+        cid_cache=cid_cache,
+        resolution_cache=resolution_cache,
+        parent_record_cache=parent_record_cache,
+    )
+
+    assert "CHEMBL1" in parent_record_cache
+    parent_series = parent_record_cache["CHEMBL1"]
+    assert isinstance(parent_series, pd.Series)
+    assert parent_series["canonical_smiles"] == "C"
+    assert (
+        result.loc[result["molecule_chembl_id"] == "CHEMBL2", "pubchem_cid"]
+        .iloc[0]
+        == "111"
+    )
+
+
 def test_add_pubchem_data_prefers_local_smiles(monkeypatch: pytest.MonkeyPatch) -> None:
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- replace the dictionary conversion used to cache local molecule records with an indexed DataFrame and reuse it when loading parent rows
- update the PubChem parent loader to consult the indexed local records before the cache and simplify membership checks
- add a regression test to ensure duplicate molecule identifiers still prime the parent cache correctly

## Testing
- PYTHONPATH=.:scripts pytest tests/test_get_testitem_data.py::test_add_pubchem_data_primes_parent_cache_with_duplicates


------
https://chatgpt.com/codex/tasks/task_e_68da4140d18083249fd06fe5da10c729