### PR TITLE
Align get_testitem_data PubChem helper with pipeline

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -46,7 +46,6 @@ from library.testitem_pipeline import (
     _DEFAULT_CATALOG_CFG,
     _FETCH_ERROR_SAMPLE_SIZE,
     _MOLECULE_HIERARCHY_COLUMNS,
-    _PLACEHOLDER_CONTACT_EMAIL,
     _PUBCHEM_CACHE_SCHEMA_VERSION,
     _TYPO_PARENT_COLUMN,
     analyze_table_quality as _analyze_table_quality,
@@ -97,8 +96,6 @@ DEFAULT_OUTPUT_STEM = "testitems"
 
 _FETCH_ERROR_SAMPLE_SIZE = 10
 
-_PLACEHOLDER_CONTACT_EMAIL = "contact@example.org"
-
 @dataclass
 class ReadInputIdsResult:
     """Container holding the identifier iterator and a diagnostic sample."""
@@ -137,34 +134,6 @@ def _normalise_identifier(value: Any, *, uppercase: bool = False) -> str | None:
     if not normalised:
         return None
     return normalised.upper() if uppercase else normalised
-
-
-def _is_placeholder_user_agent(user_agent: str | None) -> bool:
-    """Return ``True`` if *user_agent* still uses the default placeholder contact."""
-
-    if not user_agent:
-        return True
-    return _PLACEHOLDER_CONTACT_EMAIL in user_agent
-
-
-def _prepare_pubchem_api_cfg(cfg: Config, api_cfg: ApiCfg) -> ApiCfg:
-    """Return an :class:`ApiCfg` with a valid PubChem user agent."""
-
-    pubchem_user_agent = cfg.pubchem.user_agent.strip()
-    api_user_agent = api_cfg.user_agent.strip()
-
-    if not _is_placeholder_user_agent(pubchem_user_agent):
-        if pubchem_user_agent != api_user_agent:
-            return api_cfg.model_copy(update={"user_agent": pubchem_user_agent})
-        return api_cfg
-
-    if not _is_placeholder_user_agent(api_user_agent):
-        return api_cfg
-
-    raise ValueError(
-        "PubChem configuration requires a user_agent with real contact details; "
-        "set sources.pubchem.user_agent or api.user_agent in config.yaml.",
-    )
 
 
 @lru_cache(maxsize=None)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -294,6 +294,10 @@ def test_prepare_pubchem_api_cfg_prefers_pubchem_override(cfg: Config) -> None:
     assert pubchem_cfg is not cfg.api
 
 
+def test_prepare_pubchem_api_cfg_reexport_matches_pipeline() -> None:
+    assert gtd._prepare_pubchem_api_cfg is pipeline._prepare_pubchem_api_cfg
+
+
 def test_prepare_pubchem_api_cfg_requires_custom_user_agent(cfg: Config) -> None:
     placeholder = "chembl-da/0.1 (mailto:contact@example.org)"
     cfg.api.user_agent = placeholder


### PR DESCRIPTION
## Summary
- remove the redundant `_prepare_pubchem_api_cfg` implementation from `scripts/get_testitem_data.py`
- ensure the script re-exports the pipeline helper and add a regression test confirming the re-export

## Testing
- pytest tests/test_get_testitem_data.py -k pubchem_api_cfg

------
https://chatgpt.com/codex/tasks/task_e_68dd60601820832497cf6aff87638c3d