### PR TITLE
Refine test item ID sampling and fetch tracking

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -479,7 +479,7 @@ def fetch_parent_catalog_for(
             existing=result,
             catalog_cfg=cfg,
             allow_rebatch=False,
-            allow_single_lookup=True,
+            allow_single_lookup=not parentless_filtered,
         )
         result.update(fallback_result)
         return result
@@ -523,7 +523,7 @@ def fetch_parent_catalog_for(
                 timeout=effective_timeout,
                 existing=result,
                 catalog_cfg=cfg,
-                allow_single_lookup=True,
+                allow_single_lookup=not parentless_filtered,
             )
             result.update(fallback_result)
 

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -6,12 +6,13 @@ from pathlib import Path
 import sys
 
 import argparse
+import json
 from collections import OrderedDict, deque
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
-from itertools import islice, tee
+from itertools import chain, islice
 from functools import lru_cache
-from typing import Any, NamedTuple
+from typing import Any, Mapping, NamedTuple
 
 import pandas as pd
 import requests
@@ -23,6 +24,7 @@ if str(_REPO_ROOT) not in sys.path:
 from library import chembl_library as cl
 from library import cli
 from library import io
+from library import pubchem_library as pl
 
 from library.clients import pubchem as pc
 from library.chembl_client import ChemblClient
