### PR TITLE
Use deterministic CSV writer with configurable chunking

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -27,6 +27,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import cli
 from library import io
+from library.csv_utils import write_csv_deterministic
 from library.clients import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -214,12 +215,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         rows_dropped = rows_total - rows_kept
         try:
             key_cols = [c for c in ["activity_id"] if c in df.columns]
-            csv_path = io.write_csv(
+            sort_columns = key_cols or sorted(df.columns)
+            csv_path = write_csv_deterministic(
                 df,
                 output,
-                cfg=cfg,
-                key_cols=key_cols or None,
+                key_cols=sort_columns,
                 col_order=col_order,
+                chunksize=cfg.io.csv_chunksize,
+                sort_chunksize=cfg.io.csv_chunksize,
+                sep=cfg.io.csv_sep,
+                encoding=cfg.io.csv_encoding,
+                cfg=cfg,
             )
             logger.info("write_done", rows=rows_kept, path=str(csv_path))
         except OSError as exc:

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -42,9 +42,9 @@ def test_run_chembl_respects_limit(
     monkeypatch.setattr(cl, "get_activities", fake_get)
 
     monkeypatch.setattr(
-        io,
-        "write_csv",
-        lambda df, output, *, cfg, sep=None, encoding=None, **__: output,
+        gad,
+        "write_csv_deterministic",
+        lambda df, output, *, key_cols, col_order, chunksize, sort_chunksize, sep, encoding, cfg, **__: output,
     )
     monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
     monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
@@ -113,11 +113,23 @@ def test_run_chembl_column_order(
 
     captured: dict[str, list[str]] = {}
 
-    def fake_write_csv(df, output, *, cfg, key_cols=None, col_order=None, **__) -> Path:
+    def fake_write_csv(
+        df,
+        output,
+        *,
+        key_cols,
+        col_order,
+        chunksize,
+        sort_chunksize,
+        sep,
+        encoding,
+        cfg,
+        **__,
+    ) -> Path:
         captured["col_order"] = list(col_order or [])
         return output
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gad, "write_csv_deterministic", fake_write_csv)
 
     rc = gad.run_chembl(cfg, args)
     assert rc == 0
@@ -135,3 +147,91 @@ def test_run_chembl_column_order(
     expected_head = [c for c in schema_cols if c in available]
     expected_tail = sorted(available - set(schema_cols))
     assert captured["col_order"] == expected_head + expected_tail
+
+
+def test_run_chembl_streams_large_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Ensure large datasets trigger chunked deterministic CSV writes."""
+
+    chunk_size = cfg.io.csv_chunksize
+    total_rows = chunk_size * 2 + 5
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\n" + "\n".join(str(i) for i in range(total_rows)))
+
+    monkeypatch.setattr(
+        io,
+        "read_ids",
+        lambda *_, **__: (str(i) for i in range(total_rows)),
+    )
+
+    def fake_get(ids, cfg, client, chunk_size, timeout, **kwargs):
+        data = list(ids)
+        return pd.DataFrame(
+            {
+                "activity_id": data,
+                "standard_value": [1.0] * len(data),
+                "standard_type": ["IC50"] * len(data),
+            }
+        )
+
+    monkeypatch.setattr(cl, "get_activities", fake_get)
+    monkeypatch.setattr(gad, "normalize_activities", lambda df: df)
+    monkeypatch.setattr(gad, "add_pipeline_metadata", lambda df: df)
+    monkeypatch.setattr(gad, "compute_activity_bounds", lambda df, cfg: df)
+    monkeypatch.setattr(
+        gad,
+        "apply_activity_annotations",
+        lambda df, action_cfg, properties_cfg: df,
+    )
+
+    class _Result:
+        def __init__(self, data: pd.DataFrame) -> None:
+            self.data = data
+            self.failure_cases = pd.DataFrame()
+
+    monkeypatch.setattr(
+        gad,
+        "validate_activities",
+        lambda df, return_result: _Result(df),
+    )
+    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
+
+    captured: dict[str, object] = {}
+
+    def fake_write_csv(
+        df: pd.DataFrame,
+        output: Path,
+        *,
+        key_cols,
+        col_order,
+        chunksize,
+        sort_chunksize,
+        sep,
+        encoding,
+        cfg,
+        **__,
+    ) -> Path:
+        chunk_count = (len(df) + chunksize - 1) // chunksize if chunksize else 1
+        captured.update(
+            {
+                "chunksize": chunksize,
+                "sort_chunksize": sort_chunksize,
+                "chunk_count": chunk_count,
+                "rows": len(df),
+            }
+        )
+        return output
+
+    monkeypatch.setattr(gad, "write_csv_deterministic", fake_write_csv)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+    rc = gad.run_chembl(cfg, args)
+
+    assert rc == 0
+    assert captured["rows"] == total_rows
+    assert captured["chunksize"] == chunk_size
+    assert captured["sort_chunksize"] == chunk_size
+    assert captured["chunk_count"] > 1


### PR DESCRIPTION
## Summary
- switch the activity pipeline to call write_csv_deterministic directly so chunking respects io.csv_chunksize for both writing and sorting
- cover the new behaviour with regression tests, including a large dataset scenario that asserts chunk sizing

## Testing
- pytest tests/test_get_activity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4ecbbbdc8324ba26fab2f05439d0