### PR TITLE
Add configurable skip-quality flag for report generation

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -655,6 +655,18 @@
       "title": "DocTypeCfg",
       "type": "object"
     },
+    "ReportsCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enable_quality": {
+          "default": true,
+          "title": "Enable Quality",
+          "type": "boolean"
+        }
+      },
+      "title": "ReportsCfg",
+      "type": "object"
+    },
     "DocumentAllCfg": {
       "additionalProperties": false,
       "properties": {
@@ -1422,6 +1434,9 @@
         },
         "doc_type": {
           "$ref": "#/$defs/DocTypeCfg"
+        },
+        "reports": {
+          "$ref": "#/$defs/ReportsCfg"
         }
       },
       "title": "SystemCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -310,6 +310,8 @@ system:
       - 502
       - 503
       - 504
+  reports:
+    enable_quality: true  # Generate CSV/JSON quality artefacts alongside exports
   doc_type:
     weights:
       pubmed: 4

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -61,6 +61,10 @@ are preserved.
   next to the dataset, while `library.utils.cli_tools.get_input_initialisation`
   stores them under `<output>/data_validity_report/`.
 
+  Pass `--skip-quality` (or set `system.reports.enable_quality: false` in the
+  configuration) to suppress these CSV summaries and any document-level
+  `<base>.quality.json` files when diagnostics are not required.
+
 All files are saved with UTF-8 encoding and deterministic row/column ordering to
 simplify diffing across runs.
 

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -56,6 +56,10 @@ data/output/
   выгрузкой, а `library.utils.cli_tools.get_input_initialisation` использует
   подкаталог `<output>/data_validity_report/`.
 
