### PR TITLE
Adjust setuptools configuration for scripts package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,13 +69,6 @@ check-determinism = "library.utils.cli_tools.check_determinism:main"
 
 [tool.setuptools]
 include-package-data = true
-py-modules = [
-  "scripts.get_activity_data",
-  "scripts.get_assay_data",
-  "scripts.get_document_data",
-  "scripts.get_target_data",
-  "scripts.get_testitem_data",
-]
 
 [tool.setuptools.packages.find]
 include = [
@@ -85,6 +78,8 @@ include = [
   "schemas.*",
   "config",
   "dictionary",
+  "scripts",
+  "scripts.*",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary
- remove the explicit `py-modules` list from the setuptools configuration
- ensure the `scripts` package hierarchy is included in automatic discovery

## Testing
- python -m build --wheel
- python -m venv /tmp/chembl_venv && source /tmp/chembl_venv/bin/activate && pip install dist/chembl_data_acquisition-0.1.0-py3-none-any.whl
- get-activity-data --help

------
https://chatgpt.com/codex/tasks/task_e_68dcf50fc66c8324b6efa71244ab279f