### PR TITLE
Guard PubChem session initialisation with a lock

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import threading
 from collections import ChainMap, OrderedDict, deque
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -346,6 +347,7 @@ def _pubchem_session_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
 
 
 _PUBCHEM_SESSION_SIGNATURE: str | None = None
+_PUBCHEM_SESSION_LOCK = threading.Lock()
 
 
 @dataclass
@@ -1798,9 +1800,10 @@ def augment_pubchem(
     if getattr(pubchem_cfg, "enable", True):
         global _PUBCHEM_SESSION_SIGNATURE
         session_signature = _pubchem_session_signature(api_cfg, retry_cfg)
-        if session_signature != _PUBCHEM_SESSION_SIGNATURE:
-            pl.init_session(api_cfg, retry_cfg)
-            _PUBCHEM_SESSION_SIGNATURE = session_signature
+        with _PUBCHEM_SESSION_LOCK:
+            if session_signature != _PUBCHEM_SESSION_SIGNATURE:
+                pl.init_session(api_cfg, retry_cfg)
+                _PUBCHEM_SESSION_SIGNATURE = session_signature
         pubchem_cid_cache = _load_pubchem_cid_cache(
             getattr(pubchem_cfg, "cid_cache_path", None),
             ttl_hours=getattr(pubchem_cfg, "cache_ttl_hours", None),

--- a/tests/test_testitem_pipeline_threadsafe.py
+++ b/tests/test_testitem_pipeline_threadsafe.py
@@ -1,0 +1,68 @@
+"""Concurrency tests for :mod:`library.testitem_pipeline`."""
+
+from __future__ import annotations
+
+import threading
+
+import pandas as pd
+
+from library.config import ApiCfg, PubChemCfg, RetryCfg
+from library import testitem_pipeline as pipeline
+
+
+def test_augment_pubchem_single_initialisation(monkeypatch) -> None:
+    """Ensure concurrent augmentation initialises the PubChem session once."""
+
+    threads = 5
+    barrier = threading.Barrier(threads)
+    init_lock = threading.Lock()
+    init_calls = 0
+
+    def fake_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
+        barrier.wait()
+        return "signature"
+
+    def fake_init_session(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> None:
+        nonlocal init_calls
+        with init_lock:
+            init_calls += 1
+
+    def fake_add_pubchem_data(df: pd.DataFrame, *_args, **_kwargs) -> pd.DataFrame:
+        return df
+
+    monkeypatch.setattr(pipeline, "_PUBCHEM_SESSION_SIGNATURE", None)
+    monkeypatch.setattr(pipeline, "_PUBCHEM_SESSION_LOCK", threading.Lock())
+    monkeypatch.setattr(pipeline, "_pubchem_session_signature", fake_signature)
+    monkeypatch.setattr(pipeline.pl, "init_session", fake_init_session)
+    monkeypatch.setattr(pipeline, "_load_pubchem_cid_cache", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(pipeline, "add_pubchem_data", fake_add_pubchem_data)
+
+    api_cfg = ApiCfg()
+    retry_cfg = RetryCfg()
+    pubchem_cfg = PubChemCfg()
+    df = pd.DataFrame()
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            pipeline.augment_pubchem(
+                df,
+                pubchem_cfg=pubchem_cfg,
+                api_cfg=api_cfg,
+                retry_cfg=retry_cfg,
+                timeout=1.0,
+                client=object(),
+                fields=None,
+                request_limit=10,
+            )
+        except BaseException as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    workers = [threading.Thread(target=worker) for _ in range(threads)]
+    for thread in workers:
+        thread.start()
+    for thread in workers:
+        thread.join()
+
+    assert not errors
+    assert init_calls == 1


### PR DESCRIPTION
## Summary
- protect the PubChem session signature update with a lock to avoid duplicate initialisation under concurrency
- add a threading-based unit test ensuring augment_pubchem only initialises the session once

## Testing
- pytest tests/test_testitem_pipeline_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd31a6efcc832480fa1dc0ba0f2305