### PR TITLE
Support mapping_uniprot_id fallback in IUPHAR pipeline

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -111,9 +111,41 @@ class IUPHARData:
         rows = self.target_df.loc[mask, "target_id"].dropna().astype(str)
         return list(rows.unique())
 
+    @staticmethod
+    def _split_pipe_values(value: Any) -> list[str]:
+        """Return non-empty items from a pipe-delimited string."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            raw = value
+        else:
+            if pd.isna(value):
+                return []
+            raw = str(value)
+        return [item.strip() for item in raw.split("|") if item and item.strip()]
+
+    def _target_ids_from_uniprot_values(self, values: Iterable[str]) -> list[str]:
+        """Collect unique target identifiers resolved from UniProt accessions."""
+
+        resolved: list[str] = []
+        for value in values:
+            for accession in self._split_pipe_values(value):
+                ids = self._select_target_ids(
+                    self.target_df["uniprot_id"].eq(accession)
+                )
+                for identifier in ids:
+                    if identifier not in resolved:
+                        resolved.append(identifier)
+        return resolved
+
     def target_id_by_uniprot(self, uniprot_id: str) -> str:
-        """Return the first target ID mapped to ``uniprot_id``."""
-        ids = self._select_target_ids(self.target_df["uniprot_id"].eq(uniprot_id))
+        """Return the first target ID mapped to ``uniprot_id``.
+
+        Pipe-delimited accession lists are resolved sequentially until a
+        matching target is found, mirroring the Power Query fallback logic.
+        """
+
+        ids = self._target_ids_from_uniprot_values([uniprot_id])
         return ids[0] if ids else ""
 
     def target_id_by_hgnc_name(self, hgnc_name: str) -> str:
@@ -194,12 +226,21 @@ class IUPHARData:
         identifiers, mirroring the behaviour of the legacy Power Query
         implementation.
         """
-        uniprot = self.target_id_by_uniprot(row.get("uniprot_id", ""))
+        mapping_ids = self._target_ids_from_uniprot_values(
+            [row.get("mapping_uniprot_id", "")]
+        )
+        mapping = "|".join(mapping_ids) if mapping_ids else ""
+        uniprot_ids = self._target_ids_from_uniprot_values([
+            row.get("uniprot_id", "")
+        ])
+        uniprot = "|".join(uniprot_ids) if uniprot_ids else ""
         hgnc_name = self.target_id_by_hgnc_name(row.get("hgnc_name", ""))
         hgnc_id = self.target_id_by_hgnc_id(row.get("hgnc_id", ""))
         name = ""
         synonyms = ""
-        all_ids = [x for x in [uniprot, hgnc_name, hgnc_id, name, synonyms] if x]
+        all_ids = [
+            x for x in [mapping, uniprot, hgnc_name, hgnc_id, name, synonyms] if x
+        ]
         unique = sorted({i for part in all_ids for i in part.split("|") if i})
         if not unique:
             return "N/A"
@@ -257,6 +298,12 @@ class IUPHARData:
             df["target_id"] = df["GuidetoPHARMACOLOGY"].str.split("|").str[0]
         else:
             df["target_id"] = ""
+
+        if "mapping_uniprot_id" in df.columns:
+            mask = df["target_id"].eq("")
+            df.loc[mask, "target_id"] = df.loc[mask, "mapping_uniprot_id"].apply(
+                self.target_id_by_uniprot
+            )
 
         # Resolve remaining identifiers with a series of fallbacks. The search
         # order mirrors the Power Query logic: UniProt accession, HGNC name,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1021,6 +1021,15 @@ def fetch_iuphar(
         elif right_series is not None:
             combined_df["uniprot_id"] = right_series
 
