### PR TITLE
Allow PubChem client to reuse default user agent after initialisation

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -65,13 +65,14 @@ _DEFAULT_API_CFG = ApiCfg(user_agent="chembl-da/1.0 (mailto:chembl-data@ebi.ac.u
 _DEFAULT_RETRY_CFG = RetryCfg()
 _SESSION_CFG: tuple[ApiCfg, RetryCfg] = (_DEFAULT_API_CFG, _DEFAULT_RETRY_CFG)
 _SESSION_SIGNATURE = _config_signature(*_SESSION_CFG)
+_SESSION_INITIALISED = False
 _session: Session | None = session_with_retry(*_SESSION_CFG)
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session."""
 
-    global _SESSION_CFG, _SESSION_SIGNATURE, _session
+    global _SESSION_CFG, _SESSION_SIGNATURE, _SESSION_INITIALISED, _session
     signature = _config_signature(api, retry)
     old_session: Session | None = None
     with _SESSION_LOCK:
@@ -79,6 +80,7 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
         _session = None
         _SESSION_CFG = (api, retry)
         _SESSION_SIGNATURE = signature
+        _SESSION_INITIALISED = True
     if old_session is not None:
         old_session.close()
 
@@ -86,7 +88,7 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
 def get_session(cfg: ApiCfg | None = None) -> Session:
     """Return the shared HTTP session, creating or refreshing as needed."""
 
-    global _SESSION_CFG, _SESSION_SIGNATURE, _session
+    global _SESSION_CFG, _SESSION_SIGNATURE, _SESSION_INITIALISED, _session
     old_session: Session | None = None
     with _SESSION_LOCK:
         current_api, current_retry = _SESSION_CFG
@@ -95,7 +97,10 @@ def get_session(cfg: ApiCfg | None = None) -> Session:
         needs_refresh = signature != _SESSION_SIGNATURE or _session is None
         _SESSION_CFG = (target_api, current_retry)
         if needs_refresh:
-            if target_api.user_agent == _DEFAULT_API_CFG.user_agent:
+            if (
+                target_api.user_agent == _DEFAULT_API_CFG.user_agent
+                and not _SESSION_INITIALISED
+            ):
                 raise ValueError(
                     "PubChem client requires a custom User-Agent; "
                     "call init_session with contact details before making requests."
@@ -109,7 +114,10 @@ def get_session(cfg: ApiCfg | None = None) -> Session:
         old_session.close()
     if session is None:
         raise RuntimeError("Failed to initialise PubChem session")
-    if session.headers.get("User-Agent") == _DEFAULT_API_CFG.user_agent:
+    if (
+        session.headers.get("User-Agent") == _DEFAULT_API_CFG.user_agent
+        and not _SESSION_INITIALISED
+    ):
         raise ValueError(
             "PubChem client requires a custom User-Agent; "
             "call init_session with contact details before making requests."

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -73,6 +73,7 @@ def reset_pubchem_session() -> None:
     with pc._SESSION_LOCK:  # type: ignore[attr-defined]
         original_cfg = pc._SESSION_CFG  # type: ignore[attr-defined]
         original_signature = pc._SESSION_SIGNATURE  # type: ignore[attr-defined]
+        original_initialised = pc._SESSION_INITIALISED  # type: ignore[attr-defined]
         original_session = pc._session  # type: ignore[attr-defined]
     try:
         yield
@@ -81,6 +82,7 @@ def reset_pubchem_session() -> None:
             current_session = pc._session  # type: ignore[attr-defined]
             pc._SESSION_CFG = original_cfg  # type: ignore[attr-defined]
             pc._SESSION_SIGNATURE = original_signature  # type: ignore[attr-defined]
+            pc._SESSION_INITIALISED = original_initialised  # type: ignore[attr-defined]
             pc._session = session_with_retry(*original_cfg)  # type: ignore[attr-defined]
         if current_session is not None:
             current_session.close()
@@ -94,6 +96,25 @@ def _configure_session(user_agent: str = "pubchem-tests/1.0 (mailto:tests@exampl
     pc.init_session(api_cfg, retry_cfg)
     pc.get_session(api_cfg)
     return api_cfg
+
+
+def test_get_session_requires_initialisation_for_default_user_agent() -> None:
+    """Default configuration must call init_session before use."""
+
+    with pytest.raises(ValueError, match="requires a custom User-Agent"):
+        pc.get_session(ApiCfg())
+
+
+def test_get_session_allows_default_after_initialisation() -> None:
+    """Calling init_session enables reuse of the bundled default agent."""
+
+    api_cfg = ApiCfg()
+    retry_cfg = RetryCfg()
+    pc.init_session(api_cfg, retry_cfg)
+
+    session = pc.get_session()
+
+    assert session.headers.get("User-Agent") == api_cfg.user_agent
 
 
 def test_make_request_serves_cached_results_across_threads(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- track whether the PubChem HTTP session has been initialised explicitly
- permit the bundled default User-Agent once init_session has been called while still guarding against implicit use
- extend the PubChem client thread-safety tests to cover the updated behaviour

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd936a674483248436694d1b3cbd62