### PR TITLE
Fix missing logger import in IUPHAR library

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -29,6 +29,7 @@ from .clients.iuphar import (
     query_gene_symbol,
 )
 from .config import IupharCfg, RetryCfg
+from .log import logger
 
 @dataclass
 class IUPHARData:


### PR DESCRIPTION
## Summary
- import the shared structured logger in `library/iuphar_library.py` so logging works inside `map_uniprot_file`

## Testing
- python -m compileall library/iuphar_library.py

------
https://chatgpt.com/codex/tasks/task_e_68da88fce5a08324a866f1377d5f5bb4