### PR TITLE
Fix mapper batch generics for Python 3.11

### DIFF
--- a/library/mapper_batch_library.py
+++ b/library/mapper_batch_library.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TypeVar
 
 from .config import UniprotMappingCfg
 from .log import logger
@@ -11,7 +12,10 @@ from .mapper_library import map_chembl_to_uniprot
 from .rate_limiter import get_limiter
 
 
-def batch_iterable[T](iterable: Iterable[T], batch_size: int) -> Iterator[list[T]]:
+T = TypeVar("T")
+
+
+def batch_iterable(iterable: Iterable[T], batch_size: int) -> Iterator[list[T]]:
     """Yield items from ``iterable`` in batches of ``batch_size``.
 
     Parameters

--- a/tests/test_mapper_batch_library_import.py
+++ b/tests/test_mapper_batch_library_import.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_mapper_batch_library_imports() -> None:
+    """Ensure mapper_batch_library imports without errors."""
+
+    module = importlib.import_module("library.mapper_batch_library")
+    assert module.__name__ == "library.mapper_batch_library"


### PR DESCRIPTION
## Summary
- replace the mapper batch helper with TypeVar-based generics compatible with Python 3.11
- add a regression test that verifies `library.mapper_batch_library` imports cleanly

## Testing
- pytest tests/test_mapper_batch_library_import.py

------
https://chatgpt.com/codex/tasks/task_e_68dd029c593083248dc56535586ac7c3