### PR TITLE
Ensure cache writes are atomic

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -13,6 +13,8 @@ from time import perf_counter
 from urllib.parse import urlencode, urljoin
 
 from library.clients import ChemblClient, _chunked
+from library.utils.atomic import open_atomic
+
 from .config import ApiCfg, MoleculeCatalogCfg
 from .log import logger
 from .rate_limiter import sleep
@@ -650,7 +652,7 @@ def _write_cache_from_items(
     entries = list(items)
 
     if cache_path.suffix.lower() == ".csv":
-        with cache_path.open("w", encoding="utf-8", newline="") as fh:
+        with open_atomic(cache_path, encoding="utf-8", newline="") as fh:
             writer = csv.DictWriter(
                 fh,
                 fieldnames=[catalog_cfg.child_field, catalog_cfg.parent_field],
@@ -665,10 +667,8 @@ def _write_cache_from_items(
                 )
         return
 
-    cache_path.write_text(
-        json.dumps(dict(entries), indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+    with open_atomic(cache_path, encoding="utf-8") as fh:
+        json.dump(dict(entries), fh, indent=2, sort_keys=True)
 
 
 def _write_parent_catalog_sqlite(

--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -40,6 +40,7 @@ from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
+from library.utils.atomic import open_atomic
 from schemas import TestitemsSchema, normalize_testitems
 
 
@@ -826,7 +827,6 @@ def _write_pubchem_cid_cache(
 
     if path is None:
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
     serialisable: dict[str, str] = {}
     for key, value in cache.items():
         if not key:
@@ -835,7 +835,7 @@ def _write_pubchem_cid_cache(
             continue
         serialisable[key] = value
     try:
-        with path.open("w", encoding=PUBCHEM_CID_CACHE_ENCODING) as handle:
+        with open_atomic(path, encoding=PUBCHEM_CID_CACHE_ENCODING) as handle:
             payload = {
                 "metadata": {
                     "version": _PUBCHEM_CACHE_SCHEMA_VERSION,

--- a/library/utils/__init__.py
+++ b/library/utils/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import bootstrap
+from . import atomic, bootstrap
 
-__all__ = ["bootstrap"]
+__all__ = ["atomic", "bootstrap"]

--- a/library/utils/atomic.py
+++ b/library/utils/atomic.py
@@ -1,0 +1,63 @@
+"""Atomic file writing helpers with cross-platform file locking."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, TextIO
+
+import portalocker
+
+_LOCK_TIMEOUT_SECONDS = 10.0
+
+
+@contextmanager
+def open_atomic(
+    path: Path,
+    *,
+    mode: str = "w",
+    encoding: str | None = None,
+    newline: str | None = None,
+    lock_timeout: float = _LOCK_TIMEOUT_SECONDS,
+) -> Iterator[TextIO]:
+    """Open *path* for atomic writing.
+
+    A temporary file is created in the same directory and moved into place with
+    :func:`os.replace` after the context manager exits successfully. A
+    ``.lock`` sidecar file is used to coordinate concurrent writers.
+    """
+
+    if "w" not in mode and "+" not in mode and "a" not in mode:
+        msg = "atomic writes require a write-capable mode"
+        raise ValueError(msg)
+
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lock_path = path.with_name(f"{path.name}.lock")
+
+    with portalocker.Lock(
+        str(lock_path),
+        mode="w",
+        timeout=lock_timeout,
+    ):
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            text="b" not in mode,
+        )
+        try:
+            with os.fdopen(fd, mode, encoding=encoding, newline=newline) as tmp_file:
+                yield tmp_file
+        except Exception:
+            raise
+        else:
+            os.replace(tmp_name, path)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pandera~=0.26.1",
   "cachetools~=5.3.2",
   "pydantic~=2.11.3",
+  "portalocker~=3.1.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_molecule_catalog_cache.py
+++ b/tests/test_molecule_catalog_cache.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from library.config import MoleculeCatalogCfg
 from library import molecule_catalog as mc
+from library.utils import atomic as atomic_utils
 
 
 def _cfg(cache_path: Path) -> MoleculeCatalogCfg:
@@ -55,3 +57,21 @@ def test_read_cache_invalid_json_logs_warning(
 
     assert result == {}
     assert any(event == "invalid_catalog_cache" for event, _ in events)
+
+
+def test_write_cache_crash_leaves_existing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "catalog.json"
+    original = {"CHEMBL1": "CHEMBL2"}
+    path.write_text(json.dumps(original), encoding="utf-8")
+    cfg = _cfg(path)
+
+    def fail_replace(src: str | Path, dst: str | Path) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(atomic_utils.os, "replace", fail_replace)
+
+    with pytest.raises(OSError):
+        mc._write_cache_from_items([("CHEMBL3", "CHEMBL4")], cfg)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == original
+    assert not list(path.parent.glob(f".{path.name}.*.tmp"))


### PR DESCRIPTION
## Summary
- add an atomic file writing helper that locks cache files, writes via a temporary file, and replaces them atomically
- update molecule catalog and PubChem CID cache writers to use the new helper
- extend cache regression tests to verify atomic behaviour and add portalocker as a dependency

## Testing
- pytest tests/test_molecule_catalog_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1c638b38832498da1a798111eae7