### PR TITLE
Update README documentation for CHEMBL_DA_BASE alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,17 @@ to confirm nothing broke during the upgrade.
 
 ```dotenv
 CHEMBL_DA_LOG_LEVEL=INFO
-CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
+CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 ```
+
+**EN.** Use either the short alias `CHEMBL_DA_BASE` or the fully qualified
+`CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; both expand to the same setting.
+Refer to the [alias table](library/config.py#L1471-L1498) in
+`library/config.py` for all supported mappings. / **RU.** Допустимо указывать
+как короткий алиас `CHEMBL_DA_BASE`, так и полное имя
+`CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE` — обе переменные настраивают
+одно и то же значение. Полный список алиасов приведён в
+[`library/config.py`](library/config.py#L1471-L1498).
 
 См. также файл `.env.example` с типовыми переменными для контактных e-mail.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -233,8 +233,13 @@ Example file:
 
 ```dotenv
 CHEMBL_DA_LOG_LEVEL=INFO
-CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
+CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 ```
+
+Use either the short alias `CHEMBL_DA_BASE` or the fully qualified
+`CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; both expand to the same setting.
+See the [alias table](library/config.py#L1471-L1498) in `library/config.py` for
+the complete mapping list.
 
 See `.env.example` for typical contact e-mail variables.
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -217,8 +217,13 @@ pre-commit run --all-files
 
 ```dotenv
 CHEMBL_DA_LOG_LEVEL=INFO
-CHEMBL_API_BASE=https://www.ebi.ac.uk/chembl/api/data
+CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 ```
+
+Допустимо указывать как короткий алиас `CHEMBL_DA_BASE`, так и полное имя
+`CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; обе переменные настраивают одно
+и то же значение. Полный список доступных алиасов приведён в
+[`library/config.py`](library/config.py#L1471-L1498).
 
 Типовые переменные с контактными e-mail приведены в `.env.example`.
 


### PR DESCRIPTION
## Summary
- replace the deprecated `CHEMBL_API_BASE` environment variable with the supported `CHEMBL_DA_BASE` alias across all README variants
- document that both the short and fully-qualified aliases are supported and link to the alias table in `library/config.py`

## Testing
- python -m markdown README.md > /tmp/readme.html
- python -m markdown README_EN.md > /tmp/readme_en.html
- python -m markdown README_RU.md > /tmp/readme_ru.html

------
https://chatgpt.com/codex/tasks/task_e_68dcf550a24083249b687b066bd82622