### PR TITLE
Remove responses from runtime dependency list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "numpy~=2.3.3",
   "pandas~=2.3.2",
   "requests~=2.32.5",
-  "responses~=0.25.8",
   "PyYAML~=6.0.2",
   "openpyxl~=3.1.5",
   "pyarrow~=17.0.0",


### PR DESCRIPTION
## Summary
- drop the responses mock server from the runtime dependency list in favour of the existing dev extra
- verified that the development extras still install correctly via pip install .[dev]

## Testing
- pip install .[dev]


------
https://chatgpt.com/codex/tasks/task_e_68ddad889c8c8324a96a254006d5dc24