### PR TITLE
Fix missing chembl library import in testitem pipeline

### DIFF
--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -18,7 +18,7 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-from library import io, testitem_enrichment
+from library import chembl_library as cl, io, testitem_enrichment
 from library.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.config import (


### PR DESCRIPTION
## Summary
- import the chembl library facade in the test item pipeline CLI so the Chembl helper alias is defined during fetches

## Testing
- pytest tests/test_get_testitem_data.py *(fails: requires optional modules and external services in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc0b70e688324a82d33a9383be84c