### PR TITLE
Fix logging reuse and CLI overrides for target pipeline

### DIFF
--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -52,6 +52,7 @@ from .pubchem import (
     _PUBCHEM_CACHE_SCHEMA_VERSION,
     _PUBCHEM_SESSION_LOCK,
     _PUBCHEM_SESSION_SIGNATURE,
+    _merge_pubchem_properties,
     _load_pubchem_cid_cache,
     _prepare_pubchem_caches,
     _prefetch_parents,

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     Iterator,
     Sequence,
+    TypeVar,
 )
 
 import pandas as pd
@@ -51,6 +52,18 @@ from .catalog import (
     run_parent_enrichment,
 )
 from .pubchem import PUBCHEM_COLUMNS, add_pubchem_data, augment_pubchem
+
+_T = TypeVar("_T")
+
+
+def _resolve_override(name: str, default: _T) -> _T:
+    """Return patched attribute ``name`` from the package when available."""
+
+    module = sys.modules.get(__package__)
+    if module is None:
+        return default
+    override = getattr(module, name, None)
+    return override if override is not None else default
 
 _FETCH_ERROR_SAMPLE_SIZE = 10
 _MISSING_IDENTIFIER_LOG_SAMPLE_SIZE = 10
@@ -426,6 +439,19 @@ def run_testitem_pipeline(
     pubchem_api_cfg = _prepare_pubchem_api_cfg(cfg, api_cfg)
     pc.init_session(pubchem_api_cfg, cfg.retry)
 
+    read_ids_fn = _resolve_override("read_input_ids", read_input_ids)
+    fetch_fn = _resolve_override("fetch_testitems", fetch_testitems)
+    prepare_fn = _resolve_override(
+        "prepare_parent_enrichment", prepare_parent_enrichment
+    )
+    parent_run_fn = _resolve_override("run_parent_enrichment", run_parent_enrichment)
+    augment_fn = _resolve_override("augment_pubchem", augment_pubchem)
+    enrichment_fn = _resolve_override(
+        "apply_testitem_enrichment", apply_testitem_enrichment
+    )
+    finalize_fn = _resolve_override("finalize_output", finalize_output)
+    client_factory = _resolve_override("ChemblClient", ChemblClient)
+
     requested_ids: tuple[str, ...] = ()
     missing_ids: list[str] = []
     parent_stats = ParentLookupStats(
@@ -440,8 +466,8 @@ def run_testitem_pipeline(
     output_csv = Path(options.output_csv) if options.output_csv is not None else None
     offset = options.offset if options.offset is not None else cfg.testitem.offset
 
-    with ChemblClient(api_cfg, cfg.retry, cfg.chembl) as client:
-        read_status, read_result = read_input_ids(
+    with client_factory(api_cfg, cfg.retry, cfg.chembl) as client:
+        read_status, read_result = read_ids_fn(
             input_csv,
             column=cfg.testitem.column,
             io_cfg=cfg.io,
@@ -451,7 +477,7 @@ def run_testitem_pipeline(
         if read_status != 0 or read_result is None:
             return read_status
 
-        fetch_status, chunk_iter, requested_ids = fetch_testitems(
+        fetch_status, chunk_iter, requested_ids = fetch_fn(
             read_result.ids_iter,
             api_cfg=api_cfg,
             batch_size=cfg.testitem.batch_size,
@@ -502,7 +528,7 @@ def run_testitem_pipeline(
             try:
                 for chunk in chunk_iter:
                     rows_counter += len(chunk)
-                    prep_status, prep = prepare_parent_enrichment(
+                    prep_status, prep = prepare_fn(
                         chunk,
                         catalog_cfg=cfg.molecule_catalog,
                         io_cfg=cfg.io,
@@ -514,7 +540,7 @@ def run_testitem_pipeline(
                     if prep_status != 0 or prep is None:
                         raise TestitemPipelineStageError(prep_status)
 
-                    parent_status, parent_result = run_parent_enrichment(
+                    parent_status, parent_result = parent_run_fn(
                         prep,
                         client=client,
                         api_cfg=api_cfg,
@@ -529,7 +555,7 @@ def run_testitem_pipeline(
                         parent_stats_holder["value"], parent_result.parent_stats
                     )
 
-                    current = augment_pubchem(
+                    current = augment_fn(
                         current,
                         pubchem_cfg=cfg.pubchem,
                         api_cfg=pubchem_api_cfg,
@@ -540,7 +566,7 @@ def run_testitem_pipeline(
                         request_limit=cfg.testitem.request_limit,
                     )
 
-                    enrichment_status, enriched_df = apply_testitem_enrichment(
+                    enrichment_status, enriched_df = enrichment_fn(
                         current,
                         enrichment_cfg=cfg.testitem_molecule_enrichment,
                         io_cfg=cfg.io,
@@ -584,7 +610,7 @@ def run_testitem_pipeline(
         )
 
         try:
-            exit_code = finalize_output(
+            exit_code = finalize_fn(
                 _processed_chunks(),
                 cfg=cfg,
                 output=output_path,

--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -136,13 +136,6 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         default=None,
         help="Destination CSV aligned to TargetsSchema",
     )
-    parser.add_argument(
-        "--out",
-        dest="final_out",
-        type=path_argument,
-        default=argparse.SUPPRESS,
-        help=argparse.SUPPRESS,
-    )
     return parser, log_cfg
 
 
@@ -371,6 +364,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     setattr(args, "raw_out", resolved_raw)
     final_candidate = getattr(args, "final_out", None)
+    legacy_final = getattr(args, "_deprecated_out", None)
+    if legacy_final not in (None, argparse.SUPPRESS):
+        final_candidate = legacy_final
     if final_candidate in (None, argparse.SUPPRESS):
         final_candidate = getattr(args, "output_csv", None)
     resolved_final = _resolve_optional_output(

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -956,10 +956,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 1
 
+    column_name = getattr(args, "column", cfg.target.chembl.column)
     try:
-        ids_iter = io.read_ids(
-            args.input_csv, column=cfg.target.chembl.column, cfg=cfg.io
-        )
+        ids_iter = io.read_ids(args.input_csv, column=column_name, cfg=cfg.io)
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
             "read_fail",
@@ -1005,29 +1004,34 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     raw_chunks: list[pd.DataFrame] = []
     parsed_chunks: list[pd.DataFrame] = []
 
-    if limited_ids:
-        try:
-            with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
-                for _, raw_chunk, parsed_chunk in cl.iter_target_batches(
-                    limited_ids,
-                    cfg=cfg.api,
-                    client=client,
-                    mapping_cfg=cfg.uniprot_mapping,
-                    chunk_size=cfg.target.chembl.chunk_size,
-                    timeout=cfg.target.chembl.timeout,
-                ):
-                    if not raw_chunk.empty:
-                        raw_chunks.append(raw_chunk)
-                    if not parsed_chunk.empty:
-                        parsed_chunks.append(parsed_chunk)
-        except (requests.RequestException, ValueError) as exc:
-            logger.error(
-                "chembl_fetch_failed",
-                error=str(exc),
+    try:
+        with ChemblClient(cfg.api, cfg.retry, cfg.chembl) as client:
+            if not limited_ids:
+                logger.error(
+                    "chembl_no_identifiers",
+                    path=str(args.input_csv),
+                )
+                return 1
+            for _, raw_chunk, parsed_chunk in cl.iter_target_batches(
+                limited_ids,
+                cfg=cfg.api,
+                client=client,
+                mapping_cfg=cfg.uniprot_mapping,
                 chunk_size=cfg.target.chembl.chunk_size,
                 timeout=cfg.target.chembl.timeout,
-            )
-            return 1
+            ):
+                if not raw_chunk.empty:
+                    raw_chunks.append(raw_chunk)
+                if not parsed_chunk.empty:
+                    parsed_chunks.append(parsed_chunk)
+    except (requests.RequestException, ValueError) as exc:
+        logger.error(
+            "chembl_fetch_failed",
+            error=str(exc),
+            chunk_size=cfg.target.chembl.chunk_size,
+            timeout=cfg.target.chembl.timeout,
+        )
+        return 1
 
     raw_df = (
         pd.concat(raw_chunks, ignore_index=True) if raw_chunks else pd.DataFrame()
@@ -2338,7 +2342,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     SystemExit
         Raised when invalid command-line options are provided to the parser.
     """
-    parser, log_cfg = build_parser()
+    parser, base_log_cfg = build_parser()
     args = parser.parse_args(argv)
     prepare_io_paths(
         args,
@@ -2353,83 +2357,91 @@ def main(argv: Sequence[str] | None = None) -> int:
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"get_target_data_{date_value}.log"
     with log_path.open("a", encoding="utf-8") as log_stream:
-        log_cfg.stream = log_stream
-        configure_logger(log_cfg)
-
-        limit_value = getattr(args, "limit", None)
-        if limit_value == 0:
-            logger.info("pipeline_skip_limit", limit=limit_value)
-            return 0
-        subparser_map = getattr(parser, "subparsers_map", {})
-        subparser = subparser_map.get(args.command, parser)
-        if limit_value is not None and limit_value < 0:
-            subparser.error("--limit must be zero or a positive integer")
-        offset_value = getattr(args, "offset", 0)
-        if offset_value < 0:
-            subparser.error("--offset must be zero or a positive integer")
-        mapping: dict[str, str] = {}
-        if args.command == "uniprot":
-            mapping = {
-                "column": "target.uniprot.column",
-                "data_dir": "target.uniprot.data_dir",
-                "limit": "target.uniprot.limit",
-            }
-        elif args.command == "chembl":
-            mapping = {
-                "column": "target.chembl.column",
-                "chunk_size": "target.chembl.chunk_size",
-                "timeout": "target.chembl.timeout",
-                "limit": "target.chembl.limit",
-            }
-        elif args.command == "iuphar":
-            mapping = {
-                "target_csv": "target.iuphar.target_csv",
-                "family_csv": "target.iuphar.family_csv",
-                "limit": "target.iuphar.limit",
-            }
-        elif args.command == "all":
-            mapping = {
-                "timeout": "target.all.timeout",
-                "data_dir": "target.all.data_dir",
-                "target_csv": "target.all.target_csv",
-                "family_csv": "target.all.family_csv",
-                "uniprot_column": "target.all.uniprot_column",
-                "chembl_out": "target.all.chembl_out",
-                "uniprot_out": "target.all.uniprot_out",
-                "iuphar_out": "target.all.iuphar_out",
-                "limit": "target.all.limit",
-            }
-        args_dict = vars(args).copy()
-        output_candidate = args_dict.get("output_csv")
-        if output_candidate in (
-            None,
-            argparse.SUPPRESS,
-        ):
-            final_value = args_dict.get("final_out")
-            if final_value in (None, argparse.SUPPRESS):
-                date_token = args_dict.get(
-                    "date", datetime.now(timezone.utc).strftime("%Y%m%d")
-                )
-                inferred = Path(args_dict["input_csv"]).with_name(
-                    f"output.{DEFAULT_OUTPUT_STEM}_{date_token}.csv"
-                )
-                args_dict["final_out"] = inferred
-                args_dict["output_csv"] = inferred
-            else:
-                candidate = Path(final_value)
-                args_dict["final_out"] = candidate
-                args_dict["output_csv"] = candidate
-        else:
-            args_dict["output_csv"] = Path(output_candidate)
-        exit_code = run_cli_command(
-            args=argparse.Namespace(**args_dict),
-            parser=subparser,
-            base_parser=parser,
-            log_cfg=log_cfg,
-            mapping=mapping,
-            run=run,
-            logger=logger,
+        file_log_cfg = LoggerConfig(
+            level=base_log_cfg.level,
+            run_id=base_log_cfg.run_id,
+            stream=log_stream,
         )
+        configure_logger(file_log_cfg)
+        try:
+            limit_value = getattr(args, "limit", None)
+            if limit_value == 0:
+                logger.info("pipeline_skip_limit", limit=limit_value)
+                return 0
+            subparser_map = getattr(parser, "subparsers_map", {})
+            subparser = subparser_map.get(args.command, parser)
+            if limit_value is not None and limit_value < 0:
+                subparser.error("--limit must be zero or a positive integer")
+            offset_value = getattr(args, "offset", 0)
+            if offset_value < 0:
+                subparser.error("--offset must be zero or a positive integer")
+            mapping: dict[str, str] = {}
+            if args.command == "uniprot":
+                mapping = {
+                    "column": "target.uniprot.column",
+                    "data_dir": "target.uniprot.data_dir",
+                    "limit": "target.uniprot.limit",
+                }
+            elif args.command == "chembl":
+                mapping = {
+                    "column": "target.chembl.column",
+                    "chunk_size": "target.chembl.chunk_size",
+                    "timeout": "target.chembl.timeout",
+                    "limit": "target.chembl.limit",
+                }
+            elif args.command == "iuphar":
+                mapping = {
+                    "target_csv": "target.iuphar.target_csv",
+                    "family_csv": "target.iuphar.family_csv",
+                    "limit": "target.iuphar.limit",
+                }
+            elif args.command == "all":
+                mapping = {
+                    "timeout": "target.all.timeout",
+                    "data_dir": "target.all.data_dir",
+                    "target_csv": "target.all.target_csv",
+                    "family_csv": "target.all.family_csv",
+                    "uniprot_column": "target.all.uniprot_column",
+                    "chembl_out": "target.all.chembl_out",
+                    "uniprot_out": "target.all.uniprot_out",
+                    "iuphar_out": "target.all.iuphar_out",
+                    "limit": "target.all.limit",
+                }
+            args_dict = vars(args).copy()
+            output_candidate = args_dict.get("output_csv")
+            if output_candidate in (
+                None,
+                argparse.SUPPRESS,
+            ):
+                final_value = args_dict.get("final_out")
+                if final_value in (None, argparse.SUPPRESS):
+                    date_token = args_dict.get(
+                        "date", datetime.now(timezone.utc).strftime("%Y%m%d")
+                    )
+                    inferred = Path(args_dict["input_csv"]).with_name(
+                        f"output.{DEFAULT_OUTPUT_STEM}_{date_token}.csv"
+                    )
+                    args_dict["final_out"] = inferred
+                    args_dict["output_csv"] = inferred
+                else:
+                    candidate = Path(final_value)
+                    args_dict["final_out"] = candidate
+                    args_dict["output_csv"] = candidate
+            else:
+                args_dict["output_csv"] = Path(output_candidate)
+            exit_code = run_cli_command(
+                args=argparse.Namespace(**args_dict),
+                parser=subparser,
+                base_parser=parser,
+                log_cfg=file_log_cfg,
+                mapping=mapping,
+                run=run,
+                logger=logger,
+            )
+        finally:
+            configure_logger(
+                LoggerConfig(level=base_log_cfg.level, run_id=base_log_cfg.run_id)
+            )
 
     return exit_code
 


### PR DESCRIPTION
## Summary
- expose `_merge_pubchem_properties` from the test item pipeline package so downstream modules can patch it reliably
- allow the test item pipeline runner to respect monkeypatched helpers and clients when orchestrating parent enrichment and PubChem augmentation
- stabilise target CLI logging/column overrides, handling empty input identifiers, and keep the legacy `--out` option working without argparse conflicts

## Testing
- pytest tests/test_get_testitem_data.py::test_read_input_ids_missing_file
- pytest tests/test_pipeline_targets_cli.py::test_backward_compatibility_out_alias
- pytest tests/test_get_testitem_data.py::test_merge_pubchem_properties_preserves_existing_values
- pytest tests/test_testitem_pipeline_threadsafe.py::test_run_pipeline_streams_chunks
- pytest tests/test_init_session_retry.py::test_init_session_uses_cfg_retry[scripts.get_target_data-run_chembl]


------
https://chatgpt.com/codex/tasks/task_e_68de45eb49808324b0d75d88bfdd1f49