### PR TITLE
Refactor Semantic Scholar client

### DIFF
--- a/library/clients/semantic_scholar.py
+++ b/library/clients/semantic_scholar.py
@@ -1,0 +1,196 @@
+"""HTTP client for the Semantic Scholar API.
+
+Changelog
+========
+* Extracted from :mod:`library.pubmed.query` to provide a dedicated client
+  layer for Semantic Scholar interactions.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+from ..config import SemanticScholarCfg
+from ..pubmed.query import _do_request
+
+__all__ = ["fetch_semantic_scholar", "fetch_semantic_scholar_batch"]
+
+_SEMANTIC_SCHOLAR_FIELDS = "publicationTypes,externalIds,paperId,venue"
+_SEMANTIC_SCHOLAR_HEADERS = {"Accept": "application/json"}
+
+
+def fetch_semantic_scholar(
+    session: requests.Session,
+    pmid: str,
+    sleep: float,
+    cfg: SemanticScholarCfg | None = None,
+) -> dict[str, str]:
+    """Retrieve Semantic Scholar metadata for ``pmid``."""
+
+    cfg = cfg or SemanticScholarCfg()
+    base = cfg.base.rstrip("/")
+    url = f"{base}/paper/PMID:{pmid}"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(
+        session,
+        url,
+        sleep * 5,
+        headers=_SEMANTIC_SCHOLAR_HEADERS,
+        params={"fields": _SEMANTIC_SCHOLAR_FIELDS},
+        retries=cfg.retries,
+        timeout=timeout,
+    )
+    if error or not isinstance(data, dict):
+        return {
+            "scholar.PMID": pmid,
+            "scholar.Venue": "",
+            "scholar.PublicationTypes": "",
+            "scholar.SemanticScholarId": "",
+            "scholar.ExternalIds": "",
+            "scholar.DOI": "",
+            "scholar.Error": error or "Invalid response",
+        }
+
+    external_ids = data.get("externalIds") or {}
+    doi = external_ids.get("DOI") or ""
+    pubtypes = data.get("publicationTypes") or []
+    return {
+        "scholar.PMID": pmid,
+        "scholar.Venue": data.get("venue", ""),
+        "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
+        "scholar.SemanticScholarId": data.get("paperId", ""),
+        "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
+        "scholar.DOI": doi,
+        "scholar.Error": "",
+    }
+
+
+def fetch_semantic_scholar_batch(
+    session: requests.Session,
+    pmids: list[str],
+    sleep: float,
+    cfg: SemanticScholarCfg | None = None,
+) -> list[dict[str, str]]:
+    """Retrieve Semantic Scholar metadata for multiple PMIDs."""
+
+    if not pmids:
+        return []
+
+    cfg = cfg or SemanticScholarCfg()
+    base = cfg.base.rstrip("/")
+    url = f"{base}/paper/batch"
+    timeout = (cfg.timeout_connect, cfg.timeout_read)
+    data, error = _do_request(
+        session,
+        url,
+        sleep,
+        headers=_SEMANTIC_SCHOLAR_HEADERS,
+        json={"ids": [f"PMID:{pmid}" for pmid in pmids]},
+        method="POST",
+        params={"fields": _SEMANTIC_SCHOLAR_FIELDS},
+        retries=cfg.retries,
+        timeout=timeout,
+    )
+    if error:
+        return [
+            {
+                "scholar.PMID": pmid,
+                "scholar.Venue": "",
+                "scholar.PublicationTypes": "",
+                "scholar.SemanticScholarId": "",
+                "scholar.ExternalIds": "",
+                "scholar.DOI": "",
+                "scholar.Error": error,
+            }
+            for pmid in pmids
+        ]
+
+    if not isinstance(data, list):
+        return [
+            {
+                "scholar.PMID": pmid,
+                "scholar.Venue": "",
+                "scholar.PublicationTypes": "",
+                "scholar.SemanticScholarId": "",
+                "scholar.ExternalIds": "",
+                "scholar.DOI": "",
+                "scholar.Error": "Invalid batch response format",
+            }
+            for pmid in pmids
+        ]
+
+    def _resolve_pmid(item: dict[str, Any]) -> str | None:
+        external_ids = item.get("externalIds")
+        if isinstance(external_ids, dict):
+            for key in ("PubMed", "PMID", "pubmed", "pubMed"):
+                value = external_ids.get(key)
+                if isinstance(value, str):
+                    candidate = value.strip()
+                    if candidate:
+                        return candidate
+                elif isinstance(value, list | tuple | set):
+                    for entry in value:
+                        if isinstance(entry, str):
+                            candidate = entry.strip()
+                            if candidate:
+                                return candidate
+                        elif entry is not None:
+                            return str(entry)
+                elif value is not None:
+                    return str(value)
+        for key in ("pmid", "PMID"):
+            value = item.get(key)
+            if isinstance(value, str):
+                candidate = value.strip()
+                if candidate:
+                    return candidate
+            elif value is not None:
+                return str(value)
+        return None
+
+    lookup: dict[str, dict[str, Any]] = {}
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        pmid_value = _resolve_pmid(entry)
+        if pmid_value:
+            lookup.setdefault(pmid_value, entry)
+
+    results: list[dict[str, str]] = []
+    for pmid in pmids:
+        item = lookup.get(pmid)
+        if item is None:
+            results.append(
+                {
+                    "scholar.PMID": pmid,
+                    "scholar.Venue": "",
+                    "scholar.PublicationTypes": "",
+                    "scholar.SemanticScholarId": "",
+                    "scholar.ExternalIds": "",
+                    "scholar.DOI": "",
+                    "scholar.Error": "Not found",
+                }
+            )
+            continue
+
+        external_ids = item.get("externalIds") or {}
+        doi = external_ids.get("DOI") or ""
+        pubtypes = item.get("publicationTypes") or []
+
+        results.append(
+            {
+                "scholar.PMID": pmid,
+                "scholar.Venue": item.get("venue", ""),
+                "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
+                "scholar.SemanticScholarId": item.get("paperId", ""),
+                "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
+                "scholar.DOI": doi,
+                "scholar.Error": "",
+            }
+        )
+
+    return results
+

--- a/library/pubmed/__init__.py
+++ b/library/pubmed/__init__.py
@@ -17,8 +17,6 @@ from .query import (
     fetch_openalex,
     fetch_pubmed,
     fetch_pubmed_batch,
-    fetch_semantic_scholar,
-    fetch_semantic_scholar_batch,
     read_pmids,
 )
 
@@ -29,8 +27,6 @@ __all__ = [
     "_do_request",
     "fetch_pubmed_batch",
     "fetch_pubmed",
-    "fetch_semantic_scholar",
-    "fetch_semantic_scholar_batch",
     "fetch_openalex",
     "fetch_crossref",
     "text_or_none",

--- a/library/pubmed/query.py
+++ b/library/pubmed/query.py
@@ -1,13 +1,11 @@
 """HTTP queries for publication metadata.
 
 This module provides functions for retrieving metadata from PubMed,
