### PR TITLE
Bundle default config with the wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,23 @@ sections:
 * ``system`` – shared concerns such as logging, retry strategy, rate limiting
   and document-type normalisation.
 
+Because the wheel bundles ``config/config.yaml``, any custom configuration file
+can simply extend it by overriding the keys you need while omitting the rest.
+Create a lightweight YAML such as:
+
+```
+sources:
+  chembl:
+    api:
+      rps: 10
+system:
+  log:
+    level: DEBUG
+```
+
+Pass this file via ``--config`` (or ``CHEMBL_DA__...`` environment variables)
+and the loader will merge your overrides with the packaged defaults.
+
 The companion ``config.schema.json`` file documents these fields and is useful
 for editor validation, but it must **not** be passed to ``--config`` because it
 lacks runtime values such as ``sources.chembl.api.user_agent``. A minimal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ get-activities = "library.utils.cli_tools.get_activities:main"
 check-determinism = "library.utils.cli_tools.check_determinism:main"
 
 [tool.setuptools]
+include-package-data = true
 py-modules = [
   "scripts.get_activity_data",
   "scripts.get_assay_data",
@@ -72,7 +73,10 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["library", "schemas"]
+include = ["library", "schemas", "config"]
+
+[tool.setuptools.package-data]
+"config" = ["config.yaml"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- configure setuptools to include the config package when discovering packages and to ship config/config.yaml as package data
- document that custom YAML overrides can extend the packaged defaults in config/config.yaml

## Testing
- python -m build --wheel

------
https://chatgpt.com/codex/tasks/task_e_68dc43c74f9083249660a0aded28e308