### PR TITLE
Document CLI entry points across README and usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ The README is available in multiple languages:
 * Полная статическая типизация (PEP 484), линтинг `ruff`, форматирование
   `black`, проверка типов `mypy`, юнит‑тесты `pytest`.
 
+## Console entry points / Консольные точки входа
+
+**EN.** Installing the project via `pip install .` registers dedicated
+console scripts for each pipeline. Use them interchangeably with the
+`python -m …` invocations shown throughout the documentation.
+
+**RU.** После установки `pip install .` для каждого пайплайна становятся
+доступны консольные команды. Их можно использовать вместо вызовов
+`python -m …`, приведённых в примерах ниже.
+
+| Console script | Module equivalent | Назначение |
+| -------------- | ----------------- | ---------- |
+| `get-data` | `python -m scripts.get_data` | Orchestrates the full export / Оркестратор всех этапов |
+| `get-activity-data` | `python -m scripts.get_activity_data` | Activity data export / Выгрузка активностей |
+| `get-assay-data` | `python -m scripts.get_assay_data` | Assay metadata / Метаданные ассайев |
+| `get-document-data` | `python -m scripts.get_document_data` | Document metadata / Метаданные документов |
+| `get-target-data` | `python -m scripts.get_target_data` | Target aggregation / Агрегация таргетов |
+| `get-testitem-data` | `python -m scripts.get_testitem_data` | Test item enrichment / Обогащение тест-объектов |
+| `csv-utils` | `python -m library.utils.cli_tools.csv_utils_main` | CSV helpers / Утилиты работы с CSV |
+| `mapper` | `python -m library.utils.cli_tools.mapper_main` | Identifier mapping / Маппинг идентификаторов |
+| `table-quality` | `python -m library.utils.cli_tools.table_quality_main` | Quality reports / Отчёты качества |
+| `chunk-io` | `python -m library.utils.cli_tools.chunk_io_main` | Chunked IO harness / Обвязка чтения чанков |
+| `get-activities` | `python -m library.utils.cli_tools.get_activities` | Smoke logger / Демонстрация логов |
+| `check-determinism` | `python -m library.utils.cli_tools.check_determinism` | Determinism checks / Проверка детерминизма |
+
 ## Требования
 
 | Компонент     | Минимальная версия | Последняя протестированная |

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,25 +76,40 @@ for usage guidelines.
 
    Git hooks ensure formatting, linting, static type checks and tests run before each commit.
 
-3. **Run a sample script**
+3. **Explore the installed console scripts**
+
+   After running `pip install .`, the package exposes dedicated entry points for each pipeline. The commands mirror the
+   `python -m …` launches used during development:
+
+   | Console script | Module equivalent |
+   | -------------- | ----------------- |
+   | `get-data` | `python -m scripts.get_data` |
+   | `get-activity-data` | `python -m scripts.get_activity_data` |
+   | `get-assay-data` | `python -m scripts.get_assay_data` |
+   | `get-document-data` | `python -m scripts.get_document_data` |
+   | `get-target-data` | `python -m scripts.get_target_data` |
+   | `get-testitem-data` | `python -m scripts.get_testitem_data` |
+
+   Use `--help` to inspect the interface and run smoke-grade exports straight from the shell:
+
+   ```bash
+   get-activity-data --input tests/data/activity_ids_small.csv \
+       --output out/activities.csv --limit 10 --log-level INFO
+   get-document-data pubmed --input tests/data/pmids.csv \
+       --output out/documents.csv --limit 5 --log-level INFO
+   ```
+
+   The console scripts accept the same options as their module counterparts, so existing `python -m …` workflows remain valid:
 
    ```bash
    python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
-   ```
-
-   This lightweight helper only emits structured log messages describing the dummy activity rows it would generate; it neither
-   reads input files nor writes outputs. Use it to verify logging configuration and CLI wiring before launching full pipelines.
-   Common CLI flags include `--limit` to cap processed records, `--log-level` for verbosity, `--sep` for CSV delimiters and
-   `--encoding` for file encoding. For end-to-end exports that create files, run one of the data pipelines, for example:
-
-   ```bash
    python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
        --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
    python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
        --output out/quality --table-name chembl_targets --log-level INFO
    ```
 
