### PR TITLE
Handle mapping_uniprot_id during IUPHAR lookups

### DIFF
--- a/library/iuphar_library.py
+++ b/library/iuphar_library.py
@@ -123,6 +123,19 @@ class IUPHARData:
             if value and value.strip()
         ]
 
+    @classmethod
+    def _merge_uniprot_sources(
+        cls, values: Iterable[str | float | None]
+    ) -> str:
+        """Return a pipe-joined list of unique accessions from *values*."""
+
+        merged: list[str] = []
+        for raw in values:
+            for candidate in cls._normalise_uniprot_values(raw):
+                if candidate not in merged:
+                    merged.append(candidate)
+        return "|".join(merged)
+
     def target_id_by_uniprot(self, uniprot_id: str) -> str:
         """Return the first target ID mapped to any of the supplied accessions."""
 
@@ -283,16 +296,24 @@ class IUPHARData:
         # order mirrors the Power Query logic: UniProt accession, mapped
         # UniProt identifiers supplied by the ChEMBL fallback, HGNC name, HGNC
         # ID, gene symbol and finally any supplied synonyms.
-        mask = df["target_id"].eq("")
-        df.loc[mask, "target_id"] = df.loc[mask, "uniprot_id"].apply(
-            self.target_id_by_uniprot
+        uniprot_series = df.get(
+            "uniprot_id", pd.Series("", index=df.index, dtype=object)
+        ).fillna("")
+        mapping_series = df.get(
+            "mapping_uniprot_id", pd.Series("", index=df.index, dtype=object)
+        ).fillna("")
+        combined_lookup = pd.Series(
+            [
+                self.target_id_by_uniprot(
+                    self._merge_uniprot_sources((primary, secondary))
+                )
+                for primary, secondary in zip(uniprot_series, mapping_series)
+            ],
+            index=df.index,
+            dtype=object,
         )
-
-        if "mapping_uniprot_id" in df.columns:
-            mask = df["target_id"].eq("")
-            df.loc[mask, "target_id"] = df.loc[mask, "mapping_uniprot_id"].apply(
-                self.target_id_by_uniprot
-            )
+        mask = df["target_id"].eq("")
+        df.loc[mask, "target_id"] = combined_lookup.loc[mask]
 
         if "hgnc_name" in df.columns:
             mask = df["target_id"].eq("")

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1263,6 +1263,10 @@ def fetch_iuphar(
         combined_df["mapping_uniprot_id"] = (
             combined_df["mapping_uniprot_id"].fillna("").astype(str)
         )
+    else:
+        combined_df["mapping_uniprot_id"] = pd.Series(
+            "", index=combined_df.index, dtype=object
+        )
 
     from tempfile import NamedTemporaryFile
 

--- a/tests/test_iuphar_library.py
+++ b/tests/test_iuphar_library.py
@@ -259,3 +259,40 @@ def test_map_uniprot_file_uses_mapping_uniprot(tmp_path: Path) -> None:
     assert result.loc[0, "IUPHAR_class"] == "Enzyme"
     assert result.loc[0, "IUPHAR_subclass"] == "Transferase"
     assert result.loc[0, "mapping_uniprot_id"] == "P12345|Q99999"
+
+
+def test_map_uniprot_file_resolves_secondary_mapping_value(tmp_path: Path) -> None:
+    target_df = pd.DataFrame(
+        {
+            "target_id": ["T2"],
+            "uniprot_id": ["Q11111"],
+            "family_id": ["F2"],
+            "type": ["Enzyme.Transferase"],
+            "target_name": ["Another target"],
+        }
+    )
+    family_df = pd.DataFrame(
+        {
+            "family_id": ["F2"],
+            "parent_family_id": [pd.NA],
+            "family_name": ["Second family"],
+            "type": ["Enzyme.Transferase"],
+        }
+    )
+    data = ii.IUPHARData(target_df=target_df, family_df=family_df)
+
+    input_df = pd.DataFrame(
+        {
+            "uniprot_id": [""],
+            "mapping_uniprot_id": ["P22222|Q11111"],
+        }
+    )
+    input_csv = tmp_path / "input_secondary.csv"
+    output_csv = tmp_path / "output_secondary.csv"
+    input_df.to_csv(input_csv, index=False)
+
+    result = data.map_uniprot_file(input_csv, output_csv)
+
+    assert result.loc[0, "target_id"] == "T2"
+    assert result.loc[0, "IUPHAR_class"] == "Enzyme"
+    assert result.loc[0, "IUPHAR_subclass"] == "Transferase"


### PR DESCRIPTION
## Summary
- combine UniProt and mapping identifiers during IUPHAR fallback resolution so alternate IDs are honoured
- always include the mapping_uniprot_id column in the CSV produced for the IUPHAR stage
- add a regression test that verifies classifications are found when only mapping_uniprot_id is populated

## Testing
- pytest tests/test_iuphar_library.py::test_map_uniprot_file_uses_mapping_uniprot tests/test_iuphar_library.py::test_map_uniprot_file_resolves_secondary_mapping_value


------
https://chatgpt.com/codex/tasks/task_e_68ddbf6e3824832484762699a6e32165