### PR TITLE
Respect PubMed-specific rate limiter configuration

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -123,8 +123,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 
-    limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
-    delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
+    pubmed_rps = cfg.pubmed.rps or cfg.rate.global_rps
+    pubmed_burst = cfg.pubmed.burst or cfg.rate.global_burst
+    limiter = get_limiter("pubmed", pubmed_rps, pubmed_burst)
+    delay = 1.0 / pubmed_rps if pubmed_rps > 0 else 0.0
 
     pmid_df = read_pmids(args.input_csv, cfg=cfg.pubmed)
     pmids = pmid_df["PMID"].tolist()

--- a/tests/test_pubmed_library_config_single.py
+++ b/tests/test_pubmed_library_config_single.py
@@ -76,3 +76,78 @@ def test_pubmed_library_single_config(
     df = pd.read_csv(output_csv)
     assert not df.empty
     assert calls["cfg"] == 1
+
+
+def test_pubmed_library_rate_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PubMed-specific rate overrides should control limiter and delays."""
+
+    calls: dict[str, list[tuple[str, float, int | None]]] = {"limiters": []}
+    delays: dict[str, float] = {}
+
+    def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None, *, client=None):
+        delays["pubmed"] = delay
+        return [
+            {
+                "PubMed.PMID": pid,
+                "PubMed.DOI": "10.1000/example",  # pragma: no cover - deterministic field
+                "PubMed.ArticleTitle": "Example",
+            }
+            for pid in pmids
+        ]
+
+    def fake_fetch_semantic_scholar_batch(session, pmids, delay, cfg=None):
+        delays["semantic_scholar"] = delay
+        return [
+            {
+                "scholar.PMID": pid,
+                "scholar.DOI": "10.1000/example",  # pragma: no cover - deterministic field
+                "scholar.Error": "",
+            }
+            for pid in pmids
+        ]
+
+    monkeypatch.setattr(pl, "fetch_pubmed_batch", fake_fetch_pubmed_batch)
+    monkeypatch.setattr(pl, "fetch_semantic_scholar_batch", fake_fetch_semantic_scholar_batch)
+    monkeypatch.setattr(pl, "fetch_openalex", lambda *a, **k: {"OpenAlex.Error": ""})
+    monkeypatch.setattr(pl, "fetch_crossref", lambda *a, **k: {"crossref.Error": ""})
+
+    def fake_get_limiter(name, rps, burst=None):
+        calls["limiters"].append((name, rps, burst))
+        return DummyLimiter()
+
+    monkeypatch.setattr(pl, "get_limiter", fake_get_limiter)
+
+    base_cfg = pl.Config()
+    cfg_dict = base_cfg.model_dump()
+    cfg_dict["system"]["rate"]["global_rps"] = 8
+    cfg_dict["system"]["rate"]["global_burst"] = 9
+    cfg_dict["sources"]["pubmed"]["rps"] = 5
+    cfg_dict["sources"]["pubmed"]["burst"] = 6
+    custom_cfg = pl.Config.model_validate(cfg_dict)
+
+    def fake_apply_config_overrides(*args, **kwargs):
+        return custom_cfg
+
+    monkeypatch.setattr(pl.cli, "apply_config_overrides", fake_apply_config_overrides)
+
+    input_csv = Path("tests/data/pmids.csv")
+    output_csv = tmp_path / "override.csv"
+
+    exit_code = pl.main(
+        [
+            "--input-csv",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--log-level",
+            "ERROR",
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    assert calls["limiters"][0] == ("pubmed", 5, 6)
+    assert delays["pubmed"] == pytest.approx(1 / 5)
+    assert delays["semantic_scholar"] == pytest.approx(1 / 5)


### PR DESCRIPTION
## Summary
- derive PubMed-specific rate and burst limits, falling back to global settings, and feed them into the shared limiter and request delay
- ensure the computed delay is propagated to downstream batch fetchers
- add a regression test covering PubMed rate override behaviour

## Testing
- pytest tests/test_pubmed_library_config_single.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8e042c488324b27d17180fd760c6