### PR TITLE
Stream PubMed fetch results and add streaming tests

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -555,45 +555,61 @@ def fetch_pubmed_records(
             return _failure_records(batch_list, str(exc))
 
     iterator = (p for p in pmids if p)
-    records: list[dict[str, str]] = []
-    tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
-    ordered: dict[int, list[dict[str, str]]] = {}
     processed = 0
     max_in_flight = max(1, max_workers * 2)
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        offset = 0
-        pending: set[Future[list[dict[str, str]]]] = set()
-        for batch in _chunked(iterator, batch_size):
-            if not batch:
-                continue
-            future = ex.submit(_fetch_batch, batch)
-            tasks[future] = (offset, batch)
-            pending.add(future)
-            offset += len(batch)
-            if len(pending) >= max_in_flight:
+
+    def _iter_records() -> Iterator[list[dict[str, str]]]:
+        nonlocal processed
+
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            tasks: dict[
+                Future[list[dict[str, str]]], tuple[int, int]
+            ] = {}
+            pending: set[Future[list[dict[str, str]]]] = set()
+            completed: dict[int, list[dict[str, str]]] = {}
+            batch_index = 0
+            next_to_emit = 0
+
+            for batch in _chunked(iterator, batch_size):
+                if not batch:
+                    continue
+                future = ex.submit(_fetch_batch, batch)
+                tasks[future] = (batch_index, len(batch))
+                pending.add(future)
+                batch_index += 1
+                if len(pending) >= max_in_flight:
+                    done_future = next(as_completed(list(pending)))
+                    pending.remove(done_future)
+                    batch_id, batch_len = tasks.pop(done_future)
+                    completed[batch_id] = done_future.result()
+                    processed += batch_len
+                    logger.info("documents_processed", count=processed)
+                    while next_to_emit in completed:
+                        yield completed.pop(next_to_emit)
+                        next_to_emit += 1
+
+            while pending:
                 done_future = next(as_completed(list(pending)))
                 pending.remove(done_future)
-                batch_offset, submitted_batch = tasks.pop(done_future)
-                ordered[batch_offset] = done_future.result()
-                processed += len(submitted_batch)
+                batch_id, batch_len = tasks.pop(done_future)
+                completed[batch_id] = done_future.result()
+                processed += batch_len
                 logger.info("documents_processed", count=processed)
+                while next_to_emit in completed:
+                    yield completed.pop(next_to_emit)
+                    next_to_emit += 1
 
-        while pending:
-            done_future = next(as_completed(list(pending)))
-            pending.remove(done_future)
-            batch_offset, submitted_batch = tasks.pop(done_future)
-            ordered[batch_offset] = done_future.result()
-            processed += len(submitted_batch)
-            logger.info("documents_processed", count=processed)
+            while next_to_emit in completed:
+                yield completed.pop(next_to_emit)
+                next_to_emit += 1
 
     def _iter_frames() -> Iterator[pd.DataFrame]:
-        for offset in sorted(ordered):
-            batch_records = ordered[offset]
-            if not batch_records:
+        for records_batch in _iter_records():
+            if not records_batch:
                 yield build_dataframe([], columns=DOCUMENT_SCHEMA_COLUMNS)
                 continue
             yield build_dataframe(
-                batch_records, columns=DOCUMENT_SCHEMA_COLUMNS
+                records_batch, columns=DOCUMENT_SCHEMA_COLUMNS
             )
 
     frame_iter = _iter_frames()
@@ -1110,7 +1126,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
         fallback_doi_map = fallback_map or None
 
     try:
-        df = fetch_pubmed_records(
+        frame_iter = fetch_pubmed_records(
             pmids,
             cfg,
             sleep=getattr(args, "sleep", pubmed_defaults.sleep),
@@ -1121,11 +1137,12 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             max_workers=getattr(args, "workers", pubmed_defaults.workers),
             batch_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
             fallback_doi_map=fallback_doi_map,
+            return_generator=True,
         )
         output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
-        df = normalize_documents(df)
+        normalised_frames = (normalize_documents(frame) for frame in frame_iter)
         exit_code = _finalise_export(
-            df,
+            normalised_frames,
             output,
             cfg,
             input_csv=Path(args.input_csv),
@@ -1325,7 +1342,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 for pmid, doi in zip(masked_pmids, masked_dois, strict=True)
             }
     pmids = pubmed_ids.dropna().astype(str).tolist()
-    pub_df = fetch_pubmed_records(
+    pubmed_frames = fetch_pubmed_records(
         pmids,
         cfg,
         sleep=getattr(args, "sleep", all_defaults.sleep),
@@ -1336,7 +1353,15 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         batch_size=getattr(args, "batch_size", all_defaults.batch_size),
         pubmed_cfg=cfg.pubmed,
         fallback_doi_map=doi_fallback_map or None,
+        return_generator=True,
     )
+    concat_iter = iter(pubmed_frames)
+    try:
+        first_frame = next(concat_iter)
+    except StopIteration:
+        pub_df = build_dataframe([], columns=DOCUMENT_SCHEMA_COLUMNS)
+    else:
+        pub_df = pd.concat(chain([first_frame], concat_iter), ignore_index=True)
     doc_df["pubmed_id"] = pubmed_ids.astype("Int64").astype("string").fillna("")
     merged = merge_with_chembl(doc_df, pub_df)
     processed = dp.postprocess_documents(merged)

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -112,6 +112,9 @@ def test_cli_uses_custom_column(
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})
+    monkeypatch.setattr(
+        gdd, "_load_export_ready_frame", lambda path, cfg: pd.DataFrame()
+    )
     monkeypatch.setattr(gdd, "ensure_dirs", lambda cfg: None)
 
     rc = gdd.main(
@@ -321,7 +324,8 @@ def test_run_pubmed_uses_keyword_arguments(
         max_workers: int,
         batch_size: int,
         fallback_doi_map: dict[str, str] | None = None,
-    ) -> pd.DataFrame:
+        return_generator: bool = False,
+    ) -> Iterable[pd.DataFrame]:
         captured["pmids"] = list(pmids)
         captured["cfg"] = cfg_param
         captured["sleep"] = sleep
@@ -332,15 +336,32 @@ def test_run_pubmed_uses_keyword_arguments(
         captured["max_workers"] = max_workers
         captured["batch_size"] = batch_size
         captured["fallback_doi_map"] = fallback_doi_map
-        return pd.DataFrame({"PMID": ["1", "2"]})
+        assert return_generator is True
+
+        def _generator() -> Iterator[pd.DataFrame]:
+            yield pd.DataFrame({"PMID": ["1", "2"]})
+
+        return _generator()
 
     monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
     monkeypatch.setattr(gdd, "normalize_documents", lambda df: df)
-    monkeypatch.setattr(
-        gdd,
-        "_finalise_export",
-        lambda df, output, cfg, input_csv, key_columns, **kwargs: 0,
-    )
+
+    def fake_finalise_export(
+        frames: Iterable[pd.DataFrame],
+        output: Path,
+        cfg: Config,
+        *,
+        input_csv: Path,
+        key_columns: Sequence[str] | None,
+        **kwargs: Any,
+    ) -> int:
+        assert not isinstance(frames, pd.DataFrame)
+        collected = list(frames)
+        assert len(collected) == 1
+        assert collected[0]["PMID"].tolist() == ["1", "2"]
+        return 0
+
+    monkeypatch.setattr(gdd, "_finalise_export", fake_finalise_export)
 
     cfg = Config()
     args = argparse.Namespace(
@@ -411,9 +432,15 @@ def test_run_pubmed_uses_fallback_csv(
         max_workers: int,
         batch_size: int,
         fallback_doi_map: dict[str, str] | None = None,
-    ) -> pd.DataFrame:
+        return_generator: bool = False,
+    ) -> Iterable[pd.DataFrame]:
         captured["fallback_doi_map"] = fallback_doi_map
-        return pd.DataFrame({"PMID": list(pmids)})
+        assert return_generator is True
+
+        def _generator() -> Iterator[pd.DataFrame]:
+            yield pd.DataFrame({"PMID": list(pmids)})
+
+        return _generator()
 
     monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
 
@@ -430,6 +457,71 @@ def test_run_pubmed_uses_fallback_csv(
 
     assert exit_code == 0
     assert captured["fallback_doi_map"] == {"1": "10.1000/foo"}
+
+
+def test_run_pubmed_streams_batches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PubMed CLI should stream chunks to the exporter."""
+
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n1\n2\n3\n4\n5\n6\n")
+
+    monkeypatch.setattr(
+        lib_io,
+        "read_ids",
+        lambda *_, **__: iter(["1", "2", "3", "4", "5", "6"]),
+    )
+
+    chunk_lengths: list[int] = []
+
+    def fake_fetch_pubmed_records(
+        *_,
+        return_generator: bool = False,
+        **__: Any,
+    ) -> Iterable[pd.DataFrame]:
+        assert return_generator is True
+
+        def _generator() -> Iterator[pd.DataFrame]:
+            for start in range(0, 6, 2):
+                yield pd.DataFrame({"PMID": [str(start + 1), str(start + 2)]})
+
+        return _generator()
+
+    def fake_normalize(df: pd.DataFrame) -> pd.DataFrame:
+        chunk_lengths.append(len(df))
+        return df
+
+    def fake_finalise_export(
+        frames: Iterable[pd.DataFrame],
+        output: Path,
+        cfg: Config,
+        *,
+        input_csv: Path,
+        key_columns: Sequence[str] | None,
+        **kwargs: Any,
+    ) -> int:
+        lengths = [len(frame) for frame in frames]
+        assert lengths == [2, 2, 2]
+        return 0
+
+    monkeypatch.setattr(gdd, "fetch_pubmed_records", fake_fetch_pubmed_records)
+    monkeypatch.setattr(gdd, "normalize_documents", fake_normalize)
+    monkeypatch.setattr(gdd, "_finalise_export", fake_finalise_export)
+
+    cfg = Config()
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "out.csv",
+        fallback_doi_csv=None,
+        fallback_doi_pmid_column="PMID",
+        fallback_doi_value_column="DOI",
+    )
+
+    exit_code = gdd.run_pubmed(cfg, args)
+
+    assert exit_code == 0
+    assert chunk_lengths == [2, 2, 2]
 
 
 def test_write_csv_column_order(
@@ -485,6 +577,9 @@ def test_write_csv_column_order(
     monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "build_quality_report", lambda df: {})
+    monkeypatch.setattr(
+        gdd, "_load_export_ready_frame", lambda path, cfg: pd.DataFrame()
+    )
 
     cfg = Config()
     args = argparse.Namespace(
@@ -611,6 +706,80 @@ def test_fetch_pubmed_records_returns_generator_in_order(
     )
 
     assert combined["PubMed.PMID"].tolist() == pmids
+
+
+def test_fetch_pubmed_records_streams_large_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large input should be streamed in bounded chunks."""
+
+    pmids = [str(i) for i in range(30)]
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"PubMed.PMID": pmid, "PubMed.DOI": f"10.1000/{pmid}"}
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        session: Any,
+        ids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"scholar.PMID": pmid, "scholar.DOI": f"10.1000/{pmid}"}
+            for pmid in ids
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_, **__: {"scholar.DOI": "10.1000/fallback"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda session, pmid, cfg, limiter: {"OpenAlex.Id": f"OA{pmid}"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda session, doi, cfg, limiter: {"crossref.DOI": doi},
+    )
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=2,
+        batch_size=5,
+        return_generator=True,
+    )
+
+    batch_sizes = [len(frame) for frame in generator]
+    assert batch_sizes == [5, 5, 5, 5, 5, 5]
 
 
 def test_fetch_pubmed_records_accepts_config(


### PR DESCRIPTION
## Summary
- stream PubMed fetch batches directly from futures to reduce in-memory buffering
- stream the pubmed and combined document commands by consuming generator batches
- add tests to cover streaming behaviour and large dataset handling in the CLI

## Testing
- pytest tests/test_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfbe42ce8832490254ceb28095003