### PR TITLE
Prioritize UniProt values during target merge

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1173,28 +1173,73 @@ def fetch_iuphar(
         suffixes=("_chembl", "_uniprot"),
     )
 
+    merge_suffix_priority = ("_uniprot", "_chembl")
+
+    def _base_name(column: str) -> str | None:
+        for suffix in merge_suffix_priority:
+            if column.endswith(suffix):
+                return column[: -len(suffix)]
+        return None
+
+    def _coalesce_column(df: pd.DataFrame, column: str) -> None:
+        preferred: pd.Series | None = None
+        for suffix in merge_suffix_priority:
+            candidate_name = f"{column}{suffix}"
+            if candidate_name not in df.columns:
+                continue
+            candidate = df.pop(candidate_name).astype(object)
+            if preferred is None:
+                preferred = candidate
+            else:
+                preferred = _prefer_primary(preferred, candidate)
+        if preferred is not None:
+            df[column] = preferred
+
+    critical_columns = set(TARGETS_COLUMN_ORDER)
+    critical_columns.update(
+        {
+            "gene",
+            "gene_name",
+            "synonyms",
+            "component_description",
+            "chembl_alternative_name",
+            "names",
+            "mapping_uniprot_id",
+            "ec_numbers",
+            "reaction_ec_numbers",
+            "ec_code",
+        }
+    )
+
+    suffixed_columns = [
+        column
+        for column in combined_df.columns
+        if _base_name(column) is not None
+    ]
+    base_columns = {_base_name(column) for column in suffixed_columns if _base_name(column)}
+
+    for column in sorted(base_columns & critical_columns):
+        _coalesce_column(combined_df, column)
+
+    for column in sorted(base_columns - critical_columns):
+        _coalesce_column(combined_df, column)
+
+    remaining_suffixes = [
+        column
+        for column in combined_df.columns
+        if _base_name(column) is not None
+    ]
+    if remaining_suffixes:
+        rename_map = {
+            column: _base_name(column)
+            for column in remaining_suffixes
+            if _base_name(column)
+        }
+        combined_df = combined_df.rename(columns=rename_map)
+
     combined_df = combined_df.drop(columns=[lookup_column], errors="ignore")
     if "original_id" in combined_df.columns:
         combined_df = combined_df.drop(columns=["original_id"])
-
-    overlap_columns = sorted(
-        set(chembl_for_merge.columns)
-        & (set(uniprot_df.columns) - {"original_id"})
-    )
-    for column in overlap_columns:
-        chembl_col = f"{column}_chembl"
-        uniprot_col = f"{column}_uniprot"
-        chembl_series = (
-            combined_df.pop(chembl_col)
-            if chembl_col in combined_df.columns
-            else None
-        )
-        uniprot_series = (
-            combined_df.pop(uniprot_col)
-            if uniprot_col in combined_df.columns
-            else None
-        )
-        combined_df[column] = _prefer_primary(uniprot_series, chembl_series)
 
     if "gene" not in combined_df.columns:
         combined_df["gene"] = pd.Series(

--- a/tests/test_get_target_data_merge.py
+++ b/tests/test_get_target_data_merge.py
@@ -102,6 +102,8 @@ def test_fetch_iuphar_prioritises_uniprot_columns(
             "isoform_names": ["ChemblIso"],
             "GuidetoPHARMACOLOGY": ["chembl_gtop"],
             "gene": ["CHEMBLGENE"],
+            "geneName": ["ChemblGeneName"],
+            "family": ["chembl_family"],
         }
     )
     uniprot_df = pd.DataFrame(
@@ -112,6 +114,8 @@ def test_fetch_iuphar_prioritises_uniprot_columns(
             "isoform_names": [""],
             "GuidetoPHARMACOLOGY": ["uni_gtop"],
             "gene": ["UNIPROTGENE"],
+            "geneName": ["UniGeneName"],
+            "family": ["uni_family"],
         }
     )
     out = tmp_path / "iuphar.csv"
@@ -126,14 +130,24 @@ def test_fetch_iuphar_prioritises_uniprot_columns(
 
     combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
 
-    assert all(
-        not column.endswith("_chembl") and not column.endswith("_uniprot")
+    allowed_suffix_columns = {"xref_chembl", "xref_uniprot"}
+    disallowed_combined = [
+        column
         for column in combined_df.columns
-    )
+        if (
+            column.endswith("_chembl") and column not in allowed_suffix_columns
+        )
+        or (
+            column.endswith("_uniprot") and column not in allowed_suffix_columns
+        )
+    ]
+    assert not disallowed_combined
     assert combined_df.loc[0, "isoform_ids"] == "UNI_ISO"
     assert combined_df.loc[0, "isoform_names"] == "ChemblIso"
     assert combined_df.loc[0, "GuidetoPHARMACOLOGY"] == "uni_gtop"
     assert combined_df.loc[0, "gene"] == "UNIPROTGENE"
+    assert combined_df.loc[0, "geneName"] == "UniGeneName"
+    assert combined_df.loc[0, "family"] == "uni_family"
 
     merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
     processed = tp.postprocess_targets(merged)
@@ -141,4 +155,19 @@ def test_fetch_iuphar_prioritises_uniprot_columns(
     assert processed.loc[0, "isoform_ids"].lower() == "uni_iso"
     assert processed.loc[0, "isoform_names"].lower() == "chembliso"
     assert processed.loc[0, "GuidetoPHARMACOLOGY"] == "uni_gtop"
-    assert processed.loc[0, "gene"] == "UNIPROTGENE"
+    gene_value = processed.loc[0, "gene"]
+    assert gene_value.startswith("UNIPROTGENE")
+    assert "UNIGENENAME" in gene_value
+    assert processed.loc[0, "geneName"] == "UniGeneName"
+    assert processed.loc[0, "family"] == "uni_family"
+    disallowed_processed = [
+        column
+        for column in processed.columns
+        if (
+            column.endswith("_chembl") and column not in allowed_suffix_columns
+        )
+        or (
+            column.endswith("_uniprot") and column not in allowed_suffix_columns
+        )
+    ]
+    assert not disallowed_processed


### PR DESCRIPTION
## Summary
- ensure `fetch_iuphar` coalesces overlapping UniProt and ChEMBL fields with explicit UniProt-first priority and drops merge suffixes
- extend the merge unit test to cover additional prioritized columns and verify suffix cleanup after post-processing

## Testing
- pytest tests/test_get_target_data_merge.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbeb5e398832494c525f563af7312