### PR TITLE
Refactor pipeline CLIs to use shared run_pipeline helper

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -1,15 +1,310 @@
-"""Helpers for building lightweight CLIs with shared arguments.
+"""Helpers shared across the command line interfaces.
 
-The utilities here assemble an ``argparse`` parser using the common options
-from :mod:`library.cli` for scripts that expose deterministic CSV operations.
+This module exposes utilities for constructing ``argparse`` parsers and
+coordinating the execution of data extraction pipelines.  The
+``run_pipeline`` helper consolidates the boilerplate shared by multiple
+scripts: fetching raw data in chunks, applying metadata hooks, validating
+against Pandera schemas and writing deterministic CSV outputs alongside
+metadata files.
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Protocol, TypeVar, overload
+
+import pandas as pd
+from pandera.errors import SchemaErrors
 
 from .cli import add_common_arguments, path_argument
+from .log import logger as default_logger
+from .metadata import Stats, file_sha256, write_meta_yaml
+from .sidecar import SidecarErrors
 from .utils.config import DEFAULT_CONFIG_RELATIVE
+
+SchemaT = TypeVar("SchemaT")
+
+
+class ValidationResult(Protocol):
+    """Protocol describing the return type of validator callables."""
+
+    data: pd.DataFrame
+    failure_cases: pd.DataFrame
+
+
+class Validator(Protocol):
+    """Callable interface for data frame validators."""
+
+    def __call__(self, df: pd.DataFrame) -> ValidationResult:  # pragma: no cover - Protocol
+        ...
+
+
+MetadataHook = Callable[[pd.DataFrame], pd.DataFrame]
+Writer = Callable[[Iterable[pd.DataFrame], Path, Sequence[str], Sequence[str]], Path]
+TableQualityHook = Callable[[Path], None]
+Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
+
+
+class PipelineError(RuntimeError):
+    """Raised when a pipeline step encounters a fatal error."""
+
+
+@overload
+def _as_iterable(source: pd.DataFrame) -> Iterator[pd.DataFrame]:
+    ...
+
+
+@overload
+def _as_iterable(source: Iterable[pd.DataFrame]) -> Iterator[pd.DataFrame]:
+    ...
+
+
+def _as_iterable(source: pd.DataFrame | Iterable[pd.DataFrame]) -> Iterator[pd.DataFrame]:
+    """Return ``source`` as an iterator of data frames."""
+
+    if isinstance(source, pd.DataFrame):
+        yield source
+    else:
+        yield from source
+
+
+def run_pipeline(
+    *,
+    fetcher: Fetcher,
+    schema: SchemaT,
+    schema_name: str,
+    validators: Sequence[Validator],
+    metadata_hooks: Sequence[MetadataHook],
+    writer: Writer,
+    output_path: Path,
+    failure_path: Path,
+    command: str,
+    config_snapshot: Mapping[str, object],
+    inputs: Mapping[str, object],
+    key_columns: Sequence[str],
+    table_quality: TableQualityHook,
+    logger: logging.Logger | None = None,
+) -> int:
+    """Execute a data pipeline and write deterministic CSV output.
+
+    Parameters
+    ----------
+    fetcher:
+        Callable returning an iterable of raw :class:`pandas.DataFrame`
+        objects.  Each frame represents a chunk of data retrieved from an
+        upstream service.
+    schema:
+        Pandera schema describing the expected output columns.  The helper
+        inspects ``schema.columns`` to determine required and optional fields
+        as well as to construct the preferred column order.
+    schema_name:
+        Human readable name of ``schema`` persisted in the metadata file.
+    validators:
+        Sequence of callables returning Pandera ``ValidationResult`` objects.
+        Every validated chunk is passed through each validator in order.
+    metadata_hooks:
+        Callables applied sequentially to every chunk before validation.
+    writer:
+        Function responsible for serialising the validated chunks to ``CSV``.
+        It receives the chunk iterator, destination path, final column order
+        and the subset of ``key_columns`` present in the output.
+    output_path:
+        Destination ``CSV`` file.
+    failure_path:
+        Path for persisting validation failure cases.
+    command:
+        Command used to launch the pipeline.  Stored in metadata output.
+    config_snapshot:
+        Mapping of configuration values persisted to metadata.
+    inputs:
+        Mapping of input file descriptions persisted to metadata.
+    key_columns:
+        Preferred key columns used when sorting deterministic output.  Only
+        columns present in the final dataset are forwarded to ``writer``.
+    table_quality:
+        Callable invoked after writing the CSV to compute quality metrics.
+    logger:
+        Optional logger.  Defaults to :data:`library.log.logger` when omitted.
+
+    Returns
+    -------
+    int
+        Zero on success, one when validation fails or ``writer`` raises an
+        exception.  ``PipelineError`` exceptions raised by ``fetcher`` are
+        converted into a non-zero return code.
+    """
+
+    use_logger = logger or default_logger
+
+    required_cols = {
+        name for name, column in getattr(schema, "columns", {}).items() if column.required
+    }
+    optional_cols = set(getattr(schema, "columns", {})) - required_cols
+
+    errors = SidecarErrors()
+    rows_total = 0
+    rows_kept = 0
+    rows_dropped = 0
+    total_failures = 0
+    exit_code = 0
+    present_columns: set[str] = set()
+    missing_required_columns: set[str] = set()
+    all_columns: set[str] = set()
+    validation_enabled = True
+
+    try:
+        iterable = _as_iterable(fetcher())
+    except PipelineError:
+        return 1
+
+    with TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        chunk_paths: list[Path] = []
+
+        try:
+            iterator = enumerate(iterable)
+            for index, chunk in iterator:
+                if chunk is None:
+                    continue
+                chunk_rows_total = len(chunk)
+                rows_total += chunk_rows_total
+
+                for hook in metadata_hooks:
+                    chunk = hook(chunk)
+
+                chunk_columns = set(chunk.columns)
+                present_columns.update(chunk_columns)
+                all_columns.update(chunk_columns)
+
+                missing_chunk_required = required_cols - chunk_columns
+                if missing_chunk_required:
+                    missing_required_columns.update(missing_chunk_required)
+                    validation_enabled = False
+
+                validated_chunk = chunk
+                if validation_enabled and validators and not chunk.empty:
+                    for validator in validators:
+                        try:
+                            result = validator(validated_chunk)
+                        except SchemaErrors as exc:
+                            failure_cases = exc.failure_cases
+                            if not failure_cases.empty:
+                                for row in failure_cases.to_dict("records"):
+                                    errors.add_error(row)
+                                total_failures += len(failure_cases)
+                                exit_code = 1
+                                use_logger.error(
+                                    "validation_failed",
+                                    failures=len(failure_cases),
+                                    path=str(failure_path),
+                                )
+                            validated_chunk = getattr(
+                                exc, "validated_data", validated_chunk
+                            )
+                        else:
+                            validated_chunk = result.data
+                            failure_cases = result.failure_cases
+                            if not failure_cases.empty:
+                                for row in failure_cases.to_dict("records"):
+                                    errors.add_error(row)
+                                total_failures += len(failure_cases)
+                                exit_code = 1
+                                use_logger.error(
+                                    "validation_failed",
+                                    failures=len(failure_cases),
+                                    path=str(failure_path),
+                                )
+
+                rows_kept += len(validated_chunk)
+                rows_dropped += chunk_rows_total - len(validated_chunk)
+                present_columns.update(validated_chunk.columns)
+                all_columns.update(validated_chunk.columns)
+
+                chunk_path = tmpdir / f"chunk_{index}.pkl"
+                validated_chunk.to_pickle(chunk_path)
+                chunk_paths.append(chunk_path)
+        except PipelineError:
+            return 1
+
+        if not chunk_paths:
+            empty = pd.DataFrame()
+            for hook in metadata_hooks:
+                empty = hook(empty)
+            present_columns.update(empty.columns)
+            all_columns.update(empty.columns)
+            chunk_path = tmpdir / "chunk_0.pkl"
+            empty.to_pickle(chunk_path)
+            chunk_paths.append(chunk_path)
+
+        schema_columns = list(getattr(schema, "columns", {}))
+        head = [column for column in schema_columns if column in all_columns]
+        tail = sorted(column for column in all_columns if column not in schema_columns)
+        col_order = head + tail
+        resolved_keys = [column for column in key_columns if column in col_order]
+
+        def _iter_validated() -> Iterator[pd.DataFrame]:
+            for path in chunk_paths:
+                df = pd.read_pickle(path)
+                if col_order:
+                    df = df.reindex(columns=col_order)
+                yield df
+
+        try:
+            csv_path = writer(_iter_validated(), output_path, col_order, resolved_keys)
+        except OSError as exc:
+            use_logger.error(
+                "write_fail",
+                error=str(exc),
+                path=str(output_path),
+            )
+            return 1
+
+    if missing_required_columns:
+        use_logger.warning(
+            "validation_skipped",
+            missing_columns=sorted(missing_required_columns),
+        )
+    elif optional_cols - present_columns:
+        use_logger.warning(
+            "optional_columns_missing",
+            columns=sorted(optional_cols - present_columns),
+        )
+
+    if total_failures:
+        errors.save(failure_path)
+
+    stats: Stats = {
+        "rows_total": rows_total,
+        "rows_kept": rows_kept,
+        "rows_dropped": rows_dropped,
+        "output_sha256": file_sha256(csv_path),
+    }
+    write_meta_yaml(
+        csv_path=csv_path,
+        command=command,
+        config_subset=config_snapshot,
+        inputs=inputs,
+        stats=stats,
+        schema=schema_name,
+    )
+
+    try:
+        table_quality(csv_path)
+    except ValueError as exc:
+        use_logger.error(
+            "quality_report_failed",
+            error=str(exc),
+            path=str(output_path),
+        )
+        return 1
+
+    if exit_code == 0:
+        use_logger.info("write_done", rows=rows_kept, path=str(csv_path))
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from functools import partial
 from itertools import islice
 from pathlib import Path
