### PR TITLE
Stream assay CSV writer

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -27,6 +27,7 @@ from library import assay_postprocessing as ap
 from library import chembl_library as cl
 from library import cli
 from library import io
+from library.csv_utils import write_csv_chunks_deterministic
 from library.clients import ChemblClient
 from library.cli import (
     LoggerConfig,
@@ -136,18 +137,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         col_order: Sequence[str],
         key_cols: Sequence[str],
     ) -> Path:
-        frames = [chunk for chunk in chunks]
-        if frames:
-            df = pd.concat(frames, ignore_index=True)
-        else:
-            df = pd.DataFrame(columns=col_order)
-        resolved_keys = list(key_cols) or None
-        return io.write_csv(
-            df,
+        sort_columns = list(key_cols) or sorted(col_order)
+        return write_csv_chunks_deterministic(
+            chunks,
             destination,
-            cfg=cfg,
-            key_cols=resolved_keys,
+            key_cols=sort_columns,
             col_order=col_order,
+            chunksize=cfg.io.csv_chunksize,
+            sort_chunksize=cfg.io.csv_chunksize,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            cfg=cfg,
         )
 
     table_quality = partial(

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 import pandas as pd
@@ -50,3 +51,124 @@ def test_run_chembl_orders_columns(
         "aaa",
         "zzz",
     ]
+
+
+def test_run_chembl_streams_chunks_and_applies_hooks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Chunk iterator remains lazy and includes metadata/validator output."""
+
+    input_csv = tmp_path / "assays.csv"
+    input_csv.write_text("assay_chembl_id\nA1\nA2\n")
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["A1", "A2"]))
+
+    df = pd.DataFrame(
+        {
+            "assay_chembl_id": ["A1", "A2"],
+            "document_chembl_id": ["D1", "D2"],
+        }
+    )
+
+    monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
+
+    hook_calls: dict[str, int] = {"postprocess": 0, "normalize": 0, "metadata": 0}
+
+    def fake_postprocess(frame: pd.DataFrame) -> pd.DataFrame:
+        hook_calls["postprocess"] += 1
+        return frame.assign(postprocessed=True)
+
+    def fake_normalize(frame: pd.DataFrame) -> pd.DataFrame:
+        hook_calls["normalize"] += 1
+        assert "postprocessed" in frame.columns
+        return frame.assign(normalized=True)
+
+    def fake_metadata(frame: pd.DataFrame) -> pd.DataFrame:
+        hook_calls["metadata"] += 1
+        assert "normalized" in frame.columns
+        return frame.assign(pipeline_version="1.0", timestamp_utc="now")
+
+    monkeypatch.setattr(gas.ap, "postprocess_assays", fake_postprocess)
+    monkeypatch.setattr(gas, "normalize_assays", fake_normalize)
+    monkeypatch.setattr(gas, "add_pipeline_metadata", fake_metadata)
+
+    class _Result:
+        def __init__(self, data: pd.DataFrame) -> None:
+            self.data = data
+            self.failure_cases = pd.DataFrame()
+
+    validator_calls = {"count": 0}
+
+    def fake_validate(frame: pd.DataFrame, *, return_result: bool) -> _Result:
+        validator_calls["count"] += 1
+        assert "timestamp_utc" in frame.columns
+        return _Result(frame)
+
+    monkeypatch.setattr(gas, "validate_assays", fake_validate)
+    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
+
+    captured: dict[str, object] = {}
+
+    def fake_write(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        *,
+        key_cols: Sequence[str],
+        col_order: Sequence[str],
+        chunksize: int,
+        sort_chunksize: int,
+        sep: str,
+        encoding: str,
+        cfg: Config,
+        **kwargs: object,
+    ) -> Path:
+        assert not isinstance(chunks, list)
+        frames = list(chunks)
+        captured["chunk_count"] = len(frames)
+        captured["columns"] = [set(frame.columns) for frame in frames]
+        captured["key_cols"] = list(key_cols)
+        return destination
+
+    monkeypatch.setattr(gas, "write_csv_chunks_deterministic", fake_write)
+
+    rc = gas.run_chembl(cfg, args)
+    assert rc == 0
+    assert hook_calls == {"postprocess": 1, "normalize": 1, "metadata": 1}
+    assert validator_calls["count"] == 1
+    assert captured["chunk_count"] == 1
+    assert all({"postprocessed", "normalized", "pipeline_version", "timestamp_utc"}.issubset(cols) for cols in captured["columns"])
+    assert captured["key_cols"] == ["assay_chembl_id"]
+
+
+def test_run_chembl_sorts_output_deterministically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    """Rows are sorted by key columns when writing output."""
+
+    input_csv = tmp_path / "assays.csv"
+    input_csv.write_text("assay_chembl_id\nA2\nA1\n")
+    args = argparse.Namespace(input_csv=input_csv, output_csv=tmp_path / "out.csv")
+
+    monkeypatch.setattr(io, "read_ids", lambda *_, **__: iter(["A2", "A1"]))
+
+    df = pd.DataFrame(
+        {
+            "assay_chembl_id": ["A2", "A1"],
+            "document_chembl_id": ["D2", "D1"],
+        }
+    )
+
+    monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
+    monkeypatch.setattr(gas.ap, "postprocess_assays", lambda frame: frame)
+    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
+    monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
+
+    rc = gas.run_chembl(cfg, args)
+    assert rc == 0
+
+    result = pd.read_csv(args.output_csv)
+    assert list(result["assay_chembl_id"]) == ["A1", "A2"]


### PR DESCRIPTION
## Summary
- stream assay pipeline output through `write_csv_chunks_deterministic` for parity with other extractors
- keep metadata hooks and validators operating per chunk while passing deterministic sorting parameters
- extend assay tests to cover streaming behaviour and deterministic ordering

## Testing
- `pytest tests/test_get_assay_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd609be8a48324a5da0550a3eb2ea2