### PR TITLE
Add UniProt fallback handling to target post-processing

### DIFF
--- a/library/target_postprocessing.py
+++ b/library/target_postprocessing.py
@@ -42,6 +42,7 @@ LOWERCASE_COLUMNS: list[str] = [
 TEXT_COLUMNS: list[str] = [
     "target_chembl_id",
     "uniprotkb_Id",
+    "uniProtkbIdFallback",
     "uniprot_id",
     "secondary_uniprot_id",
     "gene_name",
@@ -370,8 +371,26 @@ def postprocess_targets(
         df = df.rename(columns={chembl_col: internal_id})
 
     # --- normalise identifiers -------------------------------------------------
+    raw_uniprot_ids = df.get("uniProtkbId")
+    if raw_uniprot_ids is not None:
+        raw_uniprot_ids = raw_uniprot_ids.astype("string")
+    else:
+        raw_uniprot_ids = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    fallback_uniprot_ids = df.get("uniProtkbIdFallback")
+    if fallback_uniprot_ids is not None:
+        fallback_uniprot_ids = fallback_uniprot_ids.astype("string")
+        resolved_uniprot_ids = raw_uniprot_ids.fillna(fallback_uniprot_ids)
+    else:
+        resolved_uniprot_ids = raw_uniprot_ids.copy()
+
+    if "uniprot_id" in df.columns:
+        resolved_uniprot_ids = resolved_uniprot_ids.fillna(
+            df["uniprot_id"].astype("string")
+        )
+
     df["uniprotkb_Id"] = (
-        df.get("uniProtkbId", pd.Series(dtype=str))
+        resolved_uniprot_ids.fillna("")
         .astype(str)
         .str.split("_")
         .str[0]
@@ -584,7 +603,25 @@ def finalise_targets(
     ]
     _validate_columns(df, required_columns)
 
-    mask_nan = df["uniprotkb_Id"].astype(str) == "nan"
+    uniprot_series = df["uniprotkb_Id"].astype("string")
+    fallback_series = df.get("uniProtkbIdFallback")
+    if fallback_series is not None:
+        fallback_series = fallback_series.astype("string")
+    else:
+        fallback_series = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    missing_uniprot = (
+        uniprot_series.isna()
+        | (uniprot_series.str.strip() == "")
+        | (uniprot_series.str.lower() == "nan")
+    )
+    fallback_available = ~(
+        fallback_series.isna()
+        | (fallback_series.str.strip() == "")
+        | (fallback_series.str.lower() == "nan")
+    )
+
+    mask_nan = missing_uniprot & ~fallback_available
     if mask_nan.any():
         logger.debug("Dropping %d rows with missing UniProt IDs", mask_nan.sum())
     df = df[~mask_nan]

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -129,6 +129,7 @@ UNIPROT_OUTPUT_COLUMNS: list[str] = [
     "pipeline_version",
     "timestamp_utc",
     "uniProtkbId",
+    "uniProtkbIdFallback",
     "secondaryAccessions",
     "recommendedName",
     "geneName",
@@ -281,17 +282,9 @@ def extract_organism(data: Any) -> dict[str, str]:
     return result
 
 
-def extract_uniprotkb_id(data: Any) -> str | None:
-    """Return the ``uniProtkbId`` for the first entry in ``data``.
+def _first_entry(data: Any) -> dict[str, Any] | None:
+    """Return the first UniProt entry from *data* when available."""
 
-    Args:
-        data: A UniProt JSON structure, list of entries, or search results
-            containing UniProt entries.
-
-    Returns:
-        The ``uniProtkbId`` string when present, otherwise ``None``.
-
-    """
     if isinstance(data, dict) and "results" in data:
         entries = data["results"]
     elif isinstance(data, list):
@@ -300,11 +293,43 @@ def extract_uniprotkb_id(data: Any) -> str | None:
         entries = [data]
     for entry in entries:
         if isinstance(entry, dict):
-            value = entry.get("uniProtkbId")
-            if isinstance(value, str):
-                return value
-            break
+            return entry
     return None
+
+
+def extract_uniprotkb_id(
+    data: Any, *, allow_primary: bool = False, default: str | None = None
+) -> str | None:
+    """Return the ``uniProtkbId`` (optionally with fallbacks) for ``data``.
+
+    Args:
+        data: A UniProt JSON structure, list of entries, or search results
+            containing UniProt entries.
+        allow_primary: When ``True`` and ``uniProtkbId`` is missing, fall back to
+            ``primaryAccession``.
+        default: Value returned when neither ``uniProtkbId`` nor
+            ``primaryAccession`` (when ``allow_primary`` is enabled) is present.
+
+    Returns:
+        The ``uniProtkbId`` string when present. If ``allow_primary`` is set,
+        the ``primaryAccession`` value is returned when ``uniProtkbId`` is
+        absent. ``default`` is used as a final fallback.
+
+    """
+
+    entry = _first_entry(data)
+    if not entry:
+        return default
+    value = entry.get("uniProtkbId")
+    if isinstance(value, str) and value:
+        return value
+    if allow_primary:
+        primary = entry.get("primaryAccession")
+        if isinstance(primary, str) and primary:
+            return primary
+    return default
+
+
 
 
 def extract_secondary_accessions(data: Any) -> list[str]:
@@ -1059,6 +1084,7 @@ def collect_info(
         "uniprot_version": "",
         "pipeline_version": "",
         "timestamp_utc": "",
+        "uniProtkbIdFallback": "",
     }
     try:
         with open(json_path, encoding="utf-8") as handle:
@@ -1135,7 +1161,12 @@ def collect_info(
     result.update(cross)
     _update_gtop_metadata(result, cfg=gtop_cfg)
     result.update(activity)
-    result["uniProtkbId"] = extract_uniprotkb_id(data)
+    uni_protkb_id = extract_uniprotkb_id(data)
+    fallback_uniprotkb_id = (
+        uni_protkb_id or extract_uniprotkb_id(data, allow_primary=True)
+    )
+    result["uniProtkbId"] = uni_protkb_id
+    result["uniProtkbIdFallback"] = fallback_uniprotkb_id or uid
     result["secondaryAccessions"] = extract_secondary_accessions(data)
     result["recommendedName"] = extract_recommended_name(data)
     result["geneName"] = extract_gene_name(data)

--- a/tests/test_target_postprocessing.py
+++ b/tests/test_target_postprocessing.py
@@ -52,6 +52,45 @@ def test_postprocess_targets_merges_and_normalises() -> None:
     assert row["synonyms"].startswith("g2|g3|g1|name2|name3")
 
 
+def test_finalise_targets_retains_rows_with_fallback_id() -> None:
+    """Rows using the UniProt fallback identifier are preserved."""
+
+    df = pd.DataFrame(
+        {
+            "chembl_id": ["CHEMBL1"],
+            "uniProtkbId": [None],
+            "uniProtkbIdFallback": ["P12345"],
+            "uniprot_id": ["Q12345"],
+            "secondaryAccessions": [None],
+            "pref_name": ["Protein kinase"],
+            "gene_name_x": [""],
+            "geneName": [""],
+            "gene": ["g1"],
+            "secondaryAccessionNames": [""],
+            "component_description": [""],
+            "chembl_alternative_name": [""],
+            "recommendedName": [""],
+            "names": [""],
+            "synonyms_x": [""],
+            "synonyms": [""],
+            "ec_number": [""],
+            "ec_code": [""],
+            "genus": ["Homo"],
+            "lineage_superkingdom": ["Eukaryota"],
+            "lineage_phylum": ["Chordata"],
+            "lineage_class": ["Mammalia"],
+        }
+    )
+
+    processed = tp.postprocess_targets(df, chembl_col="chembl_id")
+    assert processed.loc[0, "uniprotkb_Id"] == "P12345"
+
+    final = tp.finalise_targets(processed, chembl_col="chembl_id")
+
+    assert not final.empty
+    assert list(final["target_chembl_id"]) == ["CHEMBL1"]
+
+
 def test_postprocess_targets_orders_columns() -> None:
     """Columns from the schema appear first and others alphabetically."""
 


### PR DESCRIPTION
## Summary
- add UniProt ID fallback capture when collecting UniProt metadata
- resolve UniProt identifiers in target post-processing using the captured fallback column
- keep fallback-backed rows during finalisation and cover the case with a new unit test

## Testing
- pytest tests/test_target_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68de2082f6d88324a7fcdd0cafb14afc