### PR TITLE
Fix duplicate pytest quiet flag in QA process guide

### DIFF
--- a/docs/QA_PROCESS_EN.md
+++ b/docs/QA_PROCESS_EN.md
@@ -29,9 +29,11 @@ mypy --strict
    ```bash
    pytest --maxfail=1 --durations=10
    ```
-2. Full suite, keeping warnings visible for triage:
+2. Full suite, keeping warnings visible for triage.
+   Use quiet mode (`-q`) for routine certification runs.
+   Switch to verbose (`-vv`) output when you need detailed failure context:
    ```bash
-   pytest -q --disable-warnings -q
+   pytest -q --disable-warnings
    ```
 
 ## 4. Determinism and CLI smoke checks


### PR DESCRIPTION
## Summary
- remove the duplicated `-q` option in the pytest full-suite example
- explain when to use quiet versus verbose output during certification runs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ddae21d1048324ae187a433985f7ec