### PR TITLE
Enhance chunk IO CLI configuration handling

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -6,6 +6,7 @@ import argparse
 from collections.abc import Sequence
 from pathlib import Path
 
+from library import cli
 from library.chunk_io import process_csv_chunks
 from library.cli import (
     LoggerConfig,
@@ -13,7 +14,8 @@ from library.cli import (
     configure_logger,
     path_argument,
 )
-from library.config import Config, ensure_dirs
+from library.config import Config, ensure_dirs, print_config
+from library.utils.config import DEFAULT_CONFIG_RELATIVE
 from library.io.paths import default_output_path
 from library.log import logger
 
@@ -41,6 +43,18 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=path_argument,
         default=Path("checkpoint.json"),
         help="Path to checkpoint file",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config",
+        type=path_argument,
+        default=DEFAULT_CONFIG_RELATIVE,
+        help="YAML configuration file",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
     )
     return parser, LoggerConfig(level="INFO")
 
@@ -99,7 +113,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     log_cfg.level = args.log_level
     configure_logger(log_cfg)
-    cfg = Config()
+    try:
+        cfg = cli.apply_config_overrides(args, parser, args.config)
+    except (TypeError, ValueError) as exc:
+        logger.error(
+            "config_error",
+            error=str(exc),
+            config=str(args.config),
+        )
+        return 1
+    if args.print_config:
+        print_config(cfg)
+        return 0
     return run(cfg, args)
 
 

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+import textwrap
 
 import pandas as pd
+import yaml
 
 from library.utils.cli_tools import chunk_io_main as cli
 
@@ -64,3 +66,92 @@ def test_cli_creates_output_directory(tmp_path: Path) -> None:
     assert output_path.exists()
     result = pd.read_csv(output_path)
     assert len(result) == len(df)
+
+
+def test_cli_print_config_honours_overrides(tmp_path: Path, capsys) -> None:
+    """CLI prints the effective configuration with overrides applied."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            system:
+              log:
+                level: "ERROR"
+            local:
+              io:
+                csv_sep: ";"
+                csv_encoding: "utf-8"
+                exist_ok: true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--output",
+            str(tmp_path / "out.csv"),
+            "--log-level",
+            "DEBUG",
+            "--sep",
+            "|",
+            "--print-config",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = yaml.safe_load(captured.out)
+    assert data["system"]["log"]["level"] == "DEBUG"
+    assert data["local"]["io"]["csv_sep"] == "|"
+
+
+def test_cli_invalid_config_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """CLI reports invalid configurations and exits with code 1."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            system:
+              log:
+                level: "NOT_A_LEVEL"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    logged: list[tuple[str, dict[str, object]]] = []
+
+    def fake_error(event: str, *args: object, **kwargs: object) -> None:
+        logged.append((event, kwargs))
+
+    monkeypatch.setattr(cli.logger, "error", fake_error)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--output",
+            str(tmp_path / "out.csv"),
+            "--log-level",
+            "INFO",
+        ]
+    )
+
+    assert exit_code == 1
+    assert logged
+    event, payload = logged[0]
+    assert event == "config_error"
+    assert payload.get("config") == str(config_path)


### PR DESCRIPTION
## Summary
- load the chunked IO CLI configuration through `apply_config_overrides`, add config printing, and surface invalid configuration errors
- extend the chunk IO CLI parser with `--config`/`--print-config` options to mirror other tools
- add regression tests covering configuration overrides and invalid configuration handling

## Testing
- pytest tests/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dd370b8c6883248325d1d444aa08ea