### PR TITLE
Respect PubChem batch size when fetching properties

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1236,6 +1236,7 @@
         },
         "batch_size": {
           "default": 50,
+          "description": "Maximum PubChem property lookups submitted per batch; concurrency is capped by pubchem.rps",
           "minimum": 1,
           "title": "Batch Size",
           "type": "integer"

--- a/library/config.py
+++ b/library/config.py
@@ -370,7 +370,11 @@ class PubChemCfg(_BaseModel):
         default=Path("data/cache/pubchem_cid_cache.json"),
         description="Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
     )
-    batch_size: int = Field(50, ge=1)
+    batch_size: int = Field(
+        50,
+        ge=1,
+        description="Maximum PubChem property lookups submitted per batch; concurrency is capped by pubchem.rps",
+    )
     prefer_local_smiles: bool = Field(
         False,
         description="Skip PubChem lookups when existing pubchem_* columns are complete",

--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -1543,7 +1543,9 @@ def _merge_pubchem_properties(
 
     lookup_order = sorted(lookup_cids)
     if lookup_order:
-        batch_size = max(int(getattr(cfg, "rps", 1)), 1)
+        configured_batch_size = max(int(getattr(cfg, "batch_size", 1)), 1)
+        rps_limit = max(int(getattr(cfg, "rps", configured_batch_size)), 1)
+        batch_size = min(configured_batch_size, rps_limit)
 
         def _fetch_properties(cid: str) -> pl.Properties:
             return pl.get_properties(cid, cfg)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -872,6 +872,100 @@ def test_merge_pubchem_properties_preserves_existing_values(
     assert pubchem_df.loc[2, "pubchem_molecular_formula"] == "formula"
 
 
+def test_merge_pubchem_properties_throttles_by_rps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    count = 5
+    frame = pd.DataFrame({"value": range(count)})
+    cid_series = pd.Series(
+        [f"CID-{idx}" for idx in range(count)], index=frame.index, dtype="string"
+    )
+    lookup_cids = set(cid_series.tolist())
+    cfg = pl.PubChemCfg(delay=0, rps=2, batch_size=10)
+
+    lock = threading.Lock()
+    active = 0
+    peak_active = 0
+
+    def fake_get_properties(cid: str, pubchem_cfg: pl.PubChemCfg) -> pl.Properties:
+        nonlocal active, peak_active
+        assert pubchem_cfg is cfg
+        with lock:
+            active += 1
+            peak_active = max(peak_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+        return pl.Properties(f"name-{cid}", None, None, None, None, None)
+
+    monkeypatch.setattr(pl, "get_properties", fake_get_properties)
+
+    skip_mask = pd.Series(False, index=frame.index)
+    prefer_local_mask = pd.Series(False, index=frame.index)
+
+    result = pipeline._merge_pubchem_properties(
+        frame,
+        cid_series,
+        lookup_cids,
+        cfg=cfg,
+        skip_mask=skip_mask,
+        prefer_local_mask=prefer_local_mask,
+    )
+
+    assert peak_active == cfg.rps
+    assert result["pubchem_cid"].tolist() == cid_series.tolist()
+    assert result["pubchem_iupac_name"].tolist() == [
+        f"name-{cid}" for cid in cid_series.tolist()
+    ]
+
+
+def test_merge_pubchem_properties_uses_batch_size_when_below_rps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    count = 6
+    frame = pd.DataFrame({"value": range(count)})
+    cid_series = pd.Series(
+        [f"CID-{idx}" for idx in range(count)], index=frame.index, dtype="string"
+    )
+    lookup_cids = set(cid_series.tolist())
+    cfg = pl.PubChemCfg(delay=0, rps=10, batch_size=3)
+
+    lock = threading.Lock()
+    active = 0
+    peak_active = 0
+
+    def fake_get_properties(cid: str, pubchem_cfg: pl.PubChemCfg) -> pl.Properties:
+        nonlocal active, peak_active
+        assert pubchem_cfg is cfg
+        with lock:
+            active += 1
+            peak_active = max(peak_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+        return pl.Properties(f"name-{cid}", None, None, None, None, None)
+
+    monkeypatch.setattr(pl, "get_properties", fake_get_properties)
+
+    skip_mask = pd.Series(False, index=frame.index)
+    prefer_local_mask = pd.Series(False, index=frame.index)
+
+    result = pipeline._merge_pubchem_properties(
+        frame,
+        cid_series,
+        lookup_cids,
+        cfg=cfg,
+        skip_mask=skip_mask,
+        prefer_local_mask=prefer_local_mask,
+    )
+
+    assert peak_active == cfg.batch_size
+    assert result["pubchem_cid"].tolist() == cid_series.tolist()
+    assert result["pubchem_iupac_name"].tolist() == [
+        f"name-{cid}" for cid in cid_series.tolist()
+    ]
+
+
 def test_add_pubchem_data_fetches_properties_in_parallel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- derive PubChem property fetch batch size from the configured value while capping concurrency by the rps limit
- document the updated PubChem batch behaviour in the generated configuration schema
- add unit tests that cover both rps throttling and batch size limited property fetches

## Testing
- pytest tests/test_get_testitem_data.py::test_merge_pubchem_properties_throttles_by_rps tests/test_get_testitem_data.py::test_merge_pubchem_properties_uses_batch_size_when_below_rps

------
https://chatgpt.com/codex/tasks/task_e_68dd446479c08324a85592bd0582e6dc