### PR TITLE
Optimize get_testitem_data request parameters

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 import pandas as pd
 
@@ -113,6 +113,24 @@ TESTITEM_COLUMNS = [
     "standard_inchi",
     "standard_inchi_key",
 ]
+
+
+TESTITEM_QUERY_FIELDS = (
+    "molecule_chembl_id",
+    "parent_molecule_chembl_id",
+    "pref_name",
+    "max_phase",
+    "molecule_type",
+    "first_approval",
+    "oral",
+    "parenteral",
+    "topical",
+    "black_box_warning",
+    "structure_type",
+    "molecule_structures.canonical_smiles",
+    "molecule_structures.standard_inchi",
+    "molecule_structures.standard_inchi_key",
+)
 
 
 def get_assay(
@@ -333,7 +351,14 @@ def get_testitem(
         return pd.DataFrame(columns=TESTITEM_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = f"{cfg.chembl_base.rstrip('/')}/molecule.json?format=json"
+    base_params: list[tuple[str, str]] = [("format", "json")]
+    per_request_limit = chunk_size
+    if per_request_limit:
+        base_params.append(("limit", str(per_request_limit)))
+    if TESTITEM_QUERY_FIELDS:
+        base_params.append(("fields", ",".join(TESTITEM_QUERY_FIELDS)))
+    query_string = urlencode(base_params)
+    base = f"{cfg.chembl_base.rstrip('/')}/molecule.json?{query_string}"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         chunk_key = ",".join(chunk)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -218,7 +218,10 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        lookup[molecule_id] = parent_id or None
+        parent = parent_id or None
+        if parent is not None and parent == molecule_id:
+            parent = None
+        lookup[molecule_id] = parent
 
     return lookup
 
@@ -1424,7 +1427,7 @@ def prepare_parent_enrichment(
     parent_lookup_data = ParentLookupPreparedData(
         child_ids=normalised_ids,
         existing_parent_ids=existing_parent,
-        need_lookup=set(need_lookup),
+        need_lookup=set(initial_need_lookup),
     )
     if (
         lookup_resolved


### PR DESCRIPTION
## Summary
- set the molecule query limit to the configured chunk size and centralise the field selection for Chembl test item requests to avoid truncated batches
- filter hierarchy mappings where the parent equals the child and keep the lookup mask based on the original request set so fetched parents attach correctly

## Testing
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_failure -q
- pytest tests/smoke/test_get_testitem_parent.py::test_get_testitem_parent_catalog -q

------
https://chatgpt.com/codex/tasks/task_e_68da5ea8db9c8324b4092dc63987beab