### PR TITLE
Integrate config overrides into CSV utility CLI

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import argparse
 
-from .cli import add_common_arguments
+from .cli import add_common_arguments, path_argument
+from .utils.config import DEFAULT_CONFIG_RELATIVE
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,5 +42,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=1000,
         help="Rows loaded per temporary file during merge",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=DEFAULT_CONFIG_RELATIVE,
+        help="YAML configuration file",
     )
     return parser

--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from library import cli
 from library.cli import LoggerConfig, configure_logger
 from library.cli_utils import build_parser
 from library.csv_utils import write_csv_chunks_deterministic
@@ -44,18 +45,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         ns.output_csv = Path(ns.input_csv).with_name(
             f"output_{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
         )
-    args = CSVExportArgs.model_validate(vars(ns))
+    cfg = cli.apply_config_overrides(
+        ns,
+        parser,
+        ns.config,
+        mapping={"chunk_size": "io.csv_chunksize"},
+    )
+    arg_data = {field: getattr(ns, field) for field in CSVExportArgs.model_fields}
+    args = CSVExportArgs.model_validate(arg_data)
     if not args.key_cols:
         parser.error("--key-cols must be provided")
     configure_logger(LoggerConfig(level=args.log_level))
 
     start = time.perf_counter()
 
+    sep = args.sep or cfg.io.csv_sep
+    encoding = args.encoding or cfg.io.csv_encoding
+    chunk_size = args.chunk_size or cfg.io.csv_chunksize
+
     reader = pd.read_csv(
         args.input_csv,
-        sep=args.sep,
-        encoding=args.encoding,
-        chunksize=args.chunk_size,
+        sep=sep,
+        encoding=encoding,
+        chunksize=chunk_size,
     )
     output = args.output_csv or Path(args.input_csv).with_name(
         f"output_{Path(args.input_csv).stem}.csv"
@@ -65,8 +77,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         output,
         col_order=args.col_order or None,
         key_cols=args.key_cols,
-        chunksize=args.chunk_size,
+        chunksize=chunk_size,
         merge_chunksize=args.merge_chunk_size,
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+        cfg=cfg,
         drop_unexpected_cols=True,
     )
     elapsed = time.perf_counter() - start

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pandas as pd
 import pytest
+import yaml
 
 from library.utils.cli_tools import csv_utils_main as cli
 
@@ -47,6 +48,8 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
         called["output"] = output
         called["write_chunksize"] = chunksize
         called["merge_chunksize"] = merge_chunksize
+        called["write_sep"] = kwargs.get("sep")
+        called["write_encoding"] = kwargs.get("encoding")
         list(chunks)  # exhaust generator
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
@@ -81,6 +84,8 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     assert called["chunksize"] == 2
     assert called["write_chunksize"] == 2
     assert called["merge_chunksize"] == 3
+    assert called["write_sep"] == "|"
+    assert called["write_encoding"] == "latin1"
 
 
 def test_cli_generates_output_path(
@@ -131,3 +136,76 @@ def test_cli_generates_output_path(
     assert rc == 0
     expected = input_csv.with_name("output_input_20240102.csv")
     assert called["output"] == expected
+
+
+def test_cli_uses_configured_delimiter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    input_csv = tmp_path / "in.csv"
+    input_csv.write_text("a,b\n1,2\n", encoding="utf8")
+    config_path = tmp_path / "cfg.yaml"
+    config_data = yaml.safe_load(Path("config/config.yaml").read_text(encoding="utf8"))
+    config_data["local"]["io"]["csv_sep"] = ";"
+    config_data["local"]["io"]["csv_encoding"] = "latin1"
+    config_data["local"]["io"]["csv_chunksize"] = 256
+    config_path.write_text(yaml.safe_dump(config_data), encoding="utf8")
+
+    called: dict[str, object] = {}
+
+    def fake_read_csv(
+        path: Path | str,
+        sep: str,
+        encoding: str,
+        chunksize: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Iterator[pd.DataFrame]:
+        called["path"] = path
+        called["sep"] = sep
+        called["encoding"] = encoding
+        called["chunksize"] = chunksize
+
+        def gen() -> Iterator[pd.DataFrame]:
+            yield pd.DataFrame({"a": [1], "b": [2]})
+
+        return gen()
+
+    def fake_write(
+        chunks: Iterable[pd.DataFrame],
+        output: Path | str,
+        col_order: list[str] | None = None,
+        key_cols: list[str] | None = None,
+        chunksize: int | None = None,
+        merge_chunksize: int | None = None,
+        drop_unexpected_cols: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        called["output"] = output
+        called["write_chunksize"] = chunksize
+        called["merge_chunksize"] = merge_chunksize
+        called["write_sep"] = kwargs.get("sep")
+        called["write_encoding"] = kwargs.get("encoding")
+        list(chunks)
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    monkeypatch.setattr(cli, "write_csv_chunks_deterministic", fake_write)
+
+    rc = cli.main(
+        [
+            "--input",
+            str(input_csv),
+            "--key-cols",
+            "a",
+            "--config",
+            str(config_path),
+        ]
+    )
+    assert rc == 0
+    assert called["path"] == input_csv
+    assert called["sep"] == ";"
+    assert called["encoding"] == "latin1"
+    assert called["chunksize"] == 256
+    assert called["write_sep"] == ";"
+    assert called["write_encoding"] == "latin1"
+    assert called["write_chunksize"] == 256


### PR DESCRIPTION
## Summary
- update the CSV utility CLI to load configuration overrides and use configured CSV defaults
- forward configuration-derived delimiter, encoding, and chunk size to deterministic CSV writer
- cover configuration delimiter override behaviour with a dedicated CLI test

## Testing
- pytest tests/test_csv_utils_main_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4ec77c80832484309abff21c0939