### PR TITLE
Fix get_testitem_data path resolution when executed as a script

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -21,6 +21,10 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from library import chembl_library as cl
 from library import cli
 from library import io, molecule_catalog, testitem_enrichment


### PR DESCRIPTION
## Summary
- ensure the project root is added to `sys.path` before importing local modules so the script works when invoked via a relative path

## Testing
- python scripts/get_testitem_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68da4e1bf7b08324a87bb71afeddd819