### PR TITLE
Ensure assay CLI resolves repository imports

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -12,6 +12,11 @@ from itertools import islice
 import requests
 from pandera.errors import SchemaErrors
 
+# Ensure repository package imports work when the script is executed directly.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import cli


### PR DESCRIPTION
## Summary
- ensure the assay CLI adds the repository root to sys.path when executed directly
- document the import path handling to clarify intent

## Testing
- python scripts/get_assay_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68dce86f1de48324977835d0966f646e