-from tempfile import TemporaryDirectory
-
-import pandas as pd
 
 
 def _ensure_project_root() -> None:
@@ -25,8 +23,8 @@ def _ensure_project_root() -> None:
 if __package__ in {None, ""}:
     _ensure_project_root()
 
+import pandas as pd
 import requests
-from pandera.errors import SchemaErrors
 
 from library import chembl_library as cl
 from library import cli
@@ -40,19 +38,10 @@ from library.cli import (
 from library.cli import (
     build_parser as base_parser,
 )
-from library.config import (
-    ActivityActionTypeCfg,
-    ActivityBoundsCfg,
-    ActivityPropertiesCfg,
-    Config,
-    _serialize_paths,
-    ensure_dirs,
-    print_config,
-)
+from library.cli_utils import PipelineError, run_pipeline
+from library.config import Config, _serialize_paths, ensure_dirs, print_config
 from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
-from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_activities
 from library.processing.activity import (
@@ -94,70 +83,50 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("dry_run", limit=expected)
         return 0
 
-    # Configure HTTP session with the supplied User-Agent and retry policy
-    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-        try:
-            ids_iter = io.read_ids(
-                args.input_csv, column=cfg.activity.column, cfg=cfg.io
-            )
-        except (FileNotFoundError, ValueError) as exc:
-            logger.error(
-                "read_fail",
-                error=str(exc),
-                path=str(args.input_csv),
-            )
-            return 1
+    try:
+        ids_iter = io.read_ids(args.input_csv, column=cfg.activity.column, cfg=cfg.io)
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error(
+            "read_fail",
+            error=str(exc),
+            path=str(args.input_csv),
+        )
+        return 1
 
-        offset = getattr(args, "offset", 0)
-        if offset:
-            ids_iter = islice(ids_iter, offset, None)
-            logger.info("process_offset", offset=offset)
+    offset = getattr(args, "offset", 0)
+    if offset:
+        ids_iter = islice(ids_iter, offset, None)
+        logger.info("process_offset", offset=offset)
 
-        # Apply the ``limit`` without materialising the entire iterator first.
-        ids = islice(ids_iter, limit) if limit is not None else ids_iter
+    processed_ids = 0
 
-        enrichment_cfg = cfg.activity_enrichment
-        extra_columns: list[str] = []
-        action_cfg = enrichment_cfg.action_type
-        if action_cfg.enabled or action_cfg.log_missing or action_cfg.log_distribution:
-            extra_columns.append(action_cfg.column)
-        extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}
+    def _iter_ids() -> Iterator[str]:
+        nonlocal processed_ids
+        for identifier in ids_iter:
+            processed_ids += 1
+            yield identifier
 
-        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    limited_ids: Iterator[str]
+    if limit is not None:
+        limited_ids = islice(_iter_ids(), limit)
+    else:
+        limited_ids = _iter_ids()
 
-        processed_ids = 0
+    id_chunks = _chunked(limited_ids, cfg.activity.batch_size)
 
-        def _iter_ids() -> Iterator[str]:
-            nonlocal processed_ids
-            for identifier in ids:
-                processed_ids += 1
-                yield identifier
+    enrichment_cfg = cfg.activity_enrichment
+    extra_columns: list[str] = []
+    action_cfg = enrichment_cfg.action_type
+    if action_cfg.enabled or action_cfg.log_missing or action_cfg.log_distribution:
+        extra_columns.append(action_cfg.column)
+    extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}
 
