### PR TITLE
Use Python 3.11 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # Install the hooks with `pre-commit install` and run them with `pre-commit run --all-files`.
 
 default_language_version:
-  python: python3.12
+  python: python3.11
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Summary
- configure pre-commit to run hooks with Python 3.11
- reinstall hooks in the repository using Python 3.11

## Testing
- pre-commit install

------
https://chatgpt.com/codex/tasks/task_e_68dda7e2c9e8832489f767a73e5d9dde