### PR TITLE
Update CI smoke checks to run CLI entry points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,16 @@ jobs:
         run: pytest
       - name: Smoke test get_data orchestrator
         run: pytest -k "get_data_main_smoke"
-      - name: Verify deterministic CSV output
-        run: python scripts/check_determinism.py --log-level DEBUG
+      - name: Smoke CLI entry points
+        run: |
+          set -euxo pipefail
+          python -m scripts.get_data --help
+          tmp_output="$(mktemp -d)"
+          python -m library.utils.cli_tools.pipeline_targets_main \
+            --input tests/data/chembl_targets_min.csv \
+            --output "${tmp_output}/targets.csv" \
+            --log-level INFO \
+            --limit 2
       - name: Upload output data
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Sensitive configuration such as API tokens belongs in a local ``.env`` file – 
 pre-commit run --all-files
 pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
+python -m scripts.get_data --help
+tmp_dir=$(mktemp -d) && python -m library.utils.cli_tools.pipeline_targets_main \
+    --input tests/data/chembl_targets_min.csv \
+    --output "${tmp_dir}/targets.csv" --log-level INFO --limit 2
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
     --output out/mapped.csv --log-level INFO


### PR DESCRIPTION
## Summary
- replace the deprecated determinism script in CI with CLI smoke coverage for the get_data orchestrator and the cached target pipeline
- document the new smoke commands that CI exercises in the README test instructions

## Testing
- python -m scripts.get_data --help | head
- tmp_dir=$(mktemp -d) && python -m library.utils.cli_tools.pipeline_targets_main --input tests/data/chembl_targets_min.csv --output "${tmp_dir}/targets.csv" --log-level INFO --limit 2

------
https://chatgpt.com/codex/tasks/task_e_68dd2fcd8f448324b2c66481a83d7d17