### PR TITLE
Ensure document schema columns are unique

### DIFF
--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -111,6 +111,10 @@ DOCUMENT_SCHEMA_COLUMNS: list[str] = (
     ]
 )
 
+# Remove accidental duplicates while preserving declaration order. Downstream
+# code assumes a one-to-one mapping between column name and position.
+DOCUMENT_SCHEMA_COLUMNS = list(dict.fromkeys(DOCUMENT_SCHEMA_COLUMNS))
+
 
 # ---------------------------------------------------------------------------
 # Normalisation helpers
@@ -206,21 +210,23 @@ def build_dataframe(
 ) -> pd.DataFrame:
     """Return a :class:`~pandas.DataFrame` with deterministic column order."""
 
+    unique_columns = list(dict.fromkeys(columns))
+
     if isinstance(data, pd.DataFrame):
         df = data.copy()
     else:
         if not data:
-            return pd.DataFrame(columns=list(columns))
+            return pd.DataFrame(columns=unique_columns)
         df = pd.DataFrame.from_records(data)
 
     if fill_missing:
-        for col in columns:
+        for col in unique_columns:
             if col not in df.columns:
                 df[col] = ""
 
-    extra = sorted(c for c in df.columns if c not in columns)
-    head = [c for c in columns if c in df.columns]
-    ordered = head + extra if not fill_missing else list(columns) + extra
+    extra = sorted(c for c in df.columns if c not in unique_columns)
+    head = [c for c in unique_columns if c in df.columns]
+    ordered = head + extra if not fill_missing else unique_columns + extra
     return df[ordered]
 
 

--- a/tests/test_document_pipeline.py
+++ b/tests/test_document_pipeline.py
@@ -20,6 +20,12 @@ from library.config import CrossRefCfg, OpenAlexCfg, PubMedCfg, SemanticScholarC
 import scripts.get_document_data as gdd
 
 
+def test_document_schema_columns_are_unique() -> None:
+    """Schema column declaration should not contain duplicates."""
+
+    assert len(DOCUMENT_SCHEMA_COLUMNS) == len(set(DOCUMENT_SCHEMA_COLUMNS))
+
+
 def test_merge_metadata_normalises_fields() -> None:
     """``merge_metadata`` normalises DOI and computes publication scores."""
 


### PR DESCRIPTION
## Summary
- normalise the document schema column declaration to remove duplicates while keeping order
- ensure `build_dataframe` works with deduplicated column sequences
- add a regression test that asserts the schema column list stays unique

## Testing
- pytest tests/test_document_pipeline.py::test_document_schema_columns_are_unique

------
https://chatgpt.com/codex/tasks/task_e_68dd02854f2883248dfcfb917abb6871