### PR TITLE
Handle Retry-After headers in PubMed client

### DIFF
--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import requests
 
-from ..config import PubMedCfg
+from ..config import PubMedCfg, RetryCfg
 from ..log import logger
 from ..rate_limiter import sleep
 
@@ -28,7 +30,7 @@ def _make_request(
     method: str,
     timeout: float | tuple[float, float],
     **kwargs: Any,
-) -> tuple[int, str, dict[str, Any] | str | None, str]:
+) -> tuple[int, str, dict[str, Any] | str | None, str, Mapping[str, str]]:
     """Issue a single HTTP request and parse its body."""
 
     if method.upper() == "POST":
@@ -42,9 +44,33 @@ def _make_request(
             try:
                 content = resp.json()
             except ValueError as exc:
-                return status_code, text, None, str(exc)
-            return status_code, text, content, ""
-        return status_code, text, text or "", ""
+                return status_code, text, None, str(exc), resp.headers
+            return status_code, text, content, "", resp.headers
+        return status_code, text, text or "", "", resp.headers
+
+
+def _retry_after_delay(headers: Mapping[str, str]) -> float | None:
+    """Parse the ``Retry-After`` header into a delay in seconds."""
+
+    header = headers.get("Retry-After")
+    if header is None:
+        return None
+    value = header.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        return max((retry_at - now).total_seconds(), 0.0)
+    else:
+        return max(seconds, 0.0)
 
 
 def _handle_response(
@@ -56,49 +82,51 @@ def _handle_response(
     expect_json: bool,
     attempt: int,
     retries: int,
-) -> tuple[dict[str, Any] | str | None, str, bool]:
+    headers: Mapping[str, str],
+) -> tuple[dict[str, Any] | str | None, str, bool, float | None]:
     """Process an HTTP response and decide whether to retry."""
 
     if status_code in (429, 500, 502, 503, 504):
+        retry_after = _retry_after_delay(headers)
         if attempt >= retries:
             logger.info(
                 "request_fail",
                 extra={"stage": "request_fail", "url": url, "status": status_code},
             )
-            return None, f"HTTP {status_code}: {text[:100]}", False
-        return None, "", True
+            return None, f"HTTP {status_code}: {text[:100]}", False, retry_after
+        return None, "", True, retry_after
     if status_code == 404:
         logger.info(
             "request_fail",
             extra={"stage": "request_fail", "url": url, "status": status_code},
         )
-        return None, "PMID not found", False
+        return None, "PMID not found", False, None
     if status_code == 400:
         logger.info(
             "request_fail",
             extra={"stage": "request_fail", "url": url, "status": status_code},
         )
-        return None, f"Bad request: {text[:100]}", False
+        return None, f"Bad request: {text[:100]}", False, None
     if status_code != 200:
         logger.info(
             "request_fail",
             extra={"stage": "request_fail", "url": url, "status": status_code},
         )
-        return None, f"HTTP {status_code}: {text[:100]}", False
+        return None, f"HTTP {status_code}: {text[:100]}", False, None
     if expect_json:
         if parse_error:
             logger.info("request_fail", extra={"stage": "request_fail", "url": url})
-            return None, f"Invalid JSON: {parse_error}", False
+            return None, f"Invalid JSON: {parse_error}", False, None
         logger.info(
             "request_ok",
             extra={"stage": "request_ok", "url": url, "status": status_code},
         )
-        return content, "", False
+        return content, "", False, None
     logger.info(
         "request_ok",
         extra={"stage": "request_ok", "url": url, "status": status_code},
     )
-    return content or "", "", False
+    return content or "", "", False, None
 
 
 def _do_request(
@@ -109,18 +137,28 @@ def _do_request(
     retries: int = 2,
     method: str = "GET",
     timeout: float | tuple[float, float] = 10,
+    retry_cfg: RetryCfg | None = None,
     **kwargs: Any,
 ) -> tuple[dict[str, Any] | str | None, str]:
     """Perform an HTTP request with retry logic."""
 
+    retry_policy = retry_cfg or RetryCfg()
+    retry_after_delay: float | None = None
     for attempt in range(retries + 1):
         event = "request_start" if attempt == 0 else "request_retry"
         logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
         if attempt:
-            sleep(delay * attempt)
+            wait = retry_after_delay
+            if wait is None:
+                wait = retry_policy.backoff_factor * (2 ** (attempt - 1))
+                if wait <= 0 and delay > 0:
+                    wait = delay
+            retry_after_delay = None
+            if wait and wait > 0:
+                sleep(wait)
 
         try:
-            status_code, text, content, parse_error = _make_request(
+            status_code, text, content, parse_error, headers = _make_request(
                 session, url, expect_json, method, timeout, **kwargs
             )
         except requests.RequestException as exc:
@@ -131,8 +169,16 @@ def _do_request(
                 return None, str(exc)
             continue
 
-        data, error, retry = _handle_response(
-            url, status_code, text, content, parse_error, expect_json, attempt, retries
+        data, error, retry, retry_after_delay = _handle_response(
+            url,
+            status_code,
+            text,
+            content,
+            parse_error,
+            expect_json,
+            attempt,
+            retries,
+            headers,
         )
         if retry:
             continue

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -13,11 +13,7 @@ import requests
 from library import rate_limiter as rl
 
 from library.clients import pubmed as pc
-from library.config import (
-    Config,
-    PubMedCfg,
-    SemanticScholarCfg,
-)
+from library.config import Config, PubMedCfg, RetryCfg, SemanticScholarCfg
 
 from library.clients import semantic_scholar as ss_client
 
@@ -43,11 +39,16 @@ def test_read_pmids_missing_column(tmp_path: Path) -> None:
 
 class DummyResponse:
     def __init__(
-        self, status: int, text: str = "", json_data: dict[str, Any] | None = None
+        self,
+        status: int,
+        text: str = "",
+        json_data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.status_code = status
         self._text = text
         self._json = json_data
+        self._headers = headers or {}
 
     def __enter__(self) -> DummyResponse:  # pragma: no cover - context manager proto
         return self
@@ -68,6 +69,10 @@ class DummyResponse:
         if self._json is None:
             raise ValueError("no json")
         return self._json
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
 
 
 class DummySession:
@@ -111,13 +116,15 @@ def test_do_request_attempt_count(monkeypatch: pytest.MonkeyPatch) -> None:
     statuses = [500, 500, 200]
     calls: list[int] = []
 
-    def fake_make_request(*args: Any, **kwargs: Any) -> tuple[int, str, Any, str]:
+    def fake_make_request(
+        *args: Any, **kwargs: Any
+    ) -> tuple[int, str, Any, str, dict[str, str]]:
         idx = len(calls)
         calls.append(idx)
         status = statuses[idx]
         if status >= 500:
-            return status, "error", None, ""
-        return status, "{}", {"ok": True}, ""
+            return status, "error", None, "", {}
+        return status, "{}", {"ok": True}, "", {}
 
     monkeypatch.setattr(pc, "_make_request", fake_make_request)
 
@@ -135,64 +142,121 @@ def test_do_request_attempt_count(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(calls) == 3
 
 
+def test_do_request_retry_after_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry loop should respect Retry-After headers between attempts."""
+
+    responses: list[tuple[int, str, Any, str, dict[str, str]]] = [
+        (429, "rate limited", None, "", {"Retry-After": "1.5"}),
+        (200, "{}", {"ok": True}, "", {}),
+    ]
+
+    def fake_make_request(*args: Any, **kwargs: Any) -> tuple[int, str, Any, str, dict[str, str]]:
+        return responses.pop(0)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(pc, "_make_request", fake_make_request)
+    monkeypatch.setattr(pc, "sleep", lambda value: sleeps.append(value))
+
+    data, err = pc._do_request(requests.Session(), "http://example.org", delay=0.1, retries=1)
+
+    assert data == {"ok": True}
+    assert err == ""
+    assert sleeps == [pytest.approx(1.5)]
+
+
+def test_do_request_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry loop falls back to RetryCfg exponential backoff."""
+
+    responses: list[tuple[int, str, Any, str, dict[str, str]]] = [
+        (500, "error", None, "", {}),
+        (200, "{}", {"ok": True}, "", {}),
+    ]
+
+    def fake_make_request(*args: Any, **kwargs: Any) -> tuple[int, str, Any, str, dict[str, str]]:
+        return responses.pop(0)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(pc, "_make_request", fake_make_request)
+    monkeypatch.setattr(pc, "sleep", lambda value: sleeps.append(value))
+
+    retry_cfg = RetryCfg(backoff_factor=0.2)
+    data, err = pc._do_request(
+        requests.Session(),
+        "http://example.org",
+        delay=0.0,
+        retries=1,
+        retry_cfg=retry_cfg,
+    )
+
+    assert data == {"ok": True}
+    assert err == ""
+    assert sleeps == [pytest.approx(0.2)]
+
+
 def test_handle_response_retryable() -> None:
     """500 response triggers a retry on non-final attempts."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 500, "error", None, "", True, 0, 1
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 500, "error", None, "", True, 0, 1, {"Retry-After": "7"}
     )
     assert data is None
     assert err == ""
     assert retry is True
+    assert retry_after == pytest.approx(7.0)
 
 
 def test_handle_response_retryable_last_attempt() -> None:
     """Retryable error returns a message on the last attempt."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 500, "error", None, "", True, 1, 1
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 500, "error", None, "", True, 1, 1, {}
     )
     assert data is None
     assert retry is False
     assert err.startswith("HTTP 500")
+    assert retry_after is None
 
 
 def test_handle_response_parse_error() -> None:
     """Invalid JSON is reported as a failure."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 200, "", None, "boom", True, 0, 0
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 200, "", None, "boom", True, 0, 0, {}
     )
     assert data is None
     assert retry is False
     assert err.startswith("Invalid JSON")
+    assert retry_after is None
 
 
 def test_handle_response_success_text() -> None:
     """Text responses are returned when JSON is not expected."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 200, "hi", "hi", "", False, 0, 0
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 200, "hi", "hi", "", False, 0, 0, {}
     )
     assert data == "hi"
     assert err == ""
     assert retry is False
+    assert retry_after is None
 
 
 def test_handle_response_404() -> None:
     """404 error returns a specific message."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 404, "not found", None, "", True, 0, 0
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 404, "not found", None, "", True, 0, 0, {}
     )
     assert data is None
     assert err == "PMID not found"
     assert retry is False
+    assert retry_after is None
 
 
 def test_handle_response_400() -> None:
     """400 error is reported as a bad request."""
-    data, err, retry = pc._handle_response(
-        "http://example.org", 400, "bad", None, "", True, 0, 0
+    data, err, retry, retry_after = pc._handle_response(
+        "http://example.org", 400, "bad", None, "", True, 0, 0, {}
     )
     assert data is None
     assert retry is False
     assert err.startswith("Bad request")
+    assert retry_after is None
 
 
 def test_fetch_pubmed_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- return response headers from `_make_request` and surface Retry-After values via `_handle_response`
- base `_do_request` backoff delays on either Retry-After headers or the configured exponential retry policy
- extend unit tests to cover header parsing and RetryCfg-based fallbacks

## Testing
- pytest tests/test_pubmed_query.py tests/test_openalex_crossref_library.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb987d4ac8324a5239dedf2501b2f