### PR TITLE
Downgrade cache_set logs to DEBUG

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -394,7 +394,8 @@ Typical log entries look like:
 
 ```json
 {"ts":"2024-05-01T12:00:00Z","level":"INFO","event":"pipeline_start","run_id":"abc123","stage":"pipeline"}
-{"ts":"2024-05-01T12:00:01Z","level":"INFO","event":"request_ok","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":200}
+{"ts":"2024-05-01T12:00:01Z","level":"DEBUG","event":"request_ok","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":200}
+{"ts":"2024-05-01T12:00:01Z","level":"DEBUG","event":"cache_set","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":"hit"}
 {"ts":"2024-05-01T12:00:02Z","level":"INFO","event":"validate_done","run_id":"abc123","stage":"validate","rows":42}
 {"ts":"2024-05-01T12:00:03Z","level":"INFO","event":"pipeline_done","run_id":"abc123","stage":"pipeline","elapsed":3.2}
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -376,7 +376,8 @@ jq 'select(.event=="dry_run")' log.jsonl
 
 ```json
 {"ts":"2024-05-01T12:00:00Z","level":"INFO","event":"pipeline_start","run_id":"abc123","stage":"pipeline"}
-{"ts":"2024-05-01T12:00:01Z","level":"INFO","event":"request_ok","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":200}
+{"ts":"2024-05-01T12:00:01Z","level":"DEBUG","event":"request_ok","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":200}
+{"ts":"2024-05-01T12:00:01Z","level":"DEBUG","event":"cache_set","run_id":"abc123","stage":"fetch","url":"https://api.example.org","status":"hit"}
 {"ts":"2024-05-01T12:00:02Z","level":"INFO","event":"validate_done","run_id":"abc123","stage":"validate","rows":42}
 {"ts":"2024-05-01T12:00:03Z","level":"INFO","event":"pipeline_done","run_id":"abc123","stage":"pipeline","elapsed":3.2}
 ```

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -5,5 +5,5 @@
 - Clarified the minimum supported Python version as 3.11 across documentation and runtime checks.
 - Documented the requirement to configure `api.user_agent` with a real contact, including validation behaviour and the
   `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT` environment override.
-- Downgraded ChEMBL cache hit/miss logging to DEBUG to reduce noise in default INFO logs.
+- Downgraded ChEMBL and PubChem cache hit/miss logging to DEBUG to reduce noise in default INFO logs.
 

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -208,7 +208,7 @@ class ChemblClient:
                         if cached is not None:
                             return cast(dict[str, Any], cached)
                         self.cache[cache_key] = data
-                        logger.info("cache_set", extra={"url": url, "rps": cfg.rps})
+                        logger.debug("cache_set", extra={"url": url, "rps": cfg.rps})
                         return data
             except ValueError as exc:
                 last_exc = exc

--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -439,7 +439,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                 with _CACHE_LOCK:
                     cache = _ensure_cache(cfg.cache_ttl)
                     cache[url] = _CacheEntry(payload=data, outcome="hit")
-                logger.info("cache_set", url=url, rps=cfg.rps, status="hit")
+                logger.debug("cache_set", url=url, rps=cfg.rps, status="hit")
                 return data
         except requests.RequestException as exc:  # pragma: no cover - network
             last_failure_details = {
@@ -499,7 +499,7 @@ def _store_cache_miss(
     }
     if details_copy:
         log_data.update(details_copy)
-    logger.info("cache_set", **log_data)
+    logger.debug("cache_set", **log_data)
 
 
 def _extract_cids(bindings: list[dict[str, Any]]) -> list[str]:

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import threading
+import io
+import json
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -12,6 +14,7 @@ from cachetools import TTLCache
 from library import pubchem_library as pl
 from library.clients import pubchem as pc
 from library.config import ApiCfg, RetryCfg, session_with_retry
+from library.logging_setup import LoggerConfig, configure_logger
 
 
 class DummyResponse:
@@ -400,3 +403,76 @@ def test_init_session_closes_previous_session(monkeypatch) -> None:
     assert closed == [first_api.user_agent]
     assert first_session.closed is True
     assert second_session.closed is False
+
+
+def test_make_request_logs_cache_set_hit_as_debug(monkeypatch) -> None:
+    """Successful requests should log cache writes at DEBUG level."""
+
+    buf = io.StringIO()
+    test_logger = configure_logger(
+        LoggerConfig(level="DEBUG", run_id="test", stream=buf)
+    ).bind(status=None, rps=None)
+    monkeypatch.setattr(pc, "logger", test_logger)
+
+    url = "https://example.org/cache-hit"
+    payload = {"value": 1}
+    cfg = pl.PubChemCfg(retries=0, delay=0)
+
+    api_cfg = _configure_session()
+    session = pc.get_session(api_cfg)
+
+    monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
+    monkeypatch.setattr(pc, "sleep", lambda *_: None)
+    monkeypatch.setattr(
+        session,
+        "get",
+        lambda *args, **kwargs: DummyResponse(payload),
+    )
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    result = pc.make_request(url, cfg)
+
+    assert result == payload
+
+    records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    cache_records = [record for record in records if record.get("event") == "cache_set"]
+
+    assert cache_records
+    assert cache_records[0]["level"] == "DEBUG"
+    assert cache_records[0]["status"] == "hit"
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+
+def test_store_cache_miss_logs_debug(monkeypatch) -> None:
+    """Cached miss entries should emit DEBUG logs with context."""
+
+    buf = io.StringIO()
+    test_logger = configure_logger(
+        LoggerConfig(level="DEBUG", run_id="test", stream=buf)
+    ).bind(status=None, rps=None)
+    monkeypatch.setattr(pc, "logger", test_logger)
+
+    cfg = pl.PubChemCfg(retries=0, delay=0)
+    url = "https://example.org/cache-miss"
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    pc._store_cache_miss(url, cfg, "not_found", {"reason": "rate_limited"})
+
+    records = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+    cache_records = [record for record in records if record.get("event") == "cache_set"]
+
+    assert cache_records
+    cache_record = cache_records[0]
+    assert cache_record["level"] == "DEBUG"
+    assert cache_record["status"] == "miss"
+    assert cache_record["outcome"] == "not_found"
+    assert cache_record["reason"] == "rate_limited"
+
+    with pc._CACHE_LOCK:
+        pc._CACHE = None


### PR DESCRIPTION
## Summary
- lower the cache_set event level to DEBUG for ChemBL and PubChem clients
- refresh the logging examples and release notes to document the new verbosity
- extend PubChem threading tests to assert cache_set hit/miss events log at DEBUG

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb9b1f4f48324b4ce1f090578ab63