### PR TITLE
Protect parent catalog load with a lock

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import sqlite3
+import threading
 from collections.abc import Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -23,7 +24,7 @@ _PARENT_LOOKUP_SINGLE_ATTEMPTS_MIN = 1
 _SQLITE_VARIABLE_LIMIT = 900
 _PARENT_LOOKUP_SINGLE_CONCURRENCY = 4
 
-_PARENT_CATALOG_LOADING = False
+_PARENT_CATALOG_LOCK = threading.Lock()
 
 __all__ = [
     "fetch_parent_catalog",
@@ -315,7 +316,7 @@ def _fetch_parent_catalog_via_helper(
                     continue
                 seen_outstanding.add(chembl_id)
                 outstanding.append(chembl_id)
-        if outstanding and not _PARENT_CATALOG_LOADING:
+        if outstanding and not _PARENT_CATALOG_LOCK.locked():
             try:
                 load_parent_catalog(
                     client=client,
@@ -808,25 +809,21 @@ def load_parent_catalog(
 ) -> dict[str, str]:
     """Return the molecule parent catalogue, using the on-disk cache if present."""
 
-    cache_path = catalog_cfg.cache_path
-    sqlite_path = catalog_cfg.sqlite_path
-    if not force_refresh:
-        sqlite_data, sqlite_ok = _read_sqlite_cache(sqlite_path)
-        if sqlite_ok:
-            return sqlite_data
-        cached = _read_cache(cache_path, catalog_cfg)
-        if cached:
-            items = sorted(cached.items())
-            _write_parent_catalog_sqlite(items, catalog_cfg, replace=True)
-            return cached
+    with _PARENT_CATALOG_LOCK:
+        cache_path = catalog_cfg.cache_path
+        sqlite_path = catalog_cfg.sqlite_path
+        if not force_refresh:
+            sqlite_data, sqlite_ok = _read_sqlite_cache(sqlite_path)
+            if sqlite_ok:
+                return sqlite_data
+            cached = _read_cache(cache_path, catalog_cfg)
+            if cached:
+                items = sorted(cached.items())
+                _write_parent_catalog_sqlite(items, catalog_cfg, replace=True)
+                return cached
 
-    global _PARENT_CATALOG_LOADING
-    _PARENT_CATALOG_LOADING = True
-    try:
         result = fetch_parent_catalog(
             client=client, api_cfg=api_cfg, catalog_cfg=catalog_cfg, timeout=timeout
         )
-    finally:
-        _PARENT_CATALOG_LOADING = False
-    write_parent_catalog_cache(result, catalog_cfg)
-    return result
+        write_parent_catalog_cache(result, catalog_cfg)
+        return result

--- a/tests/test_molecule_catalog_threadsafe.py
+++ b/tests/test_molecule_catalog_threadsafe.py
@@ -1,0 +1,116 @@
+"""Concurrency regression tests for :mod:`library.molecule_catalog`."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+
+from library.config import ApiCfg, MoleculeCatalogCfg
+from library import molecule_catalog
+
+
+def test_load_parent_catalog_serialises_concurrent_calls(tmp_path, monkeypatch) -> None:
+    """Only one thread should fetch the catalogue while others wait for the cache."""
+
+    catalog_data = {"CHEMBL1": "CHEMBL2"}
+    fetch_started = threading.Event()
+    release_fetch = threading.Event()
+    fetch_calls = 0
+
+    def fake_fetch(*args, **kwargs):
+        nonlocal fetch_calls
+        fetch_calls += 1
+        fetch_started.set()
+        if not release_fetch.wait(timeout=1):
+            raise RuntimeError("fetch not released in time")
+        return dict(catalog_data)
+
+    monkeypatch.setattr(molecule_catalog, "fetch_parent_catalog", fake_fetch)
+
+    cfg = MoleculeCatalogCfg(
+        cache_path=tmp_path / "catalog.json",
+        sqlite_path=tmp_path / "catalog.sqlite",
+    )
+    api_cfg = ApiCfg(user_agent="chembl-da-tests (mailto:test@example.org)")
+    client = object()
+
+    results: dict[str, Mapping[str, str]] = {}
+    second_started = threading.Event()
+
+    def first_call() -> None:
+        results["first"] = molecule_catalog.load_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=cfg,
+            timeout=None,
+            force_refresh=True,
+        )
+
+    def second_call() -> None:
+        second_started.set()
+        results["second"] = molecule_catalog.load_parent_catalog(
+            client=client,
+            api_cfg=api_cfg,
+            catalog_cfg=cfg,
+        )
+
+    first_thread = threading.Thread(target=first_call, name="catalog-first")
+    second_thread = threading.Thread(target=second_call, name="catalog-second")
+
+    try:
+        first_thread.start()
+        assert fetch_started.wait(timeout=1)
+
+        second_thread.start()
+        assert second_started.wait(timeout=1)
+        assert fetch_calls == 1
+        assert second_thread.is_alive()
+    finally:
+        release_fetch.set()
+        first_thread.join(timeout=2)
+        second_thread.join(timeout=2)
+
+    assert fetch_calls == 1
+    assert results["first"] == catalog_data
+    assert results["second"] == catalog_data
+
+
+def test_helper_skips_catalog_refresh_when_lock_held(monkeypatch) -> None:
+    """Helper should not trigger a refresh when the catalogue lock is active."""
+
+    monkeypatch.setattr(
+        molecule_catalog,
+        "_fetch_parent_catalog_chunk",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        molecule_catalog, "query_parent_catalog", lambda ids, cfg: {}
+    )
+    monkeypatch.setattr(
+        molecule_catalog, "fetch_parent_for_id", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(molecule_catalog, "sleep", lambda delay: None)
+
+    load_calls: list[dict[str, object]] = []
+
+    def fake_load(**kwargs):
+        load_calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(molecule_catalog, "load_parent_catalog", fake_load)
+
+    api_cfg = ApiCfg(user_agent="chembl-da-tests (mailto:test@example.org)")
+    cfg = MoleculeCatalogCfg()
+
+    with molecule_catalog._PARENT_CATALOG_LOCK:
+        result = molecule_catalog._fetch_parent_catalog_via_helper(
+            ["CHEMBL1", "CHEMBL2"],
+            client=object(),
+            api_cfg=api_cfg,
+            timeout=0.1,
+            existing={},
+            catalog_cfg=cfg,
+        )
+
+    assert result == {}
+    assert load_calls == []


### PR DESCRIPTION
## Summary
- replace the global parent catalog loading flag with a threading lock and guard load operations
- prevent the helper refresh path from racing with active loads and cover the behaviour with new concurrency tests

## Testing
- pytest tests/test_molecule_catalog_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dced87c6fc832480497542bd1af3f9