-Semantic Scholar, OpenAlex and Crossref.  It also contains helpers for
+OpenAlex and Crossref.  It also contains helpers for
 issuing robust HTTP requests.
 """
 
 from __future__ import annotations
-
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,7 +15,7 @@ from xml.etree import ElementTree as ET
 import pandas as pd
 import requests
 
-from ..config import CrossRefCfg, OpenAlexCfg, PubMedCfg, SemanticScholarCfg
+from ..config import CrossRefCfg, OpenAlexCfg, PubMedCfg
 from ..log import logger
 from ..rate_limiter import get_limiter, sleep
 from .parsing import EMPTY_PUBMED, combine, parse_pubmed_article
@@ -33,15 +31,11 @@ __all__ = [
     "_do_request",
     "fetch_pubmed_batch",
     "fetch_pubmed",
-    "fetch_semantic_scholar",
-    "fetch_semantic_scholar_batch",
     "fetch_openalex",
     "fetch_crossref",
 ]
 
 
-_SEMANTIC_SCHOLAR_FIELDS = "publicationTypes,externalIds,paperId,venue"
-_SEMANTIC_SCHOLAR_HEADERS = {"Accept": "application/json"}
 _PUBMED_FALLBACK_ENCODINGS: tuple[str, ...] = (
     "utf-8-sig",
     "cp1251",
@@ -268,177 +262,6 @@ def fetch_pubmed(
     """Fetch metadata for a single PMID."""
 
     return fetch_pubmed_batch(session, [pmid], sleep, cfg=cfg)[0]
-
-
-def fetch_semantic_scholar(
-    session: requests.Session,
-    pmid: str,
-    sleep: float,
-    cfg: SemanticScholarCfg | None = None,
-) -> dict[str, str]:
-    """Retrieve Semantic Scholar metadata for ``pmid``."""
-    cfg = cfg or SemanticScholarCfg()
-    base = cfg.base.rstrip("/")
-    url = f"{base}/paper/PMID:{pmid}"
-    timeout = (cfg.timeout_connect, cfg.timeout_read)
-    data, error = _do_request(
-        session,
-        url,
-        sleep * 5,
-        headers=_SEMANTIC_SCHOLAR_HEADERS,
-        params={"fields": _SEMANTIC_SCHOLAR_FIELDS},
-        retries=cfg.retries,
-        timeout=timeout,
-    )
-    if error or not isinstance(data, dict):
-        return {
-            "scholar.PMID": pmid,
-            "scholar.Venue": "",
-            "scholar.PublicationTypes": "",
-            "scholar.SemanticScholarId": "",
-            "scholar.ExternalIds": "",
-            "scholar.DOI": "",
-            "scholar.Error": error or "Invalid response",
-        }
-    external_ids = data.get("externalIds") or {}
-    doi = external_ids.get("DOI") or ""
-    pubtypes = data.get("publicationTypes") or []
-    return {
-        "scholar.PMID": pmid,
-        "scholar.Venue": data.get("venue", ""),
-        "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
-        "scholar.SemanticScholarId": data.get("paperId", ""),
-        "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
-        "scholar.DOI": doi,
-        "scholar.Error": "",
-    }
-
-
-def fetch_semantic_scholar_batch(
-    session: requests.Session,
-    pmids: list[str],
-    sleep: float,
-    cfg: SemanticScholarCfg | None = None,
-) -> list[dict[str, str]]:
-    """Retrieve Semantic Scholar metadata for multiple PMIDs."""
-
-    if not pmids:
-        return []
-
-    cfg = cfg or SemanticScholarCfg()
-    base = cfg.base.rstrip("/")
-    url = f"{base}/paper/batch"
-    timeout = (cfg.timeout_connect, cfg.timeout_read)
-    data, error = _do_request(
-        session,
-        url,
-        sleep,
-        headers=_SEMANTIC_SCHOLAR_HEADERS,
-        json={"ids": [f"PMID:{pmid}" for pmid in pmids]},
-        method="POST",
-        params={"fields": _SEMANTIC_SCHOLAR_FIELDS},
-        retries=cfg.retries,
-        timeout=timeout,
-    )
-    if error:
-        return [
-            {
-                "scholar.PMID": pmid,
-                "scholar.Venue": "",
-                "scholar.PublicationTypes": "",
-                "scholar.SemanticScholarId": "",
-                "scholar.ExternalIds": "",
-                "scholar.DOI": "",
-                "scholar.Error": error,
-            }
-            for pmid in pmids
-        ]
-
-    if not isinstance(data, list):
-        return [
-            {
-                "scholar.PMID": pmid,
-                "scholar.Venue": "",
-                "scholar.PublicationTypes": "",
-                "scholar.SemanticScholarId": "",
-                "scholar.ExternalIds": "",
-                "scholar.DOI": "",
-                "scholar.Error": "Invalid batch response format",
-            }
-            for pmid in pmids
-        ]
-
-    def _resolve_pmid(item: dict[str, Any]) -> str | None:
-        external_ids = item.get("externalIds")
-        if isinstance(external_ids, dict):
-            for key in ("PubMed", "PMID", "pubmed", "pubMed"):
-                value = external_ids.get(key)
-                if isinstance(value, str):
-                    candidate = value.strip()
-                    if candidate:
-                        return candidate
-                elif isinstance(value, list | tuple | set):
-                    for entry in value:
-                        if isinstance(entry, str):
-                            candidate = entry.strip()
-                            if candidate:
-                                return candidate
-                        elif entry is not None:
-                            return str(entry)
-                elif value is not None:
-                    return str(value)
-        for key in ("pmid", "PMID"):
-            value = item.get(key)
-            if isinstance(value, str):
-                candidate = value.strip()
-                if candidate:
-                    return candidate
-            elif value is not None:
-                return str(value)
-        return None
-
-    lookup: dict[str, dict[str, Any]] = {}
-    for entry in data:
-        if not isinstance(entry, dict):
-            continue
-        pmid_value = _resolve_pmid(entry)
-        if pmid_value:
-            lookup.setdefault(pmid_value, entry)
-
-    results: list[dict[str, str]] = []
-    for pmid in pmids:
-        item = lookup.get(pmid)
-        if item is None:
-            results.append(
-                {
-                    "scholar.PMID": pmid,
-                    "scholar.Venue": "",
-                    "scholar.PublicationTypes": "",
-                    "scholar.SemanticScholarId": "",
-                    "scholar.ExternalIds": "",
-                    "scholar.DOI": "",
-                    "scholar.Error": "Not found",
-                }
-            )
-            continue
-
-        external_ids = item.get("externalIds") or {}
-        doi = external_ids.get("DOI") or ""
-        pubtypes = item.get("publicationTypes") or []
-
-        results.append(
-            {
-                "scholar.PMID": pmid,
-                "scholar.Venue": item.get("venue", ""),
-                "scholar.PublicationTypes": "; ".join(pubtypes) if pubtypes else "",
-                "scholar.SemanticScholarId": item.get("paperId", ""),
-                "scholar.ExternalIds": json.dumps(external_ids, ensure_ascii=False),
-                "scholar.DOI": doi,
-                "scholar.Error": "",
-            }
-        )
-
-    return results
 
 
 def fetch_openalex(

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -14,6 +14,10 @@ from pathlib import Path
 import pandas as pd
 
 from . import cli
+from .clients.semantic_scholar import (
+    fetch_semantic_scholar,
+    fetch_semantic_scholar_batch,
+)
 from .cli import LoggerConfig, configure_logger, path_argument
 from .cli import build_parser as base_parser
 from .config import Config, ensure_dirs, print_config, session_with_retry
@@ -28,8 +32,6 @@ from .pubmed import (
     fetch_openalex,
     fetch_pubmed,
     fetch_pubmed_batch,
-    fetch_semantic_scholar,
-    fetch_semantic_scholar_batch,
     find_all,
     find_one,
     merge_records,

--- a/library/semantic_scholar_library.py
+++ b/library/semantic_scholar_library.py
@@ -1,16 +1,15 @@
 """Semantic Scholar query utilities.
 
