### PR TITLE
Batch PubChem property fetches

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from collections import ChainMap
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
@@ -1286,20 +1287,37 @@ def add_pubchem_data(
     def _value_or_na(value: str | None) -> object:
         return value if value not in (None, "") else pd.NA
 
-    properties: dict[str, pl.Properties] = {}
-    for cid in sorted(lookup_cids):
-        properties[cid] = pl.get_properties(cid, cfg)
-
     properties_records: dict[str, dict[str, object]] = {}
-    for cid, props in properties.items():
-        properties_records[cid] = {
-            "pubchem_iupac_name": _value_or_na(props.IUPACName),
-            "pubchem_molecular_formula": _value_or_na(props.MolecularFormula),
-            "pubchem_isomeric_smiles": _value_or_na(props.iSMILES),
-            "pubchem_canonical_smiles": _value_or_na(props.cSMILES),
-            "pubchem_inchi": _value_or_na(props.InChI),
-            "pubchem_inchikey": _value_or_na(props.InChIKey),
-        }
+
+    lookup_order = sorted(lookup_cids)
+    if lookup_order:
+        batch_size = max(int(getattr(cfg, "rps", 1)), 1)
+
+        def _fetch_properties(cid: str) -> pl.Properties:
+            return pl.get_properties(cid, cfg)
+
+        with ThreadPoolExecutor(max_workers=batch_size) as executor:
+            for start in range(0, len(lookup_order), batch_size):
+                batch = lookup_order[start : start + batch_size]
+                future_map = {
+                    executor.submit(_fetch_properties, cid): cid for cid in batch
+                }
+                for future, cid in future_map.items():
+                    try:
+                        props = future.result()
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.warning("pubchem_properties_failed", cid=cid, error=str(exc))
+                        props = pl.Properties(None, None, None, None, None, None)
+                    properties_records[cid] = {
+                        "pubchem_iupac_name": _value_or_na(props.IUPACName),
+                        "pubchem_molecular_formula": _value_or_na(
+                            props.MolecularFormula
+                        ),
+                        "pubchem_isomeric_smiles": _value_or_na(props.iSMILES),
+                        "pubchem_canonical_smiles": _value_or_na(props.cSMILES),
+                        "pubchem_inchi": _value_or_na(props.InChI),
+                        "pubchem_inchikey": _value_or_na(props.InChIKey),
+                    }
 
     properties_df = pd.DataFrame.from_dict(properties_records, orient="index")
     pubchem_df = cid_series.to_frame("pubchem_cid").join(properties_df, on="pubchem_cid")

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+import threading
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -949,6 +951,78 @@ def test_add_pubchem_data_preserves_existing_values(
     assert result.loc[1, "pubchem_cid"] == "222"
     assert result.loc[1, "pubchem_iupac_name"] == "mixture"
     assert result.loc[2, "pubchem_cid"] == "333"
+
+
+def test_add_pubchem_data_fetches_properties_in_parallel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    df = pd.DataFrame(
+        {
+            "molecule_chembl_id": [
+                "CHEMBL1",
+                "CHEMBL2",
+                "CHEMBL3",
+                "CHEMBL4",
+            ],
+            "canonical_smiles": ["C", "CC", "CCC", "CCCC"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0, rps=2)
+
+    monkeypatch.setattr(pipeline, "_load_pubchem_cid_cache", lambda *_, **__: {})
+    monkeypatch.setattr(pipeline, "_write_pubchem_cid_cache", lambda *_, **__: None)
+
+    cid_map = {
+        "C": "1",
+        "CC": "2",
+        "CCC": "3",
+        "CCCC": "4",
+    }
+
+    def fake_resolve(
+        row: pd.Series,
+        cache: MutableMapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        **_: object,
+    ) -> str:
+        cid = cid_map[row["canonical_smiles"]]
+        chembl_id = row["molecule_chembl_id"]
+        if chembl_id:
+            cache[chembl_id] = cid
+        return cid
+
+    monkeypatch.setattr(pipeline, "resolve_pubchem_cid", fake_resolve)
+
+    lock = threading.Lock()
+    active = 0
+    peak_active = 0
+    call_order: list[str] = []
+    sleep_duration = 0.1
+
+    def fake_get_properties(cid: str, pubchem_cfg: pl.PubChemCfg) -> pl.Properties:
+        nonlocal active, peak_active
+        with lock:
+            active += 1
+            peak_active = max(peak_active, active)
+        call_order.append(cid)
+        time.sleep(sleep_duration)
+        with lock:
+            active -= 1
+        return pl.Properties(f"name-{cid}", None, None, None, None, None)
+
+    monkeypatch.setattr(pl, "get_properties", fake_get_properties)
+
+    start = time.perf_counter()
+    result = pipeline.add_pubchem_data(df, cfg)
+    elapsed = time.perf_counter() - start
+
+    assert peak_active <= cfg.rps
+    assert peak_active > 1
+    assert sorted(call_order) == sorted(cid_map.values())
+    assert elapsed < sleep_duration * len(cid_map) * 0.75
+
+    expected_names = [f"name-{cid_map[value]}" for value in df["canonical_smiles"]]
+    assert result["pubchem_iupac_name"].tolist() == expected_names
 
 
 def test_resolve_pubchem_cid_prefers_inchikey(


### PR DESCRIPTION
## Summary
- batch PubChem property lookups using a thread pool constrained by the configured rps
- reuse the existing limiter-aware client while capturing property results safely across workers
- extend the testitem smoke tests to assert parallel property enrichment and runtime improvements

## Testing
- pytest tests/test_get_testitem_data.py::test_add_pubchem_data_fetches_properties_in_parallel -q

------
https://chatgpt.com/codex/tasks/task_e_68dd1c487c8c83248447527ae45c0b47