+  Чтобы пропустить эти CSV и связанный `<base>.quality.json`, передайте флаг
+  `--skip-quality` или установите `system.reports.enable_quality: false` в
+  конфигурации.
+
 Все файлы пишутся в UTF-8 и соблюдают детерминированный порядок строк и колонок,
 что упрощает сравнение версий.
 

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -132,6 +132,7 @@ def add_common_arguments(
     output_default: Path | None | object = None if defaults else argparse.SUPPRESS
     sep_default: str | object = "," if defaults else argparse.SUPPRESS
     enc_default: str | object = "utf8" if defaults else argparse.SUPPRESS
+    quality_default: bool | object = True if defaults else argparse.SUPPRESS
 
     parser.add_argument("--log-level", default=log_level, help="Logging level")
     parser.add_argument(
@@ -150,6 +151,13 @@ def add_common_arguments(
     )
     parser.add_argument("--sep", default=sep_default, help="CSV delimiter")
     parser.add_argument("--encoding", default=enc_default, help="File encoding")
+    parser.add_argument(
+        "--skip-quality",
+        dest="enable_quality",
+        action="store_false",
+        default=quality_default,
+        help="Skip generating table quality reports",
+    )
     return parser
 
 
@@ -330,6 +338,7 @@ _PATH_PREFIXES: dict[str, list[str]] = {
     "log": ["system", "log"],
     "rate": ["system", "rate"],
     "retry": ["system", "retry"],
+    "reports": ["system", "reports"],
     "doc_type": ["system", "doc_type"],
 }
 
@@ -353,6 +362,7 @@ _DEFAULT_OVERRIDES: dict[str, str] = {
         "encoding": "io.csv_encoding",
         "log_level": "log.level",
         "timeout": "api.timeout_read",
+        "enable_quality": "reports.enable_quality",
     }.items()
 }
 

--- a/library/config.py
+++ b/library/config.py
@@ -395,6 +395,15 @@ class DocTypeCfg(_BaseModel):
     limit: int | None = Field(default=None, ge=0)
 
 
+class ReportsCfg(_BoolModel):
+    enable_quality: bool = True
+
+    @field_validator("enable_quality", mode="before")
+    @classmethod
+    def _bool(cls, value: Any) -> bool:
+        return cls._parse_bool(value)
+
+
 class ResourcesCfg(_BaseModel):
     dictionary_dir: Path = Path("dictionary")
     iuphar_target_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_target.csv")
@@ -857,6 +866,7 @@ class SystemCfg(_BaseModel):
     rate: RateCfg = Field(default_factory=lambda: RateCfg())
     retry: RetryCfg = Field(default_factory=lambda: RetryCfg())
     doc_type: DocTypeCfg = Field(default_factory=lambda: DocTypeCfg())
+    reports: ReportsCfg = Field(default_factory=lambda: ReportsCfg())
 
 
 class Config(_BaseModel):
@@ -927,6 +937,10 @@ class Config(_BaseModel):
     @property
     def doc_type(self) -> DocTypeCfg:
         return self.system.doc_type
+
+    @property
+    def reports(self) -> ReportsCfg:
+        return self.system.reports
 
     @property
     def resources(self) -> ResourcesCfg:
@@ -1469,6 +1483,7 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_LOG_DATEFMT": ["system", "log", "datefmt"],
     "CHEMBL_DA_RETRY_MAX_ATTEMPTS": ["system", "retry", "max_attempts"],
     "CHEMBL_DA_RETRY_BACKOFF_FACTOR": ["system", "retry", "backoff_factor"],
+    "CHEMBL_DA_ENABLE_QUALITY": ["system", "reports", "enable_quality"],
 }
 
 _ALIAS_MAP: dict[str, list[str]] = {
@@ -1490,6 +1505,7 @@ __all__ = [
     "PubMedCfg",
     "SemanticScholarCfg",
     "DocTypeCfg",
+    "ReportsCfg",
     "ActivityCfg",
     "ActivityActionTypeCfg",
     "ActivityEnrichmentCfg",

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -101,12 +101,14 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         if missing:
             raise RuntimeError("failed to write output files: " + ", ".join(missing))
 
-        logger.info("generate_quality_reports")
-        report_dir = out_dir / "data_validity_report"
-        report_dir.mkdir(parents=True, exist_ok=True)
-        for entity, path in paths.items():
-            logger.info("profiling", entity=entity)
-            analyze_table_quality(path, table_name=str(report_dir / path.stem))
+        quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
+        if quality_enabled:
+            logger.info("generate_quality_reports")
+            report_dir = out_dir / "data_validity_report"
+            report_dir.mkdir(parents=True, exist_ok=True)
+            for entity, path in paths.items():
+                logger.info("profiling", entity=entity)
+                analyze_table_quality(path, table_name=str(report_dir / path.stem))
 
         logger.info("save_done", tables=len(paths), path=str(out_dir))
         return 0

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -80,6 +80,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     limit = cfg.activity.limit
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="activity.limit", limit=limit)
         return 1
@@ -245,15 +246,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             schema="ActivitiesSchema",
         )
 
-        try:
-            analyze_table_quality(df, table_name=str(output.with_suffix("")))
-        except ValueError as exc:
-            logger.error(
-                "quality_report_failed",
-                error=str(exc),
-                path=str(output),
-            )
-            return 1
+        if quality_enabled:
+            try:
+                analyze_table_quality(df, table_name=str(output.with_suffix("")))
+            except ValueError as exc:
+                logger.error(
+                    "quality_report_failed",
+                    error=str(exc),
+                    path=str(output),
+                )
+                return 1
         return exit_code
 
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -60,6 +60,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     limit = cfg.assay.limit
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="assay.limit", limit=limit)
         return 1
@@ -201,15 +202,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             schema="AssaysSchema",
         )
 
