### PR TITLE
Document CLI modules and enforce docstring coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
         run: ruff format --check .
       - name: Lint
         run: ruff check .
+      - name: Docstring coverage
+        run: >-
+          ruff check
+          --select D100,D101,D102,D103
+          scripts/get_activity_data.py
+          scripts/get_assay_data.py
+          scripts/get_document_data.py
+          scripts/get_target_data.py
+          scripts/get_testitem_data.py
+          library/io/paths.py
       - name: Type check
         run: mypy --strict library
       - name: Run tests

--- a/library/io/paths.py
+++ b/library/io/paths.py
@@ -9,7 +9,28 @@ from ..config import IoCfg
 
 
 def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
-    """Return the default output path for ``input_path``."""
+    """Construct a deterministic output path based on the input file name.
+
+    Parameters
+    ----------
+    input_path : str or pathlib.Path
+        Location of the CSV supplied to the pipeline. Only the stem is used
+        when generating the output file name.
+    cfg : IoCfg
+        IO configuration containing the destination directory for derived
+        artefacts.
+
+    Returns
+    -------
+    pathlib.Path
+        Path pointing to ``cfg.output_dir / f"output_<stem>_<YYYYMMDD>.csv"``.
+
+    Raises
+    ------
+    TypeError
+        Raised when ``cfg.output_dir`` cannot be coerced into a
+        :class:`pathlib.Path` instance.
+    """
 
     inp = Path(input_path)
     date_str = datetime.now().strftime("%Y%m%d")

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -1,4 +1,9 @@
-"""Command line interface for retrieving ChEMBL activity data."""
+"""Command line interface for retrieving ChEMBL activity data.
+
+The module exposes a ``main`` entry point compatible with setuptools console
+scripts as well as helpers that can be invoked directly from other
+applications or tests.
+"""
 
 from __future__ import annotations
 
@@ -61,7 +66,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration providing API credentials, retry strategy
+        and CSV export options.
     args : argparse.Namespace
         Parsed command-line arguments. ``args.limit`` constrains the number of
         identifiers processed, while ``args.dry_run`` skips network calls and
@@ -70,8 +76,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success, non-zero when validation or I/O failures are
+        encountered. Upstream API errors are logged and converted into a
+        failure code by :func:`library.cli_utils.run_pipeline`.
     """
     limit = cfg.activity.limit
     if limit is not None and limit < 0:
@@ -214,7 +221,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
-    """Create the command-line argument parser."""
+    """Create the command-line argument parser.
+
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        A tuple containing the fully configured parser and the logging
+        configuration populated with defaults.
+    """
     parser, log_cfg = base_parser(
         "ChEMBL activity data utilities",
         column="activity_id",
@@ -250,7 +264,25 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Execute the activity pipeline with optional argument overrides.
+
+    Parameters
+    ----------
+    argv : Sequence[str] | None, optional
+        Command-line arguments to parse. When ``None`` the values from
+        :data:`sys.argv` are used.
+
+    Returns
+    -------
+    int
+        ``0`` on success, non-zero otherwise. Errors are logged with
+        structured context for easier diagnosis.
+
+    Raises
+    ------
+    SystemExit
+        Raised when argument parsing fails, mirroring ``argparse`` behaviour.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit <= 0:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -1,4 +1,9 @@
-"""Command line interface for retrieving ChEMBL assay data."""
+"""Command line interface for retrieving ChEMBL assay data.
+
+The script provides a reusable :func:`main` entry point together with helper
+functions that unit tests import directly. Functions return explicit exit codes
+instead of terminating the interpreter to make orchestration easier.
+"""
 
 from __future__ import annotations
 
@@ -43,21 +48,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """Execute assay retrieval from the ChEMBL API.
 
     The output CSV arranges columns so that fields defined in
