### PR TITLE
Improve UniProt staging performance and add benchmark

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 # ruff: noqa: E402
 import argparse
-import csv
 import sys
 from collections.abc import Sequence
 from itertools import islice
@@ -448,7 +447,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         if limit is not None:
             df = df.head(limit)
             logger.info("process_limit", limit=len(df))
-        ids = df[column].tolist()
+        ids = df[column].to_numpy(copy=False)
         rows_total = len(ids)
 
         from tempfile import NamedTemporaryFile
@@ -456,13 +455,14 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         with NamedTemporaryFile(
             "w", delete=False, encoding=cfg.io.csv_encoding, newline=""
         ) as tmp:
-            writer = csv.DictWriter(
-                tmp, fieldnames=["uniprot_id"], delimiter=cfg.io.csv_sep
-            )
-            writer.writeheader()
-            for uid in ids:
-                writer.writerow({"uniprot_id": uid})
             tmp_path = Path(tmp.name)
+
+        pd.DataFrame({"uniprot_id": ids}).to_csv(
+            tmp_path,
+            index=False,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
 
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         data_dir = cfg.target.uniprot.data_dir
@@ -485,7 +485,11 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         )
         rows_kept = len(out_df)
         if "mapping_uniprot_id" in df.columns:
-            out_df.insert(1, "mapping_uniprot_id", df["mapping_uniprot_id"].tolist())
+            out_df.insert(
+                1,
+                "mapping_uniprot_id",
+                df["mapping_uniprot_id"].to_numpy(copy=False),
+            )
         csv_path = io.write_csv(
             out_df,
             output,
@@ -848,24 +852,30 @@ def fetch_uniprot(
     """
 
     logger.info("fetch_uniprot_start", output=str(output_csv))
-    uids = [
-        u
-        for u in chembl_df.get(cfg.target.all.uniprot_column, [])
-        if isinstance(u, str) and u
-    ]
+    column = cfg.target.all.uniprot_column
+    series = chembl_df.get(column)
+    if series is None:
+        uids: list[str] = []
+    else:
+        values = series.to_numpy(copy=False)
+        uids = [
+            uid
+            for uid in values
+            if isinstance(uid, str) and uid
+        ]
     from tempfile import NamedTemporaryFile
 
     with NamedTemporaryFile(
         "w", delete=False, encoding=cfg.io.csv_encoding, newline=""
     ) as tmp:
-        writer = csv.DictWriter(
-            tmp, fieldnames=["uniprot_id"], delimiter=cfg.io.csv_sep
-        )
-
-        writer.writeheader()
-        for uid in uids:
-            writer.writerow({"uniprot_id": uid})
         tmp_path = Path(tmp.name)
+
+    pd.DataFrame({"uniprot_id": uids}).to_csv(
+        tmp_path,
+        index=False,
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+    )
 
     uniprot_args = argparse.Namespace(input_csv=tmp_path, output_csv=output_csv)
     orig_dir = cfg.target.uniprot.data_dir
@@ -880,7 +890,7 @@ def fetch_uniprot(
     df = pd.read_csv(
         output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
     )
-    df["original_id"] = uids
+    df["original_id"] = pd.Series(uids, index=df.index, dtype=object)
     logger.info("fetch_uniprot_done", rows=len(df))
     return df
 

--- a/tests/test_get_target_data_all.py
+++ b/tests/test_get_target_data_all.py
@@ -10,10 +10,12 @@ expected content.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import shutil
 from pathlib import Path
 
 import pandas as pd
+import pytest
 from pytest import MonkeyPatch
 
 from library import protein_classification as pc
@@ -21,6 +23,9 @@ from library.config import Config
 from schemas import TargetsSchema
 from schemas.targets import TARGETS_COLUMN_ORDER
 from scripts import get_target_data as gtd
+
+
+HAS_PYTEST_BENCHMARK = importlib.util.find_spec("pytest_benchmark") is not None
 
 
 class DummyRecord:
@@ -175,3 +180,55 @@ def test_run_all_uses_local_inputs(
         row["protein_synonym_list"]
         == "gene1|genea|sec1|alpha component|alt|recommended|name1|name2|alpha"
     )
+
+
+@pytest.mark.skipif(
+    not HAS_PYTEST_BENCHMARK, reason="requires pytest-benchmark for benchmarking"
+)
+def test_run_uniprot_large_input_benchmark(
+    tmp_path: Path, monkeypatch: MonkeyPatch, cfg: Config, benchmark
+) -> None:
+    """Benchmark ``run_uniprot`` with a large synthetic input dataset."""
+
+    rows = 10_000
+    column = cfg.target.uniprot.column
+    input_df = pd.DataFrame({column: [f"P{idx:05d}" for idx in range(rows)]})
+    input_csv = tmp_path / "large_uniprot_input.csv"
+    output_csv = tmp_path / "large_uniprot_output.csv"
+    meta_csv = output_csv.with_name(output_csv.name + ".meta.yaml")
+    input_df.to_csv(
+        input_csv,
+        index=False,
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+    )
+
+    def fake_process(
+        *,
+        input_csv: str,
+        output_csv: str,
+        data_dir: Path | None,
+        cfg: object,
+        gtop_cfg: object,
+        sep: str,
+        encoding: str,
+    ) -> None:
+        frame = pd.read_csv(input_csv, sep=sep, encoding=encoding, dtype=str)
+        frame.to_csv(output_csv, index=False, sep=sep, encoding=encoding)
+
+    monkeypatch.setattr(gtd.uu, "process", fake_process)
+    monkeypatch.setattr(gtd.uu, "init_session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gtd, "analyze_table_quality", lambda *args, **kwargs: None)
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+
+    def runner() -> int:
+        output_csv.unlink(missing_ok=True)
+        meta_csv.unlink(missing_ok=True)
+        return gtd.run_uniprot(cfg, args)
+
+    result = benchmark(runner)
+    assert result == 0
+
+    output_df = pd.read_csv(output_csv, sep=cfg.io.csv_sep, dtype=str)
+    assert len(output_df) == rows


### PR DESCRIPTION
## Summary
- vectorize the UniProt staging workflow to drop `.tolist()` loops and use pandas-based CSV writes
- update the shared UniProt fetch helper to reuse the vectorised staging path while preserving original identifiers
- extend the target data tests with a large-input benchmark that exercises the new pipeline

## Testing
- pytest tests/test_get_target_data_all.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf50e4ff48324ac9bd4b0b3d3cd66