### PR TITLE
Remove local ParentEnrichment dataclass overrides

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -86,25 +86,6 @@ class ReadInputIdsResult:
 
 
 
-@dataclass
-class ParentEnrichmentPreparation:
-    """Intermediate data required to attach parent identifiers."""
-
-    df: pd.DataFrame
-    lookup_data: "ParentLookupPreparedData"
-    parent_catalog: dict[str, str] | None
-    parent_catalog_source: str
-    parent_stats: "ParentLookupStats"
-
-
-@dataclass
-class ParentEnrichmentResult:
-    """Result returned after running the parent enrichment stage."""
-
-    df: pd.DataFrame
-    parent_stats: "ParentLookupStats"
-
-
 def ensure_no_parant_column(df: pd.DataFrame) -> None:
     """Raise a :class:`ValueError` if the legacy typo column is present."""
 


### PR DESCRIPTION
## Summary
- remove the redundant ParentEnrichmentPreparation and ParentEnrichmentResult dataclasses from `scripts/get_testitem_data.py` so the CLI uses the shared pipeline implementations

## Testing
- pytest tests/smoke/test_get_testitem_parent.py *(fails: parent molecule enrichment smoke tests currently fail even on main)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfe436828832499ab0fbef52fc183