### PR TITLE
Adjust downstream capacity for document fetching

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -719,6 +719,15 @@ def fetch_pubmed_records(
     openalex_capacity = _executor_capacity(openalex_limiter, openalex_cfg.burst)
     crossref_capacity = _executor_capacity(crossref_limiter, crossref_cfg.burst)
 
+    downstream_capacity = max(
+        1,
+        min(
+            max_workers,
+            openalex_capacity or max_workers,
+            crossref_capacity or max_workers,
+        ),
+    )
+
     openalex_executor: ThreadPoolExecutor | None = None
     crossref_executor: ThreadPoolExecutor | None = None
 
@@ -729,7 +738,7 @@ def fetch_pubmed_records(
     next_to_emit = 0
     processed = 0
     completed_batches = 0
-    max_in_flight = max(1, max_workers * 2)
+    max_in_flight = downstream_capacity * 2
 
     stack = ExitStack()
     batch_executor = stack.enter_context(ThreadPoolExecutor(max_workers=max_workers))

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -2662,20 +2662,29 @@ def test_fetch_pubmed_records_reuses_service_executors(
         },
     )
 
+    openalex_cfg = OpenAlexCfg()
+    crossref_cfg = CrossRefCfg()
+    max_workers = 1
+
     df = gdd.fetch_pubmed_records(
         pmids,
         sleep=0.0,
         pubmed_cfg=PubMedCfg(),
         semantic_scholar_cfg=SemanticScholarCfg(),
-        openalex_cfg=OpenAlexCfg(),
-        crossref_cfg=CrossRefCfg(),
-        max_workers=1,
+        openalex_cfg=openalex_cfg,
+        crossref_cfg=crossref_cfg,
+        max_workers=max_workers,
         batch_size=2,
     )
 
     assert df["PubMed.PMID"].tolist() == pmids
     assert len(creations) == 3
-    assert creations.count(1) == 1
+
+    expected_downstream_capacity = max(
+        1,
+        min(max_workers, openalex_cfg.burst, crossref_cfg.burst),
+    )
+    assert creations[0] == expected_downstream_capacity
 
 
 def test_fetch_pubmed_records_generator_batches(


### PR DESCRIPTION
## Summary
- compute a downstream capacity for PubMed batch execution based on worker and service limits
- use the downstream capacity when capping in-flight batch submissions
- update executor usage test expectations to reflect the new downstream capacity limit

## Testing
- pytest tests/test_get_document_data.py::test_fetch_pubmed_records_reuses_service_executors *(fails: missing dependency `responses`)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc4d7f8ac8324961cbd1c66b0b6a0