### PR TITLE
Ensure target snapshots use deterministic writer

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -50,6 +50,7 @@ from library.config import (
     Config,
     _serialize_paths,
 )
+from library.csv_utils import write_csv_deterministic
 from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
@@ -319,11 +320,13 @@ def _prepare_targets_for_schema(
 
 
 def _save_snapshot(df: pd.DataFrame, base: Path, step: str, cfg: Config) -> Path:
-    """Write ``df`` to a uniquely named snapshot CSV file.
+    """Write ``df`` to a uniquely named snapshot CSV file with metadata.
 
     The file is created alongside ``base`` using the pattern
     ``<base>_<step>_<n>.csv`` where ``n`` increments to avoid overwriting
-    existing files.
+    existing files. Snapshot exports respect the configured CSV separator and
+    encoding, and a ``.meta.yaml`` sidecar is generated containing minimal
+    provenance details for reproducibility.
 
     Parameters
     ----------
@@ -335,8 +338,7 @@ def _save_snapshot(df: pd.DataFrame, base: Path, step: str, cfg: Config) -> Path
     step:
         Descriptive label inserted into the snapshot file name.
     cfg:
-        Application configuration (currently unused but kept for API
-        compatibility).
+        Application configuration providing CSV export options.
 
     Returns
     -------
@@ -349,8 +351,41 @@ def _save_snapshot(df: pd.DataFrame, base: Path, step: str, cfg: Config) -> Path
     while True:
         candidate = base.with_name(f"{stem}_{step}_{index}{suffix}")
         if not candidate.exists():
-            df.to_csv(candidate, index=False)
-            return candidate
+            work = df.copy()
+            if work.columns.empty:
+                key_cols: list[str] = []
+            else:
+                key_cols = [
+                    column
+                    for column in TARGETS_COLUMN_ORDER
+                    if column in work.columns
+                ]
+                if not key_cols:
+                    key_cols = list(work.columns)
+            csv_path = write_csv_deterministic(
+                work,
+                candidate,
+                col_order=list(df.columns),
+                key_cols=key_cols,
+                sep=cfg.io.csv_sep,
+                encoding=cfg.io.csv_encoding,
+                cfg=None,
+            )
+            stats: Stats = {
+                "rows_total": len(df),
+                "rows_kept": len(df),
+                "rows_dropped": 0,
+                "output_sha256": file_sha256(csv_path),
+            }
+            write_meta_yaml(
+                csv_path=csv_path,
+                command=" ".join(sys.argv),
+                config_subset=_serialize_paths(cfg.to_dict()),
+                inputs={"base": str(base), "step": step},
+                stats=stats,
+                schema="TargetSnapshot",
+            )
+            return csv_path
         index += 1
 
 

--- a/tests/test_get_target_data_helpers.py
+++ b/tests/test_get_target_data_helpers.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from library.config import Config
 from scripts.get_target_data import _first_token, _pipe_merge, _save_snapshot
@@ -26,7 +27,31 @@ def test_first_token_extracts_head() -> None:
 def test_save_snapshot_creates_unique_files(tmp_path: Path, cfg: Config) -> None:
     df = pd.DataFrame({"a": [1]})
     base = tmp_path / "out.csv"
-    _save_snapshot(df, base, "step", cfg)
-    _save_snapshot(df, base, "step", cfg)
+    first = _save_snapshot(df, base, "step", cfg)
+    second = _save_snapshot(df, base, "step", cfg)
     files = sorted(tmp_path.glob("out_step_*.csv"))
     assert len(files) == 2
+    for path in (first, second):
+        meta = path.with_name(path.name + ".meta.yaml")
+        assert meta.exists()
+
+
+def test_save_snapshot_respects_io_settings(tmp_path: Path, cfg: Config) -> None:
+    df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "pref_name": ["café"],
+        }
+    )
+    base = tmp_path / "snapshot.csv"
+    cfg.io.csv_sep = ";"
+    cfg.io.csv_encoding = "latin1"
+    path = _save_snapshot(df, base, "stage", cfg)
+
+    with pytest.raises(UnicodeDecodeError):
+        path.read_text(encoding="utf-8")
+    content = path.read_text(encoding=cfg.io.csv_encoding)
+    assert content.startswith("target_chembl_id;pref_name")
+
+    meta = path.with_name(path.name + ".meta.yaml")
+    assert meta.exists()


### PR DESCRIPTION
## Summary
- write target snapshots using `write_csv_deterministic`, respecting the configured CSV settings and emitting metadata sidecars
- extend helper tests to cover separator/encoding behaviour and metadata generation

## Testing
- pytest tests/test_get_target_data_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcbe95b908324a06ea5120b9c3c1a