### PR TITLE
Ensure orchestrator cleans partial pipeline outputs on failure

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -91,11 +91,13 @@ class PipelineStep:
     main: Callable[[Sequence[str] | None], int]
     subcommand: str | None
 
-    def build_arguments(self, cfg: PipelineRunConfig) -> list[str]:
+    def build_arguments(
+        self, cfg: PipelineRunConfig, output_path: Path | None = None
+    ) -> list[str]:
         """Return CLI arguments forwarded to the wrapped ``main`` function."""
 
         input_csv = cfg.input_path(self.name)
-        output_csv = cfg.output_path(self.name)
+        output_csv = output_path if output_path is not None else cfg.output_path(self.name)
         args = ["--config", str(cfg.config_path), "--input", str(input_csv)]
         args.extend(["--output", str(output_csv)])
         args.extend(["--log-level", cfg.log_level])
@@ -227,23 +229,91 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
     )
 
 
-def _run_step(step: PipelineStep, cfg: PipelineRunConfig) -> int:
+@dataclass(frozen=True)
+class StepExecutionResult:
+    """Summarize the outcome of invoking a pipeline step."""
+
+    exit_code: int
+    executed: bool
+
+
+def _temporary_output_path(output_path: Path) -> Path:
+    """Return the path used for intermediate artefacts of ``output_path``."""
+
+    return output_path.with_name(f".{output_path.name}.tmp")
+
+
+def _failure_sentinel_path(output_path: Path) -> Path:
+    """Return the sentinel path recorded when a pipeline step fails."""
+
+    return output_path.with_name(f"{output_path.name}.failed")
+
+
+def _run_step(
+    step: PipelineStep,
+    cfg: PipelineRunConfig,
+    final_output: Path,
+    working_output: Path,
+) -> StepExecutionResult:
     """Execute ``step`` with ``cfg`` returning the resulting exit code."""
 
     input_path = step.required_input(cfg)
     if not input_path.exists():
         _LOGGER.error("step_input_missing", step=step.name, path=str(input_path))
-        return 1
-    output_path = step.expected_output(cfg)
-    if cfg.skip_existing and output_path.exists() and not cfg.force:
+        return StepExecutionResult(exit_code=1, executed=False)
+    if cfg.skip_existing and final_output.exists() and not cfg.force:
         _LOGGER.info(
-            "step_skipped_existing", step=step.name, path=str(output_path)
+            "step_skipped_existing", step=step.name, path=str(final_output)
         )
-        return 0
+        return StepExecutionResult(exit_code=0, executed=False)
 
-    arguments = step.build_arguments(cfg)
+    arguments = step.build_arguments(cfg, output_path=working_output)
     _LOGGER.debug("step_arguments", step=step.name, arguments=arguments)
-    return step.main(arguments)
+    exit_code = step.main(arguments)
+    return StepExecutionResult(exit_code=exit_code, executed=True)
+
+
+def _finalize_step_success(
+    final_output: Path, working_output: Path, sentinel_path: Path
+) -> None:
+    """Rename temporary outputs into place and clear failure sentinels."""
+
+    if working_output.exists():
+        working_output.replace(final_output)
+    if sentinel_path.exists():
+        sentinel_path.unlink()
+
+
+def _cleanup_failed_step(
+    final_output: Path,
+    working_output: Path,
+    sentinel_path: Path,
+    *,
+    executed: bool,
+) -> None:
+    """Remove partial outputs and persist a failure sentinel."""
+
+    candidates = [working_output]
+    if executed:
+        candidates.append(final_output)
+    for candidate in candidates:
+        if candidate.exists():
+            try:
+                candidate.unlink()
+            except OSError as exc:  # pragma: no cover - defensive guard
+                _LOGGER.warning(
+                    "step_cleanup_failed",
+                    path=str(candidate),
+                    error=str(exc),
+                )
+    try:
+        sentinel_path.touch()
+    except OSError as exc:  # pragma: no cover - defensive guard
+        _LOGGER.warning(
+            "sentinel_write_failed",
+            path=str(sentinel_path),
+            error=str(exc),
+        )
 
 
 def run_pipeline(cfg: PipelineRunConfig) -> int:
