### PR TITLE
Lower verbosity of Chembl and PubChem per-request logs

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -144,7 +144,9 @@ class ChemblClient:
         for attempt in range(1, total_attempts + 1):
             limiter.acquire()
             event = "request_start" if attempt == 1 else "request_retry"
-            logger.info(event, extra={"url": url, "attempt": attempt, "rps": cfg.rps})
+            logger.debug(
+                event, extra={"url": url, "attempt": attempt, "rps": cfg.rps}
+            )
             try:
                 with self._session_lock:
                     with self.session.get(
@@ -158,7 +160,7 @@ class ChemblClient:
                             raise ValueError(
                                 f"invalid JSON in response from {url}"
                             ) from exc
-                        logger.info(
+                        logger.debug(
                             "request_ok",
                             extra={
                                 "url": url,

--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -145,7 +145,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             )
             return None
         event = "request_start" if attempt == 1 else "request_retry"
-        logger.info(
+        logger.debug(
             event,
             url=url,
             attempt=attempt,
@@ -272,7 +272,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             )
             return None
 
-        logger.info(
+        logger.debug(
             "request_ok",
             url=url,
             status=status,

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import random
 import time
@@ -12,6 +13,7 @@ import pytest
 from library import rate_limiter as rl
 from library.clients import ChemblClient
 from library.config import ApiCfg, RetryCfg
+from library.logging_setup import LoggerConfig, configure_logger
 
 cachetools = pytest.importorskip("cachetools")
 from cachetools import TTLCache  # type: ignore[import-untyped]  # noqa: E402
@@ -166,6 +168,39 @@ def test_request_json_retries_with_mocked_session() -> None:
 
     assert result == {"ok": True}
     assert session.get.call_count == 2
+
+
+def test_request_json_logs_per_request_events_as_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-request logging should use DEBUG level for verbose events."""
+
+    buf = io.StringIO()
+    test_logger = configure_logger(
+        LoggerConfig(level="DEBUG", run_id="test", stream=buf)
+    ).bind(status=None, rps=None)
+    monkeypatch.setattr("library.clients.chembl.logger", test_logger)
+
+    session = DummySession(failures=1)
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)
+    client.clear_cache()
+
+    monkeypatch.setattr("library.clients.chembl.sleep", lambda _: None)
+    monkeypatch.setattr("library.clients.chembl.random.uniform", lambda a, b: 0.0)
+
+    cfg = api_cfg(retries=2, backoff_factor=0)
+    client.request_json("http://example.com", cfg=cfg)
+
+    records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    levels = {
+        record["event"]: record["level"]
+        for record in records
+        if record["event"] in {"request_start", "request_retry", "request_ok"}
+    }
+
+    assert levels["request_start"] == "DEBUG"
+    assert levels["request_retry"] == "DEBUG"
+    assert levels["request_ok"] == "DEBUG"
 
 
 def test_request_json_reuses_session(monkeypatch) -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -41,3 +41,26 @@ def test_warnings_are_logged() -> None:
     assert record["logger"] == "py.warnings"
     assert "problem occurred" in str(record.get("event"))
     assert record["run_id"] == "rid"
+
+
+def test_debug_events_filtered_by_default() -> None:
+    """DEBUG-level request events should be hidden when log level is INFO."""
+
+    code = (
+        "import io; "
+        "from library.logging_setup import LoggerConfig, configure_logger; "
+        "buf = io.StringIO(); "
+        "logger = configure_logger(LoggerConfig(level='INFO', run_id='rid', stream=buf)); "
+        "logger.debug('request_start', url='https://example.org'); "
+        "logger.info('request_fail', url='https://example.org'); "
+        "print(buf.getvalue())"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    records = _parse(result.stdout)
+    assert all(record["event"] != "request_start" for record in records)
+    assert any(
+        record["event"] == "request_fail" and record["level"] == "INFO"
+        for record in records
+    )

--- a/tests/test_pubchem_library.py
+++ b/tests/test_pubchem_library.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import time
 
+import io
+import json
+
 import pytest
 import requests
 
@@ -13,6 +16,7 @@ responses = pytest.importorskip("responses")
 from library import pubchem_library as pl  # noqa: E402
 from library.clients import pubchem as pc  # noqa: E402
 from library import rate_limiter as rl  # noqa: E402
+from library.logging_setup import LoggerConfig, configure_logger  # noqa: E402
 
 
 @responses.activate
@@ -160,6 +164,63 @@ def test_make_request_waits_between_retries(monkeypatch) -> None:
 
     assert sleeps == [1]
     assert attempts["n"] == 2
+
+
+def test_make_request_logs_per_request_events_as_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-request PubChem logs should use DEBUG for verbose events."""
+
+    buf = io.StringIO()
+    test_logger = configure_logger(
+        LoggerConfig(level="DEBUG", run_id="test", stream=buf)
+    ).bind(status=None, rps=None)
+    monkeypatch.setattr(pc, "logger", test_logger)
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, object]:
+            return {}
+
+        def raise_for_status(self) -> None:  # pragma: no cover - no error
+            return None
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get(self, url: str, timeout: tuple[int, int]) -> DummyResponse:
+            self.calls += 1
+            if self.calls == 1:
+                raise requests.RequestException("boom")
+            return DummyResponse()
+
+    monkeypatch.setattr(pc, "_session", DummySession())
+
+    class Limiter:
+        def acquire(self) -> None:  # pragma: no cover - simple stub
+            return None
+
+    monkeypatch.setattr(pc, "get_limiter", lambda *a, **k: Limiter())
+    monkeypatch.setattr(pc, "sleep", lambda *_: None)
+    pc._CACHE = None
+
+    cfg = pl.PubChemCfg(retries=1, delay=0, backoff_initial_seconds=0)
+    result = pl.make_request("https://example.org", cfg)
+
+    assert result == {}
+
+    records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    levels = {
+        record["event"]: record["level"]
+        for record in records
+        if record["event"] in {"request_start", "request_retry", "request_ok"}
+    }
+
+    assert levels["request_start"] == "DEBUG"
+    assert levels["request_retry"] == "DEBUG"
+    assert levels["request_ok"] == "DEBUG"
 
 
 def test_make_request_uses_all_attempts(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- downgrade Chembl and PubChem per-request request_start/request_retry/request_ok logs to DEBUG while leaving summary/error events unchanged
- extend logging and client tests to assert the new DEBUG level behaviour and that INFO-level filters hide these events by default

## Testing
- pytest tests/test_logging.py tests/test_chembl_client.py tests/test_pubchem_library.py

------
https://chatgpt.com/codex/tasks/task_e_68dc44876e488324aa9cd70ab5acf52e