### PR TITLE
Stream document export chunks and verify deterministic streaming

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -705,6 +705,23 @@ def _write_export_chunks(
     )
 
 
+def _load_export_ready_frame(path: Path, *, cfg: Config) -> pd.DataFrame:
+    """Load the streamed CSV export for quality reporting."""
+
+    try:
+        loaded = pd.read_csv(
+            path,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
+    except pd.errors.EmptyDataError:
+        loaded = pd.DataFrame(columns=list(_EXPORT_COLUMNS))
+    missing = [column for column in _EXPORT_COLUMNS if column not in loaded.columns]
+    for column in missing:
+        loaded[column] = ""
+    return loaded[_EXPORT_COLUMNS]
+
+
 def _finalise_export(
     df: pd.DataFrame | Iterable[pd.DataFrame],
     output: Path,
@@ -760,10 +777,10 @@ def _finalise_export(
     rows_total = 0
     rows_kept = 0
     exit_code = 0
-    validated_chunks: list[pd.DataFrame] = []
+    emitted_chunk = False
 
     def _validated_chunks() -> Iterator[pd.DataFrame]:
-        nonlocal rows_total, rows_kept, exit_code
+        nonlocal rows_total, rows_kept, exit_code, emitted_chunk
         for frame in process_iter:
             with_metadata = add_pipeline_metadata(frame)
             ordered = build_dataframe(
@@ -789,8 +806,18 @@ def _finalise_export(
             cleaned = build_dataframe(
                 validated, columns=DOCUMENT_SCHEMA_COLUMNS, fill_missing=False
             )
-            validated_chunks.append(cleaned)
             for chunk in _iter_export_chunks(cleaned, chunk_size=stream_chunk):
+                emitted_chunk = True
+                yield chunk
+
+        if not emitted_chunk:
+            empty = build_dataframe(
+                add_pipeline_metadata(pd.DataFrame()),
+                columns=DOCUMENT_SCHEMA_COLUMNS,
+                fill_missing=False,
+            )
+            for chunk in _iter_export_chunks(empty, chunk_size=stream_chunk):
+                emitted_chunk = True
                 yield chunk
 
     export_generator = _validated_chunks()
@@ -832,22 +859,11 @@ def _finalise_export(
     rows_dropped = rows_total - rows_kept
     logger.info("write_done", rows=rows_kept, path=str(csv_path))
 
-    if not validated_chunks:
-        export_ready = build_dataframe(
-            add_pipeline_metadata(pd.DataFrame()),
-            columns=DOCUMENT_SCHEMA_COLUMNS,
-            fill_missing=False,
-        )
-    elif len(validated_chunks) == 1:
-        export_ready = validated_chunks[0]
-    else:
-        export_ready = pd.concat(validated_chunks, ignore_index=True)
-
-    renamed_columns = {
-        column: _EXPORT_COLUMN_RENAMES.get(column, column)
-        for column in export_ready.columns
-    }
-    final_column_names = set(renamed_columns.values())
+    try:
+        export_ready = _load_export_ready_frame(csv_path, cfg=cfg)
+    except (OSError, ValueError) as exc:
+        logger.error("quality_frame_load_failed", error=str(exc), path=str(csv_path))
+        return 1
 
     stats: Stats = {
         "rows_total": rows_total,

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -1077,6 +1077,11 @@ def test_finalise_export_falls_back_to_default_key(
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd,
+        "_load_export_ready_frame",
+        lambda path, cfg: df.copy(),
+    )
     monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
 
     exit_code = gdd._finalise_export(
@@ -1135,6 +1140,11 @@ def test_finalise_export_accepts_generator(
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {"rows": len(df)})
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd,
+        "_load_export_ready_frame",
+        lambda path, cfg: pd.concat(frames, ignore_index=True),
+    )
 
     exit_code = gdd._finalise_export(
         iter(frames),
@@ -1153,6 +1163,65 @@ def test_finalise_export_accepts_generator(
         ["101"],
         ["102"],
     ]
+
+
+def test_finalise_export_streaming_is_deterministic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Streaming export should preserve deterministic ordering and payload."""
+
+    cfg = Config()
+    output = tmp_path / "documents.csv"
+
+    def frame_generator() -> Iterator[pd.DataFrame]:
+        yield pd.DataFrame(
+            {
+                "document_chembl_id": ["CHEMBL2"],
+                "PubMed.PMID": ["102"],
+            }
+        )
+        yield pd.DataFrame(
+            {
+                "document_chembl_id": ["CHEMBL1"],
+                "PubMed.PMID": ["101"],
+            }
+        )
+
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
+    monkeypatch.setattr(gdd, "file_sha256", lambda path: "deadbeef")
+    monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
+
+    def fake_build_quality_report(df: pd.DataFrame) -> dict[str, Any]:
+        captured["quality_df"] = df.copy()
+        return {"rows": len(df)}
+
+    monkeypatch.setattr(gdd, "build_quality_report", fake_build_quality_report)
+    monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
+
+    def fake_analyze_table_quality(df: pd.DataFrame, table_name: str) -> None:
+        captured["quality_table_name"] = table_name
+        captured["quality_table_df"] = df.copy()
+        return None
+
+    monkeypatch.setattr(gdd, "analyze_table_quality", fake_analyze_table_quality)
+
+    exit_code = gdd._finalise_export(
+        frame_generator(),
+        output,
+        cfg,
+        input_csv=tmp_path / "input.csv",
+        key_columns=["PubMed.PMID"],
+        chunk_size=1,
+    )
+
+    exported = pd.read_csv(output, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding)
+
+    assert exit_code == 0
+    assert exported["PubMed.PMID"].astype(str).tolist() == ["101", "102"]
+    assert captured["quality_df"]["PubMed.PMID"].astype(str).tolist() == ["101", "102"]
+    assert captured["quality_table_df"]["PubMed.PMID"].astype(str).tolist() == ["101", "102"]
 
 
 @pytest.mark.parametrize("context_position", ["suffix", "prefix"])


### PR DESCRIPTION
## Summary
- stream document exports directly through the deterministic CSV writer and fall back to an empty chunk when no data is emitted
- load the streamed CSV for quality reporting and reuse configuration-aware settings
- extend document export tests with a streaming determinism check and adjust existing tests to mock the new loader

## Testing
- pytest tests/test_get_document_data.py -k finalise_export

------
https://chatgpt.com/codex/tasks/task_e_68dce90134d88324ba8bcea9cbaabeac