### PR TITLE
Clarify structured logging configuration docs

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -340,9 +340,7 @@ IUPHAR and UniProt lookups are stored there by default.
 
 | Sub-section | Key | Default | Description |
 | --- | --- | --- | --- |
-| `log` | `level` | `INFO` | Default logging level. |
-|  | `format` | `[%(asctime)s] %(levelname)s %(name)s: %(message)s` | Log message format. |
-|  | `datefmt` | `%Y-%m-%d %H:%M:%S` | Timestamp format. |
+| `log` | `level` | `INFO` | Default logging level. Structured JSON output keeps a fixed schema handled by [`library/logging_setup.py`](../library/logging_setup.py), so message and timestamp formatting are not configurable here. |
 | `rate` | `global_rps` | `100` | Global requests-per-second budget shared across clients. |
 |  | `global_burst` | `100` | Global token bucket burst capacity. |
 |  | `limiter_cache_maxsize` | `128` | Maximum cached limiter instances. |
@@ -410,6 +408,8 @@ Common short aliases:
 | `CHEMBL_DA_PUBCHEM_USER_AGENT` | `sources.pubchem.user_agent` |
 
 Any other key can be targeted using the long `CHEMBL_DA__...` form.
+
+> Structured logging details live in [`library/log.py`](../library/log.py) and [`library/logging_setup.py`](../library/logging_setup.py), explaining why the JSON layout (including date formatting) cannot be overridden via `config.yaml`.
 
 ## CLI overrides
 

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -328,9 +328,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 
 | Подсекция | Ключ | Значение | Описание |
 | --- | --- | --- | --- |
-| `log` | `level` | `INFO` | Уровень логирования. |
-|  | `format` | `[%(asctime)s] %(levelname)s %(name)s: %(message)s` | Формат сообщений. |
-|  | `datefmt` | `%Y-%m-%d %H:%M:%S` | Формат времени. |
+| `log` | `level` | `INFO` | Уровень логирования по умолчанию. Структурированный JSON-вывод использует фиксированную схему из [`library/logging_setup.py`](../library/logging_setup.py), поэтому формат сообщения и таймстемпа через конфигурацию не меняется. |
 | `rate` | `global_rps` | `100` | Глобальный лимит запросов в секунду. |
 |  | `global_burst` | `100` | Ёмкость глобального токен-бакета. |
 |  | `limiter_cache_maxsize` | `128` | Максимум кэшированных лимитеров. |
@@ -394,6 +392,8 @@ export CHEMBL_DA__LOCAL__IO__OUTPUT_DIR=/mnt/datasets
 | `CHEMBL_DA_PUBCHEM_USER_AGENT` | `sources.pubchem.user_agent` |
 
 Любой другой ключ можно задать в длинной форме `CHEMBL_DA__...`.
+
+> Детали JSON-формата описаны в [`library/log.py`](../library/log.py) и [`library/logging_setup.py`](../library/logging_setup.py); из-за этого `config.yaml` не позволяет переопределить формат сообщений и дату.
 
 ## CLI-переопределения
 


### PR DESCRIPTION
## Summary
- explain that only `system.log.level` is configurable because structured JSON logging fixes format/timestamp
- point readers to `library/log.py` and `library/logging_setup.py` for the logging schema details in both English and Russian docs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de196f117c8324a19c2084e3b0dd60