### PR TITLE
Normalize CLI path handling in helper commands

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -107,10 +107,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     -------
     int
         ``0`` for success, ``1`` if an error occurred during processing.
+
+    Notes
+    -----
+    The command honours ``--base-path``, ``--input-dir`` and ``--output-dir``
+    for resolving relative file locations.
     """
 
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     configure_logger(log_cfg)
     try:

--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -3,8 +3,10 @@
 This script reads an input CSV file and re-serialises it deterministically
 using :func:`library.csv_utils.write_csv_deterministic`.
 
-If ``--output`` is omitted, a file named
-``output.<input-stem>_<YYYYMMDD>.csv`` is created next to the input.
+The command understands ``--base-path``, ``--input-dir`` and ``--output-dir``
+for resolving relative paths. When ``--output`` is omitted, a file named
+``output.<input-stem>_<YYYYMMDD>.csv`` is created next to the resolved input or
+inside the selected output directory.
 """
 
 from __future__ import annotations
@@ -41,10 +43,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = build_parser()
     ns = parser.parse_args(argv)
-    if ns.output_csv is None:
-        ns.output_csv = Path(ns.input_csv).with_name(
-            f"output.{Path(ns.input_csv).stem}_{date.today():%Y%m%d}.csv"
-        )
+    input_path = getattr(ns, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(ns, output_stem=output_stem)
+    if ns.output_csv is None and output_stem is not None:
+        target_dir = ns.output_dir or ns.base_path or Path(ns.input_csv).parent
+        date_value = getattr(ns, "date", None)
+        if date_value is None:
+            date_value = f"{date.today():%Y%m%d}"
+            setattr(ns, "date", date_value)
+        ns.output_csv = (target_dir / f"output.{output_stem}_{date_value}.csv").resolve()
     cfg = cli.apply_config_overrides(
         ns,
         parser,

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from library import cli
 from library.activities import get_activities
@@ -37,7 +38,11 @@ def parse_args(
         action="store_true",
         help="Log actions without generating data",
     )
-    return parser.parse_args(argv), log_cfg
+    args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
+    return args, log_cfg
 
 
 def run(limit: int, dry_run: bool) -> int:
@@ -65,7 +70,13 @@ def run(limit: int, dry_run: bool) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command-line entry point."""
+    """Command-line entry point.
+
+    Notes
+    -----
+    Path options ``--base-path``, ``--input-dir`` and ``--output-dir`` are
+    respected when resolving CLI inputs.
+    """
     args, log_cfg = parse_args(argv)
     log_cfg.level = args.log_level
     cli.configure_logger(log_cfg)

--- a/library/utils/cli_tools/get_document_type.py
+++ b/library/utils/cli_tools/get_document_type.py
@@ -8,6 +8,7 @@ scoring logic.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
 
 import pandas as pd
 
@@ -78,7 +79,12 @@ def classify_dataframe(
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command-line entry point for document type classification."""
+    """Command-line entry point for document type classification.
+
+    Notes
+    -----
+    Relative paths honour ``--base-path``, ``--input-dir`` and ``--output-dir``.
+    """
 
     parser, log_cfg = base_parser(
         __doc__ or "Document type classification", column="chembl_id"
@@ -132,6 +138,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Maximum number of rows to process",
     )
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     if args.limit is not None and args.limit <= 0:
         parser.error("--limit must be a positive integer")
     log_cfg.level = args.log_level

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -163,10 +163,18 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry point using :class:`Config` for defaults."""
+    """Entry point using :class:`Config` for defaults.
+
+    Notes
+    -----
+    Relative paths honour ``--base-path``, ``--input-dir`` and ``--output-dir``.
+    """
     parser, log_cfg = build_parser()
 
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/library/utils/cli_tools/mapper_batch_main.py
+++ b/library/utils/cli_tools/mapper_batch_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable, Sequence
+from pathlib import Path
 
 import pandas as pd
 
@@ -107,9 +108,17 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry point for the batch mapper script."""
+    """Entry point for the batch mapper script.
+
+    Notes
+    -----
+    Relative paths honour ``--base-path``, ``--input-dir`` and ``--output-dir``.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 from urllib.error import URLError
 
 import pandas as pd
@@ -141,10 +142,18 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Command line entry point using :class:`Config` for defaults.
+
+    Notes
+    -----
+    Relative paths honour ``--base-path``, ``--input-dir`` and ``--output-dir``.
+    """
     parser, log_cfg = build_parser()
 
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -1,4 +1,8 @@
-"""CLI wrapper for :mod:`library.pipeline_targets`."""
+"""CLI wrapper for :mod:`library.pipeline_targets`.
+
+The interface honours ``--base-path``, ``--input-dir`` and ``--output-dir`` when
+resolving file locations.
+"""
 
 from __future__ import annotations
 
@@ -219,6 +223,9 @@ def run(cfg: Config, options: PipelineConfig) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     log_cfg = LoggerConfig(level=log_cfg.level, run_id=log_cfg.run_id)
     logger_inst = configure_logger(log_cfg)

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -155,9 +155,17 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults."""
+    """Command line entry point using :class:`Config` for defaults.
+
+    Notes
+    -----
+    Relative paths honour ``--base-path``, ``--input-dir`` and ``--output-dir``.
+    """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    input_path = getattr(args, "input_csv", None)
+    output_stem = Path(input_path).stem if input_path else None
+    cli.prepare_io_paths(args, output_stem=output_stem)
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -230,6 +230,69 @@ def test_cli_uses_configured_delimiter(
     assert called["write_chunksize"] == 256
 
 
+def test_cli_resolves_paths_with_base_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base_dir = tmp_path / "workspace"
+    input_dir = base_dir / "input"
+    output_dir = base_dir / "output"
+    input_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    input_csv = input_dir / "dataset.csv"
+    input_csv.write_text("a,b\n1,2\n", encoding="utf8")
+    called: dict[str, Path | str] = {}
+
+    def fake_read_csv(
+        path: Path | str,
+        sep: str,
+        encoding: str,
+        chunksize: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> DummyReader:
+        called["path"] = path
+        return DummyReader([pd.DataFrame({"a": [1], "b": [2]})])
+
+    def fake_write(
+        chunks: Iterable[pd.DataFrame],
+        output: Path | str,
+        col_order: list[str] | None = None,
+        key_cols: list[str] | None = None,
+        chunksize: int | None = None,
+        merge_chunksize: int | None = None,
+        drop_unexpected_cols: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        called["output"] = output
+        list(chunks)
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    monkeypatch.setattr(cli, "write_csv_chunks_deterministic", fake_write)
+
+    rc = cli.main(
+        [
+            "--base-path",
+            str(base_dir),
+            "--input-dir",
+            "input",
+            "--output-dir",
+            "output",
+            "--input",
+            "dataset.csv",
+            "--date",
+            "20240203",
+            "--key-cols",
+            "a",
+        ]
+    )
+
+    assert rc == 0
+    assert called["path"] == input_csv
+    expected = (output_dir / "output.dataset_20240203.csv").resolve()
+    assert Path(called["output"]) == expected
+
+
 def test_cli_does_not_leak_file_descriptors(tmp_path: Path) -> None:
     input_csv = tmp_path / "input.csv"
     input_csv.write_text("id,value\n1,a\n2,b\n", encoding="utf8")


### PR DESCRIPTION
## Summary
- call `cli.prepare_io_paths` in CLI helpers so base/input/output directory options are honoured
- update csv_utils output defaulting to work with resolved paths and refresh relevant docstrings
- extend csv_utils CLI argument tests with a base-path scenario

## Testing
- pytest tests/test_csv_utils_main_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d65cc48324bf3efe3d5afcf6ac