### PR TITLE
Ensure augment_pubchem initialises PubChem session

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -25,6 +25,7 @@ from library.config import (
     IoCfg,
     MoleculeCatalogCfg,
     PubChemCfg,
+    RetryCfg,
     _serialize_paths,
 )
 from library.csv_utils import write_csv_deterministic
@@ -66,6 +67,19 @@ _CID_CACHE_MISSING = object()
 _PUBCHEM_CACHE_SCHEMA_VERSION = 1
 
 _DEFAULT_CATALOG_CFG = MoleculeCatalogCfg()
+
+
+def _pubchem_session_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
+    """Return a stable signature for the PubChem session configuration."""
+
+    payload = {
+        "api": api_cfg.model_dump(mode="json"),
+        "retry": retry_cfg.model_dump(mode="json"),
+    }
+    return json.dumps(payload, sort_keys=True)
+
+
+_PUBCHEM_SESSION_SIGNATURE: str | None = None
 
 
 @dataclass
@@ -1362,12 +1376,18 @@ def augment_pubchem(
     *,
     pubchem_cfg: PubChemCfg,
     api_cfg: ApiCfg,
+    retry_cfg: RetryCfg,
     timeout: float,
     client: ChemblClient,
     fields: Sequence[str] | None,
     request_limit: int,
 ) -> pd.DataFrame:
-    """Augment ``df`` with PubChem information if enabled."""
+    """Augment ``df`` with PubChem information if enabled.
+
+    The shared PubChem client session is initialised with ``api_cfg`` and
+    ``retry_cfg`` before enrichment. Callers must therefore provide both
+    configurations even when invoking this function directly.
+    """
 
     pubchem_cid_cache: dict[str, str | None] | None = None
     pubchem_resolution_cache: (
@@ -1375,6 +1395,11 @@ def augment_pubchem(
     ) = None
     pubchem_parent_record_cache: dict[str, pd.Series | None] | None = None
     if getattr(pubchem_cfg, "enable", True):
+        global _PUBCHEM_SESSION_SIGNATURE
+        session_signature = _pubchem_session_signature(api_cfg, retry_cfg)
+        if session_signature != _PUBCHEM_SESSION_SIGNATURE:
+            pl.init_session(api_cfg, retry_cfg)
+            _PUBCHEM_SESSION_SIGNATURE = session_signature
         pubchem_cid_cache = _load_pubchem_cid_cache(
             getattr(pubchem_cfg, "cid_cache_path", None),
             ttl_hours=getattr(pubchem_cfg, "cache_ttl_hours", None),

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1515,6 +1515,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             df,
             pubchem_cfg=cfg.pubchem,
             api_cfg=api_cfg,
+            retry_cfg=cfg.retry,
             timeout=cfg.testitem.timeout,
             client=client,
             fields=cfg.testitem.fields,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -418,6 +418,7 @@ def test_augment_pubchem_initialises_caches(
         df,
         pubchem_cfg=cfg.pubchem,
         api_cfg=cfg.api,
+        retry_cfg=cfg.retry,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
         fields=cfg.testitem.fields,
@@ -429,6 +430,58 @@ def test_augment_pubchem_initialises_caches(
     assert captured["add_kwargs"].get("testitem_fields") == cfg.testitem.fields
     assert captured["add_kwargs"].get("request_limit") == cfg.testitem.request_limit
     assert "pubchem_cid" in result.columns
+
+
+def test_augment_pubchem_initialises_session_once(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+    cfg.pubchem.enable = True
+
+    monkeypatch.setattr(pipeline, "_PUBCHEM_SESSION_SIGNATURE", None, raising=False)
+
+    captured: dict[str, object] = {"init_calls": 0}
+
+    def fake_init_session(api: object, retry: object) -> None:
+        captured["init_calls"] = captured["init_calls"] + 1
+        captured["init_args"] = (api, retry)
+
+    def fake_add(
+        frame: pd.DataFrame,
+        pubchem_cfg: pl.PubChemCfg,
+        **kwargs: object,
+    ) -> pd.DataFrame:
+        return frame.assign(pubchem_cid="1")
+
+    monkeypatch.setattr(pipeline.pl, "init_session", fake_init_session)
+    monkeypatch.setattr(pipeline, "add_pubchem_data", fake_add)
+
+    first = pipeline.augment_pubchem(
+        df,
+        pubchem_cfg=cfg.pubchem,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.retry,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        fields=cfg.testitem.fields,
+        request_limit=cfg.testitem.request_limit,
+    )
+
+    second = pipeline.augment_pubchem(
+        df,
+        pubchem_cfg=cfg.pubchem,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.retry,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        fields=cfg.testitem.fields,
+        request_limit=cfg.testitem.request_limit,
+    )
+
+    assert captured["init_calls"] == 1
+    assert captured["init_args"] == (cfg.api, cfg.retry)
+    assert "pubchem_cid" in first.columns
+    assert "pubchem_cid" in second.columns
 
 
 def test_apply_testitem_enrichment_disable(cfg: Config) -> None:


### PR DESCRIPTION
## Summary
- initialise the shared PubChem session within `augment_pubchem` using the provided retry configuration
- pass the retry configuration from the data acquisition script and document the requirement in the pipeline docstring
- add regression coverage to ensure the session is created once when augmenting without prior initialisation

## Testing
- pytest tests/test_get_testitem_data.py -k augment_pubchem --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68dd1c4b1b6c8324ac5d283cdfd398c7