### PR TITLE
Avoid printing config without flag in target pipeline CLI

### DIFF
--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -183,10 +183,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     pipeline_logger = logger_inst.bind(stage="pipeline")
     pipeline_logger.info("pipeline_start")
     cfg = cli.apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
-    print_config(cfg)
     if args.print_config:
+        print_config(cfg)
         return 0
+    ensure_dirs(cfg)
     try:
         options = PipelineConfig.model_validate(
             {

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -162,3 +162,55 @@ def test_cli_limit_restricts_rows(
     assert captured["batch_size"] == 100
     assert captured["chunks"] == [["CHEMBL1", "CHEMBL2"]]
     assert captured["written_path"] == output_csv
+
+
+def test_cli_does_not_print_config_when_flag_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf8")
+    output_csv = tmp_path / "out.csv"
+
+    def fake_run_pipeline(
+        chunk_iterator: Any,
+        cfg: Config,
+        *,
+        chembl_fetcher: Any,
+        batch_size: int | None,
+        **_: Any,
+    ) -> PipelineResult:
+        next(chunk_iterator())
+        return PipelineResult(chembl=pd.DataFrame({"target_chembl_id": ["CHEMBL1"]}))
+
+    def fake_write_csv(
+        df: pd.DataFrame,
+        path: Path | str,
+        *,
+        cfg: Config,
+        sep: str | None = None,
+        encoding: str | None = None,
+    ) -> Path:
+        return Path(path)
+
+    dummy_logger = _DummyLogger()
+    monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *a: Config())
+    monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
+
+    def fail_print_config(_: Config) -> None:
+        raise AssertionError("print_config should not be called")
+
+    monkeypatch.setattr(cli, "print_config", fail_print_config)
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(cli, "write_csv", fake_write_csv)
+
+    args = [
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+    ]
+    exit_code = cli.main(args)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
## Summary
- ensure the target pipeline CLI only prints configuration when explicitly requested
- short-circuit configuration printing before directory validation to keep normal runs quiet
- add a regression test verifying the CLI does not emit stdout during regular execution

## Testing
- pytest tests/test_pipeline_targets_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dd370e99fc8324b8a9102dd3b595a8