### PR TITLE
Fix bootstrap import when running get_target_data script

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -23,7 +23,18 @@ from typing import Any, cast
 
 from datetime import datetime, timezone
 
-from library.utils.bootstrap import ensure_project_root
+try:
+    from library.utils.bootstrap import ensure_project_root
+except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    import sys
+    from pathlib import Path
+
+    def ensure_project_root() -> None:
+        """Add the repository root to ``sys.path`` when the package is missing."""
+
+        project_root = str(Path(__file__).resolve().parent.parent)
+        if project_root not in sys.path:
+            sys.path.insert(0, project_root)
 
 
 if __package__ in {None, ""}:


### PR DESCRIPTION
## Summary
- add a fallback bootstrap implementation so get_target_data.py can add the project root to sys.path when executed directly

## Testing
- python scripts/get_target_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68de47dfe8ec832494a79ef8b223d238