### PR TITLE
Make metadata timestamps timezone-aware

### DIFF
--- a/library/io/metadata.py
+++ b/library/io/metadata.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -27,7 +27,7 @@ def write_meta_yaml(
         dtypes = {col: "string" for col in columns}
 
     meta = {
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(timezone.utc).isoformat(),
         "git_sha": _git_sha(),
         "command": " ".join(sys.argv),
         "columns": list(columns or []),

--- a/tests/test_csv_utils.py
+++ b/tests/test_csv_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import string
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -183,8 +183,15 @@ def test_write_csv_deterministic_hash_stable(
     path = tmp_path / "out.csv"
 
     # Freeze timestamp to keep metadata deterministic across runs
-    fixed_now = datetime(2024, 1, 1)
-    monkeypatch.setattr("library.io.metadata.datetime", SimpleNamespace(now=lambda: fixed_now))
+    fixed_now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def _fixed_now(tz: object | None = None) -> datetime:
+        return fixed_now
+
+    monkeypatch.setattr(
+        "library.io.metadata.datetime",
+        SimpleNamespace(now=_fixed_now),
+    )
 
     write_csv_deterministic(df.copy(), path, key_cols=sorted(df.columns))
     first_hash = sha256_file(path)


### PR DESCRIPTION
## Summary
- ensure metadata timestamps are generated as timezone-aware UTC values
- adjust CSV utility tests to patch the timezone-aware datetime helper

## Testing
- `pytest -q tests/test_csv_utils.py::test_write_csv_deterministic_hash_stable` *(fails to collect when Hypothesis is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dd66d10ed48324af88b78efeb8e67a