### PR TITLE
Fix target pipeline to retain UniProt identifiers

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -387,10 +387,19 @@ def _prepare_targets_for_schema(
         columns that were injected.
     """
 
-    missing_required = TARGETS_REQUIRED_COLUMNS - set(df.columns)
+    columns_present = set(df.columns)
+    missing_required = TARGETS_REQUIRED_COLUMNS - columns_present
     missing_optional = {
-        column for column in TARGETS_OPTIONAL_COLUMNS if column not in df.columns
+        column for column in TARGETS_OPTIONAL_COLUMNS if column not in columns_present
     }
+
+    extra_preserve: dict[str, pd.Series] = {}
+
+    if "uniprot_id_primary" not in df.columns and "uniprot_id" in df.columns:
+        extra_preserve["uniprot_id_primary"] = df["uniprot_id"].astype(object)
+
+    if "mapping_uniprot_id" in df.columns:
+        extra_preserve["mapping_uniprot_id"] = df["mapping_uniprot_id"].astype(object)
 
     if missing_optional:
         fill_values = {
@@ -405,7 +414,16 @@ def _prepare_targets_for_schema(
     else:
         prepared = df.copy()
 
-    prepared = prepared.reindex(columns=TARGETS_COLUMN_ORDER)
+    reindex_columns = TARGETS_COLUMN_ORDER
+    if extra_preserve:
+        reindex_columns = reindex_columns + [column for column in extra_preserve if column not in TARGETS_COLUMN_ORDER]
+
+    prepared = prepared.reindex(columns=reindex_columns)
+
+    if extra_preserve:
+        for column, series in extra_preserve.items():
+            prepared[column] = series.reindex(prepared.index)
+
     for column in TARGETS_OBJECT_COLUMNS & set(prepared.columns):
         prepared[column] = prepared[column].astype(object)
     return prepared, missing_required, missing_optional
@@ -1472,7 +1490,7 @@ def fetch_chembl(
     id_cols: Sequence[str] | None = None,
     chunk_size: int | None = None,
     offset: int = 0,
-    normalize_at_export: bool = False,
+    normalize_at_export: bool = True,
     no_reindex_raw: bool = False,
 ) -> pd.DataFrame:
     """Fetch target information from ChEMBL.
@@ -1495,7 +1513,9 @@ def fetch_chembl(
     Returns
     -------
     pandas.DataFrame
-        Retrieved ChEMBL data loaded from ``final_out``.
+        Retrieved ChEMBL data loaded from ``final_out``. The export is
+        normalised by default to ensure that downstream steps receive the
+        canonical schema (including columns such as ``uniprot_id``).
 
     Raises
     ------

--- a/tests/test_get_target_data_all.py
+++ b/tests/test_get_target_data_all.py
@@ -103,6 +103,7 @@ def test_run_all_uses_local_inputs(
     recorded: dict[str, int] = {}
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        assert args.normalize_at_export is True
         recorded["chunk_size"] = cfg.target.chembl.chunk_size
         df = pd.read_csv(chembl_data)
         df["type"] = "Legacy"

--- a/tests/test_get_target_data_fetch.py
+++ b/tests/test_get_target_data_fetch.py
@@ -50,6 +50,7 @@ def test_fetch_chembl(monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config) -> 
     inp = tmp_path / "in.csv"
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        assert args.normalize_at_export is True
         normalized = gtd._normalized_output_path(Path(args.output_csv))
         pd.DataFrame({"target_chembl_id": ["C1"], "uniprot_id": ["P1"]}).to_csv(
             args.final_out,
@@ -72,6 +73,7 @@ def test_fetch_chembl_custom_chunk_size(
     original_chunk = cfg.target.chembl.chunk_size
 
     def fake_run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+        assert args.normalize_at_export is True
         recorded["chunk_size"] = cfg.target.chembl.chunk_size
 
         pd.DataFrame({"target_chembl_id": ["C1"]}).to_csv(
@@ -584,7 +586,8 @@ def test_run_all_preserves_reaction_ec_numbers(
     exit_code = gtd.run_all(cfg, args)
     assert exit_code == 0
 
-    result = pd.read_csv(output_csv, dtype=str)
+    normalized_output = gtd._normalized_output_path(output_csv)
+    result = pd.read_csv(normalized_output, dtype=str)
     assert result.loc[0, "reaction_ec_numbers"] == "2.2.2.2|4.4.4.4"
     assert result.loc[0, "target_type"] == "Multicellular organism"
     assert result.loc[0, "protein_class_pred_L1"] == "ClassA"


### PR DESCRIPTION
## Summary
- ensure the ChEMBL fetch step exports the normalised dataset so UniProt identifiers are preserved
- keep the original `uniprot_id` and `mapping_uniprot_id` values when aligning to the Targets schema
- update tests to cover the new behaviour and read the normalised outputs

## Testing
- `pytest tests/test_get_target_data_fetch.py::test_fetch_chembl tests/test_get_target_data_fetch.py::test_fetch_chembl_custom_chunk_size tests/test_get_target_data_fetch.py::test_run_all_preserves_reaction_ec_numbers`


------
https://chatgpt.com/codex/tasks/task_e_68de4f0b0ad883248736989216ddf55c