### PR TITLE
Track document placeholder errors in quality reports

### DIFF
--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -139,6 +139,7 @@ contains:
 | `doi_coverage` | Float | Fraction of documents with a DOI (0.0–1.0). |
 | `publication_class_counts` | Object | Counts of `review`, `experimental`, `unknown`; missing categories are reported as zero. |
 | `error_counts` | Object | Failure counters per upstream service (`pubmed`, `semantic_scholar`, `openalex`, `crossref`). |
+| `error_placeholder_counts` | Object | Number of placeholder rows emitted after unrecoverable errors, keyed by `error_source` (`pubmed`, `semantic_scholar`, `openalex`, `crossref`, `unknown`). |
 
 ## Test item enrichment
 

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -128,6 +128,7 @@ data/output/
 | `doi_coverage` | Число | Доля документов с DOI (0.0–1.0). |
 | `publication_class_counts` | Объект | Количество строк по меткам `review`, `experimental`, `unknown`; отсутствующие категории представляются нулём. |
 | `error_counts` | Объект | Число ошибок по источникам (`pubmed`, `semantic_scholar`, `openalex`, `crossref`). |
+| `error_placeholder_counts` | Объект | Количество строк-заглушек после критических сбоев, агрегированных по `error_source` (`pubmed`, `semantic_scholar`, `openalex`, `crossref`, `unknown`). |
 
 ## Экспорт тест-объектов
 

--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -94,11 +94,14 @@ DERIVED_COLUMNS: list[str] = [
     "publication_class",
 ]
 
+PIPELINE_STATUS_COLUMNS: list[str] = ["fetch_status", "error_source"]
+
 # The combined list intentionally mirrors the downstream document pipeline so
 # CSV exports preserve a deterministic order.
 DOCUMENT_SCHEMA_COLUMNS: list[str] = (
     CH_EMBL_COLUMNS
     + DERIVED_COLUMNS
+    + PIPELINE_STATUS_COLUMNS
     + PUBMED_COLUMNS
     + SEMANTIC_SCHOLAR_COLUMNS
     + OPENALEX_COLUMNS
@@ -346,6 +349,7 @@ class DocumentQualityAccumulator:
         self._doi_total = 0
         self._class_counts: Counter[str] = Counter()
         self._error_counts: Counter[str] = Counter()
+        self._placeholder_counts: Counter[str] = Counter()
 
     def consume(self, frame: pd.DataFrame) -> None:
         if not isinstance(frame, pd.DataFrame):
@@ -389,9 +393,33 @@ class DocumentQualityAccumulator:
                 series.astype(str)
                 .str.strip()
                 .astype(bool)
-                .sum()
             )
-            self._error_counts[key] += int(truthy)
+            self._error_counts[key] += int(truthy.sum())
+
+        status = frame.get("fetch_status")
+        if status is not None:
+            status_strings = status.astype("string").fillna("")
+            is_error = status_strings.str.strip().str.lower() == "error"
+            if bool(is_error.any()):
+                sources = frame.get("error_source")
+                if sources is None:
+                    source_strings = pd.Series(
+                        ["unknown"] * len(frame),
+                        index=status_strings.index,
+                        dtype="string",
+                    )
+                else:
+                    source_strings = (
+                        sources.astype("string")
+                        .fillna("unknown")
+                        .str.strip()
+                        .str.lower()
+                    )
+                    source_strings = source_strings.replace("", "unknown")
+                counts = source_strings[is_error].value_counts()
+                self._placeholder_counts.update(
+                    {str(source): int(count) for source, count in counts.items()}
+                )
 
     def build(self) -> dict[str, Any]:
         doi_coverage = (
@@ -409,7 +437,24 @@ class DocumentQualityAccumulator:
                 "openalex": int(self._error_counts.get("openalex", 0)),
                 "crossref": int(self._error_counts.get("crossref", 0)),
             },
+            "error_placeholder_counts": self._build_placeholder_counts(),
         }
