### PR TITLE
Fix CSV CLI separator and encoding handling

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -101,8 +101,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             key_cols=args.key_cols,
             chunksize=chunk_size,
             merge_chunksize=merge_chunk_size,
-            sep=cfg.io.csv_sep,
-            encoding=cfg.io.csv_encoding,
+            sep=sep,
+            encoding=encoding,
             cfg=cfg,
             drop_unexpected_cols=True,
         )

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -114,6 +114,34 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     assert called["write_encoding"] == "latin1"
 
 
+def test_cli_writes_with_custom_separator_and_encoding(tmp_path: Path) -> None:
+    input_csv = tmp_path / "in.csv"
+    input_csv.write_text("id;value\n1;á\n", encoding="latin1")
+    output_csv = tmp_path / "out.csv"
+
+    rc = cli.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--sep",
+            ";",
+            "--encoding",
+            "latin1",
+            "--key-cols",
+            "id",
+            "--log-level",
+            "INFO",
+        ]
+    )
+
+    assert rc == 0
+    content = output_csv.read_text(encoding="latin1")
+    assert "id;value" in content.splitlines()[0]
+    assert "1;á" in content.splitlines()[1]
+
+
 def test_chunk_size_rejects_zero(capsys: pytest.CaptureFixture[str]) -> None:
     parser = cli.build_parser()
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
## Summary
- ensure the CLI forwards the resolved separator and encoding to `write_csv_chunks_deterministic`
- add a regression test that runs the CLI end-to-end and verifies the written file keeps the requested delimiter and encoding

## Testing
- pytest tests/test_csv_utils_main_args.py


------
https://chatgpt.com/codex/tasks/task_e_68dda7b334bc8324b57dc9cf0a669d84