### PR TITLE
Skip CrossRef lookups for missing DOIs

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -516,9 +516,9 @@ def fetch_pubmed_records(
                     if pmid:
                         openalex_lookup.setdefault(pmid, []).append(index)
                         openalex_total += 1
-                    crossref_key = doi or ""
-                    crossref_lookup.setdefault(crossref_key, []).append(index)
-                    crossref_total += 1
+                    if doi:
+                        crossref_lookup.setdefault(doi, []).append(index)
+                        crossref_total += 1
 
                 openalex_results: dict[int, dict[str, str]] = {}
                 crossref_results: dict[int, dict[str, str]] = {}
@@ -565,7 +565,7 @@ def fetch_pubmed_records(
                     for idx in indexes:
                         openalex_results[idx] = result
 
-                crossref_jobs = list(crossref_lookup.keys())
+                crossref_jobs = [doi for doi in crossref_lookup.keys() if doi]
                 def _fetch_crossref_job(doi: str) -> dict[str, str]:
                     _acquire_documents(
                         crossref_service_limiter, use_global=False

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -1136,6 +1136,89 @@ def test_openalex_and_crossref_jobs_acquire_service_limiters(
     assert limiters["documents_crossref"].acquisitions == 1
 
 
+def test_crossref_jobs_skip_missing_doi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CrossRef jobs ignore records without a DOI when scheduling fetches."""
+
+    class TrackingLimiter:
+        def __init__(self) -> None:
+            self.acquisitions = 0
+            self._lock = threading.Lock()
+
+        def acquire(self) -> None:
+            with self._lock:
+                self.acquisitions += 1
+
+    limiters = {
+        "documents_global": DummyLimiter(),
+        "documents_crossref": TrackingLimiter(),
+    }
+
+    def fake_get_limiter(name: str, *_, **__) -> Any:
+        return limiters.get(name, DummyLimiter())
+
+    monkeypatch.setattr(gdd, "get_limiter", fake_get_limiter)
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            return None
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: DummySession())
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "PubMed.PMID": pmid,
+                "PubMed.DOI": "10.1000/xyz" if pmid != "1" else "",
+            }
+            for pmid in batch
+        ]
+
+    def fake_semantic_batch(
+        session: Any,
+        pmids: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [{"scholar.PMID": pmid} for pmid in pmids]
+
+    seen_crossref: list[str] = []
+
+    def fake_crossref(
+        session: Any, doi: str, cfg: Any, limiter: Any
+    ) -> dict[str, str]:
+        seen_crossref.append(doi)
+        return {}
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", lambda *_, **__: {})
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
+
+    gdd.fetch_pubmed_records(
+        ["1", "2"],
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+    )
+
+    assert limiters["documents_crossref"].acquisitions == 1
+    assert seen_crossref == ["10.1000/xyz"]
+
+
 def test_documents_limiter_enforces_shared_pace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- skip scheduling CrossRef lookups for records without DOIs and avoid counting them in reuse metrics
- ensure CrossRef jobs list never includes blank identifiers
- add regression test confirming CrossRef limiter statistics ignore rows missing DOIs

## Testing
- pytest tests/test_get_document_data.py -k crossref

------
https://chatgpt.com/codex/tasks/task_e_68dd3c0ee04083248b2873d312119f62