### PR TITLE
Allow implicit PubChem session initialisation

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -68,6 +68,23 @@ _SESSION_SIGNATURE = _config_signature(*_SESSION_CFG)
 _SESSION_INITIALISED = False
 _session: Session | None = session_with_retry(*_SESSION_CFG)
 
+_PLACEHOLDER_CONTACT = "contact@example.org"
+_USER_AGENT_ERROR = (
+    "PubChem client requires a custom User-Agent; "
+    "call init_session with contact details before making requests."
+)
+
+
+def _has_contact_details(user_agent: str | None) -> bool:
+    """Return ``True`` when *user_agent* contains usable contact details."""
+
+    if not user_agent:
+        return False
+    lowered = user_agent.casefold()
+    if _PLACEHOLDER_CONTACT in lowered:
+        return False
+    return "@" in lowered
+
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session."""
@@ -97,31 +114,26 @@ def get_session(cfg: ApiCfg | None = None) -> Session:
         needs_refresh = signature != _SESSION_SIGNATURE or _session is None
         _SESSION_CFG = (target_api, current_retry)
         if needs_refresh:
-            if (
-                target_api.user_agent == _DEFAULT_API_CFG.user_agent
-                and not _SESSION_INITIALISED
+            if not _SESSION_INITIALISED and not _has_contact_details(
+                target_api.user_agent
             ):
-                raise ValueError(
-                    "PubChem client requires a custom User-Agent; "
-                    "call init_session with contact details before making requests."
-                )
+                raise ValueError(_USER_AGENT_ERROR)
             new_session = session_with_retry(target_api, current_retry)
             old_session = _session
             _session = new_session
             _SESSION_SIGNATURE = signature
+            if not _SESSION_INITIALISED:
+                _SESSION_INITIALISED = True
         session = _session
     if old_session is not None:
         old_session.close()
     if session is None:
         raise RuntimeError("Failed to initialise PubChem session")
-    if (
-        session.headers.get("User-Agent") == _DEFAULT_API_CFG.user_agent
-        and not _SESSION_INITIALISED
-    ):
-        raise ValueError(
-            "PubChem client requires a custom User-Agent; "
-            "call init_session with contact details before making requests."
-        )
+    if not _SESSION_INITIALISED:
+        user_agent = session.headers.get("User-Agent")
+        if not _has_contact_details(user_agent):
+            raise ValueError(_USER_AGENT_ERROR)
+        _SESSION_INITIALISED = True
     return session
 
 

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -100,11 +100,14 @@ def _configure_session(
     return api_cfg
 
 
-def test_get_session_requires_initialisation_for_default_user_agent() -> None:
-    """Default configuration must call init_session before use."""
+def test_get_session_initialises_for_default_user_agent() -> None:
+    """Default configuration should initialise lazily when unused."""
 
-    with pytest.raises(ValueError, match="requires a custom User-Agent"):
-        pc.get_session(ApiCfg())
+    api_cfg = ApiCfg()
+
+    session = pc.get_session(api_cfg)
+
+    assert session.headers.get("User-Agent") == api_cfg.user_agent
 
 
 def test_get_session_allows_default_after_initialisation() -> None:


### PR DESCRIPTION
## Summary
- allow the PubChem client to lazily accept configurations that already provide contact details
- update the PubChem client thread-safety test to cover the new lazy initialisation path

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9bcf23348324be20d48273c45570