### PR TITLE
Adopt dot-separated default output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-`--output` по умолчанию формируется как `output_<имя_входа>_YYYYMMDD.csv`
+`--output` по умолчанию формируется как `output.<имя_входа>_YYYYMMDD.csv`
 в каталоге, заданном `local.io.output_dir`.
 Для дополнительных примеров см. [`docs/USAGE_RU.md`](docs/USAGE_RU.md) и английскую версию [`docs/USAGE_EN.md`](docs/USAGE_EN.md).
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -389,7 +389,7 @@ All CLI scripts share a common set of flags:
 python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 ```
 
-`--output` defaults to `output_<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. For additional
+`--output` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. For additional
 examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version: [`docs/USAGE_RU.md`](docs/USAGE_RU.md)).
 
 ## Project structure
@@ -504,7 +504,7 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-`--output` defaults to `output_<input_name>_YYYYMMDD.csv` in the directory specified by `local.io.output_dir`.
+`--output` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory specified by `local.io.output_dir`.
 For additional examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version: [`docs/USAGE_RU.md`](docs/USAGE_RU.md)).
 
 ## Output and metadata

--- a/README_RU.md
+++ b/README_RU.md
@@ -370,7 +370,7 @@ python -m library.utils.cli_tools.table_quality_main --input tests/data/activity
     --table-name activity
 ```
 
-По умолчанию `--output` формируется как `output_<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`. Дополнительные примеры приведены в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
+По умолчанию `--output` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`. Дополнительные примеры приведены в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 ## Структура проекта
 
@@ -472,7 +472,7 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-По умолчанию `--output` формируется как `output_<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Дополнительные примеры см. в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
+По умолчанию `--output` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Дополнительные примеры см. в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 ## Вывод и метаданные
 

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -8,7 +8,7 @@ creation.
 
 Exports are written to `local.io.output_dir` (default `data/output`). By
 default each CLI command derives the destination file as
-`output_<stem>_<date>.csv`, where `<stem>` is the input filename without
+`output.<stem>_<date>.csv`, where `<stem>` is the input filename without
 extension and `<date>` is the host-local calendar date in `YYYYMMDD` format.
 The writer creates parent directories automatically when `local.io.exist_ok`
 is `true`. If your automation requires UTC-based filenames, wrap the CLI with a
@@ -17,11 +17,11 @@ inject an alternate timestamp.
 
 ```
 data/output/
-├── output_activity_20240105.csv
-├── output_activity_20240105.csv.meta.yaml
-├── output_activity_20240105_failure_cases.csv
-├── output_activity_20240105_quality_report_table.csv
-└── output_activity_20240105_data_correlation_report_table.csv
+├── output.activity_20240105.csv
+├── output.activity_20240105.csv.meta.yaml
+├── output.activity_20240105_failure_cases.csv
+├── output.activity_20240105_quality_report_table.csv
+└── output.activity_20240105_data_correlation_report_table.csv
 ```
 
 Document-oriented pipelines (for example `scripts/get_document_data.py`) append
@@ -37,7 +37,7 @@ arguments remain supported when a different layout (for example,
 
 Each CSV export is accompanied by `<base>.csv.meta.yaml` created via
 `library.metadata.write_meta_yaml`, where `<base>` matches the CSV filename
-without the extension (for example `output_activity_20240105`). The metadata
+without the extension (for example `output.activity_20240105`). The metadata
 captures the following keys:
 
 * `generated_at` – ISO 8601 timestamp (UTC) when the file was produced.
@@ -60,7 +60,7 @@ are preserved.
   interrupting the main export.
 * `library.table_quality.analyze_table_quality` generates
   `<base>_quality_report_table.csv` and
-  `<base>_data_correlation_report_table.csv`. CLI utilities write these reports
+`<base>_data_correlation_report_table.csv`. CLI utilities write these reports
   next to the dataset, while `library.utils.cli_tools.get_input_initialisation`
   stores them under `<output>/data_validity_report/`.
 
@@ -108,7 +108,7 @@ when the signal is inconclusive.
 
 ## Activity bounds (`lower_value`, `upper_value`)
 
-The activity export (`output_activity_<date>.csv` by default) exposes canonical
+The activity export (`output.activity_<date>.csv` by default) exposes canonical
 value ranges derived from ChEMBL `standard_*`
 columns in `scripts/get_activity_data.py`. Bounds are resolved in the following
 priority order:

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -6,18 +6,18 @@ Acquisition, а также вспомогательные модули, отве
 ## Структура каталогов
 
 Экспорты сохраняются в `local.io.output_dir` (по умолчанию `data/output`). По
-умолчанию CLI формирует имя как `output_<stem>_<date>.csv`, где `<stem>` — имя
+умолчанию CLI формирует имя как `output.<stem>_<date>.csv`, где `<stem>` — имя
 входного файла без расширения, а `<date>` — текущая дата в формате `YYYYMMDD`.
 Запись автоматически создаёт родительские каталоги, если `local.io.exist_ok`
 равно `true`.
 
 ```
 data/output/
