### PR TITLE
Propagate configuration metadata to sidecar outputs

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -151,6 +151,7 @@ def run_pipeline(
     inputs: Mapping[str, object],
     key_columns: Sequence[str],
     table_quality: TableQualityHook,
+    cfg: Config | None = None,
     logger: logging.Logger | None = None,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
@@ -191,6 +192,8 @@ def run_pipeline(
         columns present in the final dataset are forwarded to ``writer``.
     table_quality:
         Callable invoked after writing the CSV to compute quality metrics.
+    cfg:
+        Optional application configuration forwarded to sidecar metadata.
     logger:
         Optional logger.  Defaults to :data:`library.log.logger` when omitted.
 
@@ -345,7 +348,7 @@ def run_pipeline(
         )
 
     if total_failures:
-        errors.save(failure_path)
+        errors.save(failure_path, cfg=cfg)
 
     stats: Stats = {
         "rows_total": rows_total,

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -347,6 +347,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         inputs=inputs,
         key_columns=["PubMed.PMID"],
         table_quality=table_quality,
+        cfg=cfg,
         logger=logger,
     )
     if output_path.exists():

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -215,6 +215,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         inputs={"input_csv": str(args.input_csv)},
         key_columns=["activity_id"],
         table_quality=table_quality,
+        cfg=cfg,
         logger=logger,
     )
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -176,6 +176,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         inputs={"input_csv": str(args.input_csv)},
         key_columns=["assay_chembl_id"],
         table_quality=table_quality,
+        cfg=cfg,
         logger=logger,
     )
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1112,7 +1112,7 @@ def _finalise_export(
         logger.error("csv_write_failed", error=str(exc), path=str(output))
         return 1
 
-    errors.save(failure_path)
+    errors.save(failure_path, cfg=cfg)
 
     rows_dropped = rows_total - rows_kept
     logger.info("write_done", rows=rows_kept, path=str(csv_path))

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -711,6 +711,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         inputs={"input_csv": str(args.input_csv)},
         key_columns=["target_chembl_id"],
         table_quality=table_quality,
+        cfg=cfg,
         logger=logger,
     )
 
@@ -1198,7 +1199,7 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
             errors = SidecarErrors()
             for row in exc.failure_cases.to_dict("records"):
                 errors.add_error(row)
-            errors.save(failure_path)
+            errors.save(failure_path, cfg=cfg)
             logger.error(
                 "validation_failed",
                 failures=len(exc.failure_cases),

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import yaml
 
+from library.config import Config, _mask_secrets, _serialize_paths
 from library.cli_utils import build_parser, run_pipeline
 from schemas import AssaysSchema
 
@@ -26,6 +28,13 @@ def test_cli_utils_flags_and_help() -> None:
         "--key-cols",
         "--chunk-size",
         "--merge-chunk-size",
+        "--base-path",
+        "--date",
+        "--force",
+        "--input-dir",
+        "--output-dir",
+        "--print-config",
+        "--skip-existing",
     }
     assert set(actions) == expected
     assert actions["--log-level"].help == "Logging level"
@@ -55,7 +64,7 @@ class _ValidationResult:
         self.failure_cases = failure_cases
 
 
-def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path) -> None:
+def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path, cfg: Config) -> None:
     output = tmp_path / "assays.csv"
     failure_path = tmp_path / "assays_failure_cases.csv"
     frames = [
@@ -112,6 +121,7 @@ def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path) -> None:
         inputs={},
         key_columns=["assay_chembl_id"],
         table_quality=quality,
+        cfg=cfg,
     )
 
     assert exit_code == 0
@@ -129,7 +139,7 @@ def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path) -> None:
     assert meta_path.exists()
 
 
-def test_run_pipeline_writes_failure_cases(tmp_path: Path) -> None:
+def test_run_pipeline_writes_failure_cases(tmp_path: Path, cfg: Config) -> None:
     output = tmp_path / "assays.csv"
     failure_path = tmp_path / "assays_failure_cases.csv"
 
@@ -176,6 +186,7 @@ def test_run_pipeline_writes_failure_cases(tmp_path: Path) -> None:
         inputs={},
         key_columns=["assay_chembl_id"],
         table_quality=lambda path: None,
+        cfg=cfg,
     )
 
     assert exit_code == 1
@@ -183,9 +194,15 @@ def test_run_pipeline_writes_failure_cases(tmp_path: Path) -> None:
     failure_csv = failure_path.read_text()
     assert "column" in failure_csv
     assert "value" in failure_csv
+    meta_path = Path(str(failure_path) + ".meta.yaml")
+    assert meta_path.exists()
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf8"))
+    expected_config = _mask_secrets(_serialize_paths(cfg.to_dict()))
+    normalized_expected = yaml.safe_load(yaml.safe_dump(expected_config))
+    assert meta["config"] == normalized_expected
 
 
-def test_run_pipeline_missing_required_columns(tmp_path: Path) -> None:
+def test_run_pipeline_missing_required_columns(tmp_path: Path, cfg: Config) -> None:
     output = tmp_path / "assays.csv"
     failure_path = tmp_path / "assays_failure_cases.csv"
 
@@ -219,6 +236,7 @@ def test_run_pipeline_missing_required_columns(tmp_path: Path) -> None:
         inputs={},
         key_columns=["assay_chembl_id"],
         table_quality=quality,
+        cfg=cfg,
     )
 
     assert exit_code == 1

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,17 +1,30 @@
 from pathlib import Path
 
+import pytest
+import yaml
+
+from library.config import Config
+from library.config import _mask_secrets, _serialize_paths
+
 from library.sidecar import SidecarErrors
 
 
-def test_sidecar_writes_rows(tmp_path: Path) -> None:
+def test_sidecar_writes_rows(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = tmp_path / "errors.csv"
     sc = SidecarErrors()
     sc.add_error({"col": "first", "msg": "one"})
     sc.add_error({"col": "second", "msg": "two"})
-    sc.save(path)
+    monkeypatch.setattr(Config, "to_dict", lambda self: {"api_token": "secret"})
+    sc.save(path, cfg=cfg)
     assert path.read_text(encoding="utf8") == "col,msg\nfirst,one\nsecond,two\n"
     meta = Path(str(path) + ".meta.yaml")
     assert meta.exists()
+    meta_data = yaml.safe_load(meta.read_text(encoding="utf8"))
+    expected_config = _mask_secrets(_serialize_paths(cfg.to_dict()))
+    assert meta_data["config"] == expected_config
+    assert meta_data["config"]["api_token"] == "***"
 
 
 def test_sidecar_skips_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- forward optional configuration objects through `run_pipeline` and persist them when writing sidecar CSVs
- update document export logic to include configuration metadata in its failure reports
- extend unit tests to cover masked configuration in sidecar `.meta.yaml` files

## Testing
- pytest tests/test_sidecar.py tests/test_cli_utils.py
- pytest tests/test_meta_yaml.py
- pytest tests/test_get_document_data.py -k finalise_export

------
https://chatgpt.com/codex/tasks/task_e_68dd9bf9bdec8324905175aa832ac815