### PR TITLE
Handle PubChem Retry-After headers

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from threading import Lock
 from time import monotonic
 from typing import Any, cast
@@ -49,10 +51,35 @@ class _CacheEntry:
 
     payload: dict[str, Any] | None
     outcome: str
+    details: dict[str, Any] | None = None
 
     @property
     def is_hit(self) -> bool:
         return self.payload is not None
+
+
+def _retry_after_seconds(value: str | None, *, now: datetime | None = None) -> float | None:
+    """Return the delay in seconds represented by ``Retry-After`` header ``value``."""
+
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        seconds = float(text)
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(text)
+        except (TypeError, ValueError):
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        reference = now or datetime.now(timezone.utc)
+        seconds = (parsed - reference).total_seconds()
+    if seconds < 0:
+        return 0.0
+    return seconds
 
 
 # Cache is initialised lazily to allow configuration of the TTL via
@@ -190,12 +217,14 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         if cached.is_hit:
             logger.debug("cache_hit", url=url, rps=cfg.rps, status="hit")
             return cast(dict[str, Any], cached.payload)
+        miss_details = cached.details or {}
         logger.debug(
             "cache_hit",
             url=url,
             rps=cfg.rps,
             status="miss",
             outcome=cached.outcome,
+            **miss_details,
         )
         return None
     logger.debug("cache_miss", url=url, rps=cfg.rps, status="miss")
@@ -207,6 +236,16 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     deadline: float | None = None
     if cfg.timeout_seconds > 0:
         deadline = monotonic() + cfg.timeout_seconds
+    last_failure_details: dict[str, Any] | None = None
+
+    def details_excluding(*keys: str) -> dict[str, Any]:
+        if not last_failure_details:
+            return {}
+        return {
+            key: value
+            for key, value in last_failure_details.items()
+            if key not in keys
+        }
 
     for attempt in range(1, total_attempts + 1):
         if deadline is not None and monotonic() >= deadline:
@@ -216,14 +255,16 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 attempt=attempt,
                 total_attempts=total_attempts,
                 rps=cfg.rps,
+                **(last_failure_details or {}),
             )
-            _store_cache_miss(url, cfg, "timeout")
+            _store_cache_miss(url, cfg, "timeout", last_failure_details)
             logger.debug(
                 "request_fail",
                 url=url,
                 status=None,
                 total_attempts=total_attempts,
                 rps=cfg.rps,
+                **details_excluding("status"),
             )
             return None
         event = "request_start" if attempt == 1 else "request_retry"
@@ -242,19 +283,31 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
             ) as response:
                 status = response.status_code
                 if status == 404:
