### PR TITLE
Avoid helper fallback for parentless-filtered parent catalog lookups

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -231,7 +231,10 @@ def _fetch_parent_catalog_via_helper(
 
     try:
         if not allow_single_lookup:
-            chunk_size = max(1, cfg.page_size)
+            if allow_rebatch:
+                chunk_size = max(1, cfg.page_size)
+            else:
+                chunk_size = max(1, len(pending))
             for chunk in _chunked(pending, chunk_size):
                 batch_attempts += 1
                 try:
@@ -434,6 +437,15 @@ def fetch_parent_catalog_for(
     parentless_filtered = _filters_exclude_parentless(cfg)
 
     if len(unique_ids) <= _PARENT_LOOKUP_FALLBACK_THRESHOLD:
+        if parentless_filtered:
+            chunk_result = _fetch_parent_catalog_chunk(
+                unique_ids,
+                client=client,
+                api_cfg=api_cfg,
+                timeout=effective_timeout,
+            )
+            result.update(chunk_result)
+            return result
         fallback_result = _fetch_parent_catalog_via_helper(
             unique_ids,
             client=client,
@@ -442,7 +454,7 @@ def fetch_parent_catalog_for(
             existing=result,
             catalog_cfg=cfg,
             allow_rebatch=False,
-            allow_single_lookup=not parentless_filtered,
+            allow_single_lookup=True,
         )
         result.update(fallback_result)
         return result

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -195,6 +195,40 @@ def test_fetch_parent_catalog_skips_single_when_parentless(
     assert all("/molecule.json" in url for url in captured_urls)
 
 
+def test_fetch_parent_catalog_single_entry_parentless_uses_bulk_only(
+    cfg: Config,
+) -> None:
+    captured_urls: list[str] = []
+
+    class DummyClient:
+        def request_json(
+            self,
+            url: str,
+            *,
+            cfg: ApiCfg,
+            timeout: float | None,
+        ) -> Mapping[str, object]:
+            captured_urls.append(url)
+            if "/molecule.json" in url:
+                return {"molecules": []}
+            raise AssertionError("single molecule fetch should be skipped")
+
+    client = DummyClient()
+    cfg.molecule_catalog.filters = {"parent_molecule_chembl_id__isnull": "false"}
+
+    result = molecule_catalog.fetch_parent_catalog_for(
+        ["CHEMBL1"],
+        client=client,
+        api_cfg=cfg.api,
+        timeout=cfg.testitem.timeout,
+        catalog_cfg=cfg.molecule_catalog,
+    )
+
+    assert result == {}
+    assert captured_urls
+    assert all("/molecule.json" in url for url in captured_urls)
+
+
 def test_prepare_parent_enrichment_uses_lookup_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- honour configured parentless filters by skipping the helper fallback for small parent catalogue batches
- allow the helper fallback to disable rebatching when single lookups are forbidden
- add a regression test to ensure parentless IDs only trigger bulk catalogue requests

## Testing
- pytest tests/test_get_testitem_data.py::test_fetch_parent_catalog_skips_single_when_parentless tests/test_get_testitem_data.py::test_fetch_parent_catalog_single_entry_parentless_uses_bulk_only

------
https://chatgpt.com/codex/tasks/task_e_68daed2f53d8832490233efbaf4e295b