-    :class:`~schemas.assays.AssaysSchema` appear first.  Any additional columns
+    :class:`~schemas.assays.AssaysSchema` appear first. Any additional columns
     are appended alphabetically.
 
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration providing API credentials, retry strategy and
+        CSV export settings.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments accepted by the ``assay`` CLI command.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success, non-zero when validation or I/O failures occur.
+        Upstream API errors are logged and converted into a failure code by
+        :func:`library.cli_utils.run_pipeline`.
     """
     limit = cfg.assay.limit
     if limit is not None and limit < 0:
@@ -163,7 +170,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
-    """Create the command-line argument parser."""
+    """Create the command-line argument parser.
+
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        A tuple containing the fully configured parser and default logging
+        configuration for the pipeline run.
+    """
     parser, log_cfg = base_parser(
         "ChEMBL assay data utilities",
         column="assay_chembl_id",
@@ -194,7 +208,25 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Execute the assay pipeline with optional argument overrides.
+
+    Parameters
+    ----------
+    argv : Sequence[str] | None, optional
+        Command-line arguments to parse. When ``None`` the process arguments
+        from :data:`sys.argv` are used.
+
+    Returns
+    -------
+    int
+        ``0`` on success, non-zero otherwise. Failures are logged with context
+        describing the failing section.
+
+    Raises
+    ------
+    SystemExit
+        Raised when invalid command-line options are supplied.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     if args.limit is not None and args.limit <= 0:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -189,6 +189,14 @@ def fetch_pubmed_records(
         :class:`~pandas.DataFrame` batches is returned instead of a single
         concatenated frame.
 
+    Raises
+    ------
+    TypeError
+        Raised when required configuration arguments are omitted or supplied
+        multiple times. The function accepts either a
+        :class:`~library.config.Config` instance or explicit keyword arguments
+        describing the external services.
+
     Notes
     -----
     For backward compatibility the function also accepts a
@@ -1089,15 +1097,17 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration containing rate limiting, API and CSV export
+        settings.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments produced by :func:`build_parser`.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success. A non-zero value indicates that an error occurred
+        while reading input identifiers, fetching metadata or writing the
+        resulting CSV.
     """
     pubmed_defaults = cfg.document.pubmed
     limit = getattr(args, "limit", pubmed_defaults.limit)
@@ -1194,15 +1204,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration providing ChEMBL client, retry and CSV export
+        options.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments produced by :func:`build_parser`.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success. A non-zero value indicates that reading the input
+        identifiers, fetching ChEMBL data or exporting the CSV failed. Network
+        errors are logged and converted into placeholder rows where possible.
     """
     chembl_defaults = cfg.document.chembl
     limit = getattr(args, "limit", chembl_defaults.limit)
@@ -1273,15 +1285,21 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration combining all document pipeline defaults.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments produced by :func:`build_parser`.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
+        ``0`` on success. Non-zero results indicate that reading identifiers,
+        fetching data from upstream APIs or writing derived artefacts failed.
 
+    Raises
+    ------
+    ValueError
+        Raised when DOI fallback information derived from the ChEMBL payload is
+        internally inconsistent.
     """
     all_defaults = cfg.document.all
     limit = getattr(args, "limit", all_defaults.limit)
@@ -1423,8 +1441,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     Returns
     -------
     tuple[argparse.ArgumentParser, LoggerConfig]
-        Parser populated with all sub-commands and logging configuration.
-
+        Parser populated with all sub-commands and default logging
+        configuration used by :func:`main`.
     """
     root, shared, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
@@ -1597,7 +1615,26 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Command line entry point using :class:`Config` for defaults.
+
+    Parameters
+    ----------
+    argv : Sequence[str] | None, optional
+        Command-line arguments to parse. When ``None`` the process arguments
+        from :data:`sys.argv` are used.
+
+    Returns
+    -------
+    int
+        ``0`` when the selected pipeline completes successfully, non-zero
+        otherwise.
+
+    Raises
+    ------
+    SystemExit
+        Raised when argument validation fails and ``argparse`` aborts
+        execution.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     subparser_map = getattr(parser, "subparsers_map", {})

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -185,6 +185,12 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     data from individual sources (UniProt, ChEMBL and IUPHAR) as well as a
     convenience ``all`` command that runs all pipelines and merges their
     outputs.
+
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        Parser populated with every sub-command alongside the logging
+        configuration used by :func:`main`.
     """
 
     root, shared, log_cfg = build_root_parser()
@@ -404,20 +410,19 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
-    args:
-        Parsed command-line arguments specific to the ``uniprot`` sub-command.
+        Application configuration containing UniProt-specific overrides and
+        shared IO settings.
+    args : argparse.Namespace
+        Parsed command-line arguments produced by :func:`build_parser` for the
+        ``uniprot`` sub-command.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
-    Tests
-    -----
-    The post-processing step is covered by
-    :mod:`tests.test_target_postprocessing`.
-
+        ``0`` on success. Non-zero values indicate failures while reading the
+        input CSV, interacting with the UniProt data directory or producing the
+        derived artefacts. Input validation errors are logged and converted into
+        a failure code.
     """
     limit = cfg.target.uniprot.limit
     if limit is not None and limit < 0:
@@ -542,15 +547,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration providing ChEMBL client settings, retry
+        policy and CSV export behaviour.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments produced by :func:`build_parser`.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success. Non-zero values indicate that reading identifiers,
+        fetching data from the ChEMBL API, validating the result or writing the
+        CSV artefact failed. All errors are logged with structured context.
     """
     limit = cfg.target.chembl.limit
     if limit is not None and limit < 0:
