### PR TITLE
Handle print-config flag in csv utils CLI

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -410,4 +410,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_CONFIG_RELATIVE,
         help="YAML configuration file",
     )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print effective configuration and exit",
+    )
     return parser

--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -21,6 +21,7 @@ from library import cli
 from library.cli import LoggerConfig, configure_logger
 from library.cli_utils import build_parser
 from library.csv_utils import write_csv_chunks_deterministic
+from library.config import print_config
 from library.log import logger
 from library.parser_schema import CSVExportArgs
 
@@ -51,6 +52,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         ns.config,
         mapping={"chunk_size": "io.csv_chunksize"},
     )
+    if getattr(ns, "print_config", False):
+        print_config(cfg)
+        configure_logger(LoggerConfig(level=ns.log_level))
+        return 0
     arg_data = {field: getattr(ns, field) for field in CSVExportArgs.model_fields}
     args = CSVExportArgs.model_validate(arg_data)
     if not args.key_cols:

--- a/tests/test_csv_utils_main_print_config.py
+++ b/tests/test_csv_utils_main_print_config.py
@@ -1,0 +1,59 @@
+"""Regression tests for ``csv_utils_main`` configuration handling."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import yaml
+
+from library.utils.cli_tools import csv_utils_main as cli
+
+
+def test_csv_utils_cli_print_config_exits_without_writing(
+    tmp_path: Path, capsys
+) -> None:
+    """Printing the configuration exits early and avoids writing CSV output."""
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("a,b\n1,2\n", encoding="utf-8")
+    output_csv = tmp_path / "out.csv"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            system:
+              log:
+                level: "ERROR"
+            local:
+              io:
+                csv_sep: ","
+                csv_encoding: "utf-8"
+                exist_ok: true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "DEBUG",
+            "--sep",
+            "|",
+            "--print-config",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = yaml.safe_load(captured.out)
+    assert data["system"]["log"]["level"] == "DEBUG"
+    assert data["local"]["io"]["csv_sep"] == "|"
+    assert not output_csv.exists()


### PR DESCRIPTION
## Summary
- add the missing `--print-config` option to the CSV utilities CLI parser
- exit early when the flag is provided after printing the effective configuration
- add a regression test that verifies the configuration is printed and no CSV file is written

## Testing
- pytest tests/test_csv_utils_main_print_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d26dd883248c3ebf3ec5629db8