-        id_chunks = _chunked(_iter_ids(), cfg.activity.batch_size)
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
-        required_cols = {
-            name for name, col in ActivitiesSchema.columns.items() if col.required
-        }
-        optional_cols = set(ActivitiesSchema.columns) - required_cols
-        present_columns: set[str] = set()
-        total_failures = 0
-        rows_total = 0
-        rows_kept = 0
-        rows_dropped = 0
-        exit_code = 0
-        failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
-        errors = SidecarErrors()
-
-        chunk_paths: list[Path] = []
-        all_columns: set[str] = set()
-
-        validation_enabled = True
-        missing_required_columns: set[str] = set()
-
-        csv_path: Path | None = None
-        with TemporaryDirectory() as tmpdir_name:
-            tmpdir = Path(tmpdir_name)
-            for chunk_index, chunk_ids in enumerate(id_chunks):
+    def fetcher() -> Iterator[pd.DataFrame]:
+        with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+            for chunk_ids in id_chunks:
                 try:
                     chunk_df = cl.get_activities(
                         chunk_ids,
@@ -175,160 +144,73 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                         batch_size=cfg.activity.batch_size,
                         timeout=cfg.activity.timeout,
                     )
-                    return 1
+                    raise PipelineError(str(exc)) from exc
+                yield chunk_df
 