@@ -688,15 +695,17 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     Parameters
     ----------
     cfg : Config
-        Application configuration.
+        Application configuration containing paths to the IUPHAR export files
+        and shared IO settings.
     args : argparse.Namespace
-        Parsed command-line arguments.
+        Parsed command-line arguments produced by :func:`build_parser`.
 
     Returns
     -------
     int
-        Zero on success, non-zero on failure.
-
+        ``0`` on success. Non-zero values indicate that the IUPHAR sources
+        could not be read, the combined dataset failed validation or the CSV
+        output could not be written.
     """
     limit = cfg.target.iuphar.limit
     if limit is not None and limit < 0:
@@ -790,19 +799,28 @@ def fetch_chembl(
 
     Parameters
     ----------
-    cfg:
-        Application configuration.
-    input_csv:
-        Source of ChEMBL identifiers.
-    output_csv:
-        Destination for the retrieved records.
-    limit:
-        Optional maximum number of identifiers to process.
+    cfg : Config
+        Application configuration used to drive the ChEMBL pipeline.
+    input_csv : pathlib.Path
+        Source CSV containing target identifiers.
+    output_csv : pathlib.Path
+        Destination path used by :func:`run_chembl` to persist results.
+    limit : int, optional
+        Maximum number of identifiers to process. ``None`` processes all rows.
+    chunk_size : int, optional
+        Temporary override for the batch size used when calling the API.
+    offset : int, optional
+        Number of identifiers to skip before starting the retrieval.
 
     Returns
     -------
     pandas.DataFrame
-        Retrieved ChEMBL data.
+        Retrieved ChEMBL data loaded from ``output_csv``.
+
+    Raises
+    ------
+    RuntimeError
+        Raised when :func:`run_chembl` reports a non-zero exit code.
     """
 
     logger.info("fetch_chembl_start", input=str(input_csv), output=str(output_csv))
