### PR TITLE
Ensure CSV CLI closes chunk readers and add FD leak test

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -63,27 +63,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     encoding = args.encoding or cfg.io.csv_encoding
     chunk_size = args.chunk_size or cfg.io.csv_chunksize
 
-    reader = pd.read_csv(
+    output = args.output_csv or Path(args.input_csv).with_name(
+        f"output.{Path(args.input_csv).stem}.csv"
+    )
+    with pd.read_csv(
         args.input_csv,
         sep=sep,
         encoding=encoding,
         chunksize=chunk_size,
-    )
-    output = args.output_csv or Path(args.input_csv).with_name(
-        f"output.{Path(args.input_csv).stem}.csv"
-    )
-    write_csv_chunks_deterministic(
-        reader,
-        output,
-        col_order=args.col_order or None,
-        key_cols=args.key_cols,
-        chunksize=chunk_size,
-        merge_chunksize=args.merge_chunk_size,
-        sep=cfg.io.csv_sep,
-        encoding=cfg.io.csv_encoding,
-        cfg=cfg,
-        drop_unexpected_cols=True,
-    )
+    ) as reader:
+        write_csv_chunks_deterministic(
+            reader,
+            output,
+            col_order=args.col_order or None,
+            key_cols=args.key_cols,
+            chunksize=chunk_size,
+            merge_chunksize=args.merge_chunk_size,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            cfg=cfg,
+            drop_unexpected_cols=True,
+        )
     elapsed = time.perf_counter() - start
     logger.info("write_done", path=str(args.output_csv))
     logger.info("run_completed", elapsed=elapsed)

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -10,6 +10,35 @@ import yaml
 from library.utils.cli_tools import csv_utils_main as cli
 
 
+def _fd_count() -> int:
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.exists():
+        pytest.skip("/proc filesystem required to inspect file descriptors")
+    return sum(1 for _ in fd_dir.iterdir())
+
+
+class DummyReader(Iterator[pd.DataFrame]):
+    def __init__(self, frames: Iterable[pd.DataFrame]):
+        self._frames = iter(frames)
+        self.closed = False
+
+    def __iter__(self) -> "DummyReader":
+        return self
+
+    def __next__(self) -> pd.DataFrame:
+        return next(self._frames)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> "DummyReader":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        self.close()
+        return False
+
+
 def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     input_csv = tmp_path / "in.csv"
     input_csv.write_text("a|b\n1|2\n", encoding="latin1")
@@ -23,16 +52,13 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
         chunksize: int,
         *args: Any,
         **kwargs: Any,
-    ) -> Iterator[pd.DataFrame]:
+    ) -> DummyReader:
         called["path"] = path
         called["sep"] = sep
         called["encoding"] = encoding
         called["chunksize"] = chunksize
 
-        def gen() -> Iterator[pd.DataFrame]:
-            yield pd.DataFrame({"a": [1], "b": [2]})
-
-        return gen()
+        return DummyReader([pd.DataFrame({"a": [1], "b": [2]})])
 
     def fake_write(
         chunks: Iterable[pd.DataFrame],
@@ -102,13 +128,9 @@ def test_cli_generates_output_path(
         chunksize: int,
         *args: Any,
         **kwargs: Any,
-    ) -> Iterator[pd.DataFrame]:
+    ) -> DummyReader:
         called["path"] = path
-
-        def gen() -> Iterator[pd.DataFrame]:
-            yield pd.DataFrame({"a": [1], "b": [2]})
-
-        return gen()
+        return DummyReader([pd.DataFrame({"a": [1], "b": [2]})])
 
     def fake_write(
         chunks: Iterable[pd.DataFrame],
@@ -159,16 +181,13 @@ def test_cli_uses_configured_delimiter(
         chunksize: int,
         *args: Any,
         **kwargs: Any,
-    ) -> Iterator[pd.DataFrame]:
+    ) -> DummyReader:
         called["path"] = path
         called["sep"] = sep
         called["encoding"] = encoding
         called["chunksize"] = chunksize
 
-        def gen() -> Iterator[pd.DataFrame]:
-            yield pd.DataFrame({"a": [1], "b": [2]})
-
-        return gen()
+        return DummyReader([pd.DataFrame({"a": [1], "b": [2]})])
 
     def fake_write(
         chunks: Iterable[pd.DataFrame],
@@ -209,3 +228,26 @@ def test_cli_uses_configured_delimiter(
     assert called["write_sep"] == ";"
     assert called["write_encoding"] == "latin1"
     assert called["write_chunksize"] == 256
+
+
+def test_cli_does_not_leak_file_descriptors(tmp_path: Path) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id,value\n1,a\n2,b\n", encoding="utf8")
+
+    baseline = _fd_count()
+    base_args = [
+        "--input",
+        str(input_csv),
+        "--key-cols",
+        "id",
+        "--chunk-size",
+        "1",
+    ]
+
+    for run in range(3):
+        output = tmp_path / f"out_{run}.csv"
+        rc = cli.main([*base_args, "--output", str(output)])
+        assert rc == 0
+        assert output.exists()
+
+    assert _fd_count() == baseline


### PR DESCRIPTION
## Summary
- wrap the CSV export CLI chunk reader in a context manager so the file handle closes deterministically
- adapt the CLI argument tests to provide context-manageable fake readers
- add a regression test that ensures file descriptor counts remain stable across repeated CLI runs

## Testing
- pytest tests/test_csv_utils_main_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dd371b67208324bedce872b2257e2b