### PR TITLE
Ensure thread resources close when generator is garbage collected

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -32,8 +32,9 @@ from contextlib import ExitStack, contextmanager, AbstractContextManager
 from itertools import chain, islice, tee
 import tempfile
 from pathlib import Path
+import weakref
 
-from threading import Lock, local
+from threading import local
 from typing import Any, cast, TypeVar
 
 
@@ -446,8 +447,12 @@ def fetch_pubmed_records(
             self.session_pools = session_pools
 
     thread_local_state = local()
-    thread_resources: list[_ThreadResources] = []
-    thread_resources_lock = Lock()
+
+    def _close_thread_resources(resources: _ThreadResources) -> None:
+        try:
+            resources.stack.close()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("thread_resources_close_failed")
 
     def _get_thread_resources() -> _ThreadResources:
         resources = getattr(thread_local_state, "resources", None)
@@ -489,8 +494,10 @@ def fetch_pubmed_records(
         resources = _ThreadResources(session_stack, base_session, pools)
         setattr(thread_local_state, "resources", resources)
 
-        with thread_resources_lock:
-            thread_resources.append(resources)
+        finalizer = weakref.finalize(
+            thread_local_state, _close_thread_resources, resources
+        )
+        setattr(thread_local_state, "resources_finalizer", finalizer)
 
         return resources
 
@@ -800,11 +807,14 @@ def fetch_pubmed_records(
                 yield build_dataframe(records_batch, columns=DOCUMENT_SCHEMA_COLUMNS)
         finally:
             stack.close()
-            with thread_resources_lock:
-                resources_to_close = list(thread_resources)
-                thread_resources.clear()
-            for resources in resources_to_close:
-                resources.stack.close()
+            finalizer = getattr(thread_local_state, "resources_finalizer", None)
+            if finalizer is not None:
+                try:
+                    finalizer()
+                finally:
+                    delattr(thread_local_state, "resources_finalizer")
+            if hasattr(thread_local_state, "resources"):
+                delattr(thread_local_state, "resources")
 
     frame_iter = _iter_frames()
     if return_generator:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import io
 import shutil
 import json
@@ -1040,6 +1041,100 @@ def test_fetch_pubmed_records_returns_generator_in_order(
     )
 
     assert combined["PubMed.PMID"].tolist() == pmids
+
+
+def test_fetch_pubmed_records_closes_sessions_when_generator_gc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generator GC should release thread resources and close sessions."""
+
+    pmids = ["1", "2", "3"]
+
+    class TrackingSession:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class TrackingContext:
+        def __init__(self, session: TrackingSession) -> None:
+            self._session = session
+
+        def __enter__(self) -> TrackingSession:
+            sessions.append(self._session)
+            return self._session
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - deterministic
+            self._session.close()
+
+    sessions: list[TrackingSession] = []
+
+    monkeypatch.setattr(
+        gdd,
+        "session_with_retry",
+        lambda *_, **__: TrackingContext(TrackingSession()),
+    )
+
+    def fake_pubmed_batch(
+        session: Any,
+        batch: list[str],
+        sleep: float,
+        cfg: Any | None = None,
+        *,
+        retry_cfg: Any | None = None,
+        client: Any | None = None,
+    ) -> list[dict[str, str]]:
+        return [
+            {"PubMed.PMID": pmid, "PubMed.DOI": f"10.1000/{pmid}"} for pmid in batch
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar_batch",
+        lambda *_, **__: [],
+    )
+    monkeypatch.setattr(
+        gdd.ssl,
+        "fetch_semantic_scholar",
+        lambda *_, **__: {},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_openalex",
+        lambda *_, **__: {},
+    )
+    monkeypatch.setattr(
+        gdd.ocl,
+        "fetch_crossref",
+        lambda *_, **__: {},
+    )
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    generator = gdd.fetch_pubmed_records(
+        pmids,
+        sleep=0.0,
+        semantic_scholar_cfg=SemanticScholarCfg(),
+        openalex_cfg=OpenAlexCfg(),
+        crossref_cfg=CrossRefCfg(),
+        max_workers=1,
+        batch_size=1,
+        return_generator=True,
+    )
+
+    next(generator)
+    assert any(not session.closed for session in sessions)
+
+    del generator
+    gc.collect()
+
+    deadline = time.time() + 1.0
+    while any(not session.closed for session in sessions) and time.time() < deadline:
+        gc.collect()
+        time.sleep(0.01)
+
+    assert sessions and all(session.closed for session in sessions)
 
 
 def test_fetch_pubmed_records_drains_pending_batches(


### PR DESCRIPTION
## Summary
- register a weakref finalizer on thread-local PubMed resources so stacks close even if the iterator finaliser is skipped
- ensure iterator shutdown clears thread-local handles to the resources
- add a regression test that forces premature generator GC and asserts the backing sessions are closed

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_closes_sessions_when_generator_gc

------
https://chatgpt.com/codex/tasks/task_e_68ddc3cb2e908324bb1a4073a4ff2a9e