### PR TITLE
Share documents rate limiter across metadata sources

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1248,6 +1248,32 @@
           "minimum": 0,
           "title": "Retries",
           "type": "integer"
+        },
+        "rps": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rps"
+        },
+        "burst": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Burst"
         }
       },
       "title": "PubMedCfg",
@@ -1372,6 +1398,32 @@
           "minimum": 0,
           "title": "Retries",
           "type": "integer"
+        },
+        "rps": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rps"
+        },
+        "burst": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Burst"
         }
       },
       "title": "SemanticScholarCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -180,11 +180,15 @@ sources:
     timeout_connect: 5  # (env: CHEMBL_DA_PUBMED_TIMEOUT_CONNECT)
     timeout_read: 10  # (env: CHEMBL_DA_PUBMED_TIMEOUT_READ)
     retries: 2  # (env: CHEMBL_DA_PUBMED_RETRIES)
+    rps: null  # Optional requests-per-second override for document acquisition
+    burst: null  # Optional burst override for document acquisition
   semantic_scholar:
     base: "https://api.semanticscholar.org/graph/v1"  # Semantic Scholar API root (env: CHEMBL_DA__SOURCES__SEMANTIC_SCHOLAR__BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_SEMANTIC_SCHOLAR_TIMEOUT_CONNECT)
     timeout_read: 10  # (env: CHEMBL_DA_SEMANTIC_SCHOLAR_TIMEOUT_READ)
     retries: 2  # (env: CHEMBL_DA_SEMANTIC_SCHOLAR_RETRIES)
