### PR TITLE
Handle missing UniProt data in target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -74,6 +74,8 @@ TARGETS_OBJECT_COLUMNS: set[str] = {
     if str(column.dtype) == "object"
 }
 
+UNIPROT_MISSING_VALUE = ""
+
 
 DEFAULT_INPUT_NAME = "target.csv"
 DEFAULT_OUTPUT_STEM = "targets"
@@ -989,21 +991,48 @@ def fetch_iuphar(
     """
 
     logger.info("fetch_iuphar_start", output=str(output_csv))
-    if cfg.target.all.uniprot_column != "uniprot_id":
+    merge_column = cfg.target.all.uniprot_column
+
+    if merge_column != "uniprot_id":
         chembl_for_merge = chembl_df.drop(columns=["uniprot_id"], errors="ignore")
     else:
         chembl_for_merge = chembl_df.copy()
 
+    if merge_column not in chembl_for_merge.columns:
+        logger.warning("missing_uniprot_column", column=merge_column)
+        placeholder = pd.Series(
+            UNIPROT_MISSING_VALUE,
+            index=chembl_for_merge.index,
+            dtype=object,
+        )
+        chembl_for_merge = chembl_for_merge.assign(**{merge_column: placeholder})
+
     combined_df = pd.merge(
         chembl_for_merge,
         uniprot_df,
-        left_on=cfg.target.all.uniprot_column,
+        left_on=merge_column,
         right_on="original_id",
         how="left",
-    ).drop(columns=["original_id"])
-    if cfg.target.all.uniprot_column == "uniprot_id":
-        combined_df = combined_df.drop(columns=["uniprot_id_x"], errors="ignore")
-        combined_df = combined_df.rename(columns={"uniprot_id_y": "uniprot_id"})
+    )
+
+    if "original_id" in combined_df.columns:
+        combined_df = combined_df.drop(columns=["original_id"])
+    if merge_column == "uniprot_id":
+        left_series = combined_df.pop("uniprot_id_x") if "uniprot_id_x" in combined_df else None
+        right_series = combined_df.pop("uniprot_id_y") if "uniprot_id_y" in combined_df else None
+        if left_series is not None and right_series is not None:
+            combined_df["uniprot_id"] = right_series.fillna(left_series)
+        elif left_series is not None:
+            combined_df["uniprot_id"] = left_series
+        elif right_series is not None:
+            combined_df["uniprot_id"] = right_series
+
+    if "gene" not in combined_df.columns:
+        combined_df["gene"] = pd.Series(
+            UNIPROT_MISSING_VALUE,
+            index=combined_df.index,
+            dtype=object,
+        )
 
     ec_number_columns = [
         column for column in combined_df.columns if column.startswith("ec_numbers")
@@ -1197,15 +1226,22 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
         encoding=cfg.io.csv_encoding,
         col_order=TARGETS_COLUMN_ORDER,
     )
-    try:
-        analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output),
+    if final_df.empty:
+        logger.info(
+            "quality_report_skipped",
+            reason="empty_dataframe",
+            table=str(output.with_suffix("")),
         )
-        return 1
+    else:
+        try:
+            analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
+        except ValueError as exc:
+            logger.error(
+                "quality_report_failed",
+                error=str(exc),
+                path=str(output),
+            )
+            return 1
     logger.info("validate_write_done", rows=len(final_df))
     return exit_code
 

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -13,6 +13,7 @@ from pytest import MonkeyPatch
 from library import protein_classification as pc
 from library.config import Config
 from schemas import TargetsSchema
+from schemas.targets import TARGETS_COLUMN_ORDER
 from scripts import get_target_data as gtd
 
 
@@ -328,6 +329,26 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     assert iuphar_df.loc[0, "IUPHAR_class"] == "Enzyme"
 
 
+def test_fetch_iuphar_missing_uniprot_column(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    chembl_df = pd.DataFrame({"target_chembl_id": ["C1"]})
+    uniprot_df = pd.DataFrame(columns=["uniprot_id", "original_id"])
+    out = tmp_path / "iuphar.csv"
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        pd.DataFrame(columns=["uniprot_id"]).to_csv(args.output_csv, index=False)
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+    combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
+
+    merge_column = cfg.target.all.uniprot_column
+    assert merge_column in combined_df.columns
+    assert combined_df.loc[0, merge_column] == gtd.UNIPROT_MISSING_VALUE
+    assert iuphar_df.empty
+
+
 def test_run_all_preserves_reaction_ec_numbers(
     monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
 ) -> None:
@@ -391,3 +412,15 @@ def test_run_all_preserves_reaction_ec_numbers(
     assert result.loc[0, "protein_class_pred_L1"] == "ClassA"
     assert result.loc[0, "protein_class_pred_rule_id"] == "target_id"
     assert classifier.calls
+
+
+def test_validate_and_write_skips_quality_for_empty(
+    tmp_path: Path, cfg: Config
+) -> None:
+    df = pd.DataFrame(columns=TARGETS_COLUMN_ORDER)
+    output = tmp_path / "targets.csv"
+
+    exit_code = gtd.validate_and_write(df, output, cfg)
+
+    assert exit_code == 0
+    assert output.exists()


### PR DESCRIPTION
## Summary
- add a placeholder UniProt identifier when the configured column is missing so the merge and downstream processing remain stable
- retain the left-hand UniProt accession during merges and inject an empty gene column to satisfy post-processing expectations
- skip table-quality analysis for empty exports and extend unit coverage for the new behaviours

## Testing
- pytest tests/test_get_target_data_fetch.py
- python scripts/get_data.py --limit 1 *(fails later in the workflow because data/input/assay.csv lacks the expected assay_chembl_id column)*

------
https://chatgpt.com/codex/tasks/task_e_68dd93e25c3483249349bf8b0c101778