### PR TITLE
Add client package scaffolding

### DIFF
--- a/library/clients/__init__.py
+++ b/library/clients/__init__.py
@@ -1,0 +1,58 @@
+"""Client-facing abstractions for third-party integrations.
+
+This package defines the public interface for service clients used across the
+ChEMBL data acquisition stack. Downstream modules should import client
+contracts from ``library.clients`` instead of reaching into concrete client
+implementations. This keeps the dependency direction flowing outwards from the
+pipelines toward infrastructure and simplifies substitution during testing.
+
+Import rules for higher layers:
+* Business logic in ``library`` may depend on these exported protocols and
+  dataclasses.
+* Concrete pipeline steps must not import private modules from future client
+  packages directly; rely on the abstractions defined here instead.
+* Test suites may import concrete clients for fixtures, but prefer the
+  interfaces below for type-safe mocking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
+
+__all__ = [
+    "ClientConfig",
+    "ClientError",
+    "ClientPayload",
+    "ClientProtocol",
+]
+
+
+@dataclass(slots=True)
+class ClientConfig:
+    """Common configuration options for HTTP-like service clients."""
+
+    base_url: str
+    headers: Mapping[str, str]
+    timeout_seconds: float
+
+
+@dataclass(slots=True)
+class ClientPayload:
+    """Normalized response payload shared by client implementations."""
+
+    data: Sequence[MutableMapping[str, Any]]
+
+
+class ClientError(RuntimeError):
+    """Raised when a client encounters an unrecoverable error."""
+
+
+class ClientProtocol(Protocol):
+    """Skeleton protocol for strongly typed service clients."""
+
+    config: ClientConfig
+
+    def fetch(self, *, params: Mapping[str, Any] | None = None) -> ClientPayload:
+        """Retrieve data from the upstream service."""
+


### PR DESCRIPTION
## Summary
- add the `library.clients` package with documented interface exports for future service clients

## Testing
- mypy library/clients *(fails: library/config.py returns `Any` in strict mode; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68da509c64e08324b2b7fc7dfbcce7d1