### PR TITLE
Stream sidecar error writes

### DIFF
--- a/library/sidecar.py
+++ b/library/sidecar.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import csv
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -15,12 +17,29 @@ class SidecarErrors:
 
     The class stores each error as a mapping of column names to values.
     Errors are written to disk only when :meth:`save` is called and at least
-    one error was recorded.
+    one error was recorded.  When an optional ``chunk_size`` is provided the
+    class will periodically spill buffered rows to a temporary CSV file in
+    order to bound memory usage.
     """
 
-    def __init__(self) -> None:
-        """Initialize an empty error collection."""
+    def __init__(self, *, chunk_size: int | None = None) -> None:
+        """Initialize an empty error collection.
+
+        Parameters
+        ----------
+        chunk_size:
+            Optional maximum number of error rows kept in memory.  When the
+            buffer reaches this size it is flushed to an on-disk CSV.
+        """
+        if chunk_size is not None and chunk_size <= 0:
+            msg = "chunk_size must be a positive integer"
+            raise ValueError(msg)
+        self._chunk_size = chunk_size
         self._errors: list[dict[str, Any]] = []
+        self._fieldnames: set[str] = set()
+        self._overflow_path: Path | None = None
+        self._headers_written = False
+        self._needs_rewrite = False
 
     def add_error(self, row: dict[str, Any]) -> None:
         """Add a validation error description.
@@ -31,6 +50,13 @@ class SidecarErrors:
             Mapping describing a single validation failure.
         """
         self._errors.append(row)
+        new_fields = set(row.keys()) - self._fieldnames
+        if new_fields:
+            self._fieldnames.update(new_fields)
+            if self._headers_written:
+                self._needs_rewrite = True
+        if self._chunk_size is not None and len(self._errors) >= self._chunk_size:
+            self._flush_buffer()
 
     def save(self, path: Path, *, cfg: Config | None = None) -> None:
         """Write collected errors to ``path`` as CSV and emit metadata.
@@ -46,12 +72,77 @@ class SidecarErrors:
         -----
         The file is created only if at least one error was recorded.
         """
+        if not self._errors and self._overflow_path is None:
+            return
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        if self._overflow_path is not None and self._errors:
+            self._flush_buffer()
+
+        if not self._fieldnames:
+            self._fieldnames.update({k for row in self._errors for k in row.keys()})
+
+        fieldnames = sorted(self._fieldnames)
+
+        if self._overflow_path is None:
+            with path.open("w", newline="", encoding="utf8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=fieldnames, restval="")
+                writer.writeheader()
+                writer.writerows(self._errors)
+        else:
+            if self._needs_rewrite:
+                self._rewrite_overflow()
+            with path.open("w", newline="", encoding="utf8") as dst:
+                writer = csv.DictWriter(dst, fieldnames=fieldnames, restval="")
+                writer.writeheader()
+                with self._overflow_path.open("r", newline="", encoding="utf8") as src:
+                    reader = csv.DictReader(src)
+                    for row in reader:
+                        writer.writerow(row)
+            self._overflow_path.unlink()
+            self._overflow_path = None
+            self._headers_written = False
+            self._needs_rewrite = False
+
+        write_meta_yaml(path, cfg, columns=fieldnames)
+        self._errors.clear()
+        self._fieldnames.clear()
+
+    def _flush_buffer(self) -> None:
         if not self._errors:
             return
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fieldnames = sorted({k for row in self._errors for k in row.keys()})
-        with path.open("w", newline="", encoding="utf8") as fh:
-            writer = csv.DictWriter(fh, fieldnames=fieldnames)
-            writer.writeheader()
+        if self._overflow_path is None:
+            fd, name = tempfile.mkstemp(prefix="sidecar_", suffix=".csv")
+            os.close(fd)
+            self._overflow_path = Path(name)
+        if self._needs_rewrite:
+            self._rewrite_overflow()
+        fieldnames = sorted(self._fieldnames)
+        mode = "a" if self._headers_written else "w"
+        with self._overflow_path.open(mode, newline="", encoding="utf8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames, restval="")
+            if not self._headers_written:
+                writer.writeheader()
+                self._headers_written = True
             writer.writerows(self._errors)
-        write_meta_yaml(path, cfg, columns=fieldnames)
+        self._errors.clear()
+
+    def _rewrite_overflow(self) -> None:
+        assert self._overflow_path is not None
+        fd, name = tempfile.mkstemp(prefix="sidecar_rewrite_", suffix=".csv")
+        os.close(fd)
+        tmp_path = Path(name)
+        fieldnames = sorted(self._fieldnames)
+        with (
+            self._overflow_path.open("r", newline="", encoding="utf8") as src,
+            tmp_path.open("w", newline="", encoding="utf8") as dst,
+        ):
+            reader = csv.DictReader(src)
+            writer = csv.DictWriter(dst, fieldnames=fieldnames, restval="")
+            writer.writeheader()
+            for row in reader:
+                writer.writerow(row)
+        self._overflow_path.unlink()
+        tmp_path.rename(self._overflow_path)
+        self._needs_rewrite = False

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -33,3 +33,33 @@ def test_sidecar_skips_empty(tmp_path: Path) -> None:
     sc.save(path)
     assert not path.exists()
     assert not Path(str(path) + ".meta.yaml").exists()
+
+
+def test_sidecar_streams_large_batches(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "errors.csv"
+    sc = SidecarErrors(chunk_size=10)
+    total = 105
+    max_buffer = 0
+    for index in range(total):
+        row: dict[str, str | int] = {
+            "col": f"value_{index}",
+            "msg": str(index),
+        }
+        if index == 60:
+            row["extra"] = "boom"
+        sc.add_error(row)
+        max_buffer = max(max_buffer, len(sc._errors))
+
+    sc.save(path, cfg=cfg)
+
+    assert max_buffer <= 10
+    contents = path.read_text(encoding="utf8").splitlines()
+    assert len(contents) == total + 1
+    assert contents[0] == "col,extra,msg"
+
+    meta = Path(str(path) + ".meta.yaml")
+    assert meta.exists()
+    meta_data = yaml.safe_load(meta.read_text(encoding="utf8"))
+    assert meta_data["columns"] == ["col", "extra", "msg"]


### PR DESCRIPTION
## Summary
- add optional chunked spilling to SidecarErrors so large failure sets stream to disk and still emit metadata
- handle header evolution when streaming and keep metadata generation for fully streamed runs
- add a stress test to ensure chunked sidecar writes bound in-memory buffering

## Testing
- pytest tests/test_sidecar.py
- pytest tests/test_meta_yaml.py tests/test_activity_schema_sidecar.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcb87c58083248c6421dec37d54c8