### PR TITLE
Clarify documentation for quality report outputs

### DIFF
--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -21,9 +21,12 @@ data/output/
 ├── output_activity_20240105.csv.meta.yaml
 ├── output_activity_20240105_failure_cases.csv
 ├── output_activity_20240105_quality_report_table.csv
-├── output_activity_20240105_data_correlation_report_table.csv
-└── output_activity_20240105.quality.json
+└── output_activity_20240105_data_correlation_report_table.csv
 ```
+
+Document-oriented pipelines (for example `scripts/get_document_data.py`) append
+`<base>.quality.json` next to the CSV to summarise DOI coverage and service
+errors. Activity, assay and target jobs do not generate this report.
 
 Intermediate artefacts produced by the target `all` pipeline (`*_chembl.csv`,
 `*_uniprot.csv`, `*_iuphar.csv`) follow the same pattern. Custom `--output`

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -17,9 +17,12 @@ data/output/
 ├── output_activity_20240105.csv.meta.yaml
 ├── output_activity_20240105_failure_cases.csv
 ├── output_activity_20240105_quality_report_table.csv
-├── output_activity_20240105_data_correlation_report_table.csv
-└── output_activity_20240105.quality.json
+└── output_activity_20240105_data_correlation_report_table.csv
 ```
+
+Документные пайплайны (например, `scripts/get_document_data.py`) дополняют
+выгрузку файлом `<base>.quality.json`, который агрегирует покрытие DOI и ошибки
+внешних сервисов. Активности, биотесты и таргеты такой отчёт не создают.
 
 Промежуточные файлы таргет-пайплайна в режиме `all`
 (`*_chembl.csv`, `*_uniprot.csv`, `*_iuphar.csv`) используют тот же шаблон.


### PR DESCRIPTION
## Summary
- update the example output directory layout to reflect actual activity exports
- note that only document pipelines emit the quality JSON report
- mirror the clarification in the Russian documentation to keep both guides aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4e75b9348324b389a6632c787d02