### PR TITLE
Reject placeholder contact emails for OpenAlex and CrossRef

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -613,7 +613,7 @@
           "type": "integer"
         },
         "mailto": {
-          "default": "contact@example.org",
+          "default": "chembl-data@ebi.ac.uk",
           "title": "Mailto",
           "type": "string"
         }
@@ -1114,7 +1114,7 @@
           "type": "integer"
         },
         "mailto": {
-          "default": "contact@example.org",
+          "default": "chembl-data@ebi.ac.uk",
           "title": "Mailto",
           "type": "string"
         }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -120,7 +120,7 @@ sources:
     retries: 3  # Retry attempts
     rps: 5  # Requests per second limit (env: CHEMBL_DA_OPENALEX_RPS)
     burst: 5  # Burst size for rate limiter (env: CHEMBL_DA_OPENALEX_BURST)
-    mailto: "contact@example.org"  # Required contact email (env: CHEMBL_DA_OPENALEX_MAILTO)
+    mailto: "chembl-data@ebi.ac.uk"  # Required contact email; replace with your team's address before production use (env: CHEMBL_DA_OPENALEX_MAILTO). Placeholder domains such as example.org are rejected.
   crossref:
     base: "https://api.crossref.org"  # CrossRef API root URL (env: CHEMBL_DA_CROSSREF_BASE)
     timeout_connect: 5  # (env: CHEMBL_DA_CROSSREF_TIMEOUT_CONNECT)
@@ -128,7 +128,7 @@ sources:
     retries: 3
     rps: 5  # (env: CHEMBL_DA_CROSSREF_RPS)
     burst: 5  # (env: CHEMBL_DA_CROSSREF_BURST)
-    mailto: "contact@example.org"  # Required contact email (env: CHEMBL_DA_CROSSREF_MAILTO)
+    mailto: "chembl-data@ebi.ac.uk"  # Required contact email; replace with your team's address before production use (env: CHEMBL_DA_CROSSREF_MAILTO). Placeholder domains such as example.org are rejected.
   uniprot:
     api:
       base: "https://rest.uniprot.org"  # UniProt REST API root (env: CHEMBL_DA_UNIPROT_BASE)

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -251,7 +251,7 @@ applies exponential backoff between attempts before surfacing the error.
 
 | Section | Default base URL | Key settings |
 | --- | --- | --- |
-| `openalex` | `https://api.openalex.org` | `timeout_connect=5`, `timeout_read=30`, `retries=3`, `rps=5`, `burst=5`, `mailto="contact@example.org"`. |
+| `openalex` | `https://api.openalex.org` | `timeout_connect=5`, `timeout_read=30`, `retries=3`, `rps=5`, `burst=5`, `mailto="chembl-data@ebi.ac.uk"` (replace with your own contact; placeholder domains such as `example.org` are rejected). |
 | `crossref` | `https://api.crossref.org` | Same structure as `openalex`; provide a personal `mailto`. |
 | `uniprot.api` | `https://rest.uniprot.org` | `timeout_connect=5`, `timeout_read=30`, `rps=25`, `burst=25`, `delay=0.25` seconds. |
 | `uniprot.mapping` | `https://rest.uniprot.org/idmapping` | `poll_interval=0.5` seconds, `timeout=300.0` seconds, `cache_ttl=null`. |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -240,7 +240,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 
 | Раздел | Базовый URL | Ключевые параметры |
 | --- | --- | --- |
-| `openalex` | `https://api.openalex.org` | `timeout_connect=5`, `timeout_read=30`, `retries=3`, `rps=5`, `burst=5`, `mailto="contact@example.org"`. |
+| `openalex` | `https://api.openalex.org` | `timeout_connect=5`, `timeout_read=30`, `retries=3`, `rps=5`, `burst=5`, `mailto="chembl-data@ebi.ac.uk"` (в проде замените на свой контакт; домены-заглушки вроде `example.org` отвергаются). |
 | `crossref` | `https://api.crossref.org` | Та же структура, важно указать персональный `mailto`. |
 | `uniprot.api` | `https://rest.uniprot.org` | `timeout_connect=5`, `timeout_read=30`, `rps=25`, `burst=25`, `delay=0.25`. |
 | `uniprot.mapping` | `https://rest.uniprot.org/idmapping` | `poll_interval=0.5`, `timeout=300.0`, `cache_ttl=null`. |

