### PR TITLE
Handle duplicate ChEMBL identifiers in fetch_testitems

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1390,6 +1390,18 @@ def fetch_testitems(
     else:
         logger.info("chembl_all_identifiers_retrieved")
 
+    duplicates_mask = df["molecule_chembl_id"].duplicated(keep=False)
+    if duplicates_mask.any():
+        duplicate_ids = (
+            df.loc[duplicates_mask, "molecule_chembl_id"].dropna().unique().tolist()
+        )
+        logger.warning(
+            "chembl_duplicate_identifiers",
+            duplicate_count=len(duplicate_ids),
+            duplicate_ids=duplicate_ids,
+        )
+        df = df.drop_duplicates(subset="molecule_chembl_id", keep="first")
+
     index = pd.Index(requested_ids, name="molecule_chembl_id")
     df = df.set_index("molecule_chembl_id", drop=False).reindex(index)
     df["molecule_chembl_id"] = pd.Series(


### PR DESCRIPTION
## Summary
- log duplicate ChEMBL identifiers returned from the API when fetching test items
- drop duplicate records before reindexing so repeated identifiers do not cause pandas errors

## Testing
- pytest -q *(fails: existing environment/config failures in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68db68a2680c8324b910df504236356a