-This module wraps :func:`library.pubmed_library.fetch_semantic_scholar` to
-provide a dedicated namespace for Semantic Scholar related functionality.
-The underlying implementation already performs robust error handling and
-request retries.
+This module provides a thin processing wrapper around
+``library.clients.semantic_scholar``.  The client encapsulates HTTP concerns,
+while this module offers a semantic namespace for higher-level pipelines.
 """
 
 from __future__ import annotations
 
 import requests
 
-from . import pubmed_library as _pl
+from .clients import semantic_scholar as _client
 from .config import SemanticScholarCfg
 
 
@@ -40,7 +39,7 @@ def fetch_semantic_scholar(
         returned dictionary and never raise exceptions.
 
     """
-    return _pl.fetch_semantic_scholar(session, pmid, sleep, cfg=cfg)
+    return _client.fetch_semantic_scholar(session, pmid, sleep, cfg=cfg)
 
 
 def fetch_semantic_scholar_batch(
@@ -67,4 +66,4 @@ def fetch_semantic_scholar_batch(
         dictionary and never raise exceptions.
 
     """
-    return _pl.fetch_semantic_scholar_batch(session, pmids, sleep, cfg=cfg)
+    return _client.fetch_semantic_scholar_batch(session, pmids, sleep, cfg=cfg)

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -11,11 +11,8 @@ import pytest
 import requests
 
 from library import rate_limiter as rl
-from library.config import (
-    Config,
-    PubMedCfg,
-    SemanticScholarCfg,
-)
+from library.clients import semantic_scholar as ss_client
+from library.config import Config, PubMedCfg, SemanticScholarCfg
 from library.pubmed import query as pq
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -363,18 +360,15 @@ def test_fetch_semantic_scholar_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> Non
         )
         return {"publicationTypes": [], "externalIds": {}}, ""
 
-    sleeps: list[float] = []
-    monkeypatch.setattr(pq, "_do_request", fake_do_request)
-    monkeypatch.setattr(pq, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(ss_client, "_do_request", fake_do_request)
 
     session = requests.Session()
-    res = pq.fetch_semantic_scholar(session, "1", 0.2, cfg=cfg)
+    res = ss_client.fetch_semantic_scholar(session, "1", 0.2, cfg=cfg)
     assert res["scholar.Error"] == ""
     assert captured["url"] == "https://api.example.org/v1/paper/PMID:1"
     assert captured["timeout"] == (1, 2)
     assert captured["retries"] == 4
     assert captured["sleep"] == pytest.approx(1.0)
-    assert sleeps == []
 
 
 def test_fetch_semantic_scholar_batch_partial_response(
@@ -398,10 +392,10 @@ def test_fetch_semantic_scholar_batch_partial_response(
         },
     ]
 
-    monkeypatch.setattr(pq, "_do_request", lambda *_, **__: (payload, ""))
+    monkeypatch.setattr(ss_client, "_do_request", lambda *_, **__: (payload, ""))
 
     session = requests.Session()
-    results = pq.fetch_semantic_scholar_batch(session, ["1", "2", "3"], 0.0)
+    results = ss_client.fetch_semantic_scholar_batch(session, ["1", "2", "3"], 0.0)
 
     assert results[0]["scholar.Error"] == ""
     assert results[0]["scholar.PMID"] == "1"


### PR DESCRIPTION
## Summary
- add a dedicated `library.clients.semantic_scholar` client extracted from the former PubMed query module
- rewire wrappers and re-exports to use the new client path for Semantic Scholar
- update the Semantic Scholar tests to exercise the client module directly

## Testing
- pytest tests/test_pubmed_query.py
- pytest tests/test_pubmed_library_main_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68da515a49ec8324b33632cbdfa2593d