### PR TITLE
Include PubChem fields in default test item configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -68,6 +68,13 @@ sources:
           - molecule_structures.canonical_smiles
           - molecule_structures.standard_inchi
           - molecule_structures.standard_inchi_key
+          - pubchem_cid
+          - pubchem_iupac_name
+          - pubchem_molecular_formula
+          - pubchem_isomeric_smiles
+          - pubchem_canonical_smiles
+          - pubchem_inchi
+          - pubchem_inchikey
       document:
         pubmed:
           column: "PMID"

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -176,7 +176,7 @@ The CLI only exposes high-level switches such as `--batch-size` or `--dry-run`; 
 | `request_limit` | `1000` | Hard cap on the number of paginated requests performed in a single execution. |
 | `retries` | `5` | Maximum number of retry attempts applied to failed API calls. |
 | `backoff_factor` | `0.5` | Multiplier controlling exponential backoff between retry attempts. |
-| `fields` | `['molecule_chembl_id', 'parent_molecule_chembl_id', 'pref_name', 'max_phase', 'molecule_type', 'first_approval', 'oral', 'parenteral', 'topical', 'black_box_warning', 'structure_type', 'molecule_structures.canonical_smiles', 'molecule_structures.standard_inchi', 'molecule_structures.standard_inchi_key']` | List of ChEMBL fields requested for each test item batch. |
+| `fields` | `['molecule_chembl_id', 'parent_molecule_chembl_id', 'pref_name', 'max_phase', 'molecule_type', 'first_approval', 'oral', 'parenteral', 'topical', 'black_box_warning', 'structure_type', 'molecule_structures.canonical_smiles', 'molecule_structures.standard_inchi', 'molecule_structures.standard_inchi_key', 'pubchem_cid', 'pubchem_iupac_name', 'pubchem_molecular_formula', 'pubchem_isomeric_smiles', 'pubchem_canonical_smiles', 'pubchem_inchi', 'pubchem_inchikey']` | List of ChEMBL and PubChem fields requested for each test item batch. |
 
 Pagination now tracks both the starting `offset` and a `request_limit`, allowing operators to resume large exports and bound the
 number of pages consumed per run. Network failures are handled via the shared retry policy (`retries`/`backoff_factor`) that

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -170,7 +170,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `request_limit` | `1000` | Максимальное число объектов в одном запросе API. |
 | `retries` | `5` | Количество повторов при временных ошибках ChEMBL. |
 | `backoff_factor` | `0.5` | Множитель экспоненциальной задержки между повторами. |
-| `fields` | `["molecule_chembl_id", "parent_molecule_chembl_id", "pref_name", "max_phase", "molecule_type", "first_approval", "oral", "parenteral", "topical", "black_box_warning", "structure_type", "molecule_structures.canonical_smiles", "molecule_structures.standard_inchi", "molecule_structures.standard_inchi_key"]` | Список полей, запрашиваемых у ChEMBL. |
+| `fields` | `["molecule_chembl_id", "parent_molecule_chembl_id", "pref_name", "max_phase", "molecule_type", "first_approval", "oral", "parenteral", "topical", "black_box_warning", "structure_type", "molecule_structures.canonical_smiles", "molecule_structures.standard_inchi", "molecule_structures.standard_inchi_key", "pubchem_cid", "pubchem_iupac_name", "pubchem_molecular_formula", "pubchem_isomeric_smiles", "pubchem_canonical_smiles", "pubchem_inchi", "pubchem_inchikey"]` | Список полей, запрашиваемых у ChEMBL и PubChem. |
 
 Параметры `offset` и `request_limit` помогают управлять пагинацией API: первый задаёт стартовую позицию, второй ограничивает размер одной страницы, который по умолчанию равен максимально допустимым 1000 объектам. Цикл повторов контролируется парами `retries`/`backoff_factor`, позволяя сгладить временные ошибки сервиса. Список `fields` определяет точный набор колонок в ответе и по умолчанию отражает рекомендуемый минимальный профиль тест-объекта.
 

--- a/library/config.py
+++ b/library/config.py
@@ -127,7 +127,7 @@ class _BoolModel(_BaseModel):
         raise ValueError(f"Invalid boolean value: {value!r}")
 
 
-# ChEMBL test item fields requested by default when fetching molecule data.
+# ChEMBL and PubChem test item fields requested by default when fetching molecule data.
 TESTITEM_FIELD_DEFAULTS: tuple[str, ...] = (
     "molecule_chembl_id",
     "parent_molecule_chembl_id",
@@ -143,6 +143,13 @@ TESTITEM_FIELD_DEFAULTS: tuple[str, ...] = (
     "molecule_structures.canonical_smiles",
     "molecule_structures.standard_inchi",
     "molecule_structures.standard_inchi_key",
+    "pubchem_cid",
+    "pubchem_iupac_name",
+    "pubchem_molecular_formula",
+    "pubchem_isomeric_smiles",
+    "pubchem_canonical_smiles",
+    "pubchem_inchi",
+    "pubchem_inchikey",
 )
 
 


### PR DESCRIPTION
## Summary
- extend the default test item field list to include PubChem identifiers and properties
- align the YAML configuration defaults and documentation tables with the expanded field list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd723fb8e88324adf6bcdb416814fc