### PR TITLE
Normalize integral floats in configuration parsing

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -87,6 +87,20 @@ def _valid_url(url: str) -> bool:
     return bool(parsed.scheme and parsed.netloc)
 
 
+def _coerce_integral_numbers(value: Any) -> Any:
+    """Return *value* with floats that represent integers converted to ``int``."""
+
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else value
+    if isinstance(value, list):
+        return [_coerce_integral_numbers(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_coerce_integral_numbers(item) for item in value)
+    if isinstance(value, dict):
+        return {key: _coerce_integral_numbers(val) for key, val in value.items()}
+    return value
+
+
 class ConfigError(RuntimeError):
     """Raised when configuration loading fails."""
 
@@ -1200,7 +1214,7 @@ def _parse_env_value(env_key: str, raw_value: str) -> Any:
     if raw_value and raw_value.strip() == "":
         return raw_value
     try:
-        return yaml.safe_load(raw_value)
+        value = yaml.safe_load(raw_value)
     except yaml.YAMLError as exc:
         logger.debug(
             "treating %s as plain string due to YAML parse error: %s",
@@ -1208,6 +1222,7 @@ def _parse_env_value(env_key: str, raw_value: str) -> Any:
             exc,
         )
         return raw_value
+    return _coerce_integral_numbers(value)
 
 
 def _normalize_env_errors(
@@ -1349,6 +1364,8 @@ def load_config(
         data, resolved_path = load_yaml_config(path)
     except ConfigLoaderError as exc:
         raise ConfigError(str(exc)) from exc
+
+    data = _coerce_integral_numbers(data)
 
     # Guard against accidentally passing the JSON schema instead of a runtime
     # configuration file. The schema contains the ``$defs`` key at the top

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,6 +81,43 @@ def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert cfg.openalex.rps == 6
 
 
+def test_yaml_integral_float_coercion(tmp_path: Path) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        "sources:\n"
+        "  chembl:\n"
+        "    api:\n"
+        "      timeout_connect: 5.0\n"
+        "      timeout_read: 30.0\n"
+    )
+
+    cfg = load_config(path)
+
+    assert cfg.api.timeout_read == 30
+    assert isinstance(cfg.api.timeout_read, int)
+    assert cfg.api.timeout_connect == 5
+    assert isinstance(cfg.api.timeout_connect, int)
+
+
+def test_env_integral_float_coercion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        "sources:\n"
+        "  chembl:\n"
+        "    api:\n"
+        "      timeout_read: 10\n"
+    )
+
+    monkeypatch.setenv("CHEMBL_DA_TIMEOUT_READ", "30.0")
+
+    cfg = load_config(path)
+
+    assert cfg.api.timeout_read == 30
+    assert isinstance(cfg.api.timeout_read, int)
+
+
 def test_alias_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure shorthand environment variables map to the correct fields."""
 


### PR DESCRIPTION
## Summary
- coerce integral float values in loaded configuration data to integers before validation
- apply the same coercion to environment override values to avoid pydantic serialization warnings
- add regression tests covering YAML and environment overrides with integral floats

## Testing
- pytest tests/test_config.py::test_yaml_integral_float_coercion tests/test_config.py::test_env_integral_float_coercion

------
https://chatgpt.com/codex/tasks/task_e_68de4489ff6083249d934ba153afb490