### PR TITLE
Align test item PubChem columns across pipeline

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -92,10 +92,29 @@ ACTIVITY_COLUMNS = [
     "assay_variant_mutation",
 ]
 
+TESTITEM_PUBCHEM_COLUMNS: tuple[str, ...] = (
+    "pubchem_cid",
+    "pubchem_iupac_name",
+    "pubchem_molecular_formula",
+    "pubchem_isomeric_smiles",
+    "pubchem_canonical_smiles",
+    "pubchem_inchi",
+    "pubchem_inchikey",
+)
+
+
 TESTITEM_STRUCTURE_COLUMNS = {
     "molecule_structures.canonical_smiles": "canonical_smiles",
     "molecule_structures.standard_inchi": "standard_inchi",
     "molecule_structures.standard_inchi_key": "standard_inchi_key",
+    "pubchem.cid": "pubchem_cid",
+    "pubchem.canonical_smiles": "pubchem_canonical_smiles",
+    "pubchem.isomeric_smiles": "pubchem_isomeric_smiles",
+    "pubchem.inchi": "pubchem_inchi",
+    "pubchem.inchikey": "pubchem_inchikey",
+    "pubchem.inchi_key": "pubchem_inchikey",
+    "pubchem.iupac_name": "pubchem_iupac_name",
+    "pubchem.molecular_formula": "pubchem_molecular_formula",
 }
 
 TESTITEM_COLUMNS = [
@@ -113,6 +132,7 @@ TESTITEM_COLUMNS = [
     "canonical_smiles",
     "standard_inchi",
     "standard_inchi_key",
+    *TESTITEM_PUBCHEM_COLUMNS,
 ]
 
 
@@ -489,4 +509,5 @@ __all__ = [
     "ASSAY_COLUMNS",
     "ACTIVITY_COLUMNS",
     "TESTITEM_COLUMNS",
+    "TESTITEM_PUBCHEM_COLUMNS",
 ]

--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -31,6 +31,7 @@ from pandera.errors import SchemaErrors
 from library import chembl_library as cl
 from library import io, molecule_catalog, testitem_enrichment
 from library import pubchem_library as pl
+from library.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
 from library.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.config import (
@@ -68,15 +69,7 @@ _MOLECULE_HIERARCHY_COLUMNS = (
     "parent_molecule_chembl_id",
 )
 
-PUBCHEM_COLUMNS = [
-    "pubchem_cid",
-    "pubchem_iupac_name",
-    "pubchem_molecular_formula",
-    "pubchem_isomeric_smiles",
-    "pubchem_canonical_smiles",
-    "pubchem_inchi",
-    "pubchem_inchikey",
-]
+PUBCHEM_COLUMNS = list(TESTITEM_PUBCHEM_COLUMNS)
 
 _CID_CACHE_MISSING = object()
 _PUBCHEM_CACHE_SCHEMA_VERSION = 1


### PR DESCRIPTION
## Summary
- expose a shared `TESTITEM_PUBCHEM_COLUMNS` constant and extend the test item column order to include PubChem fields
- map nested `pubchem.*` payload keys onto the flattened schema columns during test item ingestion
- reuse the shared PubChem column order inside the pipeline to keep enrichment logic aligned with the ingestion schema

## Testing
- pytest tests/test_chembl_assay.py
- pytest tests/test_get_testitem_data.py::test_add_pubchem_data_fetches_properties_in_parallel

------
https://chatgpt.com/codex/tasks/task_e_68dd720b05f88324ae5637f9cc6f0683