### PR TITLE
Ensure PubChem session respects per-request user agent

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -241,6 +241,8 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         return None
     logger.debug("cache_miss", url=url, rps=cfg.rps, status="miss")
 
+    api_cfg = ApiCfg(user_agent=cfg.user_agent)
+
     total_attempts = cfg.retries + 1
     if total_attempts <= 0:
         total_attempts = 1
@@ -289,7 +291,7 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         )
         get_limiter("pubchem", cfg.rps, cfg.burst).acquire()
         try:
-            session = get_session()
+            session = get_session(api_cfg)
             with session.get(
                 url, timeout=(cfg.timeout_connect, cfg.timeout_read)
             ) as response:

--- a/tests/test_pubchem_client_threadsafe.py
+++ b/tests/test_pubchem_client_threadsafe.py
@@ -187,6 +187,55 @@ def test_make_request_serves_cached_results_across_threads(monkeypatch) -> None:
         pc._CACHE = None
 
 
+def test_make_request_refreshes_session_for_new_user_agent(monkeypatch) -> None:
+    """Requests with different agents should recreate the underlying session."""
+
+    url_one = "https://example.org/first"
+    url_two = "https://example.org/second"
+    cfg_one = pl.PubChemCfg(
+        retries=0,
+        delay=0,
+        user_agent="pubchem-tests/4.0 (mailto:tests@example.org)",
+    )
+    cfg_two = pl.PubChemCfg(
+        retries=0,
+        delay=0,
+        user_agent="pubchem-tests/5.0 (mailto:tests@example.org)",
+    )
+
+    created_sessions: list[DummySession] = []
+    close_log: list[str] = []
+
+    def fake_session_with_retry(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> DummySession:
+        session = DummySession(api_cfg.user_agent, closed_log=close_log)
+
+        def fake_get(url: str, timeout: tuple[int, int]) -> DummyResponse:
+            return DummyResponse({"user_agent": session.headers["User-Agent"]})
+
+        session.get = fake_get  # type: ignore[attr-defined]
+        created_sessions.append(session)
+        return session
+
+    monkeypatch.setattr(pc, "session_with_retry", fake_session_with_retry)
+    monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
+    monkeypatch.setattr(pc, "sleep", lambda *_: None)
+
+    pc.init_session(
+        ApiCfg(user_agent="pubchem-tests/init (mailto:tests@example.org)"), RetryCfg()
+    )
+    with pc._CACHE_LOCK:
+        pc._CACHE = None
+
+    first_response = pc.make_request(url_one, cfg_one)
+    second_response = pc.make_request(url_two, cfg_two)
+
+    assert created_sessions[0].headers["User-Agent"] == cfg_one.user_agent
+    assert created_sessions[1].headers["User-Agent"] == cfg_two.user_agent
+    assert close_log == [cfg_one.user_agent]
+    assert first_response == {"user_agent": cfg_one.user_agent}
+    assert second_response == {"user_agent": cfg_two.user_agent}
+
+
 def test_make_request_cache_reinitialisation_threadsafe(monkeypatch) -> None:
     """Reinitialising the cache under concurrency should be safe."""
 
@@ -211,8 +260,12 @@ def test_make_request_cache_reinitialisation_threadsafe(monkeypatch) -> None:
     with pc._CACHE_LOCK:
         pc._CACHE = None
 
-    initial_cfg = pl.PubChemCfg(retries=1, delay=0, cache_ttl=1)
-    updated_cfg = pl.PubChemCfg(retries=1, delay=0, cache_ttl=2)
+    initial_cfg = pl.PubChemCfg(retries=1, delay=0, cache_ttl=1).model_copy(
+        update={"user_agent": api_cfg.user_agent}
+    )
+    updated_cfg = pl.PubChemCfg(retries=1, delay=0, cache_ttl=2).model_copy(
+        update={"user_agent": api_cfg.user_agent}
+    )
 
     # Prime the cache with the initial configuration.
     assert pc.make_request(url, initial_cfg) == payload
@@ -235,11 +288,14 @@ def test_make_request_closes_response(monkeypatch) -> None:
 
     url = "https://example.org/close-check"
     payload = {"ok": True}
-    cfg = pl.PubChemCfg(retries=0, delay=0)
     close_log: list[object] = []
 
     api_cfg = _configure_session()
     session = pc.get_session(api_cfg)
+
+    cfg = pl.PubChemCfg(retries=0, delay=0).model_copy(
+        update={"user_agent": api_cfg.user_agent}
+    )
 
     monkeypatch.setattr(pc, "get_limiter", lambda *args, **kwargs: NoopLimiter())
     monkeypatch.setattr(pc, "sleep", lambda *_: None)
@@ -263,10 +319,13 @@ def test_make_request_retry_after_adjusts_delay(monkeypatch) -> None:
 
     url = "https://example.org/rate-limit"
     payload = {"ok": True}
-    cfg = pl.PubChemCfg(retries=1, delay=0, backoff_initial_seconds=0.1)
 
     api_cfg = _configure_session()
     session = pc.get_session(api_cfg)
+
+    cfg = pl.PubChemCfg(retries=1, delay=0, backoff_initial_seconds=0.1).model_copy(
+        update={"user_agent": api_cfg.user_agent}
+    )
 
     responses = [
         DummyResponse(
@@ -304,15 +363,15 @@ def test_make_request_timeout_records_retry_after(monkeypatch) -> None:
     """Timeouts should cache the last failure details including Retry-After."""
 
     url = "https://example.org/timeout"
+    api_cfg = _configure_session()
+    session = pc.get_session(api_cfg)
+
     cfg = pl.PubChemCfg(
         retries=3,
         delay=0,
         backoff_initial_seconds=0,
         timeout_seconds=3,
-    )
-
-    api_cfg = _configure_session()
-    session = pc.get_session(api_cfg)
+    ).model_copy(update={"user_agent": api_cfg.user_agent})
 
     responses = [
         DummyResponse(None, status_code=429, headers={"Retry-After": "2"}),


### PR DESCRIPTION
## Summary
- construct an ApiCfg from the PubChem configuration and pass it to get_session so that user-agent overrides take effect
- add a regression test covering consecutive requests with different user agents and align existing tests with the new session handling

## Testing
- pytest tests/test_pubchem_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb9b6efc08324a41a9c8f52642a12