-                chunk_df = normalize_activities(chunk_df)
-                chunk_df = add_pipeline_metadata(chunk_df)
-                chunk_df = compute_activity_bounds(chunk_df, cfg.activity_bounds)
-                chunk_df = apply_activity_annotations(
-                    chunk_df,
-                    action_cfg=enrichment_cfg.action_type,
-                    properties_cfg=enrichment_cfg.activity_properties,
-                )
+    def _compute_bounds(frame: pd.DataFrame) -> pd.DataFrame:
+        return compute_activity_bounds(frame, cfg.activity_bounds)
 
-                chunk_columns = set(chunk_df.columns)
-                present_columns.update(chunk_columns)
-                missing_chunk_required = required_cols - chunk_columns
-                if missing_chunk_required:
-                    missing_required_columns.update(missing_chunk_required)
-                    validation_enabled = False
-
-                rows_total += len(chunk_df)
-
-                validated_chunk = chunk_df
-                if validation_enabled and not chunk_df.empty:
-                    try:
-                        validation_result = validate_activities(
-                            chunk_df, return_result=True
-                        )
-                    except SchemaErrors as exc:
-                        for row in exc.failure_cases.to_dict("records"):
-                            errors.add_error(row)
-                        total_failures += len(exc.failure_cases)
-                        logger.error(
-                            "validation_failed",
-                            failures=len(exc.failure_cases),
-                            path=str(failure_path),
-                        )
-                        validated_chunk = getattr(exc, "validated_data", chunk_df)
-                        exit_code = 1
-                    else:
-                        validated_chunk = validation_result.data
-                        if not validation_result.failure_cases.empty:
-                            cases = validation_result.failure_cases.to_dict("records")
-                            for row in cases:
-                                errors.add_error(row)
-                            total_failures += len(cases)
-                            logger.error(
-                                "validation_failed",
-                                failures=len(cases),
-                                path=str(failure_path),
-                            )
-                            exit_code = 1
-
-                rows_kept += len(validated_chunk)
-                rows_dropped += len(chunk_df) - len(validated_chunk)
-                present_columns.update(validated_chunk.columns)
-                all_columns.update(validated_chunk.columns)
-
-                chunk_path = Path(tmpdir) / f"chunk_{chunk_index}.pkl"
-                validated_chunk.to_pickle(chunk_path)
-                chunk_paths.append(chunk_path)
-
-            if not chunk_paths:
-                empty_chunk = apply_activity_annotations(
-                    compute_activity_bounds(
-                        add_pipeline_metadata(pd.DataFrame()), cfg.activity_bounds
-                    ),
-                    action_cfg=enrichment_cfg.action_type,
-                    properties_cfg=enrichment_cfg.activity_properties,
-                )
-                present_columns.update(empty_chunk.columns)
-                all_columns.update(empty_chunk.columns)
-                chunk_path = Path(tmpdir) / "chunk_0.pkl"
-                empty_chunk.to_pickle(chunk_path)
-                chunk_paths.append(chunk_path)
-
-            schema_cols = list(ActivitiesSchema.columns)
-            head = [c for c in schema_cols if c in all_columns]
-            tail = sorted(c for c in all_columns if c not in schema_cols)
-            col_order = head + tail
-
-            def _iter_validated_chunks() -> Iterator[pd.DataFrame]:
-                for path in chunk_paths:
-                    df_chunk = pd.read_pickle(path)
-                    if col_order:
-                        df_chunk = df_chunk.reindex(columns=col_order)
-                    yield df_chunk
-
-            try:
-                key_cols = [c for c in ["activity_id"] if c in col_order]
-                sort_columns = key_cols or sorted(col_order)
-                csv_path = write_csv_chunks_deterministic(
-                    _iter_validated_chunks(),
-                    output,
-                    key_cols=sort_columns,
-                    col_order=col_order,
-                    chunksize=cfg.io.csv_chunksize,
-                    sort_chunksize=cfg.io.csv_chunksize,
-                    sep=cfg.io.csv_sep,
-                    encoding=cfg.io.csv_encoding,
-                    cfg=cfg,
-                )
-                logger.info("write_done", rows=rows_kept, path=str(csv_path))
-            except OSError as exc:
-                logger.error(
-                    "write_fail",
-                    error=str(exc),
-                    path=str(output),
-                )
-                return 1
-
-        if limit is not None:
-            logger.info("process_limit", limit=processed_ids)
-
-        if missing_required_columns:
-            logger.warning(
-                "validation_skipped",
-                missing_columns=sorted(missing_required_columns),
-            )
-            validation_enabled = False
-        elif optional_cols - present_columns:
-            logger.warning(
-                "optional_columns_missing",
-                columns=sorted(optional_cols - present_columns),
-            )
-
-        if total_failures:
-            errors.save(failure_path)
-
-        assert csv_path is not None
-
-        stats: Stats = {
-            "rows_total": rows_total,
-            "rows_kept": rows_kept,
-            "rows_dropped": rows_dropped,
-            "output_sha256": file_sha256(csv_path),
-        }
-        write_meta_yaml(
-            csv_path=csv_path,
-            command=" ".join(sys.argv),
-            config_subset=_serialize_paths(cfg.to_dict()),
-            inputs={"input_csv": str(args.input_csv)},
-            stats=stats,
-            schema="ActivitiesSchema",
+    def _apply_annotations(frame: pd.DataFrame) -> pd.DataFrame:
+        return apply_activity_annotations(
+            frame,
+            action_cfg=enrichment_cfg.action_type,
+            properties_cfg=enrichment_cfg.activity_properties,
         )
 
-        try:
-            analyze_table_quality(csv_path, table_name=str(output.with_suffix("")))
-        except ValueError as exc:
-            logger.error(
-                "quality_report_failed",
-                error=str(exc),
-                path=str(output),
-            )
-            return 1
-        return exit_code
+    metadata_hooks = [
+        normalize_activities,
+        add_pipeline_metadata,
+        _compute_bounds,
+        _apply_annotations,
+    ]
+
+    validators = [partial(validate_activities, return_result=True)]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: Sequence[str],
+        key_cols: Sequence[str],
+    ) -> Path:
+        sort_columns = list(key_cols) or sorted(col_order)
+        return write_csv_chunks_deterministic(
+            chunks,
+            destination,
+            key_cols=sort_columns,
+            col_order=col_order,
+            chunksize=cfg.io.csv_chunksize,
+            sort_chunksize=cfg.io.csv_chunksize,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            cfg=cfg,
+        )
+
+    table_quality = partial(
+        analyze_table_quality,
+        table_name=str(Path(output).with_suffix("")),
+    )
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=ActivitiesSchema,
+        schema_name="ActivitiesSchema",
+        validators=validators,
+        metadata_hooks=metadata_hooks,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command=" ".join(sys.argv),
+        config_snapshot=_serialize_paths(cfg.to_dict()),
+        inputs={"input_csv": str(args.input_csv)},
+        key_columns=["activity_id"],
+        table_quality=table_quality,
+        logger=logger,
+    )
+
+    if limit is not None:
+        logger.info("process_limit", limit=processed_ids)
+
+    return exit_code
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -6,11 +6,12 @@ import sys
 from pathlib import Path
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from functools import partial
 from itertools import islice
 
