### PR TITLE
Handle Retry-After delays in Chembl client retries

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import random
 import threading
 from collections.abc import Iterable, Iterator
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from itertools import islice
 from dataclasses import dataclass, field
 from types import TracebackType
@@ -208,7 +210,7 @@ class ChemblClient:
                         self.cache[cache_key] = data
                         logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
                         return data
-            except (requests.RequestException, ValueError) as exc:
+            except ValueError as exc:
                 last_exc = exc
                 if attempt >= total_attempts:
                     logger.exception(
@@ -216,8 +218,33 @@ class ChemblClient:
                         extra={"url": url, "status": None, "rps": cfg.rps},
                     )
                     break
-                delay = cfg.backoff_factor * (2 ** (attempt - 1))
-                delay += random.uniform(0, cfg.backoff_factor)
+                delay = _backoff_delay(attempt, cfg, header_delay=None)
+                _log_retry_delay(url, attempt, None, delay)
+                sleep(delay)
+            except requests.HTTPError as exc:
+                last_exc = exc
+                response = exc.response
+                status = getattr(response, "status_code", None)
+                if attempt >= total_attempts:
+                    logger.exception(
+                        "request_fail",
+                        extra={"url": url, "status": status, "rps": cfg.rps},
+                    )
+                    break
+                header_delay = _retry_after_delay(response)
+                delay = _backoff_delay(attempt, cfg, header_delay)
+                _log_retry_delay(url, attempt, status, delay, header_delay)
+                sleep(delay)
+            except requests.RequestException as exc:
+                last_exc = exc
+                if attempt >= total_attempts:
+                    logger.exception(
+                        "request_fail",
+                        extra={"url": url, "status": None, "rps": cfg.rps},
+                    )
+                    break
+                delay = _backoff_delay(attempt, cfg, header_delay=None)
+                _log_retry_delay(url, attempt, None, delay)
                 sleep(delay)
 
         if last_exc is not None:
@@ -265,6 +292,72 @@ def _chunked(items: Iterable[T], size: int) -> Iterator[list[T]]:
         if not chunk:
             break
         yield chunk
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _retry_after_delay(response: requests.Response | None) -> float | None:
+    if response is None:
+        return None
+    status = getattr(response, "status_code", None)
+    if status is None or not _is_retry_after_applicable(status):
+        return None
+    header = response.headers.get("Retry-After") if hasattr(response, "headers") else None
+    if header is None:
+        return None
+    value = header.strip()
+    if not value:
+        return None
+    try:
+        delay = float(value)
+        return max(0.0, delay)
+    except ValueError:
+        try:
+            dt = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = (dt - _utcnow()).total_seconds()
+        return max(0.0, delta)
+
+
+def _is_retry_after_applicable(status: int) -> bool:
+    return status == 429 or 500 <= status < 600
+
+
+def _backoff_delay(
+    attempt: int, cfg: ApiCfg, header_delay: float | None
+) -> float:
+    base = cfg.backoff_factor * (2 ** (attempt - 1))
+    jitter = random.uniform(0, cfg.backoff_factor)
+    delay = base + jitter
+    if header_delay is not None:
+        delay = max(delay, header_delay)
+    return delay
+
+
+def _log_retry_delay(
+    url: str,
+    attempt: int,
+    status: int | None,
+    delay: float,
+    header_delay: float | None = None,
+) -> None:
+    logger.debug(
+        "retry_sleep",
+        extra={
+            "url": url,
+            "attempt": attempt,
+            "status": status,
+            "delay": delay,
+            "retry_after": header_delay,
+        },
+    )
 
 
 __all__ = ["ChemblClient", "_chunked"]

--- a/tests/test_chembl_client.py
+++ b/tests/test_chembl_client.py
@@ -4,11 +4,14 @@ import io
 import json
 import random
 import time
+from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+
+from email.utils import format_datetime
 
 from library import rate_limiter as rl
 from library.clients import ChemblClient
@@ -61,6 +64,16 @@ class DummySession:
         if len(self.calls) <= self.failures:
             raise requests.RequestException("boom")
         return DummyResponse()
+
+
+class DummyHttpErrorResponse(DummyResponse):
+    def __init__(self, status_code: int, headers: dict[str, str]) -> None:
+        super().__init__()
+        self.status_code = status_code
+        self.headers = headers
+
+    def raise_for_status(self) -> None:
+        raise requests.HTTPError("boom", response=self)
 
 
 def test_client_closes_session() -> None:
@@ -138,6 +151,65 @@ def test_request_json_backoff_grows(monkeypatch) -> None:
 
     assert sleep_times == [1.0, 2.0]
     assert len(session.calls) == 3
+
+
+def test_request_json_uses_retry_after_seconds(monkeypatch) -> None:
+    class RetryAfterSession:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get(self, url: str, timeout: Any) -> DummyResponse:
+            self.calls += 1
+            if self.calls == 1:
+                return DummyHttpErrorResponse(429, {"Retry-After": "7"})
+            return DummyResponse()
+
+    sleep_times: list[float] = []
+    monkeypatch.setattr("library.clients.chembl.sleep", lambda t: sleep_times.append(t))
+    monkeypatch.setattr("library.clients.chembl.random.uniform", lambda a, b: 0.0)
+
+    session = RetryAfterSession()
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)  # type: ignore[arg-type]
+    client.clear_cache()
+
+    cfg = api_cfg(retries=2, backoff_factor=1)
+    result = client.request_json("http://example.com", cfg=cfg)
+
+    assert result == {"ok": True}
+    assert sleep_times == [7.0]
+    assert session.calls == 2
+
+
+def test_request_json_uses_retry_after_http_date(monkeypatch) -> None:
+    fixed_now = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    header_delay = 20
+    header_value = format_datetime(fixed_now + timedelta(seconds=header_delay))
+
+    class RetryAfterSession:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get(self, url: str, timeout: Any) -> DummyResponse:
+            self.calls += 1
+            if self.calls == 1:
+                return DummyHttpErrorResponse(503, {"Retry-After": header_value})
+            return DummyResponse()
+
+    sleep_times: list[float] = []
+    monkeypatch.setattr("library.clients.chembl.sleep", lambda t: sleep_times.append(t))
+    monkeypatch.setattr("library.clients.chembl.random.uniform", lambda a, b: 0.0)
+    monkeypatch.setattr("library.clients.chembl._utcnow", lambda: fixed_now)
+
+    session = RetryAfterSession()
+    client = ChemblClient(api_cfg(), RetryCfg(), session=session)  # type: ignore[arg-type]
+    client.clear_cache()
+
+    cfg = api_cfg(retries=2, backoff_factor=1)
+    result = client.request_json("http://example.com", cfg=cfg)
+
+    assert result == {"ok": True}
+    assert sleep_times == [float(header_delay)]
+    assert session.calls == 2
 
 
 def test_request_json_respects_zero_retries() -> None:


### PR DESCRIPTION
## Summary
- read Retry-After headers for throttled or server-error responses in the Chembl client retry loop
- compute retry delays using the maximum of exponential backoff and any Retry-After value while logging the selected delay
- add unit tests covering Retry-After values expressed as seconds and HTTP dates

## Testing
- pytest tests/test_chembl_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9beb5560832482b3da78088e23b5