### PR TITLE
Fix fetch_pubmed_records batch ordering and add coverage

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -566,69 +566,74 @@ def fetch_pubmed_records(
     openalex_executor: ThreadPoolExecutor | None = None
     crossref_executor: ThreadPoolExecutor | None = None
 
-    iterator = (p for p in pmids if p)
-
-    tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
-    completed: dict[int, list[dict[str, str]]] = {}
-    next_to_emit = 0
-    processed = 0
     max_in_flight = max(1, max_workers * 2)
 
-    with ExitStack() as stack:
-        batch_executor = stack.enter_context(
-            ThreadPoolExecutor(max_workers=max_workers)
-        )
-        if openalex_capacity > 1:
-            openalex_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=openalex_capacity)
+    def _iter_records() -> Iterator[list[dict[str, str]]]:
+        nonlocal openalex_executor, crossref_executor
+
+        iterator = (p for p in pmids if p)
+
+        tasks: dict[Future[list[dict[str, str]]], tuple[int, list[str]]] = {}
+        completed: dict[int, list[dict[str, str]]] = {}
+        next_to_emit = 0
+        processed = 0
+        batch_index = 0
+
+        with ExitStack() as stack:
+            batch_executor = stack.enter_context(
+                ThreadPoolExecutor(max_workers=max_workers)
             )
-        if crossref_capacity > 1:
-            crossref_executor = stack.enter_context(
-                ThreadPoolExecutor(max_workers=crossref_capacity)
-            )
+            if openalex_capacity > 1:
+                openalex_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=openalex_capacity)
+                )
+            if crossref_capacity > 1:
+                crossref_executor = stack.enter_context(
+                    ThreadPoolExecutor(max_workers=crossref_capacity)
+                )
 
-        offset = 0
-        pending: set[Future[list[dict[str, str]]]] = set()
+            pending: set[Future[list[dict[str, str]]]] = set()
 
-        def _drain_future(
-            done_future: Future[list[dict[str, str]]],
-        ) -> Iterator[list[dict[str, str]]]:
-            nonlocal processed, next_to_emit
+            def _emit_ready_batches() -> Iterator[list[dict[str, str]]]:
+                nonlocal next_to_emit
 
-            pending.remove(done_future)
-            batch_id, batch_pmids = tasks.pop(done_future)
-            completed[batch_id] = done_future.result()
-            processed += len(batch_pmids)
-            logger.info("documents_processed", count=processed)
+                while next_to_emit in completed:
+                    yield completed.pop(next_to_emit)
+                    next_to_emit += 1
 
-            while next_to_emit in completed:
-                yield completed.pop(next_to_emit)
-                next_to_emit += 1
+            def _drain_future(
+                done_future: Future[list[dict[str, str]]],
+            ) -> Iterator[list[dict[str, str]]]:
+                nonlocal processed
 
-        for batch in _chunked(iterator, batch_size):
-            if not batch:
-                continue
-            future = batch_executor.submit(_fetch_batch, batch)
-            tasks[future] = (offset, batch)
-            pending.add(future)
-            offset += len(batch)
-            if len(pending) >= max_in_flight:
+                pending.remove(done_future)
+                batch_id, batch_pmids = tasks.pop(done_future)
+                completed[batch_id] = done_future.result()
+                processed += len(batch_pmids)
+                logger.info("documents_processed", count=processed)
 
-                done_future = next(as_completed(list(pending)))
+                yield from _emit_ready_batches()
+
+            for batch in _chunked(iterator, batch_size):
+                if not batch:
+                    continue
+                future = batch_executor.submit(_fetch_batch, batch)
+                tasks[future] = (batch_index, batch)
+                pending.add(future)
+                batch_index += 1
+                if len(pending) >= max_in_flight:
+
+                    done_future = next(as_completed(list(pending)))
+                    yield from _drain_future(done_future)
+
+                yield from _emit_ready_batches()
+
+            for done_future in as_completed(pending):
                 yield from _drain_future(done_future)
 
