### PR TITLE
Add offset support to data retrieval scripts

### DIFF
--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -20,6 +20,7 @@ directly.
 | `--encoding` | File encoding forwarded to `cfg.io.csv_encoding`. |
 | `--column` | Name of the identifier column. Defaults are populated from the configuration during start-up. |
 | `--batch-size` / `--chunk-size` | Maximum number of identifiers per API request (option name depends on the pipeline). |
+| `--offset` | Number of identifiers to skip before processing, useful for resuming interrupted runs. |
 
 Each parser may add domain-specific switches such as `--timeout`, `--limit` or `--dry-run`. After parsing, `apply_config_overrides`
 loads `config/config.yaml`, applies environment variables, merges CLI overrides back into the configuration, and updates missing CLI
@@ -41,6 +42,7 @@ All entry points rely on `library.logging_setup.Logger` and emit JSON lines enri
 | `pipeline_start` | Immediately after the CLI configures logging and before validation begins. |
 | `documents_processed` | Document pipeline progress counter emitted after each processed batch. |
 | `process_limit` | Recorded when `--limit` (or configuration equivalents) trims the identifier set. |
+| `process_offset` | Emitted when `--offset` advances the identifier iterator before processing. |
 | `write_done` | Successful CSV write including the path and retained row count. |
 | `pipeline_done` / `pipeline_fail` | Final outcome logged before exit. |
 
@@ -60,13 +62,14 @@ python scripts/get_activity_data.py \
   --input tests/data/activity_ids_small.csv \
   --column activity_id \
   --batch-size 25 \
-  --timeout 45
+  --timeout 45 \
+  --offset 5
 ```
 
 * The repository ships `tests/data/activity_ids_small.csv` for smoke-style runs; override `--column` to the file header (`activity_id`) or rename the column to `activity_chembl_id` to rely on defaults.
 * Reads the column configured at `sources.chembl.pipelines.activity.column` (`activity_chembl_id` by default).
 * Writes the main CSV, `*.meta.yaml`, optional `*_failure_cases.csv` and quality reports.
-* Supports `--limit` to restrict the number of identifiers and `--dry-run` to validate inputs without API calls.
+* Supports `--limit` to restrict the number of identifiers, `--offset` to resume after a known checkpoint and `--dry-run` to validate inputs without API calls.
 * Populates `lower_value` and `upper_value` using canonical `standard_*` fields. Tweak the behaviour via `activity_bounds.*` in the configuration (relation-based inference, ± parsing, rounding, clamping and logging).
 * Monitor warnings such as `activity_bounds_unknown_relation` or `activity_bounds_missing_standard_value` in the log output; they indicate rows where bounds could not be derived or the relation marker is not recognised.
 
@@ -91,7 +94,7 @@ python scripts/get_document_data.py all \
 ```
 
 The script merges ChEMBL and PubMed sources. Prepare a CSV with the `document_chembl_id` column or override `--column` to match your schema—the repository does not bundle a smoke dataset for this pipeline. Use the exposed flags (`--batch-size`, `--timeout`, `--limit`, `--dry-run`) for
-one-off tweaks. Nested parameters such as the PubMed batch size are managed via configuration or environment variables, for
+one-off tweaks. All sub-commands accept `--offset` to resume from a particular position in the input file. Nested parameters such as the PubMed batch size are managed via configuration or environment variables, for
 example:
 
 ```bash
@@ -131,6 +134,8 @@ python scripts/get_target_data.py chembl \
 
 Combines ChEMBL, UniProt and IUPHAR sources according to `sources.chembl.pipelines.target.*`. Create a CSV with a `target_chembl_id` header (one identifier per row) to execute the pipeline; no fixture ships with the repository. Swap `chembl` in the example for `uniprot`, `iuphar` or `all` to choose a different source mix.
 
+* Use `--offset` on any sub-command to skip identifiers that have already been processed in a previous run.
+
 ## Target pipeline harness (`library.utils.cli_tools.pipeline_targets_main`)
 
 ```bash
