### PR TITLE
Refactor mapper CLI to use batch mapping

### DIFF
--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -13,13 +13,14 @@ from library import io
 from library.cli import (
     LoggerConfig,
     configure_logger,
+    positive_int,
 )
 from library.cli import (
     build_parser as base_parser,
 )
 from library.config import Config, ensure_dirs, print_config
 from library.log import logger
-from library.mapper_library import map_chembl_to_uniprot
+from library.mapper_batch_library import map_chembl_ids_to_uniprot
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -55,26 +56,47 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             logger.error("missing_column", column=args.column, path=str(args.input_csv))
             return 1
 
-        uniprot_ids: list[str | None] = []
-        for chembl_id in df[args.column]:
-            if pd.isna(chembl_id) or not str(chembl_id).strip():
-                uniprot_ids.append(None)
-                continue
-            try:
-                uniprot_id = map_chembl_to_uniprot(str(chembl_id), cfg.uniprot_mapping)
-                uniprot_ids.append(uniprot_id)
+        def _normalize(value: object) -> str | None:
+            if pd.isna(value):
+                return None
+            text = str(value).strip()
+            return text or None
+
+        ids_to_map: list[str] = []
+        for value in df[args.column]:
+            normalized = _normalize(value)
+            if normalized is not None:
+                ids_to_map.append(normalized)
+
+        try:
+            mappings = map_chembl_ids_to_uniprot(
+                ids_to_map,
+                cfg.uniprot_mapping,
+                batch_size=args.chunk_size,
+                rps=args.rps,
+                max_workers=args.workers,
+            )
+        except (ValueError, TimeoutError, URLError) as exc:
+            logger.warning("map_failed", error=str(exc))
+            df["mapping_uniprot_id"] = [None for _ in df[args.column]]
+        else:
+            for chembl_id in ids_to_map:
+                uniprot_id = mappings.get(chembl_id)
                 if uniprot_id:
                     logger.info(
                         "mapped",
-                        chembl_id=str(chembl_id),
+                        chembl_id=chembl_id,
                         uniprot_id=uniprot_id,
                     )
                 else:
-                    logger.warning("uniprot_id_missing", chembl_id=str(chembl_id))
-            except (ValueError, TimeoutError, URLError) as exc:
-                logger.warning("map_failed", chembl_id=str(chembl_id), error=str(exc))
-                uniprot_ids.append(None)
-        df["mapping_uniprot_id"] = uniprot_ids
+                    logger.warning("uniprot_id_missing", chembl_id=chembl_id)
+            mapped_values: list[str | None] = []
+            for value in df[args.column]:
+                normalized = _normalize(value)
+                mapped_values.append(
+                    mappings.get(normalized) if normalized is not None else None
+                )
+            df["mapping_uniprot_id"] = mapped_values
         output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
         try:
             io.write_csv(
@@ -106,6 +128,13 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--key-cols",
         nargs="*",
         help="Columns used to sort the output CSV deterministically",
+    )
+    parser.add_argument("--rps", type=float, default=1.0, help="Max requests per second")
+    parser.add_argument(
+        "--workers",
+        type=positive_int,
+        default=1,
+        help="Number of worker threads",
     )
     parser.set_defaults(func=run)
     return parser, log_cfg

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -33,9 +33,16 @@ def test_mapper_run_defaults_to_io_output_dir(
         sep=",",
         encoding="utf8",
         key_cols=None,
+        chunk_size=1,
+        rps=1.0,
+        workers=1,
     )
 
-    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", lambda _i, _cfg: "P12345")
+    monkeypatch.setattr(
+        mapper_main,
+        "map_chembl_ids_to_uniprot",
+        lambda ids, _cfg, *, batch_size, rps, max_workers: {ids[0]: "P12345"},
+    )
     monkeypatch.setattr(io, "write_meta_yaml", lambda *_a, **_k: None)
 
     rc = mapper_main.run(cfg, args)

--- a/tests/test_mapper_logging.py
+++ b/tests/test_mapper_logging.py
@@ -32,10 +32,15 @@ def test_mapper_main_logs_mapping(
 ) -> None:
     """Mapper CLI emits structured mapping log records."""
 
-    def fake_map(cid: str, cfg: object) -> str | None:
-        return "P12345"
+    def fake_map(ids: list[str], cfg: object, *, batch_size: int, rps: float, max_workers: int | None) -> dict[str, str | None]:
+        assert ids == ["CHEMBL1"]
+        assert batch_size == 1
+        assert rps == 1.0
+        assert max_workers == 1
+        return {"CHEMBL1": "P12345"}
 
-    monkeypatch.setattr(mapper_main, "map_chembl_to_uniprot", fake_map)
+    monkeypatch.setattr(mapper_main, "map_chembl_ids_to_uniprot", fake_map)
+
     df = pd.DataFrame({"chembl_id": ["CHEMBL1"]})
     input_path = tmp_path / "in.csv"
     df.to_csv(input_path, index=False)
