### PR TITLE
Fix target pipeline output handling

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -500,13 +500,15 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         )
         parser_obj.add_argument(
             "--no-reindex-raw",
+            dest="no_reindex_raw",
             action="store_true",
             default=no_reindex_default,
             help="Skip column reindexing when exporting the raw dataset",
         )
         parser_obj.add_argument(
             "--normalize-at-export",
-            action="store_true",
+            dest="normalize_at_export",
+            action=argparse.BooleanOptionalAction,
             default=normalize_default,
             help="Apply normalisation immediately before writing the final output",
         )
@@ -604,30 +606,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=int,
         default=0,
         help="Number of identifiers to skip before processing",
-    )
-    chembl.add_argument(
-        "--id-cols",
-        nargs="+",
-        dest="id_cols",
-        default=None,
-        help="Columns used to identify and sort rows in the output",
-    )
-    chembl.add_argument(
-        "--normalize-at-export",
-        dest="normalize_at_export",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help=(
-            "Apply normalization and schema validation before writing the final export. "
-            "Use --no-normalize-at-export to emit raw payload output."
-        ),
-    )
-    chembl.add_argument(
-        "--no-reindex-raw",
-        dest="reindex_raw",
-        action="store_false",
-        default=True,
-        help="Preserve raw payload column order when writing dumps.",
     )
     chembl.set_defaults(func=run_chembl)
 
@@ -825,7 +803,8 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             encoding=cfg.io.csv_encoding,
         )
 
-        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        output_candidate = getattr(args, "output_csv", None)
+        output = output_candidate or io.default_output_path(args.input_csv, cfg.io)
         data_dir = cfg.target.uniprot.data_dir
         uu.init_session(cfg.api, cfg.retry)
         try:
@@ -955,17 +934,30 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     limited_ids = list(islice(ids_iter, limit)) if limit is not None else list(ids_iter)
     processed_ids = len(limited_ids)
 
+    output_candidate = getattr(args, "output_csv", None)
     base_output = Path(
-        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        output_candidate or io.default_output_path(args.input_csv, cfg.io)
     )
-    raw_destination = (
-        Path(args.raw_output)
-        if getattr(args, "raw_output", None) is not None
-        else _raw_output_path(base_output)
+
+    raw_candidate = getattr(args, "raw_out", None)
+    if raw_candidate in (None, argparse.SUPPRESS):
+        legacy_raw_candidate = getattr(args, "raw_output", None)
+        if legacy_raw_candidate not in (None, argparse.SUPPRESS):
+            raw_candidate = legacy_raw_candidate
+    raw_path_override = (
+        Path(raw_candidate)
+        if raw_candidate not in (None, argparse.SUPPRESS)
+        else None
     )
+    raw_destination = raw_path_override or _raw_output_path(base_output)
     normalized_output = _normalized_output_path(base_output)
-    normalize_at_export = getattr(args, "normalize_at_export", True)
-    reindex_raw = getattr(args, "reindex_raw", True)
+
+    normalize_flag = getattr(args, "normalize_at_export", None)
+    if normalize_flag in (None, argparse.SUPPRESS):
+        normalize_at_export = True
+    else:
+        normalize_at_export = bool(normalize_flag)
+    reindex_raw = not bool(getattr(args, "no_reindex_raw", False))
 
     raw_chunks: list[pd.DataFrame] = []
     parsed_chunks: list[pd.DataFrame] = []
@@ -1044,14 +1036,35 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             cfg=cfg,
             logger=logger,
         )
+        if exit_code != 0:
+            return exit_code
+
+        if not raw_destination.exists():
+            logger.error("raw_dump_missing", path=str(raw_destination))
+            return 1
+
+        destination = base_output
+        if raw_destination != destination:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(raw_destination, destination)
+            except OSError as exc:
+                logger.error(
+                    "raw_to_final_copy_failed",
+                    error=str(exc),
+                    source=str(raw_destination),
+                    destination=str(destination),
+                )
+                return 1
+
         if limit is not None:
             logger.info("process_limit", limit=processed_ids)
         logger.info(
             "chembl_normalization_skipped",
-            output=str(raw_destination),
+            output=str(destination),
             rows=len(raw_df),
         )
-        return exit_code
+        return 0
 
 
     final_candidate = getattr(args, "final_out", None)
@@ -1060,11 +1073,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     else:
         final_output = Path(final_candidate)
 
-    raw_candidate = getattr(args, "raw_out", None)
-    if raw_candidate in (None, argparse.SUPPRESS):
+    if raw_path_override is None:
         raw_output = final_output
     else:
-        raw_output = Path(raw_candidate)
+        raw_output = raw_path_override
 
     raw_format = str(getattr(args, "raw_format", "csv") or "csv").lower()
     if raw_format not in {"csv", "parquet"}:
@@ -1073,7 +1085,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         raw_format = "csv"
     reindex_raw = not bool(getattr(args, "no_reindex_raw", False))
-    normalize_at_export = bool(getattr(args, "normalize_at_export", False))
+    # ``normalize_at_export`` already coerced above to avoid divergent values.
     id_cols_value = getattr(args, "id_cols", None)
     if id_cols_value in (None, argparse.SUPPRESS):
         key_columns = ["target_chembl_id"]
@@ -1354,7 +1366,8 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
             family_path=cfg.target.iuphar.family_csv,
             encoding=cfg.io.csv_encoding,
         )
-        output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+        output_candidate = getattr(args, "output_csv", None)
+        output = output_candidate or io.default_output_path(args.input_csv, cfg.io)
         data.map_uniprot_file(
             input_path=source_csv,
             output_path=output,
@@ -1431,6 +1444,7 @@ def fetch_chembl(
     chembl_args = argparse.Namespace(
         input_csv=input_csv,
         final_out=final_out,
+        output_csv=final_out,
         raw_out=raw_out,
         raw_format=raw_format,
         id_cols=list(id_cols) if id_cols is not None else None,
@@ -1452,7 +1466,7 @@ def fetch_chembl(
             cfg.target.chembl.limit = original_limit
         if chunk_size is not None:
             cfg.target.chembl.chunk_size = original_chunk_size
-    normalized_output = _normalized_output_path(output_csv)
+    normalized_output = _normalized_output_path(final_out)
     df = pd.read_csv(
 
         final_out, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
@@ -1962,6 +1976,8 @@ def validate_and_write(
     logger.info("validate_write_start", output=str(output))
 
     key_columns = list(id_cols) if id_cols else ["target_chembl_id"]
+    normalized_output = _normalized_output_path(output)
+    input_rows = len(df)
 
     if raw_out is not None:
         raw_format_value = (raw_format or "csv").lower()
@@ -2001,6 +2017,7 @@ def validate_and_write(
     prepared, missing_required, missing_optional = _prepare_targets_for_schema(
         normalized
     )
+    final_df = prepared
     logger.info("prepare_targets_rows", rows=len(final_df))
 
     drop_reasons: dict[str, set[Any]] = {


### PR DESCRIPTION
## Summary
- ensure the target ChEMBL runner respects the configured raw output, copies the raw dump into the final artefact when normalisation is disabled, and avoids missing-file regressions
- pass the working output path through fetch_chembl so orchestration reads the expected CSV and stabilise ancillary CLI helpers when outputs are suppressed
- initialise validation bookkeeping with deterministic row counters and the derived normalised path before emitting metadata

## Testing
- python scripts/get_data.py --limit 1 *(fails at the assay stage with “ValueError: I/O operation on closed file”, but the document and target stages complete)*

------
https://chatgpt.com/codex/tasks/task_e_68de3bb25a188324873316c9d0fcb33f