### PR TITLE
Document pipeline targets CLI helper

### DIFF
--- a/docs/CLI_TOOLS.md
+++ b/docs/CLI_TOOLS.md
@@ -16,6 +16,7 @@ while preserving direct module execution for ad-hoc debugging.
 | `library.utils.cli_tools.get_input_initialisation` | `python -m library.utils.cli_tools.get_input_initialisation --same-doc path.xlsx --all-doc path.xlsx` | Combine Excel workbooks that initialise input pairs for downstream QA. |
 | `library.utils.cli_tools.mapper_batch_main` | `python -m library.utils.cli_tools.mapper_batch_main --input ids.csv --output mapped.csv` | Map ChEMBL identifiers to UniProt accessions using batch configuration. |
 | `library.utils.cli_tools.mapper_main` | `python -m library.utils.cli_tools.mapper_main --input ids.csv --output mapped.csv` | Lightweight interactive mapper for quick lookups and diagnostics. |
+| `library.utils.cli_tools.pipeline_targets_main` | `python -m library.utils.cli_tools.pipeline_targets_main --input targets.csv` | Run the cached target pipeline harness to refresh stored artefacts. |
 | `library.utils.cli_tools.table_quality_main` | `python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data` | Generate column-level quality reports for arbitrary CSV datasets. |
 
 All modules continue to expose a `main` function so they can still be wired into


### PR DESCRIPTION
## Summary
- add the pipeline_targets_main helper to the CLI tools reference
- normalise the table rows so each command is on a single line for consistent formatting

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dc4b6b445883249772ba0678f82377