### PR TITLE
Refactor ChEMBL target export to support raw payload workflows

### DIFF
--- a/library/chembl_library.py
+++ b/library/chembl_library.py
@@ -18,8 +18,12 @@ from library.clients import _chunked
 from .chembl_document import get_documents
 from .chembl_target import (
     extend_target,
+    get_target_payload,
     get_target,
     get_targets,
+    get_targets_payloads,
+    get_targets_raw_frame,
+    iter_target_batches,
 )
 
 __all__ = [
@@ -29,7 +33,11 @@ __all__ = [
     "get_testitem",
     "get_documents",
     "get_target",
+    "get_target_payload",
     "get_targets",
+    "get_targets_payloads",
+    "get_targets_raw_frame",
+    "iter_target_batches",
     "extend_target",
     "_chunked",
 ]

--- a/library/chembl_target.py
+++ b/library/chembl_target.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
 import pandas as pd
@@ -282,6 +282,57 @@ def _parse_target_record(
     return res
 
 
+def _normalise_target_payloads(payloads: Sequence[dict[str, Any]]) -> pd.DataFrame:
+    """Return a DataFrame created from raw ``payloads`` using :func:`json_normalize`."""
+
+    if not payloads:
+        return pd.DataFrame()
+    frame = pd.json_normalize(payloads, sep=".")
+    return frame
+
+
+def iter_target_batches(
+    ids: Sequence[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    mapping_cfg: UniprotMappingCfg,
+    chunk_size: int = 5,
+    timeout: float | None = None,
+) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
+    """Yield payloads, raw and parsed target data frames for ``ids``."""
+
+    if not ids:
+        return
+
+    base = (
+        f"{cfg.chembl_base.rstrip('/')}/target.json?format=json"
+        f"&include={TARGET_INCLUDE_PARAMS}"
+    )
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+
+    for chunk in _chunked(ids, chunk_size):
+        url = f"{base}&target_chembl_id__in={','.join(chunk)}"
+        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
+        items = data.get("targets") or data.get("target") or []
+        payloads = [
+            _extract_target_payload(item)
+            for item in items
+            if isinstance(item, (dict, list))
+        ]
+        payloads = [payload for payload in payloads if payload]
+        if not payloads:
+            continue
+        raw_frame = _normalise_target_payloads(payloads)
+        records = [_parse_target_record(payload, mapping_cfg) for payload in payloads]
+        parsed_frame = pd.DataFrame(records)
+        if parsed_frame.empty:
+            parsed_frame = pd.DataFrame(columns=TARGET_FIELDS)
+        else:
+            parsed_frame = parsed_frame.reindex(columns=TARGET_FIELDS)
+        yield payloads, raw_frame, parsed_frame
+
+
 def get_target(
     chembl_target_id: str,
     *,
@@ -317,6 +368,24 @@ def get_target(
     return _parse_target_record(payload, mapping_cfg)
 
 
+def get_target_payload(
+    chembl_target_id: str,
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Return the raw payload for ``chembl_target_id`` without post-processing."""
+
+    if chembl_target_id in {"", "#N/A"}:
+        return {}
+    base = cfg.chembl_base.rstrip("/")
+    url = f"{base}/target/{chembl_target_id}.json?include={TARGET_INCLUDE_PARAMS}"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+    data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
+    return _extract_target_payload(data)
+
+
 def get_targets(
     ids: Iterable[str],
     *,
@@ -347,21 +416,82 @@ def get_targets(
     if not valid:
         return pd.DataFrame(columns=TARGET_FIELDS)
 
-    records: list[dict[str, Any]] = []
-    base = (
-        f"{cfg.chembl_base.rstrip('/')}/target.json?format=json"
-        f"&include={TARGET_INCLUDE_PARAMS}"
-    )
-    effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    for chunk in _chunked(valid, chunk_size):
-        url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("targets") or data.get("target") or []
-        records.extend(_parse_target_record(item, mapping_cfg) for item in items)
-    if not records:
+    parsed_frames: list[pd.DataFrame] = []
+    for _, _, parsed in iter_target_batches(
+        valid,
+        cfg=cfg,
+        client=client,
+        mapping_cfg=mapping_cfg,
+        chunk_size=chunk_size,
+        timeout=timeout,
+    ):
+        if parsed.empty:
+            continue
+        parsed_frames.append(parsed)
+    if not parsed_frames:
         return pd.DataFrame(columns=TARGET_FIELDS)
-    df = pd.DataFrame(records)
+    df = pd.concat(parsed_frames, ignore_index=True)
     return df.reindex(columns=TARGET_FIELDS)
+
+
+def get_targets_payloads(
+    ids: Iterable[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    mapping_cfg: UniprotMappingCfg,
+    chunk_size: int = 5,
+    timeout: float | None = None,
+) -> list[dict[str, Any]]:
+    """Return a list of raw payloads for ``ids`` without flattening."""
+
+    valid = [i for i in ids if i not in {"", "#N/A"}]
+    if not valid:
+        return []
+
+    payloads: list[dict[str, Any]] = []
+    for batch_payloads, _, _ in iter_target_batches(
+        valid,
+        cfg=cfg,
+        client=client,
+        mapping_cfg=mapping_cfg,
+        chunk_size=chunk_size,
+        timeout=timeout,
+    ):
+        payloads.extend(batch_payloads)
+    return payloads
+
+
+def get_targets_raw_frame(
+    ids: Iterable[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    mapping_cfg: UniprotMappingCfg,
+    chunk_size: int = 5,
+    timeout: float | None = None,
+) -> pd.DataFrame:
+    """Return a DataFrame created from the raw payloads for ``ids``."""
+
+    valid = [i for i in ids if i not in {"", "#N/A"}]
+    if not valid:
+        return pd.DataFrame()
+
+    frames: list[pd.DataFrame] = []
+    for _, raw_frame, _ in iter_target_batches(
+        valid,
+        cfg=cfg,
+        client=client,
+        mapping_cfg=mapping_cfg,
+        chunk_size=chunk_size,
+        timeout=timeout,
+    ):
+        if raw_frame.empty:
+            continue
+        frames.append(raw_frame)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
 
 
 def extend_target(
@@ -400,7 +530,11 @@ def extend_target(
 
 __all__ = [
     "get_target",
+    "get_target_payload",
     "get_targets",
+    "get_targets_payloads",
+    "get_targets_raw_frame",
+    "iter_target_batches",
     "extend_target",
     "TARGET_FIELDS",
 ]

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -54,7 +54,9 @@ class Validator(Protocol):
 
 
 MetadataHook = Callable[[pd.DataFrame], pd.DataFrame]
-Writer = Callable[[Iterable[pd.DataFrame], Path, Sequence[str], Sequence[str]], Path]
+Writer = Callable[
+    [Iterable[pd.DataFrame], Path, Sequence[str] | None, Sequence[str]], Path
+]
 TableQualityHook = Callable[[Path], None]
 Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
 
@@ -141,10 +143,10 @@ def _as_iterable(
 def run_pipeline(
     *,
     fetcher: Fetcher,
-    schema: SchemaT,
+    schema: SchemaT | None,
     schema_name: str,
-    validators: Sequence[Validator],
-    metadata_hooks: Sequence[MetadataHook],
+    validators: Sequence[Validator] | None,
+    metadata_hooks: Sequence[MetadataHook] | None,
     writer: Writer,
     output_path: Path,
     failure_path: Path,
@@ -209,12 +211,19 @@ def run_pipeline(
 
     use_logger = logger or default_logger
 
-    required_cols = {
-        name
-        for name, column in getattr(schema, "columns", {}).items()
-        if column.required
-    }
-    optional_cols = set(getattr(schema, "columns", {})) - required_cols
+    metadata_hooks = list(metadata_hooks or [])
+    validators = list(validators or [])
+
+    if schema is not None:
+        required_cols = {
+            name
+            for name, column in getattr(schema, "columns", {}).items()
+            if column.required
+        }
+        optional_cols = set(getattr(schema, "columns", {})) - required_cols
+    else:
+        required_cols = set()
+        optional_cols = set()
 
     errors = SidecarErrors()
     rows_total = 0
@@ -320,11 +329,18 @@ def run_pipeline(
             empty.to_pickle(chunk_path)
             chunk_paths.append(chunk_path)
 
-        schema_columns = list(getattr(schema, "columns", {}))
-        head = [column for column in schema_columns if column in all_columns]
-        tail = sorted(column for column in all_columns if column not in schema_columns)
-        col_order = head + tail
-        resolved_keys = [column for column in key_columns if column in col_order]
+        if schema is not None:
+            schema_columns = list(getattr(schema, "columns", {}))
+            head = [column for column in schema_columns if column in all_columns]
+            tail = sorted(
+                column for column in all_columns if column not in schema_columns
+            )
+            col_order: Sequence[str] | None = head + tail
+            available_columns = set(col_order)
+        else:
+            col_order = None
+            available_columns = set(all_columns)
+        resolved_keys = [column for column in key_columns if column in available_columns]
 
         def _iter_validated() -> Iterator[pd.DataFrame]:
             for path in chunk_paths:
@@ -343,7 +359,7 @@ def run_pipeline(
             )
             return 1
 
-    if optional_cols - present_columns:
+    if optional_cols and (optional_cols - present_columns):
         use_logger.warning(
             "optional_columns_missing",
             columns=sorted(optional_cols - present_columns),

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -36,7 +36,7 @@ from library import iuphar_library as ii
 from library import protein_classification as pc
 from library import target_postprocessing as tp
 from library import uniprot_library as uu
-from library.clients import ChemblClient, _chunked
+from library.clients import ChemblClient
 from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
@@ -79,6 +79,8 @@ UNIPROT_MISSING_VALUE = ""
 
 DEFAULT_INPUT_NAME = "target.csv"
 DEFAULT_OUTPUT_STEM = "targets"
+RAW_SUFFIX = "_raw"
+NORMALIZED_SUFFIX = "_normalized"
 
 
 @dataclass(frozen=True)
@@ -214,6 +216,49 @@ def _resolve_uniprot_matches(
         resolved.append(match)
 
     return pd.Series(resolved, index=plan.row_index, dtype=object)
+
+
+def _normalized_output_path(base: Path) -> Path:
+    """Return deterministic path for the normalized export derived from ``base``."""
+
+    suffix = base.suffix or ".csv"
+    return base.with_name(f"{base.stem}{NORMALIZED_SUFFIX}{suffix}")
+
+
+def _raw_output_path(base: Path) -> Path:
+    """Return default path for the raw payload dump derived from ``base``."""
+
+    suffix = base.suffix or ".csv"
+    return base.with_name(f"{base.stem}{RAW_SUFFIX}{suffix}")
+
+
+def _write_raw_dump(
+    df: pd.DataFrame,
+    destination: Path,
+    *,
+    cfg: Config,
+    reindex_columns: bool,
+) -> Path:
+    """Persist ``df`` to ``destination`` honouring CSV or Parquet formats."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if reindex_columns and not df.empty:
+        df = df.reindex(columns=sorted(df.columns))
+    suffix = destination.suffix.lower()
+    if suffix in {".parquet", ".pq"}:
+        try:
+            df.to_parquet(destination, index=False)
+        except (ImportError, ValueError) as exc:
+            raise OSError(f"failed to write parquet: {exc}") from exc
+    else:
+        df.to_csv(
+            destination,
+            index=False,
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+        )
+    logger.info("raw_dump_written", rows=len(df), path=str(destination))
+    return destination
 
 
 def _pipe_merge(values: Sequence[str | None]) -> str:
@@ -484,6 +529,32 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=int,
         default=0,
         help="Number of identifiers to skip before processing",
+    )
+    chembl.add_argument(
+        "--raw-output",
+        type=path_argument,
+        default=None,
+        help=(
+            "Optional path for the raw payload dump. "
+            "Defaults to '<output>_raw<suffix>'."
+        ),
+    )
+    chembl.add_argument(
+        "--normalize-at-export",
+        dest="normalize_at_export",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Apply normalization and schema validation before writing the final export. "
+            "Use --no-normalize-at-export to emit raw payload output."
+        ),
+    )
+    chembl.add_argument(
+        "--no-reindex-raw",
+        dest="reindex_raw",
+        action="store_false",
+        default=True,
+        help="Preserve raw payload column order when writing dumps.",
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -808,23 +879,106 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if offset:
         ids_iter = islice(ids_iter, offset, None)
         logger.info("process_offset", offset=offset)
-    processed_ids = 0
+    limited_ids = list(islice(ids_iter, limit)) if limit is not None else list(ids_iter)
+    processed_ids = len(limited_ids)
 
-    def _iter_ids() -> Iterator[str]:
-        nonlocal processed_ids
-        for identifier in ids_iter:
-            processed_ids += 1
-            yield identifier
+    base_output = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    raw_destination = (
+        Path(args.raw_output)
+        if getattr(args, "raw_output", None) is not None
+        else _raw_output_path(base_output)
+    )
+    normalized_output = _normalized_output_path(base_output)
+    normalize_at_export = getattr(args, "normalize_at_export", True)
+    reindex_raw = getattr(args, "reindex_raw", True)
 
-    limited_ids: Iterator[str]
-    if limit is not None:
-        limited_ids = islice(_iter_ids(), limit)
+    raw_chunks: list[pd.DataFrame] = []
+    parsed_chunks: list[pd.DataFrame] = []
+
+    if limited_ids:
+        try:
+            with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+                for _, raw_chunk, parsed_chunk in cl.iter_target_batches(
+                    limited_ids,
+                    cfg=cfg.api,
+                    client=client,
+                    mapping_cfg=cfg.uniprot_mapping,
+                    chunk_size=cfg.target.chembl.chunk_size,
+                    timeout=cfg.target.chembl.timeout,
+                ):
+                    if not raw_chunk.empty:
+                        raw_chunks.append(raw_chunk)
+                    if not parsed_chunk.empty:
+                        parsed_chunks.append(parsed_chunk)
+        except (requests.RequestException, ValueError) as exc:
+            logger.error(
+                "chembl_fetch_failed",
+                error=str(exc),
+                chunk_size=cfg.target.chembl.chunk_size,
+                timeout=cfg.target.chembl.timeout,
+            )
+            return 1
+
+    raw_df = (
+        pd.concat(raw_chunks, ignore_index=True) if raw_chunks else pd.DataFrame()
+    )
+
+    if normalize_at_export:
+        try:
+            _write_raw_dump(
+                raw_df, raw_destination, cfg=cfg, reindex_columns=reindex_raw
+            )
+        except (OSError, ValueError) as exc:
+            logger.error("raw_dump_failed", error=str(exc), path=str(raw_destination))
+            return 1
     else:
-        limited_ids = _iter_ids()
+        def _raw_fetcher() -> Iterator[pd.DataFrame]:
+            yield raw_df
 
-    output_path = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    output = Path(output_path)
-    failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        def _raw_writer(
+            chunks: Iterator[pd.DataFrame],
+            destination: Path,
+            col_order: Sequence[str] | None,
+            key_cols: Sequence[str],
+        ) -> Path:
+            frames = list(chunks)
+            if frames:
+                merged = pd.concat(frames, ignore_index=True)
+            else:
+                merged = pd.DataFrame()
+            _write_raw_dump(merged, destination, cfg=cfg, reindex_columns=reindex_raw)
+            return destination
+
+        failure_path = raw_destination.with_name(
+            f"{raw_destination.stem}_failure_cases.csv"
+        )
+        exit_code = run_pipeline(
+            fetcher=_raw_fetcher,
+            schema=None,
+            schema_name="raw_target_payload",
+            validators=[],
+            metadata_hooks=[],
+            writer=_raw_writer,
+            output_path=raw_destination,
+            failure_path=failure_path,
+            command=" ".join(sys.argv),
+            config_snapshot=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            key_columns=[],
+            table_quality=lambda _: None,
+            cfg=cfg,
+            logger=logger,
+        )
+        if limit is not None:
+            logger.info("process_limit", limit=processed_ids)
+        logger.info(
+            "chembl_normalization_skipped",
+            output=str(raw_destination),
+            rows=len(raw_df),
+        )
+        return exit_code
 
     missing_optional_columns: set[str] = set()
 
@@ -845,34 +999,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
         return ValidationResult(validated, pd.DataFrame(), "TargetsSchema")
 
+    fetch_source: list[pd.DataFrame]
+    if parsed_chunks:
+        fetch_source = parsed_chunks
+    else:
+        fetch_source = [pd.DataFrame(columns=TARGET_FIELDS)]
+
     def fetcher() -> Iterator[pd.DataFrame]:
-        with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-            for chunk_ids in _chunked(limited_ids, cfg.target.chembl.chunk_size):
-                if not chunk_ids:
-                    continue
-                try:
-                    chunk_df = cl.get_targets(
-                        chunk_ids,
-                        cfg=cfg.api,
-                        client=client,
-                        mapping_cfg=cfg.uniprot_mapping,
-                        chunk_size=cfg.target.chembl.chunk_size,
-                        timeout=cfg.target.chembl.timeout,
-                    )
-                except (requests.RequestException, ValueError) as exc:
-                    logger.error(
-                        "chembl_fetch_failed",
-                        error=str(exc),
-                        chunk_size=cfg.target.chembl.chunk_size,
-                        timeout=cfg.target.chembl.timeout,
-                    )
-                    raise PipelineError(str(exc)) from exc
-                yield chunk_df
+        yield from fetch_source
 
     def writer(
         chunks: Iterator[pd.DataFrame],
         destination: Path,
-        col_order: Sequence[str],
+        col_order: Sequence[str] | None,
         key_cols: Sequence[str],
     ) -> Path:
         key_columns = list(key_cols)
@@ -887,9 +1026,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             chunksize=cfg.io.csv_chunksize,
         )
 
+    failure_path = normalized_output.with_name(
+        f"{normalized_output.stem}_failure_cases.csv"
+    )
     table_quality = partial(
         analyze_table_quality,
-        table_name=str(output.with_suffix("")),
+        table_name=str(normalized_output.with_suffix("")),
     )
 
     metadata_hooks = [
@@ -905,11 +1047,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         validators=[_validate_chunk],
         metadata_hooks=metadata_hooks,
         writer=writer,
-        output_path=output,
+        output_path=normalized_output,
         failure_path=failure_path,
         command=" ".join(sys.argv),
         config_snapshot=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
+        inputs={
+            "input_csv": str(args.input_csv),
+            "raw_dump": str(raw_destination),
+        },
         key_columns=["target_chembl_id"],
         table_quality=table_quality,
         cfg=cfg,
@@ -1080,8 +1225,12 @@ def fetch_chembl(
             cfg.target.chembl.limit = original_limit
         if chunk_size is not None:
             cfg.target.chembl.chunk_size = original_chunk_size
+    normalized_output = _normalized_output_path(output_csv)
     df = pd.read_csv(
-        output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
+        normalized_output,
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+        dtype=str,
     )
     logger.info("fetch_chembl_done", rows=len(df))
     return df
@@ -1533,41 +1682,49 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
     logger.info("validate_write_start", output=str(output))
     normalized = normalize_targets(df)
     normalized = add_pipeline_metadata(normalized)
-    final_df, missing_required, missing_optional = _prepare_targets_for_schema(
+    prepared, missing_required, missing_optional = _prepare_targets_for_schema(
         normalized
     )
-    exit_code = 0
-    if not missing_required:
-        if missing_optional:
-            logger.warning(
-                "optional_columns_missing",
-                columns=sorted(missing_optional),
-            )
-        try:
-            final_df = TargetsSchema.validate(final_df, lazy=True)
-        except SchemaErrors as exc:
-            failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
-            errors = SidecarErrors()
-            for row in exc.failure_cases.to_dict("records"):
-                errors.add_error(row)
-            errors.save(failure_path, cfg=cfg)
-            logger.error(
-                "validation_failed",
-                failures=len(exc.failure_cases),
-                path=str(failure_path),
-            )
-            final_df = getattr(exc, "validated_data", final_df)
-            exit_code = 1
-    else:
+    if missing_required:
         logger.warning(
             "validation_skipped",
             missing_columns=sorted(missing_required),
         )
-    final_df = final_df.fillna("-")
+        return 1
+    if missing_optional:
+        logger.warning(
+            "optional_columns_missing",
+            columns=sorted(missing_optional),
+        )
+
+    exit_code = 0
+    try:
+        validated = TargetsSchema.validate(
+            prepared,
+            lazy=False,
+            coerce=True,
+            strict=True,
+        )
+    except SchemaErrors as exc:
+        failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
+        errors = SidecarErrors()
+        for row in exc.failure_cases.to_dict("records"):
+            errors.add_error(row)
+        errors.save(failure_path, cfg=cfg)
+        logger.error(
+            "validation_failed",
+            failures=len(exc.failure_cases),
+            path=str(failure_path),
+        )
+        validated = getattr(exc, "validated_data", prepared)
+        exit_code = 1
+
+    final_df = validated.reindex(columns=TARGETS_COLUMN_ORDER).fillna("-")
     final_df = final_df.drop_duplicates()
+    normalized_output = _normalized_output_path(output)
     io.write_csv(
         final_df,
-        output,
+        normalized_output,
         cfg=cfg,
         sep=cfg.io.csv_sep,
         encoding=cfg.io.csv_encoding,
@@ -1577,16 +1734,18 @@ def validate_and_write(df: pd.DataFrame, output: Path, cfg: Config) -> int:
         logger.info(
             "quality_report_skipped",
             reason="empty_dataframe",
-            table=str(output.with_suffix("")),
+            table=str(normalized_output.with_suffix("")),
         )
     else:
         try:
-            analyze_table_quality(final_df, table_name=str(output.with_suffix("")))
+            analyze_table_quality(
+                final_df, table_name=str(normalized_output.with_suffix(""))
+            )
         except ValueError as exc:
             logger.error(
                 "quality_report_failed",
                 error=str(exc),
-                path=str(output),
+                path=str(normalized_output),
             )
             return 1
     logger.info("validate_write_done", rows=len(final_df))

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 
 import pandas as pd
@@ -49,8 +50,9 @@ def test_fetch_chembl(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     inp = tmp_path / "in.csv"
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        normalized = gtd._normalized_output_path(Path(args.output_csv))
         pd.DataFrame({"target_chembl_id": ["C1"], "uniprot_id": ["P1"]}).to_csv(
-            args.output_csv, index=False
+            normalized, index=False
         )
         return 0
 
@@ -70,7 +72,10 @@ def test_fetch_chembl_custom_chunk_size(
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         recorded["chunk_size"] = cfg.target.chembl.chunk_size
-        pd.DataFrame({"target_chembl_id": ["C1"]}).to_csv(args.output_csv, index=False)
+        normalized = gtd._normalized_output_path(Path(args.output_csv))
+        pd.DataFrame({"target_chembl_id": ["C1"]}).to_csv(
+            normalized, index=False
+        )
         return 0
 
     monkeypatch.setattr(gtd, "run_chembl", fake_run_chembl)
@@ -99,18 +104,26 @@ def test_run_chembl_streams_chunks(
 
     chunk_calls: list[list[str]] = []
 
-    def fake_get_targets(
-        chunk_ids: list[str],
+    def fake_iter_target_batches(
+        ids: Sequence[str],
         *,
         cfg: object,
         client: object,
         mapping_cfg: object,
         chunk_size: int,
         timeout: float | None,
-    ) -> pd.DataFrame:
-        ids = list(chunk_ids)
-        chunk_calls.append(ids)
-        return pd.DataFrame({"target_chembl_id": ids})
+    ) -> Iterator[tuple[list[dict[str, str]], pd.DataFrame, pd.DataFrame]]:
+        records = list(ids)
+        for start in range(0, len(records), chunk_size):
+            chunk = list(records[start : start + chunk_size])
+            chunk_calls.append(chunk)
+            payloads = [
+                {"target_chembl_id": value, "pref_name": value.lower()}
+                for value in chunk
+            ]
+            raw = pd.DataFrame(payloads)
+            parsed = pd.DataFrame({"target_chembl_id": chunk})
+            yield payloads, raw, parsed
 
     class DummyClient:
         def __init__(self, *args: object, **kwargs: object) -> None:
@@ -128,6 +141,7 @@ def test_run_chembl_streams_chunks(
             return False
 
     frames_to_write: list[pd.DataFrame] = []
+    raw_dumps: list[pd.DataFrame] = []
 
     def fake_write_csv(
         df: pd.DataFrame | list[pd.DataFrame],
@@ -147,9 +161,21 @@ def test_run_chembl_streams_chunks(
         destination.write_text("dummy", encoding=encoding or cfg.io.csv_encoding)
         return destination
 
-    monkeypatch.setattr(gtd.cl, "get_targets", fake_get_targets)
+    def fake_write_raw_dump(
+        df: pd.DataFrame,
+        destination: Path,
+        *,
+        cfg: Config,
+        reindex_columns: bool,
+    ) -> Path:
+        raw_dumps.append(df.copy())
+        df.to_csv(destination, index=False)
+        return destination
+
+    monkeypatch.setattr(gtd.cl, "iter_target_batches", fake_iter_target_batches)
     monkeypatch.setattr(gtd, "ChemblClient", DummyClient)
     monkeypatch.setattr(gtd.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(gtd, "_write_raw_dump", fake_write_raw_dump)
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *_, **__: None)
     monkeypatch.setattr(
         TargetsSchema, "validate", staticmethod(lambda df, lazy=True: df)
@@ -164,6 +190,13 @@ def test_run_chembl_streams_chunks(
         ["CHEMBL5"],
     ]
     assert [df["target_chembl_id"].tolist() for df in frames_to_write] == chunk_calls
+    assert raw_dumps and raw_dumps[0]["target_chembl_id"].tolist() == [
+        "CHEMBL1",
+        "CHEMBL2",
+        "CHEMBL3",
+        "CHEMBL4",
+        "CHEMBL5",
+    ]
 
 
 def test_fetch_uniprot(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> None:

--- a/tests/test_get_target_data_limit.py
+++ b/tests/test_get_target_data_limit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -108,19 +109,31 @@ def test_run_chembl_limit_uses_generator(
 
         return generator()
 
-    consumed: list[str] = []
+    received_batches: list[list[str]] = []
 
-    def fake_get_targets(ids_iter: Any, **__: object) -> pd.DataFrame:
-        if isinstance(ids_iter, list):
-            assert len(ids_iter) <= config.target.chembl.chunk_size
-        for value in ids_iter:
-            consumed.append(value)
-        return pd.DataFrame({"target_chembl_id": consumed})
+    def fake_iter_target_batches(
+        ids: Sequence[str],
+        *,
+        cfg: object,
+        client: object,
+        mapping_cfg: object,
+        chunk_size: int,
+        timeout: float | None,
+    ) -> Iterator[tuple[list[dict[str, str]], pd.DataFrame, pd.DataFrame]]:
+        batch = list(ids)
+        received_batches.append(batch)
+        payloads = [
+            {"target_chembl_id": value, "pref_name": value.lower()}
+            for value in batch
+        ]
+        raw = pd.DataFrame(payloads)
+        parsed = pd.DataFrame({"target_chembl_id": batch})
+        yield payloads, raw, parsed
 
     dummy_logger = DummyLogger()
     monkeypatch.setattr(gtd, "logger", dummy_logger)
     monkeypatch.setattr(gtd.io, "read_ids", fake_read_ids)
-    monkeypatch.setattr(gtd.cl, "get_targets", fake_get_targets)
+    monkeypatch.setattr(gtd.cl, "iter_target_batches", fake_iter_target_batches)
     monkeypatch.setattr(gtd, "ChemblClient", DummyClient)
     monkeypatch.setattr(gtd, "normalize_targets", lambda df: df)
     monkeypatch.setattr(gtd, "add_pipeline_metadata", lambda df: df)
@@ -144,10 +157,10 @@ def test_run_chembl_limit_uses_generator(
     exit_code = gtd.run_chembl(config, args)
 
     assert exit_code == 0
-    assert consumed == ["CHEMBL1", "CHEMBL2"]
+    assert received_batches == [["CHEMBL1", "CHEMBL2"]]
     assert any(
         level == "info"
         and event == "process_limit"
-        and call_kwargs.get("limit") == len(consumed)
+        and call_kwargs.get("limit") == len(received_batches[0])
         for level, event, call_kwargs in dummy_logger.calls
     )

--- a/tests/test_get_target_data_validate.py
+++ b/tests/test_get_target_data_validate.py
@@ -18,5 +18,6 @@ def test_validate_and_write(
     out = tmp_path / "out.csv"
     monkeypatch.setattr(gtd, "analyze_table_quality", lambda *a, **k: None)
     exit_code = gtd.validate_and_write(df, out, cfg)
+    normalized = gtd._normalized_output_path(out)
     assert exit_code == 0
-    assert out.exists()
+    assert normalized.exists()


### PR DESCRIPTION
## Summary
- add reusable helpers in `chembl_target` for iterating raw payload batches, exposing untouched records, and building normalized frames for downstream use
- extend the ChEMBL CLI to emit raw dumps, gate normalization/validation behind `--normalize-at-export`, and tighten final schema alignment with the `_normalized` output naming
- relax `run_pipeline` to handle optional schemas/validators and update target pipeline tests for the new raw workflow options

## Testing
- pytest *(fails: missing optional dependency `responses` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de278029ec8324936b9d1bdec6359b