### PR TITLE
Ensure default output path uses UTC timestamp

### DIFF
--- a/library/io/paths.py
+++ b/library/io/paths.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from ..config import IoCfg
@@ -33,5 +33,5 @@ def default_output_path(input_path: str | Path, cfg: IoCfg) -> Path:
     """
 
     inp = Path(input_path)
-    date_str = datetime.now().strftime("%Y%m%d")
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
     return Path(cfg.output_dir) / f"output.{inp.stem}_{date_str}.csv"

--- a/tests/test_default_output_dir.py
+++ b/tests/test_default_output_dir.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -8,22 +9,38 @@ import pytest
 
 from library import io
 from library.config import Config, IoCfg
+from library.io import paths as io_paths
 from library.utils.cli_tools import mapper_main
 
 
-def test_default_output_path_uses_output_dir(tmp_path: Path) -> None:
+UTC_FREEZE_TIME = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+def _freeze_datetime(monkeypatch: pytest.MonkeyPatch, *, frozen: datetime) -> None:
+    class FrozenDateTime:
+        @staticmethod
+        def now(tz: timezone | None = None) -> datetime:
+            if tz is None:
+                return frozen
+            return frozen.astimezone(tz)
+
+    monkeypatch.setattr(io_paths, "datetime", FrozenDateTime)
+
+
+def test_default_output_path_uses_output_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _freeze_datetime(monkeypatch, frozen=UTC_FREEZE_TIME)
     cfg = IoCfg(output_dir=tmp_path)
     result = io.default_output_path(tmp_path / "input.csv", cfg)
     assert result.parent == tmp_path
-    assert result.name.startswith("output.input_")
-    stem_prefix, date_part = result.stem.split("_", maxsplit=1)
-    assert stem_prefix == "output.input"
-    assert len(date_part) == 8 and date_part.isdigit()
+    assert result.name == f"output.input_{UTC_FREEZE_TIME.strftime('%Y%m%d')}.csv"
 
 
 def test_mapper_run_defaults_to_io_output_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:
+    _freeze_datetime(monkeypatch, frozen=UTC_FREEZE_TIME)
     input_path = tmp_path / "data.csv"
     input_path.write_text("chembl_id\nCHEMBL1\n")
 
@@ -47,15 +64,13 @@ def test_mapper_run_defaults_to_io_output_dir(
         lambda ids, _cfg, *, batch_size, rps, max_workers: {ids[0]: "P12345"},
     )
     monkeypatch.setattr(io, "write_meta_yaml", lambda *_a, **_k: None)
+    monkeypatch.setattr(mapper_main, "mapping_failed", False, raising=False)
 
     rc = mapper_main.run(cfg, args)
     assert rc == 0
 
     expected = io.default_output_path(input_path, cfg.io)
     assert expected.exists()
-    assert expected.name.startswith("output.data_")
-    stem_prefix, date_part = expected.stem.split("_", maxsplit=1)
-    assert stem_prefix == "output.data"
-    assert len(date_part) == 8 and date_part.isdigit()
+    assert expected.name == f"output.data_{UTC_FREEZE_TIME.strftime('%Y%m%d')}.csv"
     df = pd.read_csv(expected)
     assert "mapping_uniprot_id" in df.columns


### PR DESCRIPTION
## Summary
- ensure default output paths are generated using a UTC timestamp
- freeze time in the default output path tests to assert the UTC-based naming convention

## Testing
- pytest tests/test_default_output_dir.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcb3aa72c83249b1eac7c0669e740