### PR TITLE
Align CLI default outputs with documented naming pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ python -m scripts.get_data \
 ```
 
 The command reads files such as `data/input/document.csv`, writes outputs like
-`data/output/20240101_documents.csv` and stops if any step fails. / Команда
+`data/output/output.documents_20240101.csv` and stops if any step fails. / Команда
 использует входы вида `data/input/document.csv`, сохраняет результаты в
-файлы `data/output/20240101_documents.csv` и прерывает выполнение при ошибке
+файлы `data/output/output.documents_20240101.csv` и прерывает выполнение при ошибке
 любого шага.
 
 **EN.** `library.utils.cli_tools.pipeline_targets_main` is a cached harness

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -604,7 +604,8 @@ def prepare_io_paths(
         target_dir = output_dir or base_path
         if target_dir is not None:
             effective_date = date_str or datetime.now(timezone.utc).strftime("%Y%m%d")
-            resolved_output = (target_dir / f"{effective_date}_{output_stem}{suffix}").resolve()
+            filename = f"output.{output_stem}_{effective_date}{suffix}"
+            resolved_output = (target_dir / filename).resolve()
             date_str = effective_date
 
     if resolved_output is not None:

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -52,7 +52,7 @@ def _cli_args(*extra: str, date: str = DEFAULT_DATE, log_level: str = "ERROR") -
 def _expected_output(output_dir: Path, stem: str, *, date: str = DEFAULT_DATE) -> Path:
     """Return the expected output path for ``stem`` and ``date``."""
 
-    return output_dir / f"{date}_{stem}.csv"
+    return output_dir / f"output.{stem}_{date}.csv"
 
 
 def test_get_data_main_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,7 +136,9 @@ def test_get_data_main_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert exit_code == 0
     assert invocations == [step.name for step in stub_steps]
     for step in stub_steps:
-        path = output_dir / f"20240101_{get_data._DEFAULT_OUTPUT_STEMS[step.name]}.csv"
+        path = output_dir / (
+            f"output.{get_data._DEFAULT_OUTPUT_STEMS[step.name]}_20240101.csv"
+        )
         assert path.exists()
         assert path.read_text() == f"{step.name} output\n"
 
@@ -209,7 +211,7 @@ def test_get_activity_data_smoke(
     exit_code = get_activity_data.main(_cli_args())
     assert exit_code == 0
     assert output_csv.exists()
-    assert output_csv.name == f"{DEFAULT_DATE}_activities.csv"
+    assert output_csv.name == f"output.activities_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
 
     df = pd.read_csv(output_csv)
@@ -268,7 +270,7 @@ def test_get_assay_data_smoke(
     exit_code = get_assay_data.main(_cli_args())
     assert exit_code == 0
     assert output_csv.exists()
-    assert output_csv.name == f"{DEFAULT_DATE}_assays.csv"
+    assert output_csv.name == f"output.assays_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
 
     df = pd.read_csv(output_csv)
@@ -329,7 +331,7 @@ def test_get_document_data_smoke(
     exit_code = get_document_data.main(["chembl", *_cli_args()])
     assert exit_code == 0
     assert output_csv.exists()
-    assert output_csv.name == f"{DEFAULT_DATE}_documents.csv"
+    assert output_csv.name == f"output.documents_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
 
     df = pd.read_csv(output_csv)
@@ -382,7 +384,7 @@ def test_get_target_data_smoke(
     exit_code = get_target_data.main(["chembl", *_cli_args()])
     assert exit_code == 0
     assert output_csv.exists()
-    assert output_csv.name == f"{DEFAULT_DATE}_targets.csv"
+    assert output_csv.name == f"output.targets_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
 
     df = pd.read_csv(output_csv)
@@ -506,7 +508,7 @@ def test_get_testitem_data_smoke(
     exit_code = get_testitem_data.main(_cli_args())
     assert exit_code == 0
     assert output_csv.exists()
-    assert output_csv.name == f"{DEFAULT_DATE}_testitems.csv"
+    assert output_csv.name == f"output.testitems_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
     assert polymer_smiles not in smiles_calls
     assert mixture_smiles not in smiles_calls

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -16,6 +16,9 @@ def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:
     result = io.default_output_path(tmp_path / "input.csv", cfg)
     assert result.parent == tmp_path
     assert result.name.startswith("output.input_")
+    stem_prefix, date_part = result.stem.split("_", maxsplit=1)
+    assert stem_prefix == "output.input"
+    assert len(date_part) == 8 and date_part.isdigit()
 
 
 def test_mapper_run_defaults_to_io_output_dir(
@@ -50,5 +53,9 @@ def test_mapper_run_defaults_to_io_output_dir(
 
     expected = io.default_output_path(input_path, cfg.io)
     assert expected.exists()
+    assert expected.name.startswith("output.data_")
+    stem_prefix, date_part = expected.stem.split("_", maxsplit=1)
+    assert stem_prefix == "output.data"
+    assert len(date_part) == 8 and date_part.isdigit()
     df = pd.read_csv(expected)
     assert "mapping_uniprot_id" in df.columns


### PR DESCRIPTION
## Summary
- update `library.cli.prepare_io_paths` to synthesize `output.<step>_<date>.csv` filenames when no output is provided
- extend CLI/path smoke coverage to assert the updated naming convention and adjust expectations accordingly
- refresh README guidance so documented examples match the generated filenames

## Testing
- pytest tests/test_default_output_dir.py tests/smoke/test_get_data_scripts.py *(fails: SyntaxError in scripts/get_testitem_data.py during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68dd34db96048324872c0bf981d37bfc