### PR TITLE
Handle closed logger stream when emitting CLI deprecation warning

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import uuid
 import os
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path, PureWindowsPath
 from typing import Any
@@ -24,6 +25,32 @@ from ..version import require_python_version
 from ..utils.config import DEFAULT_CONFIG_PATH
 
 require_python_version()
+
+
+_DEPRECATED_OUTPUT_OPTION = "--output"
+_DEPRECATED_OUTPUT_REPLACEMENT = "--final-out"
+_DEPRECATED_OUTPUT_MESSAGE = (
+    f"{_DEPRECATED_OUTPUT_OPTION} is deprecated; use {_DEPRECATED_OUTPUT_REPLACEMENT}"
+)
+
+
+def _emit_deprecated_output_warning() -> None:
+    """Log a deprecation warning without failing when the logger stream is closed."""
+
+    try:
+        log.logger.warning(
+            "cli_option_deprecated",
+            option=_DEPRECATED_OUTPUT_OPTION,
+            replacement=_DEPRECATED_OUTPUT_REPLACEMENT,
+        )
+    except ValueError as exc:
+        if "closed file" not in str(exc).lower():
+            raise
+        warnings.warn(
+            _DEPRECATED_OUTPUT_MESSAGE,
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 def create_logger_config(level: str) -> LoggerConfig:
@@ -621,11 +648,7 @@ def prepare_io_paths(
         if final_candidate in (None, argparse.SUPPRESS):
             final_candidate = output_candidate
             setattr(args, "final_out", final_candidate)
-        log.logger.warning(
-            "cli_option_deprecated",
-            option="--output",
-            replacement="--final-out",
-        )
+        _emit_deprecated_output_warning()
 
     raw_format_value = getattr(args, "raw_format", None)
     if raw_format_value in (None, argparse.SUPPRESS):

--- a/tests/test_cli_prepare_io_paths.py
+++ b/tests/test_cli_prepare_io_paths.py
@@ -1,0 +1,48 @@
+"""Tests for :mod:`library.cli.parser.prepare_io_paths`."""
+
+from __future__ import annotations
+
+import argparse
+import warnings
+from io import StringIO
+
+import pytest
+
+from library.cli import prepare_io_paths
+from library.cli import parser as cli_parser
+from library.logging_setup import Logger, LoggerConfig
+
+
+def _build_namespace() -> argparse.Namespace:
+    return argparse.Namespace(
+        base_path=None,
+        input_dir=None,
+        output_dir=None,
+        _deprecated_out=argparse.SUPPRESS,
+        output_csv="output.csv",
+        final_out=None,
+        input_csv="input.csv",
+        raw_format=None,
+        raw_out=None,
+        date=None,
+        force=False,
+        skip_existing=False,
+    )
+
+
+def test_prepare_io_paths_warns_when_logger_stream_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    closed_stream = StringIO()
+    closed_stream.close()
+    closed_logger = Logger(LoggerConfig(stream=closed_stream))
+    monkeypatch.setattr(cli_parser.log, "logger", closed_logger)
+
+    args = _build_namespace()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        prepare_io_paths(args, output_stem="assays")
+
+    assert any(
+        "--final-out" in str(item.message)
+        for item in caught
+    ), "Deprecation warning should fall back to warnings when logger stream is closed"


### PR DESCRIPTION
## Summary
- guard the deprecated --output warning in `prepare_io_paths` so a closed log stream no longer raises a ValueError
- add a regression test that verifies the warning falls back to the warnings module when the logger stream is closed

## Testing
- pytest tests/test_cli_prepare_io_paths.py
- pytest tests/test_get_assay_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de453beb248324a6d43cbf89c470ea