### PR TITLE
Add replace_root flag to structured logging configuration

### DIFF
--- a/library/logging_setup.py
+++ b/library/logging_setup.py
@@ -294,19 +294,29 @@ class Logger:
 # Public factory
 
 
-def configure_logger(cfg: LoggerConfig) -> Logger:
+_STRUCTURED_LOGGER_NAME = "library.structured"
+
+
+def configure_logger(cfg: LoggerConfig, replace_root: bool = True) -> Logger:
     """Return a :class:`Logger` instance configured with ``cfg``.
 
-    The root :mod:`logging` logger is configured to forward records to the
-    structured :class:`Logger` instance. This ensures a single log format is
-    used for both direct :class:`Logger` calls and the standard :mod:`logging`
-    module, including messages originating from :func:`warnings.warn` when
-    :func:`logging.captureWarnings` is enabled.
+    When ``replace_root`` is :data:`True`, the root :mod:`logging` logger is
+    configured to forward records to the structured :class:`Logger` instance.
+    This ensures a single log format is used for both direct :class:`Logger`
+    calls and the standard :mod:`logging` module, including messages
+    originating from :func:`warnings.warn` when :func:`logging.captureWarnings`
+    is enabled. When ``replace_root`` is :data:`False`, the handler is instead
+    attached to the ``"library.structured"`` logger leaving the root logger
+    and ``py.warnings`` configuration untouched.
 
     Parameters
     ----------
     cfg:
         Logger configuration.
+    replace_root:
+        If :data:`True` (default), replace handlers on the root logger and the
+        ``py.warnings`` logger. If :data:`False`, attach the handler to a
+        dedicated ``"library.structured"`` logger.
 
     Returns
     -------
@@ -328,21 +338,27 @@ def configure_logger(cfg: LoggerConfig) -> Logger:
             extras["logger"] = record.name
             logger.log(record.levelname, record.getMessage(), extra=extras)
 
-    root_logger = logging.getLogger()
     handler = _ForwardHandler()
-    root_logger.handlers = [handler]
-    root_logger.setLevel(_level_no(cfg.level))
+    if replace_root:
+        root_logger = logging.getLogger()
+        root_logger.handlers = [handler]
+        root_logger.setLevel(_level_no(cfg.level))
 
-    # Route ``warnings.warn`` calls through the structured logger.  ``logging``
-    # redirects warnings to the ``py.warnings`` logger when captureWarnings is
-    # enabled.  We attach the same handler used for the root logger to ensure
-    # a single JSON-formatted output.
-    logging.captureWarnings(True)
-    warnings.simplefilter("default")
-    warnings_logger = logging.getLogger("py.warnings")
-    warnings_logger.handlers.clear()
-    warnings_logger.addHandler(handler)
-    warnings_logger.setLevel(_level_no(cfg.level))
-    warnings_logger.propagate = False
+        # Route ``warnings.warn`` calls through the structured logger.
+        # ``logging`` redirects warnings to the ``py.warnings`` logger when
+        # captureWarnings is enabled.  We attach the same handler used for the
+        # root logger to ensure a single JSON-formatted output.
+        logging.captureWarnings(True)
+        warnings.simplefilter("default")
+        warnings_logger = logging.getLogger("py.warnings")
+        warnings_logger.handlers.clear()
+        warnings_logger.addHandler(handler)
+        warnings_logger.setLevel(_level_no(cfg.level))
+        warnings_logger.propagate = False
+    else:
+        structured_logger = logging.getLogger(_STRUCTURED_LOGGER_NAME)
+        structured_logger.handlers = [handler]
+        structured_logger.setLevel(_level_no(cfg.level))
+        structured_logger.propagate = False
 
     return logger

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -12,7 +12,9 @@ Run linters and tests on this module with::
 
 from __future__ import annotations
 
+import io
 import json
+import logging
 import sys
 import threading
 from typing import Any
@@ -133,3 +135,60 @@ def test_logger_bind_preserves_parent_context(
     assert records[0]["stage"] == "extract"
     parent = next(rec for rec in records if rec["event"] == "parent_event")
     assert "stage" not in parent
+
+
+def test_configure_logger_without_replacing_root_preserves_handlers() -> None:
+    """Opting out of root replacement keeps existing handlers intact."""
+
+    root = logging.getLogger()
+    warnings_logger = logging.getLogger("py.warnings")
+    structured_logger = logging.getLogger("library.structured")
+
+    class DummyHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - noop
+            return None
+
+    original_root_handlers = list(root.handlers)
+    original_root_level = root.level
+    original_warnings_handlers = list(warnings_logger.handlers)
+    original_warnings_level = warnings_logger.level
+    original_warnings_propagate = warnings_logger.propagate
+    original_structured_handlers = list(structured_logger.handlers)
+    original_structured_level = structured_logger.level
+    original_structured_propagate = structured_logger.propagate
+
+    root_handler = DummyHandler()
+    warnings_handler = DummyHandler()
+    root.handlers = [root_handler]
+    warnings_logger.handlers = [warnings_handler]
+    warnings_logger.propagate = True
+
+    buffer = io.StringIO()
+
+    try:
+        logger = configure_logger(
+            LoggerConfig(level="INFO", run_id="rid", stream=buffer),
+            replace_root=False,
+        )
+
+        assert root.handlers == [root_handler]
+        assert root.level == original_root_level
+        assert warnings_logger.handlers == [warnings_handler]
+        assert warnings_logger.level == original_warnings_level
+        assert warnings_logger.propagate is True
+
+        structured_logger.info("std_event")
+        logger.info("direct_event")
+
+        records = [json.loads(line) for line in buffer.getvalue().splitlines()]
+        events = {record["event"] for record in records}
+        assert {"std_event", "direct_event"}.issubset(events)
+    finally:
+        root.handlers = original_root_handlers
+        root.setLevel(original_root_level)
+        warnings_logger.handlers = original_warnings_handlers
+        warnings_logger.setLevel(original_warnings_level)
+        warnings_logger.propagate = original_warnings_propagate
+        structured_logger.handlers = original_structured_handlers
+        structured_logger.setLevel(original_structured_level)
+        structured_logger.propagate = original_structured_propagate


### PR DESCRIPTION
## Summary
- add a `replace_root` flag to `configure_logger` so structured logging can avoid mutating the root logger
- document the new configuration option and direct structured output to a dedicated named logger when desired
- cover the new behaviour with a regression test that verifies existing root and warning handlers remain untouched

## Testing
- pytest tests/test_logging_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68dd605843208324bd53e522f631965f