### PR TITLE
Fix ordered draining of PubMed batch futures

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -566,38 +566,57 @@ def fetch_pubmed_records(
     openalex_executor: ThreadPoolExecutor | None = None
     crossref_executor: ThreadPoolExecutor | None = None
 
-    iterator = (p for p in pmids if p)
+    def _iter_records() -> Iterator[list[dict[str, str]]]:
+        nonlocal openalex_executor, crossref_executor
 
-    tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
-    ordered: dict[int, list[dict[str, str]]] = {}
-    processed = 0
-    max_in_flight = max(1, max_workers * 2)
+        iterator = (p for p in pmids if p)
 
-    with ExitStack() as stack:
-        batch_executor = stack.enter_context(
-            ThreadPoolExecutor(max_workers=max_workers)
-        )
-        if openalex_capacity > 1:
-            openalex_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=openalex_capacity)
+        tasks: dict[Future[list[dict[str, str]]], tuple[int, int]] = {}
+        completed: dict[int, list[dict[str, str]]] = {}
+        next_to_emit = 0
+        processed = 0
+        max_in_flight = max(1, max_workers * 2)
+
+        with ExitStack() as stack:
+            batch_executor = stack.enter_context(
+                ThreadPoolExecutor(max_workers=max_workers)
             )
-        if crossref_capacity > 1:
-            crossref_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=crossref_capacity)
-            )
+            if openalex_capacity > 1:
+                openalex_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=openalex_capacity)
+                )
+            if crossref_capacity > 1:
+                crossref_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=crossref_capacity)
+                )
 
-        offset = 0
-        pending: set[Future[list[dict[str, str]]]] = set()
-        for batch in _chunked(iterator, batch_size):
-            if not batch:
-                continue
-            future = batch_executor.submit(_fetch_batch, batch)
-            tasks[future] = (offset, batch)
-            pending.add(future)
-            offset += len(batch)
-            if len(pending) >= max_in_flight:
+            batch_index = 0
+            pending: set[Future[list[dict[str, str]]]] = set()
+            for batch in _chunked(iterator, batch_size):
+                if not batch:
+                    continue
+                future = batch_executor.submit(_fetch_batch, batch)
+                tasks[future] = (batch_index, len(batch))
+                pending.add(future)
+                batch_index += 1
+                if len(pending) >= max_in_flight:
 
-                done_future = next(as_completed(list(pending)))
+                    done_future = next(as_completed(pending))
+                    pending.remove(done_future)
+                    batch_id, batch_len = tasks.pop(done_future)
+                    completed[batch_id] = done_future.result()
+                    processed += batch_len
+                    logger.info("documents_processed", count=processed)
+                    while next_to_emit in completed:
+                        yield completed.pop(next_to_emit)
+                        next_to_emit += 1
+
+                while next_to_emit in completed:
+                    yield completed.pop(next_to_emit)
+                    next_to_emit += 1
+
+            while pending:
+                done_future = next(as_completed(pending))
                 pending.remove(done_future)
                 batch_id, batch_len = tasks.pop(done_future)
                 completed[batch_id] = done_future.result()

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -720,6 +720,90 @@ def test_fetch_pubmed_records_returns_generator_in_order(
     assert combined["PubMed.PMID"].tolist() == pmids
 
 
+def test_fetch_pubmed_records_handles_multiple_pending_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent execution should drain pending futures in order."""
+
+    pmids = [str(i) for i in range(6)]
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"PubMed.PMID": pmid, "PubMed.DOI": f"10.1000/{pmid}"} for pmid in batch]
+
+    def fake_semantic_batch(
+        session: Any,
+        ids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"scholar.PMID": pmid, "scholar.DOI": f"10.1000/{pmid}"}
+            for pmid in ids
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_, **__: {"scholar.DOI": "10.1000/fallback"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda session, pmid, cfg, limiter: {"OpenAlex.Id": f"OA{pmid}"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda session, doi, cfg, limiter: {"crossref.DOI": doi},
+    )
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+        return_generator=True,
+    )
+
+    frames = list(generator)
+    flattened = [pmid for frame in frames for pmid in frame["PubMed.PMID"].tolist()]
+    assert flattened == pmids
+
+    combined = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert combined["PubMed.PMID"].tolist() == pmids
+
+
 def test_fetch_pubmed_records_streams_large_batches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure `fetch_pubmed_records` tracks completed futures with a queue keyed by submission order
- drain remaining futures after scheduling completes so generator batches stay ordered
- cover the multi-batch generator path with a regression test to catch NameErrors

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_returns_generator_in_order tests/test_get_document_data.py::test_fetch_pubmed_records_handles_multiple_pending_batches

------
https://chatgpt.com/codex/tasks/task_e_68dd0292f1388324826a5937751569b4