-   In the second example the `--output` argument must point to a directory where the report files will be created.
+   In the reporting example above the `--output` argument must point to a directory where the report files will be created.
 
 4. **Run the tests** – see [Tests](#tests).
 
@@ -149,6 +164,9 @@ as a CI artifact.
 ## Usage
 
 The examples below demonstrate how to run the main CLI tools with common options such as `--input`, `--output` and `--limit`.
+After installing the project with `pip install .`, the same pipelines can be started via the console scripts listed in the
+[Quick Start](#quick-start) table—for example, `get-activity-data --help` is equivalent to `python -m scripts.get_activity_data --help`.
+Both forms accept identical arguments, so feel free to swap between them depending on your environment.
 
 ### `scripts/get_document_data.py`
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -75,22 +75,39 @@ pre-commit install
 
    Git-хуки гарантируют запуск форматирования, линтеров, статических проверок и тестов перед каждым коммитом.
 
-3. **Запустите демонстрационный скрипт**
+3. **Изучите установленные консольные скрипты**
+
+   После выполнения `pip install .` пакет публикует точки входа для каждого пайплайна. Команды полностью повторяют запуск через `python -m …`, используемый в разработке:
+
+   | Консольная команда | Эквивалент модуля |
+   | ------------------ | ----------------- |
+   | `get-data` | `python -m scripts.get_data` |
+   | `get-activity-data` | `python -m scripts.get_activity_data` |
+   | `get-assay-data` | `python -m scripts.get_assay_data` |
+   | `get-document-data` | `python -m scripts.get_document_data` |
+   | `get-target-data` | `python -m scripts.get_target_data` |
+   | `get-testitem-data` | `python -m scripts.get_testitem_data` |
+
+   Используйте `--help`, чтобы изучить интерфейс, и запускайте дымовые проверки напрямую из консоли:
+
+   ```bash
+   get-activity-data --input tests/data/activity_ids_small.csv \
+       --output out/activities.csv --limit 10 --log-level INFO
+   get-document-data pubmed --input tests/data/pmids.csv \
+       --output out/documents.csv --limit 5 --log-level INFO
+   ```
+
+   Консольные утилиты принимают те же аргументы, поэтому привычные сценарии `python -m …` продолжают работать:
 
    ```bash
    python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
-   ```
-
-   Лёгкий хелпер выводит структурированные логи о фиктивных строках активностей и не выполняет чтение/запись файлов. Используйте его для проверки настроек логирования и обвязки CLI перед запуском полноценных пайплайнов. Распространённые флаги: `--limit` для ограничения записей, `--log-level` для детализации, `--sep` для разделителей CSV и `--encoding` для кодировок. Для полной выгрузки запустите один из рабочих пайплайнов, например:
-
-   ```bash
    python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
        --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
    python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
        --output out/quality --table-name chembl_targets --log-level INFO
    ```
 
-   Во втором примере аргумент `--output` должен указывать на каталог, куда будут сохранены файлы отчёта.
+   В примере с отчётностью аргумент `--output` должен указывать на каталог, где будут сохранены результаты.
 
 4. **Запустите тесты** — см. раздел [Тесты](#тесты).
 
@@ -139,6 +156,10 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 ## Использование
 
 Ниже приведены примеры запуска основных CLI-инструментов с типовыми флагами (`--input`, `--output`, `--limit`).
+После установки пакета через `pip install .` те же пайплайны доступны в виде консольных скриптов из таблицы в разделе
+[Быстрый старт](#быстрый-старт) — например, `get-activity-data --help` полностью эквивалентен
+`python -m scripts.get_activity_data --help`. Оба варианта принимают одинаковые аргументы, поэтому выбирайте форму, удобную
+для вашей среды.
 
 ### `scripts/get_document_data.py`
 

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -2,8 +2,21 @@
 
 ## Shared CLI options
 
-All `scripts/get_*_data.py` commands share a common interface. Only
-`scripts/get_document_data.py` and `scripts/get_target_data.py` expose
+All `scripts/get_*_data.py` commands share a common interface. After
+installing the package with `pip install .`, each pipeline is also
+available as a console entry point:
+
+| Console script | Module form |
+| -------------- | ----------- |
+| `get-data` | `python -m scripts.get_data` |
+| `get-activity-data` | `python -m scripts.get_activity_data` |
+| `get-assay-data` | `python -m scripts.get_assay_data` |
+| `get-document-data` | `python -m scripts.get_document_data` |
+| `get-target-data` | `python -m scripts.get_target_data` |
+| `get-testitem-data` | `python -m scripts.get_testitem_data` |
+
+Pick whichever style fits your environment; both accept identical options.
+Only `scripts/get_document_data.py` and `scripts/get_target_data.py` expose
 source-selection sub-commands (`chembl`, `uniprot`, `iuphar`, or `all`);
 the remaining pipelines (`get_activity_data.py`, `get_assay_data.py`, and
 `get_testitem_data.py`) are single-command CLIs that accept options
@@ -54,7 +67,7 @@ diagnose problematic batches.
 Pipe the output through `jq` or similar tooling for real-time monitoring:
 
 ```bash
-python scripts/get_document_data.py all --input docs.csv --column document_chembl_id \
+get-document-data all --input docs.csv --column document_chembl_id \
   | tee run.log | jq -r '"\(.level) \(.event) :: \(.msg // "")"'
 ```
 
@@ -62,8 +75,20 @@ Adjust verbosity with `--log-level DEBUG` for troubleshooting, or rely on the de
 
 ## Activity data (`get_activity_data.py`)
 
+Console form:
+
 ```bash
-python scripts/get_activity_data.py \
+get-activity-data --input tests/data/activity_ids_small.csv \
+  --column activity_id \
+  --batch-size 25 \
+  --timeout 45 \
+  --offset 5
+```
+
+Module form:
+
+```bash
+python -m scripts.get_activity_data \
   --input tests/data/activity_ids_small.csv \
   --column activity_id \
   --batch-size 25 \
@@ -80,8 +105,18 @@ python scripts/get_activity_data.py \
 
 ## Assay descriptions (`get_assay_data.py`)
 
+Console form:
+
 ```bash
-python scripts/get_assay_data.py \
+get-assay-data --input path/to/assay_ids.csv \
+  --column assay_chembl_id \
+  --batch-size 25
+```
+
+Module form:
+
+```bash
+python -m scripts.get_assay_data \
   --input path/to/assay_ids.csv \
   --column assay_chembl_id \
   --batch-size 25
@@ -91,8 +126,18 @@ Fetches assay metadata from ChEMBL using the configured identifier column. Prepa
 
 ## Document metadata (`get_document_data.py`)
 
+Console form:
+
 ```bash
-python scripts/get_document_data.py all \
+get-document-data all --input path/to/documents.csv \
+  --column document_chembl_id \
+  --batch-size 20
+```
+
+Module form:
+
+```bash
+python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
   --batch-size 20
@@ -103,19 +148,32 @@ example:
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
-  python scripts/get_document_data.py all \
-    --input path/to/documents.csv \
+  get-document-data all --input path/to/documents.csv \
     --column document_chembl_id
 ```
 
 The same effect can be achieved by editing `sources.chembl.pipelines.document.pubmed.batch_size` in `config/config.yaml`.
 Choose the `pubmed`, `chembl`, or `all` sub-command depending on the desired sources.
-Consult `python scripts/get_document_data.py --help` for a summary and
-`python scripts/get_document_data.py <sub-command> --help` for the
+Consult `get-document-data --help` for a summary and
+`get-document-data <sub-command> --help` for the
 allowed switches (for example, `--batch-size` for PubMed batching).
 
+Console form:
+
 ```bash
-python scripts/get_document_data.py pubmed \
+get-document-data pubmed --input path/to/documents.csv \
+  --column PMID \
+  --openalex-rps 2.5 \
+  --crossref-rps 1.5 \
+  --fallback-doi-csv path/to/doi_overrides.csv \
+  --fallback-doi-pmid-column pmid_override \
+  --fallback-doi-value-column doi_override
+```
+
+Module form:
+
+```bash
+python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
   --openalex-rps 2.5 \
@@ -130,8 +188,17 @@ CSV parameters plug in a minimal PMID→DOI mapping before the remote services a
  
 ## Target aggregation (`get_target_data.py`)
 
+Console form:
+
 ```bash
-python scripts/get_target_data.py chembl \
+get-target-data chembl --input path/to/targets.csv \
+  --column target_chembl_id
+```
+
+Module form:
+
+```bash
+python -m scripts.get_target_data chembl \
   --input path/to/targets.csv \
   --column target_chembl_id
 ```
@@ -162,8 +229,17 @@ before hitting external APIs.
 
 ## Test item enrichment (`get_testitem_data.py`)
 
+Console form:
+
 ```bash
-python scripts/get_testitem_data.py \
+get-testitem-data --input tests/data/input-smoke/testitem.csv \
+  --column molecule_chembl_id
+```
+
+Module form:
+
+```bash
+python -m scripts.get_testitem_data \
   --input tests/data/input-smoke/testitem.csv \
   --column molecule_chembl_id
 ```
@@ -187,8 +263,19 @@ sources:
 
 Run a configuration-backed export with the tuned settings:
 
+Console form:
+
 ```bash
-python scripts/get_testitem_data.py \
+get-testitem-data --config config/config.yaml \
+  --input data/input/testitem_ids.csv \
+  --batch-size 750 \
+  --offset 500
+```
+
+Module form:
+
+```bash
+python -m scripts.get_testitem_data \
   --config config/config.yaml \
   --input data/input/testitem_ids.csv \
   --batch-size 750 \
@@ -274,7 +361,7 @@ CLI flags cover the documented arguments for each script. For example, the activ
 `--batch-size`, `--timeout`, `--limit` and `--dry-run`:
 
 ```bash
-python scripts/get_activity_data.py --batch-size 25 --timeout 45
+get-activity-data --batch-size 25 --timeout 45
 ```
 
 Nested configuration values are adjusted via `config/config.yaml` or environment variables. To temporarily raise the
@@ -282,7 +369,7 @@ ChEMBL API rate limit without editing the file, export an override and execute t
 
 ```bash
 export CHEMBL_DA__SOURCES__CHEMBL__API__RPS=10
-python scripts/get_activity_data.py
+get-activity-data
 ```
 
 Inspect the effective configuration with `--print-config` before running the pipeline when needed.

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -6,6 +6,19 @@
 ## Общие параметры CLI
 
 Все команды `scripts/get_*_data.py` поддерживают единый набор аргументов.
+После установки пакета командой `pip install .` каждый пайплайн доступен
+и как консольный скрипт:
+
+| Консольная команда | Запуск через `python -m` |
+| ------------------ | ------------------------ |
+| `get-data` | `python -m scripts.get_data` |
+| `get-activity-data` | `python -m scripts.get_activity_data` |
+| `get-assay-data` | `python -m scripts.get_assay_data` |
+| `get-document-data` | `python -m scripts.get_document_data` |
+| `get-target-data` | `python -m scripts.get_target_data` |
+| `get-testitem-data` | `python -m scripts.get_testitem_data` |
+
+Выбирайте подходящий формат — оба варианта принимают идентичные аргументы.
 Подкоманды для выбора источника (`chembl`, `uniprot`, `iuphar`, `all`)
 доступны только у `scripts/get_document_data.py` и
 `scripts/get_target_data.py`; остальные скрипты (`get_activity_data.py`,
@@ -55,7 +68,7 @@ CLI без вложенных подкоманд.
 Для онлайн-контроля направляйте вывод через `jq` или аналогичный инструмент:
 
 ```bash
-python scripts/get_document_data.py all --input documents.csv --column document_chembl_id \
+get-document-data all --input documents.csv --column document_chembl_id \
   | tee run.log | jq -r '"\(.level) \(.event) :: \(.msg // "")"'
 ```
 
@@ -63,8 +76,19 @@ python scripts/get_document_data.py all --input documents.csv --column document_
 
 ## Данные активностей (`get_activity_data.py`)
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_activity_data.py \
+get-activity-data --input tests/data/activity_ids_small.csv \
+  --column activity_id \
+  --batch-size 25 \
+  --timeout 45
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_activity_data \
   --input tests/data/activity_ids_small.csv \
   --column activity_id \
   --batch-size 25 \
@@ -80,8 +104,18 @@ python scripts/get_activity_data.py \
 
 ## Описания ассайев (`get_assay_data.py`)
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_assay_data.py \
+get-assay-data --input path/to/assay_ids.csv \
+  --column assay_chembl_id \
+  --batch-size 25
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_assay_data \
   --input path/to/assay_ids.csv \
   --column assay_chembl_id \
   --batch-size 25
@@ -91,8 +125,18 @@ python scripts/get_assay_data.py \
 
 ## Метаданные документов (`get_document_data.py`)
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_document_data.py all \
+get-document-data all --input path/to/documents.csv \
+  --column document_chembl_id \
+  --batch-size 20
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
   --batch-size 20
@@ -104,20 +148,33 @@ python scripts/get_document_data.py all \
 
 ```bash
 CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
-  python scripts/get_document_data.py all \
-    --input path/to/documents.csv \
+  get-document-data all --input path/to/documents.csv \
     --column document_chembl_id
 ```
 
 Альтернативно обновите значение в `config/config.yaml`.
 
 Выберите подкоманду `pubmed`, `chembl` или `all` в зависимости от требуемых источников.
-Сводку и список ключей смотрите в справке: `python scripts/get_document_data.py --help`
-и `python scripts/get_document_data.py <подкоманда> --help`
+Сводку и список ключей смотрите в справке: `get-document-data --help`
+и `get-document-data <подкоманда> --help`
 (например, `--batch-size` управляет размером пакета для PubMed).
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_document_data.py pubmed \
+get-document-data pubmed --input path/to/documents.csv \
+  --column PMID \
+  --openalex-rps 2.5 \
+  --crossref-rps 1.5 \
+  --fallback-doi-csv path/to/doi_overrides.csv \
+  --fallback-doi-pmid-column pmid_override \
+  --fallback-doi-value-column doi_override
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
   --openalex-rps 2.5 \
@@ -133,8 +190,17 @@ python scripts/get_document_data.py pubmed \
 
 ## Агрегация таргетов (`get_target_data.py`)
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_target_data.py chembl \
+get-target-data chembl --input path/to/targets.csv \
+  --column target_chembl_id
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_target_data chembl \
   --input path/to/targets.csv \
   --column target_chembl_id
 ```
@@ -163,8 +229,17 @@ python -m library.utils.cli_tools.pipeline_targets_main \
 
 ## Обогащение тест-объектов (`get_testitem_data.py`)
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_testitem_data.py \
+get-testitem-data --input tests/data/input-smoke/testitem.csv \
+  --column molecule_chembl_id
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_testitem_data \
   --input tests/data/input-smoke/testitem.csv \
   --column molecule_chembl_id
 ```
@@ -188,8 +263,19 @@ sources:
 
 Пример запуска с кастомными настройками:
 
+Вариант консольного скрипта:
+
 ```bash
-python scripts/get_testitem_data.py \
+get-testitem-data --config config/config.yaml \
+  --input data/input/testitem_ids.csv \
+  --batch-size 750 \
+  --offset 500
+```
+
+Запуск через модуль:
+
+```bash
+python -m scripts.get_testitem_data \
   --config config/config.yaml \
   --input data/input/testitem_ids.csv \
   --batch-size 750 \
@@ -268,7 +354,7 @@ CLI-флаги покрывают задокументированные арг�
 `--batch-size`, `--timeout`, `--limit`, `--dry-run`:
 
 ```bash
-python scripts/get_activity_data.py --batch-size 25 --timeout 45
+get-activity-data --batch-size 25 --timeout 45
 ```
 
 Вложенные параметры меняются через `config/config.yaml` или переменные окружения. Чтобы временно увеличить лимит запросов
@@ -276,7 +362,7 @@ python scripts/get_activity_data.py --batch-size 25 --timeout 45
 
 ```bash
 export CHEMBL_DA__SOURCES__CHEMBL__API__RPS=10
-python scripts/get_activity_data.py
+get-activity-data
 ```
 
 При необходимости проверьте итоговую конфигурацию флагом `--print-config` до запуска пайплайна.


### PR DESCRIPTION
## Summary
- list the installed console entry points in the bilingual root README to keep documentation consistent
- extend the English and Russian READMEs with quick-start instructions and usage notes for the console scripts alongside existing module invocations
- expand both usage guides with tables mapping console scripts to python -m equivalents and dual-form command examples for each pipeline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd483dc0588324b5b1fc99670cd7fc