### PR TITLE
Handle mapper failures with explicit exit code

### DIFF
--- a/library/utils/cli_tools/mapper_main.py
+++ b/library/utils/cli_tools/mapper_main.py
@@ -77,7 +77,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         mapped_count = 0
         missing_count = 0
         missing_sample: list[str] = []
-
+        mapping_failed = False
 
         try:
             mappings = map_chembl_ids_to_uniprot(
@@ -92,6 +92,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             df["mapping_uniprot_id"] = [None for _ in df[args.column]]
             missing_count = total_ids
             missing_sample = ids_to_map[:SUMMARY_SAMPLE_LIMIT]
+            mapping_failed = True
         else:
             for chembl_id in ids_to_map:
                 uniprot_id = mappings.get(chembl_id)
@@ -147,7 +148,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         except OSError as exc:
             logger.error("write_fail", error=str(exc))
             return 1
-        return 0 if not mapping_failed else 1
+        return 1 if mapping_failed else 0
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("run_fail", exc=exc)
         return 1

--- a/tests/test_mapper_run_exception.py
+++ b/tests/test_mapper_run_exception.py
@@ -40,3 +40,37 @@ def test_run_logs_exception(monkeypatch, tmp_path: Path, cfg: Config) -> None:
     assert any(
         r["event"] == "run_fail" and r["exc_type"] == "RuntimeError" for r in records
     )
+
+
+def test_run_returns_failure_when_mapping_fails(
+    monkeypatch, tmp_path: Path, cfg: Config
+) -> None:
+    """Mapping errors should result in a non-zero exit code."""
+
+    input_path = tmp_path / "in.csv"
+    input_path.write_text("chembl_id\nCHEMBL1\n", encoding="utf8")
+
+    def failing_mapper(*args, **kwargs):
+        raise ValueError("bad mapping")
+
+    monkeypatch.setattr(mapper_main, "map_chembl_ids_to_uniprot", failing_mapper)
+    buffer = io.StringIO()
+    configure_logger(LoggerConfig(stream=buffer, level="INFO"))
+    cfg_ns = SimpleNamespace(
+        io=cfg.io,
+        uniprot_mapping=cfg.uniprot_mapping,
+        to_dict=lambda: {},
+    )
+    args = argparse.Namespace(
+        input_csv=input_path,
+        output_csv=tmp_path / "out.csv",
+        column="chembl_id",
+        sep=",",
+        encoding="utf8",
+        key_cols=None,
+        chunk_size=1,
+        rps=1.0,
+        workers=1,
+    )
+    exit_code = mapper_main.run(cfg_ns, args)
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- ensure mapper CLI run function tracks mapping failures and returns a non-zero exit code
- add regression test that simulates a mapping failure to assert the exit code handling

## Testing
- pytest tests/test_mapper_run_exception.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcbdb951c8324bccfb96d21e4da34