### PR TITLE
Ensure csv utils writes log path

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -66,6 +66,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     output = args.output_csv or Path(args.input_csv).with_name(
         f"output.{Path(args.input_csv).stem}.csv"
     )
+    ns.output_csv = output
+    if args.output_csv != output:
+        args = args.model_copy(update={"output_csv": output})
     with pd.read_csv(
         args.input_csv,
         sep=sep,

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -120,6 +120,7 @@ def test_cli_generates_output_path(
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("a,b\n1,2\n", encoding="utf8")
     called: dict[str, Path | str] = {}
+    recorded: dict[str, str | None] = {}
 
     def fake_read_csv(
         path: Path | str,
@@ -154,10 +155,17 @@ def test_cli_generates_output_path(
         type("D", (), {"today": staticmethod(lambda: date(2024, 1, 2))}),
     )
 
+    def fake_info(event: str, *args: Any, **kwargs: Any) -> None:
+        if event == "write_done":
+            recorded["path"] = kwargs.get("path")
+
+    monkeypatch.setattr(cli.logger, "info", fake_info)
+
     rc = cli.main(["--input", str(input_csv), "--key-cols", "a"])
     assert rc == 0
     expected = input_csv.with_name("output.input_20240102.csv")
     assert called["output"] == expected
+    assert recorded.get("path") == str(expected)
 
 
 def test_cli_uses_configured_delimiter(


### PR DESCRIPTION
## Summary
- update the CSV utils CLI to persist the resolved output path on the namespace and validated args
- extend the CLI argument test to capture the logged path and ensure it matches the generated output file

## Testing
- pytest tests/test_csv_utils_main_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d38c5883248e8d79f7db07844e