### PR TITLE
Clarify legacy separator options in config docs

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -111,8 +111,8 @@ This block controls derived annotations appended to every activity row. It works
 * `column` — name of the raw JSON-like source column (`activity_properties`).
 * `summary_column` — destination column for the rendered text summary (`activity_property_summary`).
 * `name_field`, `value_field`, `units_field` identify keys within each property record (`type`, `value`, `units`).
-* `separator` and `pair_separator` control formatting when properties are concatenated (`"; "` between pairs,
-  `"="` between name and value).
+* `separator` and `pair_separator` are legacy formatting knobs retained for backwards compatibility; the current
+  JSON serialisation ignores them.
 * `drop_source_column` removes the original structured column after summarisation (`true`).
 * Logging flags default to `false`, muting missing/distribution reports unless troubleshooting is required.
 * `allowlist` restricts which property groups are retained (measurement, assay, comments, effect_features, triage, mechanism,

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -110,7 +110,8 @@
 * `column` — исходная колонка со структурированными свойствами (`activity_properties`).
 * `summary_column` — колонка для текстового резюме (`activity_property_summary`).
 * `name_field`, `value_field`, `units_field` задают имена ключей внутри записей (`type`, `value`, `units`).
-* `separator` и `pair_separator` управляют форматированием списка свойств (`"; "` между парами и `"="` между названием и значением).
+* `separator` и `pair_separator` — устаревшие параметры форматирования, сохранённые для совместимости; текущая
+  сериализация JSON их не использует.
 * `drop_source_column` удаляет исходную структурированную колонку после агрегации (`true`).
 * Флаги логирования по умолчанию выключены (`log_missing=false`, `log_distribution=false`).
 * `allowlist` ограничивает перечень сохраняемых групп (measurement, assay, comments, effect_features, triage, mechanism,


### PR DESCRIPTION
## Summary
- note that `separator` and `pair_separator` in the activity properties configuration are legacy knobs not used by current JSON serialisation
- update both English and Russian configuration references to keep the documentation in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4e86d40c8324b4b6a31971373647