### PR TITLE
Ensure chunked CLI creates output directories

### DIFF
--- a/library/chunk_io.py
+++ b/library/chunk_io.py
@@ -131,6 +131,7 @@ def process_csv_chunks(
     checkpoint_path: Path | None = None,
     sep: str | None = None,
     encoding: str | None = None,
+    ensure_directory: bool = False,
 ) -> int:
     """Copy ``input_path`` to ``output_path`` using chunked I/O.
 
@@ -154,6 +155,10 @@ def process_csv_chunks(
         Location of a checkpoint file storing processed row counts.
     sep, encoding:
         CSV formatting options overriding ``cfg`` defaults.
+    ensure_directory:
+        When ``True``, create the parent directory of ``output_path`` if it does
+        not exist and :attr:`IoCfg.exist_ok` permits directory creation. When
+        ``False``, callers must ensure the directory is available.
 
     Returns
     -------
@@ -163,11 +168,25 @@ def process_csv_chunks(
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
 
+    output_path = Path(output_path)
+    if ensure_directory:
+        parent = output_path.parent
+        if parent.exists():
+            if not parent.is_dir():
+                msg = f"{parent} is not a directory"
+                raise NotADirectoryError(msg)
+        else:
+            if cfg.exist_ok:
+                parent.mkdir(parents=True, exist_ok=True)
+            else:
+                msg = f"{parent} does not exist"
+                raise FileNotFoundError(msg)
+
     processed = 0
     header_written = False
     if checkpoint_path is not None:
         processed = _read_checkpoint(checkpoint_path)
-        header_written = Path(output_path).exists() and processed > 0
+        header_written = output_path.exists() and processed > 0
         if processed:
             logger.info("resume_from_row", row=processed)
 

--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -53,7 +53,15 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         if args.limit is not None and args.limit <= 0:
             raise SystemExit("--limit must be a positive integer")
 
-        output = args.output_csv or default_output_path(args.input_csv, cfg.io)
+        output = Path(args.output_csv or default_output_path(args.input_csv, cfg.io))
+        parent = output.parent
+        if not parent.exists():
+            if cfg.io.exist_ok:
+                parent.mkdir(parents=True, exist_ok=True)
+            else:
+                raise SystemExit(f"output directory {parent} does not exist")
+        elif not parent.is_dir():
+            raise SystemExit(f"output directory {parent} is not a directory")
         ensure_dirs(cfg)
         rows = process_csv_chunks(
             args.input_csv,
@@ -64,6 +72,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             checkpoint_path=args.checkpoint,
             sep=args.sep,
             encoding=args.encoding,
+            ensure_directory=False,
         )
         logger.info("rows_processed", rows=rows)
         return 0

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -34,3 +34,33 @@ def test_cli_limit(tmp_path: Path) -> None:
     )
     result = pd.read_csv(output_path)
     assert len(result) == 100
+
+
+def test_cli_creates_output_directory(tmp_path: Path) -> None:
+    """CLI creates missing output directories when allowed by configuration."""
+    input_path = tmp_path / "input.csv"
+    df = pd.DataFrame({"a": range(10)})
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "missing" / "sub" / "out.csv"
+    checkpoint = tmp_path / "cp.json"
+    assert not output_path.parent.exists()
+
+    exit_code = cli.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "5",
+            "--checkpoint",
+            str(checkpoint),
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_path.exists()
+    result = pd.read_csv(output_path)
+    assert len(result) == len(df)


### PR DESCRIPTION
## Summary
- add an optional directory creation flag to `process_csv_chunks` for clarity
- update the chunked CSV CLI to create missing output parent directories when allowed by configuration
- extend CLI tests to cover handling of non-existent output directories

## Testing
- python -m pytest tests/test_chunk_io.py tests/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4ed78520832488336a49da517c1c