### PR TITLE
Update chunk IO CLI to respect config overrides

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -6,16 +6,19 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+from library import cli
 from library.chunk_io import process_csv_chunks
 from library.cli import (
     LoggerConfig,
     add_common_arguments,
     configure_logger,
+    create_logger_config,
     path_argument,
 )
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
 from library.io.paths import default_output_path
 from library.log import logger
+from library.utils.config import DEFAULT_CONFIG_RELATIVE
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
@@ -42,7 +45,20 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=Path("checkpoint.json"),
         help="Path to checkpoint file",
     )
-    return parser, LoggerConfig(level="INFO")
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=DEFAULT_CONFIG_RELATIVE,
+        help="YAML configuration file",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
+    log_cfg = create_logger_config(parser.get_default("log_level"))
+    return parser, log_cfg
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -90,7 +106,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     configure_logger(log_cfg)
-    cfg = Config()
+    cfg = cli.apply_config_overrides(args, parser, args.config)
+    log_cfg.level = cfg.log.level
+    configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+    if args.print_config:
+        print_config(cfg)
+        return 0
     return run(cfg, args)
 
 

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from library.utils.cli_tools import chunk_io_main as cli
 
@@ -34,3 +35,62 @@ def test_cli_limit(tmp_path: Path) -> None:
     )
     result = pd.read_csv(output_path)
     assert len(result) == 100
+
+
+def test_cli_uses_config_separator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI honours ``io.csv_sep`` from the provided configuration file."""
+
+    config_path = tmp_path / "config.yaml"
+    output_dir = tmp_path / "output"
+    cache_dir = tmp_path / "cache"
+    config_path.write_text(
+        "local:\n"
+        "  io:\n"
+        "    csv_sep: ';'\n"
+        f"    output_dir: '{output_dir.as_posix()}'\n"
+        f"    cache_dir: '{cache_dir.as_posix()}'\n"
+        "system:\n"
+        "  log:\n"
+        "    level: INFO\n"
+    )
+
+    input_path = tmp_path / "input.csv"
+    df = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    df.to_csv(input_path, index=False, sep=";")
+
+    captured: dict[str, object] = {}
+
+    def _stub_process(
+        input_csv: Path,
+        output_csv: Path,
+        *,
+        cfg,
+        chunk_size: int,
+        limit,
+        checkpoint_path,
+        sep,
+        encoding,
+    ) -> int:
+        captured.update({"sep": sep, "cfg_sep": cfg.csv_sep})
+        return 0
+
+    monkeypatch.setattr(cli, "process_csv_chunks", _stub_process)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--output",
+            str(tmp_path / "result.csv"),
+            "--checkpoint",
+            str(tmp_path / "checkpoint.json"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["sep"] == ";"
+    assert captured["cfg_sep"] == ";"


### PR DESCRIPTION
## Summary
- load the chunk_io CLI configuration through apply_config_overrides and expose --config/--print-config switches while reusing configured logging settings
- ensure the CLI passes the loaded Config to run and honours its I/O defaults
- add an integration test covering csv separator overrides delivered through a temporary YAML file

## Testing
- pytest tests/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4d8aeb1c8324a2ac6281f15c6c6a