### PR TITLE
Stop writing outputs when required columns are missing

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -245,6 +245,8 @@ def run_pipeline(
                 if missing_chunk_required:
                     missing_required_columns.update(missing_chunk_required)
                     validation_enabled = False
+                    exit_code = 1
+                    break
 
                 validated_chunk = chunk
                 if validation_enabled and validators and not chunk.empty:
@@ -291,6 +293,13 @@ def run_pipeline(
         except PipelineError:
             return 1
 
+        if missing_required_columns:
+            use_logger.warning(
+                "validation_skipped",
+                missing_columns=sorted(missing_required_columns),
+            )
+            return exit_code or 1
+
         if not chunk_paths:
             empty = pd.DataFrame()
             for hook in metadata_hooks:
@@ -324,12 +333,7 @@ def run_pipeline(
             )
             return 1
 
-    if missing_required_columns:
-        use_logger.warning(
-            "validation_skipped",
-            missing_columns=sorted(missing_required_columns),
-        )
-    elif optional_cols - present_columns:
+    if optional_cols - present_columns:
         use_logger.warning(
             "optional_columns_missing",
             columns=sorted(optional_cols - present_columns),

--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -2087,6 +2087,7 @@ def finalize_output(
             "validation_skipped",
             missing_columns=sorted(missing_required),
         )
+        return 1
 
     rows_kept = len(df)
     rows_dropped = rows_total - rows_kept

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from library.cli_utils import build_parser, run_pipeline
 from schemas import AssaysSchema
@@ -178,3 +179,44 @@ def test_run_pipeline_writes_failure_cases(tmp_path: Path) -> None:
     failure_csv = failure_path.read_text()
     assert "column" in failure_csv
     assert "value" in failure_csv
+
+
+def test_run_pipeline_missing_required_columns(tmp_path: Path) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [pd.DataFrame({"document_chembl_id": ["D1"]})]
+
+    hooks = [lambda df: df]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str],
+        key_cols: list[str],
+    ) -> Path:
+        pytest.fail("writer should not be called when required columns are missing")
+
+    def quality(_: Path) -> None:
+        pytest.fail("table quality should not run when required columns are missing")
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[],
+        metadata_hooks=hooks,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=quality,
+    )
+
+    assert exit_code == 1
+    assert not output.exists()
+    assert not failure_path.exists()

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -579,6 +579,42 @@ def test_finalize_output_success(
     assert exit_code == 0
 
 
+def test_finalize_output_missing_required_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    df = pd.DataFrame({"extra": ["value"]})
+    parent_stats = pipeline.ParentLookupStats(
+        source=pipeline.PARENT_LOOKUP_SOURCE_CACHE,
+        missing=0,
+        unique=0,
+        attached=0,
+        uncovered=0,
+    )
+
+    monkeypatch.setattr(
+        pipeline,
+        "write_csv_deterministic",
+        lambda *args, **kwargs: pytest.fail("should not write output when required columns are missing"),
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "analyze_table_quality",
+        lambda *args, **kwargs: pytest.fail("should not analyze quality when required columns are missing"),
+    )
+
+    exit_code = pipeline.finalize_output(
+        df,
+        cfg=cfg,
+        output=tmp_path / "out.csv",
+        parent_stats=parent_stats,
+        input_csv=tmp_path / "in.csv",
+        rows_total=len(df),
+    )
+
+    assert exit_code == 1
+    assert not (tmp_path / "out.csv").exists()
+
+
 def test_finalize_output_streams_sorted_chunks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- abort CLI pipelines before writing when a chunk is missing required columns
- treat missing required columns as a fatal condition in the test item finaliser
- add regression tests covering the non-zero exit codes for both execution paths

## Testing
- pytest tests/test_cli_utils.py::test_run_pipeline_missing_required_columns tests/test_get_testitem_data.py::test_finalize_output_missing_required_columns

------
https://chatgpt.com/codex/tasks/task_e_68dd608588b88324a6af014966ba5891