### PR TITLE
Remove bootstrap shims from CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Retrieve document metadata for a list of PubMed IDs using the bundled
 sample file:
 
 ```bash
-python scripts/get_document_data.py pubmed \
+python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
     --output out/documents.csv \
     --limit 5 \
@@ -200,7 +200,7 @@ python -m library.pubmed_library \
 Fetch basic target information from ChEMBL:
 
 ```bash
-python scripts/get_target_data.py chembl \
+python -m scripts.get_target_data chembl \
     --input path/to/targets.csv \
     --output out/targets.csv \
     --limit 5 \
@@ -280,7 +280,7 @@ CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
 Запустить скрипт с автоматической подгрузкой настроек можно так:
 
 ```bash
-python -m dotenv run -- python scripts/get_assay_data.py --input assay_ids.csv \\
+python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \\
     --output out/assays.csv
 ```
 
@@ -375,7 +375,7 @@ api:
 Пример включения JSON‑формата через переменную окружения:
 
 ```bash
-LOG_FORMAT=json python scripts/get_assay_data.py --input assay_ids.csv \
+LOG_FORMAT=json python -m scripts.get_assay_data --input assay_ids.csv \
     --output out/assays.csv --log-level INFO
 ```
 
@@ -383,7 +383,7 @@ LOG_FORMAT=json python scripts/get_assay_data.py --input assay_ids.csv \
 `CHEMBL_DA_LOG_LEVEL`:
 
 ```bash
-CHEMBL_DA_LOG_LEVEL=DEBUG python scripts/get_assay_data.py --input assay_ids.csv \
+CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
     --output out/assays.csv
 ```
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -10,16 +10,6 @@ from pathlib import Path
 import requests
 from pandera.errors import SchemaErrors
 
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
-from library.utils import bootstrap
-
-bootstrap.ensure_project_root()
-
 from library import chembl_library as cl
 from library import cli
 from library import io

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -9,18 +9,8 @@ import argparse
 from collections.abc import Sequence
 from itertools import islice
 
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 import requests
 from pandera.errors import SchemaErrors
-
-from library.utils import bootstrap
-
-bootstrap.ensure_project_root()
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -33,19 +33,9 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from itertools import chain, islice
 from typing import cast
 
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
-
-from library.utils import bootstrap
-
-bootstrap.ensure_project_root()
 
 from library import chembl_library as cl
 from library import cli

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -22,16 +22,6 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
-from library.utils import bootstrap
-
-bootstrap.ensure_project_root()
-
 from library import chembl_library as cl
 from library import cli
 from library import io

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -17,19 +17,9 @@ from functools import lru_cache
 from itertools import islice, tee
 from typing import Any, NamedTuple
 
-if __package__ in {None, ""}:
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
-
-from library.utils import bootstrap
-
-bootstrap.ensure_project_root()
 
 from library import chembl_library as cl
 from library import cli


### PR DESCRIPTION
## Summary
- remove the manual project-root bootstrapping from the CLI scripts and use direct package imports
- update the README examples to show `python -m scripts.<name>` execution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da49b2fc44832495a46a7919e91510