### PR TITLE
Handle mapping UniProt fallbacks for IUPHAR classification

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -111,10 +111,26 @@ class IUPHARData:
         rows = self.target_df.loc[mask, "target_id"].dropna().astype(str)
         return list(rows.unique())
 
+    @staticmethod
+    def _normalise_uniprot_values(uniprot_id: str | float | None) -> list[str]:
+        """Split pipe-delimited UniProt accessions into individual entries."""
+
+        if not uniprot_id or (isinstance(uniprot_id, float) and pd.isna(uniprot_id)):
+            return []
+        return [
+            value.strip()
+            for value in str(uniprot_id).split("|")
+            if value and value.strip()
+        ]
+
     def target_id_by_uniprot(self, uniprot_id: str) -> str:
-        """Return the first target ID mapped to ``uniprot_id``."""
-        ids = self._select_target_ids(self.target_df["uniprot_id"].eq(uniprot_id))
-        return ids[0] if ids else ""
+        """Return the first target ID mapped to any of the supplied accessions."""
+
+        for accession in self._normalise_uniprot_values(uniprot_id):
+            ids = self._select_target_ids(self.target_df["uniprot_id"].eq(accession))
+            if ids:
+                return ids[0]
+        return ""
 
     def target_id_by_hgnc_name(self, hgnc_name: str) -> str:
         """Return target IDs whose HGNC name equals ``hgnc_name``."""
@@ -195,11 +211,16 @@ class IUPHARData:
         implementation.
         """
         uniprot = self.target_id_by_uniprot(row.get("uniprot_id", ""))
+        mapped_uniprot = self.target_id_by_uniprot(row.get("mapping_uniprot_id", ""))
         hgnc_name = self.target_id_by_hgnc_name(row.get("hgnc_name", ""))
         hgnc_id = self.target_id_by_hgnc_id(row.get("hgnc_id", ""))
         name = ""
         synonyms = ""
-        all_ids = [x for x in [uniprot, hgnc_name, hgnc_id, name, synonyms] if x]
+        all_ids = [
+            x
+            for x in [uniprot, mapped_uniprot, hgnc_name, hgnc_id, name, synonyms]
+            if x
+        ]
         unique = sorted({i for part in all_ids for i in part.split("|") if i})
         if not unique:
             return "N/A"
@@ -259,12 +280,19 @@ class IUPHARData:
             df["target_id"] = ""
 
         # Resolve remaining identifiers with a series of fallbacks. The search
-        # order mirrors the Power Query logic: UniProt accession, HGNC name,
-        # HGNC ID, gene symbol and finally any supplied synonyms.
+        # order mirrors the Power Query logic: UniProt accession, mapped
+        # UniProt identifiers supplied by the ChEMBL fallback, HGNC name, HGNC
+        # ID, gene symbol and finally any supplied synonyms.
         mask = df["target_id"].eq("")
         df.loc[mask, "target_id"] = df.loc[mask, "uniprot_id"].apply(
             self.target_id_by_uniprot
         )
+
+        if "mapping_uniprot_id" in df.columns:
+            mask = df["target_id"].eq("")
+            df.loc[mask, "target_id"] = df.loc[mask, "mapping_uniprot_id"].apply(
+                self.target_id_by_uniprot
+            )
 
         if "hgnc_name" in df.columns:
             mask = df["target_id"].eq("")

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1084,6 +1084,11 @@ def fetch_iuphar(
     )
     combined_df = combined_df.drop(columns=["ec_numbers"], errors="ignore")
 
+    if "mapping_uniprot_id" in combined_df.columns:
+        combined_df["mapping_uniprot_id"] = (
+            combined_df["mapping_uniprot_id"].fillna("").astype(str)
+        )
+
     from tempfile import NamedTemporaryFile
 
     with NamedTemporaryFile(

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -297,6 +297,7 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
         {
             "target_chembl_id": ["C1"],
             "uniprot_id": ["P1"],
+            "mapping_uniprot_id": ["P1|ALT1"],
             "pref_name": ["pref"],
             "component_description": ["desc"],
             "gene": ["GENE"],
@@ -318,6 +319,14 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     out = tmp_path / "iuphar.csv"
 
     def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        input_df = pd.read_csv(
+            args.input_csv,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            dtype=str,
+        )
+        assert "mapping_uniprot_id" in input_df.columns
+        assert input_df.loc[0, "mapping_uniprot_id"] == "P1|ALT1"
         pd.DataFrame({"uniprot_id": ["P1"], "IUPHAR_class": ["Enzyme"]}).to_csv(
             args.output_csv, index=False
         )

--- a/tests/test_iuphar_library.py
+++ b/tests/test_iuphar_library.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pathlib import Path
+
 pd = pytest.importorskip("pandas")
 requests = pytest.importorskip("requests")
 responses = pytest.importorskip("responses")
@@ -219,3 +221,41 @@ def test_iuphar_upload_retries(monkeypatch) -> None:
     assert not df.empty
     assert sleeps == [pytest.approx(1.0)]
     assert calls["n"] == 3
+
+
+def test_map_uniprot_file_uses_mapping_uniprot(tmp_path: Path) -> None:
+    target_df = pd.DataFrame(
+        {
+            "target_id": ["T1"],
+            "uniprot_id": ["P12345"],
+            "family_id": ["F1"],
+            "type": ["Enzyme.Transferase"],
+            "target_name": ["Example target"],
+        }
+    )
+    family_df = pd.DataFrame(
+        {
+            "family_id": ["F1"],
+            "parent_family_id": [pd.NA],
+            "family_name": ["Example family"],
+            "type": ["Enzyme.Transferase"],
+        }
+    )
+    data = ii.IUPHARData(target_df=target_df, family_df=family_df)
+
+    input_df = pd.DataFrame(
+        {
+            "uniprot_id": [""],
+            "mapping_uniprot_id": ["P12345|Q99999"],
+        }
+    )
+    input_csv = tmp_path / "input.csv"
+    output_csv = tmp_path / "output.csv"
+    input_df.to_csv(input_csv, index=False)
+
+    result = data.map_uniprot_file(input_csv, output_csv)
+
+    assert result.loc[0, "target_id"] == "T1"
+    assert result.loc[0, "IUPHAR_class"] == "Enzyme"
+    assert result.loc[0, "IUPHAR_subclass"] == "Transferase"
+    assert result.loc[0, "mapping_uniprot_id"] == "P12345|Q99999"


### PR DESCRIPTION
## Summary
- normalise UniProt inputs so mapping_uniprot_id values with pipes can resolve IUPHAR target IDs
- include the mapping_uniprot_id column in the temporary input prepared for the IUPHAR pipeline
- cover the new fallback path with tests for both the mapper and fetch_iuphar helpers

## Testing
- pytest tests/test_iuphar_library.py tests/test_get_target_data_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb8a6ac4c8324b100528bd7b5b2fd