-            while next_to_emit in completed:
-                yield completed.pop(next_to_emit)
-                next_to_emit += 1
+            pending.clear()
 
-        for done_future in as_completed(pending):
-            yield from _drain_future(done_future)
-
-        pending.clear()
-
-        while next_to_emit in completed:
-            yield completed.pop(next_to_emit)
-            next_to_emit += 1
+            yield from _emit_ready_batches()
 
     def _iter_frames() -> Iterator[pd.DataFrame]:
         for records_batch in _iter_records():

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -704,7 +704,12 @@ def test_fetch_pubmed_records_returns_generator_in_order(
         return_generator=True,
     )
 
-    frames = list(generator)
+    frames = [
+        frame
+        if isinstance(frame, pd.DataFrame)
+        else gdd.build_dataframe(frame, columns=gdd.DOCUMENT_SCHEMA_COLUMNS)
+        for frame in generator
+    ]
     assert [frame["PubMed.PMID"].tolist() for frame in frames] == [["1", "2"], ["3", "4"]]
 
     combined = gdd.fetch_pubmed_records(
@@ -790,7 +795,12 @@ def test_fetch_pubmed_records_drains_pending_batches(
         return_generator=True,
     )
 
-    frames = list(generator)
+    frames = [
+        frame
+        if isinstance(frame, pd.DataFrame)
+        else gdd.build_dataframe(frame, columns=gdd.DOCUMENT_SCHEMA_COLUMNS)
+        for frame in generator
+    ]
     assert [frame["PubMed.PMID"].tolist() for frame in frames] == [
         ["0", "1"],
         ["2", "3"],
@@ -804,6 +814,108 @@ def test_fetch_pubmed_records_drains_pending_batches(
         openalex_cfg=OpenAlexCfg(),
         crossref_cfg=CrossRefCfg(),
         max_workers=1,
+        batch_size=2,
+    )
+
+    assert combined["PubMed.PMID"].tolist() == pmids
+
+
+def test_fetch_pubmed_records_preserves_submission_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Out-of-order completions should still be emitted sequentially."""
+
+    pmids = [str(i) for i in range(6)]
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    release_first = threading.Event()
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        if batch[0] == "0":
+            if not release_first.wait(timeout=1):  # pragma: no cover - timeout guard
+                pytest.fail("second batch did not finish in time")
+        elif batch[0] == "2":
+            release_first.set()
+        return [
+            {"PubMed.PMID": pmid, "PubMed.DOI": f"10.1000/{pmid}"}
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        session: Any,
+        ids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"scholar.PMID": pmid, "scholar.DOI": f"10.1000/{pmid}"}
+            for pmid in ids
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_, **__: {"scholar.DOI": "10.1000/fallback"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda session, pmid, cfg, limiter: {"OpenAlex.Id": f"OA{pmid}"},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda session, doi, cfg, limiter: {"crossref.DOI": doi},
+    )
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=2,
+        batch_size=2,
+        return_generator=True,
+    )
+
+    frames = [
+        frame
+        if isinstance(frame, pd.DataFrame)
+        else gdd.build_dataframe(frame, columns=gdd.DOCUMENT_SCHEMA_COLUMNS)
+        for frame in generator
+    ]
+    assert [frame["PubMed.PMID"].tolist() for frame in frames] == [
+        ["0", "1"],
+        ["2", "3"],
+        ["4", "5"],
+    ]
+
+    combined = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=2,
         batch_size=2,
     )
 


### PR DESCRIPTION
## Summary
- wrap the threaded fetch_pubmed_records submission loop in an internal `_iter_records` generator so results are buffered until they can be emitted in order
- use monotonically increasing batch indices to drain completed futures deterministically when multiple batches are in flight
- extend the document data tests to exercise out-of-order completions and normalise batches into DataFrames before asserting on them

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_preserves_submission_order tests/test_get_document_data.py::test_fetch_pubmed_records_drains_pending_batches

------
https://chatgpt.com/codex/tasks/task_e_68dd163319488324a5aa7afc5e393904