### PR TITLE
Replace portalocker dependency with native file lock implementation

### DIFF
--- a/library/utils/atomic.py
+++ b/library/utils/atomic.py
@@ -2,15 +2,94 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, TextIO
 
-import portalocker
+if os.name == "nt":  # pragma: no cover - platform-specific import
+    import msvcrt
+else:  # pragma: no cover - platform-specific import
+    import fcntl
 
 _LOCK_TIMEOUT_SECONDS = 10.0
+_LOCK_POLL_INTERVAL_SECONDS = 0.1
+
+
+class FileLock:
+    """Lightweight file lock implementation using OS primitives."""
+
+    def __init__(self, path: Path, *, timeout: float, poll_interval: float) -> None:
+        self._path = path
+        self._timeout = timeout
+        self._poll_interval = poll_interval
+        self._handle: TextIO | None = None
+
+    def __enter__(self) -> "FileLock":
+        start_time = time.monotonic()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self._path.open("w+")
+
+        while True:
+            if _try_lock(handle):
+                self._handle = handle
+                return self
+
+            elapsed = time.monotonic() - start_time
+            if elapsed >= self._timeout:
+                handle.close()
+                msg = (
+                    f"Could not acquire lock for '{self._path}' within "
+                    f"{self._timeout:.2f} seconds"
+                )
+                raise TimeoutError(msg)
+
+            time.sleep(self._poll_interval)
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if self._handle is None:
+            return
+
+        _unlock(self._handle)
+        self._handle.close()
+        self._handle = None
+
+
+def _try_lock(handle: TextIO) -> bool:
+    """Attempt to acquire an exclusive lock on *handle* without blocking."""
+
+    try:
+        if os.name == "nt":  # pragma: no cover - platform-specific behaviour
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:  # pragma: no cover - platform-specific behaviour
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if _is_lock_contended(exc):
+            return False
+        raise
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _unlock(handle: TextIO) -> None:
+    """Release a previously acquired lock on *handle*."""
+
+    if os.name == "nt":  # pragma: no cover - platform-specific behaviour
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:  # pragma: no cover - platform-specific behaviour
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _is_lock_contended(exc: OSError) -> bool:
+    """Return ``True`` when *exc* indicates the lock is already held."""
+
+    err_no = exc.errno
+    win_err = getattr(exc, "winerror", None)
+    return err_no in {errno.EACCES, errno.EAGAIN} or win_err == 33
 
 
 @contextmanager
@@ -38,10 +117,10 @@ def open_atomic(
 
     lock_path = path.with_name(f"{path.name}.lock")
 
-    with portalocker.Lock(
-        str(lock_path),
-        mode="w",
+    with FileLock(
+        lock_path,
         timeout=lock_timeout,
+        poll_interval=_LOCK_POLL_INTERVAL_SECONDS,
     ):
         fd, tmp_name = tempfile.mkstemp(
             dir=path.parent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "pandera~=0.26.1",
   "cachetools~=5.3.2",
   "pydantic~=2.11.3",
-  "portalocker~=3.1.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- implement a lightweight cross-platform file lock helper used by `open_atomic`
- remove the third-party `portalocker` dependency from the project metadata

## Testing
- python -m compileall library/utils/atomic.py

------
https://chatgpt.com/codex/tasks/task_e_68dd56c5cf9c8324bdfcaf3d82a93daf