### PR TITLE
Handle cached missing PubChem CIDs

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -1108,13 +1108,14 @@ def _write_pubchem_cid_cache(
 
     if path is None:
         return
-    serialisable: dict[str, str] = {}
+    serialisable: dict[str, str | None] = {}
     for key, value in cache.items():
         if not key:
             continue
         if value is None:
-            continue
-        serialisable[key] = value
+            serialisable[key] = None
+        else:
+            serialisable[key] = value
     try:
         with open_atomic(path, encoding=PUBCHEM_CID_CACHE_ENCODING) as handle:
             payload = {
@@ -1471,7 +1472,7 @@ def _resolve_pubchem_cids(
         )
 
     def _is_cached(chembl_id: str | None) -> bool:
-        return bool(chembl_id and cid_cache.get(chembl_id))
+        return bool(chembl_id) and chembl_id in cid_cache
 
     cached_mask = chembl_norm.map(_is_cached)
     needs_lookup_mask = (
@@ -1492,9 +1493,10 @@ def _resolve_pubchem_cids(
     cache_dirty = False
     for idx, chembl_id in chembl_norm[cached_mask].items():
         cached_value = cid_cache.get(chembl_id)
-        if cached_value:
-            cid_series.loc[idx] = cached_value
-            lookup_cids.add(cached_value)
+        if cached_value is None:
+            continue
+        cid_series.loc[idx] = cached_value
+        lookup_cids.add(cached_value)
 
     for progress, row in enumerate(frame.loc[needs_lookup_mask].itertuples(), start=1):
         logger.info("pubchem_progress", current=progress, total=total)

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -857,6 +857,53 @@ def test_resolve_pubchem_cids_skips_marked_rows(
     assert cache_dirty
 
 
+def test_resolve_pubchem_cids_skips_cached_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "canonical_smiles": ["C", "N"],
+        }
+    )
+    cfg = pl.PubChemCfg(delay=0)
+    cid_cache: dict[str, str | None] = {"CHEMBL1": None}
+    resolution_cache: dict[tuple[str | None, ...], pl.PubChemResolution] = {}
+    calls: list[str] = []
+
+    def fake_resolve(
+        row: pd.Series,
+        cache: MutableMapping[str, str | None],
+        cfg: pl.PubChemCfg,
+        **_: object,
+    ) -> str:
+        chembl_id = row["molecule_chembl_id"]
+        calls.append(chembl_id)
+        cache[chembl_id] = "111"
+        return "111"
+
+    monkeypatch.setattr(pipeline, "resolve_pubchem_cid", fake_resolve)
+
+    skip_mask = pd.Series(False, index=frame.index)
+    prefer_local_mask = pd.Series(False, index=frame.index)
+
+    cid_series, lookup_cids, cache_dirty = pipeline._resolve_pubchem_cids(
+        frame,
+        cfg,
+        cid_cache=cid_cache,
+        resolution_cache=resolution_cache,
+        load_parent_record=lambda _: None,
+        skip_mask=skip_mask,
+        prefer_local_mask=prefer_local_mask,
+    )
+
+    assert calls == ["CHEMBL2"]
+    assert pd.isna(cid_series.iloc[0])
+    assert cid_series.iloc[1] == "111"
+    assert lookup_cids == {"111"}
+    assert cache_dirty
+
+
 def test_merge_pubchem_properties_preserves_existing_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1265,11 +1312,13 @@ def test_write_pubchem_cid_cache_creates_parent_dir(tmp_path: Path) -> None:
 
     assert not cache_path.parent.exists()
 
-    pipeline._write_pubchem_cid_cache(cache_path, {"CHEMBL1": "321"})
+    pipeline._write_pubchem_cid_cache(
+        cache_path, {"CHEMBL1": "321", "CHEMBL2": None}
+    )
 
     assert cache_path.exists()
     payload = json.loads(cache_path.read_text())
-    assert payload["values"] == {"CHEMBL1": "321"}
+    assert payload["values"] == {"CHEMBL1": "321", "CHEMBL2": None}
     assert payload["metadata"]["version"] == pipeline._PUBCHEM_CACHE_SCHEMA_VERSION
 
 


### PR DESCRIPTION
## Summary
- allow the PubChem CID cache writer to persist explicit null sentinels and load them back without re-normalisation
- treat cached missing CIDs as resolved so the resolver skips redundant lookups and honour the cached sentinel
- add coverage to ensure cached null entries survive round-trips and prevent additional PubChem resolution calls

## Testing
- pytest tests/test_get_testitem_data.py::test_write_pubchem_cid_cache_creates_parent_dir tests/test_get_testitem_data.py::test_resolve_pubchem_cids_skips_cached_missing

------
https://chatgpt.com/codex/tasks/task_e_68dd609a551c8324885d0b97b646a304