### PR TITLE
Validate CSV chunk sizes in CLI

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -26,6 +26,7 @@ from .cli import (
     apply_config_overrides,
     configure_logger,
     path_argument,
+    positive_int,
 )
 from .config import Config, ensure_dirs, print_config
 from .log import logger as default_logger
@@ -393,13 +394,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--key-cols", nargs="*", help="Columns used for sorting")
     parser.add_argument(
         "--chunk-size",
-        type=int,
+        type=positive_int,
         default=1000,
         help="Number of rows read per chunk",
     )
     parser.add_argument(
         "--merge-chunk-size",
-        type=int,
+        type=positive_int,
         default=1000,
         help="Rows loaded per temporary file during merge",
     )

--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -62,6 +62,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     sep = args.sep or cfg.io.csv_sep
     encoding = args.encoding or cfg.io.csv_encoding
     chunk_size = args.chunk_size or cfg.io.csv_chunksize
+    merge_chunk_size = args.merge_chunk_size
+    if merge_chunk_size is None:
+        merge_chunk_size = max(chunk_size, 1)
 
     output = args.output_csv or Path(args.input_csv).with_name(
         f"output.{Path(args.input_csv).stem}.csv"
@@ -78,7 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             col_order=args.col_order or None,
             key_cols=args.key_cols,
             chunksize=chunk_size,
-            merge_chunksize=args.merge_chunk_size,
+            merge_chunksize=merge_chunk_size,
             sep=cfg.io.csv_sep,
             encoding=cfg.io.csv_encoding,
             cfg=cfg,

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -114,6 +114,24 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     assert called["write_encoding"] == "latin1"
 
 
+def test_chunk_size_rejects_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["--chunk-size", "0", "--key-cols", "id"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "chunk size must be a positive integer" in err
+
+
+def test_merge_chunk_size_rejects_negative(capsys: pytest.CaptureFixture[str]) -> None:
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["--merge-chunk-size", "-5", "--key-cols", "id"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "chunk size must be a positive integer" in err
+
+
 def test_cli_generates_output_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- require positive integers for CSV chunk size arguments in the shared CLI parser
- default the merge chunk size to at least one chunk when unspecified after validation
- cover invalid chunk size inputs with unit tests

## Testing
- pytest tests/test_csv_utils_main_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dd66d71ee883248df2b747bde64225