### PR TITLE
Fix missing ensure_dirs import for testitem CLI

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -33,7 +33,14 @@ from library import pubchem_library as pl
 from library.cli import LoggerConfig, configure_logger
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command
-from library.config import ApiCfg, Config, IoCfg, MoleculeCatalogCfg, PubChemCfg
+from library.config import (
+    ApiCfg,
+    Config,
+    IoCfg,
+    MoleculeCatalogCfg,
+    PubChemCfg,
+    ensure_dirs,
+)
 from library.log import logger
 from library.clients import pubchem as pc  # noqa: F401 - patched in tests
 from library import testitem_pipeline as pipeline


### PR DESCRIPTION
## Summary
- import `ensure_dirs` from `library.config` in the test item CLI to prevent runtime NameError

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd665b60d483248046a0d63ad015da