+import pandas as pd
 import requests
-from pandera.errors import SchemaErrors
 
 # Ensure repository package imports work when the script is executed directly.
 ROOT = Path(__file__).resolve().parents[1]
@@ -27,16 +28,10 @@ from library.cli import (
     configure_logger,
 )
 from library.cli import build_parser as base_parser
-from library.config import (
-    Config,
-    _serialize_paths,
-    ensure_dirs,
-    print_config,
-)
+from library.cli_utils import PipelineError, run_pipeline
+from library.config import Config, _serialize_paths, ensure_dirs, print_config
 from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
-from library.sidecar import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_assays
 from schemas import AssaysSchema, normalize_assays
@@ -69,153 +64,102 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("invalid_limit", section="assay.limit", limit=limit)
         return 1
 
-    # Prepare HTTP session for ChEMBL requests
-    with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-        try:
-            ids_iter = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
-        except (FileNotFoundError, ValueError) as exc:
-            logger.error(
-                "read_fail",
-                error=str(exc),
-                path=str(args.input_csv),
-            )
-            return 1
+    try:
+        ids_iter = io.read_ids(args.input_csv, column=cfg.assay.column, cfg=cfg.io)
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error(
+            "read_fail",
+            error=str(exc),
+            path=str(args.input_csv),
+        )
+        return 1
 