+    if "mapping_uniprot_id" in combined_df.columns:
+        combined_df["mapping_uniprot_id"] = combined_df["mapping_uniprot_id"].fillna("")
+    else:
+        combined_df["mapping_uniprot_id"] = pd.Series(
+            "",
+            index=combined_df.index,
+            dtype=object,
+        )
+
     if "gene" not in combined_df.columns:
         combined_df["gene"] = pd.Series(
             UNIPROT_MISSING_VALUE,

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -303,6 +303,7 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
             "chembl_alternative_name": ["alt"],
             "ec_numbers": ["1.1.1.1"],
             "reaction_ec_numbers": ["2.2.2.2"],
+            "mapping_uniprot_id": ["P1"],
         }
     )
     uniprot_df = pd.DataFrame(
@@ -326,7 +327,43 @@ def test_fetch_iuphar(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
     combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
     assert "synonyms" in combined_df.columns
+    assert combined_df.loc[0, "mapping_uniprot_id"] == "P1"
     assert iuphar_df.loc[0, "IUPHAR_class"] == "Enzyme"
+
+
+def test_fetch_iuphar_passes_mapping_to_csv(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["C1"],
+            "uniprot_id": [""],
+            "mapping_uniprot_id": ["PX"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {
+            "uniprot_id": ["PX"],
+            "original_id": ["PX"],
+        }
+    )
+    out = tmp_path / "iuphar.csv"
+    captured: dict[str, pd.DataFrame] = {}
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        captured["input"] = pd.read_csv(args.input_csv, dtype=str)
+        pd.DataFrame({"uniprot_id": ["PX"], "IUPHAR_class": ["Class"]}).to_csv(
+            args.output_csv, index=False
+        )
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+    combined_df, _ = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
+
+    assert "mapping_uniprot_id" in combined_df.columns
+    assert combined_df.loc[0, "mapping_uniprot_id"] == "PX"
+    assert "mapping_uniprot_id" in captured["input"].columns
+    assert captured["input"].loc[0, "mapping_uniprot_id"] == "PX"
 
 
 def test_fetch_iuphar_missing_uniprot_column(

--- a/tests/test_iuphar_library.py
+++ b/tests/test_iuphar_library.py
@@ -157,6 +157,40 @@ def test_query_gene_symbol_backoff(monkeypatch):
     assert sleeps == [pytest.approx(1.0)]
 
 
+def test_map_uniprot_file_uses_mapping_uniprot(tmp_path):
+    target_df = pd.DataFrame(
+        {
+            "target_id": ["T1"],
+            "uniprot_id": ["P12345"],
+            "family_id": ["F1"],
+            "target_name": ["Target One"],
+            "type": ["Enzyme.Transferase"],
+        }
+    )
+    family_df = pd.DataFrame(
+        {
+            "family_id": ["F1", "ROOT"],
+            "family_name": ["Family", "Root"],
+            "parent_family_id": ["ROOT", pd.NA],
+            "type": ["Enzyme.Transferase", "Other Protein Target"],
+        }
+    )
+    data = ii.IUPHARData(target_df=target_df, family_df=family_df)
+
+    source = tmp_path / "input.csv"
+    output = tmp_path / "output.csv"
+    pd.DataFrame(
+        {"uniprot_id": [""], "mapping_uniprot_id": ["P12345|Q99999"]}
+    ).to_csv(source, index=False)
+
+    result = data.map_uniprot_file(source, output)
+
+    assert result.loc[0, "target_id"] == "T1"
+    assert result.loc[0, "mapping_uniprot_id"] == "P12345|Q99999"
+    assert result.loc[0, "IUPHAR_family_id"] == "F1"
+    assert result.loc[0, "IUPHAR_type"] == "Enzyme.Transferase"
+
+
 def test_iuphar_upload_retries(monkeypatch) -> None:
     """``iuphar_upload`` retries failed downloads with backoff."""
 


### PR DESCRIPTION
## Summary
- extend the IUPHAR lookup helpers to split pipe-delimited accessions and use mapping_uniprot_id in the fallback chain
- ensure fetch_iuphar always preserves mapping_uniprot_id in the CSV consumed by the classifier
- add tests covering classification via mapping_uniprot_id and propagation through fetch_iuphar

## Testing
- pytest tests/test_iuphar_library.py tests/test_get_target_data_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbb2276808324a2fcf2c38b6ac3fd