### PR TITLE
Fix test item CLI parent column validation

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -3,6 +3,8 @@
 The module wraps :func:`library.testitem_pipeline.run_testitem_pipeline` while
 exposing helpers that tests can import directly. Entry points return numeric
 exit codes rather than terminating the interpreter to simplify orchestration.
+The :func:`ensure_no_parant_column` helper guards against legacy CSV exports
+that still include the misspelled parent identifier column.
 """
 
 from __future__ import annotations
@@ -40,6 +42,7 @@ from library.testitem_pipeline import (
     PUBCHEM_CID_CACHE_ENCODING as _pipeline_pubchem_cid_cache_encoding,
     ReadInputIdsResult as _ReadInputIdsResult,
     TestitemPipelineOptions,
+    _TYPO_PARENT_COLUMN,
     analyze_table_quality as _analyze_table_quality,
     file_sha256 as _pipeline_file_sha256,
     fetch_testitems as _fetch_testitems,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -26,6 +26,17 @@ from schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
 
 
+def test_ensure_no_parant_column_smoke() -> None:
+    """The helper re-exports the pipeline validation logic."""
+
+    valid_df = pd.DataFrame({"parent_molecule_id": ["CHEMBL1"]})
+    gtd.ensure_no_parant_column(valid_df)
+
+    invalid_df = pd.DataFrame({pipeline._TYPO_PARENT_COLUMN: ["CHEMBL1"]})
+    with pytest.raises(ValueError):
+        gtd.ensure_no_parant_column(invalid_df)
+
+
 def prepare_parent_lookup_data(
     df: pd.DataFrame, catalog_cfg
 ) -> pipeline.ParentLookupPreparedData:


### PR DESCRIPTION
## Summary
- document the CLI helper that validates legacy typo columns
- import the pipeline typo-column constant into the CLI module to keep the guard in sync
- add a smoke test covering valid and invalid inputs for `ensure_no_parant_column`

## Testing
- pytest tests/test_get_testitem_data.py -k ensure_no_parant_column_smoke

------
https://chatgpt.com/codex/tasks/task_e_68dd445ff11083248948f40acd172c5a