### PR TITLE
Add doc quality toggles and sampling controls to table quality CLI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -655,6 +655,61 @@
       "title": "DocTypeCfg",
       "type": "object"
     },
+    "DocQualityCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "sample_rows": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sample Rows"
+        },
+        "include_columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include Columns"
+        },
+        "exclude_columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Columns"
+        }
+      },
+      "title": "DocQualityCfg",
+      "type": "object"
+    },
     "DocumentAllCfg": {
       "additionalProperties": false,
       "properties": {
@@ -1471,6 +1526,9 @@
         },
         "retry": {
           "$ref": "#/$defs/RetryCfg"
+        },
+        "doc_quality": {
+          "$ref": "#/$defs/DocQualityCfg"
         },
         "doc_type": {
           "$ref": "#/$defs/DocTypeCfg"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -314,6 +314,11 @@ system:
       - 502
       - 503
       - 504
+  doc_quality:
+    enable: true  # Toggle generation of table quality reports
+    sample_rows: null  # Limit profiling to the first N rows (null keeps all)
+    include_columns: null  # Optional allow list of column names to analyse
+    exclude_columns: null  # Optional deny list of column names to skip
   doc_type:
     weights:
       pubmed: 4

--- a/docs/CLI_TOOLS.md
+++ b/docs/CLI_TOOLS.md
@@ -17,7 +17,7 @@ while preserving direct module execution for ad-hoc debugging.
 | `library.utils.cli_tools.mapper_batch_main` | `python -m library.utils.cli_tools.mapper_batch_main --input ids.csv --output mapped.csv` | Map ChEMBL identifiers to UniProt accessions using batch configuration. |
 | `library.utils.cli_tools.mapper_main` | `python -m library.utils.cli_tools.mapper_main --input ids.csv --output mapped.csv` | Lightweight interactive mapper for quick lookups and diagnostics. |
 | `library.utils.cli_tools.pipeline_targets_main` | `python -m library.utils.cli_tools.pipeline_targets_main --input targets.csv` | Run the cached target pipeline harness to refresh stored artefacts. |
-| `library.utils.cli_tools.table_quality_main` | `python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data` | Generate column-level quality reports for arbitrary CSV datasets. |
+| `library.utils.cli_tools.table_quality_main` | `python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data` | Generate column-level quality reports for arbitrary CSV datasets with optional sampling and column filters. |
 
 All modules continue to expose a `main` function so they can still be wired into
 `pyproject.toml` entry points. When invoking them programmatically, import the

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -12,7 +12,7 @@
 | --- | --- |
 | `sources` | Connectivity details for external services such as ChEMBL, UniProt, CrossRef, PubChem and PubMed. |
 | `local` | Paths to local resources, CSV defaults and initialisation workbooks. |
-| `system` | Logging, retry policy, global rate limiting and document classification weights. |
+| `system` | Logging, retry policy, global rate limiting, table quality profiling and document classification weights. |
 
 Sensitive values (API tokens, personal e-mails) should be injected via environment variables rather than committed to the repository.
 
@@ -346,6 +346,10 @@ IUPHAR and UniProt lookups are stored there by default.
 | `retry` | `max_attempts` | `3` | Number of retry attempts for recoverable errors. |
 |  | `backoff_factor` | `0.5` | Base multiplier for exponential backoff. |
 |  | `status_forcelist` | `[429, 500, 502, 503, 504]` | HTTP status codes that trigger retries. |
+| `doc_quality` | `enable` | `true` | Toggle generation of table quality reports. |
+|  | `sample_rows` | `null` | Limit analysis to the first `N` rows; `null` processes the full dataset. |
+|  | `include_columns` | `null` | Optional allow list of column names to profile. |
+|  | `exclude_columns` | `null` | Optional deny list of column names to skip. |
 | `doc_type` | `weights` | `{pubmed: 4, openalex: 3, scholar: 2}` | Weighting applied to document sources. |
 |  | `thresholds` | `{review: 1, experimental: 1, unknown: 2}` | Minimum counts for document type classification. |
 |  | `limit` | `null` | Optional limit on classified records. |

--- a/library/config.py
+++ b/library/config.py
@@ -414,6 +414,13 @@ class DocTypeCfg(_BaseModel):
     limit: int | None = Field(default=None, ge=0)
 
 
+class DocQualityCfg(_BaseModel):
+    enable: bool = True
+    sample_rows: int | None = Field(default=None, ge=1)
+    include_columns: tuple[str, ...] | None = None
+    exclude_columns: tuple[str, ...] | None = None
+
+
 class ResourcesCfg(_BaseModel):
     dictionary_dir: Path = Field(default_factory=_dictionary_resource)
     iuphar_target_csv: Path = Field(
@@ -902,6 +909,7 @@ class SystemCfg(_BaseModel):
     rate: RateCfg = Field(default_factory=lambda: RateCfg())
     retry: RetryCfg = Field(default_factory=lambda: RetryCfg())
     doc_type: DocTypeCfg = Field(default_factory=lambda: DocTypeCfg())
+    doc_quality: DocQualityCfg = Field(default_factory=lambda: DocQualityCfg())
 
 
 class Config(_BaseModel):
@@ -972,6 +980,10 @@ class Config(_BaseModel):
     @property
     def doc_type(self) -> DocTypeCfg:
         return self.system.doc_type
+
+    @property
+    def doc_quality(self) -> DocQualityCfg:
+        return self.system.doc_quality
 
     @property
     def resources(self) -> ResourcesCfg:
@@ -1543,6 +1555,7 @@ __all__ = [
     "PubMedCfg",
     "SemanticScholarCfg",
     "DocTypeCfg",
+    "DocQualityCfg",
     "ActivityCfg",
     "ActivityActionTypeCfg",
     "ActivityEnrichmentCfg",

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import argparse
 import os
+from argparse import BooleanOptionalAction
 from collections.abc import Sequence
 
 import pandas as pd
@@ -52,6 +53,46 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
+        doc_cfg = cfg.system.doc_quality
+        enable = getattr(args, "doc_quality_enable", None)
+        if enable is None:
+            enable = doc_cfg.enable
+        if not enable:
+            logger.info("doc_quality_disabled", table_name=args.table_name)
+            return 0
+
+        sample_rows = getattr(args, "sample_rows", None)
+        if sample_rows is None:
+            sample_rows = doc_cfg.sample_rows
+        include_columns = getattr(args, "include_columns", None)
+        if include_columns is None:
+            include_columns = doc_cfg.include_columns
+        exclude_columns = getattr(args, "exclude_columns", None)
+        if exclude_columns is None:
+            exclude_columns = doc_cfg.exclude_columns
+
+        if sample_rows is not None:
+            df = df.head(sample_rows)
+
+        include_columns = tuple(include_columns) if include_columns else None
+        exclude_columns = tuple(exclude_columns) if exclude_columns else None
+
+        if include_columns is not None:
+            missing = sorted(set(include_columns) - set(df.columns))
+            if missing:
+                logger.warning("include_columns_missing", columns=missing)
+            df = df.loc[:, [col for col in df.columns if col in include_columns]]
+
+        if exclude_columns is not None:
+            missing = sorted(set(exclude_columns) - set(df.columns))
+            if missing:
+                logger.warning("exclude_columns_missing", columns=missing)
+            excluded = set(exclude_columns)
+            df = df.loc[:, [col for col in df.columns if col not in excluded]]
+
+        if df.shape[1] == 0:
+            logger.warning("no_columns_after_filter", table_name=args.table_name)
+
         original_cwd = Path.cwd()
         try:
             args.output_csv.mkdir(parents=True, exist_ok=True)
@@ -73,6 +114,32 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         required=True,
         help="Base name used for output report files",
     )
+    parser.add_argument(
+        "--doc-quality-enable",
+        dest="doc_quality_enable",
+        action=BooleanOptionalAction,
+        default=None,
+        help="Enable or disable table profiling (config: system.doc_quality.enable)",
+    )
+    parser.add_argument(
+        "--sample-rows",
+        dest="sample_rows",
+        type=cli.positive_int,
+        default=None,
+        help="Limit profiling to the first N rows",
+    )
+    parser.add_argument(
+        "--include-columns",
+        nargs="+",
+        default=None,
+        help="Only analyse the specified columns",
+    )
+    parser.add_argument(
+        "--exclude-columns",
+        nargs="+",
+        default=None,
+        help="Exclude the specified columns from analysis",
+    )
     parser.set_defaults(func=run, output_csv=Path("."), encoding="utf-8-sig")
     return parser, log_cfg
 
@@ -85,7 +152,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     try:
-        cfg: Config = cli.apply_config_overrides(args, parser, args.config)
+        cfg: Config = cli.apply_config_overrides(
+            args,
+            parser,
+            args.config,
+            mapping={
+                "doc_quality_enable": "system.doc_quality.enable",
+                "sample_rows": "system.doc_quality.sample_rows",
+                "include_columns": "system.doc_quality.include_columns",
+                "exclude_columns": "system.doc_quality.exclude_columns",
+            },
+        )
         if args.print_config:
             print_config(cfg)
             configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import os
 import warnings
+from argparse import Namespace
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
+from library.config import Config
 from library.table_quality import analyze_table_quality
+from library.utils.cli_tools.table_quality_main import run
 
 
 def test_analyze_table_quality(tmp_path: Path) -> None:
@@ -62,3 +65,69 @@ def test_analyze_table_quality_handles_sequences(tmp_path: Path) -> None:
 
     non_empty = int(quality.loc[quality["column"] == "seq", "non_empty"].iloc[0])
     assert non_empty == 2
+
+
+def test_table_quality_run_skips_when_disabled(tmp_path: Path) -> None:
+    df = pd.DataFrame({"keep": [1, 2], "drop": [3, 4]})
+    csv_path = tmp_path / "input.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+    cfg.system.doc_quality.enable = False
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=tmp_path,
+        table_name="disabled",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+
+    assert exit_code == 0
+    assert not any(tmp_path.glob("disabled_*"))
+
+
+def test_table_quality_run_respects_sampling_and_filters(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "keep": [1, 2, 3, 4],
+            "drop": [10, 20, 30, 40],
+            "text": ["a", "b", "c", "d"],
+        }
+    )
+    csv_path = tmp_path / "filtered.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+    cfg.system.doc_quality.sample_rows = 2
+    cfg.system.doc_quality.include_columns = ("keep", "drop")
+    cfg.system.doc_quality.exclude_columns = ("drop",)
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=tmp_path,
+        table_name="filtered",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+    assert exit_code == 0
+
+    report_path = tmp_path / "filtered_quality_report_table.csv"
+    assert report_path.exists()
+
+    report = pd.read_csv(report_path)
+    assert set(report["column"]) == {"keep"}
+    non_null = int(report.loc[report["column"] == "keep", "non_null"].iloc[0])
+    assert non_null == 2


### PR DESCRIPTION
## Summary
- add a `system.doc_quality` configuration model and defaults to control table profiling enablement, sampling and column filters
- extend the table quality CLI to honour the new configuration/CLI switches and apply sampling plus allow/deny column lists before profiling
- document the additional options and add tests that cover skipping analysis as well as sampling and filtering behaviours

## Testing
- pytest tests/test_table_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68dce910dcc083249d7b9d7f48ca0d90