### PR TITLE
Fix PubChem retry attempt accounting

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -116,37 +116,59 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         return cast(dict[str, Any], cached)
     logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
 
-    attempts = max(cfg.retries, 1)
+    total_attempts = cfg.retries + 1
+    if total_attempts <= 0:
+        total_attempts = 1
     backoff_delay = cfg.backoff_initial_seconds
     deadline: float | None = None
     if cfg.timeout_seconds > 0:
         deadline = monotonic() + cfg.timeout_seconds
 
-    for attempt in range(1, attempts + 1):
+    for attempt in range(1, total_attempts + 1):
         if deadline is not None and monotonic() >= deadline:
-            logger.warning("request_timeout", url=url, attempt=attempt, rps=cfg.rps)
-            logger.info("request_fail", url=url, status=None, rps=cfg.rps)
+            logger.warning(
+                "request_timeout",
+                url=url,
+                attempt=attempt,
+                total_attempts=total_attempts,
+                rps=cfg.rps,
+            )
+            logger.info(
+                "request_fail",
+                url=url,
+                status=None,
+                total_attempts=total_attempts,
+                rps=cfg.rps,
+            )
             return None
         event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(event, url=url, attempt=attempt, rps=cfg.rps)
+        logger.info(
+            event,
+            url=url,
+            attempt=attempt,
+            total_attempts=total_attempts,
+            rps=cfg.rps,
+        )
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
         try:
             response = _session.get(
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)
             )
         except requests.RequestException as exc:  # pragma: no cover - network
-            if attempt >= attempts:
+            if attempt >= total_attempts:
                 logger.error(
                     "request_error",
                     url=url,
                     error=str(exc),
                     attempt=attempt,
+                    total_attempts=total_attempts,
                     rps=cfg.rps,
                 )
                 logger.info(
                     "request_fail",
                     url=url,
                     status=None,
+                    total_attempts=total_attempts,
                     rps=cfg.rps,
                 )
                 return None
@@ -157,7 +179,13 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         status = response.status_code
         if status == 404:
             logger.info("request_not_found", url=url, status=status, rps=cfg.rps)
-            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            logger.info(
+                "request_fail",
+                url=url,
+                status=status,
+                total_attempts=total_attempts,
+                rps=cfg.rps,
+            )
             return None
         if status == 429 or 500 <= status < 600:
             event_name = (
@@ -168,10 +196,17 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 url=url,
                 status=status,
                 attempt=attempt,
+                total_attempts=total_attempts,
                 rps=cfg.rps,
             )
-            if attempt >= attempts:
-                logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            if attempt >= total_attempts:
+                logger.info(
+                    "request_fail",
+                    url=url,
+                    status=status,
+                    total_attempts=total_attempts,
+                    rps=cfg.rps,
+                )
                 return None
             delay = backoff_delay if backoff_delay > 0 else cfg.delay
             if delay > 0:
@@ -185,22 +220,35 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 status=status,
                 rps=cfg.rps,
             )
-            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            logger.info(
+                "request_fail",
+                url=url,
+                status=status,
+                total_attempts=total_attempts,
+                rps=cfg.rps,
+            )
             return None
 
         try:
             response.raise_for_status()
             data = cast(dict[str, Any], response.json())
         except requests.RequestException as exc:  # pragma: no cover - network
-            if attempt >= attempts:
+            if attempt >= total_attempts:
                 logger.error(
                     "request_error",
                     url=url,
                     error=str(exc),
                     attempt=attempt,
+                    total_attempts=total_attempts,
                     rps=cfg.rps,
                 )
-                logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+                logger.info(
+                    "request_fail",
+                    url=url,
+                    status=status,
+                    total_attempts=total_attempts,
+                    rps=cfg.rps,
+                )
                 return None
             if cfg.delay > 0:
                 sleep(cfg.delay)
@@ -212,7 +260,13 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 status=status,
                 rps=cfg.rps,
             )
-            logger.info("request_fail", url=url, status=status, rps=cfg.rps)
+            logger.info(
+                "request_fail",
+                url=url,
+                status=status,
+                total_attempts=total_attempts,
+                rps=cfg.rps,
+            )
             return None
 
         logger.info(

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -162,6 +162,31 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
     assert attempts["n"] == 2
 
 
+def test_make_request_uses_all_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``make_request`` should honour the configured retry count."""
+
+    attempts = {"n": 0}
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> None:
+        attempts["n"] += 1
+        raise requests.RequestException("boom")
+
+    class Limiter:
+        def acquire(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    monkeypatch.setattr(pc, "get_limiter", lambda *a, **k: Limiter())
+    monkeypatch.setattr(pc._session, "get", fake_get)
+    monkeypatch.setattr(pc, "sleep", lambda *_: None)
+    pc._CACHE = None
+
+    cfg = pl.PubChemCfg(retries=2, delay=0, backoff_initial_seconds=0)
+    result = pl.make_request("https://example.org", cfg)
+
+    assert result is None
+    assert attempts["n"] == cfg.retries + 1
+
+
 def test_make_request_aborts_when_timeout_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure PubChem client derives total attempts from the configured retries and include the value in retry logging
- update request failure handling to report the total number of attempts across timeout, error, and response paths
- add a regression test that verifies the client performs retries up to the configured count

## Testing
- pytest tests/test_pubchem_library.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3ca9a1f8832481a193e88577684f