### PR TITLE
Handle optional legacy config keys

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1303,6 +1303,13 @@ def _is_valid_path(path: list[str]) -> bool:
     return True
 
 
+_OPTIONAL_UNKNOWN_KEYS: frozenset[str] = frozenset(
+    {
+        "local.io.csv_fallback_separators",
+    }
+)
+
+
 def _collect_unknown_keys(
     data: dict[str, Any], model: type[BaseModel], prefix: str = ""
 ) -> list[str]:
@@ -1355,6 +1362,16 @@ def load_config(
             _set_by_path(data, key.split("."), val)
 
     unknown = _collect_unknown_keys(data, Config)
+    ignored_unknown = [
+        key for key in unknown if key in _OPTIONAL_UNKNOWN_KEYS
+    ]
+    unknown = [key for key in unknown if key not in _OPTIONAL_UNKNOWN_KEYS]
+    if ignored_unknown:
+        logger.warning(
+            "config_unknown_ignored",
+            keys=", ".join(sorted(ignored_unknown)),
+            hint="Upgrade the application to use these options.",
+        )
     if unknown:
         msg = (
             "Unknown configuration key(s) in "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -321,6 +321,23 @@ def test_unknown_key_warning_non_strict(tmp_path: Path) -> None:
     assert "Unknown configuration key" in msg
 
 
+def test_optional_unknown_key_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text("legacy: true\n")
+    monkeypatch.setattr(config_module, "_OPTIONAL_UNKNOWN_KEYS", {"legacy"})
+    buf = io.StringIO()
+    configure_logger(LoggerConfig(stream=buf))
+    cfg = load_config(path, strict=True)
+    assert isinstance(cfg, Config)
+    lines = buf.getvalue().splitlines()
+    assert lines
+    record = json.loads(lines[-1])
+    assert record.get("event") == "config_unknown_ignored"
+    assert record.get("keys") == "legacy"
+
+
 def test_unknown_key_error(tmp_path: Path) -> None:
     path = tmp_path / "cfg.yaml"
     path.write_text("unknown: 1\n")


### PR DESCRIPTION
## Summary
- allow certain legacy configuration keys to be ignored rather than aborting strict validation, keeping the loader compatible when new options are introduced
- log a structured warning for ignored keys and add a regression test for the behaviour

## Testing
- pytest tests/test_config.py::test_optional_unknown_key_ignored


------
https://chatgpt.com/codex/tasks/task_e_68ddb685ea888324b8136461f7a59756