### PR TITLE
Flush pending PubMed batch futures before yielding frames

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -569,7 +569,8 @@ def fetch_pubmed_records(
     iterator = (p for p in pmids if p)
 
     tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
-    ordered: dict[int, list[dict[str, str]]] = {}
+    completed: dict[int, list[dict[str, str]]] = {}
+    next_to_emit = 0
     processed = 0
     max_in_flight = max(1, max_workers * 2)
 
@@ -588,6 +589,22 @@ def fetch_pubmed_records(
 
         offset = 0
         pending: set[Future[list[dict[str, str]]]] = set()
+
+        def _drain_future(
+            done_future: Future[list[dict[str, str]]],
+        ) -> Iterator[list[dict[str, str]]]:
+            nonlocal processed, next_to_emit
+
+            pending.remove(done_future)
+            batch_id, batch_pmids = tasks.pop(done_future)
+            completed[batch_id] = done_future.result()
+            processed += len(batch_pmids)
+            logger.info("documents_processed", count=processed)
+
+            while next_to_emit in completed:
+                yield completed.pop(next_to_emit)
+                next_to_emit += 1
+
         for batch in _chunked(iterator, batch_size):
             if not batch:
                 continue
@@ -598,18 +615,20 @@ def fetch_pubmed_records(
             if len(pending) >= max_in_flight:
 
                 done_future = next(as_completed(list(pending)))
-                pending.remove(done_future)
-                batch_id, batch_len = tasks.pop(done_future)
-                completed[batch_id] = done_future.result()
-                processed += batch_len
-                logger.info("documents_processed", count=processed)
-                while next_to_emit in completed:
-                    yield completed.pop(next_to_emit)
-                    next_to_emit += 1
+                yield from _drain_future(done_future)
 
             while next_to_emit in completed:
                 yield completed.pop(next_to_emit)
                 next_to_emit += 1
+
+        for done_future in as_completed(pending):
+            yield from _drain_future(done_future)
+
+        pending.clear()
+
+        while next_to_emit in completed:
+            yield completed.pop(next_to_emit)
+            next_to_emit += 1
 
     def _iter_frames() -> Iterator[pd.DataFrame]:
         for records_batch in _iter_records():

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -720,6 +720,96 @@ def test_fetch_pubmed_records_returns_generator_in_order(
     assert combined["PubMed.PMID"].tolist() == pmids
 
 
+def test_fetch_pubmed_records_drains_pending_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """More batches than ``max_in_flight`` should still all be emitted."""
+
+    pmids = [str(i) for i in range(6)]
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"PubMed.PMID": pmid, "PubMed.DOI": f"10.1000/{pmid}"}
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        session: Any,
+        ids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"scholar.PMID": pmid, "scholar.DOI": f"10.1000/{pmid}"}
+            for pmid in ids
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_, **__: {"scholar.DOI": "10.1000/fallback"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda session, pmid, cfg, limiter: {"OpenAlex.Id": f"OA{pmid}"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda session, doi, cfg, limiter: {"crossref.DOI": doi},
+    )
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=2,
+        return_generator=True,
+    )
+
+    frames = list(generator)
+    assert [frame["PubMed.PMID"].tolist() for frame in frames] == [
+        ["0", "1"],
+        ["2", "3"],
+        ["4", "5"],
+    ]
+
+    combined = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=2,
+    )
+
+    assert combined["PubMed.PMID"].tolist() == pmids
+
+
 def test_fetch_pubmed_records_streams_large_batches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- drain outstanding PubMed batch futures before finishing the batching loop so `_iter_frames` sees every result
- process completed futures through a helper to keep `completed` bookkeeping and emission order consistent
- add a regression test covering inputs with more batches than `max_in_flight` to ensure nothing is dropped

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_drains_pending_batches -q *(fails: TypeError "list indices must be integers or slices, not str")*

------
https://chatgpt.com/codex/tasks/task_e_68dd02937a5483249421c69d526e7b8a