### PR TITLE
Fix target CLI argument conflicts

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -575,6 +575,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "chembl",
         parents=[shared],
         help="Retrieve target information from ChEMBL",
+        conflict_handler="resolve",
     )
     chembl.add_argument(
         "--column",


### PR DESCRIPTION
## Summary
- allow the target Chembl subcommand parser to resolve duplicate option overrides inherited from the shared parser
- prevent argparse from raising a conflicting option error when the pipeline adds Chembl-specific flags

## Testing
- PYTHONPATH=. python scripts/get_target_data.py chembl --help

------
https://chatgpt.com/codex/tasks/task_e_68de3b58e6f88324a5b8840d2f5dfb35