### PR TITLE
Add dtype override to csv utils reader

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -88,11 +88,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     ns.output_csv = output
     if args.output_csv != output:
         args = args.model_copy(update={"output_csv": output})
+    csv_dtype = getattr(cfg.io, "csv_dtype", str)
     with pd.read_csv(
         args.input_csv,
         sep=sep,
         encoding=encoding,
         chunksize=chunk_size,
+        dtype=csv_dtype,
     ) as reader:
         write_csv_chunks_deterministic(
             reader,

--- a/tests/test_csv_utils_streaming.py
+++ b/tests/test_csv_utils_streaming.py
@@ -10,6 +10,7 @@ import pytest
 
 
 from library.csv_utils import write_csv_deterministic
+from library.utils.cli_tools import csv_utils_main as cli
 
 
 def test_write_csv_deterministic_respects_chunksize(
@@ -57,3 +58,23 @@ def test_write_csv_deterministic_uses_chunksize(tmp_path: Path, monkeypatch) -> 
 
     assert recorded["chunksize"] == 64
     assert out_path.exists()
+
+
+def test_cli_preserves_leading_zeroes(tmp_path: Path) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id,value\n001,a\n010,b\n", encoding="utf8")
+    output_csv = tmp_path / "out.csv"
+
+    rc = cli.main([
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--key-cols",
+        "id",
+    ])
+
+    assert rc == 0
+    contents = output_csv.read_text(encoding="utf8").splitlines()
+    assert contents[1].startswith("001,")
+    assert contents[2].startswith("010,")


### PR DESCRIPTION
## Summary
- ensure `csv_utils_main` forwards a `dtype` to `pandas.read_csv` so streaming preserves leading zero identifiers
- add a regression test covering CLI streaming behaviour with leading zeros

## Testing
- pytest tests/test_csv_utils_streaming.py

------
https://chatgpt.com/codex/tasks/task_e_68dda7b4e704832495735a4e866c5147