### PR TITLE
Add jittered backoff for PubMed retries

### DIFF
--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import random
 from collections.abc import Callable
 from typing import Any
 
 import requests
 
-from ..config import PubMedCfg
+from ..config import PubMedCfg, RetryCfg
 from ..log import logger
 from ..rate_limiter import sleep
 
@@ -101,6 +102,45 @@ def _handle_response(
     return content or "", "", False
 
 
+def _max_timeout(timeout: float | tuple[float, float] | None) -> float | None:
+    """Return the maximum timeout value from ``timeout``."""
+
+    if timeout is None:
+        return None
+    if isinstance(timeout, tuple):
+        values = [float(value) for value in timeout if value is not None]
+        if not values:
+            return None
+        return max(values)
+    return float(timeout)
+
+
+def _retry_delay(
+    attempt: int,
+    base_delay: float,
+    retry_cfg: RetryCfg | None,
+    timeout: float | tuple[float, float] | None,
+) -> float:
+    """Calculate the delay before the next retry attempt."""
+
+    if attempt <= 0:
+        return 0.0
+
+    min_delay = max(base_delay, 0.0)
+    delay = min_delay
+
+    if retry_cfg is not None and retry_cfg.backoff_factor > 0:
+        backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
+        jitter = random.uniform(0.0, retry_cfg.backoff_factor)
+        delay = max(delay, backoff + jitter)
+
+    timeout_cap = _max_timeout(timeout)
+    if timeout_cap is not None:
+        delay = min(delay, timeout_cap)
+
+    return delay
+
+
 def _do_request(
     session: requests.Session,
     url: str,
@@ -109,15 +149,31 @@ def _do_request(
     retries: int = 2,
     method: str = "GET",
     timeout: float | tuple[float, float] = 10,
+    retry_cfg: RetryCfg | None = None,
     **kwargs: Any,
 ) -> tuple[dict[str, Any] | str | None, str]:
     """Perform an HTTP request with retry logic."""
 
     for attempt in range(retries + 1):
         event = "request_start" if attempt == 0 else "request_retry"
-        logger.info(event, extra={"stage": event, "url": url, "attempt": attempt + 1})
+        extra = {"stage": event, "url": url, "attempt": attempt + 1}
+
         if attempt:
-            sleep(delay * attempt)
+            retry_delay = _retry_delay(attempt, delay, retry_cfg, timeout)
+            extra["delay"] = retry_delay
+            logger.info(event, extra=extra)
+            if retry_delay > 0:
+                logger.debug(
+                    "retry_sleep",
+                    extra={
+                        "url": url,
+                        "attempt": attempt + 1,
+                        "delay": retry_delay,
+                    },
+                )
+                sleep(retry_delay)
+        else:
+            logger.info(event, extra=extra)
 
         try:
             status_code, text, content, parse_error = _make_request(
@@ -147,6 +203,8 @@ def fetch_pubmed_batch(
     pmids: list[str],
     sleep: float,
     cfg: PubMedCfg | None = None,
+    *,
+    retry_cfg: RetryCfg | None = None,
 ) -> tuple[str | None, str]:
     """Fetch raw PubMed XML for ``pmids`` using a single request."""
 
@@ -156,7 +214,13 @@ def fetch_pubmed_batch(
     url = f"{base}/efetch.fcgi?db=pubmed&id={ids}&retmode=xml"
     timeout = (cfg.timeout_connect, cfg.timeout_read)
     text, error = _do_request(
-        session, url, sleep, expect_json=False, retries=cfg.retries, timeout=timeout
+        session,
+        url,
+        sleep,
+        expect_json=False,
+        retries=cfg.retries,
+        timeout=timeout,
+        retry_cfg=retry_cfg,
     )
     if error:
         return None, error
@@ -170,10 +234,14 @@ def fetch_pubmed(
     pmid: str,
     sleep: float,
     cfg: PubMedCfg | None = None,
+    *,
+    retry_cfg: RetryCfg | None = None,
 ) -> tuple[str | None, str]:
     """Fetch raw PubMed XML for a single PMID."""
 
-    text, error = fetch_pubmed_batch(session, [pmid], sleep, cfg=cfg)
+    text, error = fetch_pubmed_batch(
+        session, [pmid], sleep, cfg=cfg, retry_cfg=retry_cfg
+    )
     if error:
         return None, error
     return text, ""
@@ -186,15 +254,29 @@ class PubMedClient:
         self.cfg = cfg or PubMedCfg()
 
     def fetch_pubmed_batch(
-        self, session: requests.Session, pmids: list[str], sleep: float
+        self,
+        session: requests.Session,
+        pmids: list[str],
+        sleep: float,
+        *,
+        retry_cfg: RetryCfg | None = None,
     ) -> tuple[str | None, str]:
         """Retrieve raw XML for ``pmids`` using configured settings."""
 
-        return fetch_pubmed_batch(session, pmids, sleep, cfg=self.cfg)
+        return fetch_pubmed_batch(
+            session, pmids, sleep, cfg=self.cfg, retry_cfg=retry_cfg
+        )
 
     def fetch_pubmed(
-        self, session: requests.Session, pmid: str, sleep: float
+        self,
+        session: requests.Session,
+        pmid: str,
+        sleep: float,
+        *,
+        retry_cfg: RetryCfg | None = None,
     ) -> tuple[str | None, str]:
         """Retrieve raw XML for a single PMID."""
 
-        return fetch_pubmed(session, pmid, sleep, cfg=self.cfg)
+        return fetch_pubmed(
+            session, pmid, sleep, cfg=self.cfg, retry_cfg=retry_cfg
+        )

--- a/library/pubmed/query.py
+++ b/library/pubmed/query.py
@@ -22,7 +22,13 @@ from ..clients import (
     pubmed as pubmed_client,
     semantic_scholar as semantic_client,
 )
-from ..config import CrossRefCfg, OpenAlexCfg, PubMedCfg, SemanticScholarCfg
+from ..config import (
+    CrossRefCfg,
+    OpenAlexCfg,
+    PubMedCfg,
+    RetryCfg,
+    SemanticScholarCfg,
+)
 
 from .parsing import EMPTY_PUBMED, combine, parse_pubmed_article
 
@@ -97,6 +103,7 @@ def fetch_pubmed_batch(
     cfg: PubMedCfg | None = None,
     *,
     client: pubmed_client.PubMedClient | None = None,
+    retry_cfg: RetryCfg | None = None,
 ) -> list[dict[str, str]]:
     """Fetch and parse PubMed metadata for multiple PMIDs."""
 
@@ -104,7 +111,9 @@ def fetch_pubmed_batch(
         raise ValueError("Specify either cfg or client, not both")
 
     resolved_client = client or pubmed_client.PubMedClient(cfg=cfg)
-    xml_text, error = resolved_client.fetch_pubmed_batch(session, pmids, sleep)
+    xml_text, error = resolved_client.fetch_pubmed_batch(
+        session, pmids, sleep, retry_cfg=retry_cfg
+    )
     results: list[dict[str, str]] = []
     if error:
         for pid in pmids:
@@ -155,6 +164,7 @@ def fetch_pubmed(
     cfg: PubMedCfg | None = None,
     *,
     client: pubmed_client.PubMedClient | None = None,
+    retry_cfg: RetryCfg | None = None,
 ) -> dict[str, str]:
     """Fetch metadata for a single PMID."""
 
@@ -164,6 +174,7 @@ def fetch_pubmed(
         [pmid],
         sleep,
         client=resolved_client,
+        retry_cfg=retry_cfg,
     )[0]
 
 

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -167,7 +167,11 @@ def _stream_pubmed_batches(
             batch_pmids = pmids[i : i + batch_size]
             limiter.acquire()
             pubmed_list = fetch_pubmed_batch(
-                session, batch_pmids, delay, client=pubmed_client
+                session,
+                batch_pmids,
+                delay,
+                client=pubmed_client,
+                retry_cfg=retry_cfg,
             )
             limiter.acquire()
             semsch_list = fetch_semantic_scholar_batch(

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -539,7 +539,11 @@ def fetch_pubmed_records(
                     return fetcher(nested_session, identifier, cfg_obj, limiter)
             _acquire_documents(pubmed_service_limiter)
             pubmed_list = pl.fetch_pubmed_batch(
-                base_session, batch_list, sleep, cfg=pubmed_cfg
+                base_session,
+                batch_list,
+                sleep,
+                cfg=pubmed_cfg,
+                retry_cfg=session_cfg.retry,
             )
 
             pmids_in_batch = [p.get("PubMed.PMID", "") for p in pubmed_list]

--- a/tests/test_document_pipeline.py
+++ b/tests/test_document_pipeline.py
@@ -211,6 +211,8 @@ def test_fetch_pubmed_records_uses_fresh_sessions_per_job(
         batch: list[str],
         _sleep: float,
         cfg: PubMedCfg | None = None,
+        *,
+        retry_cfg=None,
     ) -> list[dict[str, str]]:
         pubmed_sessions.append(session)
         return [
@@ -381,6 +383,8 @@ def test_fetch_pubmed_records_reuses_duplicate_identifiers(
         batch: list[str],
         _sleep: float,
         cfg: PubMedCfg | None = None,
+        *,
+        retry_cfg=None,
     ) -> list[dict[str, str]]:
         return [
             {

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -976,6 +976,7 @@ def test_fetch_pubmed_records_returns_generator_in_order(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [
@@ -1063,6 +1064,7 @@ def test_fetch_pubmed_records_drains_pending_batches(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [
@@ -1152,6 +1154,7 @@ def test_fetch_pubmed_records_streams_large_batches(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [
@@ -1232,6 +1235,7 @@ def test_fetch_pubmed_records_accepts_config(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         assert sleep == expected_sleep
@@ -1324,6 +1328,7 @@ def test_fetch_pubmed_records_acquires_documents_limiter(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         batches_seen.append(list(batch))
@@ -1414,6 +1419,7 @@ def test_openalex_and_crossref_jobs_acquire_service_limiters(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [
@@ -1489,6 +1495,7 @@ def test_crossref_jobs_skip_missing_doi(monkeypatch: pytest.MonkeyPatch) -> None
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [
@@ -1568,6 +1575,7 @@ def test_documents_limiter_enforces_shared_pace(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         return [{"PubMed.PMID": pmid} for pmid in batch]
@@ -1633,6 +1641,7 @@ def test_fetch_pubmed_records_uses_explicit_pubmed_cfg(
         sleep: float,
         cfg: PubMedCfg | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         seen_cfg["value"] = cfg
@@ -1681,6 +1690,7 @@ def test_fetch_pubmed_records_uses_fallback_doi(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         assert batch == ["123"]
@@ -1750,6 +1760,7 @@ def test_fetch_pubmed_records_falls_back_to_single_semantic_call(
         sleep: float,
         cfg: Any | None = None,
         *,
+        retry_cfg: Any | None = None,
         client: Any | None = None,
     ) -> list[dict[str, str]]:
         assert batch == ["123"]

--- a/tests/test_pubmed_library_config_single.py
+++ b/tests/test_pubmed_library_config_single.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from library import pubmed_library as pl
+from library.config import RetryCfg
 
 
 class DummyLimiter:
@@ -14,7 +15,15 @@ class DummyLimiter:
 
 
 def _stub_network(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None, *, client=None):
+    def fake_fetch_pubmed_batch(
+        session,
+        pmids,
+        delay,
+        cfg=None,
+        *,
+        retry_cfg: RetryCfg | None = None,
+        client=None,
+    ):
         return [
             {
                 "PubMed.PMID": pid,
@@ -86,7 +95,15 @@ def test_pubmed_library_rate_override(
     calls: dict[str, list[tuple[str, float, int | None]]] = {"limiters": []}
     delays: dict[str, float] = {}
 
-    def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None, *, client=None):
+    def fake_fetch_pubmed_batch(
+        session,
+        pmids,
+        delay,
+        cfg=None,
+        *,
+        retry_cfg: RetryCfg | None = None,
+        client=None,
+    ):
         delays["pubmed"] = delay
         return [
             {

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 import hashlib
 
 import pandas as pd
@@ -8,6 +9,8 @@ import pytest
 import yaml
 
 from library import pubmed_library as pl
+from library.clients import pubmed as pubmed_client
+from library.config import RetryCfg
 
 
 def test_pubmed_library_main_smoke(
@@ -18,7 +21,18 @@ def test_pubmed_library_main_smoke(
     output_csv = tmp_path / "out.csv"
     verbose_output_csv = tmp_path / "out_verbose.csv"
 
-    def fake_fetch_pubmed_batch(session, pmids, delay, cfg=None, *, client=None):
+    seen_retry_cfg: list[RetryCfg | None] = []
+
+    def fake_fetch_pubmed_batch(
+        session,
+        pmids,
+        delay,
+        cfg=None,
+        *,
+        retry_cfg: RetryCfg | None = None,
+        client=None,
+    ):
+        seen_retry_cfg.append(retry_cfg)
         return [
             {
                 "PubMed.PMID": pid if pid != "2" else "",
@@ -140,3 +154,77 @@ def test_pubmed_library_main_smoke(
     second_meta = yaml.safe_load(second_meta_path.read_text())
     assert second_meta["stats"]["output_sha256"] == second_digest
     assert second_meta["schema"] == "PubMedDocumentsSchema"
+
+    assert seen_retry_cfg
+    assert all(cfg is not None for cfg in seen_retry_cfg)
+    expected_backoff = pl.Config().retry.backoff_factor
+    assert all(
+        cfg.backoff_factor == pytest.approx(expected_backoff)
+        for cfg in seen_retry_cfg
+        if cfg is not None
+    )
+
+
+def test_pubmed_client_retry_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PubMed client should log retry delay with jitter for 429 responses."""
+
+    responses = iter(
+        [
+            (429, "Too Many Requests", None, ""),
+            (200, "<xml/>", "<xml/>", ""),
+        ]
+    )
+
+    def fake_make_request(*_args: Any, **_kwargs: Any) -> tuple[int, str, Any, str]:
+        try:
+            return next(responses)
+        except StopIteration:  # pragma: no cover - defensive
+            raise AssertionError("Unexpected request count")
+
+    sleep_calls: list[float] = []
+
+    class RecordingLogger:
+        def __init__(self) -> None:
+            self.records: list[tuple[str, str, dict[str, Any]]] = []
+
+        def info(
+            self, event: str, *args: Any, extra: dict[str, Any] | None = None, **kwargs: Any
+        ) -> None:
+            self.records.append(("info", event, extra.copy() if extra else {}))
+
+        def debug(
+            self, event: str, *args: Any, extra: dict[str, Any] | None = None, **kwargs: Any
+        ) -> None:
+            self.records.append(("debug", event, extra.copy() if extra else {}))
+
+    monkeypatch.setattr(pubmed_client, "_make_request", fake_make_request)
+    monkeypatch.setattr(pubmed_client, "sleep", lambda value: sleep_calls.append(value))
+    monkeypatch.setattr(pubmed_client.random, "uniform", lambda _a, _b: 0.2)
+
+    fake_logger = RecordingLogger()
+    monkeypatch.setattr(pubmed_client, "logger", fake_logger)
+
+    retry_cfg = RetryCfg(max_attempts=2, backoff_factor=0.5)
+    data, error = pubmed_client._do_request(
+        session=object(),
+        url="http://example",
+        delay=0.3,
+        expect_json=False,
+        retries=1,
+        timeout=(1, 5),
+        retry_cfg=retry_cfg,
+    )
+
+    assert data == "<xml/>"
+    assert error == ""
+
+    base = retry_cfg.backoff_factor * (2 ** (1 - 1))
+    expected_delay = pytest.approx(max(0.3, base + 0.2))
+    assert sleep_calls == [expected_delay]
+
+    retry_records = [r for r in fake_logger.records if r[1] == "request_retry"]
+    assert retry_records and "delay" in retry_records[0][2]
+    assert retry_records[0][2]["delay"] == expected_delay
+
+    sleep_logs = [r for r in fake_logger.records if r[1] == "retry_sleep"]
+    assert sleep_logs and sleep_logs[0][2]["delay"] == expected_delay

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -209,6 +209,9 @@ def test_fetch_pubmed_uses_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
         pmids: list[str],
         delay: float,
         cfg: PubMedCfg | None = None,
+        *,
+        retry_cfg: Any | None = None,
+        client: Any | None = None,
     ) -> tuple[str, str]:
         captured.update(
             {


### PR DESCRIPTION
## Summary
- compute retry delays in the PubMed client from the shared retry configuration with jitter and logging
- thread the retry configuration through the PubMed helpers and CLI so the client receives it
- update PubMed-related tests for the new signatures and cover the retry logging behaviour

## Testing
- pytest tests/test_pubmed_library_main_smoke.py
- pytest tests/test_pubmed_library_config_single.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb9a8f3d883249b132c394aa441c7