### PR TITLE
Ensure ID columns normalise to string dtype

### DIFF
--- a/schemas/normalize.py
+++ b/schemas/normalize.py
@@ -40,7 +40,10 @@ def _normalize_common(df: pd.DataFrame) -> pd.DataFrame:
                 series, lambda s: _RELATION_MAP.get(s.strip(), s.strip())
             )
         if "id" in col.lower():
+            # Ensure identifier columns are consistently treated as strings
+            series = series.astype(pd.StringDtype())
             series = _apply_if_string(series, str.strip)
+            series = series.astype(pd.StringDtype())
         result[col] = series
     return result
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from library import validation
+from schemas import normalize_testitems
 
 
 def test_validate_columns_ok() -> None:
@@ -109,3 +110,22 @@ def test_validate_testitems_all_valid() -> None:
     assert isinstance(result, validation.ValidationResult)
     assert result.has_failures is False
     pd.testing.assert_frame_equal(result.data.reset_index(drop=True), df)
+
+
+def test_validate_testitems_numeric_ids_preserved() -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": [123456],
+            "pref_name": ["Name"],
+        }
+    )
+
+    normalized = normalize_testitems(df)
+
+    assert normalized["molecule_chembl_id"].dtype == pd.StringDtype()
+
+    result = validation.validate_testitems(normalized, return_result=True)
+
+    assert isinstance(result, validation.ValidationResult)
+    assert result.has_failures is False
+    assert result.data["molecule_chembl_id"].tolist() == ["123456"]


### PR DESCRIPTION
## Summary
- coerce identifier columns to Pandas StringDtype during normalization so numeric IDs are preserved as strings
- add a validation test ensuring numeric test item IDs survive normalization and schema validation

## Testing
- pytest tests/test_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68daf510ffb08324a457730224a51b43