+                    last_failure_details = {"reason": "not_found", "status": status}
                     logger.info(
-                        "request_not_found", url=url, status=status, rps=cfg.rps
+                        "request_not_found",
+                        url=url,
+                        rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
-                    _store_cache_miss(url, cfg, "not_found")
+                    _store_cache_miss(url, cfg, "not_found", last_failure_details)
                     logger.debug(
                         "request_fail",
                         url=url,
-                        status=status,
                         total_attempts=total_attempts,
                         rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
                     return None
                 if status == 429 or 500 <= status < 600:
+                    retry_after_header = response.headers.get("Retry-After")
+                    retry_after = _retry_after_seconds(retry_after_header)
+                    reason = "rate_limited" if status == 429 else "server_error"
+                    last_failure_details = {"reason": reason, "status": status}
+                    if retry_after is not None:
+                        last_failure_details["retry_after"] = retry_after
                     event_name = (
                         "request_rate_limited"
                         if status == 429
@@ -267,34 +320,49 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         attempt=attempt,
                         total_attempts=total_attempts,
                         rps=cfg.rps,
+                        **({"retry_after": retry_after}
+                          if retry_after is not None
+                          else {}),
                     )
                     if attempt >= total_attempts:
                         logger.debug(
                             "request_fail",
                             url=url,
-                            status=status,
                             total_attempts=total_attempts,
                             rps=cfg.rps,
+                            status=status,
+                            **details_excluding("status"),
                         )
                         return None
-                    delay = backoff_delay if backoff_delay > 0 else cfg.delay
+                    if retry_after is not None:
+                        delay = retry_after
+                        backoff_delay = delay * 2 if delay > 0 else backoff_delay
+                    else:
+                        delay = backoff_delay if backoff_delay > 0 else cfg.delay
+                        if delay > 0:
+                            backoff_delay = delay * 2
                     if delay > 0:
                         sleep(delay)
-                        backoff_delay = delay * 2
                     continue
                 if status >= 400:
+                    last_failure_details = {
+                        "reason": "unexpected_status",
+                        "status": status,
+                    }
                     logger.warning(
                         "request_unexpected_status",
                         url=url,
-                        status=status,
                         rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
                     logger.debug(
                         "request_fail",
                         url=url,
-                        status=status,
                         total_attempts=total_attempts,
                         rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
                     return None
 
@@ -302,6 +370,11 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     response.raise_for_status()
                     data = cast(dict[str, Any], response.json())
                 except requests.RequestException as exc:  # pragma: no cover - network
+                    last_failure_details = {
+                        "reason": "response_error",
+                        "status": status,
+                        "error": str(exc),
+                    }
                     if attempt >= total_attempts:
                         logger.error(
                             "request_error",
@@ -314,27 +387,34 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         logger.debug(
                             "request_fail",
                             url=url,
-                            status=status,
                             total_attempts=total_attempts,
                             rps=cfg.rps,
+                            status=status,
+                            **details_excluding("status"),
                         )
                         return None
                     if cfg.delay > 0:
                         sleep(cfg.delay)
                     continue
                 except ValueError:
+                    last_failure_details = {
+                        "reason": "response_not_json",
+                        "status": status,
+                    }
                     logger.warning(
                         "response_not_json",
                         url=url,
-                        status=status,
                         rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
                     logger.debug(
                         "request_fail",
                         url=url,
-                        status=status,
                         total_attempts=total_attempts,
                         rps=cfg.rps,
+                        status=status,
+                        **details_excluding("status"),
                     )
                     return None
 
@@ -350,6 +430,11 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 logger.info("cache_set", url=url, rps=cfg.rps, status="hit")
                 return data
         except requests.RequestException as exc:  # pragma: no cover - network
+            last_failure_details = {
+                "reason": "network_error",
+                "status": None,
+                "error": str(exc),
+            }
             if attempt >= total_attempts:
                 logger.error(
                     "request_error",
@@ -365,6 +450,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     status=None,
                     total_attempts=total_attempts,
                     rps=cfg.rps,
+                    **details_excluding("status"),
                 )
                 return None
             if cfg.delay > 0:
@@ -384,13 +470,24 @@ def _ensure_cache(ttl: float) -> TTLCache[str, _CacheEntry]:
     return cache
 
 
-def _store_cache_miss(url: str, cfg: PubChemCfg, outcome: str) -> None:
-    """Persist a cached miss outcome for ``url``."""
+def _store_cache_miss(
+    url: str, cfg: PubChemCfg, outcome: str, details: dict[str, Any] | None = None
+) -> None:
+    """Persist a cached miss outcome for ``url`` including optional details."""
 
+    details_copy = dict(details) if details else None
     with _CACHE_LOCK:
         cache = _ensure_cache(cfg.cache_ttl)
-        cache[url] = _CacheEntry(payload=None, outcome=outcome)
-    logger.info("cache_set", url=url, rps=cfg.rps, status="miss", outcome=outcome)
+        cache[url] = _CacheEntry(payload=None, outcome=outcome, details=details_copy)
+    log_data: dict[str, Any] = {
+        "url": url,
+        "rps": cfg.rps,
+        "status": "miss",
+        "outcome": outcome,
+    }
+    if details_copy:
+        log_data.update(details_copy)
+    logger.info("cache_set", **log_data)
 
 
 def _extract_cids(bindings: list[dict[str, Any]]) -> list[str]:

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -17,13 +17,18 @@ from library.config import ApiCfg, RetryCfg, session_with_retry
 class DummyResponse:
     """Simple response object returning a constant payload."""
 
-    status_code = 200
-
     def __init__(
-        self, payload: dict[str, object], close_log: list[object] | None = None
+        self,
+        payload: dict[str, object] | None,
+        close_log: list[object] | None = None,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self._payload = payload
         self._close_log = close_log
+        self.status_code = status_code
+        self.headers = headers or {}
         self.closed = False
 
     def __enter__(self) -> DummyResponse:
@@ -42,6 +47,8 @@ class DummyResponse:
         return None
 
     def json(self) -> dict[str, object]:
+        if self._payload is None:
+            raise ValueError("response payload not set")
         return self._payload
 
 
@@ -64,6 +71,21 @@ class DummySession:
         self.closed = True
         if self._closed_log is not None:
             self._closed_log.append(self.headers["User-Agent"])
+
+
+class FakeClock:
+    """Deterministic clock used to track sleeps without real delays."""
+
+    def __init__(self) -> None:
+        self.current = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.current
+
+    def sleep(self, duration: float) -> None:
+        self.sleeps.append(duration)
+        self.current += duration
 
 
 @pytest.fixture(autouse=True)
@@ -231,6 +253,101 @@ def test_make_request_closes_response(monkeypatch) -> None:
 
     assert result == payload
     assert close_log == [True]
+
+
+def test_make_request_retry_after_adjusts_delay(monkeypatch) -> None:
+    """Retry-After headers should dictate the backoff delay."""
+
+    url = "https://example.org/rate-limit"
+    payload = {"ok": True}
+    cfg = pl.PubChemCfg(retries=1, delay=0, backoff_initial_seconds=0.1)
+
+    api_cfg = _configure_session()
+    session = pc.get_session(api_cfg)
+
+    responses = [
+        DummyResponse(
+            None,
+            status_code=429,
+            headers={"Retry-After": "2.5"},
+        ),
+        DummyResponse(payload),
+    ]
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> DummyResponse:
+        return responses.pop(0)
+
+    clock = FakeClock()
+
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
+    monkeypatch.setattr(pc, "sleep", clock.sleep)
+    monkeypatch.setattr(pc, "monotonic", clock.monotonic)
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    result = pc.make_request(url, cfg)
+
+    assert result == payload
+    assert responses == []
+    assert clock.sleeps == [pytest.approx(2.5)]
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+
+def test_make_request_timeout_records_retry_after(monkeypatch) -> None:
+    """Timeouts should cache the last failure details including Retry-After."""
+
+    url = "https://example.org/timeout"
+    cfg = pl.PubChemCfg(
+        retries=3,
+        delay=0,
+        backoff_initial_seconds=0,
+        timeout_seconds=3,
+    )
+
+    api_cfg = _configure_session()
+    session = pc.get_session(api_cfg)
+
+    responses = [
+        DummyResponse(None, status_code=429, headers={"Retry-After": "2"}),
+        DummyResponse(None, status_code=429, headers={"Retry-After": "2"}),
+    ]
+
+    def fake_get(url: str, timeout: tuple[int, int]) -> DummyResponse:
+        return responses.pop(0)
+
+    clock = FakeClock()
+
+    monkeypatch.setattr(session, "get", fake_get)
+    monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
+    monkeypatch.setattr(pc, "sleep", clock.sleep)
+    monkeypatch.setattr(pc, "monotonic", clock.monotonic)
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    result = pc.make_request(url, cfg)
+
+    assert result is None
+    assert responses == []
+    assert clock.sleeps == [pytest.approx(2.0), pytest.approx(2.0)]
+
+    with pc._CACHE_LOCK:
+        cache = pc._CACHE
+        assert cache is not None
+        entry = cache[url]
+
+    assert entry.outcome == "timeout"
+    assert entry.details is not None
+    assert entry.details.get("reason") == "rate_limited"
+    assert entry.details.get("status") == 429
+    assert entry.details.get("retry_after") == pytest.approx(2.0)
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
 
 
 def test_get_session_initialises_once_under_concurrency(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- parse Retry-After headers on PubChem 429/5xx responses and use them to drive backoff
- record cached miss outcomes with contextual details for downstream logging
- add deterministic client tests covering Retry-After handling and timeout caching

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9be864708324a3fc84caa689d722