### PR TITLE
Cache per-thread service sessions

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -420,20 +420,6 @@ def fetch_pubmed_records(
             limit = min(limit, limiter_burst)
         return max(1, limit)
 
-    class _SessionPool:
-        def __init__(
-            self,
-            stack: ExitStack,
-            factory: Callable[[], AbstractContextManager[requests.Session]],
-        ) -> None:
-            self._stack = stack
-            self._factory = factory
-
-        @contextmanager
-        def session(self) -> Iterator[requests.Session]:
-            with self._factory() as nested_session:
-                yield nested_session
-
     class _ThreadResources:
         def __init__(
             self,
@@ -444,6 +430,39 @@ def fetch_pubmed_records(
             self.stack = stack
             self.base_session = base_session
             self.session_pools = session_pools
+            self.sessions: dict[str, requests.Session] = {}
+            self.session_finalizers: dict[str, Callable[[], None]] = {}
+
+    class _SessionPool:
+        def __init__(
+            self,
+            stack: ExitStack,
+            factory: Callable[[], AbstractContextManager[requests.Session]],
+            resources: _ThreadResources,
+            service: str,
+        ) -> None:
+            self._stack = stack
+            self._factory = factory
+            self._resources = resources
+            self._service = service
+
+        @contextmanager
+        def session(self) -> Iterator[requests.Session]:
+            cached = self._resources.sessions.get(self._service)
+            if cached is None:
+                context = self._factory()
+                session = cast(requests.Session, context.__enter__())
+
+                def _finalizer(
+                    _context: AbstractContextManager[requests.Session] = context,
+                ) -> None:
+                    _context.__exit__(None, None, None)
+
+                self._resources.sessions[self._service] = session
+                self._resources.session_finalizers[self._service] = _finalizer
+                self._stack.callback(_finalizer)
+                cached = session
+            yield cached
 
     thread_local_state = local()
     thread_resources: list[_ThreadResources] = []
@@ -481,12 +500,11 @@ def fetch_pubmed_records(
             "crossref": _service_factory(crossref_cfg.mailto),
         }
 
-        pools = {
-            service: _SessionPool(session_stack, factory)
+        resources = _ThreadResources(session_stack, base_session, {})
+        resources.session_pools = {
+            service: _SessionPool(session_stack, factory, resources, service)
             for service, factory in session_factories.items()
         }
-
-        resources = _ThreadResources(session_stack, base_session, pools)
         setattr(thread_local_state, "resources", resources)
 
         with thread_resources_lock:

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -12,6 +12,8 @@ from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Callable
 
+from contextlib import contextmanager
+
 from itertools import islice
 
 import pandas as pd
@@ -2734,3 +2736,116 @@ def test_fetch_pubmed_records_generator_batches(
         ["300"],
         ["400"],
     ]
+
+
+def test_fetch_pubmed_records_reuses_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = Config()
+    cfg.openalex.mailto = "openalex@test"
+    cfg.crossref.mailto = "crossref@test"
+
+    class DummySession:
+        creation_lock = threading.Lock()
+        creation_count = 0
+        closed_count = 0
+
+        def __init__(self) -> None:
+            with DummySession.creation_lock:
+                DummySession.creation_count += 1
+            self.headers: dict[str, str] = {}
+            self._closed = False
+
+        def close(self) -> None:
+            if self._closed:
+                return
+            self._closed = True
+            with DummySession.creation_lock:
+                DummySession.closed_count += 1
+
+    @contextmanager
+    def dummy_session_with_retry(*_: Any, **__: Any) -> Iterator[DummySession]:
+        session = DummySession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr(gdd, "session_with_retry", dummy_session_with_retry)
+    monkeypatch.setattr(gdd, "get_limiter", lambda *_, **__: DummyLimiter())
+
+    pmids = ["1", "2"]
+
+    def fake_pubmed_batch(
+        session: requests.Session,
+        batch: Sequence[str],
+        sleep: float | None,
+        *,
+        cfg: PubMedCfg,
+        retry_cfg: Any,
+    ) -> list[dict[str, str]]:
+        assert isinstance(session, DummySession)
+        return [
+            {"PubMed.PMID": pmid, "PubMed.DOI": f"10.1234/{pmid}"}
+            for pmid in batch
+        ]
+
+    monkeypatch.setattr(gdd.pl, "fetch_pubmed_batch", fake_pubmed_batch)
+
+    def fake_semantic_batch(
+        session: requests.Session,
+        identifiers: Sequence[str],
+        sleep: float | None,
+        *,
+        cfg: SemanticScholarCfg,
+    ) -> list[dict[str, str]]:
+        assert isinstance(session, DummySession)
+        return [
+            {"scholar.PMID": pmid, "scholar.DOI": f"10.1234/{pmid}"}
+            for pmid in identifiers
+        ]
+
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar_batch", fake_semantic_batch)
+    monkeypatch.setattr(gdd.ssl, "fetch_semantic_scholar", lambda *_, **__: {})
+
+    openalex_sessions: set[int] = set()
+    crossref_sessions: set[int] = set()
+
+    def fake_openalex(
+        session: requests.Session,
+        identifier: str,
+        cfg_obj: OpenAlexCfg,
+        limiter: Any,
+    ) -> dict[str, str]:
+        assert isinstance(session, DummySession)
+        openalex_sessions.add(id(session))
+        return {"OpenAlex.PMID": identifier}
+
+    def fake_crossref(
+        session: requests.Session,
+        identifier: str,
+        cfg_obj: CrossRefCfg,
+        limiter: Any,
+    ) -> dict[str, str]:
+        assert isinstance(session, DummySession)
+        crossref_sessions.add(id(session))
+        return {"crossref.DOI": identifier}
+
+    monkeypatch.setattr(gdd.ocl, "fetch_openalex", fake_openalex)
+    monkeypatch.setattr(gdd.ocl, "fetch_crossref", fake_crossref)
+
+    gdd.fetch_pubmed_records(
+        pmids,
+        cfg,
+        sleep=0.0,
+        pubmed_cfg=cfg.pubmed,
+        semantic_scholar_cfg=cfg.semantic_scholar,
+        openalex_cfg=cfg.openalex,
+        crossref_cfg=cfg.crossref,
+        max_workers=1,
+        batch_size=2,
+    )
+
+    assert DummySession.creation_count == 3
+    assert openalex_sessions and len(openalex_sessions) == 1
+    assert crossref_sessions and len(crossref_sessions) == 1
+    assert DummySession.closed_count == DummySession.creation_count
+


### PR DESCRIPTION
## Summary
- cache per-thread OpenAlex and CrossRef sessions and reuse them across fetches
- retain finalizers on thread resources so worker stacks close reused sessions
- add a regression test exercising the per-thread session cache with a dummy session implementation

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_reuses_sessions -q


------
https://chatgpt.com/codex/tasks/task_e_68ddc3e14d20832485a5952bd0e5e513