### PR TITLE
Mask secrets in CSV metadata

### DIFF
--- a/library/io/metadata.py
+++ b/library/io/metadata.py
@@ -9,7 +9,7 @@ from typing import Mapping, Sequence
 
 import yaml
 
-from ..config import Config, _serialize_paths
+from ..config import Config, _mask_secrets, _serialize_paths
 from ..git_utils import _git_sha
 
 
@@ -31,7 +31,9 @@ def write_meta_yaml(
         "command": " ".join(sys.argv),
         "columns": list(columns or []),
         "dtypes": dict(dtypes or {}),
-        "config": _serialize_paths(cfg.to_dict()) if cfg is not None else {},
+        "config": (
+            _mask_secrets(_serialize_paths(cfg.to_dict())) if cfg is not None else {}
+        ),
     }
     meta_path = Path(f"{path}.meta.yaml")
     with meta_path.open("w", encoding="utf8") as fh:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -116,6 +116,23 @@ def test_write_meta_serialises_paths(tmp_path: Path, cfg: Config) -> None:
     assert meta["config"]["local"]["io"]["output_dir"] == str(cfg.io.output_dir)
 
 
+def test_write_meta_masks_secrets(tmp_path: Path, cfg: Config) -> None:
+    class SecretConfig(Config):
+        def to_dict(self) -> dict[str, object]:
+            data = super().to_dict()
+            data["api_token"] = "dummy-token"
+            return data
+
+    secret_cfg = SecretConfig.model_validate(cfg.model_dump())
+    df = pd.DataFrame({"a": [1]})
+    path = tmp_path / "out.csv"
+    io.write_csv(df, path, cfg=secret_cfg)
+
+    meta_path = Path(f"{path}.meta.yaml")
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["config"]["api_token"] == "***"
+
+
 def test_write_csv_deterministic_hash(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"b": [3, 1], "a": [4.0, 2.0]})
     path = tmp_path / "out.csv"


### PR DESCRIPTION
## Summary
- mask sensitive config values before writing CSV metadata
- cover masking logic with a regression test for io.write_csv metadata output

## Testing
- pytest tests/test_io.py::test_write_meta_masks_secrets

------
https://chatgpt.com/codex/tasks/task_e_68dc4d8dd7a483249874f1c5b508f651