### PR TITLE
Improve chunk IO CLI error logging

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -63,9 +63,17 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the chunked copy operation."""
     try:
         if args.chunk_size <= 0:
-            raise SystemExit("--chunk-size must be a positive integer")
+            logger.error(
+                "invalid_chunk_size",
+                chunk_size=args.chunk_size,
+            )
+            return 1
         if args.limit is not None and args.limit <= 0:
-            raise SystemExit("--limit must be a positive integer")
+            logger.error(
+                "invalid_limit",
+                limit=args.limit,
+            )
+            return 1
 
         output = Path(args.output_csv or default_output_path(args.input_csv, cfg.io))
         parent = output.parent
@@ -73,9 +81,19 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             if cfg.io.exist_ok:
                 parent.mkdir(parents=True, exist_ok=True)
             else:
-                raise SystemExit(f"output directory {parent} does not exist")
+                logger.error(
+                    "output_directory_missing",
+                    directory=str(parent),
+                    output=str(output),
+                )
+                return 1
         elif not parent.is_dir():
-            raise SystemExit(f"output directory {parent} is not a directory")
+            logger.error(
+                "output_directory_not_directory",
+                directory=str(parent),
+                output=str(output),
+            )
+            return 1
         ensure_dirs(cfg)
         rows = process_csv_chunks(
             args.input_csv,

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -155,3 +155,152 @@ def test_cli_invalid_config_logs_error(tmp_path: Path, monkeypatch) -> None:
     event, payload = logged[0]
     assert event == "config_error"
     assert payload.get("config") == str(config_path)
+
+
+def test_cli_invalid_chunk_size_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """CLI rejects non-positive chunk sizes with an error message."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    output_path = tmp_path / "out.csv"
+
+    logged: list[tuple[str, dict[str, object]]] = []
+
+    def fake_error(event: str, *args: object, **kwargs: object) -> None:
+        logged.append((event, kwargs))
+
+    monkeypatch.setattr(cli.logger, "error", fake_error)
+
+    exit_code = cli.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "0",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert exit_code == 1
+    event, payload = logged[0]
+    assert event == "invalid_chunk_size"
+    assert payload.get("chunk_size") == 0
+
+
+def test_cli_invalid_limit_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """CLI rejects non-positive limits with an error message."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    output_path = tmp_path / "out.csv"
+
+    logged: list[tuple[str, dict[str, object]]] = []
+
+    def fake_error(event: str, *args: object, **kwargs: object) -> None:
+        logged.append((event, kwargs))
+
+    monkeypatch.setattr(cli.logger, "error", fake_error)
+
+    exit_code = cli.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "5",
+            "--limit",
+            "0",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert exit_code == 1
+    event, payload = logged[0]
+    assert event == "invalid_limit"
+    assert payload.get("limit") == 0
+
+
+def test_cli_missing_output_directory_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """CLI reports a missing output directory when creation is disabled."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    output_path = tmp_path / "missing" / "out.csv"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            local:
+              io:
+                exist_ok: false
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    logged: list[tuple[str, dict[str, object]]] = []
+
+    def fake_error(event: str, *args: object, **kwargs: object) -> None:
+        logged.append((event, kwargs))
+
+    monkeypatch.setattr(cli.logger, "error", fake_error)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "5",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert exit_code == 1
+    event, payload = logged[0]
+    assert event == "output_directory_missing"
+    assert payload.get("directory") == str(output_path.parent)
+
+
+def test_cli_output_parent_not_directory_logs_error(tmp_path: Path, monkeypatch) -> None:
+    """CLI reports when the output parent path is not a directory."""
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("a\n1\n", encoding="utf-8")
+    parent_path = tmp_path / "not_a_dir"
+    parent_path.write_text("content", encoding="utf-8")
+    output_path = parent_path / "out.csv"
+
+    logged: list[tuple[str, dict[str, object]]] = []
+
+    def fake_error(event: str, *args: object, **kwargs: object) -> None:
+        logged.append((event, kwargs))
+
+    monkeypatch.setattr(cli.logger, "error", fake_error)
+
+    exit_code = cli.main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--chunk-size",
+            "5",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert exit_code == 1
+    event, payload = logged[0]
+    assert event == "output_directory_not_directory"
+    assert payload.get("directory") == str(parent_path)


### PR DESCRIPTION
## Summary
- replace SystemExit usage in the chunk IO CLI with structured error logging and exit codes
- add coverage for invalid chunk size, limit, and output directory scenarios

## Testing
- pytest tests/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d412288324869b8496bd839aad