-        try:
-            analyze_table_quality(df, table_name=str(output.with_suffix("")))
-        except ValueError as exc:
-            logger.error(
-                "quality_report_failed",
-                error=str(exc),
-                path=str(output),
-            )
-            return 1
+        if quality_enabled:
+            try:
+                analyze_table_quality(df, table_name=str(output.with_suffix("")))
+            except ValueError as exc:
+                logger.error(
+                    "quality_report_failed",
+                    error=str(exc),
+                    path=str(output),
+                )
+                return 1
         return exit_code
 
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -658,6 +658,7 @@ def _finalise_export(
     input_csv: Path,
     key_columns: Sequence[str] | None = None,
     chunk_size: int | None = None,
+    quality_enabled: bool = True,
 ) -> int:
     """Validate ``df`` and write CSV/metadata artefacts."""
 
@@ -770,23 +771,24 @@ def _finalise_export(
         schema="DocumentsSchema",
     )
 
-    quality_path = csv_path.with_suffix(".quality.json")
-    try:
-        report = build_quality_report(export_ready)
-        save_quality_report(report, quality_path)
-    except (OSError, TypeError, ValueError) as exc:
-        logger.error(
-            "quality_report_write_failed",
-            error=str(exc),
-            path=str(quality_path),
-        )
-        return 1
+    if quality_enabled:
+        quality_path = csv_path.with_suffix(".quality.json")
+        try:
+            report = build_quality_report(export_ready)
+            save_quality_report(report, quality_path)
+        except (OSError, TypeError, ValueError) as exc:
+            logger.error(
+                "quality_report_write_failed",
+                error=str(exc),
+                path=str(quality_path),
+            )
+            return 1
 
-    try:
-        analyze_table_quality(export_ready, table_name=str(csv_path.with_suffix("")))
-    except ValueError as exc:
-        logger.error("quality_report_generation_failed", error=str(exc))
-        return 1
+        try:
+            analyze_table_quality(export_ready, table_name=str(csv_path.with_suffix("")))
+        except ValueError as exc:
+            logger.error("quality_report_generation_failed", error=str(exc))
+            return 1
     return exit_code
 
 
@@ -807,6 +809,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     pubmed_defaults = cfg.document.pubmed
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
     limit = getattr(args, "limit", pubmed_defaults.limit)
     if limit is not None and limit < 0:
         logger.error(
@@ -887,6 +890,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
+            quality_enabled=quality_enabled,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error("pubmed_pipeline_failed", error=str(exc))
@@ -911,6 +915,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     chembl_defaults = cfg.document.chembl
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
     limit = getattr(args, "limit", chembl_defaults.limit)
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="document.chembl", limit=limit)
@@ -969,6 +974,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
+            quality_enabled=quality_enabled,
         )
         return exit_code
 
@@ -990,6 +996,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
     """
     all_defaults = cfg.document.all
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
     limit = getattr(args, "limit", all_defaults.limit)
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="document.all", limit=limit)
@@ -1062,6 +1069,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
+            quality_enabled=quality_enabled,
         )
         return exit_code
 
@@ -1111,6 +1119,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         input_csv=Path(args.input_csv),
         key_columns=["document_chembl_id"],
         chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
+        quality_enabled=quality_enabled,
     )
     return exit_code
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -520,15 +520,17 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             output=str(output),
         )
         return 1
-    try:
-        analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output),
-        )
-        return 1
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
+    if quality_enabled:
+        try:
+            analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error(
+                "quality_report_failed",
+                error=str(exc),
+                path=str(output),
+            )
+            return 1
     return 0
 
 
@@ -666,15 +668,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         stats=stats,
         schema="TargetsSchema",
     )
-    try:
-        analyze_table_quality(df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output),
-        )
-        return 1
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
+    if quality_enabled:
+        try:
+            analyze_table_quality(df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error(
+                "quality_report_failed",
+                error=str(exc),
+                path=str(output),
+            )
+            return 1
     return exit_code
 
 
@@ -761,15 +765,17 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
-    try:
-        analyze_table_quality(output, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output),
-        )
-        return 1
+    quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
+    if quality_enabled:
+        try:
+            analyze_table_quality(output, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error(
+                "quality_report_failed",
+                error=str(exc),
+                path=str(output),
+            )
+            return 1
     return 0
 
 
@@ -1053,7 +1059,9 @@ def merge_results(
     return final_df
 
 
-def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
+def validate_and_write(
+    df: pd.DataFrame, output: Path, cfg: Config, *, quality_enabled: bool = True
+) -> int:
     """Normalise, validate and export the target table.
 
     Parameters
