### PR TITLE
Limit missing identifier logs to a sample

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -77,6 +77,7 @@ _PUBCHEM_CACHE_SCHEMA_VERSION = 1
 _DEFAULT_CATALOG_CFG = MoleculeCatalogCfg()
 
 _FETCH_ERROR_SAMPLE_SIZE = 10
+_MISSING_IDENTIFIER_LOG_SAMPLE_SIZE = 10
 _PLACEHOLDER_CONTACT_EMAIL = "contact@example.org"
 
 
@@ -164,6 +165,20 @@ def read_input_ids(
     return 0, ReadInputIdsResult(
         ids_iter=ids_iter,
         sample_ids=sample_ids,
+    )
+
+
+def _log_missing_identifier_summary(identifiers: Sequence[str]) -> None:
+    """Log a truncated list of missing identifiers including their total count."""
+
+    if not identifiers:
+        return
+
+    sample = list(islice(identifiers, _MISSING_IDENTIFIER_LOG_SAMPLE_SIZE))
+    logger.warning(
+        "chembl_missing_identifiers",
+        total=len(identifiers),
+        sample=sample,
     )
 
 
@@ -1925,12 +1940,7 @@ def run_testitem_pipeline(
 
         missing_keys = [key for key in requested_unique if key not in fetched_ids]
         missing_ids = [requested_unique[key] for key in missing_keys]
-        if missing_ids:
-            logger.warning(
-                "chembl_missing_identifiers",
-                count=len(missing_ids),
-                identifiers=missing_ids,
-            )
+        _log_missing_identifier_summary(missing_ids)
 
         rows = len(df)
         if limit is not None:

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -251,6 +251,28 @@ def test_fetch_testitems_logs_missing_summary(
     assert "missing_ids" not in missing_data
 
 
+def test_log_missing_identifier_summary_limits_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(pipeline.logger, "warning", fake_warning)
+
+    pipeline._log_missing_identifier_summary([])
+    assert captured == []
+
+    identifiers = [f"CHEMBL{index}" for index in range(20)]
+    pipeline._log_missing_identifier_summary(identifiers)
+
+    assert len(captured) == 1
+    event, payload = captured[0]
+    assert event == "chembl_missing_identifiers"
+    assert payload["total"] == len(identifiers)
+    assert payload["sample"] == identifiers[:10]
+    assert "identifiers" not in payload
+
+
 def test_fetch_parent_catalog_skips_single_when_parentless(
     cfg: Config,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a helper that logs missing identifiers with a truncated sample and total count
- update the pipeline to use the helper instead of logging the full identifier list
- cover the new log format with a unit test

## Testing
- pytest tests/test_get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8e1a78688324a1d1788c215862ed