### PR TITLE
Enforce directory output handling for table quality CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,10 @@ Running the CLI saves ``data_quality_report_table.csv`` and
 
     python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 
+Use ``--output`` to redirect these artefacts to another directory. The value must be a
+directory path (do not include the final file name). When ``local.io.exist_ok`` is set to
+``false`` the directory has to exist beforehand; otherwise it is created automatically.
+
 All scripts share a common set of flags:
 
 ## Configuration

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -100,10 +100,37 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         if df.shape[1] == 0:
             logger.warning("no_columns_after_filter", table_name=args.table_name)
 
+        output_dir = args.output_csv
+
+        if output_dir.suffix:
+            logger.error(
+                "output_directory_invalid",
+                path=str(output_dir),
+                reason="has_suffix",
+            )
+            return 1
+
+        if output_dir.exists():
+            if not output_dir.is_dir():
+                logger.error(
+                    "output_directory_invalid",
+                    path=str(output_dir),
+                    reason="not_directory",
+                )
+                return 1
+        else:
+            if not cfg.io.exist_ok:
+                logger.error(
+                    "output_directory_missing",
+                    path=str(output_dir),
+                    exist_ok=cfg.io.exist_ok,
+                )
+                return 1
+            output_dir.mkdir(parents=True, exist_ok=True)
+
         original_cwd = Path.cwd()
         try:
-            args.output_csv.mkdir(parents=True, exist_ok=True)
-            os.chdir(args.output_csv)
+            os.chdir(output_dir)
             analyze_table_quality(df, table_name=args.table_name)
         finally:
             os.chdir(original_cwd)
@@ -151,6 +178,14 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Exclude the specified columns from analysis",
     )
     parser.set_defaults(func=run, output_csv=Path("."), encoding="utf-8-sig")
+
+    for action in parser._actions:
+        if action.dest == "output_csv":
+            action.help = (
+                "Directory for profiling reports (must exist when cfg.io.exist_ok is false)"
+            )
+            action.metavar = "OUTPUT_DIR"
+            break
     return parser, log_cfg
 
 

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -177,3 +177,92 @@ def test_table_quality_run_handles_mixed_types(tmp_path: Path) -> None:
 
     assert actual_mixed["numeric_cov"] == pytest.approx(expected_mixed["numeric_cov"])
     assert actual_mixed["numeric_mean"] == pytest.approx(expected_mixed["numeric_mean"])
+
+
+def test_table_quality_run_rejects_output_with_suffix(tmp_path: Path) -> None:
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    csv_path = tmp_path / "input.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+
+    output_path = tmp_path / "report.csv"
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=output_path,
+        table_name="invalid",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+
+    assert exit_code == 1
+    assert not output_path.exists()
+
+
+def test_table_quality_run_requires_existing_directory_when_disallowed(
+    tmp_path: Path,
+) -> None:
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    csv_path = tmp_path / "input.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+    cfg.io.exist_ok = False
+
+    output_dir = tmp_path / "reports"
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=output_dir,
+        table_name="deny",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+
+    assert exit_code == 1
+    assert not output_dir.exists()
+
+
+def test_table_quality_run_creates_directory_when_allowed(tmp_path: Path) -> None:
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    csv_path = tmp_path / "input.csv"
+    df.to_csv(csv_path, index=False)
+
+    cfg = Config()
+    cfg.io.exist_ok = True
+
+    output_dir = tmp_path / "reports"
+
+    args = Namespace(
+        input_csv=csv_path,
+        sep=",",
+        encoding="utf-8-sig",
+        output_csv=output_dir,
+        table_name="created",
+        doc_quality_enable=None,
+        sample_rows=None,
+        include_columns=None,
+        exclude_columns=None,
+    )
+
+    exit_code = run(cfg, args)
+
+    assert exit_code == 0
+    assert output_dir.is_dir()
+    report = output_dir / "created_quality_report_table.csv"
+    correlation = output_dir / "created_data_correlation_report_table.csv"
+    assert report.exists()
+    assert correlation.exists()


### PR DESCRIPTION
## Summary
- validate that the table quality output path is a directory and honour cfg.io.exist_ok when creating it
- update CLI help and documentation to explain the directory requirement
- extend table quality tests to cover invalid paths and directory creation behaviour

## Testing
- pytest tests/test_table_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d4c184832494ee8cf8fbd3bd24