@@ -47,6 +49,7 @@ from library.testitem_pipeline import (
     ParentEnrichmentResult,
     ParentLookupPreparedData,
     ParentLookupStats,
+    PUBCHEM_CID_CACHE_ENCODING,
     augment_pubchem,
     apply_testitem_enrichment,
     finalize_output,
@@ -65,7 +68,6 @@ class ReadInputIdsResult:
 
     ids_iter: Iterator[str]
     sample_ids: tuple[str, ...]
-    requested_ids: tuple[str, ...]
 
 
 
@@ -1185,14 +1187,16 @@ def read_input_ids(
             cfg=io_cfg,
             keep_na_markers=io_cfg.keep_na_markers,
         )
+        ids_iter = iter(ids_iter)
         if offset:
             ids_iter = islice(ids_iter, offset, None)
+            ids_iter = iter(ids_iter)
             logger.info("process_offset", offset=offset)
         if limit is not None:
             ids_iter = islice(ids_iter, limit)
-        ids_iter, sample_iter, capture_iter = tee(ids_iter, 3)
-        sample_ids = tuple(islice(sample_iter, _FETCH_ERROR_SAMPLE_SIZE))
-        requested_ids = tuple(capture_iter)
+            ids_iter = iter(ids_iter)
+        sample_ids = tuple(islice(ids_iter, _FETCH_ERROR_SAMPLE_SIZE))
+        ids_iter = chain(sample_ids, ids_iter)
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
             "read_fail",
@@ -1204,7 +1208,6 @@ def read_input_ids(
     return 0, ReadInputIdsResult(
         ids_iter=ids_iter,
         sample_ids=sample_ids,
-        requested_ids=requested_ids,
     )
 
 
@@ -1278,15 +1281,21 @@ def fetch_testitems(
     sample_ids: Sequence[str],
     fields: Sequence[str] | None,
     page_limit: int,
-) -> tuple[int, pd.DataFrame | None]:
+) -> tuple[int, pd.DataFrame | None, tuple[str, ...]]:
     """Retrieve ChEMBL test item records for ``ids_iter``."""
 
     logger.info("chembl_fetch_start", batch_size=batch_size)
-    ids_iter, capture_iter = tee(ids_iter)
-    requested_ids_raw = list(capture_iter)
+    requested_ids_raw: list[str] = []
+
+    def _iter_with_tracking(source: Iterable[str]) -> Iterator[str]:
+        for identifier in source:
+            requested_ids_raw.append(identifier)
+            yield identifier
+
+    tracked_iter = _iter_with_tracking(ids_iter)
     try:
         df = cl.get_testitem(
-            ids_iter,
+            tracked_iter,
             cfg=api_cfg,
             client=client,
             chunk_size=batch_size,
@@ -1302,7 +1311,9 @@ def fetch_testitems(
             timeout=timeout,
             sample_ids=list(sample_ids),
         )
-        return 1, None
+        return 1, None, tuple(requested_ids_raw)
+    finally:
+        deque(tracked_iter, maxlen=0)
 
     rows = len(df)
     logger.info("chembl_fetch_done", rows=rows)
@@ -1358,7 +1369,7 @@ def fetch_testitems(
     df["molecule_chembl_id"] = df["molecule_chembl_id"].astype("string")
     df = df.reset_index(drop=True)
 
-    return 0, df
+    return 0, df, tuple(requested_ids_raw)
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -1396,8 +1407,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         if read_status != 0 or read_result is None:
             return read_status
 
-        requested_ids = read_result.requested_ids
-        fetch_status, df = fetch_testitems(
+        fetch_status, df, requested_ids = fetch_testitems(
             read_result.ids_iter,
             api_cfg=api_cfg,
             batch_size=cfg.testitem.batch_size,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -113,7 +113,7 @@ def test_fetch_testitems_failure(monkeypatch: pytest.MonkeyPatch, cfg: Config) -
 
     monkeypatch.setattr(cl, "get_testitem", fail_fetch)
 
-    status, df = gtd.fetch_testitems(
+    status, df, requested_ids = gtd.fetch_testitems(
         iter(["CHEMBL1"]),
         api_cfg=cfg.api,
         batch_size=1,
@@ -126,6 +126,7 @@ def test_fetch_testitems_failure(monkeypatch: pytest.MonkeyPatch, cfg: Config) -
 
     assert status == 1
     assert df is None
+    assert requested_ids == ()
 
 
 def test_fetch_testitems_passes_fields_and_limit(
@@ -145,11 +146,15 @@ def test_fetch_testitems_passes_fields_and_limit(
     ) -> pd.DataFrame:
         captured["fields"] = fields
         captured["page_limit"] = page_limit
-        return pd.DataFrame(columns=["molecule_chembl_id"])
+        values = list(ids)
+        return pd.DataFrame(
+            [{"molecule_chembl_id": value} for value in values],
+            columns=["molecule_chembl_id"],
+        )
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
 
-    status, df = gtd.fetch_testitems(
+    status, df, requested_ids = gtd.fetch_testitems(
         iter(["CHEMBL1", "CHEMBL2"]),
         api_cfg=cfg.api,
         batch_size=2,
@@ -164,6 +169,7 @@ def test_fetch_testitems_passes_fields_and_limit(
     assert df is not None
     assert captured["fields"] == ("a", "b")
     assert captured["page_limit"] == 500
+    assert requested_ids == ("CHEMBL1", "CHEMBL2")
 
 
 def test_fetch_parent_catalog_skips_single_when_parentless(
@@ -1228,7 +1234,7 @@ def test_run_chembl_column_order(
         captured["columns"] = list(df.columns)
         return output
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
@@ -1492,7 +1498,8 @@ def test_run_chembl_uses_lazy_identifier_stream(
     assert ids_source.iterations == 1
     assert received_ids is not None
     assert not isinstance(received_ids, list)
-    assert received_ids.__class__.__name__ == "_tee"
+    assert isinstance(received_ids, Iterator)
+    assert received_ids.__class__.__name__ == "generator"
 
 
 def test_run_chembl_calls_pubchem_once(
@@ -1642,7 +1649,7 @@ def test_run_chembl_prefills_parent_from_hierarchy(
         captured_df = df.copy()
         return output
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     rc = gtd.run_chembl(cfg, args)
 
@@ -1750,7 +1757,7 @@ def test_run_chembl_merges_parent_catalog(
         captured_df = df.copy()
         return output
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
@@ -1958,7 +1965,7 @@ def test_run_chembl_preserves_existing_parent_value_when_catalog_missing(
         captured_df = df.copy()
         return output
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     rc = gtd.run_chembl(cfg, args)
     assert rc == 0
@@ -2016,7 +2023,7 @@ def test_run_chembl_parent_catalog_error(
         called = True
         return Path("unused.csv")
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     rc = gtd.run_chembl(cfg, args)
     assert rc == 1
@@ -2086,7 +2093,7 @@ def test_run_chembl_parent_catalog_request_error(
         called = True
         return Path("unused.csv")
 
-    monkeypatch.setattr(io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(pipeline, "write_csv_deterministic", fake_write_csv)
 
     errors: list[tuple[str, dict[str, object]]] = []
 


### PR DESCRIPTION
## Summary
- sample test item identifiers without tee, re-chaining the consumed prefix and removing the cached `requested_ids` tuple
- track requested identifiers during ChEMBL fetches, returning them to callers and ensuring parent catalog fallbacks respect parentless filters
- update unit tests to assert the new iterator behaviour and refreshed fetch signatures

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfbddcb608324b710a160d372de24