### PR TITLE
Adjust verbose client logging levels

### DIFF
--- a/library/clients/openalex.py
+++ b/library/clients/openalex.py
@@ -33,7 +33,7 @@ def fetch_openalex(
     url = f"{base}/works/pmid:{pmid}?mailto={quote(cfg.mailto)}"
     timeout = (cfg.timeout_connect, cfg.timeout_read)
 
-    logger.info("request_start", extra={"stage": "request_start", "url": url})
+    logger.debug("request_start", extra={"stage": "request_start", "url": url})
     data, error = _do_request(
         session,
         url,
@@ -42,7 +42,7 @@ def fetch_openalex(
         timeout=timeout,
     )
     if error:
-        logger.info("request_fail", extra={"stage": "request_fail", "url": url})
+        logger.debug("request_fail", extra={"stage": "request_fail", "url": url})
     else:
-        logger.info("request_ok", extra={"stage": "request_ok", "url": url})
+        logger.debug("request_ok", extra={"stage": "request_ok", "url": url})
     return data, error

--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -180,9 +180,9 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         cached = cache.get(url) if cache is not None else None
     if cached is not None:
         if cached.is_hit:
-            logger.info("cache_hit", url=url, rps=cfg.rps, status="hit")
+            logger.debug("cache_hit", url=url, rps=cfg.rps, status="hit")
             return cast(dict[str, Any], cached.payload)
-        logger.info(
+        logger.debug(
             "cache_hit",
             url=url,
             rps=cfg.rps,
@@ -190,7 +190,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             outcome=cached.outcome,
         )
         return None
-    logger.info("cache_miss", url=url, rps=cfg.rps, status="miss")
+    logger.debug("cache_miss", url=url, rps=cfg.rps, status="miss")
 
     total_attempts = cfg.retries + 1
     if total_attempts <= 0:
@@ -210,7 +210,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 rps=cfg.rps,
             )
             _store_cache_miss(url, cfg, "timeout")
-            logger.info(
+            logger.debug(
                 "request_fail",
                 url=url,
                 status=None,
@@ -238,7 +238,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         "request_not_found", url=url, status=status, rps=cfg.rps
                     )
                     _store_cache_miss(url, cfg, "not_found")
-                    logger.info(
+                    logger.debug(
                         "request_fail",
                         url=url,
                         status=status,
@@ -261,7 +261,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         rps=cfg.rps,
                     )
                     if attempt >= total_attempts:
-                        logger.info(
+                        logger.debug(
                             "request_fail",
                             url=url,
                             status=status,
@@ -281,7 +281,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         status=status,
                         rps=cfg.rps,
                     )
-                    logger.info(
+                    logger.debug(
                         "request_fail",
                         url=url,
                         status=status,
@@ -303,7 +303,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                             total_attempts=total_attempts,
                             rps=cfg.rps,
                         )
-                        logger.info(
+                        logger.debug(
                             "request_fail",
                             url=url,
                             status=status,
@@ -321,7 +321,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         status=status,
                         rps=cfg.rps,
                     )
-                    logger.info(
+                    logger.debug(
                         "request_fail",
                         url=url,
                         status=status,
@@ -351,7 +351,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     total_attempts=total_attempts,
                     rps=cfg.rps,
                 )
-                logger.info(
+                logger.debug(
                     "request_fail",
                     url=url,
                     status=None,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -52,7 +52,8 @@ def test_debug_events_filtered_by_default() -> None:
         "buf = io.StringIO(); "
         "logger = configure_logger(LoggerConfig(level='INFO', run_id='rid', stream=buf)); "
         "logger.debug('request_start', url='https://example.org'); "
-        "logger.info('request_fail', url='https://example.org'); "
+        "logger.debug('request_fail', url='https://example.org'); "
+        "logger.info('request_not_found', url='https://example.org'); "
         "print(buf.getvalue())"
     )
     result = subprocess.run(
@@ -60,7 +61,8 @@ def test_debug_events_filtered_by_default() -> None:
     )
     records = _parse(result.stdout)
     assert all(record["event"] != "request_start" for record in records)
+    assert all(record["event"] != "request_fail" for record in records)
     assert any(
-        record["event"] == "request_fail" and record["level"] == "INFO"
+        record["event"] == "request_not_found" and record["level"] == "INFO"
         for record in records
     )


### PR DESCRIPTION
## Summary
- lower the cache hit/miss and per-request logging for PubChem and OpenAlex clients to DEBUG for less noise
- leave summary events at INFO while updating logging tests to reflect the new DEBUG thresholds

## Testing
- pytest tests/test_logging.py tests/test_chembl_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8e0650748324bbcdacb4d5d595a0