### PR TITLE
Track requested identifiers during ChEMBL fetch

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1334,11 +1334,17 @@ def fetch_testitems(
     """Retrieve ChEMBL test item records for ``ids_iter``."""
 
     logger.info("chembl_fetch_start", batch_size=batch_size)
-    requested_ids_raw: list[str] = []
+    requested_ids: list[str] = []
+    requested_ids_original: list[str] = []
+    original_id_lookup: dict[str, str] = {}
 
     def _iter_with_tracking(source: Iterable[str]) -> Iterator[str]:
         for identifier in source:
-            requested_ids_raw.append(identifier)
+            text_identifier = str(identifier)
+            normalised = text_identifier.strip().upper()
+            requested_ids_original.append(text_identifier)
+            requested_ids.append(normalised)
+            original_id_lookup.setdefault(normalised, text_identifier)
             yield identifier
 
     tracked_iter = _iter_with_tracking(ids_iter)
@@ -1360,20 +1366,13 @@ def fetch_testitems(
             timeout=timeout,
             sample_ids=list(sample_ids),
         )
-        return 1, None, tuple(requested_ids_raw)
+        return 1, None, tuple(requested_ids_original)
     finally:
         deque(tracked_iter, maxlen=0)
 
     rows = len(df)
     logger.info("chembl_fetch_done", rows=rows)
     logger.info("identifiers_retrieved", count=rows)
-
-    original_id_lookup: dict[str, str] = {}
-    requested_ids: list[str] = []
-    for identifier in requested_ids_raw:
-        normalised = str(identifier).strip().upper()
-        requested_ids.append(normalised)
-        original_id_lookup[normalised] = str(identifier)
 
     if "molecule_chembl_id" not in df.columns:
         df["molecule_chembl_id"] = pd.Series(dtype="string")
@@ -1420,7 +1419,7 @@ def fetch_testitems(
     df["molecule_chembl_id"] = df["molecule_chembl_id"].astype("string")
     df = df.reset_index(drop=True)
 
-    return 0, df, tuple(requested_ids_raw)
+    return 0, df, tuple(requested_ids_original)
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -197,7 +197,7 @@ def test_fetch_testitems_logs_missing_summary(
 
     monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
 
-    status, df = gtd.fetch_testitems(
+    status, df, requested_ids = gtd.fetch_testitems(
         iter(["CHEMBL1", "chembl2", "CHEMBL3"]),
         api_cfg=cfg.api,
         batch_size=2,
@@ -210,6 +210,7 @@ def test_fetch_testitems_logs_missing_summary(
 
     assert status == 0
     assert df is not None
+    assert requested_ids == ("CHEMBL1", "chembl2", "CHEMBL3")
 
     missing = next(
         (record for record in captured if record[0] == "chembl_missing_identifiers"),
@@ -1472,7 +1473,12 @@ def test_run_chembl_initialises_pubchem_session(
     rc = gtd.run_chembl(cfg, args)
 
     assert rc == 0
-    assert captured["init"] == (cfg.api, cfg.retry)
+
+    init_api, init_retry = captured["init"]
+    expected_api = gtd._prepare_pubchem_api_cfg(cfg, cfg.api)
+
+    assert init_api == expected_api
+    assert init_retry == cfg.retry
 
 
 def test_run_chembl_uses_lazy_identifier_stream(


### PR DESCRIPTION
## Summary
- wrap the identifier iterator so fetch_testitems tracks both normalised and original values while streaming requests
- rely on the tracked identifiers for ordering and missing diagnostics without re-iterating the input
- refresh tests to assert the new tracking behaviour and updated PubChem session expectations

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dd003fe1948324a24961dd4bc0d843