-        offset = getattr(args, "offset", 0)
-        if offset:
-            ids_iter = islice(ids_iter, offset, None)
-            logger.info("process_offset", offset=offset)
+    offset = getattr(args, "offset", 0)
+    if offset:
+        ids_iter = islice(ids_iter, offset, None)
+        logger.info("process_offset", offset=offset)
 
-        ids = ids_iter
-        if limit is not None:
-            limited_ids = list(islice(ids_iter, limit))
-            ids = limited_ids
-            logger.info("process_limit", limit=len(limited_ids))
+    ids_source: Iterable[str]
+    if limit is not None:
+        limited_ids = list(islice(ids_iter, limit))
+        ids_source = limited_ids
+        logger.info("process_limit", limit=len(limited_ids))
+    else:
+        ids_source = ids_iter
 
-        try:
-            df = cl.get_assays(
-                ids,
-                cfg=cfg.api,
-                client=client,
-                chunk_size=cfg.assay.batch_size,
-                timeout=cfg.assay.timeout,
-            )
-        except (requests.RequestException, ValueError) as exc:
-            logger.error(
-                "assay_fetch_failed",
-                extra={"msg": str(exc)},
-                error=str(exc),
-                batch_size=cfg.assay.batch_size,
-                timeout=cfg.assay.timeout,
-            )
-            return 1
-        df = ap.postprocess_assays(df)
-        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-        df = normalize_assays(df)
-        df = add_pipeline_metadata(df)
-        rows_total = len(df)
-        exit_code = 0
-        required_cols = {
-            name for name, col in AssaysSchema.columns.items() if col.required
-        }
-        optional_cols = set(AssaysSchema.columns) - required_cols
-        missing_required = required_cols - set(df.columns)
-        missing_optional = optional_cols - set(df.columns)
-        if not missing_required:
-            if missing_optional:
-                logger.warning(
-                    "optional_columns_missing",
-                    columns=sorted(missing_optional),
-                )
+    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
+
+    def fetcher() -> Iterable[pd.DataFrame]:
+        with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
             try:
