### PR TITLE
Disallow custom log format overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,16 +399,10 @@ api:
 
 ## Logging / Логирование
 
-**EN.** CLI helpers configure structured JSON logging via ``library.logging_setup.configure_logger``. Use environment variables or CLI flags to adjust verbosity and format.
+**EN.** CLI helpers configure structured JSON logging via ``library.logging_setup.configure_logger``. Use environment variables or CLI flags to adjust verbosity. The JSON layout is fixed and not customisable.
 
-**RU.** CLI-хелперы настраивают структурированное JSON-логирование через ``library.logging_setup.configure_logger``. Управляйте форматом и уровнем логов переменными окружения или ключами CLI.
+**RU.** CLI-хелперы настраивают структурированное JSON-логирование через ``library.logging_setup.configure_logger``. Управляйте уровнем логов переменными окружения или ключами CLI. Формат JSON фиксирован и не настраивается.
 
-Пример включения JSON‑формата через переменную окружения:
-
-```bash
-LOG_FORMAT=json python -m scripts.get_assay_data --input assay_ids.csv \
-    --output out/assays.csv --log-level INFO
-```
 
 Уровень логов можно задать флагом `--log-level` или переменной
 `CHEMBL_DA_LOG_LEVEL`:
@@ -625,8 +619,6 @@ lists every supported alias and the canonical key it maps to:
 | `CHEMBL_DA_IUPHAR_TARGET_CSV` | `CHEMBL_DA__LOCAL__RESOURCES__IUPHAR_TARGET_CSV` |
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_MAXSIZE` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_TTL` |
-| `CHEMBL_DA_LOG_DATEFMT` | `CHEMBL_DA__SYSTEM__LOG__DATEFMT` |
-| `CHEMBL_DA_LOG_FORMAT` | `CHEMBL_DA__SYSTEM__LOG__FORMAT` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__SYSTEM__LOG__LEVEL` |
 | `CHEMBL_DA_MOLECULE_CATALOG_CACHE` | `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH` |
 | `CHEMBL_DA_OPENALEX_BASE` | `CHEMBL_DA__SOURCES__OPENALEX__BASE` |

--- a/README_EN.md
+++ b/README_EN.md
@@ -333,14 +333,7 @@ as a reference artifact with the minimum `1` specified for `api.rps`.
 ## Logging
 
 CLI helpers configure structured JSON logging via `library.logging_setup.configure_logger`. Use environment variables or CLI flags to
-adjust verbosity and format.
-
-Example enabling JSON format via an environment variable:
-
-```bash
-LOG_FORMAT=json python -m scripts.get_assay_data --input assay_ids.csv \
-    --output out/assays.csv --log-level INFO
-```
+adjust verbosity. The JSON structure is fixed and cannot be customised.
 
 Set the log level via the `--log-level` flag or the `CHEMBL_DA_LOG_LEVEL` environment variable:
 
@@ -459,8 +452,6 @@ maps to:
 | `CHEMBL_DA_IUPHAR_TARGET_CSV` | `CHEMBL_DA__LOCAL__RESOURCES__IUPHAR_TARGET_CSV` |
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_MAXSIZE` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_TTL` |
-| `CHEMBL_DA_LOG_DATEFMT` | `CHEMBL_DA__SYSTEM__LOG__DATEFMT` |
-| `CHEMBL_DA_LOG_FORMAT` | `CHEMBL_DA__SYSTEM__LOG__FORMAT` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__SYSTEM__LOG__LEVEL` |
 | `CHEMBL_DA_MOLECULE_CATALOG_CACHE` | `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH` |
 | `CHEMBL_DA_OPENALEX_BASE` | `CHEMBL_DA__SOURCES__OPENALEX__BASE` |

--- a/README_RU.md
+++ b/README_RU.md
@@ -316,14 +316,8 @@ api:
 
 ## Логирование
 
-CLI-хелперы настраивают структурированное JSON-логирование через `library.logging_setup.configure_logger`. Управляйте уровнем и форматом логов переменными окружения или флагами CLI.
+CLI-хелперы настраивают структурированное JSON-логирование через `library.logging_setup.configure_logger`. Управляйте уровнем логов переменными окружения или флагами CLI. Формат JSON фиксирован и не настраивается.
 
