### PR TITLE
Add PubChem cache maxsize configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1240,6 +1240,13 @@
           "title": "Cache Ttl",
           "type": "integer"
         },
+        "cache_maxsize": {
+          "default": 1024,
+          "description": "Maximum number of entries stored in the PubChem in-memory cache",
+          "minimum": 1,
+          "title": "Cache Maxsize",
+          "type": "integer"
+        },
         "cache_ttl_hours": {
           "default": null,
           "description": "Optional TTL for the persisted CID cache in hours",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -174,6 +174,7 @@ sources:
       - inchi
       - pref_name
     cache_ttl: 3600  # Request cache time-to-live in seconds
+    cache_maxsize: 1024  # Maximum cached PubChem responses
     cache_ttl_hours: null  # Persisted CID cache TTL in hours; null disables expiry
     cid_cache_path: "data/cache/pubchem_cid_cache.json"
     batch_size: 50

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -284,6 +284,7 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | `backoff_initial_seconds` | `0.5` | Initial exponential backoff applied after 429/5xx responses. | `CHEMBL_DA_SOURCES_PUBCHEM_BACKOFF_INITIAL_SECONDS`, `CHEMBL_DA__SOURCES__PUBCHEM__BACKOFF_INITIAL_SECONDS` |
 | `resolve_order` | `cache → smiles → inchikey → inchi → pref_name` | Order in which lookup strategies are attempted when resolving PubChem CIDs. | `CHEMBL_DA_SOURCES_PUBCHEM_RESOLVE_ORDER`, `CHEMBL_DA__SOURCES__PUBCHEM__RESOLVE_ORDER` |
 | `cache_ttl` | `3600` | Lifespan (seconds) of the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
+| `cache_maxsize` | `1024` | Maximum number of entries retained by the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_MAXSIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_MAXSIZE` |
 | `cache_ttl_hours` | `null` | Optional expiry (hours) for the persisted CID cache; `null` keeps entries indefinitely. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
 | `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
 | `batch_size` | `50` | Number of rows processed per PubChem batch request; concurrency never exceeds `min(batch_size, rps)`. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |

--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -223,7 +223,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
 
     global _CACHE
     with _CACHE_LOCK:
-        cache = _ensure_cache(cfg.cache_ttl)
+        cache = _ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
         cached = cache.get(url) if cache is not None else None
     if cached is not None:
         if cached.is_hit:
@@ -437,7 +437,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                     rps=cfg.rps,
                 )
                 with _CACHE_LOCK:
-                    cache = _ensure_cache(cfg.cache_ttl)
+                    cache = _ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
                     cache[url] = _CacheEntry(payload=data, outcome="hit")
                 logger.info("cache_set", url=url, rps=cfg.rps, status="hit")
                 return data
@@ -472,13 +472,13 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
     return None
 
 
-def _ensure_cache(ttl: float) -> TTLCache[str, _CacheEntry]:
-    """Return the shared cache instance, recreating it when TTL changes."""
+def _ensure_cache(ttl: float, maxsize: int) -> TTLCache[str, _CacheEntry]:
+    """Return the shared cache instance, recreating it when TTL or maxsize change."""
 
     global _CACHE
     cache = _CACHE
-    if cache is None or cache.ttl != ttl:
-        cache = _CACHE = TTLCache(maxsize=1024, ttl=ttl)
+    if cache is None or cache.ttl != ttl or cache.maxsize != maxsize:
+        cache = _CACHE = TTLCache(maxsize=maxsize, ttl=ttl)
     return cache
 
 
@@ -489,7 +489,7 @@ def _store_cache_miss(
 
     details_copy = dict(details) if details else None
     with _CACHE_LOCK:
-        cache = _ensure_cache(cfg.cache_ttl)
+        cache = _ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
         cache[url] = _CacheEntry(payload=None, outcome=outcome, details=details_copy)
     log_data: dict[str, Any] = {
         "url": url,

--- a/library/config.py
+++ b/library/config.py
@@ -376,6 +376,11 @@ class PubChemCfg(_BaseModel):
         ge=0,
         description="Time-to-live for the in-memory PubChem request cache in seconds",
     )
+    cache_maxsize: int = Field(
+        1024,
+        ge=1,
+        description="Maximum number of entries stored in the PubChem in-memory cache",
+    )
     cache_ttl_hours: float | None = Field(
         None,
         ge=0,


### PR DESCRIPTION
## Summary
- add a `cache_maxsize` option to the PubChem configuration including schema and documentation updates
- honour the configured cache size when initialising the shared PubChem TTL cache

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb9b7e2b88324b8b7a19da987fddf