### PR TITLE
Ensure fetch_iuphar prioritises UniProt data

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1001,25 +1001,65 @@ def fetch_iuphar(
         )
         chembl_for_merge = chembl_for_merge.assign(**{merge_column: placeholder})
 
+    overlapping_columns = (
+        set(chembl_for_merge.columns)
+        .intersection(uniprot_df.columns)
+        .difference({"original_id"})
+    )
+
     combined_df = pd.merge(
         chembl_for_merge,
         uniprot_df,
         left_on=merge_column,
         right_on="original_id",
         how="left",
+        suffixes=("_chembl", "_uniprot"),
     )
+
+    def _is_missing_token(value: object) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, float) and pd.isna(value):
+            return True
+        if isinstance(value, str):
+            token = value.strip()
+            return token in {"", "-", "None"}
+        return False
+
+    def _prefer_uniprot(
+        uniprot_series: pd.Series | None, chembl_series: pd.Series | None
+    ) -> pd.Series:
+        if uniprot_series is None and chembl_series is None:
+            return pd.Series(dtype=object)
+        if uniprot_series is None:
+            return chembl_series.astype(object) if chembl_series is not None else pd.Series(dtype=object)
+        if chembl_series is None:
+            return uniprot_series.astype(object)
+
+        preferred = uniprot_series.astype(object)
+        fallback = chembl_series.astype(object)
+        result = fallback.copy()
+        mask = ~preferred.apply(_is_missing_token)
+        result.loc[mask] = preferred.loc[mask]
+        return result
+
+    for column in sorted(overlapping_columns):
+        chembl_name = f"{column}_chembl"
+        uniprot_name = f"{column}_uniprot"
+        chembl_series = combined_df.get(chembl_name)
+        uniprot_series = combined_df.get(uniprot_name)
+        combined_df[column] = _prefer_uniprot(uniprot_series, chembl_series)
+
+    suffix_columns = [
+        column
+        for column in combined_df.columns
+        if column.endswith("_chembl") or column.endswith("_uniprot")
+    ]
+    if suffix_columns:
+        combined_df = combined_df.drop(columns=suffix_columns, errors="ignore")
 
     if "original_id" in combined_df.columns:
         combined_df = combined_df.drop(columns=["original_id"])
-    if merge_column == "uniprot_id":
-        left_series = combined_df.pop("uniprot_id_x") if "uniprot_id_x" in combined_df else None
-        right_series = combined_df.pop("uniprot_id_y") if "uniprot_id_y" in combined_df else None
-        if left_series is not None and right_series is not None:
-            combined_df["uniprot_id"] = right_series.fillna(left_series)
-        elif left_series is not None:
-            combined_df["uniprot_id"] = left_series
-        elif right_series is not None:
-            combined_df["uniprot_id"] = right_series
 
     if "gene" not in combined_df.columns:
         combined_df["gene"] = pd.Series(

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import pandas as pd
@@ -86,3 +87,79 @@ def test_iuphar_merge_preserves_ec_number(
     assert merged.loc[0, "protein_class_pred_L1"] == "ClassA"
     assert merged.loc[0, "target_type"] == "Multicellular organism"
     assert classifier.calls
+
+
+def test_fetch_iuphar_prefers_uniprot_values(
+    tmp_path: Path, cfg: Config, monkeypatch: MonkeyPatch
+) -> None:
+    """Ensure UniProt values override ChEMBL data for overlapping fields."""
+
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P11111"],
+            "isoform_ids": ["CHEMBL_ISO"],
+            "GuidetoPHARMACOLOGY": ["CHEMBL_GUIDE"],
+            "geneName": ["CHEMBL_GENE"],
+            "gene": ["CHEMBL_GENE"],
+            "pref_name": ["Chembl Preferred"],
+            "component_description": ["Chembl Component"],
+            "names": ["Chembl Name"],
+            "synonyms": ["Chembl Synonym"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P11111"],
+            "isoform_ids": ["UNIPROT_ISO"],
+            "GuidetoPHARMACOLOGY": ["UNIPROT_GUIDE"],
+            "geneName": ["UniGene"],
+            "gene": ["UniGene"],
+            "pref_name": ["UniProt Preferred"],
+            "component_description": ["UniProt Component"],
+            "names": ["UniProt Name"],
+            "synonyms": ["UniProt Synonym"],
+            "original_id": ["P11111"],
+        }
+    )
+
+    output_csv = tmp_path / "iuphar.csv"
+
+    def fake_run_iuphar(config: Config, args: argparse.Namespace) -> int:
+        pd.DataFrame(
+            {
+                "uniprot_id": ["P11111"],
+                "IUPHAR_class": ["ClassA"],
+            }
+        ).to_csv(
+            args.output_csv,
+            index=False,
+            sep=config.io.csv_sep,
+            encoding=config.io.csv_encoding,
+        )
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+
+    combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, output_csv)
+
+    assert combined_df.loc[0, "isoform_ids"] == "UNIPROT_ISO"
+    assert combined_df.loc[0, "GuidetoPHARMACOLOGY"] == "UNIPROT_GUIDE"
+    assert combined_df.loc[0, "geneName"] == "UniGene"
+    assert combined_df.loc[0, "pref_name"] == "UniProt Preferred"
+
+    conflicting = {"isoform_ids", "GuidetoPHARMACOLOGY", "geneName", "pref_name"}
+    for base in conflicting:
+        assert f"{base}_chembl" not in combined_df.columns
+        assert f"{base}_uniprot" not in combined_df.columns
+
+    merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+    processed = tp.postprocess_targets(merged)
+
+    assert processed.loc[0, "isoform_ids"] == "UNIPROT_ISO"
+    assert processed.loc[0, "GuidetoPHARMACOLOGY"] == "UNIPROT_GUIDE"
+    assert processed.loc[0, "geneName"] == "UniGene"
+
+    for base in conflicting:
+        assert f"{base}_chembl" not in processed.columns
+        assert f"{base}_uniprot" not in processed.columns


### PR DESCRIPTION
## Summary
- coalesce overlapping ChEMBL and UniProt fields during fetch_iuphar using explicit suffix handling
- prefer UniProt values with fallback to ChEMBL and drop suffixed helper columns after merging
- add regression coverage to confirm coalesced columns remain suffix-free after post-processing

## Testing
- pytest tests/test_get_target_data_merge.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb8a078b08324b162bdca666e59d5