### PR TITLE
Ensure csv-utils CLI validates IO directories before processing

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -20,10 +20,10 @@ from pathlib import Path
 import pandas as pd
 
 from library import cli
-from library.cli import configure_logger, create_logger_config
+from library.cli import LoggerConfig, configure_logger, create_logger_config
 from library.cli_utils import build_parser
 from library.csv_utils import write_csv_chunks_deterministic
-from library.config import print_config
+from library.config import ensure_dirs, print_config
 from library.log import logger
 from library.parser_schema import CSVExportArgs
 
@@ -72,6 +72,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--key-cols must be provided")
     log_cfg = create_logger_config(args.log_level)
     configure_logger(log_cfg)
+
+    try:
+        ensure_dirs(cfg)
+    except OSError as exc:
+        payload = {"error": str(exc)}
+        path = getattr(exc, "filename", None)
+        if path:
+            payload["path"] = str(path)
+        logger.error("io_policy_violation", **payload)
+        return 1
 
     start = time.perf_counter()
 

--- a/tests/test_csv_utils_memory.py
+++ b/tests/test_csv_utils_memory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from library.config import Config
 from library.csv_utils import write_csv_deterministic
 
 psutil = pytest.importorskip("psutil")
@@ -17,7 +18,9 @@ def _worker(path: str, use_copy: bool, n: int) -> None:
     df = pd.DataFrame({"a": range(n), "b": range(n)})
     if use_copy:
         df = df.copy()
-    write_csv_deterministic(df, Path(path), key_cols=["a", "b"])
+    cfg = Config()
+    cfg.io.exist_ok = False
+    write_csv_deterministic(df, Path(path), key_cols=["a", "b"], cfg=cfg)
 
 
 def _peak_memory(n: int, use_copy: bool, path: Path) -> int:


### PR DESCRIPTION
## Summary
- call `ensure_dirs` in the csv-utils CLI so IO policy violations are logged and abort execution
- run the csv utils memory regression helper with a configuration that disables automatic directory creation

## Testing
- pytest tests/test_csv_utils_main_print_config.py tests/test_csv_utils_main_smoke.py tests/test_csv_utils_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68dda7c10f948324ad900b5c0236d809