@@ -252,17 +322,35 @@ def run_pipeline(cfg: PipelineRunConfig) -> int:
     overall_status = 0
     for step in _PIPELINE_STEPS:
         _LOGGER.info("step_start", step=step.name)
+        final_output = step.expected_output(cfg)
+        working_output = _temporary_output_path(final_output)
+        sentinel_path = _failure_sentinel_path(final_output)
+        if working_output.exists():
+            working_output.unlink()
         try:
-            exit_code = _run_step(step, cfg)
+            result = _run_step(step, cfg, final_output, working_output)
         except Exception as exc:  # pragma: no cover - defensive guard
             _LOGGER.exception("step_exception", step=step.name, error=str(exc))
-            return 1
-        if exit_code != 0:
-            _LOGGER.error(
-                "step_failed", step=step.name, exit_code=exit_code
+            _cleanup_failed_step(
+                final_output,
+                working_output,
+                sentinel_path,
+                executed=True,
             )
-            overall_status = exit_code
+            return 1
+        if result.exit_code != 0:
+            _LOGGER.error(
+                "step_failed", step=step.name, exit_code=result.exit_code
+            )
+            _cleanup_failed_step(
+                final_output,
+                working_output,
+                sentinel_path,
+                executed=result.executed,
+            )
+            overall_status = result.exit_code
             break
+        _finalize_step_success(final_output, working_output, sentinel_path)
         _LOGGER.info("step_done", step=step.name)
     else:
         _LOGGER.info("workflow_complete")

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from scripts import (
     get_activity_data,
     get_assay_data,
     get_document_data,
+    get_data,
     get_target_data,
     get_testitem_data,
 )
@@ -480,3 +482,76 @@ def test_get_testitem_data_smoke(
     assert polymer_row["pubchem_cid"] == "POLY-CID"
     mixture_row = df.loc[df["molecule_type"] == "Mixture"].iloc[0]
     assert mixture_row["pubchem_cid"] == "MIX-CID"
+
+
+def test_run_pipeline_failure_removes_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure failed orchestrator steps clean artefacts and emit a sentinel."""
+
+    base_dir = tmp_path
+    input_dir = base_dir / "input"
+    output_dir = base_dir / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    config_path = base_dir / "config.yaml"
+    config_path.write_text("pipeline: test\n")
+
+    input_csv = input_dir / "activity.csv"
+    input_csv.write_text("activity_id\n1\n")
+
+    cfg = get_data.PipelineRunConfig(
+        base_path=base_dir,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        config_path=config_path,
+        date_prefix="20240101",
+        log_level="ERROR",
+        force=False,
+        skip_existing=False,
+    )
+
+    final_output = cfg.output_path("activity")
+    working_output = final_output.with_name(f".{final_output.name}.tmp")
+    sentinel_path = final_output.with_name(f"{final_output.name}.failed")
+
+    def failing_main(argv: list[str] | None) -> int:
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--output")
+        parser.add_argument("--input")
+        parser.add_argument("--config")
+        parser.add_argument("--log-level")
+        ns = parser.parse_args(argv)
+        Path(ns.output).write_text("temporary output\n")
+        final_output.write_text("unexpected final output\n")
+        return 2
+
+    class DummyLogger:
+        def info(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def debug(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def error(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def warning(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+        def exception(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+            pass
+
+    monkeypatch.setattr(
+        get_data,
+        "_PIPELINE_STEPS",
+        (get_data.PipelineStep("activity", failing_main, None),),
+    )
+    monkeypatch.setattr(get_data, "_LOGGER", DummyLogger())
+
+    status = get_data.run_pipeline(cfg)
+
+    assert status == 2
+    assert not final_output.exists()
+    assert not working_output.exists()
+    assert sentinel_path.exists()


### PR DESCRIPTION
## Summary
- add temporary output handling and failure sentinels to the orchestration pipeline
- ensure failed steps clean up partial artefacts and leave a .failed marker
- extend smoke tests with a failure scenario that validates cleanup behaviour

## Testing
- pytest tests/smoke/test_get_data_scripts.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1c63472883249ba1d9a1bfa012d7