### PR TITLE
Expose shared PubChem CID selector

### DIFF
--- a/library/pubchem_library.py
+++ b/library/pubchem_library.py
@@ -27,12 +27,12 @@ from .config import PubChemCfg
 from .log import logger
 
 
-def _select_primary_cid(
+def select_primary_cid(
     candidates: str | None,
     *,
-    cache_key: str | None,
     identifier: str,
     value: str | None,
+    context_id: str | None = None,
 ) -> str | None:
     """Return the first CID from ``candidates`` logging alternatives."""
 
@@ -45,7 +45,7 @@ def _select_primary_cid(
     if len(cid_list) > 1:
         logger.info(
             "pubchem_multiple_cid",
-            chembl_id=cache_key,
+            chembl_id=context_id,
             identifier=identifier,
             value=value,
             cid=primary,
@@ -92,11 +92,11 @@ def resolve_pubchem_record(
         if cid_cache is not None and cache_key:
             cached_value = cid_cache.get(cache_key)
             if isinstance(cached_value, str) and cached_value:
-                cid = _select_primary_cid(
+                cid = select_primary_cid(
                     cached_value,
-                    cache_key=cache_key,
                     identifier="cache",
                     value=cached_value,
+                    context_id=cache_key,
                 )
                 if cid:
                     if cached_value != cid:
@@ -104,11 +104,11 @@ def resolve_pubchem_record(
                     return PubChemResolution(cid=cid, source="cache")
         existing_cid = identifiers.get("pubchem_cid")
         if existing_cid:
-            cid = _select_primary_cid(
+            cid = select_primary_cid(
                 existing_cid,
-                cache_key=cache_key,
                 identifier="pubchem_cid",
                 value=existing_cid,
+                context_id=cache_key,
             )
             if cid:
                 return PubChemResolution(cid=cid, source="pubchem_cid")
@@ -122,11 +122,11 @@ def resolve_pubchem_record(
             if not value:
                 continue
             resolved = resolver(value, cfg)
-            cid = _select_primary_cid(
+            cid = select_primary_cid(
                 resolved,
-                cache_key=cache_key,
                 identifier=identifier,
                 value=value,
+                context_id=cache_key,
             )
             if cid:
                 return PubChemResolution(cid=cid, source=identifier)
@@ -164,11 +164,11 @@ def resolve_pubchem_record(
             ("pref_name_partial", get_all_cid),
         ):
             resolved = resolver(name_value, cfg)
-            cid = _select_primary_cid(
+            cid = select_primary_cid(
                 resolved,
-                cache_key=cache_key,
                 identifier=identifier,
                 value=name_value,
+                context_id=cache_key,
             )
             if cid:
                 return PubChemResolution(cid=cid, source=identifier)

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -314,11 +314,11 @@ def _load_pubchem_cid_cache(
         value = _normalise_identifier(raw_value)
         if not value:
             continue
-        primary = _select_primary_cid(
+        primary = pl.select_primary_cid(
             value,
-            chembl_id=key,
             identifier="cache_file",
             value=value,
+            context_id=key,
         )
         if primary is not None:
             cache[key] = primary
@@ -352,35 +352,6 @@ def _write_pubchem_cid_cache(
             json.dump(payload, handle, indent=2, sort_keys=True)
     except OSError as exc:  # pragma: no cover - I/O errors
         logger.warning("pubchem_cache_write_failed", path=str(path), error=str(exc))
-
-
-def _select_primary_cid(
-    candidates: str | None,
-    *,
-    chembl_id: str | None,
-    identifier: str,
-    value: str | None,
-) -> str | None:
-    """Return the primary CID from a pipe-separated list."""
-
-    if not candidates:
-        return None
-    cid_list = [cid.strip() for cid in str(candidates).split("|") if cid.strip()]
-    if not cid_list:
-        return None
-    primary = cid_list[0]
-    if len(cid_list) > 1:
-        logger.info(
-            "pubchem_multiple_cid",
-            chembl_id=chembl_id,
-            identifier=identifier,
-            value=value,
-            cid=primary,
-            alternatives=cid_list[1:],
-        )
-    return primary
-
-
 def _pubchem_identifiers(row: pd.Series) -> dict[str, str | None]:
     """Return mapping of identifier names to normalised values."""
 

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1039,6 +1039,40 @@ def test_write_pubchem_cid_cache_creates_parent_dir(tmp_path: Path) -> None:
     assert payload["metadata"]["version"] == gtd._PUBCHEM_CACHE_SCHEMA_VERSION
 
 
+def test_load_pubchem_cid_cache_uses_shared_selector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_path = tmp_path / "cid_cache.json"
+    cache_payload = {
+        "values": {
+            "chembl1": "123 | 456",
+            "chembl2": None,
+        }
+    }
+    cache_path.write_text(json.dumps(cache_payload))
+
+    calls: list[tuple[str | None, str, str | None, str | None]] = []
+
+    def fake_select(
+        candidates: str | None,
+        *,
+        identifier: str,
+        value: str | None,
+        context_id: str | None = None,
+    ) -> str | None:
+        calls.append((candidates, identifier, value, context_id))
+        if candidates:
+            return candidates.split("|")[0].strip()
+        return None
+
+    monkeypatch.setattr(pl, "select_primary_cid", fake_select)
+
+    cache = gtd._load_pubchem_cid_cache(cache_path)
+
+    assert cache == {"CHEMBL1": "123", "CHEMBL2": None}
+    assert calls == [("123 | 456", "cache_file", "123 | 456", "CHEMBL1")]
+
+
 def test_load_pubchem_cid_cache_expires(tmp_path: Path) -> None:
     cache_path = tmp_path / "cid_cache.json"
     expired_at = datetime.now(UTC) - timedelta(hours=2)


### PR DESCRIPTION
## Summary
- expose the PubChem CID selection helper from the library for reuse
- switch the test item data script to import the shared helper and cover the integration in tests

## Testing
- pytest tests/test_get_testitem_data.py tests/test_pubchem_library.py

------
https://chatgpt.com/codex/tasks/task_e_68dc448ca19c832480be0d97297bd9a8