### PR TITLE
Fix path bootstrap for get_data script

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -29,6 +29,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Callable, Sequence
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+if __package__ in {None, ""}:
+    project_root_str = str(_PROJECT_ROOT)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
 from library.utils.bootstrap import ensure_project_root
 
 


### PR DESCRIPTION
## Summary
- ensure scripts/get_data.py can locate the project root when executed as a plain script
- keep using the shared bootstrap helper once the project root has been added

## Testing
- python scripts/get_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ddc52722348324b049b344542e439b