### PR TITLE
Refactor UniProt client into dedicated module

### DIFF
--- a/library/clients/uniprot.py
+++ b/library/clients/uniprot.py
@@ -1,0 +1,68 @@
+"""HTTP client helpers for interacting with the UniProt REST API."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import requests
+from requests import Session
+
+from ..config import ApiCfg, RetryCfg, UniprotCfg, session_with_retry
+from ..rate_limiter import get_limiter, sleep
+
+__all__ = [
+    "UniProtFetchError",
+    "init_session",
+    "fetch_uniprot",
+    "get_session",
+]
+
+
+class UniProtFetchError(RuntimeError):
+    """Raised when a UniProt record cannot be retrieved or decoded."""
+
+
+# Default session using placeholder contact details. Call :func:`init_session`
+# with a proper configuration to set your own user agent.
+_session: Session = session_with_retry(
+    ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
+)
+
+
+def init_session(api: ApiCfg, retry: RetryCfg) -> None:
+    """Initialise the shared HTTP session."""
+
+    global _session
+    _session = session_with_retry(api, retry)
+
+
+def get_session() -> Session:
+    """Expose the configured :class:`requests.Session` instance."""
+
+    return _session
+
+
+def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
+    """Fetch a UniProt JSON record from the public REST API."""
+
+    limiter = get_limiter("uniprot", cfg.rps, cfg.burst)
+    if cfg.delay:
+        sleep(cfg.delay)
+    limiter.acquire()
+    base = cfg.base.rstrip("/")
+    url = f"{base}/uniprotkb/{uniprot_id}.json"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    try:
+        with _session.get(url, timeout=timeout) as resp:
+            resp.raise_for_status()
+            try:
+                return cast(dict[str, Any], resp.json())
+            except json.JSONDecodeError as exc:  # pragma: no cover - malformed JSON
+                raise UniProtFetchError(
+                    f"Failed to decode JSON for UniProt {uniprot_id}: {exc}"
+                ) from exc
+    except requests.RequestException as exc:  # pragma: no cover - network
+        raise UniProtFetchError(
+            f"UniProt request failed for {uniprot_id}: {exc}"
+        ) from exc

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -38,29 +38,24 @@ import csv
 import json
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import requests
-from requests import Session
 
-from .config import ApiCfg, IupharCfg, RetryCfg, UniprotCfg, session_with_retry
+from .clients.uniprot import (
+    UniProtFetchError,
+    fetch_uniprot,
+    get_session as get_uniprot_session,
+    init_session as init_uniprot_session,
+)
+from .config import IupharCfg, UniprotCfg
 from .log import logger
-from .rate_limiter import get_limiter, sleep
+from .rate_limiter import get_limiter
 
 _DEFAULT_UNIPROT_DATA_DIR = Path("uniprot")
 
-# Default session using placeholder contact details. Call :func:`init_session`
-# with a proper configuration to set your own user agent.
-_session: Session = session_with_retry(
-    ApiCfg(user_agent="chembl-da/0.1 (mailto:contact@example.org)"), RetryCfg()
-)
 
-
-def init_session(api: ApiCfg, retry: RetryCfg) -> None:
-    """Initialise the shared HTTP session."""
-
-    global _session
-    _session = session_with_retry(api, retry)
+init_session = init_uniprot_session
 
 
 __all__ = [
@@ -139,55 +134,6 @@ UNIPROT_OUTPUT_COLUMNS: list[str] = [
     "geneName",
     "secondaryAccessionNames",
 ]
-
-
-class UniProtFetchError(RuntimeError):
-    """Raised when a UniProt record cannot be retrieved or decoded."""
-
-
-def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
-    """Fetch a UniProt JSON record from the public REST API.
-
-    Parameters
-    ----------
-    uniprot_id:
-        UniProt accession identifier to retrieve.
-    cfg:
-        UniProt configuration providing base URL, timeouts and rate limits.
-
-    Returns
-    -------
-    dict
-        JSON-decoded response.
-
-    Raises
-    ------
-    UniProtFetchError
-        If the request fails or the payload cannot be decoded as JSON.
-
-    """
-    limiter = get_limiter("uniprot", cfg.rps, cfg.burst)
-    if cfg.delay:
-        sleep(cfg.delay)
-    limiter.acquire()
-    base = cfg.base.rstrip("/")
-    url = f"{base}/uniprotkb/{uniprot_id}.json"
-    timeout = (cfg.timeout_connect, cfg.timeout_read)
-    try:
-        with _session.get(url, timeout=timeout) as resp:
-            resp.raise_for_status()
-            try:
-                return cast(dict[str, Any], resp.json())
-            except json.JSONDecodeError as exc:  # pragma: no cover - malformed JSON
-                raise UniProtFetchError(
-                    f"Failed to decode JSON for UniProt {uniprot_id}: {exc}"
-                ) from exc
-    except requests.RequestException as exc:  # pragma: no cover - network
-        raise UniProtFetchError(
-            f"UniProt request failed for {uniprot_id}: {exc}"
-        ) from exc
-
-
 def _collect_name_fields(name_obj: dict[str, Any]) -> Iterable[str]:
     """Yield all full and short names from a UniProt name object."""
     if not isinstance(name_obj, dict):
@@ -882,7 +828,8 @@ def _fetch_gtop_endpoint(
     timeout = (cfg.timeout_connect, cfg.timeout_read)
     limiter.acquire()
     try:
-        with _session.get(url, timeout=timeout) as response:
+        session = get_uniprot_session()
+        with session.get(url, timeout=timeout) as response:
             response.raise_for_status()
             return response.json()
     except (json.JSONDecodeError, ValueError) as exc:

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -12,6 +12,7 @@ requests = pytest.importorskip("requests")
 responses = pytest.importorskip("responses")
 
 from library import uniprot_library as ul  # noqa: E402
+from library.clients import uniprot as uniprot_client  # noqa: E402
 from library.config import IupharCfg, UniprotCfg  # noqa: E402
 
 
@@ -55,7 +56,8 @@ def test_fetch_uniprot_bad_json() -> None:
 @responses.activate
 def test_fetch_uniprot_uses_cfg(monkeypatch) -> None:
     called: dict[str, object] = {}
-    orig_get = ul._session.get
+    session = uniprot_client.get_session()
+    orig_get = session.get
 
     def capture(url: str, timeout: tuple[int, int]):
         called["url"] = url
@@ -64,7 +66,7 @@ def test_fetch_uniprot_uses_cfg(monkeypatch) -> None:
 
     sleeps: list[float] = []
 
-    monkeypatch.setattr(ul._session, "get", capture)
+    monkeypatch.setattr(session, "get", capture)
     monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
     cfg = UniprotCfg(
         base="https://example.org/api",


### PR DESCRIPTION
## Summary
- move UniProt HTTP helper code into a dedicated client module
- adjust the UniProt library to import the client and share its session for downstream lookups
- update UniProt tests to patch the new client session

## Testing
- pytest tests/test_uniprot_library.py tests/test_uniprot_process_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68da515e2b148324922d22c45c673698