### PR TITLE
Refactor UniProt and IUPHAR clients for thread-local sessions

### DIFF
--- a/library/clients/iuphar.py
+++ b/library/clients/iuphar.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import io
 import random
 import threading
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import quote
@@ -31,6 +32,7 @@ __all__ = [
     "download_gtp_to_hgnc_mapping",
     "download_gtp_to_uniprot_mapping",
     "init_session",
+    "get_session",
     "load_families",
     "load_targets",
     "query_gene_symbol",
@@ -38,8 +40,52 @@ __all__ = [
 
 # Default session uses the library-wide API configuration; callers should
 # override via :func:`init_session` when custom settings are required.
-_session: Session = session_with_retry(ApiCfg(), RetryCfg())
-_session_lock = threading.Lock()
+_session_lock = threading.RLock()
+_session_condition = threading.Condition(_session_lock)
+
+
+def _make_session_factory(api: ApiCfg, retry: RetryCfg) -> Callable[[], Session]:
+    def factory() -> Session:
+        return session_with_retry(api, retry)
+
+    return factory
+
+
+_session_factory: Callable[[], Session] = _make_session_factory(ApiCfg(), RetryCfg())
+_session_local = threading.local()
+_sessions: set[Session] = set()
+_active_requests = 0
+
+
+def _close_sessions(sessions: Iterable[Session]) -> None:
+    for session in sessions:
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()
+
+
+def _get_or_create_session_locked() -> Session:
+    session = cast(Session | None, getattr(_session_local, "session", None))
+    if session is None:
+        session = _session_factory()
+        _sessions.add(session)
+        setattr(_session_local, "session", session)
+    return session
+
+
+@contextmanager
+def _session_context() -> Iterator[Session]:
+    global _active_requests
+    with _session_condition:
+        session = _get_or_create_session_locked()
+        _active_requests += 1
+    try:
+        yield session
+    finally:
+        with _session_condition:
+            _active_requests -= 1
+            if _active_requests == 0:
+                _session_condition.notify_all()
 
 EXPECTED_TARGET_COLUMNS: tuple[str, ...] = (
     "target_id",
@@ -64,14 +110,25 @@ EXPECTED_FAMILY_COLUMNS: tuple[str, ...] = (
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session used by the IUPHAR client."""
 
-    global _session
-    old_session: Session | None = None
-    with _session_lock:
-        old_session = _session
-        _session = session_with_retry(api, retry)
+    global _session_factory, _session_local
 
-    if old_session is not None and old_session is not _session:
-        old_session.close()
+    factory = _make_session_factory(api, retry)
+    with _session_condition:
+        while _active_requests > 0:
+            _session_condition.wait()
+        old_sessions = list(_sessions)
+        _sessions.clear()
+        _session_factory = factory
+        _session_local = threading.local()
+
+    _close_sessions(old_sessions)
+
+
+def get_session() -> Session:
+    """Expose the configured :class:`requests.Session` instance."""
+
+    with _session_condition:
+        return _get_or_create_session_locked()
 
 
 def _validate_columns(df: pd.DataFrame, expected: Iterable[str]) -> None:
@@ -118,8 +175,8 @@ def _download_csv(url: str, cfg: IupharCfg, retry: RetryCfg) -> pd.DataFrame:
     for attempt in range(1, retry.max_attempts + 1):
         limiter.acquire()
         try:
-            with _session_lock:
-                with _session.get(url, timeout=timeout) as resp:
+            with _session_context() as session:
+                with session.get(url, timeout=timeout) as resp:
                     resp.raise_for_status()
                     return pd.read_csv(io.StringIO(resp.text))
         except requests.RequestException as exc:  # pragma: no cover - network
@@ -176,8 +233,8 @@ def _query_gene_symbol(
     for attempt in range(1, retry.max_attempts + 1):
         limiter.acquire()
         try:
-            with _session_lock:
-                with _session.get(url, timeout=timeout) as response:
+            with _session_context() as session:
+                with session.get(url, timeout=timeout) as response:
                     response.raise_for_status()
                     data = cast(list[dict[str, Any]], response.json())
                     return data[0] if data else {}

--- a/library/clients/uniprot.py
+++ b/library/clients/uniprot.py
@@ -7,6 +7,8 @@ import random
 
 import threading
 
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from typing import Any, cast
 
 import requests
@@ -30,34 +32,78 @@ class UniProtFetchError(RuntimeError):
 # Default session uses the application-wide API configuration. Call
 # :func:`init_session` with a custom configuration to override it.
 
-_session_lock = threading.Lock()
+_session_lock = threading.RLock()
+_session_condition = threading.Condition(_session_lock)
 
 
-_session: Session = session_with_retry(ApiCfg(), RetryCfg())
+def _make_session_factory(api: ApiCfg, retry: RetryCfg) -> Callable[[], Session]:
+    def factory() -> Session:
+        return session_with_retry(api, retry)
+
+    return factory
+
+
+_session_factory: Callable[[], Session] = _make_session_factory(ApiCfg(), RetryCfg())
+_session_local = threading.local()
+_sessions: set[Session] = set()
+_active_requests = 0
 _retry_cfg: RetryCfg = RetryCfg()
+
+
+def _close_sessions(sessions: Iterable[Session]) -> None:
+    for session in sessions:
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()
+
+
+def _get_or_create_session_locked() -> Session:
+    session = cast(Session | None, getattr(_session_local, "session", None))
+    if session is None:
+        session = _session_factory()
+        _sessions.add(session)
+        setattr(_session_local, "session", session)
+    return session
+
+
+@contextmanager
+def _session_context() -> Iterator[Session]:
+    global _active_requests
+    with _session_condition:
+        session = _get_or_create_session_locked()
+        _active_requests += 1
+    try:
+        yield session
+    finally:
+        with _session_condition:
+            _active_requests -= 1
+            if _active_requests == 0:
+                _session_condition.notify_all()
 
 
 def init_session(api: ApiCfg, retry: RetryCfg) -> None:
     """Initialise the shared HTTP session."""
 
-    global _session, _retry_cfg
+    global _session_factory, _session_local, _retry_cfg
 
-    new_session = session_with_retry(api, retry)
-    old_session: Session | None = None
-    with _session_lock:
-        old_session = _session
-        _session = new_session
+    factory = _make_session_factory(api, retry)
+    with _session_condition:
+        while _active_requests > 0:
+            _session_condition.wait()
+        old_sessions = list(_sessions)
+        _sessions.clear()
+        _session_factory = factory
+        _session_local = threading.local()
         _retry_cfg = retry
 
-    if old_session is not None:
-        old_session.close()
+    _close_sessions(old_sessions)
 
 
 def get_session() -> Session:
     """Expose the configured :class:`requests.Session` instance."""
 
-    with _session_lock:
-        return _session
+    with _session_condition:
+        return _get_or_create_session_locked()
 
 
 def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
@@ -69,8 +115,8 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
 
     attempt = 1
     while True:
-        with _session_lock:
-            retry_cfg = _retry_cfg
+        with _session_condition:
+            retry_cfg = _retry_cfg.model_copy(deep=True)
 
         if attempt > retry_cfg.max_attempts:
             break
@@ -78,9 +124,8 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
         limiter = get_limiter("uniprot", cfg.rps, cfg.burst)
         limiter.acquire()
         try:
-            with _session_lock:
-
-                with _session.get(url, timeout=timeout) as resp:
+            with _session_context() as session:
+                with session.get(url, timeout=timeout) as resp:
                     resp.raise_for_status()
                     try:
                         return cast(dict[str, Any], resp.json())

--- a/tests/test_iuphar_threadsafe.py
+++ b/tests/test_iuphar_threadsafe.py
@@ -31,9 +31,17 @@ class DummyResponse:
 class DummySession:
     def __init__(self) -> None:
         self.calls: list[int] = []
+        self.owner: int | None = None
 
     def get(self, url: str, timeout: tuple[int, int]) -> DummyResponse:
-        self.calls.append(threading.get_ident())
+        thread_id = threading.get_ident()
+        if self.owner is None:
+            self.owner = thread_id
+        else:
+            assert (
+                self.owner == thread_id
+            ), "Session reused across threads"
+        self.calls.append(thread_id)
         return DummyResponse()
 
 
@@ -44,27 +52,49 @@ class DummyLimiter:
 
 def test_websearch_gene_to_id_thread_safe(monkeypatch) -> None:
     data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
-    dummy = DummySession()
-    monkeypatch.setattr(ci, "_session", dummy)
-    monkeypatch.setattr(ci, "get_limiter", lambda name, rps, burst=None: DummyLimiter())
+    call_threads: list[int] = []
+    created_sessions: list[DummySession] = []
+
+    def session_factory() -> DummySession:
+        session = DummySession()
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(ci, "_session_factory", session_factory, raising=False)
+    monkeypatch.setattr(ci, "_session_local", threading.local(), raising=False)
+    monkeypatch.setattr(ci, "_sessions", set(), raising=False)
+    monkeypatch.setattr(ci, "_active_requests", 0, raising=False)
+    monkeypatch.setattr(
+        ci, "get_limiter", lambda name, rps, burst=None: DummyLimiter()
+    )
 
     cfg = IupharCfg(base="https://example.org/services", rps=10, burst=10)
+    genes = [f"GENE-{idx}" for idx in range(10)]
 
-    def worker() -> dict:
-        return data.websearch_gene_to_id("GENE", cfg)
+    def worker(symbol: str) -> dict:
+        result = data.websearch_gene_to_id(symbol, cfg)
+        call_threads.append(threading.get_ident())
+        return result
 
     with ThreadPoolExecutor(max_workers=10) as pool:
-        results = [f.result() for f in (pool.submit(worker) for _ in range(10))]
+        futures = [pool.submit(worker, gene) for gene in genes]
+        results = [f.result() for f in futures]
 
     assert all(r == {"id": 1} for r in results)
-    assert len(dummy.calls) == 10
+    assert len(call_threads) == 10
+    assert created_sessions
+    owners = [session.owner for session in created_sessions if session.owner is not None]
+    assert len(set(owners)) == len(owners)
+    total_calls = sum(len(session.calls) for session in created_sessions)
+    assert total_calls == len(call_threads)
 
 
 """Thread-safety tests for IUPHAR session handling."""
 
 
-def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure concurrent calls to the shared session are serialised."""
+def test_session_is_thread_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each thread obtains an independent session instance."""
+
     data = ii.IUPHARData(target_df=pd.DataFrame(), family_df=pd.DataFrame())
     cfg = IupharCfg(
         base="https://example.org", timeout_connect=1, timeout_read=1, rps=1, burst=1
@@ -76,48 +106,32 @@ def test_session_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(ci, "get_limiter", lambda *a, **k: DummyLimiter())
 
-    order: list[str] = []
-    in_use = False
-    lock = threading.Lock()
+    created_sessions: list[DummySession] = []
 
-    def fake_get(url: str, timeout: tuple[int, int]):
-        nonlocal in_use
-        with lock:
-            assert not in_use, "Concurrent session usage detected"
-            in_use = True
-            order.append("start")
-        time.sleep(0.05)
-        with lock:
-            in_use = False
-            order.append("end")
+    def session_factory() -> DummySession:
+        session = DummySession()
+        created_sessions.append(session)
+        return session
 
-        class Resp:
-            def __enter__(self):
-                return self
+    monkeypatch.setattr(ci, "_session_factory", session_factory, raising=False)
+    monkeypatch.setattr(ci, "_session_local", threading.local(), raising=False)
+    monkeypatch.setattr(ci, "_sessions", set(), raising=False)
+    monkeypatch.setattr(ci, "_active_requests", 0, raising=False)
 
-            def __exit__(self, *exc):
-                return False
+    barrier = threading.Barrier(2)
 
-            def raise_for_status(self) -> None:
-                return None
+    def worker(symbol: str) -> dict:
+        barrier.wait()
+        return data.websearch_gene_to_id(symbol, cfg)
 
-            def json(self):  # pragma: no cover - unused
-                return []
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(worker, symbol) for symbol in ("GENE-A", "GENE-B")]
+        [f.result() for f in futures]
 
-        return Resp()
+    owners = {session.owner for session in created_sessions if session.owner is not None}
 
-    monkeypatch.setattr(ci._session, "get", fake_get)
-
-    threads = [
-        threading.Thread(target=data.websearch_gene_to_id, args=("GENE", cfg))
-        for _ in range(2)
-    ]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    assert order == ["start", "end", "start", "end"]
+    assert len(created_sessions) == 2
+    assert len(owners) == 2
 
 
 def test_init_session_closes_previous_session(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -135,7 +149,10 @@ def test_init_session_closes_previous_session(monkeypatch: pytest.MonkeyPatch) -
             closed.append(self.name)
 
     dummy_initial = DummySession("initial")
-    monkeypatch.setattr(ci, "_session", dummy_initial, raising=False)
+    monkeypatch.setattr(ci, "_session_factory", lambda: dummy_initial, raising=False)
+    monkeypatch.setattr(ci, "_session_local", threading.local(), raising=False)
+    monkeypatch.setattr(ci, "_sessions", {dummy_initial}, raising=False)
+    monkeypatch.setattr(ci, "_active_requests", 0, raising=False)
 
     def fake_session_with_retry(api: ApiCfg, retry: RetryCfg) -> DummySession:
         return DummySession(api.user_agent)
@@ -147,14 +164,14 @@ def test_init_session_closes_previous_session(monkeypatch: pytest.MonkeyPatch) -
     second_api = ApiCfg(user_agent="chembl-tests/2.0 (mailto:tests@ebi.ac.uk)")
 
     ci.init_session(first_api, retry_cfg)
-    first_session = ci._session
+    first_session = ci.get_session()
 
     assert isinstance(first_session, DummySession)
     assert closed == ["initial"]
     assert dummy_initial.closed is True
 
     ci.init_session(second_api, retry_cfg)
-    second_session = ci._session
+    second_session = ci.get_session()
 
     assert isinstance(second_session, DummySession)
     assert closed == ["initial", first_api.user_agent]

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -173,16 +173,27 @@ def test_init_session_waits_for_inflight_fetch(monkeypatch: pytest.MonkeyPatch) 
         def acquire(self) -> None:
             return None
 
-    monkeypatch.setattr(uniprot_client, "_session", BlockingSession("old"))
-    monkeypatch.setattr(uniprot_client, "_retry_cfg", retry_cfg)
+    old_session = BlockingSession("old")
+    created_sessions: list[BlockingSession] = []
+
+    def fake_session_with_retry(*_args, **_kwargs) -> BlockingSession:
+        session = BlockingSession("new")
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(uniprot_client, "_retry_cfg", retry_cfg, raising=False)
     monkeypatch.setattr(
         uniprot_client, "get_limiter", lambda *_args, **_kwargs: DummyLimiter()
     )
+    monkeypatch.setattr(uniprot_client, "session_with_retry", fake_session_with_retry)
     monkeypatch.setattr(
-        uniprot_client,
-        "session_with_retry",
-        lambda *_args, **_kwargs: BlockingSession("new"),
+        uniprot_client, "_session_factory", lambda: old_session, raising=False
     )
+    monkeypatch.setattr(
+        uniprot_client, "_session_local", threading.local(), raising=False
+    )
+    monkeypatch.setattr(uniprot_client, "_sessions", set(), raising=False)
+    monkeypatch.setattr(uniprot_client, "_active_requests", 0, raising=False)
 
     try:
         with ThreadPoolExecutor(max_workers=2) as executor:
@@ -200,12 +211,12 @@ def test_init_session_waits_for_inflight_fetch(monkeypatch: pytest.MonkeyPatch) 
         release_event.set()
 
     assert close_calls == ["old"]
-    with uniprot_client._session_lock:  # type: ignore[attr-defined]
-        current_session = uniprot_client._session
+    assert created_sessions, "expected init_session to create a replacement session"
+    new_session = uniprot_client.get_session()
 
-    assert isinstance(current_session, BlockingSession)
-    assert current_session.label == "new"
-    assert current_session.closed is False
+    assert isinstance(new_session, BlockingSession)
+    assert new_session.label == "new"
+    assert new_session.closed is False
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- refactor the UniProt client to create per-thread sessions, copy retry settings safely, and close idle sessions only after in-flight requests finish
- align the IUPHAR client with the same thread-local session lifecycle and expose a helper to fetch the current thread's session
- update the UniProt and IUPHAR multithreading tests to exercise the new concurrency guarantees and session management

## Testing
- pytest tests/test_uniprot_library.py -k init_session_waits_for_inflight_fetch -q *(fails: missing responses dependency)*
- pytest tests/test_iuphar_threadsafe.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ddb99236e083248da4f05d954f355f