### PR TITLE
Clarify pipeline locations in multilingual docs

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -117,16 +117,18 @@ Before running the smoke command, create a `chembl_ids.csv` file with a `chembl_
 
 ## Data generation
 
-Six primary pipelines in [`scripts/`](scripts/) generate CSV files and store them in `data/output/`:
+Five production pipelines live in [`scripts/`](scripts/) and write CSV outputs to `data/output/`:
 
 * `get_activity_data.py` — retrieves activity data from ChEMBL and enriches it with derived value ranges.
 * `get_assay_data.py` — exports assay descriptions.
 * `get_document_data.py` — merges publication metadata from ChEMBL and aggregators (PubMed, Semantic Scholar, OpenAlex, Crossref).
 * `get_target_data.py` — collects target information from ChEMBL, UniProt and IUPHAR.
 * `get_testitem_data.py` — enriches compounds with structural attributes and PubChem data.
-* `library.utils.cli_tools.pipeline_targets_main` — a lightweight wrapper around `library.pipeline_targets.run_pipeline` that uses
-  the same CLI parameters as the production target pipeline but operates solely on local files and prepared identifier chunks
-  without network calls.
+
+The cached harness `library.utils.cli_tools.pipeline_targets_main`, located under
+[`library/utils/cli_tools/`](library/utils/cli_tools/), reuses the CLI contract of the
+production target pipeline while operating solely on local files and prepared identifier
+batches without network calls.
 
 Example full pipeline execution:
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -112,14 +112,18 @@ python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
 
 ## Генерация данных
 
-Шесть основных пайплайнов из каталога [`scripts/`](scripts/) формируют CSV-файлы и сохраняют их в `data/output/`:
+Пять рабочих пайплайнов находятся в каталоге [`scripts/`](scripts/) и сохраняют CSV в `data/output/`:
 
 * `get_activity_data.py` — выгружает активности из ChEMBL и обогащает расчётными границами значений.
 * `get_assay_data.py` — загружает описания ассайев.
 * `get_document_data.py` — объединяет метаданные публикаций из ChEMBL и агрегаторов (PubMed, Semantic Scholar, OpenAlex, Crossref).
 * `get_target_data.py` — собирает информацию о таргетах из ChEMBL, UniProt и IUPHAR.
 * `get_testitem_data.py` — дополняет соединения структурными атрибутами и данными PubChem.
-* `library.utils.cli_tools.pipeline_targets_main` — облегчённая обёртка над `library.pipeline_targets.run_pipeline`, использующая те же CLI-параметры, что и боевой таргет-пайплайн, но работающая только с локальными файлами и подготовленными чанками идентификаторов без сетевых вызовов.
+
+Кешируемая обвязка `library.utils.cli_tools.pipeline_targets_main`, размещённая в
+[`library/utils/cli_tools/`](library/utils/cli_tools/), использует те же CLI-параметры, что и
+боевой таргет-пайплайн, но работает только с локальными файлами и подготовленными чанками
+идентификаторов без сетевых вызовов.
 
 Пример запуска полного пайплайна:
 


### PR DESCRIPTION
## Summary
- update the English data generation section to note the five production pipelines under `scripts/`
- describe the cached `pipeline_targets_main` harness location under `library/utils/cli_tools/`
- mirror the same structure and wording in the Russian documentation section

## Testing
- no tests were run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dcf5533634832486876bfdfd9b0610