### PR TITLE
Add destination directory support to table quality analysis

### DIFF
--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -490,7 +490,11 @@ class TableQualityProfiler:
 
         self._rows_processed += len(frame)
 
-    def build(self, table_name: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    def build(
+        self,
+        table_name: str,
+        destination_dir: Path | str | None = None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         rows: list[dict[str, object]] = []
         numeric_candidates: dict[str, pd.Series] = {}
         for column in self._columns:
@@ -534,7 +538,11 @@ class TableQualityProfiler:
             "top_values",
         ]
         quality_report = pd.DataFrame(rows, columns=column_order)
-        quality_path = f"{table_name}_quality_report_table.csv"
+        destination = Path(destination_dir) if destination_dir is not None else Path(".")
+        if destination_dir is not None:
+            destination.mkdir(parents=True, exist_ok=True)
+
+        quality_path = destination / f"{table_name}_quality_report_table.csv"
         quality_report.to_csv(quality_path, index=False, encoding="utf-8-sig")
 
         if numeric_candidates:
@@ -542,7 +550,7 @@ class TableQualityProfiler:
         else:
             corr_report = pd.DataFrame()
 
-        corr_path = f"{table_name}_data_correlation_report_table.csv"
+        corr_path = destination / f"{table_name}_data_correlation_report_table.csv"
         corr_report.reset_index().to_csv(corr_path, index=False, encoding="utf-8-sig")
 
         return quality_report, corr_report
@@ -551,6 +559,8 @@ class TableQualityProfiler:
 def analyze_table_quality(
     table: pd.DataFrame | str | Path | Iterable[pd.DataFrame] | TableQualityProfiler,
     table_name: str,
+    *,
+    destination_dir: Path | str | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Profile ``table`` and compute correlations for numeric columns.
 
@@ -560,6 +570,9 @@ def analyze_table_quality(
         :class:`pandas.DataFrame` or path to a CSV file.
     table_name:
         Base name used for output files.
+    destination_dir:
+        Directory where output files are stored. When ``None`` the current
+        working directory is used.
 
     Returns
     -------
@@ -593,7 +606,7 @@ def analyze_table_quality(
                 "Unsupported table type. Expected DataFrame, path or chunk iterable."
             )
 
-    return profiler.build(table_name)
+    return profiler.build(table_name, destination_dir=destination_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover - illustrative usage

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import argparse
-import os
 from argparse import BooleanOptionalAction
 from collections.abc import Sequence
 
@@ -128,12 +127,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
                 return 1
             output_dir.mkdir(parents=True, exist_ok=True)
 
-        original_cwd = Path.cwd()
-        try:
-            os.chdir(output_dir)
-            analyze_table_quality(df, table_name=args.table_name)
-        finally:
-            os.chdir(original_cwd)
+        destination_dir = output_dir.resolve()
+        analyze_table_quality(
+            df,
+            table_name=args.table_name,
+            destination_dir=destination_dir,
+        )
         return 0
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("run_fail", exc=exc)

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import warnings
 from argparse import Namespace
 from pathlib import Path
@@ -22,12 +21,11 @@ def test_analyze_table_quality(tmp_path: Path) -> None:
             "flag": pd.Series([True, False, True, False], dtype="boolean"),
         }
     )
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        quality, corr = analyze_table_quality(df, table_name="sample")
-    finally:
-        os.chdir(cwd)
+    quality, corr = analyze_table_quality(
+        df,
+        table_name="sample",
+        destination_dir=tmp_path,
+    )
 
     assert set(quality["column"]) == {"num", "str", "flag"}
     assert (tmp_path / "sample_quality_report_table.csv").exists()
@@ -35,18 +33,36 @@ def test_analyze_table_quality(tmp_path: Path) -> None:
     assert corr.shape == (2, 2)
 
 
+def test_analyze_table_quality_supports_relative_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    monkeypatch.chdir(tmp_path)
+    destination = Path("relative_output")
+
+    quality, _ = analyze_table_quality(
+        df,
+        table_name="relative",
+        destination_dir=destination,
+    )
+
+    expected_dir = tmp_path / destination
+    assert expected_dir.exists()
+    assert (expected_dir / "relative_quality_report_table.csv").exists()
+    assert not quality.empty
+
+
 def test_analyze_table_quality_suppresses_warnings(tmp_path: Path) -> None:
     csv_path = tmp_path / "mixed.csv"
     csv_path.write_text("num,str\n1,2020-01-01\nx,1a; DPCPX\n")
 
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            analyze_table_quality(csv_path, table_name="mixed")
-    finally:
-        os.chdir(cwd)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        analyze_table_quality(
+            csv_path,
+            table_name="mixed",
+            destination_dir=tmp_path,
+        )
 
     assert (tmp_path / "mixed_quality_report_table.csv").exists()
 
@@ -57,12 +73,11 @@ def test_analyze_table_quality_handles_sequences(tmp_path: Path) -> None:
             "seq": [[1], [], np.array([1]), np.array([])],
         }
     )
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        quality, _ = analyze_table_quality(df, table_name="seq")
-    finally:
-        os.chdir(cwd)
+    quality, _ = analyze_table_quality(
+        df,
+        table_name="seq",
+        destination_dir=tmp_path,
+    )
 
     non_empty = int(quality.loc[quality["column"] == "seq", "non_empty"].iloc[0])
     assert non_empty == 2
@@ -165,12 +180,11 @@ def test_table_quality_run_handles_mixed_types(tmp_path: Path) -> None:
     assert report_path.exists()
     report = pd.read_csv(report_path)
 
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        expected_quality, _ = analyze_table_quality(df, table_name="expected")
-    finally:
-        os.chdir(cwd)
+    expected_quality, _ = analyze_table_quality(
+        df,
+        table_name="expected",
+        destination_dir=tmp_path,
+    )
 
     expected_mixed = expected_quality.loc[expected_quality["column"] == "mixed"].iloc[0]
     actual_mixed = report.loc[report["column"] == "mixed"].iloc[0]


### PR DESCRIPTION
## Summary
- allow the table quality profiler to write its reports into an explicit destination directory
- update the table quality CLI to pass the resolved output directory instead of changing the working directory
- refresh the table quality tests to cover the new destination handling and relative paths

## Testing
- pytest tests/test_table_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcb9edacc8324b370946ec2009875