--- a/library/config.py
+++ b/library/config.py
@@ -47,6 +47,29 @@ def _dictionary_resource(*parts: str) -> Path:
     return Path(_RESOURCE_STACK.enter_context(resources.as_file(traversable)))
 
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+_PLACEHOLDER_EMAIL_DOMAINS = {
+    "example.com",
+    "example.net",
+    "example.org",
+    "test.com",
+    "test.net",
+    "test.org",
+}
+
+
+def _require_non_placeholder_email(service: str, value: str) -> str:
+    """Ensure *value* is a real contact email for *service*."""
+
+    if not value or not _EMAIL_RE.fullmatch(value):
+        raise ValueError(f"{service}.mailto must be a valid email")
+    _, domain = value.rsplit("@", 1)
+    domain = domain.lower()
+    if domain in _PLACEHOLDER_EMAIL_DOMAINS or domain.endswith(".example"):
+        raise ValueError(
+            f"{service}.mailto must not use placeholder domain {domain}; "
+            "configure a real contact email."
+        )
+    return value
 
 
 def _valid_url(url: str) -> bool:
@@ -192,7 +215,7 @@ class OpenAlexCfg(_BaseModel):
     retries: int = Field(3, ge=0)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
-    mailto: str = "contact@example.org"
+    mailto: str = "chembl-data@ebi.ac.uk"
 
     @field_validator("base")
     @classmethod
@@ -204,9 +227,7 @@ class OpenAlexCfg(_BaseModel):
     @field_validator("mailto")
     @classmethod
     def _email(cls, v: str) -> str:
-        if not v or not _EMAIL_RE.fullmatch(v):
-            raise ValueError("openalex.mailto must be a valid email")
-        return v
+        return _require_non_placeholder_email("openalex", v)
 
 
 class CrossRefCfg(_BaseModel):
@@ -216,7 +237,7 @@ class CrossRefCfg(_BaseModel):
     retries: int = Field(3, ge=0)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
-    mailto: str = "contact@example.org"
+    mailto: str = "chembl-data@ebi.ac.uk"
 
     @field_validator("base")
     @classmethod
@@ -228,9 +249,7 @@ class CrossRefCfg(_BaseModel):
     @field_validator("mailto")
     @classmethod
     def _email(cls, v: str) -> str:
-        if not v or not _EMAIL_RE.fullmatch(v):
-            raise ValueError("crossref.mailto must be a valid email")
-        return v
+        return _require_non_placeholder_email("crossref", v)
 
 
 class UniprotCfg(_BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,13 +173,13 @@ def test_mailto_aliases_override_defaults(
     path = tmp_path / "cfg.yaml"
     path.write_text("")
 
-    monkeypatch.setenv("CHEMBL_DA_OPENALEX_MAILTO", "openalex@example.org")
-    monkeypatch.setenv("CHEMBL_DA_CROSSREF_MAILTO", "crossref@example.org")
+    monkeypatch.setenv("CHEMBL_DA_OPENALEX_MAILTO", "openalex@ebi.ac.uk")
+    monkeypatch.setenv("CHEMBL_DA_CROSSREF_MAILTO", "crossref@ebi.ac.uk")
 
     cfg = load_config(path)
 
-    assert cfg.openalex.mailto == "openalex@example.org"
-    assert cfg.crossref.mailto == "crossref@example.org"
+    assert cfg.openalex.mailto == "openalex@ebi.ac.uk"
+    assert cfg.crossref.mailto == "crossref@ebi.ac.uk"
 
 
 def test_base_aliases_override_defaults(

--- a/tests/test_config_invalid_url.py
+++ b/tests/test_config_invalid_url.py
@@ -3,9 +3,7 @@
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
-
-from library.config import load_config
+from library.config import ConfigError, load_config
 
 
 def test_env_alias_invalid_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -18,5 +16,31 @@ def test_env_alias_invalid_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         "CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT",
         "test-agent/1.0 (mailto:test@example.org)",
     )
-    with pytest.raises(ValidationError, match="api.chembl_base"):
+    with pytest.raises(ConfigError, match="api.chembl_base"):
+        load_config(path)
+
+
+def test_openalex_placeholder_mailto_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Placeholder OpenAlex email provided via env should raise ``ConfigError``."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    monkeypatch.setenv("CHEMBL_DA_OPENALEX_MAILTO", "contact@example.org")
+
+    with pytest.raises(ConfigError, match="placeholder domain"):
+        load_config(path)
+
+
+def test_crossref_placeholder_mailto_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Placeholder CrossRef email provided via env should raise ``ConfigError``."""
+
+    path = tmp_path / "cfg.yaml"
+    path.write_text("")
+    monkeypatch.setenv("CHEMBL_DA_CROSSREF_MAILTO", "contact@example.org")
+
+    with pytest.raises(ConfigError, match="placeholder domain"):
         load_config(path)


### PR DESCRIPTION
## Summary
- block placeholder domains for the OpenAlex and CrossRef `mailto` validators and update defaults to a real contact
- document the updated defaults and guidance in the configuration template and reference docs
- add tests exercising environment overrides with placeholder addresses to ensure a `ConfigError` is raised

## Testing
- pytest tests/test_config_invalid_url.py
- pytest tests/test_config.py -k mailto

------
https://chatgpt.com/codex/tasks/task_e_68dd1c5fb5248324811ce0f53ded9d30