### PR TITLE
Ensure PubChem responses are closed

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -229,9 +229,118 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
         try:
             session = get_session()
-            response = session.get(
+            with session.get(
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)
-            )
+            ) as response:
+                status = response.status_code
+                if status == 404:
+                    logger.info(
+                        "request_not_found", url=url, status=status, rps=cfg.rps
+                    )
+                    _store_cache_miss(url, cfg, "not_found")
+                    logger.info(
+                        "request_fail",
+                        url=url,
+                        status=status,
+                        total_attempts=total_attempts,
+                        rps=cfg.rps,
+                    )
+                    return None
+                if status == 429 or 500 <= status < 600:
+                    event_name = (
+                        "request_rate_limited"
+                        if status == 429
+                        else "request_server_error"
+                    )
+                    logger.warning(
+                        event_name,
+                        url=url,
+                        status=status,
+                        attempt=attempt,
+                        total_attempts=total_attempts,
+                        rps=cfg.rps,
+                    )
+                    if attempt >= total_attempts:
+                        logger.info(
+                            "request_fail",
+                            url=url,
+                            status=status,
+                            total_attempts=total_attempts,
+                            rps=cfg.rps,
+                        )
+                        return None
+                    delay = backoff_delay if backoff_delay > 0 else cfg.delay
+                    if delay > 0:
+                        sleep(delay)
+                        backoff_delay = delay * 2
+                    continue
+                if status >= 400:
+                    logger.warning(
+                        "request_unexpected_status",
+                        url=url,
+                        status=status,
+                        rps=cfg.rps,
+                    )
+                    logger.info(
+                        "request_fail",
+                        url=url,
+                        status=status,
+                        total_attempts=total_attempts,
+                        rps=cfg.rps,
+                    )
+                    return None
+
+                try:
+                    response.raise_for_status()
+                    data = cast(dict[str, Any], response.json())
+                except requests.RequestException as exc:  # pragma: no cover - network
+                    if attempt >= total_attempts:
+                        logger.error(
+                            "request_error",
+                            url=url,
+                            error=str(exc),
+                            attempt=attempt,
+                            total_attempts=total_attempts,
+                            rps=cfg.rps,
+                        )
+                        logger.info(
+                            "request_fail",
+                            url=url,
+                            status=status,
+                            total_attempts=total_attempts,
+                            rps=cfg.rps,
+                        )
+                        return None
+                    if cfg.delay > 0:
+                        sleep(cfg.delay)
+                    continue
+                except ValueError:
+                    logger.warning(
+                        "response_not_json",
+                        url=url,
+                        status=status,
+                        rps=cfg.rps,
+                    )
+                    logger.info(
+                        "request_fail",
+                        url=url,
+                        status=status,
+                        total_attempts=total_attempts,
+                        rps=cfg.rps,
+                    )
+                    return None
+
+                logger.debug(
+                    "request_ok",
+                    url=url,
+                    status=status,
+                    rps=cfg.rps,
+                )
+                with _CACHE_LOCK:
+                    cache = _ensure_cache(cfg.cache_ttl)
+                    cache[url] = _CacheEntry(payload=data, outcome="hit")
+                logger.info("cache_set", url=url, rps=cfg.rps, status="hit")
+                return data
         except requests.RequestException as exc:  # pragma: no cover - network
             if attempt >= total_attempts:
                 logger.error(
@@ -253,112 +362,6 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             if cfg.delay > 0:
                 sleep(cfg.delay)
             continue
-
-        status = response.status_code
-        if status == 404:
-            logger.info("request_not_found", url=url, status=status, rps=cfg.rps)
-            _store_cache_miss(url, cfg, "not_found")
-            logger.info(
-                "request_fail",
-                url=url,
-                status=status,
-                total_attempts=total_attempts,
-                rps=cfg.rps,
-            )
-            return None
-        if status == 429 or 500 <= status < 600:
-            event_name = (
-                "request_rate_limited" if status == 429 else "request_server_error"
-            )
-            logger.warning(
-                event_name,
-                url=url,
-                status=status,
-                attempt=attempt,
-                total_attempts=total_attempts,
-                rps=cfg.rps,
-            )
-            if attempt >= total_attempts:
-                logger.info(
-                    "request_fail",
-                    url=url,
-                    status=status,
-                    total_attempts=total_attempts,
-                    rps=cfg.rps,
-                )
-                return None
-            delay = backoff_delay if backoff_delay > 0 else cfg.delay
-            if delay > 0:
-                sleep(delay)
-                backoff_delay = delay * 2
-            continue
-        if status >= 400:
-            logger.warning(
-                "request_unexpected_status",
-                url=url,
-                status=status,
-                rps=cfg.rps,
-            )
-            logger.info(
-                "request_fail",
-                url=url,
-                status=status,
-                total_attempts=total_attempts,
-                rps=cfg.rps,
-            )
-            return None
-
-        try:
-            response.raise_for_status()
-            data = cast(dict[str, Any], response.json())
-        except requests.RequestException as exc:  # pragma: no cover - network
-            if attempt >= total_attempts:
-                logger.error(
-                    "request_error",
-                    url=url,
-                    error=str(exc),
-                    attempt=attempt,
-                    total_attempts=total_attempts,
-                    rps=cfg.rps,
-                )
-                logger.info(
-                    "request_fail",
-                    url=url,
-                    status=status,
-                    total_attempts=total_attempts,
-                    rps=cfg.rps,
-                )
-                return None
-            if cfg.delay > 0:
-                sleep(cfg.delay)
-            continue
-        except ValueError:
-            logger.warning(
-                "response_not_json",
-                url=url,
-                status=status,
-                rps=cfg.rps,
-            )
-            logger.info(
-                "request_fail",
-                url=url,
-                status=status,
-                total_attempts=total_attempts,
-                rps=cfg.rps,
-            )
-            return None
-
-        logger.debug(
-            "request_ok",
-            url=url,
-            status=status,
-            rps=cfg.rps,
-        )
-        with _CACHE_LOCK:
-            cache = _ensure_cache(cfg.cache_ttl)
-            cache[url] = _CacheEntry(payload=data, outcome="hit")
-        logger.info("cache_set", url=url, rps=cfg.rps, status="hit")
-        return data
 
     return None
 

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -19,14 +19,24 @@ class DummyResponse:
 
     status_code = 200
 
-    def __init__(self, payload: dict[str, object]) -> None:
+    def __init__(
+        self, payload: dict[str, object], close_log: list[object] | None = None
+    ) -> None:
         self._payload = payload
+        self._close_log = close_log
+        self.closed = False
 
     def __enter__(self) -> DummyResponse:
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no-op
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
         return None
+
+    def close(self) -> None:
+        self.closed = True
+        if self._close_log is not None:
+            self._close_log.append(True)
 
     def raise_for_status(self) -> None:  # pragma: no cover - no error
         return None
@@ -106,7 +116,7 @@ def test_make_request_serves_cached_results_across_threads(monkeypatch) -> None:
 
     with pc._CACHE_LOCK:
         pc._CACHE = TTLCache(maxsize=1024, ttl=cfg.cache_ttl)
-        pc._CACHE[url] = payload
+        pc._CACHE[url] = pc._CacheEntry(payload=payload, outcome="hit")  # type: ignore[attr-defined]
 
     results: list[dict[str, object]] = []
     start = threading.Event()
@@ -170,6 +180,34 @@ def test_make_request_cache_reinitialisation_threadsafe(monkeypatch) -> None:
     assert len(calls) >= 1
     with pc._CACHE_LOCK:
         pc._CACHE = None
+
+
+def test_make_request_closes_response(monkeypatch) -> None:
+    """HTTP responses should be closed after use."""
+
+    url = "https://example.org/close-check"
+    payload = {"ok": True}
+    cfg = pl.PubChemCfg(retries=0, delay=0)
+    close_log: list[object] = []
+
+    api_cfg = _configure_session()
+    session = pc.get_session(api_cfg)
+
+    monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
+    monkeypatch.setattr(pc, "sleep", lambda *_: None)
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> DummyResponse:
+        return DummyResponse(payload, close_log=close_log)
+
+    monkeypatch.setattr(session, "get", fake_get)
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    result = pc.make_request(url, cfg)
+
+    assert result == payload
+    assert close_log == [True]
 
 
 def test_get_session_initialises_once_under_concurrency(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- wrap PubChem HTTP requests in a context manager so responses are closed on every path
- update the thread-safe test stubs and add coverage ensuring response objects are closed

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd31a6b7f483248e6decc8e6888f3b