### PR TITLE
Deduplicate OpenAlex and CrossRef lookups in document pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -428,9 +428,11 @@ def fetch_pubmed_records(
                         limit = min(limit, limiter.burst)
                     return max(1, min(total, limit))
 
-                plan: list[tuple[int, dict[str, str], dict[str, str]]] = []
-                openalex_jobs: list[tuple[int, str]] = []
-                crossref_jobs: list[tuple[int, str]] = []
+                plan: list[tuple[int, dict[str, str], dict[str, str], str, str]] = []
+                openalex_lookup: dict[str, list[int]] = {}
+                crossref_lookup: dict[str, list[int]] = {}
+                openalex_total = 0
+                crossref_total = 0
 
                 for index, pubmed in enumerate(pubmed_list):
                     pmid = pubmed.get("PubMed.PMID", "")
@@ -444,14 +446,18 @@ def fetch_pubmed_records(
                         or fallback_doi
                         or ""
                     )
-                    plan.append((index, pubmed, semsch))
+                    plan.append((index, pubmed, semsch, pmid, doi))
                     if pmid:
-                        openalex_jobs.append((index, pmid))
-                    crossref_jobs.append((index, doi))
+                        openalex_lookup.setdefault(pmid, []).append(index)
+                        openalex_total += 1
+                    crossref_key = doi or ""
+                    crossref_lookup.setdefault(crossref_key, []).append(index)
+                    crossref_total += 1
 
                 openalex_results: dict[int, dict[str, str]] = {}
                 crossref_results: dict[int, dict[str, str]] = {}
 
+                openalex_jobs = list(openalex_lookup.keys())
                 openalex_workers = _pool_workers(
                     len(openalex_jobs), openalex_limiter, openalex_cfg.burst
                 )
@@ -463,25 +469,33 @@ def fetch_pubmed_records(
                         limiter=openalex_limiter,
                     )
 
+                if openalex_total:
+                    logger.info(
+                        "documents_cache_reuse",
+                        service="openalex",
+                        total=openalex_total,
+                        unique=len(openalex_jobs),
+                        hits=openalex_total - len(openalex_jobs),
+                    )
+
+                openalex_by_key: dict[str, dict[str, str]] = {}
+
                 if openalex_jobs and openalex_workers > 0:
-                    def _openalex_fetch(target_pmid: str) -> dict[str, str]:
-                        _acquire_documents(openalex_service_limiter)
-                        return ocl.fetch_openalex(
-                            session,
-                            target_pmid,
-                            openalex_cfg,
-                            openalex_limiter,
-                        )
-
                     with ThreadPoolExecutor(max_workers=openalex_workers) as pool:
-                        future_to_index = {
-                            pool.submit(_fetch_openalex_job, pmid): index
-                            for index, pmid in openalex_jobs
+                        future_to_key = {
+                            pool.submit(_fetch_openalex_job, pmid): pmid
+                            for pmid in openalex_jobs
                         }
-                        for future in as_completed(future_to_index):
-                            idx = future_to_index[future]
-                            openalex_results[idx] = future.result()
+                        for future in as_completed(future_to_key):
+                            key = future_to_key[future]
+                            openalex_by_key[key] = future.result()
 
+                for pmid, indexes in openalex_lookup.items():
+                    result = openalex_by_key.get(pmid, {})
+                    for idx in indexes:
+                        openalex_results[idx] = result
+
+                crossref_jobs = list(crossref_lookup.keys())
                 crossref_workers = _pool_workers(
                     len(crossref_jobs), crossref_limiter, crossref_cfg.burst
                 )
@@ -493,28 +507,34 @@ def fetch_pubmed_records(
                         limiter=crossref_limiter,
                     )
 
+                if crossref_total:
+                    logger.info(
+                        "documents_cache_reuse",
+                        service="crossref",
+                        total=crossref_total,
+                        unique=len(crossref_jobs),
+                        hits=crossref_total - len(crossref_jobs),
+                    )
+
+                crossref_by_key: dict[str, dict[str, str]] = {}
+
                 if crossref_jobs and crossref_workers > 0:
-                    def _crossref_fetch(target_doi: str) -> dict[str, str]:
-                        if target_doi:
-                            _acquire_documents(crossref_service_limiter)
-                        return ocl.fetch_crossref(
-                            session,
-                            target_doi,
-                            crossref_cfg,
-                            crossref_limiter,
-                        )
-
                     with ThreadPoolExecutor(max_workers=crossref_workers) as pool:
-                        future_to_index = {
-                            pool.submit(_fetch_crossref_job, doi): index
-                            for index, doi in crossref_jobs
+                        future_to_key = {
+                            pool.submit(_fetch_crossref_job, doi): doi
+                            for doi in crossref_jobs
                         }
-                        for future in as_completed(future_to_index):
-                            idx = future_to_index[future]
-                            crossref_results[idx] = future.result()
+                        for future in as_completed(future_to_key):
+                            key = future_to_key[future]
+                            crossref_by_key[key] = future.result()
 
-                for index, pubmed, semsch in plan:
-                    openalex = openalex_results.get(index, {})
+                for doi, indexes in crossref_lookup.items():
+                    result = crossref_by_key.get(doi, {})
+                    for idx in indexes:
+                        crossref_results[idx] = result
+
+                for index, pubmed, semsch, pmid, _ in plan:
+                    openalex = openalex_results.get(index, {}) if pmid else {}
                     crossref = crossref_results.get(index, {})
                     combined = merge_metadata(pubmed, semsch, openalex, crossref)
                     combined_records.append(combined)

--- a/tests/test_document_pipeline.py
+++ b/tests/test_document_pipeline.py
@@ -1,4 +1,5 @@
 import threading
+from collections import Counter
 from itertools import count
 
 import pandas as pd
@@ -265,3 +266,151 @@ def test_fetch_pubmed_records_uses_fresh_sessions_per_job(
     first_session = pubmed_sessions[0]
     assert all(session != first_session for session in openalex_sessions)
     assert all(session != first_session for session in crossref_sessions)
+
+
+def test_fetch_pubmed_records_reuses_duplicate_identifiers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAlex and CrossRef lookups reuse responses for duplicate keys."""
+
+    pmids = ["100", "200", "100"]
+
+    class DummyLimiter:
+        def __init__(self, burst: int | None = None) -> None:
+            self.burst = burst if burst is not None else 4
+
+        def acquire(self) -> None:  # pragma: no cover - simple synchronisation
+            return None
+
+    def fake_session_with_retry(*_args: object, **_kwargs: object):
+        class _Context:
+            def __enter__(self) -> str:  # pragma: no cover - simple context
+                return "session"
+
+            def __exit__(self, *_exc: object) -> None:  # pragma: no cover - simple context
+                return None
+
+        return _Context()
+
+    def fake_get_limiter(
+        _name: str, _rps: float | int | None, burst: int | None = None
+    ) -> DummyLimiter:
+        return DummyLimiter(burst)
+
+    def fake_pubmed_batch(
+        _session: str,
+        batch: list[str],
+        _sleep: float,
+        cfg: PubMedCfg | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "PubMed.PMID": pmid,
+                "PubMed.DOI": f"10.1/{pmid}",
+                "PubMed.ArticleTitle": f"Article {pmid}",
+                "PubMed.PublicationType": "",
+            }
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        _session: str,
+        batch: list[str],
+        _sleep: float,
+        cfg: SemanticScholarCfg | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "scholar.PMID": pmid,
+                "scholar.DOI": f"10.1/{pmid}",
+                "scholar.PublicationTypes": "",
+                "scholar.Error": "",
+            }
+            for pmid in batch
+        ]
+
+    def fake_semantic_single(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {
+            "scholar.PMID": "",
+            "scholar.DOI": "",
+            "scholar.PublicationTypes": "",
+            "scholar.Error": "",
+        }
+
+    openalex_calls: list[str] = []
+    crossref_calls: list[str] = []
+
+    def fake_openalex(
+        _session: str,
+        pmid: str,
+        cfg: OpenAlexCfg,
+        limiter: DummyLimiter | None = None,
+    ) -> dict[str, str]:
+        openalex_calls.append(pmid)
+        return {
+            "OpenAlex.PublicationTypes": "",
+            "OpenAlex.TypeCrossref": "",
+            "OpenAlex.Genre": "",
+            "OpenAlex.Id": pmid,
+            "OpenAlex.Venue": f"Venue {pmid}",
+            "OpenAlex.MeshDescriptors": "",
+            "OpenAlex.MeshQualifiers": "",
+            "OpenAlex.Error": "",
+        }
+
+    def fake_crossref(
+        _session: str,
+        doi: str,
+        cfg: CrossRefCfg,
+        limiter: DummyLimiter | None = None,
+    ) -> dict[str, str]:
+        crossref_calls.append(doi)
+        pmid = doi.rsplit("/", 1)[-1] if doi else ""
+        return {
+            "crossref.Type": "",
+            "crossref.Subtype": "",
+            "crossref.Title": f"Title {pmid}",
+            "crossref.Subtitle": "",
+            "crossref.Subject": "",
+            "crossref.Error": "",
+        }
+
+    info_events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_info(event: str, *args: object, extra: dict[str, object] | None = None, **kv: object) -> None:
+        payload = dict(kv)
+        if extra:
+            payload.update(extra)
+        info_events.append((event, payload))
+
+    monkeypatch.setattr(gdd, "session_with_retry", fake_session_with_retry)
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", fake_semantic_single)
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_openalex)
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
+    monkeypatch.setattr(gdd.logger, "info", fake_info)
+
+    df = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        pubmed_cfg=PubMedCfg(),
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=2,
+        batch_size=4,
+    )
+
+    assert df["PubMed.PMID"].tolist() == pmids
+    assert Counter(openalex_calls) == Counter({"100": 1, "200": 1})
+    assert Counter(crossref_calls) == Counter({"10.1/100": 1, "10.1/200": 1})
+
+    cache_logs = {
+        (event_payload["service"], event_payload["hits"])
+        for event, event_payload in info_events
+        if event == "documents_cache_reuse"
+    }
+    assert ("openalex", 1) in cache_logs
+    assert ("crossref", 1) in cache_logs


### PR DESCRIPTION
## Summary
- cache OpenAlex and CrossRef jobs per unique PMID/DOI and log cache reuse statistics
- reuse cached responses when combining batch results
- add regression test covering duplicate identifiers and cache hit logging

## Testing
- pytest tests/test_document_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf548fff08324aa9460240b90bd38