-                validation_result = validate_assays(df, return_result=True)
-            except SchemaErrors as exc:
-                failure_path = Path(output).with_name(
-                    f"{Path(output).stem}_failure_cases.csv"
+                df = cl.get_assays(
+                    ids_source,
+                    cfg=cfg.api,
+                    client=client,
+                    chunk_size=cfg.assay.batch_size,
+                    timeout=cfg.assay.timeout,
                 )
-                errors = SidecarErrors()
-                for row in exc.failure_cases.to_dict("records"):
-                    errors.add_error(row)
-                errors.save(failure_path)
+            except (requests.RequestException, ValueError) as exc:
                 logger.error(
-                    "validation_failed",
-                    failures=len(exc.failure_cases),
-                    path=str(failure_path),
+                    "assay_fetch_failed",
+                    extra={"msg": str(exc)},
+                    error=str(exc),
+                    batch_size=cfg.assay.batch_size,
+                    timeout=cfg.assay.timeout,
                 )
-                df = getattr(exc, "validated_data", df)
-                exit_code = 1
-            else:
-                df = validation_result.data
-                if not validation_result.failure_cases.empty:
-                    failure_path = Path(output).with_name(
-                        f"{Path(output).stem}_failure_cases.csv"
-                    )
-                    errors = SidecarErrors()
-                    for row in validation_result.failure_cases.to_dict("records"):
-                        errors.add_error(row)
-                    errors.save(failure_path)
-                    logger.error(
-                        "validation_failed",
-                        failures=len(validation_result.failure_cases),
-                        path=str(failure_path),
-                    )
-                    exit_code = 1
-        else:
-            logger.warning(
-                "validation_skipped",
-                missing_columns=sorted(missing_required),
-            )
-        rows_kept = len(df)
-        rows_dropped = rows_total - rows_kept
-        # Arrange columns so schema-defined fields appear first while any
-        # additional columns are sorted alphabetically and placed at the end.
-        schema_cols: list[str] = list(AssaysSchema.columns)
-        head = [c for c in schema_cols if c in df.columns]
-        tail = sorted(c for c in df.columns if c not in schema_cols)
-        col_order = head + tail
-        try:
-            key_cols = [c for c in ["assay_chembl_id"] if c in df.columns]
-            csv_path = io.write_csv(
-                df,
-                output,
-                cfg=cfg,
-                key_cols=key_cols or None,
-                col_order=col_order,
-            )
-            logger.info("write_done", rows=rows_kept, path=str(csv_path))
-        except OSError as exc:
-            logger.error(
-                "write_fail",
-                error=str(exc),
-                path=str(output),
-            )
-            return 1
+                raise PipelineError(str(exc)) from exc
+            yield df
 
-        stats: Stats = {
-            "rows_total": rows_total,
-            "rows_kept": rows_kept,
-            "rows_dropped": rows_dropped,
-            "output_sha256": file_sha256(csv_path),
-        }
-        write_meta_yaml(
-            csv_path=csv_path,
-            command=" ".join(sys.argv),
-            config_subset=_serialize_paths(cfg.to_dict()),
-            inputs={"input_csv": str(args.input_csv)},
-            stats=stats,
-            schema="AssaysSchema",
+    metadata_hooks = [
+        ap.postprocess_assays,
+        normalize_assays,
+        add_pipeline_metadata,
+    ]
+
+    validators = [partial(validate_assays, return_result=True)]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: Sequence[str],
+        key_cols: Sequence[str],
+    ) -> Path:
+        frames = [chunk for chunk in chunks]
+        if frames:
+            df = pd.concat(frames, ignore_index=True)
+        else:
+            df = pd.DataFrame(columns=col_order)
+        resolved_keys = list(key_cols) or None
+        return io.write_csv(
+            df,
+            destination,
+            cfg=cfg,
+            key_cols=resolved_keys,
+            col_order=col_order,
         )
 
-        try:
-            analyze_table_quality(df, table_name=str(output.with_suffix("")))
-        except ValueError as exc:
-            logger.error(
-                "quality_report_failed",
-                error=str(exc),
-                path=str(output),
-            )
-            return 1
-        return exit_code
+    table_quality = partial(
+        analyze_table_quality,
+        table_name=str(Path(output).with_suffix("")),
+    )
+
+    return run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=validators,
+        metadata_hooks=metadata_hooks,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command=" ".join(sys.argv),
+        config_snapshot=_serialize_paths(cfg.to_dict()),
+        inputs={"input_csv": str(args.input_csv)},
+        key_columns=["assay_chembl_id"],
+        table_quality=table_quality,
+        logger=logger,
+    )
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from library.cli_utils import build_parser
+from collections.abc import Iterable
+from pathlib import Path
+
+import pandas as pd
+
+from library.cli_utils import build_parser, run_pipeline
+from schemas import AssaysSchema
 
 
 def test_cli_utils_flags_and_help() -> None:
@@ -12,6 +18,7 @@ def test_cli_utils_flags_and_help() -> None:
         "--log-level",
         "--input",
         "--output",
+        "--config",
         "--sep",
         "--encoding",
         "--col-order",
@@ -39,3 +46,135 @@ def test_cli_utils_flags_and_help() -> None:
     assert parser.description.startswith(
         "CLI wrapper for :func:`write_csv_deterministic`"
     )
+
+
+class _ValidationResult:
+    def __init__(self, data: pd.DataFrame, failure_cases: pd.DataFrame) -> None:
+        self.data = data
+        self.failure_cases = failure_cases
+
+
+def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+    frames = [
+        pd.DataFrame(
+            {
+                "assay_chembl_id": ["A1", "A2"],
+                "document_chembl_id": ["D1", "D2"],
+                "extra": ["x", "y"],
+            }
+        )
+    ]
+
+    def fetcher() -> list[pd.DataFrame]:
+        return frames
+
+    hooks = [
+        lambda df: df.assign(extra=df["extra"].str.upper()),
+        lambda df: df.assign(new_col="value"),
+    ]
+
+    def validator(df: pd.DataFrame) -> _ValidationResult:
+        return _ValidationResult(df, pd.DataFrame())
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str],
+        key_cols: list[str],
+    ) -> Path:
+        frames = list(chunks)
+        if frames:
+            df = pd.concat(frames, ignore_index=True)
+        else:
+            df = pd.DataFrame(columns=col_order)
+        df.to_csv(destination, index=False)
+        return destination
+
+    quality_called: list[Path] = []
+
+    def quality(path: Path) -> None:
+        quality_called.append(path)
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[validator],
+        metadata_hooks=hooks,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=quality,
+    )
+
+    assert exit_code == 0
+    assert output.exists()
+    assert not failure_path.exists()
+    assert quality_called == [output]
+
+    written = pd.read_csv(output)
+    schema_columns = list(AssaysSchema.columns)
+    head = [c for c in schema_columns if c in written.columns]
+    tail = sorted(c for c in written.columns if c not in schema_columns)
+    assert list(written.columns) == head + tail
+
+    meta_path = output.with_name(output.name + ".meta.yaml")
+    assert meta_path.exists()
+
+
+def test_run_pipeline_writes_failure_cases(tmp_path: Path) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [
+            pd.DataFrame(
+                {
+                    "assay_chembl_id": ["A1"],
+                    "document_chembl_id": ["D1"],
+                }
+            )
+        ]
+
+    def validator(df: pd.DataFrame) -> _ValidationResult:
+        failures = pd.DataFrame([{"column": "extra", "value": "bad"}])
+        return _ValidationResult(df, failures)
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str],
+        key_cols: list[str],
+    ) -> Path:
+        frames = list(chunks)
+        df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(columns=col_order)
+        df.to_csv(destination, index=False)
+        return destination
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[validator],
+        metadata_hooks=[lambda df: df],
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda path: None,
+    )
+
+    assert exit_code == 1
+    assert failure_path.exists()
+    failure_csv = failure_path.read_text()
+    assert "column" in failure_csv
+    assert "value" in failure_csv

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
+import library.cli_utils as cli_utils
 from library import chembl_library as cl
 from library import io
 from library.config import Config
