### PR TITLE
Prioritize UniProt data in IUPHAR merge

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -109,6 +109,38 @@ def _first_token(value: str | None) -> str:
     return ""
 
 
+def _prefer_primary(
+    primary: pd.Series | None, secondary: pd.Series | None
+) -> pd.Series:
+    """Return a series prioritising ``primary`` values over ``secondary``.
+
+    The function coalesces two series representing the same logical column
+    coming from different data sources. Values from ``primary`` are preferred
+    unless they are missing or empty, in which case the corresponding entry
+    from ``secondary`` is used. Missing inputs yield an empty object-typed
+    series to maintain downstream compatibility.
+    """
+
+    if primary is None and secondary is None:
+        return pd.Series(dtype=object)
+
+    if primary is None:
+        return secondary.astype(object) if secondary is not None else pd.Series(dtype=object)
+
+    if secondary is None:
+        return primary.astype(object)
+
+    primary = primary.astype(object)
+    secondary = secondary.astype(object)
+    result = primary.copy()
+    if len(result) != len(secondary):
+        secondary = secondary.reindex(result.index)
+    mask = result.isna() | (result == "")
+    if mask.any():
+        result.loc[mask] = secondary.loc[mask]
+    return result
+
+
 def _prepare_targets_for_schema(
     df: pd.DataFrame,
 ) -> tuple[pd.DataFrame, set[str], set[str]]:
@@ -1007,19 +1039,30 @@ def fetch_iuphar(
         left_on=merge_column,
         right_on="original_id",
         how="left",
+        suffixes=("_chembl", "_uniprot"),
     )
 
     if "original_id" in combined_df.columns:
         combined_df = combined_df.drop(columns=["original_id"])
-    if merge_column == "uniprot_id":
-        left_series = combined_df.pop("uniprot_id_x") if "uniprot_id_x" in combined_df else None
-        right_series = combined_df.pop("uniprot_id_y") if "uniprot_id_y" in combined_df else None
-        if left_series is not None and right_series is not None:
-            combined_df["uniprot_id"] = right_series.fillna(left_series)
-        elif left_series is not None:
-            combined_df["uniprot_id"] = left_series
-        elif right_series is not None:
-            combined_df["uniprot_id"] = right_series
+
+    overlap_columns = sorted(
+        set(chembl_for_merge.columns)
+        & (set(uniprot_df.columns) - {"original_id"})
+    )
+    for column in overlap_columns:
+        chembl_col = f"{column}_chembl"
+        uniprot_col = f"{column}_uniprot"
+        chembl_series = (
+            combined_df.pop(chembl_col)
+            if chembl_col in combined_df.columns
+            else None
+        )
+        uniprot_series = (
+            combined_df.pop(uniprot_col)
+            if uniprot_col in combined_df.columns
+            else None
+        )
+        combined_df[column] = _prefer_primary(uniprot_series, chembl_series)
 
     if "gene" not in combined_df.columns:
         combined_df["gene"] = pd.Series(

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
 import pandas as pd
@@ -86,3 +87,58 @@ def test_iuphar_merge_preserves_ec_number(
     assert merged.loc[0, "protein_class_pred_L1"] == "ClassA"
     assert merged.loc[0, "target_type"] == "Multicellular organism"
     assert classifier.calls
+
+
+def test_fetch_iuphar_prioritises_uniprot_columns(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    """Ensure overlapping columns prefer UniProt data and remain unsuffixed."""
+
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["C1"],
+            "uniprot_id": ["P1"],
+            "isoform_ids": ["chembl_iso"],
+            "isoform_names": ["ChemblIso"],
+            "GuidetoPHARMACOLOGY": ["chembl_gtop"],
+            "gene": ["CHEMBLGENE"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P1"],
+            "original_id": ["P1"],
+            "isoform_ids": ["UNI_ISO"],
+            "isoform_names": [""],
+            "GuidetoPHARMACOLOGY": ["uni_gtop"],
+            "gene": ["UNIPROTGENE"],
+        }
+    )
+    out = tmp_path / "iuphar.csv"
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        pd.DataFrame({"uniprot_id": ["P1"], "IUPHAR_class": ["Enzyme"]}).to_csv(
+            args.output_csv, index=False
+        )
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+
+    combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
+
+    assert all(
+        not column.endswith("_chembl") and not column.endswith("_uniprot")
+        for column in combined_df.columns
+    )
+    assert combined_df.loc[0, "isoform_ids"] == "UNI_ISO"
+    assert combined_df.loc[0, "isoform_names"] == "ChemblIso"
+    assert combined_df.loc[0, "GuidetoPHARMACOLOGY"] == "uni_gtop"
+    assert combined_df.loc[0, "gene"] == "UNIPROTGENE"
+
+    merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
+    processed = tp.postprocess_targets(merged)
+
+    assert processed.loc[0, "isoform_ids"].lower() == "uni_iso"
+    assert processed.loc[0, "isoform_names"].lower() == "chembliso"
+    assert processed.loc[0, "GuidetoPHARMACOLOGY"] == "uni_gtop"
+    assert processed.loc[0, "gene"] == "UNIPROTGENE"


### PR DESCRIPTION
## Summary
- ensure fetch_iuphar keeps base column names by merging with explicit suffixes and coalescing overlapping fields in favour of UniProt values
- add regression coverage that fetch_iuphar and postprocess_targets expose preferred data without suffixes

## Testing
- pytest tests/test_get_target_data_merge.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbb215e288324bbca0974207606bf