### PR TITLE
Clarify summary_column behaviour in configuration docs

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -109,10 +109,10 @@ This block controls derived annotations appended to every activity row. It works
 
 * `enabled` — feature switch (`true`).
 * `column` — name of the raw JSON-like source column (`activity_properties`).
-* `summary_column` — destination column for the rendered text summary (`activity_property_summary`).
+* `summary_column` — reserved for the future text renderer. The current implementation keeps the JSON payload in `column`,
+  generates only the deterministic fingerprint in `hash_column` and does not emit a separate summary field.
 * `name_field`, `value_field`, `units_field` identify keys within each property record (`type`, `value`, `units`).
-* `separator` and `pair_separator` control formatting when properties are concatenated (`"; "` between pairs,
-  `"="` between name and value).
+* `separator` and `pair_separator` are likewise reserved; formatting knobs will take effect once the summary renderer ships.
 * `drop_source_column` removes the original structured column after summarisation (`true`).
 * Logging flags default to `false`, muting missing/distribution reports unless troubleshooting is required.
 * `allowlist` restricts which property groups are retained (measurement, assay, comments, effect_features, triage, mechanism,

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -108,9 +108,10 @@
 
 * `enabled` — флаг включения (`true`).
 * `column` — исходная колонка со структурированными свойствами (`activity_properties`).
-* `summary_column` — колонка для текстового резюме (`activity_property_summary`).
+* `summary_column` — зарезервирован под будущий текстовый рендер. Сейчас конвейер сохраняет JSON в `column`,
+  вычисляет только детерминированный отпечаток в `hash_column` и не создаёт отдельное поле с резюме.
 * `name_field`, `value_field`, `units_field` задают имена ключей внутри записей (`type`, `value`, `units`).
-* `separator` и `pair_separator` управляют форматированием списка свойств (`"; "` между парами и `"="` между названием и значением).
+* `separator` и `pair_separator` также зарезервированы; параметры форматирования заработают после появления текстового рендера.
 * `drop_source_column` удаляет исходную структурированную колонку после агрегации (`true`).
 * Флаги логирования по умолчанию выключены (`log_missing=false`, `log_distribution=false`).
 * `allowlist` ограничивает перечень сохраняемых групп (measurement, assay, comments, effect_features, triage, mechanism,


### PR DESCRIPTION
## Summary
- document that activity property enrichment now keeps the JSON payload and only stores the hash
- note that summary_column and separator options are currently reserved in both English and Russian guides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4e6a298c8324a3466ddaa8a2c721