### PR TITLE
Ensure PubChem augmentation reuses prepared API configuration

### DIFF
--- a/library/testitem_pipeline.py
+++ b/library/testitem_pipeline.py
@@ -1886,9 +1886,9 @@ def augment_pubchem(
 ) -> pd.DataFrame:
     """Augment ``df`` with PubChem information if enabled.
 
-    The shared PubChem client session is initialised with ``api_cfg`` and
-    ``retry_cfg`` before enrichment. Callers must therefore provide both
-    configurations even when invoking this function directly.
+    Callers must provide ``api_cfg`` derived from
+    :func:`_prepare_pubchem_api_cfg` so the PubChem session uses the correct
+    contact details.
     """
 
     pubchem_cid_cache: dict[str, str | None] | None = None
@@ -2079,7 +2079,7 @@ def run_testitem_pipeline(
                     current = augment_pubchem(
                         current,
                         pubchem_cfg=cfg.pubchem,
-                        api_cfg=api_cfg,
+                        api_cfg=pubchem_api_cfg,
                         retry_cfg=cfg.retry,
                         timeout=parent_timeout,
                         client=client,

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -460,10 +460,12 @@ def test_augment_pubchem_initialises_caches(
     monkeypatch.setattr(pipeline, "_load_pubchem_cid_cache", fake_load)
     monkeypatch.setattr(pipeline, "add_pubchem_data", fake_add)
 
+    pubchem_api_cfg = pipeline._prepare_pubchem_api_cfg(cfg, cfg.api)
+
     result = pipeline.augment_pubchem(
         df,
         pubchem_cfg=cfg.pubchem,
-        api_cfg=cfg.api,
+        api_cfg=pubchem_api_cfg,
         retry_cfg=cfg.retry,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
@@ -488,6 +490,8 @@ def test_augment_pubchem_initialises_session_once(
 
     captured: dict[str, object] = {"init_calls": 0}
 
+    pubchem_api_cfg = pipeline._prepare_pubchem_api_cfg(cfg, cfg.api)
+
     def fake_init_session(api: object, retry: object) -> None:
         captured["init_calls"] = captured["init_calls"] + 1
         captured["init_args"] = (api, retry)
@@ -505,7 +509,7 @@ def test_augment_pubchem_initialises_session_once(
     first = pipeline.augment_pubchem(
         df,
         pubchem_cfg=cfg.pubchem,
-        api_cfg=cfg.api,
+        api_cfg=pubchem_api_cfg,
         retry_cfg=cfg.retry,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
@@ -516,7 +520,7 @@ def test_augment_pubchem_initialises_session_once(
     second = pipeline.augment_pubchem(
         df,
         pubchem_cfg=cfg.pubchem,
-        api_cfg=cfg.api,
+        api_cfg=pubchem_api_cfg,
         retry_cfg=cfg.retry,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
@@ -525,7 +529,7 @@ def test_augment_pubchem_initialises_session_once(
     )
 
     assert captured["init_calls"] == 1
-    assert captured["init_args"] == (cfg.api, cfg.retry)
+    assert captured["init_args"] == (pubchem_api_cfg, cfg.retry)
     assert "pubchem_cid" in first.columns
     assert "pubchem_cid" in second.columns
 


### PR DESCRIPTION
## Summary
- ensure `augment_pubchem` documentation reflects that the prepared PubChem API config must be supplied
- reuse the prepared PubChem API config when augmenting test item chunks to avoid resetting the session to the ChEMBL defaults
- update unit tests to pass the prepared configuration and assert against it

## Testing
- pytest tests/test_get_testitem_data.py::test_augment_pubchem_initialises_caches tests/test_get_testitem_data.py::test_augment_pubchem_initialises_session_once tests/test_testitem_pipeline_threadsafe.py::test_augment_pubchem_single_initialisation

------
https://chatgpt.com/codex/tasks/task_e_68dd956f94d8832495b015e4cfb5d660