### PR TITLE
Configure service-specific sessions for OpenAlex and CrossRef

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1110,6 +1110,28 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
     return session
 
 
+def _session_with_mailto_header(
+    api: ApiCfg, retry: RetryCfg, mailto: str
+) -> Session:
+    """Return a session configured with the ``mailto`` contact header."""
+
+    session = session_with_retry(api, retry)
+    session.headers["mailto"] = mailto
+    return session
+
+
+def openalex_session(api: ApiCfg, retry: RetryCfg, cfg: OpenAlexCfg) -> Session:
+    """Return a session configured for OpenAlex requests."""
+
+    return _session_with_mailto_header(api, retry, cfg.mailto)
+
+
+def crossref_session(api: ApiCfg, retry: RetryCfg, cfg: CrossRefCfg) -> Session:
+    """Return a session configured for CrossRef requests."""
+
+    return _session_with_mailto_header(api, retry, cfg.mailto)
+
+
 def _set_by_path(data: dict[str, Any], path: list[str], value: Any) -> None:
     cur: dict[str, Any] = data
     for key in path[:-1]:
@@ -1616,6 +1638,8 @@ __all__ = [
     "RateCfg",
     "RetryCfg",
     "session_with_retry",
+    "openalex_session",
+    "crossref_session",
     "LogCfg",
     "ChemblSourceCfg",
     "SourcesCfg",

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -28,7 +28,7 @@ import argparse
 import sys
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, AbstractContextManager
 from itertools import chain, islice, tee
 from pathlib import Path
 from threading import Lock
@@ -77,8 +77,10 @@ from library.config import (
     SemanticScholarCfg,
     _serialize_paths,
     ensure_dirs,
+    openalex_session,
     print_config,
     session_with_retry,
+    crossref_session,
 )
 from library.document_pipeline import (
     DOCUMENT_SCHEMA_COLUMNS,
@@ -397,7 +399,7 @@ def fetch_pubmed_records(
             def __init__(
                 self,
                 stack: ExitStack,
-                factory: Callable[[], requests.Session],
+                factory: Callable[[], AbstractContextManager[requests.Session]],
             ) -> None:
                 self._stack = stack
                 self._factory = factory
@@ -429,9 +431,15 @@ def fetch_pubmed_records(
                     session_with_retry(__cfg.api, __cfg.retry)
                 )
 
-                session_factories: dict[str, Callable[[], requests.Session]] = {
-                    "openalex": lambda: session_with_retry(__cfg.api, __cfg.retry),
-                    "crossref": lambda: session_with_retry(__cfg.api, __cfg.retry),
+                session_factories: dict[
+                    str, Callable[[], AbstractContextManager[requests.Session]]
+                ] = {
+                    "openalex": lambda: openalex_session(
+                        __cfg.api, __cfg.retry, openalex_cfg
+                    ),
+                    "crossref": lambda: crossref_session(
+                        __cfg.api, __cfg.retry, crossref_cfg
+                    ),
                 }
 
                 session_pools = {
@@ -440,7 +448,7 @@ def fetch_pubmed_records(
                 }
 
                 def _invoke_with_session(
-                    service: str,
+                    factory: Callable[[], AbstractContextManager[requests.Session]],
                     fetcher: Callable[
                         [requests.Session, str, Any, RateLimiter | None], dict[str, str]
                     ],
@@ -449,7 +457,7 @@ def fetch_pubmed_records(
                     cfg_obj: Any,
                     limiter: RateLimiter | None,
                 ) -> dict[str, str]:
-                    with session_pools[service].session() as nested_session:
+                    with factory() as nested_session:
                         return fetcher(nested_session, identifier, cfg_obj, limiter)
 
                 _acquire_documents(pubmed_service_limiter)
@@ -529,7 +537,7 @@ def fetch_pubmed_records(
                         openalex_service_limiter, use_global=False
                     )
                     return _invoke_with_session(
-                        "openalex",
+                        session_pools["openalex"].session,
                         ocl.fetch_openalex,
                         pmid,
                         cfg_obj=openalex_cfg,
@@ -571,7 +579,7 @@ def fetch_pubmed_records(
                         crossref_service_limiter, use_global=False
                     )
                     return _invoke_with_session(
-                        "crossref",
+                        session_pools["crossref"].session,
                         ocl.fetch_crossref,
                         doi,
                         cfg_obj=crossref_cfg,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,13 +8,21 @@ import pandas as pd
 import pytest
 from pydantic import BaseModel, Field, ValidationError
 
+import library.config as config_module
+
 from library.cli import LoggerConfig, configure_logger
 from library.config import (
+    ApiCfg,
     Config,
     ConfigError,
+    CrossRefCfg,
+    OpenAlexCfg,
+    RetryCfg,
     build_alias_map,
+    crossref_session,
     ensure_dirs,
     load_config,
+    openalex_session,
 )
 from library.utils.config import DEFAULT_CONFIG_PATH
 from scripts import get_target_data as target_cli
@@ -413,9 +421,9 @@ def test_user_agent_default_and_overrides(
     path.write_text(
         "sources:\n"
         "  openalex:\n"
-        "    mailto: info@example.org\n"
+        "    mailto: contact@ebi.ac.uk\n"
         "  crossref:\n"
-        "    mailto: info@example.org\n"
+        "    mailto: contact@ebi.ac.uk\n"
     )
     monkeypatch.delenv("CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT", raising=False)
     cfg = load_config(path)
@@ -608,3 +616,59 @@ def test_log_level_invalid_no_mapping(
     level_names = {name.upper(): level for name, level in logging._nameToLevel.items()}
     valid = ", ".join(sorted(level_names))
     assert f"log.level must be one of {valid}, got 'verbose'" in str(exc.value)
+
+
+def test_openalex_session_applies_mailto_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAlex session helper should forward the configured contact email."""
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def __enter__(self) -> "DummySession":  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *_: object) -> bool:  # pragma: no cover - trivial
+            return False
+
+    created = DummySession()
+
+    def fake_session_with_retry(*_: object, **__: object) -> DummySession:
+        return created
+
+    monkeypatch.setattr(config_module, "session_with_retry", fake_session_with_retry)
+
+    session = openalex_session(ApiCfg(), RetryCfg(), OpenAlexCfg(mailto="contact@ebi.ac.uk"))
+
+    assert session is created
+    assert session.headers.get("mailto") == "contact@ebi.ac.uk"
+
+
+def test_crossref_session_applies_mailto_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CrossRef session helper should forward the configured contact email."""
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def __enter__(self) -> "DummySession":  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *_: object) -> bool:  # pragma: no cover - trivial
+            return False
+
+    created = DummySession()
+
+    def fake_session_with_retry(*_: object, **__: object) -> DummySession:
+        return created
+
+    monkeypatch.setattr(config_module, "session_with_retry", fake_session_with_retry)
+
+    session = crossref_session(ApiCfg(), RetryCfg(), CrossRefCfg(mailto="contact@ebi.ac.uk"))
+
+    assert session is created
+    assert session.headers.get("mailto") == "contact@ebi.ac.uk"


### PR DESCRIPTION
## Summary
- add helper utilities to build OpenAlex and CrossRef sessions that include the configured contact email
- update the document acquisition pipeline to use service-specific session factories when invoking OpenAlex and CrossRef calls
- extend configuration tests to cover the new helpers and ensure default mailto values use valid contact addresses

## Testing
- pytest tests/test_config.py -q
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_returns_generator_in_order -q
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_handles_generic_error -q

------
https://chatgpt.com/codex/tasks/task_e_68dd3c10c1748324a1c85d290d555d89