### PR TITLE
Handle sidecar files already in final location

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -465,6 +465,21 @@ def _finalize_step_success(
             continue
         destination = sidecar.destination
         destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            same_location = working_path.resolve() == destination.resolve()
+        except OSError:
+            same_location = False
+        if same_location:
+            final_path = sidecar.final_path
+            if (
+                final_path is not None
+                and final_path.exists()
+                and final_path != destination
+            ):
+                final_parent = final_path.parent
+                final_path.unlink()
+                _cleanup_empty_directories(final_parent, root=final_dir)
+            continue
         if destination.exists():
             destination.unlink()
         original_parent = working_path.parent


### PR DESCRIPTION
## Summary
- avoid unlinking and replacing sidecar artefacts when the working and destination paths are the same
- preserve cleanup of outdated final artefacts after either moving or skipping a sidecar

## Testing
- python -m compileall scripts/get_data.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd156e98883248477b42ba8ba3b78