### PR TITLE
Optimize test item retrieval and configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -682,8 +682,9 @@
           "type": "integer"
         },
         "batch_size": {
-          "default": 5,
+          "default": 1000,
           "minimum": 1,
+          "maximum": 1000,
           "title": "Batch Size",
           "type": "integer"
         },
@@ -705,6 +706,68 @@
           ],
           "default": null,
           "title": "Limit"
+        },
+        "offset": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Offset",
+          "type": "integer"
+        },
+        "fields": {
+          "default": [
+            "molecule_chembl_id",
+            "parent_molecule_chembl_id",
+            "pref_name",
+            "max_phase",
+            "molecule_type",
+            "first_approval",
+            "oral",
+            "parenteral",
+            "topical",
+            "black_box_warning",
+            "structure_type",
+            "molecule_structures.canonical_smiles",
+            "molecule_structures.standard_inchi",
+            "molecule_structures.standard_inchi_key"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "request_limit": {
+          "default": 1000,
+          "minimum": 1,
+          "maximum": 1000,
+          "title": "Request Limit",
+          "type": "integer"
+        },
+        "retries": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retries"
+        },
+        "backoff_factor": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Backoff Factor"
         }
       },
       "title": "DocumentAllCfg",
@@ -1582,8 +1645,9 @@
           "type": "string"
         },
         "batch_size": {
-          "default": 5,
+          "default": 1000,
           "minimum": 1,
+          "maximum": 1000,
           "title": "Batch Size",
           "type": "integer"
         },
@@ -1605,6 +1669,68 @@
           ],
           "default": null,
           "title": "Limit"
+        },
+        "offset": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Offset",
+          "type": "integer"
+        },
+        "fields": {
+          "default": [
+            "molecule_chembl_id",
+            "parent_molecule_chembl_id",
+            "pref_name",
+            "max_phase",
+            "molecule_type",
+            "first_approval",
+            "oral",
+            "parenteral",
+            "topical",
+            "black_box_warning",
+            "structure_type",
+            "molecule_structures.canonical_smiles",
+            "molecule_structures.standard_inchi",
+            "molecule_structures.standard_inchi_key"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "request_limit": {
+          "default": 1000,
+          "minimum": 1,
+          "maximum": 1000,
+          "title": "Request Limit",
+          "type": "integer"
+        },
+        "retries": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retries"
+        },
+        "backoff_factor": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Backoff Factor"
         }
       },
       "title": "TestitemCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,9 +46,28 @@ sources:
         limit: null
       testitem:
         column: "molecule_chembl_id"
-        batch_size: 50
+        batch_size: 1000
         timeout: 30.0
         limit: null
+        offset: 0
+        request_limit: 1000
+        retries: 5
+        backoff_factor: 0.5
+        fields:
+          - molecule_chembl_id
+          - parent_molecule_chembl_id
+          - pref_name
+          - max_phase
+          - molecule_type
+          - first_approval
+          - oral
+          - parenteral
+          - topical
+          - black_box_warning
+          - structure_type
+          - molecule_structures.canonical_smiles
+          - molecule_structures.standard_inchi
+          - molecule_structures.standard_inchi_key
       document:
         pubmed:
           column: "PMID"

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -166,6 +166,31 @@ python scripts/get_testitem_data.py \
 
 Downloads compound-centric annotations for the supplied identifiers. The command can be executed with the bundled smoke dataset in `tests/data/input-smoke/testitem.csv` or any CSV that exposes the required identifier column.
 
