### PR TITLE
Fix target pipeline output namespace

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1432,6 +1432,7 @@ def fetch_chembl(
     chembl_args = argparse.Namespace(
         input_csv=input_csv,
         final_out=final_out,
+        output_csv=final_out,
         raw_out=raw_out,
         raw_format=raw_format,
         id_cols=list(id_cols) if id_cols is not None else None,
@@ -1453,7 +1454,7 @@ def fetch_chembl(
             cfg.target.chembl.limit = original_limit
         if chunk_size is not None:
             cfg.target.chembl.chunk_size = original_chunk_size
-    normalized_output = _normalized_output_path(output_csv)
+    normalized_output = _normalized_output_path(final_out)
     df = pd.read_csv(
 
         final_out, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str


### PR DESCRIPTION
## Summary
- forward the ChEMBL export path as both final and legacy output parameters when running the subcommand
- ensure the normalized output helper works with the resolved final destination path

## Testing
- PYTHONPATH=. python scripts/get_target_data.py all --config config/config.yaml --input data/input/target.csv --output /tmp/out.csv --limit 1 *(fails: upstream command does not materialise /tmp/out_chembl.csv when normalisation is skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68de3cac04008324a4d37ae221ceb586