### PR TITLE
Fix PubMed record generator ordering

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -566,50 +566,75 @@ def fetch_pubmed_records(
     openalex_executor: ThreadPoolExecutor | None = None
     crossref_executor: ThreadPoolExecutor | None = None
 
-    iterator = (p for p in pmids if p)
+    def _iter_records() -> Iterator[list[dict[str, str]]]:
+        nonlocal openalex_executor, crossref_executor
 
-    tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
-    ordered: dict[int, list[dict[str, str]]] = {}
-    processed = 0
-    max_in_flight = max(1, max_workers * 2)
+        iterator = (p for p in pmids if p)
 
-    with ExitStack() as stack:
-        batch_executor = stack.enter_context(
-            ThreadPoolExecutor(max_workers=max_workers)
-        )
-        if openalex_capacity > 1:
-            openalex_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=openalex_capacity)
-            )
-        if crossref_capacity > 1:
-            crossref_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=crossref_capacity)
-            )
-
-        offset = 0
+        tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
+        completed: dict[int, list[dict[str, str]]] = {}
         pending: set[Future[list[dict[str, str]]]] = set()
-        for batch in _chunked(iterator, batch_size):
-            if not batch:
-                continue
-            future = batch_executor.submit(_fetch_batch, batch)
-            tasks[future] = (offset, batch)
-            pending.add(future)
-            offset += len(batch)
-            if len(pending) >= max_in_flight:
+        processed = 0
+        max_in_flight = max(1, max_workers * 2)
+        next_to_emit = 0
 
-                done_future = next(as_completed(list(pending)))
-                pending.remove(done_future)
-                batch_id, batch_len = tasks.pop(done_future)
-                completed[batch_id] = done_future.result()
-                processed += batch_len
-                logger.info("documents_processed", count=processed)
-                while next_to_emit in completed:
-                    yield completed.pop(next_to_emit)
-                    next_to_emit += 1
+        def _process_future(
+            future: Future[list[dict[str, str]]]
+        ) -> Iterator[list[dict[str, str]]]:
+            nonlocal processed, next_to_emit
 
+            batch_id, batch_items = tasks.pop(future)
+            completed[batch_id] = future.result()
+            processed += len(batch_items)
+            logger.info("documents_processed", count=processed)
             while next_to_emit in completed:
                 yield completed.pop(next_to_emit)
                 next_to_emit += 1
+
+        with ExitStack() as stack:
+            batch_executor = stack.enter_context(
+                ThreadPoolExecutor(max_workers=max_workers)
+            )
+            if openalex_capacity > 1:
+                openalex_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=openalex_capacity)
+                )
+            else:
+                openalex_executor = None
+            if crossref_capacity > 1:
+                crossref_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=crossref_capacity)
+                )
+            else:
+                crossref_executor = None
+
+            batch_index = 0
+            for batch in _chunked(iterator, batch_size):
+                if not batch:
+                    continue
+                future = batch_executor.submit(_fetch_batch, batch)
+                tasks[future] = (batch_index, batch)
+                pending.add(future)
+                batch_index += 1
+
+                if len(pending) >= max_in_flight:
+                    done_future = next(as_completed(list(pending)))
+                    pending.remove(done_future)
+                    yield from _process_future(done_future)
+
+                finished = [f for f in list(pending) if f.done()]
+                for future in finished:
+                    pending.remove(future)
+                    yield from _process_future(future)
+
+            while pending:
+                done_future = next(as_completed(list(pending)))
+                pending.remove(done_future)
+                yield from _process_future(done_future)
+
+        while next_to_emit in completed:
+            yield completed.pop(next_to_emit)
+            next_to_emit += 1
 
     def _iter_frames() -> Iterator[pd.DataFrame]:
         for records_batch in _iter_records():

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -6,7 +6,7 @@ import json
 import sys
 import threading
 import time
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -409,6 +409,97 @@ def test_build_fallback_doi_map() -> None:
     result = gdd._build_fallback_doi_map(df, pmid_column="PMID", doi_column="DOI")
 
     assert result == {"1": "10.1000/xyz"}
+
+
+def test_fetch_pubmed_records_generator_yields_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure PubMed fetch returns ordered batches when requested."""
+
+    cfg = Config()
+    pmids = ["1", "2", "3", "4"]
+    release_first = threading.Event()
+
+    monkeypatch.setattr(
+        gdd,
+        "get_limiter",
+        lambda *_, **__: DummyLimiter(burst=2),
+    )
+
+    class DummySessionContext:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(
+            self,
+            exc_type: object | None,
+            exc: object | None,
+            tb: object | None,
+        ) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        gdd,
+        "session_with_retry",
+        lambda *args, **kwargs: DummySessionContext(),
+    )
+
+    def fake_fetch_pubmed_batch(
+        _session: object,
+        batch: Sequence[str],
+        _sleep: float | None,
+        *,
+        cfg: PubMedCfg,
+    ) -> list[dict[str, str]]:
+        if batch[0] == "1":
+            release_first.wait(timeout=1)
+        else:
+            release_first.set()
+        return [{"PubMed.PMID": pmid} for pmid in batch]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_fetch_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", lambda *_, **__: [])
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", lambda *_, **__: {})
+
+    def fake_merge_metadata(
+        pubmed: Mapping[str, str],
+        *_: Mapping[str, str],
+    ) -> dict[str, str]:
+        return {"PubMed.PMID": pubmed.get("PubMed.PMID", "")}
+
+    monkeypatch.setattr(gdd, "merge_metadata", fake_merge_metadata)
+
+    def fake_build_dataframe(
+        records: Sequence[Mapping[str, str]],
+        *,
+        columns: Sequence[str],
+    ) -> pd.DataFrame:
+        frame = pd.DataFrame(records)
+        for column in columns:
+            if column not in frame.columns:
+                frame[column] = pd.NA
+        return frame[list(columns)]
+
+    monkeypatch.setattr(gdd, "build_dataframe", fake_build_dataframe)
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        pubmed_cfg=cfg.pubmed,
+        semantic_scholar_cfg=cfg.semantic_scholar,
+        openalex_cfg=cfg.openalex,
+        crossref_cfg=cfg.crossref,
+        max_workers=2,
+        batch_size=2,
+        return_generator=True,
+    )
+
+    frames = list(generator)
+    assert len(frames) == 2
+    observed = [frame["PubMed.PMID"].dropna().tolist() for frame in frames]
+    assert observed == [["1", "2"], ["3", "4"]]
 
 
 def test_run_pubmed_uses_fallback_csv(


### PR DESCRIPTION
## Summary
- add a nested `_iter_records` generator in `fetch_pubmed_records` to emit completed batches in submission order
- route `_iter_frames` through the new generator
- cover the generator behaviour with a regression test in `tests/test_get_document_data.py`

## Testing
- pytest tests/test_get_document_data.py -k generator

------
https://chatgpt.com/codex/tasks/task_e_68dd0291c0cc8324b059eda2e836f339