### PR TITLE
Fix csv-utils print-config run_id handling

### DIFF
--- a/library/utils/cli_tools/csv_utils_main.py
+++ b/library/utils/cli_tools/csv_utils_main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pandas as pd
 
 from library import cli
-from library.cli import configure_logger, create_logger_config
+from library.cli import LoggerConfig, configure_logger, create_logger_config
 from library.cli_utils import build_parser
 from library.csv_utils import write_csv_chunks_deterministic
 from library.config import print_config
@@ -62,15 +62,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         ns.config,
         mapping={"chunk_size": "io.csv_chunksize"},
     )
+    log_cfg: LoggerConfig = create_logger_config(ns.log_level)
     if getattr(ns, "print_config", False):
         print_config(cfg)
-        configure_logger(LoggerConfig(level=ns.log_level))
+        configure_logger(log_cfg)
         return 0
     arg_data = {field: getattr(ns, field) for field in CSVExportArgs.model_fields}
     args = CSVExportArgs.model_validate(arg_data)
     if not args.key_cols:
         parser.error("--key-cols must be provided")
-    log_cfg = create_logger_config(args.log_level)
+    if args.log_level != log_cfg.level:
+        log_cfg = LoggerConfig(
+            level=args.log_level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=log_cfg.stream,
+        )
     configure_logger(log_cfg)
 
     start = time.perf_counter()

--- a/tests/test_csv_utils_main_print_config.py
+++ b/tests/test_csv_utils_main_print_config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import yaml
 
+from library.cli import LoggerConfig
+
 from library.utils.cli_tools import csv_utils_main as cli
 
 
@@ -57,3 +59,19 @@ def test_csv_utils_cli_print_config_exits_without_writing(
     assert data["system"]["log"]["level"] == "DEBUG"
     assert data["local"]["io"]["csv_sep"] == "|"
     assert not output_csv.exists()
+
+
+def test_csv_utils_cli_print_config_uses_logger_config_run_id(monkeypatch) -> None:
+    """``--print-config`` configures logging with the generated run identifier."""
+
+    created_config = LoggerConfig(run_id="sentinel", level="INFO")
+    configured: list[LoggerConfig] = []
+
+    monkeypatch.setattr(cli, "create_logger_config", lambda level: created_config)
+    monkeypatch.setattr(cli, "configure_logger", lambda cfg: configured.append(cfg))
+    monkeypatch.setattr(cli, "print_config", lambda cfg: None)
+
+    exit_code = cli.main(["--print-config"])
+
+    assert exit_code == 0
+    assert configured == [created_config]


### PR DESCRIPTION
## Summary
- reuse the generated LoggerConfig when handling `--print-config` so the CLI keeps its run identifier
- adjust logger setup to respect overridden log levels and add a regression test covering the print-config path

## Testing
- pytest tests/test_csv_utils_main_print_config.py

------
https://chatgpt.com/codex/tasks/task_e_68dda7f98ff48324a60a01f190a09e1c