### PR TITLE
Fix running get_data directly

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -22,11 +22,17 @@ that the pipelines can be executed programmatically from other callers as well.
 from __future__ import annotations
 
 import argparse
+import sys
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Callable, Sequence
+
+if __package__ in {None, ""}:
+    _PROJECT_ROOT = Path(__file__).resolve().parent.parent
+    if str(_PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts import (
     get_activity_data,


### PR DESCRIPTION
## Summary
- ensure the orchestrator script can resolve package imports when executed directly from the filesystem

## Testing
- python scripts/get_data.py -h

------
https://chatgpt.com/codex/tasks/task_e_68dd5630292c8324a139764baaf14245