### PR TITLE
Allow fractional API timeouts

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -334,16 +334,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 30,
+          "default": 30.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -583,16 +583,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 30,
+          "default": 30.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1045,16 +1045,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 30,
+          "default": 30.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "rps": {
           "default": 4,
@@ -1109,16 +1109,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 30,
+          "default": 30.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "retries": {
           "default": 3,
@@ -1168,16 +1168,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 60,
+          "default": 60.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_seconds": {
           "default": 30.0,
@@ -1316,16 +1316,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 10,
+          "default": 10.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "retries": {
           "default": 2,
@@ -1466,16 +1466,16 @@
           "type": "string"
         },
         "timeout_connect": {
-          "default": 5,
+          "default": 5.0,
           "minimum": 1,
           "title": "Timeout Connect",
-          "type": "integer"
+          "type": "number"
         },
         "timeout_read": {
-          "default": 10,
+          "default": 10.0,
           "minimum": 1,
           "title": "Timeout Read",
-          "type": "integer"
+          "type": "number"
         },
         "retries": {
           "default": 2,

--- a/library/config.py
+++ b/library/config.py
@@ -179,8 +179,8 @@ class ApiCfg(_BaseModel):
     """Settings for ChEMBL API access."""
 
     chembl_base: str = "https://www.ebi.ac.uk/chembl/api/data"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(30, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(30.0, ge=1)
     retries: int = Field(3, ge=0)
     backoff_factor: float = Field(0.5, ge=0)
     rps: int = Field(5, ge=1)
@@ -239,8 +239,8 @@ class MoleculeCatalogCfg(_BaseModel):
 
 class OpenAlexCfg(_BaseModel):
     base: str = "https://api.openalex.org"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(30, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(30.0, ge=1)
     retries: int = Field(3, ge=0)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
@@ -261,8 +261,8 @@ class OpenAlexCfg(_BaseModel):
 
 class CrossRefCfg(_BaseModel):
     base: str = "https://api.crossref.org"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(30, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(30.0, ge=1)
     retries: int = Field(3, ge=0)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
@@ -283,8 +283,8 @@ class CrossRefCfg(_BaseModel):
 
 class UniprotCfg(_BaseModel):
     base: str = "https://rest.uniprot.org"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(30, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(30.0, ge=1)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
     delay: float = Field(0.25, ge=0)
@@ -330,8 +330,8 @@ class UniprotMappingCfg(_BaseModel):
 
 class IupharCfg(_BaseModel):
     base: str = "https://www.guidetopharmacology.org/services"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(30, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(30.0, ge=1)
     rps: int = Field(4, ge=1)
     burst: int = Field(5, ge=1)
 
@@ -355,8 +355,8 @@ class PubChemCfg(_BaseModel):
         "chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)",
         description="Custom User-Agent for PubChem requests including contact details",
     )
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(60, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(60.0, ge=1)
     timeout_seconds: float = Field(
         30.0,
         ge=0,
@@ -449,8 +449,8 @@ class PubChemCfg(_BaseModel):
 
 class PubMedCfg(_BaseModel):
     base: str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(10, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(10.0, ge=1)
     retries: int = Field(2, ge=0)
     rps: int | None = Field(default=None, ge=1)
     burst: int | None = Field(default=None, ge=1)
@@ -465,8 +465,8 @@ class PubMedCfg(_BaseModel):
 
 class SemanticScholarCfg(_BaseModel):
     base: str = "https://api.semanticscholar.org/graph/v1"
-    timeout_connect: int = Field(5, ge=1)
-    timeout_read: int = Field(10, ge=1)
+    timeout_connect: float = Field(5.0, ge=1)
+    timeout_read: float = Field(10.0, ge=1)
     retries: int = Field(2, ge=0)
     rps: int | None = Field(default=None, ge=1)
     burst: int | None = Field(default=None, ge=1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,9 +94,9 @@ def test_yaml_integral_float_coercion(tmp_path: Path) -> None:
     cfg = load_config(path)
 
     assert cfg.api.timeout_read == 30
-    assert isinstance(cfg.api.timeout_read, int)
+    assert isinstance(cfg.api.timeout_read, float)
     assert cfg.api.timeout_connect == 5
-    assert isinstance(cfg.api.timeout_connect, int)
+    assert isinstance(cfg.api.timeout_connect, float)
 
 
 def test_env_integral_float_coercion(
@@ -115,7 +115,7 @@ def test_env_integral_float_coercion(
     cfg = load_config(path)
 
     assert cfg.api.timeout_read == 30
-    assert isinstance(cfg.api.timeout_read, int)
+    assert isinstance(cfg.api.timeout_read, float)
 
 
 def test_alias_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- allow all HTTP timeout settings to be stored as floats instead of integers
- update the configuration schema defaults to reflect the float timeouts and adjust tests

## Testing
- pytest tests/test_config.py::test_yaml_integral_float_coercion tests/test_config.py::test_env_integral_float_coercion

------
https://chatgpt.com/codex/tasks/task_e_68de49a2a6a48324ac53b4bd51217392