### PR TITLE
Refactor document session pooling and add session reuse tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "numpy~=2.3.3",
   "pandas~=2.3.2",
   "requests~=2.32.5",
+  "responses~=0.25.8",
   "PyYAML~=6.0.2",
   "openpyxl~=3.1.5",
   "pyarrow~=17.0.0",

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -31,7 +31,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager, AbstractContextManager
 from itertools import chain, islice, tee
 from pathlib import Path
-from threading import Lock
+from threading import Lock, local
 from typing import Any, cast
 
 import pandas as pd
@@ -371,6 +371,85 @@ def fetch_pubmed_records(
             limit = min(limit, limiter.burst)
         return max(1, limit)
 
+    class _SessionPool:
+        def __init__(
+            self,
+            stack: ExitStack,
+            factory: Callable[[], AbstractContextManager[requests.Session]],
+        ) -> None:
+            self._stack = stack
+            self._factory = factory
+            self._available: list[requests.Session] = []
+            self._lock = Lock()
+
+        def _acquire(self) -> requests.Session:
+            with self._lock:
+                if self._available:
+                    return self._available.pop()
+            session_cm = self._factory()
+            return self._stack.enter_context(session_cm)
+
+        def _release(self, session: requests.Session) -> None:
+            with self._lock:
+                self._available.append(session)
+
+        @contextmanager
+        def session(self) -> Iterator[requests.Session]:
+            nested_session = self._acquire()
+            try:
+                yield nested_session
+            finally:
+                self._release(nested_session)
+
+    class _ThreadResources:
+        def __init__(
+            self,
+            stack: ExitStack,
+            base_session: requests.Session,
+            session_pools: dict[str, _SessionPool],
+        ) -> None:
+            self.stack = stack
+            self.base_session = base_session
+            self.session_pools = session_pools
+
+    thread_local_state = local()
+    thread_resources: list[_ThreadResources] = []
+    thread_resources_lock = Lock()
+
+    def _get_thread_resources() -> _ThreadResources:
+        resources = getattr(thread_local_state, "resources", None)
+        if resources is not None:
+            return resources
+
+        session_stack = ExitStack()
+        base_session = session_stack.enter_context(
+            session_with_retry(session_cfg.api, session_cfg.retry)
+        )
+
+        session_factories: dict[
+            str, Callable[[], AbstractContextManager[requests.Session]]
+        ] = {
+            "openalex": lambda: openalex_session(
+                session_cfg.api, session_cfg.retry, openalex_cfg
+            ),
+            "crossref": lambda: crossref_session(
+                session_cfg.api, session_cfg.retry, crossref_cfg
+            ),
+        }
+
+        pools = {
+            service: _SessionPool(session_stack, factory)
+            for service, factory in session_factories.items()
+        }
+
+        resources = _ThreadResources(session_stack, base_session, pools)
+        setattr(thread_local_state, "resources", resources)
+
+        with thread_resources_lock:
+            thread_resources.append(resources)
+
+        return resources
+
     def _fetch_batch(
         first: object,
         *rest: object,
@@ -397,230 +476,182 @@ def fetch_pubmed_records(
 
         batch_summary = _summarise_batch(batch_list)
 
-        class _SessionPool:
-            def __init__(
-                self,
-                stack: ExitStack,
-                factory: Callable[[], AbstractContextManager[requests.Session]],
-            ) -> None:
-                self._stack = stack
-                self._factory = factory
-                self._available: list[requests.Session] = []
-                self._lock = Lock()
-
-            def _acquire(self) -> requests.Session:
-                with self._lock:
-                    if self._available:
-                        return self._available.pop()
-                session_cm = self._factory()
-                return self._stack.enter_context(session_cm)
-
-            def _release(self, session: requests.Session) -> None:
-                with self._lock:
-                    self._available.append(session)
-
-            @contextmanager
-            def session(self) -> Iterator[requests.Session]:
-                nested_session = self._acquire()
-                try:
-                    yield nested_session
-                finally:
-                    self._release(nested_session)
-
         try:
-            with ExitStack() as session_stack:
-                base_session = session_stack.enter_context(
-                    session_with_retry(__cfg.api, __cfg.retry)
+            resources = _get_thread_resources()
+            base_session = resources.base_session
+            session_pools = resources.session_pools
+
+            def _invoke_with_session(
+                factory: Callable[[], AbstractContextManager[requests.Session]],
+                fetcher: Callable[
+                    [requests.Session, str, Any, RateLimiter | None], dict[str, str]
+                ],
+                identifier: str,
+                *,
+                cfg_obj: Any,
+                limiter: RateLimiter | None,
+            ) -> dict[str, str]:
+                with factory() as nested_session:
+                    return fetcher(nested_session, identifier, cfg_obj, limiter)
+            _acquire_documents(pubmed_service_limiter)
+            pubmed_list = pl.fetch_pubmed_batch(
+                base_session, batch_list, sleep, cfg=pubmed_cfg
+            )
+
+            pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
+            semantic_pmids = [pmid for pmid in pmids_in_batch if pmid]
+
+            semsch_map: dict[str, dict[str, str]] = {}
+            if semantic_pmids:
+                # Fetch Semantic Scholar data in a single batch
+                _acquire_documents(semantic_service_limiter)
+                semsch_list = ssl.fetch_semantic_scholar_batch(
+                    base_session, semantic_pmids, sleep, cfg=semantic_scholar_cfg
                 )
 
-                session_factories: dict[
-                    str, Callable[[], AbstractContextManager[requests.Session]]
-                ] = {
-                    "openalex": lambda: openalex_session(
-                        __cfg.api, __cfg.retry, openalex_cfg
-                    ),
-                    "crossref": lambda: crossref_session(
-                        __cfg.api, __cfg.retry, crossref_cfg
-                    ),
+                # Create a map for easy lookup
+                semsch_map = {
+                    s.get("scholar.PMID"): s
+                    for s in semsch_list
+                    if s.get("scholar.PMID")
                 }
 
-                session_pools = {
-                    service: _SessionPool(session_stack, factory)
-                    for service, factory in session_factories.items()
-                }
-
-                def _invoke_with_session(
-                    factory: Callable[[], AbstractContextManager[requests.Session]],
-                    fetcher: Callable[
-                        [requests.Session, str, Any, RateLimiter | None], dict[str, str]
-                    ],
-                    identifier: str,
-                    *,
-                    cfg_obj: Any,
-                    limiter: RateLimiter | None,
-                ) -> dict[str, str]:
-                    with factory() as nested_session:
-                        return fetcher(nested_session, identifier, cfg_obj, limiter)
-
-                _acquire_documents(pubmed_service_limiter)
-                pubmed_list = pl.fetch_pubmed_batch(
-                    base_session, batch_list, sleep, cfg=pubmed_cfg
-                )
-
-                pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]
-                semantic_pmids = [pmid for pmid in pmids_in_batch if pmid]
-
-                semsch_map: dict[str, dict[str, str]] = {}
-                if semantic_pmids:
-                    # Fetch Semantic Scholar data in a single batch
+                # Fallback to the single-record endpoint when the batch request fails
+                fallback_pmids: list[str] = []
+                seen: set[str] = set()
+                for pmid in semantic_pmids:
+                    if pmid in seen:
+                        continue
+                    seen.add(pmid)
+                    record = semsch_map.get(pmid)
+                    if record is None or record.get("scholar.Error"):
+                        fallback_pmids.append(pmid)
+                for pmid in fallback_pmids:
                     _acquire_documents(semantic_service_limiter)
-                    semsch_list = ssl.fetch_semantic_scholar_batch(
-                        base_session, semantic_pmids, sleep, cfg=semantic_scholar_cfg
+                    fallback_record = ssl.fetch_semantic_scholar(
+                        base_session, pmid, sleep, cfg=semantic_scholar_cfg
                     )
+                    semsch_map[pmid] = fallback_record
 
-                    # Create a map for easy lookup
-                    semsch_map = {
-                        s.get("scholar.PMID"): s
-                        for s in semsch_list
-                        if s.get("scholar.PMID")
+            combined_records: list[dict[str, str]] = []
+
+            plan: list[tuple[int, dict[str, str], dict[str, str], str, str]] = []
+            openalex_lookup: dict[str, list[int]] = {}
+            crossref_lookup: dict[str, list[int]] = {}
+            openalex_total = 0
+            crossref_total = 0
+
+            for index, pubmed in enumerate(pubmed_list):
+                pmid = pubmed.get("PubMed.PMID", "")
+                semsch = semsch_map.get(pmid, {}) if pmid else {}
+                fallback_doi = ""
+                if fallback_doi_map:
+                    fallback_doi = fallback_doi_map.get(pmid, "")
+                doi = (
+                    pubmed.get("PubMed.DOI")
+                    or semsch.get("scholar.DOI")
+                    or fallback_doi
+                    or ""
+                )
+                plan.append((index, pubmed, semsch, pmid, doi))
+                if pmid:
+                    openalex_lookup.setdefault(pmid, []).append(index)
+                    openalex_total += 1
+                if doi:
+                    crossref_lookup.setdefault(doi, []).append(index)
+                    crossref_total += 1
+
+            openalex_results: dict[int, dict[str, str]] = {}
+            crossref_results: dict[int, dict[str, str]] = {}
+
+            openalex_jobs = list(openalex_lookup.keys())
+
+            def _fetch_openalex_job(pmid: str) -> dict[str, str]:
+                _acquire_documents(openalex_service_limiter, use_global=False)
+                return _invoke_with_session(
+                    session_pools["openalex"].session,
+                    ocl.fetch_openalex,
+                    pmid,
+                    cfg_obj=openalex_cfg,
+                    limiter=openalex_limiter,
+                )
+
+            if openalex_total:
+                logger.info(
+                    "documents_cache_reuse",
+                    service="openalex",
+                    total=openalex_total,
+                    unique=len(openalex_jobs),
+                    hits=openalex_total - len(openalex_jobs),
+                )
+
+            openalex_by_key: dict[str, dict[str, str]] = {}
+
+            if openalex_jobs:
+                if openalex_executor is None:
+                    for pmid in openalex_jobs:
+                        openalex_by_key[pmid] = _fetch_openalex_job(pmid)
+                else:
+                    future_to_key = {
+                        openalex_executor.submit(_fetch_openalex_job, pmid): pmid
+                        for pmid in openalex_jobs
                     }
+                    for future in as_completed(future_to_key):
+                        key = future_to_key[future]
+                        openalex_by_key[key] = future.result()
 
-                    # Fallback to the single-record endpoint when the batch request fails
-                    fallback_pmids: list[str] = []
-                    seen: set[str] = set()
-                    for pmid in semantic_pmids:
-                        if pmid in seen:
-                            continue
-                        seen.add(pmid)
-                        record = semsch_map.get(pmid)
-                        if record is None or record.get("scholar.Error"):
-                            fallback_pmids.append(pmid)
-                    for pmid in fallback_pmids:
-                        _acquire_documents(semantic_service_limiter)
-                        fallback_record = ssl.fetch_semantic_scholar(
-                            base_session, pmid, sleep, cfg=semantic_scholar_cfg
-                        )
-                        semsch_map[pmid] = fallback_record
+            for pmid, indexes in openalex_lookup.items():
+                result = openalex_by_key.get(pmid, {})
+                for idx in indexes:
+                    openalex_results[idx] = result
 
-                combined_records: list[dict[str, str]] = []
+            crossref_jobs = [doi for doi in crossref_lookup.keys() if doi]
 
-                plan: list[tuple[int, dict[str, str], dict[str, str], str, str]] = []
-                openalex_lookup: dict[str, list[int]] = {}
-                crossref_lookup: dict[str, list[int]] = {}
-                openalex_total = 0
-                crossref_total = 0
+            def _fetch_crossref_job(doi: str) -> dict[str, str]:
+                _acquire_documents(crossref_service_limiter, use_global=False)
+                return _invoke_with_session(
+                    session_pools["crossref"].session,
+                    ocl.fetch_crossref,
+                    doi,
+                    cfg_obj=crossref_cfg,
+                    limiter=crossref_limiter,
+                )
 
-                for index, pubmed in enumerate(pubmed_list):
-                    pmid = pubmed.get("PubMed.PMID", "")
-                    semsch = semsch_map.get(pmid, {}) if pmid else {}
-                    fallback_doi = ""
-                    if fallback_doi_map:
-                        fallback_doi = fallback_doi_map.get(pmid, "")
-                    doi = (
-                        pubmed.get("PubMed.DOI")
-                        or semsch.get("scholar.DOI")
-                        or fallback_doi
-                        or ""
-                    )
-                    plan.append((index, pubmed, semsch, pmid, doi))
-                    if pmid:
-                        openalex_lookup.setdefault(pmid, []).append(index)
-                        openalex_total += 1
-                    if doi:
-                        crossref_lookup.setdefault(doi, []).append(index)
-                        crossref_total += 1
+            if crossref_total:
+                logger.info(
+                    "documents_cache_reuse",
+                    service="crossref",
+                    total=crossref_total,
+                    unique=len(crossref_jobs),
+                    hits=crossref_total - len(crossref_jobs),
+                )
 
-                openalex_results: dict[int, dict[str, str]] = {}
-                crossref_results: dict[int, dict[str, str]] = {}
+            crossref_by_key: dict[str, dict[str, str]] = {}
 
-                openalex_jobs = list(openalex_lookup.keys())
+            if crossref_jobs:
+                if crossref_executor is None:
+                    for doi in crossref_jobs:
+                        crossref_by_key[doi] = _fetch_crossref_job(doi)
+                else:
+                    future_to_key = {
+                        crossref_executor.submit(_fetch_crossref_job, doi): doi
+                        for doi in crossref_jobs
+                    }
+                    for future in as_completed(future_to_key):
+                        key = future_to_key[future]
+                        crossref_by_key[key] = future.result()
 
-                def _fetch_openalex_job(pmid: str) -> dict[str, str]:
-                    _acquire_documents(openalex_service_limiter, use_global=False)
-                    return _invoke_with_session(
-                        session_pools["openalex"].session,
-                        ocl.fetch_openalex,
-                        pmid,
-                        cfg_obj=openalex_cfg,
-                        limiter=openalex_limiter,
-                    )
+            for doi, indexes in crossref_lookup.items():
+                result = crossref_by_key.get(doi, {})
+                for idx in indexes:
+                    crossref_results[idx] = result
 
-                if openalex_total:
-                    logger.info(
-                        "documents_cache_reuse",
-                        service="openalex",
-                        total=openalex_total,
-                        unique=len(openalex_jobs),
-                        hits=openalex_total - len(openalex_jobs),
-                    )
-
-                openalex_by_key: dict[str, dict[str, str]] = {}
-
-                if openalex_jobs:
-                    if openalex_executor is None:
-                        for pmid in openalex_jobs:
-                            openalex_by_key[pmid] = _fetch_openalex_job(pmid)
-                    else:
-                        future_to_key = {
-                            openalex_executor.submit(_fetch_openalex_job, pmid): pmid
-                            for pmid in openalex_jobs
-                        }
-                        for future in as_completed(future_to_key):
-                            key = future_to_key[future]
-                            openalex_by_key[key] = future.result()
-
-                for pmid, indexes in openalex_lookup.items():
-                    result = openalex_by_key.get(pmid, {})
-                    for idx in indexes:
-                        openalex_results[idx] = result
-
-                crossref_jobs = [doi for doi in crossref_lookup.keys() if doi]
-
-                def _fetch_crossref_job(doi: str) -> dict[str, str]:
-                    _acquire_documents(crossref_service_limiter, use_global=False)
-                    return _invoke_with_session(
-                        session_pools["crossref"].session,
-                        ocl.fetch_crossref,
-                        doi,
-                        cfg_obj=crossref_cfg,
-                        limiter=crossref_limiter,
-                    )
-
-                if crossref_total:
-                    logger.info(
-                        "documents_cache_reuse",
-                        service="crossref",
-                        total=crossref_total,
-                        unique=len(crossref_jobs),
-                        hits=crossref_total - len(crossref_jobs),
-                    )
-
-                crossref_by_key: dict[str, dict[str, str]] = {}
-
-                if crossref_jobs:
-                    if crossref_executor is None:
-                        for doi in crossref_jobs:
-                            crossref_by_key[doi] = _fetch_crossref_job(doi)
-                    else:
-                        future_to_key = {
-                            crossref_executor.submit(_fetch_crossref_job, doi): doi
-                            for doi in crossref_jobs
-                        }
-                        for future in as_completed(future_to_key):
-                            key = future_to_key[future]
-                            crossref_by_key[key] = future.result()
-
-                for doi, indexes in crossref_lookup.items():
-                    result = crossref_by_key.get(doi, {})
-                    for idx in indexes:
-                        crossref_results[idx] = result
-
-                for index, pubmed, semsch, pmid, _ in plan:
-                    openalex = openalex_results.get(index, {}) if pmid else {}
-                    crossref = crossref_results.get(index, {})
-                    combined = merge_metadata(pubmed, semsch, openalex, crossref)
-                    combined_records.append(combined)
-                return combined_records
+            for index, pubmed, semsch, pmid, _ in plan:
+                openalex = openalex_results.get(index, {}) if pmid else {}
+                crossref = crossref_results.get(index, {})
+                combined = merge_metadata(pubmed, semsch, openalex, crossref)
+                combined_records.append(combined)
+            return combined_records
         except requests.RequestException as exc:  # pragma: no cover - network errors
             logger.warning(
                 "pubmed_batch_request_failed",
@@ -721,6 +752,11 @@ def fetch_pubmed_records(
                 yield build_dataframe(records_batch, columns=DOCUMENT_SCHEMA_COLUMNS)
         finally:
             stack.close()
+            with thread_resources_lock:
+                resources_to_close = list(thread_resources)
+                thread_resources.clear()
+            for resources in resources_to_close:
+                resources.stack.close()
 
     frame_iter = _iter_frames()
     if return_generator:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -13,6 +13,8 @@ from typing import Any, Callable
 
 import pandas as pd
 import pytest
+import requests
+import responses
 
 from library import chembl_library as cl
 from library import io as lib_io
@@ -1924,6 +1926,22 @@ def test_fetch_pubmed_records_reuses_service_sessions(
 
     monkeypatch.setattr(gdd, "session_with_retry", fake_session_with_retry)
 
+    openalex_session_labels: list[str] = []
+    crossref_session_labels: list[str] = []
+
+    def fake_openalex_session(*_args: object, **_kwargs: object) -> DummySession:
+        label = f"openalex-{len(openalex_session_labels)}"
+        openalex_session_labels.append(label)
+        return DummySession(label)
+
+    def fake_crossref_session(*_args: object, **_kwargs: object) -> DummySession:
+        label = f"crossref-{len(crossref_session_labels)}"
+        crossref_session_labels.append(label)
+        return DummySession(label)
+
+    monkeypatch.setattr(gdd, "openalex_session", fake_openalex_session)
+    monkeypatch.setattr(gdd, "crossref_session", fake_crossref_session)
+
     def fake_pubmed_batch(
         session: DummySession,
         batch: Sequence[str],
@@ -2032,11 +2050,202 @@ def test_fetch_pubmed_records_reuses_service_sessions(
     )
 
     assert df["PubMed.PMID"].tolist() == pmids
-    assert len(session_labels) == 3
+    assert len(session_labels) == 1
+    assert len(openalex_session_labels) == 1
+    assert len(crossref_session_labels) == 1
     assert openalex_sessions and len(openalex_sessions) == len(pmids)
     assert openalex_sessions == [openalex_sessions[0]] * len(openalex_sessions)
     assert crossref_sessions and len(crossref_sessions) == len(pmids)
     assert crossref_sessions == [crossref_sessions[0]] * len(crossref_sessions)
+
+
+@responses.activate
+def test_fetch_pubmed_records_reuses_sessions_across_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker threads should reuse HTTP sessions across multiple batches."""
+
+    pmids = [str(100 + i) for i in range(6)]
+
+    for pmid in pmids:
+        responses.add(
+            responses.GET,
+            f"https://pubmed.test/{pmid}",
+            json={"pmid": pmid},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"https://openalex.test/{pmid}",
+            json={"id": pmid},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"https://crossref.test/10.1234/{pmid}",
+            json={"doi": pmid},
+            status=200,
+        )
+
+    class RecordingContext:
+        def __init__(self, label: str) -> None:
+            self.label = label
+            self.session = requests.Session()
+            self.closed = False
+            self.session_id = id(self.session)
+
+        def __enter__(self) -> requests.Session:  # pragma: no cover - trivial
+            return self.session
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - trivial
+            self.closed = True
+            self.session.close()
+
+    contexts: list[RecordingContext] = []
+
+    def _make_context(label: str) -> RecordingContext:
+        ctx = RecordingContext(label)
+        contexts.append(ctx)
+        return ctx
+
+    monkeypatch.setattr(gdd, "session_with_retry", lambda *_, **__: _make_context("pubmed"))
+    monkeypatch.setattr(gdd, "openalex_session", lambda *_, **__: _make_context("openalex"))
+    monkeypatch.setattr(gdd, "crossref_session", lambda *_, **__: _make_context("crossref"))
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    pubmed_session_ids: set[int] = set()
+    openalex_session_ids: set[int] = set()
+    crossref_session_ids: set[int] = set()
+
+    def fake_pubmed_batch(
+        session: requests.Session,
+        batch: Sequence[str],
+        _sleep: float,
+        cfg: PubMedCfg | None = None,
+    ) -> list[dict[str, str]]:
+        records: list[dict[str, str]] = []
+        for pmid in batch:
+            pubmed_session_ids.add(id(session))
+            session.get(
+                f"https://pubmed.test/{pmid}",
+                headers={"X-Session": str(id(session))},
+                timeout=0.1,
+            )
+            records.append(
+                {
+                    "PubMed.PMID": pmid,
+                    "PubMed.DOI": f"10.1234/{pmid}",
+                    "PubMed.ArticleTitle": f"Article {pmid}",
+                }
+            )
+        return records
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+
+    def fake_semantic_batch(
+        _session: requests.Session,
+        batch: Sequence[str],
+        _sleep: float,
+        cfg: SemanticScholarCfg | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {
+                "scholar.PMID": pmid,
+                "scholar.DOI": f"10.1234/{pmid}",
+                "scholar.Error": "",
+            }
+            for pmid in batch
+        ]
+
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_args, **_kwargs: {
+            "scholar.PMID": "",
+            "scholar.DOI": "",
+            "scholar.Error": "unreachable",
+        },
+    )
+
+    def fake_fetch_openalex(
+        session: requests.Session,
+        pmid: str,
+        cfg: OpenAlexCfg,
+        limiter: rl.RateLimiter | None = None,
+    ) -> dict[str, str]:
+        openalex_session_ids.add(id(session))
+        session.get(
+            f"https://openalex.test/{pmid}",
+            headers={"X-Session": str(id(session))},
+            timeout=0.1,
+        )
+        return {
+            "OpenAlex.PMID": pmid,
+            "OpenAlex.DOI": f"10.1234/{pmid}",
+            "OpenAlex.Error": "",
+        }
+
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_fetch_openalex)
+
+    def fake_fetch_crossref(
+        session: requests.Session,
+        doi: str,
+        cfg: CrossRefCfg,
+        limiter: rl.RateLimiter | None = None,
+    ) -> dict[str, str]:
+        crossref_session_ids.add(id(session))
+        session.get(
+            f"https://crossref.test/{doi}",
+            headers={"X-Session": str(id(session))},
+            timeout=0.1,
+        )
+        return {
+            "crossref.DOI": doi,
+            "crossref.Title": f"Title {doi}",
+            "crossref.Error": "",
+        }
+
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_fetch_crossref)
+
+    df = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        pubmed_cfg=PubMedCfg(),
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=2,
+        batch_size=1,
+    )
+
+    assert df["PubMed.PMID"].tolist() == pmids
+
+    assert len(pubmed_session_ids) <= 2
+    assert len(openalex_session_ids) <= 2
+    assert len(crossref_session_ids) <= 2
+
+    pubmed_headers = {
+        call.request.headers.get("X-Session")
+        for call in responses.calls
+        if call.request.url.startswith("https://pubmed.test/")
+    }
+    openalex_headers = {
+        call.request.headers.get("X-Session")
+        for call in responses.calls
+        if call.request.url.startswith("https://openalex.test/")
+    }
+    crossref_headers = {
+        call.request.headers.get("X-Session")
+        for call in responses.calls
+        if call.request.url.startswith("https://crossref.test/")
+    }
+
+    assert len(pubmed_headers) <= 2
+    assert len(openalex_headers) <= 2
+    assert len(crossref_headers) <= 2
+
+    assert all(ctx.closed for ctx in contexts)
 
 
 def test_fetch_pubmed_records_reuses_service_executors(


### PR DESCRIPTION
## Summary
- refactor `fetch_pubmed_records` to create thread-local session pools that survive across batch fetches and close cleanly with the executor
- extend the document tests with responses-powered coverage for connection reuse and update existing expectations
- declare `responses` as a runtime dependency so the new tests run without optional extras

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_reuses_service_sessions
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_reuses_sessions_across_batches

------
https://chatgpt.com/codex/tasks/task_e_68dd9be580ac8324aa1f5baa97a8fa95