+
+    def _build_placeholder_counts(self) -> dict[str, int]:
+        """Return normalised placeholder counters keyed by error source."""
+
+        baseline = {
+            "pubmed": 0,
+            "semantic_scholar": 0,
+            "openalex": 0,
+            "crossref": 0,
+            "unknown": 0,
+        }
+        counts = {key: int(self._placeholder_counts.get(key, 0)) for key in baseline}
+        for key, value in self._placeholder_counts.items():
+            if key not in counts:
+                counts[key] = int(value)
+        return counts
 
 
 def build_quality_report(

--- a/schemas/documents.py
+++ b/schemas/documents.py
@@ -40,6 +40,8 @@ _COLUMN_DEFINITIONS: dict[str, pa.Column] = {
         int, required=False, nullable=True, coerce=True
     ),
     "publication_class": pa.Column(str, required=False, nullable=True),
+    "fetch_status": pa.Column(str, required=False, nullable=True),
+    "error_source": pa.Column(str, required=False, nullable=True),
     # PubMed fields
     "PubMed.PMID": pa.Column(object, required=False, nullable=True, coerce=True),
     "PubMed.DOI": pa.Column(object, required=False, nullable=True, coerce=True),

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -71,6 +71,8 @@ from library.config import (
     PubMedCfg,
     SemanticScholarCfg,
     _serialize_paths,
+    crossref_session,
+    openalex_session,
     session_with_retry,
 )
 from library.document_pipeline import (
@@ -383,16 +385,19 @@ def fetch_pubmed_records(
         if limiter is not None:
             limiter.acquire()
 
-    def _failure_records(batch: Sequence[str], message: str) -> list[dict[str, str]]:
+    def _failure_records(
+        batch: Sequence[str], message: str, *, source: str = "pubmed"
+    ) -> list[dict[str, str]]:
         """Return placeholder rows describing a failure for ``batch`` PMIDs."""
 
         records: list[dict[str, str]] = []
         for pmid in batch:
+            metadata = {"fetch_status": "error", "error_source": source}
             pubmed = {"PubMed.PMID": pmid, "PubMed.Error": message}
             scholar = {"scholar.PMID": pmid, "scholar.Error": message}
             openalex = {"OpenAlex.Error": message}
             crossref = {"crossref.Error": message}
-            records.append(merge_metadata(pubmed, scholar, openalex, crossref))
+            records.append(merge_metadata(metadata, pubmed, scholar, openalex, crossref))
         return records
 
     def _coerce_batch_argument(*candidates: object) -> list[str]:
@@ -707,14 +712,14 @@ def fetch_pubmed_records(
                 **batch_summary,
                 error=str(exc),
             )
-            return _failure_records(batch_list, str(exc))
+            return _failure_records(batch_list, str(exc), source="pubmed")
         except Exception as exc:  # pragma: no cover - defensive safety net
             logger.warning(
                 "pubmed_batch_unexpected_error",
                 **batch_summary,
                 error=str(exc),
             )
-            return _failure_records(batch_list, str(exc))
+            return _failure_records(batch_list, str(exc), source="pubmed")
 
     openalex_capacity = _executor_capacity(openalex_limiter, openalex_cfg.burst)
     crossref_capacity = _executor_capacity(crossref_limiter, crossref_cfg.burst)

--- a/tests/test_document_pipeline.py
+++ b/tests/test_document_pipeline.py
@@ -150,6 +150,8 @@ def test_build_quality_report_counts() -> None:
             "scholar.Error": ["", ""],
             "OpenAlex.Error": ["", ""],
             "crossref.Error": ["oops", ""],
+            "fetch_status": ["ok", "error"],
+            "error_source": ["", "pubmed"],
         }
     )
 
@@ -159,6 +161,24 @@ def test_build_quality_report_counts() -> None:
     assert report["publication_class_counts"]["review"] == 1
     assert report["error_counts"]["pubmed"] == 1
     assert report["error_counts"]["crossref"] == 1
+    assert report["error_placeholder_counts"]["pubmed"] == 1
+    assert report["error_placeholder_counts"]["unknown"] == 0
+
+
+def test_build_quality_report_counts_unknown_placeholders() -> None:
+    """Placeholder rows without a source default to ``unknown``."""
+
+    df = pd.DataFrame(
+        {
+            "doi": [""],
+            "publication_class": [""],
+            "fetch_status": ["error"],
+            "PubMed.Error": ["error"],
+        }
+    )
+
+    report = build_quality_report(df)
+    assert report["error_placeholder_counts"]["unknown"] == 1
 
 
 def test_fetch_pubmed_records_uses_fresh_sessions_per_job(


### PR DESCRIPTION
## Summary
- mark batch failure rows with fetch status metadata in the document fetch pipeline
- extend document schemas, quality aggregation, and docs to expose placeholder error counters
- add regression tests covering placeholder error accounting in quality reports

## Testing
- pytest tests/test_document_pipeline.py::test_fetch_pubmed_records_uses_fresh_sessions_per_job
- pytest tests/test_document_pipeline.py::test_build_quality_report_counts tests/test_document_pipeline.py::test_build_quality_report_counts_unknown_placeholders

------
https://chatgpt.com/codex/tasks/task_e_68ddc4dd42d483248044b4574f8f0f9f