### PR TITLE
Fix target CLI --out alias conflict

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -614,19 +614,8 @@ def prepare_io_paths(
     if resolved_input is not None:
         setattr(args, "input_csv", resolved_input)
 
-    alias_value = getattr(args, "final_out_alias", None)
     final_candidate = getattr(args, "final_out", None)
     output_candidate = getattr(args, "output_csv", None)
-
-    if alias_value not in (None, argparse.SUPPRESS):
-        if final_candidate in (None, argparse.SUPPRESS):
-            final_candidate = alias_value
-            setattr(args, "final_out", final_candidate)
-        log.logger.warning(
-            "cli_option_deprecated",
-            option="--out",
-            replacement="--final-out",
-        )
 
     if output_candidate not in (None, argparse.SUPPRESS):
         if final_candidate in (None, argparse.SUPPRESS):

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -510,14 +510,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
             default=normalize_default,
             help="Apply normalisation immediately before writing the final output",
         )
-        parser_obj.add_argument(
-            "--out",
-            dest="final_out_alias",
-            type=path_argument,
-            default=argparse.SUPPRESS,
-            help=argparse.SUPPRESS,
-        )
-
     _add_output_arguments(root, defaults=True)
     _add_output_arguments(shared, defaults=False)
 


### PR DESCRIPTION
## Summary
- remove the duplicate `--out` alias from the target CLI parser to avoid argparse conflicts
- rely on existing deprecated output handling in the shared IO preparation helper

## Testing
- python -m compileall scripts/get_target_data.py library/cli/parser.py

------
https://chatgpt.com/codex/tasks/task_e_68de38502fe08324be04ee172f37da33