### PR TITLE
Handle long ChEMBL testitem queries

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from urllib.parse import urlencode, urljoin
 
 import pandas as pd
@@ -116,6 +116,43 @@ TESTITEM_COLUMNS = [
 
 
 TESTITEM_QUERY_FIELDS = TESTITEM_FIELD_DEFAULTS
+
+
+MAX_TESTITEM_URL_LENGTH = 7500
+
+
+def _split_chunk_for_url(
+    chunk: Sequence[str],
+    base_url: str,
+    *,
+    max_length: int = MAX_TESTITEM_URL_LENGTH,
+) -> Iterator[list[str]]:
+    """Yield sub-chunks that keep the request URL within ``max_length``."""
+
+    prefix = f"{base_url}&molecule_chembl_id__in="
+    prefix_length = len(prefix)
+    if prefix_length >= max_length:
+        raise ValueError("base URL exceeds maximum request length")
+
+    buffer: list[str] = []
+    buffer_length = 0
+    for identifier in chunk:
+        separator = 1 if buffer else 0
+        candidate_length = buffer_length + separator + len(identifier)
+        if prefix_length + candidate_length > max_length and buffer:
+            yield buffer
+            buffer = [identifier]
+            buffer_length = len(identifier)
+        elif prefix_length + candidate_length > max_length:
+            yield [identifier]
+            buffer = []
+            buffer_length = 0
+        else:
+            buffer.append(identifier)
+            buffer_length = candidate_length
+
+    if buffer:
+        yield buffer
 
 
 def get_assay(
@@ -348,39 +385,42 @@ def get_testitem(
     base = f"{cfg.chembl_base.rstrip('/')}/molecule.json?{query_string}"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, effective_chunk):
-        chunk_key = ",".join(chunk)
-        logger.info(
-            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
-        )
-        url = f"{base}&molecule_chembl_id__in={chunk_key}"
-        next_url: str | None = url
-        seen_urls: set[str] = set()
-        chunk_frames: list[pd.DataFrame] = []
-        while next_url:
-            absolute_url = urljoin(cfg.chembl_base, next_url)
-            if absolute_url in seen_urls:
-                logger.warning(
-                    "pagination_loop_detected",
-                    extra={"stage": "chunk_loop", "chunk_key": chunk_key},
+        for url_chunk in _split_chunk_for_url(chunk, base):
+            chunk_key = ",".join(url_chunk)
+            logger.info(
+                "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
+            )
+            url = f"{base}&molecule_chembl_id__in={chunk_key}"
+            next_url: str | None = url
+            seen_urls: set[str] = set()
+            chunk_frames: list[pd.DataFrame] = []
+            while next_url:
+                absolute_url = urljoin(cfg.chembl_base, next_url)
+                if absolute_url in seen_urls:
+                    logger.warning(
+                        "pagination_loop_detected",
+                        extra={"stage": "chunk_loop", "chunk_key": chunk_key},
+                    )
+                    break
+                seen_urls.add(absolute_url)
+                data = client.request_json(
+                    absolute_url, cfg=cfg, timeout=effective_timeout
                 )
-                break
-            seen_urls.add(absolute_url)
-            data = client.request_json(absolute_url, cfg=cfg, timeout=effective_timeout)
-            items = data.get("molecules") or data.get("molecule") or []
-            if items:
-                chunk_frames.append(json_normalize_pyarrow(items))
-            page_meta = data.get("page_meta") or {}
-            next_token = page_meta.get("next")
-            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
-        if chunk_frames:
-            records.append(pd.concat(chunk_frames, ignore_index=True))
-            logger.info(
-                "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
-            )
-        else:
-            logger.info(
-                "chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key}
-            )
+                items = data.get("molecules") or data.get("molecule") or []
+                if items:
+                    chunk_frames.append(json_normalize_pyarrow(items))
+                page_meta = data.get("page_meta") or {}
+                next_token = page_meta.get("next")
+                next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+            if chunk_frames:
+                records.append(pd.concat(chunk_frames, ignore_index=True))
+                logger.info(
+                    "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
+                )
+            else:
+                logger.info(
+                    "chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key}
+                )
     if not records:
         return pd.DataFrame(columns=TESTITEM_COLUMNS)
     df = pd.concat(records, ignore_index=True)

--- a/tests/test_chembl_assay.py
+++ b/tests/test_chembl_assay.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
 
-from library.chembl_assay import get_assays
+from library.chembl_assay import (
+    MAX_TESTITEM_URL_LENGTH,
+    get_assays,
+    get_testitem,
+)
 from library.config import ApiCfg
 
 
@@ -34,6 +39,27 @@ class DummyClient:
             return next(self._responses)
         except StopIteration:  # pragma: no cover - defensive
             raise AssertionError("unexpected extra request") from None
+
+
+class RecordingTestitemClient:
+    """Client stub that records URLs and returns matching molecules."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def request_json(
+        self, url: str, *, cfg: ApiCfg, timeout: float | None = None
+    ) -> dict[str, object]:
+        self.calls.append(url)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        joined = params.get("molecule_chembl_id__in", [""])[0]
+        molecules = [
+            {"molecule_chembl_id": identifier}
+            for identifier in joined.split(",")
+            if identifier
+        ]
+        return {"molecules": molecules, "page_meta": {}}
 
 
 def test_get_assays_fetches_all_pages() -> None:
@@ -69,3 +95,17 @@ def test_get_assays_fetches_all_pages() -> None:
     assert "offset=2" in client.calls[1]
     assert isinstance(df, pd.DataFrame)
     assert list(df["assay_chembl_id"]) == ids
+
+
+def test_get_testitem_splits_requests_when_url_would_exceed_limit() -> None:
+    """Large batches must be split to keep request URLs under the limit."""
+
+    cfg = ApiCfg()
+    ids = [f"CHEMBL{i}" for i in range(1000, 1700)]
+    client = RecordingTestitemClient()
+
+    df = get_testitem(ids, cfg=cfg, client=client, chunk_size=1000, page_limit=1000)
+
+    assert len(client.calls) > 1
+    assert all(len(url) <= MAX_TESTITEM_URL_LENGTH for url in client.calls)
+    assert sorted(df["molecule_chembl_id"].dropna()) == sorted(ids)


### PR DESCRIPTION
## Summary
- split large testitem identifier batches into smaller requests to keep ChEMBL URLs within a safe length
- add a unit test that exercises the new request splitting logic with a large identifier list

## Testing
- pytest tests/test_chembl_assay.py::test_get_testitem_splits_requests_when_url_would_exceed_limit
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_passes_fields_and_limit

------
https://chatgpt.com/codex/tasks/task_e_68db68073ab48324b2586cda684b822e