### PR TITLE
Clarify api.user_agent override options

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,10 @@ api:
   user_agent: "chembl-da/0.1 (mailto:contact@example.org)"
 ```
 
-Параметр можно переопределить в `config/config.yaml`, через переменную окружения
-`CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT` или флаг CLI
-`--sources.chembl.api.user_agent`.
+Параметр можно переопределить в `config/config.yaml` или через переменную
+окружения `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT`. Отдельного CLI-флага
+для `api.user_agent` не предусмотрено (см. `library/cli/parser.py`), поэтому
+значение задаётся только через конфигурационный файл или окружение.
 
 ## Валидация конфигурации
 


### PR DESCRIPTION
## Summary
- update README guidance for configuring sources.chembl.api.user_agent
- document supported overrides via config file or environment variable only
- note absence of a CLI flag, aligning README with CONFIG_EN

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4b59c1e88324a7452819fd8aafbf