### PR TITLE
Ensure get_activity_data script resolves project root

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -7,6 +7,20 @@ import sys
 from itertools import islice
 from pathlib import Path
 
+
+def _ensure_project_root() -> None:
+    """Ensure the repository root is on ``sys.path`` when executed as a script."""
+
+    script_path = Path(__file__).resolve()
+    project_root = script_path.parents[1]
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
+
+if __package__ in {None, ""}:
+    _ensure_project_root()
+
 import requests
 from pandera.errors import SchemaErrors
 


### PR DESCRIPTION
## Summary
- add a helper that inserts the repository root on sys.path when the CLI is executed directly
- allow the activity data script to import the internal library package without requiring python -m execution

## Testing
- python scripts/get_activity_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68db62409bd48324a2aed9ae4ce8b545