### PR TITLE
Fix bootstrap project root handling

### DIFF
--- a/library/utils/bootstrap.py
+++ b/library/utils/bootstrap.py
@@ -1,8 +1,8 @@
 """Runtime helpers for script execution.
 
 This module ensures that executing a script via ``python scripts/foo.py``
-behaves the same as ``python -m scripts.foo`` by pre-pending the project
-root to :mod:`sys.path`.
+behaves the same as ``python -m scripts.foo`` by pre-pending the repository
+root (``library/utils/../..``) to :mod:`sys.path`.
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def ensure_project_root() -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,27 @@
+"""Tests for :mod:`library.utils.bootstrap`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+from library.utils import bootstrap
+
+
+def test_ensure_project_root_supports_importing_schemas(monkeypatch: pytest.MonkeyPatch) -> None:
+  """The helper pre-pends the repository root and enables importing ``schemas``."""
+
+  project_root = str(bootstrap._PROJECT_ROOT)
+  sanitized_path = [entry for entry in sys.path if entry != project_root]
+  monkeypatch.setattr(sys, "path", sanitized_path, raising=False)
+  monkeypatch.delitem(sys.modules, "schemas", raising=False)
+
+  bootstrap.ensure_project_root()
+
+  assert sys.path[0] == project_root
+
+  module: ModuleType = importlib.import_module("schemas")
+  assert module.__name__ == "schemas"


### PR DESCRIPTION
## Summary
- resolve the bootstrap project root using Path(__file__).parents[2] and update the helper documentation
- add a regression test ensuring ensure_project_root inserts the repository path and allows importing schemas

## Testing
- pytest tests/test_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3c0c3c288324b6923b602171fd02