@@ -837,18 +855,24 @@ def fetch_uniprot(
 
     Parameters
     ----------
-    cfg:
-        Application configuration.
-    chembl_df:
-        DataFrame containing at least one UniProt identifier column.
-    output_csv:
-        Destination for the UniProt data.
+    cfg : Config
+        Application configuration used to invoke :func:`run_uniprot`.
+    chembl_df : pandas.DataFrame
+        DataFrame containing ChEMBL target records with at least one UniProt
+        identifier column.
+    output_csv : pathlib.Path
+        Destination path populated by the UniProt pipeline.
 
     Returns
     -------
     pandas.DataFrame
         UniProt records with an additional ``original_id`` column preserving
         the queried accessions.
+
+    Raises
+    ------
+    RuntimeError
+        Raised when :func:`run_uniprot` returns a non-zero exit code.
     """
 
     logger.info("fetch_uniprot_start", output=str(output_csv))
@@ -905,20 +929,27 @@ def fetch_iuphar(
 
     Parameters
     ----------
-    cfg:
-        Application configuration.
-    chembl_df:
-        ChEMBL target data.
-    uniprot_df:
-        UniProt annotations with ``original_id`` column.
-    output_csv:
-        Destination for the IUPHAR mapping output.
+    cfg : Config
+        Application configuration containing IUPHAR resource paths.
+    chembl_df : pandas.DataFrame
+        ChEMBL target data obtained from :func:`fetch_chembl`.
+    uniprot_df : pandas.DataFrame
+        UniProt annotations with an ``original_id`` column provided by
+        :func:`fetch_uniprot`.
+    output_csv : pathlib.Path
+        Destination where :func:`run_iuphar` persists the retrieved
+        classifications.
 
     Returns
     -------
     tuple[pandas.DataFrame, pandas.DataFrame]
         Two data frames: the merged ChEMBL/UniProt input and the IUPHAR
         classification results.
+
+    Raises
+    ------
+    RuntimeError
+        Raised when :func:`run_iuphar` reports a non-zero exit code.
     """
 
     logger.info("fetch_iuphar_start", output=str(output_csv))
@@ -1039,17 +1070,22 @@ def merge_results(
 
     Parameters
     ----------
-    combined_df:
-        DataFrame containing ChEMBL and UniProt information.
-    iuphar_df:
-        Classification information from IUPHAR.
-    cfg:
-        Application configuration.
+    combined_df : pandas.DataFrame
+        DataFrame containing ChEMBL and UniProt information produced by
+        :func:`fetch_iuphar`.
+    iuphar_df : pandas.DataFrame
+        IUPHAR classification results aligned with ``combined_df`` on
+        ``uniprot_id``.
+    cfg : Config
+        Application configuration providing classifier settings.
+    classifier : library.iuphar_library.IUPHARClassifier, optional
+        Pre-initialised classifier. When ``None`` a classifier is created from
+        ``cfg``.
 
     Returns
     -------
     pandas.DataFrame
-        Merged and post-processed target data.
+        Merged and post-processed target data ready for validation and export.
     """
 
     logger.info("merge_results_start")
@@ -1068,17 +1104,18 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
 
     Parameters
     ----------
-    df:
+    df : pandas.DataFrame
         DataFrame produced by :func:`merge_results`.
-    output:
+    output : pathlib.Path
         Destination CSV path.
-    cfg:
-        Application configuration.
+    cfg : Config
+        Application configuration providing schema definitions and IO settings.
 
     Returns
     -------
     int
-        Zero on success, non-zero on validation failure.
+        ``0`` on success. Non-zero values indicate validation errors or
+        failures when generating table-quality reports.
     """
 
     logger.info("validate_write_start", output=str(output))
@@ -1138,7 +1175,23 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
 
 
 def run_all(cfg: Config, args: argparse.Namespace) -> int:
-    """Run the full target acquisition pipeline."""
+    """Run the full target acquisition pipeline.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration combining defaults for every individual
+        pipeline.
+    args : argparse.Namespace
+        Parsed command-line arguments produced by :func:`build_parser`.
+
+    Returns
+    -------
+    int
+        ``0`` on success. Non-zero values indicate failures while fetching
+        data, validating the merged dataset or writing the resulting CSV. The
+        offending step is logged in the ``pipeline_step_failed`` event.
+    """
 
     limit = cfg.target.all.limit
     if limit is not None and limit < 0:
@@ -1186,7 +1239,24 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Command line entry point using :class:`Config` for defaults.
+
+    Parameters
+    ----------
+    argv : Sequence[str] | None, optional
+        Command-line arguments to parse. When ``None`` the values from
+        :data:`sys.argv` are used.
+
+    Returns
+    -------
+    int
+        ``0`` when the selected target pipeline succeeds, non-zero otherwise.
+
+    Raises
+    ------
+    SystemExit
+        Raised when invalid command-line options are provided to the parser.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
     subparser_map = getattr(parser, "subparsers_map", {})

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -1,4 +1,9 @@
-"""Command line interface for retrieving ChEMBL and PubChem compound data."""
+"""Command line interface for retrieving ChEMBL test item data.
+
+The module wraps :func:`library.testitem_pipeline.run_testitem_pipeline` while
+exposing helpers that tests can import directly. Entry points return numeric
+exit codes rather than terminating the interpreter to simplify orchestration.
+"""
 
 from __future__ import annotations
 
@@ -48,7 +53,21 @@ _integrate_missing_identifiers = _integrate_missing_identifiers
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
-    """Invoke the reusable test item pipeline with CLI parameters."""
+    """Invoke the reusable test item pipeline with CLI parameters.
+
+    Parameters
+    ----------
+    cfg : Config
+        Application configuration containing ChEMBL, PubChem and IO settings.
+    args : argparse.Namespace
+        Parsed command-line arguments produced by :func:`build_parser`.
+
+    Returns
+    -------
+    int
+        ``0`` on success. Non-zero values indicate that identifier loading,
+        network requests or CSV export failed inside the test item pipeline.
+    """
 
     output_csv = getattr(args, "output_csv", None)
     options = TestitemPipelineOptions(
@@ -59,7 +78,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
-    """Create the command-line argument parser."""
+    """Create the command-line argument parser.
+
+    Returns
+    -------
+    tuple[argparse.ArgumentParser, LoggerConfig]
+        Parser configured with the common CLI options and the associated logging
+        configuration used by :func:`main`.
+    """
 
     parser, log_cfg = base_parser(
         "ChEMBL and PubChem compound data utilities",
@@ -91,7 +117,24 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Command line entry point using :class:`Config` for defaults.
+
+    Parameters
+    ----------
+    argv : Sequence[str] | None, optional
+        Command-line arguments to parse. When ``None`` the values from
+        :data:`sys.argv` are used.
+
+    Returns
+    -------
+    int
+        ``0`` when the pipeline finishes successfully, non-zero otherwise.
+
+    Raises
+    ------
+    SystemExit
+        Raised when invalid command-line options are provided.
+    """
 
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- document the public entry points in the data acquisition CLI scripts and clarify module purpose
- extend helper documentation for target data utilities and shared IO path helpers
- add a CI docstring coverage step using Ruff to guard against regressions

## Testing
- ruff check --select D100,D101,D102,D103 scripts/get_activity_data.py scripts/get_assay_data.py scripts/get_document_data.py scripts/get_target_data.py scripts/get_testitem_data.py library/io/paths.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2fce2c988324a965041ccf4f54d1