### PR TITLE
Update README alias map anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,12 @@ CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 
 **EN.** Use either the short alias `CHEMBL_DA_BASE` or the fully qualified
 `CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; both expand to the same setting.
-Refer to the [alias table](library/config.py#L1531-L1602) in
+Refer to the [alias table](library/config.py#L1531-L1634) in
 `library/config.py` for all supported mappings. / **RU.** Допустимо указывать
 как короткий алиас `CHEMBL_DA_BASE`, так и полное имя
 `CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE` — обе переменные настраивают
 одно и то же значение. Полный список алиасов приведён в
-[`library/config.py`](library/config.py#L1531-L1602).
+[`library/config.py`](library/config.py#L1531-L1634).
 
 См. также файл `.env.example` с типовыми переменными для контактных e-mail.
 
@@ -691,8 +691,8 @@ export CHEMBL_DA__LOG__LEVEL=DEBUG
 
 Most options also provide short aliases for backwards compatibility. The table
 lists every supported alias and the canonical key it maps to. See
-[`_ALIAS_OVERRIDES`](library/config.py#L1544-L1616) and
-[`_ALIAS_MAP`](library/config.py#L1618-L1620) for the authoritative source:
+[`_ALIAS_OVERRIDES`](library/config.py#L1569-L1634) and
+[`_ALIAS_MAP`](library/config.py#L1637-L1640) for the authoritative source:
 
 | Alias | Equivalent key |
 |-------|----------------|

--- a/README_EN.md
+++ b/README_EN.md
@@ -259,7 +259,7 @@ CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 
 Use either the short alias `CHEMBL_DA_BASE` or the fully qualified
 `CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; both expand to the same setting.
-See the [alias table](library/config.py#L1531-L1602) in `library/config.py` for
+See the [alias table](library/config.py#L1531-L1634) in `library/config.py` for
 the complete mapping list.
 
 See `.env.example` for typical contact e-mail variables.
@@ -452,7 +452,7 @@ export CHEMBL_DA__LOG__LEVEL=DEBUG
 ```
 
 Most options also provide short aliases for backwards compatibility. The table lists every supported alias and the canonical key it
- maps to. See [`_ALIAS_OVERRIDES`](library/config.py#L1544-L1616) and [`_ALIAS_MAP`](library/config.py#L1618-L1620) for the authoritative
+ maps to. See [`_ALIAS_OVERRIDES`](library/config.py#L1569-L1634) and [`_ALIAS_MAP`](library/config.py#L1637-L1640) for the authoritative
 source:
 
 | Alias | Equivalent key |

--- a/README_RU.md
+++ b/README_RU.md
@@ -248,7 +248,7 @@ CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 Допустимо указывать как короткий алиас `CHEMBL_DA_BASE`, так и полное имя
 `CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE`; обе переменные настраивают одно
 и то же значение. Полный список доступных алиасов приведён в
-[`library/config.py`](library/config.py#L1531-L1602).
+[`library/config.py`](library/config.py#L1531-L1634).
 
 Типовые переменные с контактными e-mail приведены в `.env.example`.
 
@@ -429,7 +429,7 @@ ChEMBL_data_acquisition/
 export CHEMBL_DA__LOG__LEVEL=DEBUG
 ```
 
-Большинство опций имеют короткие алиасы для обратной совместимости. Таблица перечисляет все поддерживаемые алиасы и их канонические ключи. См. [`_ALIAS_OVERRIDES`](library/config.py#L1544-L1616) и [`_ALIAS_MAP`](library/config.py#L1618-L1620) как первоисточник:
+Большинство опций имеют короткие алиасы для обратной совместимости. Таблица перечисляет все поддерживаемые алиасы и их канонические ключи. См. [`_ALIAS_OVERRIDES`](library/config.py#L1569-L1634) и [`_ALIAS_MAP`](library/config.py#L1637-L1640) как первоисточник:
 
 | Alias | Эквивалентный ключ |
 |-------|--------------------|


### PR DESCRIPTION
## Summary
- expand the README alias table links to cover the full `_ALIAS_OVERRIDES` range, including the OpenAlex, CrossRef, and PubChem aliases
- refresh `_ALIAS_OVERRIDES` and `_ALIAS_MAP` anchors across the English and Russian documentation variants

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68de196e76a8832492c8fe8d83b0eec3