### PR TITLE
Close previous IUPHAR session on reinitialisation

### DIFF
--- a/library/clients/iuphar.py
+++ b/library/clients/iuphar.py
@@ -65,8 +65,13 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session used by the IUPHAR client."""
 
     global _session
+    old_session: Session | None = None
     with _session_lock:
+        old_session = _session
         _session = session_with_retry(api, retry)
+
+    if old_session is not None and old_session is not _session:
+        old_session.close()
 
 
 def _validate_columns(df: pd.DataFrame, expected: Iterable[str]) -> None:

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -11,7 +11,7 @@ import pytest
 
 from library import iuphar_library as ii
 from library.clients import iuphar as ci
-from library.config import IupharCfg
+from library.config import ApiCfg, IupharCfg, RetryCfg
 
 
 class DummyResponse:
@@ -118,3 +118,45 @@ def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
         t.join()
 
     assert order == ["start", "end", "start", "end"]
+
+
+def test_init_session_closes_previous_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reinitialising the session should close the previous instance exactly once."""
+
+    closed: list[str] = []
+
+    class DummySession:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+            closed.append(self.name)
+
+    dummy_initial = DummySession("initial")
+    monkeypatch.setattr(ci, "_session", dummy_initial, raising=False)
+
+    def fake_session_with_retry(api: ApiCfg, retry: RetryCfg) -> DummySession:
+        return DummySession(api.user_agent)
+
+    monkeypatch.setattr(ci, "session_with_retry", fake_session_with_retry)
+
+    retry_cfg = RetryCfg()
+    first_api = ApiCfg(user_agent="chembl-tests/1.0 (mailto:tests@ebi.ac.uk)")
+    second_api = ApiCfg(user_agent="chembl-tests/2.0 (mailto:tests@ebi.ac.uk)")
+
+    ci.init_session(first_api, retry_cfg)
+    first_session = ci._session
+
+    assert isinstance(first_session, DummySession)
+    assert closed == ["initial"]
+    assert dummy_initial.closed is True
+
+    ci.init_session(second_api, retry_cfg)
+    second_session = ci._session
+
+    assert isinstance(second_session, DummySession)
+    assert closed == ["initial", first_api.user_agent]
+    assert first_session.closed is True
+    assert second_session.closed is False


### PR DESCRIPTION
## Summary
- close the previous IUPHAR HTTP session after installing a new one
- add a regression test that ensures the prior session is closed when init_session is called twice

## Testing
- pytest tests/test_iuphar_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd608a8bd48324873889126c813f93