### PR TITLE
Lower cache log level for ChemblClient

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -5,4 +5,5 @@
 - Clarified the minimum supported Python version as 3.11 across documentation and runtime checks.
 - Documented the requirement to configure `api.user_agent` with a real contact, including validation behaviour and the
   `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT` environment override.
+- Downgraded ChEMBL cache hit/miss logging to DEBUG to reduce noise in default INFO logs.
 

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -165,11 +165,11 @@ class ChemblClient:
         with self._cache_lock:
             cached = self.cache.get(cache_key)
             if cached is not None:
-                logger.info(
+                logger.debug(
                     "cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"}
                 )
                 return cast(dict[str, Any], cached)
-            logger.info(
+            logger.debug(
                 "cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"}
             )
 

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -190,17 +190,21 @@ def test_request_json_logs_per_request_events_as_debug(
 
     cfg = api_cfg(retries=2, backoff_factor=0)
     client.request_json("http://example.com", cfg=cfg)
+    client.request_json("http://example.com", cfg=cfg)
 
     records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
     levels = {
         record["event"]: record["level"]
         for record in records
-        if record["event"] in {"request_start", "request_retry", "request_ok"}
+        if record["event"]
+        in {"request_start", "request_retry", "request_ok", "cache_miss", "cache_hit"}
     }
 
     assert levels["request_start"] == "DEBUG"
     assert levels["request_retry"] == "DEBUG"
     assert levels["request_ok"] == "DEBUG"
+    assert levels["cache_miss"] == "DEBUG"
+    assert levels["cache_hit"] == "DEBUG"
 
 
 def test_request_json_reuses_session(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- lower the ChEMBL client cache hit/miss log level to DEBUG to reduce INFO-level noise
- extend the logging test to validate cache hit and miss events use DEBUG
- note the logging change in the release notes

## Testing
- pytest tests/test_chembl_client.py::test_request_json_logs_per_request_events_as_debug

------
https://chatgpt.com/codex/tasks/task_e_68dd372900c88324bd0cebeb78697633