### PR TITLE
Use deterministic CSV writers for postprocessing outputs

### DIFF
--- a/library/assay_postprocessing.py
+++ b/library/assay_postprocessing.py
@@ -16,6 +16,7 @@ import pandas as pd
 from schemas import AssayPostprocessSchema
 
 from .config import IoCfg
+from .csv_utils import write_csv_deterministic
 from .log import logger
 from .pandas_utils import read_csv_pyarrow
 
@@ -83,4 +84,12 @@ def postprocess_file(
     except ImportError:  # pragma: no cover - pyarrow optional
         df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_assays(df)
-    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)
+    write_csv_deterministic(
+        processed,
+        output_path,
+        col_order=list(processed.columns),
+        key_cols=["assay_chembl_id"],
+        sep=sep,
+        encoding=encoding,
+        cfg=None,
+    )

--- a/library/document_postprocessing.py
+++ b/library/document_postprocessing.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from . import validation
 from .config import IoCfg
+from .csv_utils import write_csv_deterministic
 
 # Columns that should be treated as text
 TEXT_COLUMNS: list[str] = [
@@ -296,4 +297,12 @@ def postprocess_file(
     encoding = encoding or cfg.csv_encoding
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_documents(df)
-    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)
+    write_csv_deterministic(
+        processed,
+        output_path,
+        col_order=list(processed.columns),
+        key_cols=["document_chembl_id"],
+        sep=sep,
+        encoding=encoding,
+        cfg=None,
+    )

--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -15,6 +15,7 @@ from schemas.targets import TARGETS_COLUMN_ORDER
 
 from . import organism_classification
 from .config import Config, IoCfg
+from .csv_utils import write_csv_deterministic
 from .log import logger
 
 # Columns removed in the final export
@@ -501,7 +502,15 @@ def postprocess_file(
     encoding = encoding or cfg.csv_encoding
     df = pd.read_csv(input_path, sep=sep, encoding=encoding, dtype=str)
     processed = postprocess_targets(df, chembl_col=chembl_col)
-    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)
+    write_csv_deterministic(
+        processed,
+        output_path,
+        col_order=list(processed.columns),
+        key_cols=[chembl_col],
+        sep=sep,
+        encoding=encoding,
+        cfg=None,
+    )
 
 
 def finalise_targets(
@@ -674,4 +683,12 @@ def finalise_file(
         phylum_col=phylum_col,
         class_col=class_col,
     )
-    processed.to_csv(output_path, index=False, sep=sep, encoding=encoding)
+    write_csv_deterministic(
+        processed,
+        output_path,
+        col_order=list(processed.columns),
+        key_cols=[chembl_col],
+        sep=sep,
+        encoding=encoding,
+        cfg=cfg,
+    )

--- a/tests/test_assay_postprocessing.py
+++ b/tests/test_assay_postprocessing.py
@@ -46,6 +46,7 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
             "document_chembl_id": ["doc1", "doc1"],
             "target_chembl_id": ["t1", "t1"],
             "assay_chembl_id": ["a1", "a2"],
+            "notes": [None, "info"],
         }
     )
     cfg = IoCfg(csv_sep=";", csv_encoding="utf8")
@@ -55,8 +56,17 @@ def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
 
     ap.postprocess_file(input_path, output_path, cfg=cfg)
 
-    result = pd.read_csv(output_path, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
+    result = pd.read_csv(
+        output_path,
+        sep=cfg.csv_sep,
+        encoding=cfg.csv_encoding,
+        keep_default_na=False,
+    )
     assert list(result["assay_with_same_target"]) == [2, 2]
+    assert result["notes"].tolist() == ["", "info"]
+
+    meta_path = Path(f"{output_path}.meta.yaml")
+    assert meta_path.exists()
 
 
 def test_assay_postprocess_schema() -> None:

--- a/tests/test_document_postprocessing.py
+++ b/tests/test_document_postprocessing.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from library import document_postprocessing as dp
+from library.config import IoCfg
 
 
 def test_postprocess_documents_creates_flags_and_sorts() -> None:
@@ -32,3 +33,37 @@ def test_postprocess_documents_creates_flags_and_sorts() -> None:
         "OpenAlex.PublicationTypes",
     ]:
         assert col not in result.columns
+
+
+def test_postprocess_file_roundtrip(tmp_path: Path) -> None:
+    """``postprocess_file`` writes metadata and normalises NA handling."""
+
+    df = pd.DataFrame(
+        {
+            "document_chembl_id": ["DOC1", "DOC2"],
+            "title": ["Example", None],
+            "PubMed.PublicationType": ["Review", ""],
+            "scholar.PublicationTypes": ["Review", None],
+            "OpenAlex.PublicationTypes": ["review-article", ""],
+            "Index": [0, 1],
+        }
+    )
+    cfg = IoCfg(csv_sep=";", csv_encoding="utf8")
+    input_path = tmp_path / "in.csv"
+    df.to_csv(input_path, index=False, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
+    output_path = tmp_path / "out.csv"
+
+    dp.postprocess_file(input_path, output_path, cfg=cfg)
+
+    result = pd.read_csv(
+        output_path,
+        sep=cfg.csv_sep,
+        encoding=cfg.csv_encoding,
+        keep_default_na=False,
+    )
+    assert result["title"].tolist() == ["Example", "nan"]
+    assert not result.isna().any().any()
+    assert result["PubMed.MonthCompleted"].tolist() == ["", ""]
+
+    meta_path = Path(f"{output_path}.meta.yaml")
+    assert meta_path.exists()

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -173,6 +173,9 @@ def test_finalise_file_roundtrip(tmp_path: Path, cfg: Config) -> None:
     result = pd.read_csv(output_path, dtype=str, keep_default_na=False)
     pd.testing.assert_frame_equal(result, expected)
 
+    meta_path = Path(f"{output_path}.meta.yaml")
+    assert meta_path.exists()
+
 
 def test_finalise_targets_no_downcast_warning() -> None:
     """``finalise_targets`` should not emit downcast warnings during replace."""


### PR DESCRIPTION
## Summary
- switch assay, document, and target postprocessing outputs to use write_csv_deterministic
- ensure postprocess round-trip tests assert metadata sidecar creation and NA handling

## Testing
- pytest tests/test_assay_postprocessing.py tests/test_document_postprocessing.py tests/test_target_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcbc812d8832499278626bd83ae65