### PR TITLE
Use shared project root bootstrap in CLI scripts

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -14,19 +14,11 @@ from functools import partial
 from itertools import islice
 from pathlib import Path
 
-
-def _ensure_project_root() -> None:
-    """Ensure the repository root is on ``sys.path`` when executed as a script."""
-
-    script_path = Path(__file__).resolve()
-    project_root = script_path.parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
+from library.utils.bootstrap import ensure_project_root
 
 
 if __package__ in {None, ""}:
-    _ensure_project_root()
+    ensure_project_root()
 
 import pandas as pd
 import requests

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -18,10 +18,11 @@ from itertools import islice
 import pandas as pd
 import requests
 
-# Ensure repository package imports work when the script is executed directly.
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+from library.utils.bootstrap import ensure_project_root
+
+
+if __package__ in {None, ""}:
+    ensure_project_root()
 
 from library import assay_postprocessing as ap
 from library import chembl_library as cl

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -29,10 +29,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Callable, Sequence
 
+from library.utils.bootstrap import ensure_project_root
+
+
 if __package__ in {None, ""}:
-    _PROJECT_ROOT = Path(__file__).resolve().parent.parent
-    if str(_PROJECT_ROOT) not in sys.path:
-        sys.path.insert(0, str(_PROJECT_ROOT))
+    ensure_project_root()
 
 from scripts import (
     get_activity_data,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -41,19 +41,11 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-
-def _ensure_project_root() -> None:
-    """Ensure the repository root is discoverable when executed as a script."""
-
-    script_path = Path(__file__).resolve()
-    project_root = script_path.parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
+from library.utils.bootstrap import ensure_project_root
 
 
 if __package__ in {None, ""}:
-    _ensure_project_root()
+    ensure_project_root()
 
 from library import chembl_library as cl
 from library import cli

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -18,10 +18,11 @@ from itertools import islice
 from pathlib import Path
 from typing import cast
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-PROJECT_ROOT_STR = str(PROJECT_ROOT)
-if PROJECT_ROOT_STR not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT_STR)
+from library.utils.bootstrap import ensure_project_root
+
+
+if __package__ in {None, ""}:
+    ensure_project_root()
 
 import pandas as pd
 import requests

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -31,10 +31,11 @@ from typing import (
 import pandas as pd
 import requests
 
+from library.utils.bootstrap import ensure_project_root
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
+
+if __package__ in {None, ""}:
+    ensure_project_root()
 
 from library import cli  # noqa: F401 - re-exported for monkeypatching in tests
 from library import molecule_catalog


### PR DESCRIPTION
## Summary
- import the shared ensure_project_root helper in each CLI script
- remove bespoke path-bootstrapping code and call ensure_project_root when run as a script

## Testing
- pytest tests/smoke/test_get_data_scripts.py -k smoke

------
https://chatgpt.com/codex/tasks/task_e_68ddadb85e0c83249d8a558a5d33f3dd