+    rps: null  # Optional requests-per-second override for document acquisition
+    burst: null  # Optional burst override for document acquisition
 
 local:
   resources:

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -254,8 +254,8 @@ applies exponential backoff between attempts before surfacing the error.
 | `uniprot.mapping` | `https://rest.uniprot.org/idmapping` | `poll_interval=0.5` seconds, `timeout=300.0` seconds, `cache_ttl=null`. |
 | `iuphar` | `https://www.guidetopharmacology.org/services` | `timeout_connect=5`, `timeout_read=30`, `rps=5`, `burst=5`. |
 | `pubchem` | `https://pubchem.ncbi.nlm.nih.gov/rest/pug` | See [detailed PubChem options](#pubchem-lookups-sourcespubchem). |
-| `pubmed` | `https://eutils.ncbi.nlm.nih.gov/entrez/eutils` | `timeout_connect=5`, `timeout_read=10`, `retries=2`. |
-| `semantic_scholar` | `https://api.semanticscholar.org/graph/v1` | `timeout_connect=5`, `timeout_read=10`, `retries=2`. |
+| `pubmed` | `https://eutils.ncbi.nlm.nih.gov/entrez/eutils` | `timeout_connect=5`, `timeout_read=10`, `retries=2`, optional `rps`/`burst` overrides for document acquisition. |
+| `semantic_scholar` | `https://api.semanticscholar.org/graph/v1` | `timeout_connect=5`, `timeout_read=10`, `retries=2`, optional `rps`/`burst` overrides for document acquisition. |
 
 All URLs must comply with the respective service usage policies, including rate limits and contact information requirements.
 

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -244,8 +244,8 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `uniprot.mapping` | `https://rest.uniprot.org/idmapping` | `poll_interval=0.5`, `timeout=300.0`, `cache_ttl=null`. |
 | `iuphar` | `https://www.guidetopharmacology.org/services` | `timeout_connect=5`, `timeout_read=30`, `rps=5`, `burst=5`. |
 | `pubchem` | `https://pubchem.ncbi.nlm.nih.gov/rest/pug` | См. [детальные настройки PubChem](#pubchem-sourcespubchem). |
-| `pubmed` | `https://eutils.ncbi.nlm.nih.gov/entrez/eutils` | `timeout_connect=5`, `timeout_read=10`, `retries=2`. |
-| `semantic_scholar` | `https://api.semanticscholar.org/graph/v1` | `timeout_connect=5`, `timeout_read=10`, `retries=2`. |
+| `pubmed` | `https://eutils.ncbi.nlm.nih.gov/entrez/eutils` | `timeout_connect=5`, `timeout_read=10`, `retries=2`, опциональные `rps`/`burst` для документарных запросов. |
+| `semantic_scholar` | `https://api.semanticscholar.org/graph/v1` | `timeout_connect=5`, `timeout_read=10`, `retries=2`, опциональные `rps`/`burst` для документарных запросов. |
 
 Соблюдайте требования сервисов по rate limit и указанию контактной информации.
 

--- a/library/config.py
+++ b/library/config.py
@@ -377,6 +377,8 @@ class PubMedCfg(_BaseModel):
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(10, ge=1)
     retries: int = Field(2, ge=0)
+    rps: int | None = Field(default=None, ge=1)
+    burst: int | None = Field(default=None, ge=1)
 
     @field_validator("base")
     @classmethod
@@ -391,6 +393,8 @@ class SemanticScholarCfg(_BaseModel):
     timeout_connect: int = Field(5, ge=1)
     timeout_read: int = Field(10, ge=1)
     retries: int = Field(2, ge=0)
+    rps: int | None = Field(default=None, ge=1)
+    burst: int | None = Field(default=None, ge=1)
 
     @field_validator("base")
     @classmethod
@@ -1474,6 +1478,14 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_LIMITER_CACHE_TTL": ["system", "rate", "limiter_cache_ttl"],
     "CHEMBL_DA_OUTDIR": ["local", "io", "output_dir"],
     "CHEMBL_DA_RPS": ["sources", "chembl", "api", "rps"],
+    "CHEMBL_DA_PUBMED_RPS": ["sources", "pubmed", "rps"],
+    "CHEMBL_DA_PUBMED_BURST": ["sources", "pubmed", "burst"],
+    "CHEMBL_DA_SEMANTIC_SCHOLAR_RPS": ["sources", "semantic_scholar", "rps"],
+    "CHEMBL_DA_SEMANTIC_SCHOLAR_BURST": [
+        "sources",
+        "semantic_scholar",
+        "burst",
+    ],
     "CHEMBL_DA_TARGETS_TYPE_CSV": ["local", "resources", "targets_type_csv"],
     "CHEMBL_DA_TIMEOUT_CONNECT": ["sources", "chembl", "api", "timeout_connect"],
     "CHEMBL_DA_TIMEOUT_READ": ["sources", "chembl", "api", "timeout_read"],

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -77,7 +77,7 @@ from library.document_pipeline import (
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
-from library.rate_limiter import get_limiter
+from library.rate_limiter import RateLimiter, get_limiter
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from schemas import DocumentsSchema, normalize_documents
@@ -248,10 +248,43 @@ def fetch_pubmed_records(
     rate_cfg = settings.rate
     if pubmed_cfg is None:
         pubmed_cfg = settings.pubmed
-    pubmed_limiter = get_limiter("pubmed", rate_cfg.global_rps, rate_cfg.global_burst)
-    semantic_limiter = get_limiter(
-        "semantic_scholar", rate_cfg.global_rps, rate_cfg.global_burst
+
+    documents_limiter = get_limiter(
+        "documents_global", rate_cfg.global_rps, rate_cfg.global_burst
     )
+
+    def _service_limiter(
+        name: str,
+        *,
+        rps: int | None,
+        burst: int | None,
+    ) -> RateLimiter | None:
+        effective_rps = rps if rps is not None else rate_cfg.global_rps
+        effective_burst = burst if burst is not None else rate_cfg.global_burst
+        if (
+            rps is None
+            and burst is None
+            or (
+                effective_rps == rate_cfg.global_rps
+                and effective_burst == rate_cfg.global_burst
+            )
+        ):
+            return None
+        return get_limiter(f"documents_{name}", effective_rps, effective_burst)
+
+    pubmed_service_limiter = _service_limiter(
+        "pubmed", rps=getattr(pubmed_cfg, "rps", None), burst=getattr(pubmed_cfg, "burst", None)
+    )
+    semantic_service_limiter = _service_limiter(
+        "semantic_scholar",
+        rps=getattr(semantic_scholar_cfg, "rps", None),
+        burst=getattr(semantic_scholar_cfg, "burst", None),
+    )
+
+    def _acquire_documents(limiter: RateLimiter | None) -> None:
+        documents_limiter.acquire()
+        if limiter is not None:
+            limiter.acquire()
 
     def _failure_records(batch: Sequence[str], message: str) -> list[dict[str, str]]:
         """Return placeholder rows describing a failure for ``batch`` PMIDs."""
@@ -299,7 +332,7 @@ def fetch_pubmed_records(
 
         try:
             with session_with_retry(__cfg.api, __cfg.retry) as session:
-                pubmed_limiter.acquire()
+                _acquire_documents(pubmed_service_limiter)
                 pubmed_list = pl.fetch_pubmed_batch(
                     session, batch_list, sleep, cfg=pubmed_cfg
                 )
@@ -310,7 +343,7 @@ def fetch_pubmed_records(
                 semsch_map: dict[str, dict[str, str]] = {}
                 if semantic_pmids:
                     # Fetch Semantic Scholar data in a single batch
-                    semantic_limiter.acquire()
+                    _acquire_documents(semantic_service_limiter)
                     semsch_list = ssl.fetch_semantic_scholar_batch(
                         session, semantic_pmids, sleep, cfg=semantic_scholar_cfg
                     )
@@ -333,7 +366,7 @@ def fetch_pubmed_records(
                         if record is None or record.get("scholar.Error"):
                             fallback_pmids.append(pmid)
                     for pmid in fallback_pmids:
-                        semantic_limiter.acquire()
+                        _acquire_documents(semantic_service_limiter)
                         fallback_record = ssl.fetch_semantic_scholar(
                             session, pmid, sleep, cfg=semantic_scholar_cfg
                         )

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -13,6 +13,7 @@ import pytest
 
 from library import chembl_library as cl
 from library import io as lib_io
+from library import rate_limiter as rl
 from library.cli import LoggerConfig, configure_logger
 from library.config import (
     Config,
@@ -614,10 +615,10 @@ def test_fetch_pubmed_records_accepts_config(
     assert df.loc[0, "PubMed.PMID"] == "1"
 
 
-def test_fetch_pubmed_records_acquires_pubmed_limiter(
+def test_fetch_pubmed_records_acquires_documents_limiter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PubMed batch requests should acquire the shared rate limiter."""
+    """PubMed and Semantic Scholar use the shared documents limiter."""
 
     class TrackingLimiter:
         def __init__(self) -> None:
@@ -630,6 +631,7 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
 
     tracking_limiter = TrackingLimiter()
     batches_seen: list[list[str]] = []
+    service_events: list[tuple[str, int]] = []
 
     class DummySession:
         def __enter__(self) -> DummySession:  # pragma: no cover - trivial
@@ -648,9 +650,8 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
         *,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
-        acquisition_count = tracking_limiter.acquisitions
         batches_seen.append(list(batch))
-        assert acquisition_count == len(batches_seen)
+        service_events.append(("pubmed", tracking_limiter.acquisitions))
         return [{"PubMed.PMID": pmid} for pmid in batch]
 
     def fake_semantic_batch(
@@ -659,6 +660,7 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
         sleep: float,
         cfg: Any | None = None,
     ) -> list[dict[str, str]]:
+        service_events.append(("semantic", tracking_limiter.acquisitions))
         return [{"scholar.PMID": pmid} for pmid in pmids]
 
     monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
@@ -667,7 +669,7 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
     monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
 
     def fake_get_limiter(name: str, *_, **__) -> Any:
-        if name == "pubmed":
+        if name == "documents_global":
             return tracking_limiter
         return DummyLimiter()
 
@@ -684,10 +686,91 @@ def test_fetch_pubmed_records_acquires_pubmed_limiter(
     )
 
     assert batches_seen == [["1"], ["2"]]
-    assert tracking_limiter.acquisitions == len(batches_seen)
-    assert tracking_limiter.history == [1, 2]
+    assert tracking_limiter.acquisitions == 4
+    assert tracking_limiter.history == [1, 2, 3, 4]
+    assert service_events == [
+        ("pubmed", 1),
+        ("semantic", 2),
+        ("pubmed", 3),
+        ("semantic", 4),
+    ]
     assert list(df["PubMed.PMID"]) == ["1", "2"]
 
+
+def test_documents_limiter_enforces_shared_pace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successive service calls respect the shared documents pace."""
+
+    current_time = {"value": 0.0}
+    sleep_calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return current_time["value"]
+
+    def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        current_time["value"] += delay
+
+    monkeypatch.setattr(rl.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(rl, "sleep", fake_sleep)
+
+    documents_limiter = rl.RateLimiter(rps=1, burst=1)
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"PubMed.PMID": pmid} for pmid in batch]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"scholar.PMID": pmid} for pmid in pmids]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", lambda *_, **__: {})
+
+    def fake_get_limiter(name: str, *_, **__) -> Any:
+        if name == "documents_global":
+            return documents_limiter
+        return DummyLimiter()
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    df = gdd.fetch_pubmed_records(
+        ["1", "2"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert list(df["PubMed.PMID"]) == ["1", "2"]
+    assert len(sleep_calls) >= 2
+    assert sleep_calls[0] == pytest.approx(1.0, rel=1e-6)
+    assert sleep_calls[1] == pytest.approx(1.0, rel=1e-6)
 
 def test_fetch_pubmed_records_uses_explicit_pubmed_cfg(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- use a shared `documents_global` limiter for PubMed and Semantic Scholar lookups while allowing optional per-source overrides
- add per-service rate configuration entries and environment aliases with accompanying documentation updates
- extend document acquisition tests to exercise the shared limiter and pacing behaviour

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_acquires_documents_limiter tests/test_get_document_data.py::test_documents_limiter_enforces_shared_pace

------
https://chatgpt.com/codex/tasks/task_e_68dc4f4ee6c88324b1b758d07d667e49