### PR TITLE
Add coverage for ensure_no_parant_column guard

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -56,6 +56,7 @@ from library.testitem_pipeline import (
     _prepare_pubchem_api_cfg as _pipeline_prepare_pubchem_api_cfg,
     _load_pubchem_cid_cache as _pipeline_load_pubchem_cid_cache,
     integrate_missing_identifiers as _integrate_missing_identifiers,
+    _TYPO_PARENT_COLUMN as _pipeline_typo_parent_column,
 )
 
 # Re-export helpers consumed directly by unit tests.
@@ -75,6 +76,7 @@ load_molecule_hierarchy_lookup = _pipeline_load_molecule_hierarchy_lookup
 file_sha256 = _pipeline_file_sha256
 write_meta_yaml = _pipeline_write_meta_yaml
 PUBCHEM_CID_CACHE_ENCODING = _pipeline_pubchem_cid_cache_encoding
+_TYPO_PARENT_COLUMN = _pipeline_typo_parent_column
 
 
 # ===== Parameters =====

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -133,6 +133,16 @@ def test_fetch_testitems_failure(monkeypatch: pytest.MonkeyPatch, cfg: Config) -
     assert requested_ids == ()
 
 
+def test_ensure_no_parant_column_raises() -> None:
+    df = pd.DataFrame([{"parant_molecule_id": "CHEMBL1"}])
+
+    with pytest.raises(
+        ValueError,
+        match="unexpected column 'parant_molecule_id'; use 'parent_molecule_id' instead",
+    ):
+        gtd.ensure_no_parant_column(df)
+
+
 def test_fetch_testitems_passes_fields_and_limit(
     monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- add a regression test for `ensure_no_parant_column` to cover the legacy typo column guard
- re-export the `_TYPO_PARENT_COLUMN` constant in `scripts/get_testitem_data.py` so the helper uses the pipeline value

## Testing
- `pytest` *(fails: numerous pre-existing failures unrelated to the new test; see log for details)*
- `pytest tests/test_get_testitem_data.py::test_ensure_no_parant_column_raises`


------
https://chatgpt.com/codex/tasks/task_e_68dd4465c27483249a33b3b1741a4f66