@@ -160,6 +165,8 @@ python scripts/get_testitem_data.py \
 ```
 
 Downloads compound-centric annotations for the supplied identifiers. The command can be executed with the bundled smoke dataset in `tests/data/input-smoke/testitem.csv` or any CSV that exposes the required identifier column.
+
+* Combine `--offset` with `--limit` to resume partially completed runs without re-reading identifiers that were already exported.
 
 ### Tracking `properties_hash`
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -89,6 +89,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
+        offset = getattr(args, "offset", 0)
+        if offset:
+            ids_iter = islice(ids_iter, offset, None)
+            logger.info("process_offset", offset=offset)
+
         # Apply the ``limit`` without materialising the entire iterator first.
         # ``itertools.islice`` allows lazy slicing; converting to ``list`` enables
         # length calculation for logging purposes.
@@ -260,6 +265,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Maximum number of identifiers to process",
     )
     parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Read input and exit without contacting the API or writing files",
@@ -275,6 +286,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.limit is not None and args.limit <= 0:
         # Reject non-positive limits early to provide clear CLI feedback.
         parser.error("--limit must be a positive integer")
+    if args.offset < 0:
+        parser.error("--offset must be zero or a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -76,6 +76,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
+        offset = getattr(args, "offset", 0)
+        if offset:
+            ids_iter = islice(ids_iter, offset, None)
+            logger.info("process_offset", offset=offset)
+
         ids = ids_iter
         if limit is not None:
             limited_ids = list(islice(ids_iter, limit))
@@ -229,6 +234,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -239,6 +250,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit <= 0:
         parser.error("--limit must be a positive integer")
+    if args.offset < 0:
+        parser.error("--offset must be zero or a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -828,6 +828,10 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             path=str(args.input_csv),
         )
         return 1
+    offset = getattr(args, "offset", 0)
+    if offset:
+        pmids_iter = islice(pmids_iter, offset, None)
+        logger.info("process_offset", offset=offset)
     pmids: Iterable[str] = pmids_iter
     if limit is not None:
         limited_pmids = list(islice(pmids_iter, limit))
@@ -928,6 +932,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
+        offset = getattr(args, "offset", 0)
+        if offset:
+            ids_iter = islice(ids_iter, offset, None)
+            logger.info("process_offset", offset=offset)
+
         ids: Iterable[str] = ids_iter
         if limit is not None:
             limited_ids = list(islice(ids_iter, limit))
@@ -1000,6 +1009,11 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             path=str(args.input_csv),
         )
         return 1
+
+    offset = getattr(args, "offset", 0)
+    if offset:
+        ids_iter = islice(ids_iter, offset, None)
+        logger.info("process_offset", offset=offset)
 
     ids_source: Iterable[str] = ids_iter
     if limit is not None:
@@ -1141,6 +1155,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Maximum number of identifiers to process",
     )
     pubmed.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
+    pubmed.add_argument(
         "--openalex-rps",
         type=float,
         default=None,
@@ -1196,6 +1216,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    chembl.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
     chembl.set_defaults(func=run_chembl)
 
     all_cmd = sub.add_parser(
@@ -1240,6 +1266,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Maximum number of identifiers to process",
     )
     all_cmd.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
+    all_cmd.add_argument(
         "--openalex-rps",
         type=float,
         default=None,
@@ -1271,6 +1303,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     limit_value = getattr(args, "limit", None)
     if limit_value is not None and limit_value <= 0:
         subparser.error("--limit must be a positive integer")
+    offset_value = getattr(args, "offset", 0)
+    if offset_value < 0:
+        subparser.error("--offset must be zero or a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -223,6 +223,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    uniprot.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
     uniprot.set_defaults(func=run_uniprot)
 
     # ----------------------------
@@ -255,6 +261,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=int,
         default=None,
         help="Maximum number of identifiers to process",
+    )
+    chembl.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -289,6 +301,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=int,
         default=None,
         help="Maximum number of rows to process",
+    )
+    iuphar.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
     )
     iuphar.set_defaults(func=run_iuphar)
 
@@ -363,6 +381,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    all_cmd.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
     all_cmd.set_defaults(func=run_all)
 
     parser.subparsers_map = {  # type: ignore[attr-defined]
@@ -416,6 +440,11 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         df = df[(df[column].str.strip() != "") & (df[column] != "#N/A")].reset_index(
             drop=True
         )
+        offset = getattr(args, "offset", 0)
+        if offset:
+            original_rows = len(df)
+            df = df.iloc[offset:].reset_index(drop=True)
+            logger.info("process_offset", offset=min(offset, original_rows))
         if limit is not None:
             df = df.head(limit)
             logger.info("process_limit", limit=len(df))
@@ -541,6 +570,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 path=str(args.input_csv),
             )
             return 1
+
+        offset = getattr(args, "offset", 0)
+        if offset:
+            ids_iter = islice(ids_iter, offset, None)
+            logger.info("process_offset", offset=offset)
 
         ids = ids_iter
         if limit is not None:
@@ -673,20 +707,29 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     source_csv = args.input_csv
 
     try:
-        if limit is not None:
-            df_limited = pd.read_csv(
+        df_to_process: pd.DataFrame | None = None
+        offset = getattr(args, "offset", 0)
+        if limit is not None or offset:
+            df_full = pd.read_csv(
                 args.input_csv,
                 sep=cfg.io.csv_sep,
                 encoding=cfg.io.csv_encoding,
                 dtype=str,
-                nrows=limit,
             )
-            logger.info("process_limit", limit=len(df_limited))
+            if offset:
+                total_rows = len(df_full)
+                df_full = df_full.iloc[offset:].reset_index(drop=True)
+                logger.info("process_offset", offset=min(offset, total_rows))
+            if limit is not None:
+                df_full = df_full.head(limit)
+                logger.info("process_limit", limit=len(df_full))
+            df_to_process = df_full
+        if df_to_process is not None:
             from tempfile import NamedTemporaryFile
 
             with NamedTemporaryFile(delete=False) as tmp:
                 tmp_path = Path(tmp.name)
-            df_limited.to_csv(
+            df_to_process.to_csv(
                 tmp_path,
                 index=False,
                 sep=cfg.io.csv_sep,
@@ -737,6 +780,7 @@ def fetch_chembl(
     limit: int | None = None,
     *,
     chunk_size: int | None = None,
+    offset: int = 0,
 ) -> pd.DataFrame:
     """Fetch target information from ChEMBL.
 
@@ -758,7 +802,9 @@ def fetch_chembl(
     """
 
     logger.info("fetch_chembl_start", input=str(input_csv), output=str(output_csv))
-    chembl_args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+    chembl_args = argparse.Namespace(
+        input_csv=input_csv, output_csv=output_csv, offset=offset
+    )
     original_limit = cfg.target.chembl.limit
     original_chunk_size = cfg.target.chembl.chunk_size
     if limit is not None:
@@ -1111,6 +1157,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             chembl_out,
             limit=limit,
             chunk_size=cfg.target.all.chunk_size,
+            offset=getattr(args, "offset", 0),
         )
         uniprot_df = fetch_uniprot(cfg, chembl_df, uniprot_out)
         combined_df, iuphar_df = fetch_iuphar(cfg, chembl_df, uniprot_df, iuphar_out)
@@ -1137,6 +1184,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     limit_value = getattr(args, "limit", None)
     if limit_value is not None and limit_value <= 0:
         subparser.error("--limit must be a positive integer")
+    offset_value = getattr(args, "offset", 0)
+    if offset_value < 0:
+        subparser.error("--offset must be zero or a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1225,11 +1225,15 @@ def read_input_ids(
     column: str,
     io_cfg: IoCfg,
     limit: int | None,
+    offset: int = 0,
 ) -> tuple[int, ReadInputIdsResult | None]:
     """Load identifiers from ``input_csv`` honouring ``limit`` when provided."""
 
     try:
         ids_iter = io.read_ids(input_csv, column=column, cfg=io_cfg)
+        if offset:
+            ids_iter = islice(ids_iter, offset, None)
+            logger.info("process_offset", offset=offset)
         if limit is not None:
             ids_iter = islice(ids_iter, limit)
         ids_iter, sample_iter = tee(ids_iter)
@@ -1701,6 +1705,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             column=cfg.testitem.column,
             io_cfg=cfg.io,
             limit=limit,
+            offset=getattr(args, "offset", 0),
         )
         if read_status != 0 or read_result is None:
             return read_status
@@ -1809,6 +1814,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Maximum number of identifiers to process",
     )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
     parser.set_defaults(func=run_chembl)
     return parser, log_cfg
 
@@ -1819,6 +1830,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit <= 0:
         parser.error("--limit must be a positive integer")
+    if args.offset < 0:
+        parser.error("--offset must be zero or a positive integer")
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)


### PR DESCRIPTION
## Summary
- add a shared `--offset` CLI option across the activity, assay, document, target and test item pipelines
- skip the requested number of identifiers before fetching data and log the applied offset in each runner
- document the new resume behaviour and logging events in `docs/USAGE_EN.md`

## Testing
- `PYTHONPATH=. python scripts/get_activity_data.py --config config/config.yaml --input tests/data/activity_ids_small.csv --column activity_id --batch-size 2 --offset 0 --dry-run`
- `PYTHONPATH=. python scripts/get_activity_data.py --config config/config.yaml --input tests/data/activity_ids_small.csv --column activity_id --batch-size 2 --offset 2 --dry-run`
- `PYTHONPATH=. python - <<'PY' ...`
- `pytest tests/test_chunk_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68da7efb808c832499523d481bf7fc8f