-├── output_activity_20240105.csv
-├── output_activity_20240105.csv.meta.yaml
-├── output_activity_20240105_failure_cases.csv
-├── output_activity_20240105_quality_report_table.csv
-└── output_activity_20240105_data_correlation_report_table.csv
+├── output.activity_20240105.csv
+├── output.activity_20240105.csv.meta.yaml
+├── output.activity_20240105_failure_cases.csv
+├── output.activity_20240105_quality_report_table.csv
+└── output.activity_20240105_data_correlation_report_table.csv
 ```
 
 Документные пайплайны (например, `scripts/get_document_data.py`) дополняют
@@ -33,7 +33,7 @@ data/output/
 
 Каждый CSV сопровождается `<base>.csv.meta.yaml`, который создаёт
 `library.metadata.write_meta_yaml`, где `<base>` совпадает с именем файла без
-расширения (например, `output_activity_20240105`). Файл содержит:
+расширения (например, `output.activity_20240105`). Файл содержит:
 
 * `generated_at` — отметку времени в формате ISO 8601 (UTC).
 * `git_sha` — хэш коммита на момент запуска.
@@ -99,7 +99,7 @@ data/output/
 
 ## Границы активности (`lower_value`, `upper_value`)
 
-Выгрузка активностей (`output_activity_<date>.csv` по умолчанию) включает
+Выгрузка активностей (`output.activity_<date>.csv` по умолчанию) включает
 диапазоны значений, рассчитанные из канонических полей ChEMBL `standard_*`.
 Приоритет действий:
 

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -15,7 +15,7 @@ directly.
 | `--print-config` | Print the effective configuration after overrides and exit. |
 | `--log-level` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
 | `--input` | Input CSV with identifiers (default: `input.csv`). |
-| `--output` | Destination CSV. When omitted, a file named `output_<input-stem>_<YYYYMMDD>.csv` is created inside `local.io.output_dir`. |
+| `--output` | Destination CSV. When omitted, a file named `output.<input-stem>_<YYYYMMDD>.csv` is created inside `local.io.output_dir`. |
 | `--sep` | CSV delimiter forwarded to `cfg.io.csv_sep`. |
 | `--encoding` | File encoding forwarded to `cfg.io.csv_encoding`. |
 | `--column` | Name of the identifier column. Defaults are populated from the configuration during start-up. |

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -18,7 +18,7 @@ CLI без вложенных подкоманд.
 | `--print-config` | Вывести итоговую конфигурацию после переопределений и завершить работу. |
 | `--log-level` | Уровень логирования (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
 | `--input` | Входной CSV с идентификаторами (по умолчанию `input.csv`). |
-| `--output` | Выходной CSV. Если не указан, создаётся `output_<stem>_<YYYYMMDD>.csv` в `local.io.output_dir`. |
+| `--output` | Выходной CSV. Если не указан, создаётся `output.<stem>_<YYYYMMDD>.csv` в `local.io.output_dir`. |
 | `--sep` | Разделитель CSV; записывается в `cfg.io.csv_sep`. |
 | `--encoding` | Кодировка файла; записывается в `cfg.io.csv_encoding`. |
 | `--column` | Название колонки с идентификаторами. Значение подтягивается из конфигурации на этапе запуска. |

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -124,7 +124,7 @@ def add_common_arguments(
     Notes
     -----
     When ``--output`` is omitted, a file named
-    ``output_<input-stem>_<YYYYMMDD>.csv`` is created next to the input file.
+    ``output.<input-stem>_<YYYYMMDD>.csv`` is created next to the input file.
     """
 
     log_level = "INFO" if defaults else argparse.SUPPRESS
@@ -146,7 +146,7 @@ def add_common_arguments(
         dest="output_csv",
         type=path_argument,
         default=output_default,
-        help="Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)",
+        help="Destination CSV file (default: output.<stem>_<YYYYMMDD>.csv)",
     )
     parser.add_argument("--sep", default=sep_default, help="CSV delimiter")
     parser.add_argument("--encoding", default=enc_default, help="File encoding")

--- a/library/io/paths.py
+++ b/library/io/paths.py
@@ -13,4 +13,4 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
 
     inp = Path(input_path)
     date_str = datetime.now().strftime("%Y%m%d")
-    return Path(cfg.output_dir) / f"output_{inp.stem}_{date_str}.csv"
+    return Path(cfg.output_dir) / f"output.{inp.stem}_{date_str}.csv"

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -167,7 +167,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     output_path = (
         Path(args.output_csv)
         if args.output_csv
-        else Path(f"output_{Path(args.input_csv).stem}_{date.today():%Y%m%d}.csv")
+        else Path(f"output.{Path(args.input_csv).stem}_{date.today():%Y%m%d}.csv")
     )
     write_csv_deterministic(df, output_path, key_cols=sorted(df.columns))
     logger.info("file_written", path=str(output_path))

--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -4,7 +4,7 @@ This script reads an input CSV file and re-serialises it deterministically
 using :func:`library.csv_utils.write_csv_deterministic`.
 
 If ``--output`` is omitted, a file named
-``output_<input-stem>_<YYYYMMDD>.csv`` is created next to the input.
+``output.<input-stem>_<YYYYMMDD>.csv`` is created next to the input.
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     ns = parser.parse_args(argv)
     if ns.output_csv is None:
         ns.output_csv = Path(ns.input_csv).with_name(
-            f"output_{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
+            f"output.{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
         )
     cfg = cli.apply_config_overrides(
         ns,
@@ -70,7 +70,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         chunksize=chunk_size,
     )
     output = args.output_csv or Path(args.input_csv).with_name(
-        f"output_{Path(args.input_csv).stem}.csv"
+        f"output.{Path(args.input_csv).stem}.csv"
     )
     write_csv_chunks_deterministic(
         reader,

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -79,7 +79,7 @@ class PipelineRunConfig:
         """Return the fully resolved path for ``name`` in the output directory."""
 
         stem = _DEFAULT_OUTPUT_STEMS[name]
-        filename = f"{self.date_prefix}_{stem}.csv"
+        filename = f"output.{stem}_{self.date_prefix}.csv"
         return self.output_dir / filename
 
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -31,7 +31,7 @@ def test_cli_utils_flags_and_help() -> None:
     assert actions["--input"].help == "Input CSV file"
     assert (
         actions["--output"].help
-        == "Destination CSV file (default: output_<stem>_<YYYYMMDD>.csv)"
+        == "Destination CSV file (default: output.<stem>_<YYYYMMDD>.csv)"
     )
     assert actions["--sep"].help == "CSV delimiter"
     assert actions["--encoding"].help == "File encoding"

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -134,7 +134,7 @@ def test_cli_generates_output_path(
 
     rc = cli.main(["--input", str(input_csv), "--key-cols", "a"])
     assert rc == 0
-    expected = input_csv.with_name("output_input_20240102.csv")
+    expected = input_csv.with_name("output.input_20240102.csv")
     assert called["output"] == expected
 
 

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -15,7 +15,7 @@ def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:
     cfg = IoCfg(output_dir=tmp_path)
     result = io.default_output_path(tmp_path / "input.csv", cfg)
     assert result.parent == tmp_path
-    assert result.name.startswith("output_input_")
+    assert result.name.startswith("output.input_")
 
 
 def test_mapper_run_defaults_to_io_output_dir(


### PR DESCRIPTION
## Summary
- update default output helpers and orchestrator steps to emit `output.<step>_<date>.csv`
- align CLI tooling, smoke helpers, and tests with the new filename template
- refresh English and Russian documentation with the dot-separated examples

## Testing
- pytest tests/test_default_output_dir.py tests/test_csv_utils_main_args.py tests/test_cli_utils.py *(fails: missing portalocker dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2fcbc7808324af8a57c88dd51ef0