### PR TITLE
Summarise missing ChEMBL test item logs

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - Clarified the minimum supported Python version as 3.11 across documentation and runtime checks.
+- Summarised ChEMBL test item missing identifier logging with counts and ID samples to keep records concise.

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1322,14 +1322,16 @@ def fetch_testitems(
     retrieved_ids = set(df["molecule_chembl_id"].dropna())
     missing_ids = [identifier for identifier in requested_ids if identifier not in retrieved_ids]
     if missing_ids:
+        sample_missing_ids = missing_ids[:5]
         missing_ids_original = [
             original_id_lookup.get(identifier, identifier) for identifier in missing_ids
         ]
+        sample_missing_ids_original = missing_ids_original[:5]
         logger.warning(
             "chembl_missing_identifiers",
             missing_count=len(missing_ids),
-            missing_ids=missing_ids,
-            missing_ids_original=missing_ids_original,
+            sample_missing_ids=sample_missing_ids,
+            sample_missing_ids_original=sample_missing_ids_original,
         )
     else:
         logger.info("chembl_all_identifiers_retrieved")

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -166,6 +166,58 @@ def test_fetch_testitems_passes_fields_and_limit(
     assert captured["page_limit"] == 500
 
 
+def test_fetch_testitems_logs_missing_summary(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(gtd.logger, "warning", fake_warning)
+
+    def fake_get_testitem(
+        ids: Iterable[str],
+        *,
+        cfg: ApiCfg,
+        client: object,
+        chunk_size: int,
+        timeout: float | None,
+        fields: Sequence[str] | None = None,
+        page_limit: int = 0,
+    ) -> pd.DataFrame:
+        _ = list(ids)
+        return pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+
+    status, df = gtd.fetch_testitems(
+        iter(["CHEMBL1", "chembl2", "CHEMBL3"]),
+        api_cfg=cfg.api,
+        batch_size=2,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        sample_ids=("CHEMBL1",),
+        fields=cfg.testitem.fields,
+        page_limit=500,
+    )
+
+    assert status == 0
+    assert df is not None
+
+    missing = next(
+        (record for record in captured if record[0] == "chembl_missing_identifiers"),
+        None,
+    )
+
+    assert missing is not None
+    _, missing_data = missing
+
+    assert missing_data["missing_count"] == 2
+    assert missing_data["sample_missing_ids"] == ["CHEMBL2", "CHEMBL3"]
+    assert "missing_ids" not in missing_data
+
+
 def test_fetch_parent_catalog_skips_single_when_parentless(
     cfg: Config,
 ) -> None:


### PR DESCRIPTION
## Summary
- emit concise summaries when ChEMBL test item identifiers are missing, including a count and a short ID sample
- cover the new logging fields with a targeted unit test
- document the logging change in the release notes

## Testing
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_logs_missing_summary


------
https://chatgpt.com/codex/tasks/task_e_68dcfbeed9888324bfcae10bbc2d9a36