-Пример включения JSON-формата через переменную окружения:
-
-```bash
-LOG_FORMAT=json python -m scripts.get_assay_data --input assay_ids.csv \
-    --output out/assays.csv --log-level INFO
-```
 
 Уровень логов можно задать флагом `--log-level` или переменной `CHEMBL_DA_LOG_LEVEL`:
 
@@ -435,8 +429,6 @@ export CHEMBL_DA__LOG__LEVEL=DEBUG
 | `CHEMBL_DA_IUPHAR_TARGET_CSV` | `CHEMBL_DA__LOCAL__RESOURCES__IUPHAR_TARGET_CSV` |
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_MAXSIZE` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `CHEMBL_DA__SYSTEM__RATE__LIMITER_CACHE_TTL` |
-| `CHEMBL_DA_LOG_DATEFMT` | `CHEMBL_DA__SYSTEM__LOG__DATEFMT` |
-| `CHEMBL_DA_LOG_FORMAT` | `CHEMBL_DA__SYSTEM__LOG__FORMAT` |
 | `CHEMBL_DA_LOG_LEVEL` | `CHEMBL_DA__SYSTEM__LOG__LEVEL` |
 | `CHEMBL_DA_MOLECULE_CATALOG_CACHE` | `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH` |
 | `CHEMBL_DA_OPENALEX_BASE` | `CHEMBL_DA__SOURCES__OPENALEX__BASE` |

--- a/config.schema.json
+++ b/config.schema.json
@@ -1070,16 +1070,6 @@
           "default": "INFO",
           "title": "Level",
           "type": "string"
-        },
-        "format": {
-          "default": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
-          "title": "Format",
-          "type": "string"
-        },
-        "datefmt": {
-          "default": "%Y-%m-%d %H:%M:%S",
-          "title": "Datefmt",
-          "type": "string"
         }
       },
       "title": "LogCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -299,8 +299,6 @@ activity_bounds:
 system:
   log:
     level: "INFO"  # Default logging level (env: CHEMBL_DA_LOG_LEVEL)
-    format: "[%(asctime)s] %(levelname)s %(name)s: %(message)s"  # Logging format (env: CHEMBL_DA_LOG_FORMAT)
-    datefmt: "%Y-%m-%d %H:%M:%S"  # Timestamp format (env: CHEMBL_DA__SYSTEM__LOG__DATEFMT)
   rate:
     global_rps: 100  # Global requests-per-second limit
     global_burst: 100  # Global burst size

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -382,8 +382,6 @@ Common short aliases:
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `system.rate.limiter_cache_maxsize` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `system.rate.limiter_cache_ttl` |
 | `CHEMBL_DA_LOG_LEVEL` | `system.log.level` |
-| `CHEMBL_DA_LOG_FORMAT` | `system.log.format` |
-| `CHEMBL_DA_LOG_DATEFMT` | `system.log.datefmt` |
 | `CHEMBL_DA_RETRY_MAX_ATTEMPTS` | `system.retry.max_attempts` |
 | `CHEMBL_DA_RETRY_BACKOFF_FACTOR` | `system.retry.backoff_factor` |
 | `CHEMBL_DA_DICT_DIR` | `local.resources.dictionary_dir` |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -368,8 +368,6 @@ export CHEMBL_DA__LOCAL__IO__OUTPUT_DIR=/mnt/datasets
 | `CHEMBL_DA_LIMITER_CACHE_MAXSIZE` | `system.rate.limiter_cache_maxsize` |
 | `CHEMBL_DA_LIMITER_CACHE_TTL` | `system.rate.limiter_cache_ttl` |
 | `CHEMBL_DA_LOG_LEVEL` | `system.log.level` |
-| `CHEMBL_DA_LOG_FORMAT` | `system.log.format` |
-| `CHEMBL_DA_LOG_DATEFMT` | `system.log.datefmt` |
 | `CHEMBL_DA_RETRY_MAX_ATTEMPTS` | `system.retry.max_attempts` |
 | `CHEMBL_DA_RETRY_BACKOFF_FACTOR` | `system.retry.backoff_factor` |
 | `CHEMBL_DA_DICT_DIR` | `local.resources.dictionary_dir` |

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -281,17 +281,26 @@ def configure_logger(
     cfg:
         Logging configuration containing ``run_id`` and ``level``.
     fmt, datefmt:
-        Unused parameters retained for backward compatibility.
+        Unsupported parameters retained for compatibility.
 
     Returns
     -------
     Logger
         Configured logger instance shared across the package.
+
+    Raises
+    ------
+    ValueError
+        If ``fmt`` or ``datefmt`` are supplied. Structured JSON logging has a
+        fixed layout and cannot be customised.
     """
 
-    # ``fmt`` and ``datefmt`` are ignored because JSON logs have a fixed
-    # structure. They are accepted to remain API compatible with the previous
-    # implementation that configured :mod:`logging`.
+    if fmt is not None or datefmt is not None:
+        raise ValueError(
+            "Structured logging uses a fixed JSON layout; fmt/datefmt overrides"
+            " are not supported."
+        )
+
     new_logger = _configure_logger(
         LoggerConfig(level=cfg.level, run_id=cfg.run_id, stream=cfg.stream)
     )

--- a/library/config.py
+++ b/library/config.py
@@ -494,8 +494,6 @@ class IoCfg(_BoolModel):
 
 class LogCfg(_BaseModel):
     level: str = "INFO"
-    format: str = "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
-    datefmt: str = "%Y-%m-%d %H:%M:%S"
 
     @field_validator("level")
     @classmethod
@@ -1549,8 +1547,6 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_PUBCHEM_BASE": ["sources", "pubchem", "base"],
     "CHEMBL_DA_PUBCHEM_USER_AGENT": ["sources", "pubchem", "user_agent"],
     "CHEMBL_DA_LOG_LEVEL": ["system", "log", "level"],
-    "CHEMBL_DA_LOG_FORMAT": ["system", "log", "format"],
-    "CHEMBL_DA_LOG_DATEFMT": ["system", "log", "datefmt"],
     "CHEMBL_DA_RETRY_MAX_ATTEMPTS": ["system", "retry", "max_attempts"],
     "CHEMBL_DA_RETRY_BACKOFF_FACTOR": ["system", "retry", "backoff_factor"],
 }

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -102,11 +102,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         cfg = Config.model_validate(cfg.model_dump())
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/library/utils/cli_tools/get_document_type.py
+++ b/library/utils/cli_tools/get_document_type.py
@@ -155,12 +155,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger_inst.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
         logger_inst = configure_logger(
-            log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt
+            log_cfg
         )
     except (ValueError, TypeError) as exc:
         logger.error(

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -184,7 +184,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
@@ -208,7 +208,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.same_doc is None or args.all_doc is None:
             raise ValueError("same_doc and all_doc paths must be provided")
 
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/library/utils/cli_tools/mapper_batch_main.py
+++ b/library/utils/cli_tools/mapper_batch_main.py
@@ -115,9 +115,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger.info("pipeline_start", run_id=log_cfg.run_id)
     cfg = cli.apply_config_overrides(args, parser, args.config)
     ensure_dirs(cfg)
-    logger = configure_logger(
-        log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt
-    )
+    logger = configure_logger(log_cfg)
     if args.print_config:
         print_config(cfg)
         logger.info("pipeline_end", exit_code=0)

--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -123,11 +123,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         cfg: Config = cli.apply_config_overrides(args, parser, args.config)
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error("config_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -165,11 +165,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -394,11 +394,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -274,11 +274,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1630,11 +1630,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         cfg.api.timeout_read = getattr(args, "timeout", cfg.api.timeout_read)
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error("config_override_error", error=str(exc))
         logger.info("pipeline_fail", run_id=log_cfg.run_id)

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1238,11 +1238,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1612,11 +1612,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if args.print_config:
             print_config(cfg)
-            configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+            configure_logger(log_cfg)
             logger.info("pipeline_done", run_id=log_cfg.run_id)
             return 0
         ensure_dirs(cfg)
-        logger = configure_logger(log_cfg, fmt=cfg.log.format, datefmt=cfg.log.datefmt)
+        logger = configure_logger(log_cfg)
     except (ValueError, TypeError) as exc:
         logger.error(
             "config_error",

--- a/tests/test_cli_configure_logger.py
+++ b/tests/test_cli_configure_logger.py
@@ -1,0 +1,44 @@
+"""Tests for :func:`library.cli.configure_logger`."""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from library.cli import LoggerConfig, configure_logger
+
+
+def _parse(output: str) -> list[dict[str, object]]:
+    return [json.loads(line) for line in output.strip().splitlines() if line]
+
+
+def test_configure_logger_emits_json_without_overrides() -> None:
+    """Default invocation should emit structured JSON logs."""
+
+    stream = io.StringIO()
+    logger = configure_logger(LoggerConfig(level="INFO", run_id="rid", stream=stream))
+    logger.info("cli_event", foo="bar")
+    records = _parse(stream.getvalue())
+    assert len(records) == 1
+    record = records[0]
+    assert record["event"] == "cli_event"
+    assert record["run_id"] == "rid"
+    assert record["foo"] == "bar"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"fmt": "text"},
+        {"datefmt": "%H:%M"},
+        {"fmt": "text", "datefmt": "%H:%M"},
+    ],
+)
+def test_configure_logger_rejects_format_override(kwargs: dict[str, str]) -> None:
+    """Passing ``fmt`` or ``datefmt`` should raise ``ValueError``."""
+
+    stream = io.StringIO()
+    with pytest.raises(ValueError):
+        configure_logger(LoggerConfig(stream=stream), **kwargs)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,15 +105,11 @@ def test_retry_and_log_aliases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setenv("CHEMBL_DA_RETRY_MAX_ATTEMPTS", "10")
     monkeypatch.setenv("CHEMBL_DA_RETRY_BACKOFF_FACTOR", "2.0")
-    monkeypatch.setenv("CHEMBL_DA_LOG_FORMAT", "%(levelname)s")
-    monkeypatch.setenv("CHEMBL_DA_LOG_DATEFMT", "%d/%m/%Y")
 
     cfg = load_config(path)
 
     assert cfg.retry.max_attempts == 10
     assert cfg.retry.backoff_factor == 2.0
-    assert cfg.log.format == "%(levelname)s"
-    assert cfg.log.datefmt == "%d/%m/%Y"
 
 
 def test_cache_dir_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mapper_batch_main.py
+++ b/tests/test_mapper_batch_main.py
@@ -23,6 +23,8 @@ def _configure_logger_factory(loggers: list[DummyLogger]):
     def _configure_logger(
         cfg: object, *, fmt: str | None = None, datefmt: str | None = None
     ) -> DummyLogger:
+        if fmt is not None or datefmt is not None:
+            raise AssertionError("format overrides should not be supplied")
         logger = DummyLogger()
         logger.config = {"fmt": fmt, "datefmt": datefmt, "cfg": cfg}
         loggers.append(logger)
@@ -43,8 +45,6 @@ def test_main_invokes_run_without_print_config(
 
     cfg = Config()
     cfg.api.user_agent = "test@example.org"
-    cfg.log.format = "json"
-    cfg.log.datefmt = "iso"
     monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *_, **__: cfg)
     monkeypatch.setattr(cli, "ensure_dirs", lambda *_: None)
 
@@ -89,8 +89,8 @@ def test_main_invokes_run_without_print_config(
         event == "pipeline_end" and payload.get("exit_code") == 0
         for event, payload in configured_loggers[-1].events
     )
-    assert configured_loggers[-1].config["fmt"] == cfg.log.format
-    assert configured_loggers[-1].config["datefmt"] == cfg.log.datefmt
+    assert configured_loggers[-1].config["fmt"] is None
+    assert configured_loggers[-1].config["datefmt"] is None
 
 
 def test_main_prints_config_when_requested(
@@ -104,8 +104,6 @@ def test_main_prints_config_when_requested(
     )
 
     cfg = Config()
-    cfg.log.format = "json"
-    cfg.log.datefmt = "iso"
     monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *_, **__: cfg)
     monkeypatch.setattr(cli, "ensure_dirs", lambda *_: None)
 


### PR DESCRIPTION
## Summary
- reject fmt/datefmt overrides in library.cli.configure_logger and update call sites
- simplify LogCfg to only expose the level setting and align docs/schema
- add regression tests covering the default logger path and override rejection

## Testing
- pytest tests/test_cli_configure_logger.py tests/test_mapper_batch_main.py tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0297387c83249f185975620cd45b