### PR TITLE
Validate chunk CLI numeric arguments with argparse

### DIFF
--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -29,13 +29,13 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     add_common_arguments(parser)
     parser.add_argument(
         "--chunk-size",
-        type=int,
+        type=cli.positive_int,
         default=1000,
         help="Number of rows processed per chunk",
     )
     parser.add_argument(
         "--limit",
-        type=int,
+        type=cli.positive_int,
         default=None,
         help="Optional maximum number of rows to process",
     )
@@ -63,19 +63,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the chunked copy operation."""
     try:
-        if args.chunk_size <= 0:
-            logger.error(
-                "invalid_chunk_size",
-                chunk_size=args.chunk_size,
-            )
-            return 1
-        if args.limit is not None and args.limit <= 0:
-            logger.error(
-                "invalid_limit",
-                limit=args.limit,
-            )
-            return 1
-
         output = Path(args.output_csv or default_output_path(args.input_csv, cfg.io))
         parent = output.parent
         if not parent.exists():

--- a/tests/test_chunk_io_cli.py
+++ b/tests/test_chunk_io_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import textwrap
 
 import pandas as pd
+import pytest
 import yaml
 
 from library.utils.cli_tools import chunk_io_main as cli
@@ -157,72 +158,58 @@ def test_cli_invalid_config_logs_error(tmp_path: Path, monkeypatch) -> None:
     assert payload.get("config") == str(config_path)
 
 
-def test_cli_invalid_chunk_size_logs_error(tmp_path: Path, monkeypatch) -> None:
-    """CLI rejects non-positive chunk sizes with an error message."""
+def test_cli_invalid_chunk_size_exits_with_usage(tmp_path: Path, capsys) -> None:
+    """CLI exits with a usage error when chunk size is not positive."""
 
     input_path = tmp_path / "input.csv"
     input_path.write_text("a\n1\n", encoding="utf-8")
     output_path = tmp_path / "out.csv"
 
-    logged: list[tuple[str, dict[str, object]]] = []
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--chunk-size",
+                "0",
+                "--log-level",
+                "WARNING",
+            ]
+        )
 
-    def fake_error(event: str, *args: object, **kwargs: object) -> None:
-        logged.append((event, kwargs))
-
-    monkeypatch.setattr(cli.logger, "error", fake_error)
-
-    exit_code = cli.main(
-        [
-            "--input",
-            str(input_path),
-            "--output",
-            str(output_path),
-            "--chunk-size",
-            "0",
-            "--log-level",
-            "WARNING",
-        ]
-    )
-
-    assert exit_code == 1
-    event, payload = logged[0]
-    assert event == "invalid_chunk_size"
-    assert payload.get("chunk_size") == 0
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "chunk size must be a positive integer" in captured.err
 
 
-def test_cli_invalid_limit_logs_error(tmp_path: Path, monkeypatch) -> None:
-    """CLI rejects non-positive limits with an error message."""
+def test_cli_invalid_limit_exits_with_usage(tmp_path: Path, capsys) -> None:
+    """CLI exits with a usage error when limit is not positive."""
 
     input_path = tmp_path / "input.csv"
     input_path.write_text("a\n1\n", encoding="utf-8")
     output_path = tmp_path / "out.csv"
 
-    logged: list[tuple[str, dict[str, object]]] = []
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "--input",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--chunk-size",
+                "5",
+                "--limit",
+                "0",
+                "--log-level",
+                "WARNING",
+            ]
+        )
 
-    def fake_error(event: str, *args: object, **kwargs: object) -> None:
-        logged.append((event, kwargs))
-
-    monkeypatch.setattr(cli.logger, "error", fake_error)
-
-    exit_code = cli.main(
-        [
-            "--input",
-            str(input_path),
-            "--output",
-            str(output_path),
-            "--chunk-size",
-            "5",
-            "--limit",
-            "0",
-            "--log-level",
-            "WARNING",
-        ]
-    )
-
-    assert exit_code == 1
-    event, payload = logged[0]
-    assert event == "invalid_limit"
-    assert payload.get("limit") == 0
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "chunk size must be a positive integer" in captured.err
 
 
 def test_cli_missing_output_directory_logs_error(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- enforce positive integer validation for chunk size and limit via the shared CLI helper
- drop redundant runtime guards now handled by argparse and update CLI tests for usage errors

## Testing
- pytest tests/test_chunk_io_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc3b04ef0832498cb652ae9bffc95