@@ -46,6 +51,9 @@ def test_mapper_main_logs_mapping(
         sep=",",
         encoding="utf8",
         key_cols=None,
+        chunk_size=1,
+        rps=1.0,
+        workers=1,
     )
     buffer = io.StringIO()
     configure_logger(LoggerConfig(stream=buffer, level="INFO"))
@@ -63,3 +71,112 @@ def test_mapper_main_logs_mapping(
     rec = mapped[0]
     assert rec["chembl_id"] == "CHEMBL1"
     assert rec["uniprot_id"] == "P12345"
+
+
+def test_mapper_main_concurrent_preserves_order(
+    tmp_path: Path, monkeypatch: Any, cfg: Config
+) -> None:
+    """Concurrent path retains mapping order and logging semantics."""
+
+    df = pd.DataFrame(
+        {"chembl_id": ["CHEMBL1", None, "CHEMBL2", " ", "CHEMBL3"]}
+    )
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "out.csv"
+
+    captured: dict[str, Any] = {}
+
+    def fake_map(
+        ids: list[str],
+        cfg_mapping: object,
+        *,
+        batch_size: int,
+        rps: float,
+        max_workers: int | None,
+    ) -> dict[str, str | None]:
+        captured["ids"] = list(ids)
+        captured["batch_size"] = batch_size
+        captured["rps"] = rps
+        captured["max_workers"] = max_workers
+        return {
+            "CHEMBL2": "P222",
+            "CHEMBL1": "P111",
+            "CHEMBL3": None,
+        }
+
+    monkeypatch.setattr(mapper_main, "map_chembl_ids_to_uniprot", fake_map)
+
+    written: dict[str, Any] = {}
+
+    def fake_write_csv(
+        df_out: pd.DataFrame,
+        path: Path,
+        *,
+        cfg: Config,
+        sep: str,
+        encoding: str,
+        key_cols: Any,
+    ) -> Path:
+        written["df"] = df_out.copy()
+        written["path"] = path
+        written["key_cols"] = key_cols
+        written["chembl_ids"] = df_out["chembl_id"].tolist()
+        return path
+
+    monkeypatch.setattr(mapper_main.io, "write_csv", fake_write_csv)
+
+    args = argparse.Namespace(
+        input_csv=input_path,
+        output_csv=output_path,
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+        key_cols=None,
+        chunk_size=2,
+        rps=5.0,
+        workers=3,
+    )
+
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(stream=buffer, level="INFO"))
+
+    cfg_ns = SimpleNamespace(
+        io=cfg.io,
+        uniprot_mapping=cfg.uniprot_mapping,
+        to_dict=lambda: {},
+    )
+
+    exit_code = mapper_main.run(cfg_ns, args)
+    assert exit_code == 0
+
+    assert captured["ids"] == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    assert captured["batch_size"] == 2
+    assert captured["rps"] == 5.0
+    assert captured["max_workers"] == 3
+
+    output_df = written["df"]
+    chembl_ids = [
+        value if isinstance(value, str) and value.strip() else None
+        for value in written["chembl_ids"]
+    ]
+    assert chembl_ids == ["CHEMBL1", None, "CHEMBL2", "CHEMBL3"]
+    mapped_values = [
+        value if isinstance(value, str) and value else None
+        for value in output_df["mapping_uniprot_id"].tolist()
+    ]
+    assert mapped_values == ["P111", None, "P222", None]
+    assert written["path"] == output_path
+    assert written["key_cols"] is None
+
+    records = [json.loads(line) for line in buffer.getvalue().splitlines() if line]
+    status_events = [
+        (record["event"], record.get("chembl_id"))
+        for record in records
+        if record["event"] in {"mapped", "uniprot_id_missing"}
+    ]
+    assert status_events == [
+        ("mapped", "CHEMBL1"),
+        ("mapped", "CHEMBL2"),
+        ("uniprot_id_missing", "CHEMBL3"),
+    ]

--- a/tests/test_mapper_run_exception.py
+++ b/tests/test_mapper_run_exception.py
@@ -30,6 +30,9 @@ def test_run_logs_exception(monkeypatch, tmp_path: Path, cfg: Config) -> None:
         sep=",",
         encoding="utf8",
         key_cols=None,
+        chunk_size=1,
+        rps=1.0,
+        workers=1,
     )
     exit_code = mapper_main.run(cfg_ns, args)
     assert exit_code == 1


### PR DESCRIPTION
## Summary
- switch `mapper_main` to use the batch mapping helper and expose CLI controls for chunk size, RPS, and worker count
- keep structured logging behaviour while iterating batch results back into the output frame
- expand CLI unit tests to exercise the concurrent path and verify deterministic ordering

## Testing
- pytest tests/test_mapper_logging.py tests/test_default_output_dir.py tests/test_mapper_run_exception.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0298f14883248fea3b505155b1af