### PR TITLE
Add generator for PubMed batch iteration and regression test

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -605,39 +605,45 @@ def fetch_pubmed_records(
                 yield completed.pop(next_to_emit)
                 next_to_emit += 1
 
-        for batch in _chunked(iterator, batch_size):
-            if not batch:
-                continue
-            future = batch_executor.submit(_fetch_batch, batch)
-            tasks[future] = (offset, batch)
-            pending.add(future)
-            offset += len(batch)
-            if len(pending) >= max_in_flight:
-
-                done_future = next(as_completed(list(pending)))
-                yield from _drain_future(done_future)
+        def _emit_ready_batches() -> Iterator[list[dict[str, str]]]:
+            nonlocal next_to_emit
 
             while next_to_emit in completed:
                 yield completed.pop(next_to_emit)
                 next_to_emit += 1
 
-        for done_future in as_completed(pending):
-            yield from _drain_future(done_future)
+        def _iter_records() -> Iterator[list[dict[str, str]]]:
+            nonlocal offset
 
-        pending.clear()
+            for batch in _chunked(iterator, batch_size):
+                if not batch:
+                    continue
+                future = batch_executor.submit(_fetch_batch, batch)
+                tasks[future] = (offset, batch)
+                pending.add(future)
+                offset += len(batch)
+                if len(pending) >= max_in_flight:
 
-        while next_to_emit in completed:
-            yield completed.pop(next_to_emit)
-            next_to_emit += 1
+                    done_future = next(as_completed(list(pending)))
+                    yield from _drain_future(done_future)
 
-    def _iter_frames() -> Iterator[pd.DataFrame]:
-        for records_batch in _iter_records():
-            if not records_batch:
-                yield build_dataframe([], columns=DOCUMENT_SCHEMA_COLUMNS)
-                continue
-            yield build_dataframe(
-                records_batch, columns=DOCUMENT_SCHEMA_COLUMNS
-            )
+                yield from _emit_ready_batches()
+
+            for done_future in as_completed(pending):
+                yield from _drain_future(done_future)
+
+            pending.clear()
+
+            yield from _emit_ready_batches()
+
+        def _iter_frames() -> Iterator[pd.DataFrame]:
+            for records_batch in _iter_records():
+                if not records_batch:
+                    yield build_dataframe([], columns=DOCUMENT_SCHEMA_COLUMNS)
+                    continue
+                yield build_dataframe(
+                    records_batch, columns=DOCUMENT_SCHEMA_COLUMNS
+                )
 
     frame_iter = _iter_frames()
     if return_generator:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from collections.abc import Iterable, Iterator, Sequence
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any
 
@@ -1912,3 +1913,59 @@ def test_fetch_pubmed_records_reuses_service_executors(
     assert df["PubMed.PMID"].tolist() == pmids
     assert len(creations) == 3
     assert creations.count(1) == 1
+
+
+def test_fetch_pubmed_records_generator_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generator mode should yield DataFrame batches in submission order."""
+
+    pmids = ["100", "200", "300", "400"]
+    cfg = Config()
+
+    def fake_get_limiter(*_: object, **__: object) -> DummyLimiter:
+        return DummyLimiter(burst=10)
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    def fake_as_completed(futures: Iterable[Future]) -> Iterator[Future]:
+        snapshot = list(futures)
+        for future in reversed(snapshot):
+            yield future
+
+    monkeypatch.setattr(gdd, "as_completed", fake_as_completed)
+
+    class ImmediateExecutor:
+        def __init__(self, *_: object, **__: object) -> None:
+            return None
+
+        def __enter__(self) -> ImmediateExecutor:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def submit(self, func: Any, *args: object, **__: object) -> Future:
+            _ = func
+            batch = list(args[0]) if args else []
+            future: Future = Future()
+            records = [{"PubMed.PMID": pmid} for pmid in batch]
+            future.set_result(records)
+            return future
+
+    monkeypatch.setattr(gdd, "ThreadPoolExecutor", ImmediateExecutor)
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        cfg,
+        return_generator=True,
+        batch_size=1,
+        max_workers=2,
+    )
+
+    assert isinstance(generator, Iterator)
+    frames = list(generator)
+    assert [frame["PubMed.PMID"].tolist() for frame in frames] == [
+        ["100"],
+        ["200"],
+        ["300"],
+        ["400"],
+    ]


### PR DESCRIPTION
## Summary
- add a nested `_iter_records` generator so `fetch_pubmed_records` yields completed batches in submission order
- route `_iter_frames` through the new generator when building batch dataframes
- add a regression test covering generator mode batch emission for `fetch_pubmed_records`

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_generator_batches

------
https://chatgpt.com/codex/tasks/task_e_68dd162b154c83249ac7cdfe960d5a28