### PR TITLE
Add metadata and validation outputs to PubMed library

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 from datetime import date
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -20,7 +21,13 @@ from .clients.semantic_scholar import (
 )
 from .cli import LoggerConfig, configure_logger, path_argument
 from .cli import build_parser as base_parser
-from .config import Config, ensure_dirs, print_config, session_with_retry
+from .config import (
+    Config,
+    _serialize_paths,
+    ensure_dirs,
+    print_config,
+    session_with_retry,
+)
 from .csv_utils import write_csv_deterministic
 from .clients.pubmed import PubMedClient
 from .pubmed import (
@@ -39,6 +46,9 @@ from .pubmed import (
     text_or_none,
 )
 from .rate_limiter import get_limiter
+from .metadata import Stats, file_sha256, write_meta_yaml as write_pipeline_meta_yaml
+from .sidecar import SidecarErrors
+from .table_quality import analyze_table_quality
 
 __all__ = [
     "Config",
@@ -60,6 +70,9 @@ __all__ = [
     "parse_args",
     "main",
 ]
+
+
+REQUIRED_FIELDS = ("PubMed.PMID",)
 
 
 def parse_args(
@@ -126,13 +139,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     limiter = get_limiter("global", cfg.rate.global_rps, cfg.rate.global_burst)
     delay = 1.0 / cfg.rate.global_rps if cfg.rate.global_rps > 0 else 0.0
 
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    command = " ".join(["library.pubmed_library", *map(str, raw_argv)])
     pmid_df = read_pmids(args.input_csv, cfg=cfg.pubmed)
     pmids = pmid_df["PMID"].tolist()
     openalex_limiter = get_limiter("openalex", cfg.openalex.rps, cfg.openalex.burst)
     crossref_limiter = get_limiter("crossref", cfg.crossref.rps, cfg.crossref.burst)
     pubmed_client = PubMedClient(cfg.pubmed)
 
-    records: list[dict[str, str]] = []
+    valid_records: list[dict[str, str]] = []
+    errors = SidecarErrors()
+    rows_total = 0
+    rows_kept = 0
+    total_failures = 0
     batch_size = cfg.document.pubmed.batch_size
     dump_level = "INFO" if args.keep_verbose_dumps else "DEBUG"
     with session_with_retry(cfg.api, cfg.retry) as session:
@@ -147,12 +166,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 session, batch_pmids, delay, cfg=cfg.semantic_scholar
             )
             semsch_map = {s.get("scholar.PMID"): s for s in semsch_list}
-            for pubmed in pubmed_list:
+            for index, pubmed in enumerate(pubmed_list):
+                source_pmid = batch_pmids[index]
                 pmid = pubmed.get("PubMed.PMID", "")
-                semsch = semsch_map.get(pmid, {})
+                resolved_pmid = pmid or source_pmid
+                semsch = semsch_map.get(pmid) or semsch_map.get(source_pmid, {})
 
                 openalex = fetch_openalex(
-                    session, pmid, cfg=cfg.openalex, limiter=openalex_limiter
+                    session,
+                    resolved_pmid,
+                    cfg=cfg.openalex,
+                    limiter=openalex_limiter,
                 )
                 doi = pubmed.get("PubMed.DOI") or semsch.get("scholar.DOI") or ""
                 crossref = fetch_crossref(
@@ -161,16 +185,66 @@ def main(argv: Sequence[str] | None = None) -> int:
 
                 combined = merge_records(pubmed, semsch, openalex, crossref)
                 print_results([combined], level=dump_level)
-                records.append(combined)
+                rows_total += 1
+                missing_fields = [
+                    field
+                    for field in REQUIRED_FIELDS
+                    if not str(combined.get(field, "")).strip()
+                ]
+                if missing_fields:
+                    total_failures += 1
+                    errors.add_error(
+                        {
+                            "row_index": rows_total - 1,
+                            "missing_fields": "|".join(missing_fields),
+                            "source_pmid": source_pmid,
+                            "PubMed.PMID": combined.get("PubMed.PMID", ""),
+                        }
+                    )
+                    continue
+                valid_records.append(combined)
+                rows_kept += 1
 
-    df = pd.DataFrame.from_records(records)
+    df = pd.DataFrame.from_records(valid_records)
     output_path = (
         Path(args.output_csv)
         if args.output_csv
         else Path(f"output.{Path(args.input_csv).stem}_{date.today():%Y%m%d}.csv")
     )
-    write_csv_deterministic(df, output_path, key_cols=sorted(df.columns))
-    logger.info("file_written", path=str(output_path))
+    failure_path = output_path.with_name(f"{output_path.stem}_failure_cases.csv")
+    csv_path = write_csv_deterministic(df, output_path, key_cols=sorted(df.columns))
+    rows_dropped = rows_total - rows_kept
+    if total_failures:
+        logger.error(
+            "validation_failed",
+            failures=total_failures,
+            path=str(failure_path),
+        )
+        errors.save(failure_path)
+    stats: Stats = {
+        "rows_total": rows_total,
+        "rows_kept": rows_kept,
+        "rows_dropped": rows_dropped,
+        "output_sha256": file_sha256(csv_path),
+    }
+    write_pipeline_meta_yaml(
+        csv_path=csv_path,
+        command=command,
+        config_subset=_serialize_paths(cfg.to_dict()),
+        inputs={"input_csv": str(args.input_csv)},
+        stats=stats,
+        schema="PubMedMetadata",
+    )
+    try:
+        analyze_table_quality(df, table_name=str(csv_path.with_suffix("")))
+    except ValueError as exc:
+        logger.error(
+            "quality_report_failed",
+            error=str(exc),
+            path=str(csv_path),
+        )
+        return 1
+    logger.info("file_written", path=str(csv_path))
     logger.info("pipeline_done", run_id=log_cfg.run_id)
     return 0
 

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -17,14 +17,17 @@ def test_pubmed_library_main_smoke(
     verbose_output_csv = tmp_path / "out_verbose.csv"
 
     def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None, *, client=None):
-        return [
-            {
+        records = []
+        for index, pid in enumerate(pmids):
+            record = {
                 "PubMed.PMID": pid,
                 "PubMed.DOI": "10.1000/example",
                 "PubMed.ArticleTitle": "Example",
             }
-            for pid in pmids
-        ]
+            if index == 0:
+                record.pop("PubMed.PMID")
+            records.append(record)
+        return records
 
     def fake_fetch_semantic_scholar_batch(session, pmids, delay, cfg=None):
         return [
@@ -77,6 +80,18 @@ def test_pubmed_library_main_smoke(
     assert output_csv.exists()
     df = pd.read_csv(output_csv)
     assert not df.empty
+    meta_path = Path(f"{output_csv}.meta.yaml")
+    assert meta_path.exists()
+    failure_path = output_csv.with_name(f"{output_csv.stem}_failure_cases.csv")
+    assert failure_path.exists()
+    quality_path = Path(f"{output_csv.with_suffix('')}_quality_report_table.csv")
+    correlation_path = Path(
+        f"{output_csv.with_suffix('')}_data_correlation_report_table.csv"
+    )
+    assert quality_path.exists()
+    assert correlation_path.exists()
+    failure_df = pd.read_csv(failure_path)
+    assert not failure_df.empty
 
     start_idx = len(levels)
     exit_code_verbose = pl.main(


### PR DESCRIPTION
## Summary
- collect required-field validation failures in the PubMed CLI and persist them via SidecarErrors
- enrich the generated CSV with pipeline metadata and table-quality reports
- extend the smoke test to exercise the new artefacts

## Testing
- `pytest tests/test_pubmed_library_main_smoke.py tests/test_pubmed_library_config_single.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd8e023d0c8324a1e002e694bb1b87