### PR TITLE
Respect configured HTTP retry attempts

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1078,8 +1078,10 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
     """Return an HTTP session configured for retries and user agent.
 
     The returned session retries failed requests for *all* HTTP methods,
-    including ``POST``. It also avoids raising exceptions on HTTP error status
-    codes, allowing callers to handle responses manually.
+    including ``POST``. Requests are attempted once plus
+    ``retry.max_attempts - 1`` automatic retries for retryable statuses. The
+    session avoids raising exceptions on HTTP error status codes, allowing
+    callers to handle responses manually.
 
     Parameters
     ----------
@@ -1096,9 +1098,7 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
 
     session = Session()
     retry_cfg = Retry(
-        # Automatic retries are disabled to avoid double retry loops; HTTP
-        # clients implement their own attempt counters using ``retry``.
-        total=0,
+        total=max(0, retry.max_attempts - 1),
         backoff_factor=retry.backoff_factor,
         status_forcelist=retry.status_forcelist,
         # ``None`` disables method filtering and retries all HTTP methods.

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -12,18 +12,19 @@ USER_AGENT = "test-agent/1.0 (mailto:test@example.org)"
 
 
 @responses.activate
-def test_session_with_retry_makes_single_attempt() -> None:
-    """The HTTP adapter leaves retry attempts to higher-level clients."""
+def test_session_with_retry_retries_configured_attempts() -> None:
+    """The session retries failed responses up to the configured attempts."""
 
     url = "http://example.com/post"
-    responses.add(responses.POST, url, status=500)
-    responses.add(responses.POST, url, json={"ok": True}, status=200)
+    max_attempts = 3
+    for _ in range(max_attempts):
+        responses.add(responses.POST, url, status=500)
 
     session = session_with_retry(
         ApiCfg(user_agent=USER_AGENT),
-        RetryCfg(max_attempts=2, backoff_factor=0),
+        RetryCfg(max_attempts=max_attempts, backoff_factor=0),
     )
     response = session.post(url)
 
     assert response.status_code == 500
-    assert len(responses.calls) == 1
+    assert len(responses.calls) == max_attempts


### PR DESCRIPTION
## Summary
- configure the retry adapter to honor the configured number of attempts
- clarify the session retry documentation to describe the retry policy
- extend the HTTP client test to cover the configured retry attempts

## Testing
- pytest tests/test_http_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dd605b646c83248f49a5c665b5c4ec