### PR TITLE
Ensure dictionary resources package correctly

### DIFF
--- a/dictionary/__init__.py
+++ b/dictionary/__init__.py
@@ -1,0 +1,2 @@
+"""Resource package for bundled lookup tables.
+"""

--- a/library/config.py
+++ b/library/config.py
@@ -13,10 +13,13 @@ aliases are supported; see ``_ALIAS_MAP`` for the full list.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import re
 from collections.abc import Sequence
+from contextlib import ExitStack
+from importlib import resources
 from pathlib import Path
 from typing import Any, Mapping
 from urllib.parse import urlparse
@@ -30,6 +33,18 @@ from urllib3.util.retry import Retry
 
 from .log import logger
 from .utils.config import ConfigLoaderError, load_yaml_config
+
+_RESOURCE_STACK = ExitStack()
+atexit.register(_RESOURCE_STACK.close)
+
+
+def _dictionary_resource(*parts: str) -> Path:
+    """Return a filesystem path for a bundled dictionary resource."""
+
+    traversable = resources.files("dictionary")
+    for part in parts:
+        traversable = traversable.joinpath(part)
+    return Path(_RESOURCE_STACK.enter_context(resources.as_file(traversable)))
 
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
 
@@ -396,11 +411,37 @@ class DocTypeCfg(_BaseModel):
 
 
 class ResourcesCfg(_BaseModel):
-    dictionary_dir: Path = Path("dictionary")
-    iuphar_target_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_target.csv")
-    iuphar_family_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_family.csv")
-    uniprot_data_dir: Path = Path("dictionary/_target/_uniprot")
-    targets_type_csv: Path = Path("dictionary/_Target/targets_type.csv")
+    dictionary_dir: Path = Field(default_factory=_dictionary_resource)
+    iuphar_target_csv: Path = Field(
+        default_factory=lambda: _dictionary_resource(
+            "_target", "_IUPHAR", "_IUPHAR_target.csv"
+        )
+    )
+    iuphar_family_csv: Path = Field(
+        default_factory=lambda: _dictionary_resource(
+            "_target", "_IUPHAR", "_IUPHAR_family.csv"
+        )
+    )
+    uniprot_data_dir: Path = Field(
+        default_factory=lambda: _dictionary_resource("_target", "_uniprot")
+    )
+    targets_type_csv: Path = Field(
+        default_factory=lambda: _dictionary_resource("_Target", "targets_type.csv")
+    )
+
+    @field_validator(
+        "dictionary_dir",
+        "iuphar_target_csv",
+        "iuphar_family_csv",
+        "uniprot_data_dir",
+        "targets_type_csv",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_path(cls, value: Any) -> Path | Any:
+        if isinstance(value, (str, os.PathLike)):
+            return Path(value)
+        return value
 
 
 class IoCfg(_BoolModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,18 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["library", "schemas", "config"]
+include = [
+  "library",
+  "library.*",
+  "schemas",
+  "schemas.*",
+  "config",
+  "dictionary",
+]
 
 [tool.setuptools.package-data]
 "config" = ["config.yaml"]
+"dictionary" = ["**/*"]
 
 [tool.black]
 line-length = 88

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,61 @@
+"""Packaging regression tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_wheel_exposes_resources(tmp_path: Path) -> None:
+    """Build the wheel and ensure bundled resources resolve at runtime."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            str(project_root),
+            "--no-deps",
+            "-w",
+            str(dist_dir),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    wheel_path = next(dist_dir.glob("*.whl"))
+    script = r"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from library.config import ResourcesCfg
+
+resources = ResourcesCfg()
+paths = [
+    resources.dictionary_dir,
+    resources.iuphar_target_csv,
+    resources.iuphar_family_csv,
+    resources.uniprot_data_dir,
+    resources.targets_type_csv,
+]
+missing = [str(path) for path in paths if not Path(path).exists()]
+if missing:
+    raise SystemExit("Missing packaged resources: " + ", ".join(missing))
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", script, str(wheel_path)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- package the `dictionary` resources and include them in the build configuration
- resolve default resource paths via `importlib.resources` so installed wheels can find the bundled data
- add a packaging regression test that builds the wheel and checks `ResourcesCfg` paths exist

## Testing
- pytest tests/test_packaging.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4bc1def88324802a757590c53130