@@ -1114,15 +1122,16 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
         encoding=cfg.io.csv_encoding,
         col_order=TARGETS_COLUMN_ORDER,
     )
-    try:
-        analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output),
-        )
-        return 1
+    if quality_enabled:
+        try:
+            analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error(
+                "quality_report_failed",
+                error=str(exc),
+                path=str(output),
+            )
+            return 1
     logger.info("validate_write_done", rows=len(final_df))
     return exit_code
 
@@ -1162,7 +1171,8 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         uniprot_df = fetch_uniprot(cfg, chembl_df, uniprot_out)
         combined_df, iuphar_df = fetch_iuphar(cfg, chembl_df, uniprot_df, iuphar_out)
         merged = merge_results(combined_df, iuphar_df, cfg)
-        exit_code = validate_and_write(merged, output, cfg)
+        quality_enabled = getattr(args, "enable_quality", True) and cfg.system.reports.enable_quality
+        exit_code = validate_and_write(merged, output, cfg, quality_enabled=quality_enabled)
         return exit_code
     except (FileNotFoundError, ValueError, OSError, RuntimeError) as exc:
         logger.error(

--- a/tests/test_cli_common_args.py
+++ b/tests/test_cli_common_args.py
@@ -50,6 +50,17 @@ def test_cli_overrides_config(tmp_path: Path) -> None:
     assert cfg.log.level == "DEBUG"
 
 
+def test_skip_quality_flag(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path)
+    parser = argparse.ArgumentParser()
+    add_common_arguments(parser)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
+    args = parser.parse_args(["--config", str(cfg_path), "--skip-quality"])
+    cfg = cli.apply_config_overrides(args, parser, args.config)
+    assert args.enable_quality is False
+    assert cfg.system.reports.enable_quality is False
+
+
 def test_path_argument_normalises_windows_style(tmp_path: Path) -> None:
     cfg_path = _write_config(tmp_path)
     parser = argparse.ArgumentParser()

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import types
 from pathlib import Path
 
 import pandas as pd
@@ -135,3 +136,60 @@ def test_run_chembl_column_order(
     expected_head = [c for c in schema_cols if c in available]
     expected_tail = sorted(available - set(schema_cols))
     assert captured["col_order"] == expected_head + expected_tail
+
+
+def test_run_chembl_skip_quality_omits_reports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\n1\n")
+    output_csv = tmp_path / "out.csv"
+    args = argparse.Namespace(
+        input_csv=input_csv, output_csv=output_csv, enable_quality=False
+    )
+
+    cfg.system.reports.enable_quality = True
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["1"]))
+
+    df = pd.DataFrame(
+        [
+            {
+                "activity_id": "1",
+                "assay_chembl_id": "A1",
+                "molecule_chembl_id": "CHEMBL1",
+                "standard_type": "IC50",
+                "standard_value": 10.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(cl, "get_activities", lambda *_, **__: df)
+    monkeypatch.setattr(gad, "apply_activity_annotations", lambda frame, **__: frame)
+    monkeypatch.setattr(gad, "compute_activity_bounds", lambda frame, _: frame)
+    monkeypatch.setattr(gad, "add_pipeline_metadata", lambda frame: frame)
+    def fake_write_csv(frame: pd.DataFrame, output: Path | str, *, cfg, **__) -> Path:
+        path = Path(output)
+        frame.to_csv(path, index=False)
+        return path
+
+    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gad, "write_meta_yaml", lambda **__: None)
+    monkeypatch.setattr(gad, "file_sha256", lambda _: "deadbeef")
+    monkeypatch.setattr(
+        gad,
+        "validate_activities",
+        lambda frame, return_result: types.SimpleNamespace(
+            data=frame, failure_cases=pd.DataFrame()
+        ),
+    )
+
+    rc = gad.run_chembl(cfg, args)
+    assert rc == 0
+
+    base = output_csv.with_suffix("")
+    expected_reports = [
+        base.with_name(f"{base.name}_quality_report_table.csv"),
+        base.with_name(f"{base.name}_data_correlation_report_table.csv"),
+    ]
+    for report in expected_reports:
+        assert not report.exists()

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -925,6 +925,65 @@ def test_finalise_export_falls_back_to_default_key(
     assert captured["key_cols"] == ["ChEMBL.document_chembl_id"]
 
 
+def test_finalise_export_skip_quality_reports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"document_chembl_id": ["CHEMBL1"]})
+    output = tmp_path / "documents.csv"
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("document_chembl_id\nCHEMBL1\n")
+
+    class _DummyColumn:
+        required = True
+
+    class DummySchema:
+        columns = {"document_chembl_id": _DummyColumn()}
+
+        @staticmethod
+        def validate(frame: pd.DataFrame, lazy: bool = True) -> pd.DataFrame:
+            return frame
+
+    monkeypatch.setattr(gdd, "add_pipeline_metadata", lambda frame: frame)
+    monkeypatch.setattr(gdd, "build_dataframe", lambda frame, **__: frame)
+    monkeypatch.setattr(gdd, "DocumentsSchema", DummySchema)
+    monkeypatch.setattr(gdd, "_EXPORT_COLUMNS", ["document_chembl_id"])
+    monkeypatch.setattr(gdd, "_EXPORT_COLUMN_RENAMES", {})
+    monkeypatch.setattr(gdd, "_EXPORT_SORT_FALLBACK", ["document_chembl_id"])
+    monkeypatch.setattr(gdd, "_EXPORT_STREAM_CHUNK_SIZE", 1)
+    monkeypatch.setattr(gdd, "_iter_export_chunks", lambda frame, chunk_size: (frame,))
+
+    def fake_write_chunks(
+        chunks: Iterable[pd.DataFrame], path: Path, *, cfg: Any, **__: Any
+    ) -> Path:
+        frame = next(iter(chunks))
+        path = Path(path)
+        frame.to_csv(path, index=False)
+        return path
+
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_chunks)
+    monkeypatch.setattr(gdd, "file_sha256", lambda _: "deadbeef")
+    monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
+
+    rc = gdd._finalise_export(
+        df,
+        output,
+        cfg,
+        input_csv=input_csv,
+        key_columns=["document_chembl_id"],
+        quality_enabled=False,
+    )
+
+    assert rc == 0
+    quality_json = output.with_suffix(".quality.json")
+    base = output.with_suffix("")
+    quality_tables = [
+        base.with_name(f"{base.name}_quality_report_table.csv"),
+        base.with_name(f"{base.name}_data_correlation_report_table.csv"),
+    ]
+    for artefact in [quality_json, *quality_tables]:
+        assert not artefact.exists()
+
+
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])
 def test_fetch_pubmed_records_accepts_executor_context(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add a `--skip-quality` switch that updates `system.reports.enable_quality` in configuration and defaults to current behaviour
- gate quality analysis/report writers in the activity, assay, document, target pipelines and input-initialisation CLI
- document the opt-out flag and cover the skip path with targeted pytest checks

## Testing
- pytest tests/test_cli_common_args.py tests/test_get_activity_data.py::test_run_chembl_skip_quality_omits_reports tests/test_get_document_data.py::test_finalise_export_skip_quality_reports


------
https://chatgpt.com/codex/tasks/task_e_68dc4dbed7908324acdaef851afdc8b2