### PR TITLE
Limit PubChem worker pool to RPS

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -285,7 +285,7 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | `cache_ttl` | `3600` | Lifespan (seconds) of the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_ttl_hours` | `null` | Optional expiry (hours) for the persisted CID cache; `null` keeps entries indefinitely. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
 | `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
-| `batch_size` | `50` | Number of rows processed per PubChem batch request. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
+| `batch_size` | `50` | Number of rows processed per PubChem batch request; concurrency never exceeds `min(batch_size, rps)`. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Skip remote lookups when local SMILES/InChIKey columns are already populated. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Preserve existing `pubchem_*` columns when lookups return empty payloads. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |
 | `use_parent_for_salts` | `true` | Escalate to parent structures when salt-specific lookups fail. | `CHEMBL_DA_SOURCES_PUBCHEM_USE_PARENT_FOR_SALTS`, `CHEMBL_DA__SOURCES__PUBCHEM__USE_PARENT_FOR_SALTS` |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -274,7 +274,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `cache_ttl` | `3600` | Время жизни in-memory кэша HTTP (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_ttl_hours` | `null` | TTL (часы) для постоянного CID-кэша; `null` отключает истечение. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
 | `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Путь к JSON с сохранёнными CID для повторного использования. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
-| `batch_size` | `50` | Размер батча для обработчика PubChem. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
+| `batch_size` | `50` | Размер батча для обработчика PubChem; параллелизм ограничен `min(batch_size, rps)`. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Пропускать запросы, если локальные SMILES/InChIKey уже заполнены. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Сохранять существующие колонки `pubchem_*`, если ответ пуст. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |
 | `use_parent_for_salts` | `true` | Переходить к родительским структурам, если соль не найдена. | `CHEMBL_DA_SOURCES_PUBCHEM_USE_PARENT_FOR_SALTS`, `CHEMBL_DA__SOURCES__PUBCHEM__USE_PARENT_FOR_SALTS` |

--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -1544,13 +1544,14 @@ def _merge_pubchem_properties(
     lookup_order = sorted(lookup_cids)
     if lookup_order:
         configured_batch_size = max(int(getattr(cfg, "batch_size", 1)), 1)
-        rps_limit = max(int(getattr(cfg, "rps", configured_batch_size)), 1)
-        batch_size = min(configured_batch_size, rps_limit)
+        rps_limit = int(getattr(cfg, "rps", configured_batch_size))
+        max_workers = max(1, min(configured_batch_size, rps_limit))
+        batch_size = configured_batch_size
 
         def _fetch_properties(cid: str) -> pl.Properties:
             return pl.get_properties(cid, cfg)
 
-        with ThreadPoolExecutor(max_workers=batch_size) as executor:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for start in range(0, len(lookup_order), batch_size):
                 batch = lookup_order[start : start + batch_size]
                 future_map = {

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -941,6 +941,62 @@ def test_merge_pubchem_properties_throttles_by_rps(
     ]
 
 
+def test_merge_pubchem_properties_limits_workers_to_rps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame({"value": [0, 1, 2]})
+    cid_series = pd.Series(["CID-0", "CID-1", "CID-2"], index=frame.index, dtype="string")
+    lookup_cids = set(cid_series.tolist())
+    cfg = pl.PubChemCfg(delay=0, rps=2, batch_size=5)
+
+    monkeypatch.setattr(
+        pl,
+        "get_properties",
+        lambda cid, pubchem_cfg: pl.Properties(f"name-{cid}", None, None, None, None, None),
+    )
+
+    class ImmediateFuture:
+        def __init__(self, value: object) -> None:
+            self._value = value
+
+        def result(self) -> object:
+            return self._value
+
+    captured_workers: list[int] = []
+
+    class DummyExecutor:
+        def __init__(self, max_workers: int) -> None:
+            captured_workers.append(max_workers)
+
+        def __enter__(self) -> DummyExecutor:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def submit(self, func: Callable[..., object], *args: object, **kwargs: object) -> ImmediateFuture:
+            return ImmediateFuture(func(*args, **kwargs))
+
+    monkeypatch.setattr(pipeline, "ThreadPoolExecutor", DummyExecutor)
+
+    skip_mask = pd.Series(False, index=frame.index)
+    prefer_local_mask = pd.Series(False, index=frame.index)
+
+    result = pipeline._merge_pubchem_properties(
+        frame,
+        cid_series,
+        lookup_cids,
+        cfg=cfg,
+        skip_mask=skip_mask,
+        prefer_local_mask=prefer_local_mask,
+    )
+
+    assert captured_workers == [cfg.rps]
+    assert result["pubchem_iupac_name"].tolist() == [
+        f"name-{cid}" for cid in cid_series.tolist()
+    ]
+
+
 def test_merge_pubchem_properties_uses_batch_size_when_below_rps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- cap PubChem property worker pool size at the configured RPS ceiling
- add a regression test that captures the ThreadPoolExecutor size when RPS is below the batch size
- document that PubChem concurrency is limited by the lesser of batch size and RPS

## Testing
- pytest tests/test_get_testitem_data.py -k pubchem --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68dd6093e6e883248b5bfe45861ceb25