### PR TITLE
Add session lock to ChemblClient for thread safety

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -38,6 +38,7 @@ class ChemblClient:
     session: Session = field(init=False)
     cache: TTLCache[str, dict[str, Any]] = field(init=False)
     _cache_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _session_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
     def __init__(
         self,
@@ -58,6 +59,7 @@ class ChemblClient:
         )
         self.cache = TTLCache(maxsize=maxsize, ttl=ttl)
         self._cache_lock = threading.Lock()
+        self._session_lock = threading.Lock()
 
     def close(self) -> None:
         """Close the underlying HTTP session.
@@ -144,32 +146,33 @@ class ChemblClient:
             event = "request_start" if attempt == 1 else "request_retry"
             logger.info(event, extra={"url": url, "attempt": attempt, "rps": cfg.rps})
             try:
-                with self.session.get(
-                    url, timeout=(cfg.timeout_connect, read_timeout)
-                ) as response:
-                    response.raise_for_status()
-                    try:
-                        data = cast(dict[str, Any], response.json())
-                    except ValueError as exc:
-                        logger.exception("json_error", extra={"url": url})
-                        raise ValueError(
-                            f"invalid JSON in response from {url}"
-                        ) from exc
-                    logger.info(
-                        "request_ok",
-                        extra={
-                            "url": url,
-                            "status": getattr(response, "status_code", None),
-                            "rps": cfg.rps,
-                        },
-                    )
-                    with self._cache_lock:
-                        cached = self.cache.get(cache_key)
-                        if cached is not None:
-                            return cast(dict[str, Any], cached)
-                        self.cache[cache_key] = data
-                        logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
-                        return data
+                with self._session_lock:
+                    with self.session.get(
+                        url, timeout=(cfg.timeout_connect, read_timeout)
+                    ) as response:
+                        response.raise_for_status()
+                        try:
+                            data = cast(dict[str, Any], response.json())
+                        except ValueError as exc:
+                            logger.exception("json_error", extra={"url": url})
+                            raise ValueError(
+                                f"invalid JSON in response from {url}"
+                            ) from exc
+                        logger.info(
+                            "request_ok",
+                            extra={
+                                "url": url,
+                                "status": getattr(response, "status_code", None),
+                                "rps": cfg.rps,
+                            },
+                        )
+                        with self._cache_lock:
+                            cached = self.cache.get(cache_key)
+                            if cached is not None:
+                                return cast(dict[str, Any], cached)
+                            self.cache[cache_key] = data
+                            logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
+                            return data
             except (requests.RequestException, ValueError) as exc:
                 last_exc = exc
                 if attempt >= total_attempts:

--- a/tests/test_chembl_client_threadsafe.py
+++ b/tests/test_chembl_client_threadsafe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -71,6 +72,49 @@ class ThreadTrackingSession:
     def get(self, url: str, timeout: Any) -> ThreadTrackingResponse:
         self.calls.append(threading.get_ident())
         return ThreadTrackingResponse()
+
+
+class StressResponse:
+    """Response keeping the owning session marked as in use."""
+
+    def __init__(self, session: StressSession, thread_id: int) -> None:
+        self._session = session
+        self._thread_id = thread_id
+
+    def __enter__(self) -> StressResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no-op
+        self._session.release()
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no error
+        pass
+
+    def json(self) -> dict[str, Any]:
+        time.sleep(0.005)
+        return {"thread": self._thread_id}
+
+
+class StressSession:
+    """Session detecting concurrent ``get`` calls from multiple threads."""
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+        self._lock = threading.Lock()
+        self._in_use = False
+
+    def release(self) -> None:
+        with self._lock:
+            self._in_use = False
+
+    def get(self, url: str, timeout: Any) -> StressResponse:
+        thread_id = threading.get_ident()
+        with self._lock:
+            if self._in_use:
+                raise RuntimeError("Concurrent access to shared session")
+            self._in_use = True
+        self.calls.append(thread_id)
+        return StressResponse(self, thread_id)
 
 
 def test_request_json_threadsafe(monkeypatch) -> None:
@@ -152,3 +196,36 @@ def test_cache_shared_across_threads(monkeypatch) -> None:
 
     assert all(r == {"ok": True} for r in results)
     assert client.session.calls == 1
+
+
+def test_session_lock_prevents_concurrent_access() -> None:
+    """High concurrency should serialise access to the shared session."""
+
+    session = StressSession()
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)
+    client.clear_cache()
+
+    start = threading.Event()
+    urls = [f"http://example.com/stress/{idx}" for idx in range(20)]
+    results: list[dict[str, Any]] = []
+    errors: list[Exception] = []
+
+    def worker(target_url: str) -> None:
+        start.wait()
+        try:
+            results.append(client.request_json(target_url, cfg=api_cfg()))
+        except Exception as exc:  # pragma: no cover - exercised on failure
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(url,)) for url in urls]
+    for thread in threads:
+        thread.start()
+
+    start.set()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert len(results) == len(urls)
+    assert session.calls == [result["thread"] for result in results]
+    assert len(set(session.calls)) > 1


### PR DESCRIPTION
## Summary
- protect the shared `requests.Session` in `ChemblClient` with a dedicated lock to avoid concurrent access
- add a high-concurrency stress test with a fake session to ensure the lock serialises usage

## Testing
- pytest tests/test_chembl_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4010cf6883248a7642765405711e