### PR TITLE
Ensure CSV and metadata writes are atomic

### DIFF
--- a/library/csv_utils.py
+++ b/library/csv_utils.py
@@ -26,6 +26,7 @@ from pandas.api import types as ptypes
 from .config import Config
 from .io.metadata import write_meta_yaml
 from .log import logger
+from .utils.atomic import open_atomic
 
 
 def _normalise_bool(series: pd.Series) -> pd.Series:
@@ -553,7 +554,7 @@ def write_csv_chunks_deterministic(
                     )
                     heapq.heappush(heap, (key, idx, 0))
 
-            with out_path.open("w", encoding=encoding, newline="") as fh:
+            with open_atomic(out_path, encoding=encoding, newline="") as fh:
                 writer = csv.writer(fh, delimiter=sep, lineterminator="\n")
                 writer.writerow(columns)
                 while heap:

--- a/library/io/metadata.py
+++ b/library/io/metadata.py
@@ -11,6 +11,7 @@ import yaml
 
 from ..config import Config, _mask_secrets, _serialize_paths
 from ..git_utils import _git_sha
+from ..utils.atomic import open_atomic
 
 
 def write_meta_yaml(
@@ -36,6 +37,6 @@ def write_meta_yaml(
         ),
     }
     meta_path = Path(f"{path}.meta.yaml")
-    with meta_path.open("w", encoding="utf8") as fh:
+    with open_atomic(meta_path, encoding="utf8") as fh:
         yaml.safe_dump(meta, fh, sort_keys=False)
     return meta_path

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -20,6 +20,7 @@ import yaml
 from .config import _mask_secrets
 from .git_utils import _git_sha
 from .log import logger
+from .utils.atomic import open_atomic
 
 # ``datetime.UTC`` is only available in Python 3.11 and later.
 # ``timezone.utc`` provides the same value and works on older versions.
@@ -123,7 +124,7 @@ def write_meta_yaml(
         }
     )
 
-    with meta_path.open("w", encoding="utf-8") as fh:
+    with open_atomic(meta_path, encoding="utf-8") as fh:
         yaml.safe_dump(metadata, fh, sort_keys=False)
         logger.info("metadata_written", path=str(meta_path))
 

--- a/tests/test_csv_atomic.py
+++ b/tests/test_csv_atomic.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import library.csv_utils as csv_utils
+from library.csv_utils import write_csv_chunks_deterministic
+
+
+def test_write_csv_chunks_failure_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "out.csv"
+    path.write_text("sentinel\n", encoding="utf-8-sig")
+
+    df = pd.DataFrame({"id": [1], "value": [2]})
+
+    original_open_atomic = csv_utils.open_atomic
+
+    @contextmanager
+    def failing_open_atomic(*args: Any, **kwargs: Any) -> Any:
+        with original_open_atomic(*args, **kwargs) as handle:
+            class FaultyFile:
+                def __init__(self, wrapped: Any) -> None:
+                    self._wrapped = wrapped
+                    self._writes = 0
+
+                def write(self, data: Any) -> Any:
+                    self._writes += 1
+                    if self._writes < 2:
+                        return self._wrapped.write(data)
+                    raise RuntimeError("boom")
+
+                def __getattr__(self, name: str) -> Any:
+                    return getattr(self._wrapped, name)
+
+            yield FaultyFile(handle)
+
+    monkeypatch.setattr(csv_utils, "open_atomic", failing_open_atomic)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        write_csv_chunks_deterministic(
+            [df],
+            path,
+            key_cols=["id"],
+        )
+
+    assert path.read_text(encoding="utf-8-sig") == "sentinel\n"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -92,6 +92,39 @@ def test_write_meta_yaml_preserves_existing_columns(tmp_path: Path) -> None:
     assert data["stats"] == stats
 
 
+def test_write_meta_yaml_failure_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csv_path = tmp_path / "output.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+    meta_path = csv_path.with_name(csv_path.name + ".meta.yaml")
+    meta_path.write_text("sentinel: true\n", encoding="utf-8")
+
+    stats: Stats = {
+        "rows_total": 1,
+        "rows_kept": 1,
+        "rows_dropped": 0,
+        "output_sha256": "deadbeef",
+    }
+
+    def failing_dump(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(yaml, "safe_dump", failing_dump)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        write_meta_yaml(
+            csv_path=csv_path,
+            command="cmd",
+            config_subset={},
+            inputs={},
+            stats=stats,
+            schema="Schema",
+        )
+
+    assert meta_path.read_text(encoding="utf-8") == "sentinel: true\n"
+
+
 def test_git_sha_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     """_git_sha uses the ``GIT_SHA`` environment variable when available."""
 


### PR DESCRIPTION
## Summary
- use `open_atomic` when streaming the final CSV from chunked writes
- guard both metadata writers with atomic file writes
- add tests that simulate write failures and confirm the existing files remain untouched

## Testing
- `pytest tests/test_csv_atomic.py tests/test_metadata.py::test_write_meta_yaml_failure_preserves_original`


------
https://chatgpt.com/codex/tasks/task_e_68dd3719a17c83249dd53ee77063e2dd