### PR TITLE
Ensure OpenAlex and CrossRef jobs use document limiters

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -462,6 +462,7 @@ def fetch_pubmed_records(
                     len(openalex_jobs), openalex_limiter, openalex_cfg.burst
                 )
                 def _fetch_openalex_job(pmid: str) -> dict[str, str]:
+                    _acquire_documents(openalex_service_limiter)
                     return _invoke_with_session(
                         ocl.fetch_openalex,
                         pmid,
@@ -500,6 +501,7 @@ def fetch_pubmed_records(
                     len(crossref_jobs), crossref_limiter, crossref_cfg.burst
                 )
                 def _fetch_crossref_job(doi: str) -> dict[str, str]:
+                    _acquire_documents(crossref_service_limiter)
                     return _invoke_with_session(
                         ocl.fetch_crossref,
                         doi,

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -785,6 +785,85 @@ def test_fetch_pubmed_records_acquires_documents_limiter(
     assert list(df["PubMed.PMID"]) == ["1", "2"]
 
 
+def test_openalex_and_crossref_jobs_acquire_service_limiters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAlex and CrossRef jobs use their service-specific limiters."""
+
+    class TrackingLimiter:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.acquisitions = 0
+            self._lock = threading.Lock()
+
+        def acquire(self) -> None:
+            with self._lock:
+                self.acquisitions += 1
+
+    limiters = {
+        "documents_global": TrackingLimiter("global"),
+        "documents_openalex": TrackingLimiter("openalex"),
+        "documents_crossref": TrackingLimiter("crossref"),
+    }
+
+    def fake_get_limiter(name: str, *_, **__) -> Any:
+        return limiters.get(name, DummyLimiter())
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "PubMed.PMID": pmid,
+                "PubMed.DOI": "10.1000/xyz",
+            }
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"scholar.PMID": pmid} for pmid in pmids]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+
+    gdd.fetch_pubmed_records(
+        ["1"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert limiters["documents_openalex"].acquisitions == 1
+    assert limiters["documents_crossref"].acquisitions == 1
+
+
 def test_documents_limiter_enforces_shared_pace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure OpenAlex and CrossRef job helpers acquire the shared document limiter before fetching metadata
- add a regression test that patches the limiter and verifies both services acquire their service-specific limiter

## Testing
- pytest tests/test_get_document_data.py::test_openalex_and_crossref_jobs_acquire_service_limiters

------
https://chatgpt.com/codex/tasks/task_e_68dcfbd5a9c08324824b7af22a26b80a