### PR TITLE
Clarify CLI subcommands and logging events in usage guides

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -2,9 +2,12 @@
 
 ## Shared CLI options
 
-All `scripts/get_*_data.py` commands share a common interface:
-
-Select the desired sub-command (`chembl`, `uniprot`, `iuphar`, or `all`) before supplying the shared options listed below.
+All `scripts/get_*_data.py` commands share a common interface. Only
+`scripts/get_document_data.py` and `scripts/get_target_data.py` expose
+source-selection sub-commands (`chembl`, `uniprot`, `iuphar`, or `all`);
+the remaining pipelines (`get_activity_data.py`, `get_assay_data.py`, and
+`get_testitem_data.py`) are single-command CLIs that accept options
+directly.
 
 | Option | Description |
 | --- | --- |
@@ -36,7 +39,8 @@ All entry points rely on `library.logging_setup.Logger` and emit JSON lines enri
 | Event | When it appears |
 | --- | --- |
 | `pipeline_start` | Immediately after the CLI configures logging and before validation begins. |
-| `documents_processed` / `activities_processed` | Periodic progress counters emitted inside the processing loops. |
+| `documents_processed` | Document pipeline progress counter emitted after each processed batch. |
+| `process_limit` | Recorded when `--limit` (or configuration equivalents) trims the identifier set. |
 | `write_done` | Successful CSV write including the path and retained row count. |
 | `pipeline_done` / `pipeline_fail` | Final outcome logged before exit. |
 

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -5,7 +5,12 @@
 
 ## Общие параметры CLI
 
-Все команды `scripts/get_*_data.py` поддерживают единый набор аргументов:
+Все команды `scripts/get_*_data.py` поддерживают единый набор аргументов.
+Подкоманды для выбора источника (`chembl`, `uniprot`, `iuphar`, `all`)
+доступны только у `scripts/get_document_data.py` и
+`scripts/get_target_data.py`; остальные скрипты (`get_activity_data.py`,
+`get_assay_data.py`, `get_testitem_data.py`) представляют собой одиночные
+CLI без вложенных подкоманд.
 
 | Опция | Назначение |
 | --- | --- |
@@ -37,7 +42,8 @@
 | Событие | Когда появляется |
 | --- | --- |
 | `pipeline_start` | После настройки логирования и перед валидацией конфигурации. |
-| `documents_processed` / `activities_processed` | Периодические счётчики прогресса внутри рабочих циклов. |
+| `documents_processed` | Счётчик прогресса документного пайплайна после каждого обработанного батча. |
+| `process_limit` | Фиксируется при обрезке списка идентификаторов опцией `--limit` или её эквивалентами в конфигурации. |
 | `write_done` | Успешная запись CSV с указанием пути и числа строк. |
 | `pipeline_done` / `pipeline_fail` | Финальный статус перед выходом из программы. |
 
@@ -124,7 +130,7 @@ python scripts/get_document_data.py pubmed \
 ## Агрегация таргетов (`get_target_data.py`)
 
 ```bash
-python scripts/get_target_data.py \
+python scripts/get_target_data.py chembl \
   --input path/to/targets.csv \
   --column target_chembl_id
 ```


### PR DESCRIPTION
## Summary
- clarify that only document and target pipelines expose source-selection sub-commands
- describe the remaining pipelines as single-command CLIs
- align logging tables with the actual events emitted, replacing the nonexistent activities_processed entry

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da5a47508c8324b1668e3703730017