### PR TITLE
Ensure get_target_data script can resolve project package imports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -18,6 +18,11 @@ from itertools import islice
 from pathlib import Path
 from typing import cast
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT_STR = str(PROJECT_ROOT)
+if PROJECT_ROOT_STR not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT_STR)
+
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors


### PR DESCRIPTION
## Summary
- add logic to inject the repository root into `sys.path` when running `scripts/get_target_data.py`
- prevent ModuleNotFound errors when executing the script directly via `python scripts/get_target_data.py`

## Testing
- `python -m compileall scripts/get_target_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68da7e5b9ce88324bba871d7042f12ed