### PR TITLE
Validate get-activities CLI limit argument

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -27,9 +27,17 @@ def parse_args(
         Parsed arguments and logging configuration.
     """
     parser, log_cfg = cli.build_parser("Generate dummy activity data", column="id")
+
+    def _limit(value: str) -> int:
+        """Return ``value`` validated as a non-negative integer."""
+
+        if value == "0":
+            return 0
+        return cli.positive_int(value)
+
     parser.add_argument(
         "--limit",
-        type=int,
+        type=_limit,
         default=10,
         help="Maximum number of activity rows to emit",
     )

--- a/tests/test_get_activities_cli.py
+++ b/tests/test_get_activities_cli.py
@@ -20,3 +20,24 @@ def test_get_activities_cli_smoke() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_get_activities_cli_rejects_negative_limit() -> None:
+    """Expect ``argparse`` validation errors for negative ``--limit`` values."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "library.utils.cli_tools.get_activities",
+            "--limit",
+            "-1",
+            "--dry-run",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert result.stderr.startswith("usage:")


### PR DESCRIPTION
## Summary
- validate the get-activities --limit option using the shared positive integer helper while allowing zero
- add a CLI regression test that ensures negative limits fail with usage information

## Testing
- pytest tests/test_get_activities_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc390cb78832486c869fae316f2aa