+The CLI now derives pagination defaults from `sources.chembl.pipelines.testitem` in `config.yaml`. By default the pipeline requests 1,000 molecules per call (`batch_size`/`request_limit`) and limits responses to the fields listed under `testitem.fields` to minimise payload size. Adjust these values in the configuration or via environment overrides when a smaller batch size or additional columns are required:
+
+```yaml
+sources:
+  chembl:
+    pipelines:
+      testitem:
+        offset: 500        # skip the first 500 IDs
+        request_limit: 750 # clamp per-request limit below the API maximum
+        fields:
+          - molecule_chembl_id
+          - pref_name
+          - structure_type
+```
+
+Run a configuration-backed export with the tuned settings:
+
+```bash
+python scripts/get_testitem_data.py \
+  --config config/config.yaml \
+  --input data/input/testitem_ids.csv \
+  --batch-size 750 \
+  --offset 500
+```
+
 * Combine `--offset` with `--limit` to resume partially completed runs without re-reading identifiers that were already exported.
 
 ### Tracking `properties_hash`

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -167,6 +167,31 @@ python scripts/get_testitem_data.py \
 
 Выгружает дополнительную информацию о соединениях. Можно использовать комплект `tests/data/input-smoke/testitem.csv` или собственный CSV с нужной колонкой идентификаторов.
 
