### PR TITLE
Fix optional responses dependency and clean target fetch test

### DIFF
--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -20,7 +20,8 @@ from itertools import islice
 import pandas as pd
 import pytest
 import requests
-import responses
+
+responses = pytest.importorskip("responses")
 
 from library import chembl_library as cl
 from library import io as lib_io

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -52,9 +52,8 @@ def test_fetch_chembl(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         normalized = gtd._normalized_output_path(Path(args.output_csv))
         pd.DataFrame({"target_chembl_id": ["C1"], "uniprot_id": ["P1"]}).to_csv(
-ч
-            args.final_out, index=False
-
+            args.final_out,
+            index=False,
         )
         return 0
 


### PR DESCRIPTION
## Summary
- use `pytest.importorskip` to gracefully skip document data tests when the optional `responses` dependency is unavailable
- remove a stray non-ASCII character in `test_fetch_chembl` that caused a syntax error and format the `to_csv` call cleanly

## Testing
- pytest tests/test_get_target_data_fetch.py::test_fetch_chembl -q


------
https://chatgpt.com/codex/tasks/task_e_68de42ea3d8c8324b23d5a424434c75d