### PR TITLE
Preserve table quality identifier types

### DIFF
--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 import pandas as pd
 
 from library import cli
+from library import io
 from library.cli import (
     LoggerConfig,
     configure_logger,
@@ -42,7 +43,13 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     """
     try:
         try:
-            df = pd.read_csv(args.input_csv, sep=args.sep, encoding=args.encoding)
+            df = io.read_csv(
+                args.input_csv,
+                cfg=cfg.io,
+                sep=args.sep,
+                encoding=args.encoding,
+                dtype=str,
+            )
         except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
             logger.error(
                 "input_read_failed",
@@ -108,7 +115,10 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser."""
-    parser, log_cfg = base_parser("Table quality analysis", column="chembl_id")
+    parser, log_cfg = base_parser(
+        "Table quality analysis (reads CSV data as strings to preserve identifiers)",
+        column="chembl_id",
+    )
     parser.add_argument(
         "--table-name",
         required=True,

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from library.config import Config
 from library.table_quality import analyze_table_quality
@@ -131,3 +132,48 @@ def test_table_quality_run_respects_sampling_and_filters(tmp_path: Path) -> None
     assert set(report["column"]) == {"keep"}
     non_null = int(report.loc[report["column"] == "keep", "non_null"].iloc[0])
     assert non_null == 2
+
+
+def test_table_quality_run_handles_mixed_types(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "mixed": [1, "2", 3.5, None],
+            "identifier": ["0001", "0002", "ABC123", None],
+        }
+    )
+    csv_path = tmp_path / "mixed.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=tmp_path,
+        table_name="mixed",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+    assert exit_code == 0
+
+    report_path = tmp_path / "mixed_quality_report_table.csv"
+    assert report_path.exists()
+    report = pd.read_csv(report_path)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        expected_quality, _ = analyze_table_quality(df, table_name="expected")
+    finally:
+        os.chdir(cwd)
+
+    expected_mixed = expected_quality.loc[expected_quality["column"] == "mixed"].iloc[0]
+    actual_mixed = report.loc[report["column"] == "mixed"].iloc[0]
+
+    assert actual_mixed["numeric_cov"] == pytest.approx(expected_mixed["numeric_cov"])
+    assert actual_mixed["numeric_mean"] == pytest.approx(expected_mixed["numeric_mean"])


### PR DESCRIPTION
## Summary
- load table-quality CLI input with the shared CSV reader so identifier columns stay as strings
- mention the deterministic string loading behaviour in the CLI help text
- add a regression test covering mixed-type columns to ensure numeric summaries remain stable

## Testing
- pytest tests/test_table_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68dd029ac2448324bcae7ffbffa47db9