+Параметры пагинации теперь берутся из секции `sources.chembl.pipelines.testitem` файла `config.yaml`. По умолчанию пайплайн запрашивает 1000 молекул за вызов (`batch_size`/`request_limit`) и ограничивает ответ полями из `testitem.fields`, чтобы не грузить лишние данные. При необходимости уменьшить батч или добавить дополнительные колонки достаточно изменить конфигурацию или задать переменные окружения:
+
+```yaml
+sources:
+  chembl:
+    pipelines:
+      testitem:
+        offset: 500        # пропустить первые 500 идентификаторов
+        request_limit: 750 # зафиксировать предел страницы ниже максимального значения API
+        fields:
+          - molecule_chembl_id
+          - pref_name
+          - structure_type
+```
+
+Пример запуска с кастомными настройками:
+
+```bash
+python scripts/get_testitem_data.py \
+  --config config/config.yaml \
+  --input data/input/testitem_ids.csv \
+  --batch-size 750 \
+  --offset 500
+```
+
 ### Контроль `properties_hash`
 
 PubChem-дополнение добавляет детерминированные свойства (`pubchem_cid`, `pubchem_iupac_name`, `pubchem_molecular_formula`,

--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode, urljoin
 import pandas as pd
 
 from library.clients import ChemblClient, _chunked
-from .config import ApiCfg
+from .config import ApiCfg, TESTITEM_FIELD_DEFAULTS
 from .log import logger
 from .pandas_utils import json_normalize_pyarrow
 
@@ -115,22 +115,7 @@ TESTITEM_COLUMNS = [
 ]
 
 
-TESTITEM_QUERY_FIELDS = (
-    "molecule_chembl_id",
-    "parent_molecule_chembl_id",
-    "pref_name",
-    "max_phase",
-    "molecule_type",
-    "first_approval",
-    "oral",
-    "parenteral",
-    "topical",
-    "black_box_warning",
-    "structure_type",
-    "molecule_structures.canonical_smiles",
-    "molecule_structures.standard_inchi",
-    "molecule_structures.standard_inchi_key",
-)
+TESTITEM_QUERY_FIELDS = TESTITEM_FIELD_DEFAULTS
 
 
 def get_assay(
@@ -325,6 +310,8 @@ def get_testitem(
     client: ChemblClient,
     chunk_size: int = 5,
     timeout: float | None = None,
+    fields: Sequence[str] | None = None,
+    page_limit: int = 1000,
 ) -> pd.DataFrame:
     """Fetch compound records for *ids*.
 
@@ -351,25 +338,42 @@ def get_testitem(
         return pd.DataFrame(columns=TESTITEM_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base_params: list[tuple[str, str]] = [("format", "json")]
-    per_request_limit = chunk_size
-    if per_request_limit:
-        base_params.append(("limit", str(per_request_limit)))
-    if TESTITEM_QUERY_FIELDS:
-        base_params.append(("fields", ",".join(TESTITEM_QUERY_FIELDS)))
+    effective_fields = tuple(fields) if fields else TESTITEM_QUERY_FIELDS
+    max_limit = max(1, min(page_limit, 1000))
+    effective_chunk = max(1, min(chunk_size, max_limit))
+    base_params: list[tuple[str, str]] = [("format", "json"), ("limit", str(max_limit))]
+    if effective_fields:
+        base_params.append(("fields", ",".join(effective_fields)))
     query_string = urlencode(base_params)
     base = f"{cfg.chembl_base.rstrip('/')}/molecule.json?{query_string}"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    for chunk in _chunked(valid, chunk_size):
+    for chunk in _chunked(valid, effective_chunk):
         chunk_key = ",".join(chunk)
         logger.info(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
         url = f"{base}&molecule_chembl_id__in={chunk_key}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("molecules") or data.get("molecule") or []
-        if items:
-            records.append(json_normalize_pyarrow(items))
+        next_url: str | None = url
+        seen_urls: set[str] = set()
+        chunk_frames: list[pd.DataFrame] = []
+        while next_url:
+            absolute_url = urljoin(cfg.chembl_base, next_url)
+            if absolute_url in seen_urls:
+                logger.warning(
+                    "pagination_loop_detected",
+                    extra={"stage": "chunk_loop", "chunk_key": chunk_key},
+                )
+                break
+            seen_urls.add(absolute_url)
+            data = client.request_json(absolute_url, cfg=cfg, timeout=effective_timeout)
+            items = data.get("molecules") or data.get("molecule") or []
+            if items:
+                chunk_frames.append(json_normalize_pyarrow(items))
+            page_meta = data.get("page_meta") or {}
+            next_token = page_meta.get("next")
+            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+        if chunk_frames:
+            records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(
                 "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
             )

--- a/library/config.py
+++ b/library/config.py
@@ -89,6 +89,25 @@ class _BoolModel(_BaseModel):
         raise ValueError(f"Invalid boolean value: {value!r}")
 
 
+# ChEMBL test item fields requested by default when fetching molecule data.
+TESTITEM_FIELD_DEFAULTS: tuple[str, ...] = (
+    "molecule_chembl_id",
+    "parent_molecule_chembl_id",
+    "pref_name",
+    "max_phase",
+    "molecule_type",
+    "first_approval",
+    "oral",
+    "parenteral",
+    "topical",
+    "black_box_warning",
+    "structure_type",
+    "molecule_structures.canonical_smiles",
+    "molecule_structures.standard_inchi",
+    "molecule_structures.standard_inchi_key",
+)
+
+
 class ApiCfg(_BaseModel):
     """Settings for ChEMBL API access."""
 
@@ -640,9 +659,23 @@ class AssayCfg(_BaseModel):
 
 class TestitemCfg(_BaseModel):
     column: str = "molecule_chembl_id"
-    batch_size: int = Field(5, ge=1)
+    batch_size: int = Field(1000, ge=1, le=1000)
     timeout: float = Field(30.0, ge=0)
     limit: int | None = Field(default=None, ge=0)
+    offset: int = Field(0, ge=0)
+    fields: tuple[str, ...] = Field(default=TESTITEM_FIELD_DEFAULTS)
+    request_limit: int = Field(1000, ge=1, le=1000)
+    retries: int | None = Field(default=None, ge=0)
+    backoff_factor: float | None = Field(default=None, ge=0)
+
+    @field_validator("fields", mode="before")
+    @classmethod
+    def _coerce_fields(cls, value: Any) -> tuple[str, ...]:
+        if value is None:
+            return TESTITEM_FIELD_DEFAULTS
+        if isinstance(value, (list, tuple)):
+            return tuple(str(item) for item in value)
+        raise TypeError("testitem.fields must be a list or tuple of strings")
 
 
 class TestitemMoleculeEnrichmentSourcesCfg(_BaseModel):

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -730,18 +730,19 @@ def attach_parent_molecule_ids(
         catalog_data = ChainMap({}, base_view)
     else:
         catalog_data = {}
-        queried = query_parent_catalog(unique_children, catalog_cfg)
-        if queried:
-            catalog_data.update(queried)
-            used_partial_cache = True
-            if source_resolved is None:
-                source_resolved = PARENT_LOOKUP_SOURCE_CACHE
-        else:
-            sqlite_exists = catalog_cfg.sqlite_path.is_file()
-            used_partial_cache = sqlite_exists
-            if sqlite_exists:
+        if unique_children:
+            queried = query_parent_catalog(unique_children, catalog_cfg)
+            if queried:
+                catalog_data.update(queried)
+                used_partial_cache = True
                 if source_resolved is None:
                     source_resolved = PARENT_LOOKUP_SOURCE_CACHE
+            else:
+                sqlite_exists = catalog_cfg.sqlite_path.is_file()
+                used_partial_cache = sqlite_exists
+                if sqlite_exists:
+                    if source_resolved is None:
+                        source_resolved = PARENT_LOOKUP_SOURCE_CACHE
 
     parent_map = {
         key: catalog_data[key] for key in unique_children if key in catalog_data
@@ -862,6 +863,8 @@ def add_pubchem_data(
     resolution_cache: MutableMapping[tuple[str | None, ...], pl.PubChemResolution]
     | None = None,
     parent_record_cache: MutableMapping[str, pd.Series | None] | None = None,
+    testitem_fields: Sequence[str] | None = None,
+    request_limit: int = 1000,
 ) -> pd.DataFrame:
     """Augment ChEMBL records with PubChem information.
 
@@ -1004,6 +1007,8 @@ def add_pubchem_data(
                 client=client,
                 chunk_size=chunk_size,
                 timeout=timeout,
+                fields=testitem_fields,
+                page_limit=request_limit,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.warning(
@@ -1257,6 +1262,8 @@ def fetch_testitems(
     timeout: float,
     client: ChemblClient,
     sample_ids: Sequence[str],
+    fields: Sequence[str] | None,
+    page_limit: int,
 ) -> tuple[int, pd.DataFrame | None]:
     """Retrieve ChEMBL test item records for ``ids_iter``."""
 
@@ -1268,6 +1275,8 @@ def fetch_testitems(
             client=client,
             chunk_size=batch_size,
             timeout=timeout,
+            fields=fields,
+            page_limit=page_limit,
         )
     except (requests.RequestException, ValueError) as exc:
         logger.error(
@@ -1431,7 +1440,7 @@ def prepare_parent_enrichment(
     parent_lookup_data = ParentLookupPreparedData(
         child_ids=normalised_ids,
         existing_parent_ids=existing_parent,
-        need_lookup=set(initial_need_lookup),
+        need_lookup=set(need_lookup),
     )
     if (
         lookup_resolved
@@ -1508,6 +1517,8 @@ def augment_pubchem(
     api_cfg: ApiCfg,
     timeout: float,
     client: ChemblClient,
+    fields: Sequence[str] | None,
+    request_limit: int,
 ) -> pd.DataFrame:
     """Augment ``df`` with PubChem information if enabled."""
 
@@ -1534,6 +1545,8 @@ def augment_pubchem(
         cid_cache=pubchem_cid_cache,
         resolution_cache=pubchem_resolution_cache,
         parent_record_cache=pubchem_parent_record_cache,
+        testitem_fields=fields,
+        request_limit=request_limit,
     )
     logger.info("pubchem_augment_done")
     return result
@@ -1697,26 +1710,35 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 1
 
-    pc.init_session(cfg.api, cfg.retry)
+    api_overrides: dict[str, Any] = {}
+    if cfg.testitem.retries is not None:
+        api_overrides["retries"] = cfg.testitem.retries
+    if cfg.testitem.backoff_factor is not None:
+        api_overrides["backoff_factor"] = cfg.testitem.backoff_factor
+    api_cfg = cfg.api.model_copy(update=api_overrides) if api_overrides else cfg.api
 
-    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+    pc.init_session(api_cfg, cfg.retry)
+
+    with ChemblClient(api_cfg, cfg.retry, cfg.chembl) as client:
         read_status, read_result = read_input_ids(
             args.input_csv,
             column=cfg.testitem.column,
             io_cfg=cfg.io,
             limit=limit,
-            offset=getattr(args, "offset", 0),
+            offset=getattr(args, "offset", cfg.testitem.offset),
         )
         if read_status != 0 or read_result is None:
             return read_status
 
         fetch_status, df = fetch_testitems(
             read_result.ids_iter,
-            api_cfg=cfg.api,
+            api_cfg=api_cfg,
             batch_size=cfg.testitem.batch_size,
             timeout=cfg.testitem.timeout,
             client=client,
             sample_ids=read_result.sample_ids,
+            fields=cfg.testitem.fields,
+            page_limit=cfg.testitem.request_limit,
         )
         if fetch_status != 0 or df is None:
             return fetch_status
@@ -1736,7 +1758,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df,
             catalog_cfg=cfg.molecule_catalog,
             io_cfg=cfg.io,
-            api_cfg=cfg.api,
+            api_cfg=api_cfg,
             timeout=cfg.testitem.timeout,
             client=client,
             hierarchy_lookup_path=hierarchy_lookup_path,
@@ -1748,7 +1770,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         parent_status, parent_result = run_parent_enrichment(
             prep,
             client=client,
-            api_cfg=cfg.api,
+            api_cfg=api_cfg,
             catalog_cfg=cfg.molecule_catalog,
             timeout=cfg.testitem.timeout,
         )
@@ -1761,9 +1783,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         df = augment_pubchem(
             df,
             pubchem_cfg=cfg.pubchem,
-            api_cfg=cfg.api,
+            api_cfg=api_cfg,
             timeout=cfg.testitem.timeout,
             client=client,
+            fields=cfg.testitem.fields,
+            request_limit=cfg.testitem.request_limit,
         )
 
         enrichment_status, enriched_df = apply_testitem_enrichment(
@@ -1798,7 +1822,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     parser, log_cfg = base_parser(
         "ChEMBL and PubChem compound data utilities",
         column="molecule_chembl_id",
-        chunk_size=5,
+        chunk_size=1000,
         size_option="--batch-size",
         size_dest="batch_size",
     )
@@ -1845,6 +1869,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "column": "testitem.column",
                 "batch_size": "testitem.batch_size",
                 "limit": "testitem.limit",
+                "offset": "testitem.offset",
             },
         )
         if args.print_config:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -69,6 +69,27 @@ def test_read_input_ids_limit_and_sample(
     assert result.sample_ids == ("CHEMBL1",)
 
 
+def test_read_input_ids_offset(tmp_path: Path, cfg: Config) -> None:
+    input_csv = tmp_path / "testitems.csv"
+    input_csv.write_text(
+        "molecule_chembl_id\nCHEMBL1\nCHEMBL2\nCHEMBL3\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    status, result = gtd.read_input_ids(
+        input_csv,
+        column=cfg.testitem.column,
+        io_cfg=cfg.io,
+        limit=None,
+        offset=2,
+    )
+
+    assert status == 0
+    assert result is not None
+    assert list(result.ids_iter) == ["CHEMBL3"]
+    assert result.sample_ids == ("CHEMBL3",)
+
+
 def test_read_input_ids_missing_file(tmp_path: Path, cfg: Config) -> None:
     status, result = gtd.read_input_ids(
         tmp_path / "missing.csv",
@@ -94,10 +115,50 @@ def test_fetch_testitems_failure(monkeypatch: pytest.MonkeyPatch, cfg: Config) -
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
         sample_ids=("CHEMBL1",),
+        fields=cfg.testitem.fields,
+        page_limit=cfg.testitem.request_limit,
     )
 
     assert status == 1
     assert df is None
+
+
+def test_fetch_testitems_passes_fields_and_limit(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_get_testitem(
+        ids: Iterable[str],
+        *,
+        cfg: ApiCfg,
+        client: object,
+        chunk_size: int,
+        timeout: float | None,
+        fields: Sequence[str] | None = None,
+        page_limit: int = 0,
+    ) -> pd.DataFrame:
+        captured["fields"] = fields
+        captured["page_limit"] = page_limit
+        return pd.DataFrame(columns=["molecule_chembl_id"])
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+
+    status, df = gtd.fetch_testitems(
+        iter(["CHEMBL1", "CHEMBL2"]),
+        api_cfg=cfg.api,
+        batch_size=2,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        sample_ids=("CHEMBL1",),
+        fields=("a", "b"),
+        page_limit=500,
+    )
+
+    assert status == 0
+    assert df is not None
+    assert captured["fields"] == ("a", "b")
+    assert captured["page_limit"] == 500
 
 
 def test_prepare_parent_enrichment_uses_lookup_path(
@@ -112,7 +173,7 @@ def test_prepare_parent_enrichment_uses_lookup_path(
 
     captured_path: Path | None = None
 
-    def fake_lookup(path: Path | None, *, io_cfg: IoCfg) -> dict[str, str]:
+    def fake_lookup(path: Path | None, *, io_cfg: IoCfg, **_: object) -> dict[str, str]:
         nonlocal captured_path
         captured_path = path
         return {"CHEMBL1": "CHEMBL999"}
@@ -209,10 +270,14 @@ def test_augment_pubchem_initialises_caches(
         api_cfg=cfg.api,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
+        fields=cfg.testitem.fields,
+        request_limit=cfg.testitem.request_limit,
     )
 
     assert captured["load_args"] == (cfg.pubchem.cid_cache_path, cfg.pubchem.cache_ttl_hours)
     assert "cid_cache" in captured["add_kwargs"]
+    assert captured["add_kwargs"].get("testitem_fields") == cfg.testitem.fields
+    assert captured["add_kwargs"].get("request_limit") == cfg.testitem.request_limit
     assert "pubchem_cid" in result.columns
 
 
@@ -335,7 +400,10 @@ def test_load_molecule_hierarchy_lookup_missing_columns(
 
 
 def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> None:
-    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    df = pd.DataFrame({
+        "molecule_chembl_id": ["CHEMBL1"],
+        "canonical_smiles": ["C"],
+    })
     cfg = pl.PubChemCfg(delay=0)
 
     monkeypatch.setattr(
@@ -343,12 +411,21 @@ def test_add_pubchem_data_missing_uses_na(monkeypatch: pytest.MonkeyPatch) -> No
         "resolve_pubchem_record",
         lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
     )
+    monkeypatch.setattr(gtd, "_load_pubchem_cid_cache", lambda *_, **__: {})
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, cfg: calls.append(cid) or pl.Properties(None, None, None, None, None, None),
+    )
 
     result = gtd.add_pubchem_data(df, cfg)
     pubchem_cols = [col for col in result.columns if col.startswith("pubchem_")]
     assert pubchem_cols
     assert result[pubchem_cols].isna().all().all()
     assert not (result[pubchem_cols] == "Not Found").any().any()
+    assert calls == []
 
 
 def test_add_pubchem_data_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -369,7 +446,9 @@ def test_add_pubchem_data_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_add_pubchem_data_not_found_literal(monkeypatch: pytest.MonkeyPatch) -> None:
-    df = pd.DataFrame({"canonical_smiles": ["C"]})
+    df = pd.DataFrame(
+        {"molecule_chembl_id": ["CHEMBL1"], "canonical_smiles": ["C"]}
+    )
     cfg = pl.PubChemCfg(delay=0, write_not_found_literal=True)
 
     monkeypatch.setattr(
@@ -377,6 +456,12 @@ def test_add_pubchem_data_not_found_literal(monkeypatch: pytest.MonkeyPatch) -> 
         "resolve_pubchem_record",
         lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
     )
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, cfg: pl.Properties(None, None, None, None, None, None),
+    )
+    monkeypatch.setattr(gtd, "_load_pubchem_cid_cache", lambda *_, **__: {})
 
     result = gtd.add_pubchem_data(df, cfg)
 
@@ -420,6 +505,7 @@ def test_add_pubchem_data_reuses_resolution_cache(
         "get_properties",
         lambda cid, cfg: pl.Properties(None, None, None, None, None, None),
     )
+    monkeypatch.setattr(gtd, "_load_pubchem_cid_cache", lambda *_, **__: {})
 
     result = gtd.add_pubchem_data(df, cfg)
 
@@ -452,6 +538,8 @@ def test_add_pubchem_data_prefetches_parent_records(
         client: object,
         chunk_size: int,
         timeout: float | None,
+        fields: Sequence[str] | None = None,
+        page_limit: int = 1000,
     ) -> pd.DataFrame:
         calls.append((tuple(ids), chunk_size, timeout))
         return pd.DataFrame(
@@ -628,7 +716,11 @@ def test_add_pubchem_data_preserves_existing_values(
         return "333"
 
     monkeypatch.setattr(gtd, "resolve_pubchem_cid", fake_resolve)
-    monkeypatch.setattr(pl, "get_properties", lambda cid, cfg: None)
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, cfg: pl.Properties(None, None, None, None, None, None),
+    )
     monkeypatch.setattr(
         gtd.logger,
         "warning",
@@ -922,9 +1014,8 @@ def test_run_chembl_column_order(
     )
 
     monkeypatch.setattr(cl, "get_testitem", lambda *_, **__: df)
-    monkeypatch.setattr(
-        gtd, "load_parent_catalog", lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"}
-    )
+    precomputed_catalog = {"CHEMBL1": "CHEMBL1_PARENT"}
+    monkeypatch.setattr(gtd, "load_parent_catalog", lambda **__: precomputed_catalog)
     monkeypatch.setattr(
         gtd.molecule_catalog,
         "fetch_parent_catalog_for",
@@ -997,12 +1088,20 @@ def test_run_chembl_column_order(
         prepared.existing_parent_ids.tolist()
         == expected_prepared.existing_parent_ids.tolist()
     )
-    expected_need_lookup = set(
-        expected_prepared.child_ids[
-            (expected_prepared.child_ids != "")
-            & (expected_prepared.existing_parent_ids == "")
-        ]
+    parent_field = cfg.molecule_catalog.parent_field
+    child_field = cfg.molecule_catalog.child_field
+    existing_parent = (
+        captured_frame.get(parent_field)
+        if parent_field in captured_frame
+        else pd.Series([""], index=captured_frame.index, dtype="string")
     )
+    normalised_parent = existing_parent.astype("string").fillna("").str.strip()
+    child_ids = captured_frame.get(child_field, pd.Series([], dtype="string"))
+    if child_ids.empty:
+        child_ids = prepared.child_ids
+    normalised_child = child_ids.astype("string").fillna("").str.upper()
+    expected_need_lookup = set(normalised_child[normalised_parent == ""])
+    expected_need_lookup -= set(precomputed_catalog)
     assert prepared.need_lookup == expected_need_lookup
 
     available = set(captured.get("columns", []))
@@ -1347,7 +1446,7 @@ def test_run_chembl_prefills_parent_from_hierarchy(
 
     captured_path: Path | None = None
 
-    def fake_lookup(path: Path | None, *, io_cfg: object) -> dict[str, str]:
+    def fake_lookup(path: Path | None, *, io_cfg: object, **_: object) -> dict[str, str]:
         nonlocal captured_path
         captured_path = path
         return {"CHEMBL1": "CHEMBL1_PARENT"}


### PR DESCRIPTION
## Summary
- raise the test-item pipeline defaults to the ChemBL per-request maximum and expose the new knobs via config validation
- clamp ChemBL molecule pagination, propagate field selections, and skip redundant parent lookups when no IDs remain
- document the new CLI/config options and extend the test suite to cover pagination, offsets, and cache fallbacks

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68da8a441900832485d457a39358db01