### PR TITLE
Handle mapper retries via exit code

### DIFF
--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -69,6 +69,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             if normalized is not None:
                 ids_to_map.append(normalized)
 
+        mapping_failed = False
         try:
             mappings = map_chembl_ids_to_uniprot(
                 ids_to_map,
@@ -80,6 +81,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         except (ValueError, TimeoutError, URLError) as exc:
             logger.warning("map_failed", error=str(exc))
             df["mapping_uniprot_id"] = [None for _ in df[args.column]]
+            mapping_failed = True
         else:
             for chembl_id in ids_to_map:
                 uniprot_id = mappings.get(chembl_id)
@@ -112,7 +114,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         except OSError as exc:
             logger.error("write_fail", error=str(exc))
             return 1
-        return 0
+        return 0 if not mapping_failed else 1
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("run_fail", exc=exc)
         return 1
@@ -124,6 +126,10 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "Map ChEMBL target IDs to UniProt accessions",
         column="chembl_id",
         chunk_size=1,
+    )
+    parser.epilog = (
+        "Retry failed mappings by re-running the command. "
+        "Consider reducing --chunk-size or --rps when the remote service throttles requests."
     )
     parser.add_argument(
         "--key-cols",

--- a/tests/test_mapper_logging.py
+++ b/tests/test_mapper_logging.py
@@ -185,3 +185,77 @@ def test_mapper_main_concurrent_preserves_order(
         ("mapped", "CHEMBL2"),
         ("uniprot_id_missing", "CHEMBL3"),
     ]
+
+
+def test_mapper_main_returns_error_on_mapping_failure(
+    tmp_path: Path, monkeypatch: Any, cfg: Config
+) -> None:
+    """Mapping failures keep diagnostics but result in non-zero exit."""
+
+    df = pd.DataFrame({"chembl_id": ["CHEMBL1", "CHEMBL2"]})
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False)
+    output_path = tmp_path / "out.csv"
+
+    def failing_map(*_a: Any, **_k: Any) -> dict[str, str]:
+        raise TimeoutError("request timed out")
+
+    monkeypatch.setattr(mapper_main, "map_chembl_ids_to_uniprot", failing_map)
+
+    captured: dict[str, Any] = {}
+
+    def fake_write_csv(
+        df_out: pd.DataFrame,
+        path: Path,
+        *,
+        cfg: Config,
+        sep: str,
+        encoding: str,
+        key_cols: Any,
+    ) -> Path:
+        captured["df"] = df_out.copy()
+        captured["path"] = path
+        captured["key_cols"] = key_cols
+        return path
+
+    monkeypatch.setattr(mapper_main.io, "write_csv", fake_write_csv)
+
+    args = argparse.Namespace(
+        input_csv=input_path,
+        output_csv=output_path,
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+        key_cols=None,
+        chunk_size=2,
+        rps=5.0,
+        workers=2,
+    )
+
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(stream=buffer, level="INFO"))
+
+    cfg_ns = SimpleNamespace(
+        io=cfg.io,
+        uniprot_mapping=cfg.uniprot_mapping,
+        to_dict=lambda: {},
+    )
+
+    exit_code = mapper_main.run(cfg_ns, args)
+
+    assert exit_code == 1
+
+    output_df = captured["df"]
+    assert "mapping_uniprot_id" in output_df.columns
+    assert output_df["mapping_uniprot_id"].isna().all()
+    assert captured["path"] == output_path
+    assert captured["key_cols"] is None
+
+
+def test_mapper_help_mentions_retry_guidance() -> None:
+    """Help output should include retry guidance for failed mappings."""
+
+    parser, _ = mapper_main.build_parser()
+    help_text = parser.format_help().lower()
+    assert "retry" in help_text
+    assert "chunk-size" in help_text


### PR DESCRIPTION
## Summary
- return a non-zero exit code when the mapper cannot fetch UniProt identifiers while still writing diagnostics
- document retry guidance in the mapper CLI help text
- extend mapper CLI tests to cover failure exit codes and help messaging

## Testing
- pytest tests/test_mapper_logging.py tests/test_mapper_run_exception.py tests/test_default_output_dir.py

------
https://chatgpt.com/codex/tasks/task_e_68ddae2512f0832484437dcbcd22c0d9