@@ -43,12 +45,12 @@ def test_run_chembl_respects_limit(
 
     monkeypatch.setattr(
         gad,
-        "write_csv_deterministic",
+        "write_csv_chunks_deterministic",
         lambda df, output, *, key_cols, col_order, chunksize, sort_chunksize, sep, encoding, cfg, **__: output,
     )
     monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
-    monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
-    monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
     rc = gad.run_chembl(cfg, args)
     assert rc == 0
@@ -108,8 +110,8 @@ def test_run_chembl_column_order(
 
     monkeypatch.setattr(cl, "get_activities", lambda *_, **__: df)
     monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
-    monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
-    monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
     captured: dict[str, list[str]] = {}
 
@@ -129,7 +131,7 @@ def test_run_chembl_column_order(
         captured["col_order"] = list(col_order or [])
         return output
 
-    monkeypatch.setattr(gad, "write_csv_deterministic", fake_write_csv)
+    monkeypatch.setattr(gad, "write_csv_chunks_deterministic", fake_write_csv)
 
     rc = gad.run_chembl(cfg, args)
     assert rc == 0
@@ -196,13 +198,13 @@ def test_run_chembl_streams_large_output(
         lambda df, return_result: _Result(df),
     )
     monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
-    monkeypatch.setattr(gad, "write_meta_yaml", lambda **kwargs: None)
-    monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
     captured: dict[str, object] = {}
 
     def fake_write_csv(
-        df: pd.DataFrame,
+        df: Iterable[pd.DataFrame],
         output: Path,
         *,
         key_cols,
@@ -214,18 +216,20 @@ def test_run_chembl_streams_large_output(
         cfg,
         **__,
     ) -> Path:
-        chunk_count = (len(df) + chunksize - 1) // chunksize if chunksize else 1
+        frames = list(df)
+        rows = sum(len(frame) for frame in frames)
+        chunk_count = len(frames)
         captured.update(
             {
                 "chunksize": chunksize,
                 "sort_chunksize": sort_chunksize,
                 "chunk_count": chunk_count,
-                "rows": len(df),
+                "rows": rows,
             }
         )
         return output
 
-    monkeypatch.setattr(gad, "write_csv_deterministic", fake_write_csv)
+    monkeypatch.setattr(gad, "write_csv_chunks_deterministic", fake_write_csv)
 
     args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
     rc = gad.run_chembl(cfg, args)

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+import library.cli_utils as cli_utils
 from library import chembl_library as cl
 from library import io
 from library.config import Config
@@ -34,8 +35,8 @@ def test_run_chembl_orders_columns(
     monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
     monkeypatch.setattr(gas.ap, "postprocess_assays", lambda df: df)
     monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
-    monkeypatch.setattr(gas, "write_meta_yaml", lambda **kwargs: None)
-    monkeypatch.setattr(gas, "file_sha256", lambda p: "deadbeef")
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
     rc = gas.run_chembl(cfg, args)
     assert rc == 0


### PR DESCRIPTION
## Summary
- add a reusable run_pipeline helper in library/cli_utils to manage chunked fetching, validation, and metadata writing
- refactor get_activity_data.py and get_assay_data.py to delegate processing to the shared helper while preserving entity-specific behaviour
- update CLI and pipeline tests to exercise the shared helper and adjust existing script tests for the new architecture

## Testing
- pytest tests/test_cli_utils.py tests/test_get_activity_data.py tests/test_get_assay_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1c6cab6083248bb582d7a99a7010