### PR TITLE
Stream target pipeline CLI outputs to limit memory usage

### DIFF
--- a/library/pipeline_targets.py
+++ b/library/pipeline_targets.py
@@ -12,7 +12,9 @@ import pandas as pd
 from .log import logger
 from .pipeline_metadata import add_pipeline_metadata
 
-OptionalFetcher = Callable[..., pd.DataFrame]
+FrameLike = pd.DataFrame | Iterable[pd.DataFrame]
+
+OptionalFetcher = Callable[..., FrameLike]
 
 _OPTIONAL_KEYWORDS = frozenset({"batch_size", "chunk_size"})
 
@@ -87,14 +89,14 @@ def _call_fetcher(
 
 
 @dataclass(frozen=True)
-class PipelineResult(Mapping[str, pd.DataFrame | None]):
+class PipelineResult(Mapping[str, FrameLike | None]):
     """Container holding intermediate tables produced by the pipeline."""
 
-    chembl: pd.DataFrame
-    uniprot: pd.DataFrame | None = None
-    isoforms: pd.DataFrame | None = None
-    orthologs: pd.DataFrame | None = None
-    iuphar: pd.DataFrame | None = None
+    chembl: FrameLike
+    uniprot: FrameLike | None = None
+    isoforms: FrameLike | None = None
+    orthologs: FrameLike | None = None
+    iuphar: FrameLike | None = None
 
     def __iter__(self) -> Iterator[str]:
         yield from ("chembl", "uniprot", "isoforms", "orthologs", "iuphar")
@@ -102,16 +104,48 @@ class PipelineResult(Mapping[str, pd.DataFrame | None]):
     def __len__(self) -> int:
         return 5
 
-    def __getitem__(self, key: str) -> pd.DataFrame | None:
+    def __getitem__(self, key: str) -> FrameLike | None:
         try:
             return getattr(self, key)
         except AttributeError as exc:
             raise KeyError(key) from exc
 
-    def as_dict(self) -> dict[str, pd.DataFrame | None]:
+    def as_dict(self) -> dict[str, FrameLike | None]:
         """Return pipeline outputs as a plain dictionary."""
 
         return {name: getattr(self, name) for name in self}
+
+
+def _iter_frames(data: FrameLike) -> Iterator[pd.DataFrame]:
+    """Yield dataframes from ``data`` regardless of its concrete type."""
+
+    if isinstance(data, pd.DataFrame):
+        yield data
+        return
+    yield from data
+
+
+def _metadata_stream(frames: Iterable[pd.DataFrame]) -> Iterator[pd.DataFrame]:
+    """Attach pipeline metadata to each frame in ``frames`` lazily."""
+
+    iterator = iter(frames)
+    yielded = False
+    for frame in iterator:
+        yielded = True
+        yield add_pipeline_metadata(frame)
+    if not yielded:
+        yield add_pipeline_metadata(pd.DataFrame())
+
+
+def _materialize_frames(frames: Iterable[pd.DataFrame]) -> pd.DataFrame:
+    """Return a concatenated dataframe from ``frames`` preserving order."""
+
+    collected = list(frames)
+    if not collected:
+        return pd.DataFrame()
+    if len(collected) == 1:
+        return collected[0]
+    return pd.concat(collected, ignore_index=True)
 
 
 def run_pipeline(
@@ -147,23 +181,54 @@ def run_pipeline(
 
     chembl_args = tuple(chembl_args or ())
     iterator = chunk_iterator()
-    chembl_df = _call_fetcher(
+    chembl_result = _call_fetcher(
         chembl_fetcher,
         *chembl_args,
         iterator,
         chembl_cfg,
         **chembl_kwargs,
     )
-    chembl_df = add_pipeline_metadata(chembl_df)
 
-    uniprot_df: pd.DataFrame | None = None
+    requires_materialised = any(
+        fetcher is not None
+        for fetcher in (
+            uniprot_fetcher,
+            isoform_fetcher,
+            ortholog_fetcher,
+            iuphar_fetcher,
+        )
+    )
+
+    if isinstance(chembl_result, pd.DataFrame):
+        chembl_output: FrameLike = add_pipeline_metadata(chembl_result)
+    else:
+        chembl_stream = _iter_frames(chembl_result)
+        if requires_materialised:
+            materialised = _materialize_frames(chembl_stream)
+            chembl_output = add_pipeline_metadata(materialised)
+        else:
+            chembl_output = _metadata_stream(chembl_stream)
+
+    materialised_chembl: pd.DataFrame | None
+    if isinstance(chembl_output, pd.DataFrame):
+        materialised_chembl = chembl_output
+    elif requires_materialised:
+        materialised_chembl = _materialize_frames(chembl_output)
+        materialised_chembl = add_pipeline_metadata(materialised_chembl)
+        chembl_output = materialised_chembl
+    else:
+        materialised_chembl = None
+
+    uniprot_df: FrameLike | None = None
     if uniprot_fetcher is not None:
+        if materialised_chembl is None:
+            raise RuntimeError("uniprot_fetcher requires materialised chembl data")
         uniprot_kwargs = dict(uniprot_kwargs or {})
         if batch_size is not None:
             uniprot_kwargs.setdefault("batch_size", batch_size)
         uniprot_args = tuple(uniprot_args or ())
         uniprot_positional: list[Any] = list(uniprot_args)
-        uniprot_positional.append(chembl_df)
+        uniprot_positional.append(materialised_chembl)
         if uniprot_cfg is not None:
             uniprot_positional.append(uniprot_cfg)
         uniprot_df = _call_fetcher(
@@ -171,16 +236,19 @@ def run_pipeline(
             *uniprot_positional,
             **uniprot_kwargs,
         )
-        uniprot_df = add_pipeline_metadata(uniprot_df)
+        if isinstance(uniprot_df, pd.DataFrame):
+            uniprot_df = add_pipeline_metadata(uniprot_df)
 
-    isoform_df: pd.DataFrame | None = None
+    isoform_df: FrameLike | None = None
     if isoform_fetcher is not None:
+        if materialised_chembl is None:
+            raise RuntimeError("isoform_fetcher requires materialised chembl data")
         isoform_kwargs = dict(isoform_kwargs or {})
         if batch_size is not None:
             isoform_kwargs.setdefault("batch_size", batch_size)
         isoform_args = tuple(isoform_args or ())
         isoform_positional: list[Any] = list(isoform_args)
-        isoform_positional.append(chembl_df)
+        isoform_positional.append(materialised_chembl)
         if isoform_cfg is not None:
             isoform_positional.append(isoform_cfg)
         isoform_df = _call_fetcher(
@@ -188,16 +256,19 @@ def run_pipeline(
             *isoform_positional,
             **isoform_kwargs,
         )
-        isoform_df = add_pipeline_metadata(isoform_df)
+        if isinstance(isoform_df, pd.DataFrame):
+            isoform_df = add_pipeline_metadata(isoform_df)
 
-    ortholog_df: pd.DataFrame | None = None
+    ortholog_df: FrameLike | None = None
     if ortholog_fetcher is not None:
+        if materialised_chembl is None:
+            raise RuntimeError("ortholog_fetcher requires materialised chembl data")
         ortholog_kwargs = dict(ortholog_kwargs or {})
         if batch_size is not None:
             ortholog_kwargs.setdefault("batch_size", batch_size)
         ortholog_args = tuple(ortholog_args or ())
         ortholog_positional: list[Any] = list(ortholog_args)
-        ortholog_positional.append(chembl_df)
+        ortholog_positional.append(materialised_chembl)
         if ortholog_cfg is not None:
             ortholog_positional.append(ortholog_cfg)
         ortholog_df = _call_fetcher(
@@ -205,16 +276,19 @@ def run_pipeline(
             *ortholog_positional,
             **ortholog_kwargs,
         )
-        ortholog_df = add_pipeline_metadata(ortholog_df)
+        if isinstance(ortholog_df, pd.DataFrame):
+            ortholog_df = add_pipeline_metadata(ortholog_df)
 
-    iuphar_df: pd.DataFrame | None = None
+    iuphar_df: FrameLike | None = None
     if iuphar_fetcher is not None:
+        if materialised_chembl is None:
+            raise RuntimeError("iuphar_fetcher requires materialised chembl data")
         iuphar_kwargs = dict(iuphar_kwargs or {})
         if batch_size is not None:
             iuphar_kwargs.setdefault("batch_size", batch_size)
         iuphar_args = tuple(iuphar_args or ())
         iuphar_positional: list[Any] = list(iuphar_args)
-        iuphar_positional.append(chembl_df)
+        iuphar_positional.append(materialised_chembl)
         if iuphar_cfg is not None:
             iuphar_positional.append(iuphar_cfg)
         iuphar_df = _call_fetcher(
@@ -222,10 +296,11 @@ def run_pipeline(
             *iuphar_positional,
             **iuphar_kwargs,
         )
-        iuphar_df = add_pipeline_metadata(iuphar_df)
+        if isinstance(iuphar_df, pd.DataFrame):
+            iuphar_df = add_pipeline_metadata(iuphar_df)
 
     return PipelineResult(
-        chembl=chembl_df,
+        chembl=chembl_output,
         uniprot=uniprot_df,
         isoforms=isoform_df,
         orthologs=ortholog_df,

--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Iterable, Iterator, Sequence
-from itertools import chain, islice
+from itertools import islice
 from pathlib import Path
 
 if __package__ in {None, ""}:
@@ -91,7 +91,9 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
 
     root, _shared, log_cfg = build_root_parser()
     parser = argparse.ArgumentParser(
-        description="Run the target acquisition pipeline", parents=[root]
+        description="Run the target acquisition pipeline",
+        parents=[root],
+        conflict_handler="resolve",
     )
     parser.add_argument(
         "--column",
@@ -172,6 +174,15 @@ def _chembl_frame_stream(chunks: Iterator[Iterable[str]]) -> Iterator[pd.DataFra
         yield frame
 
 
+def _frame_iterator(data: pd.DataFrame | Iterable[pd.DataFrame]) -> Iterator[pd.DataFrame]:
+    """Return an iterator over ``data`` irrespective of its concrete type."""
+
+    if isinstance(data, pd.DataFrame):
+        yield data
+        return
+    yield from data
+
+
 _PIPELINE_METADATA_COLUMNS = tuple(pipeline_metadata().keys())
 _PLACEHOLDER = "-"
 
@@ -208,8 +219,64 @@ def _raw_dump(
             encoding=encoding,
             mode="a",
             header=False,
-        )
+    )
     return path
+
+
+class _RawStreamWriter:
+    """Incrementally persist raw output chunks to disk."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        cfg: Config,
+        sep: str | None = None,
+        encoding: str | None = None,
+    ) -> None:
+        self.path = path
+        self.sep = sep or cfg.io.csv_sep
+        self.encoding = encoding or cfg.io.csv_encoding
+        self._columns: list[str] | None = None
+        self._written = False
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, chunk: pd.DataFrame) -> None:
+        if self._columns is None:
+            self._columns = list(chunk.columns)
+            chunk.to_csv(
+                self.path,
+                index=False,
+                sep=self.sep,
+                encoding=self.encoding,
+            )
+            self._written = True
+            return
+        if self._columns:
+            chunk = chunk.reindex(columns=self._columns)
+        else:
+            self._columns = list(chunk.columns)
+        chunk.to_csv(
+            self.path,
+            index=False,
+            sep=self.sep,
+            encoding=self.encoding,
+            mode="a",
+            header=False,
+        )
+        self._written = True
+
+    def close(self) -> Path:
+        if not self._written:
+            empty = pd.DataFrame(columns=self._columns or None)
+            empty.to_csv(
+                self.path,
+                index=False,
+                sep=self.sep,
+                encoding=self.encoding,
+            )
+            self._written = True
+        return self.path
 
 
 def _replace_id_placeholders(
@@ -245,7 +312,7 @@ def _prepare_final_frame(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _validate_and_write(
-    df: pd.DataFrame,
+    frames: pd.DataFrame | Iterable[pd.DataFrame],
     path: Path,
     *,
     cfg: Config,
@@ -254,11 +321,25 @@ def _validate_and_write(
 ) -> Path:
     """Validate ``df`` against :data:`TargetsSchema` and serialise to CSV."""
 
-    prepared = _prepare_final_frame(df)
-    validated = TargetsSchema.validate(prepared, lazy=True)
+    def _validated_stream() -> Iterator[pd.DataFrame]:
+        if not isinstance(frames, pd.DataFrame):
+            iterator = iter(frames)
+            yielded = False
+            for chunk in iterator:
+                yielded = True
+                prepared = _prepare_final_frame(chunk)
+                yield TargetsSchema.validate(prepared, lazy=True)
+            if not yielded:
+                prepared = _prepare_final_frame(pd.DataFrame())
+                yield TargetsSchema.validate(prepared, lazy=True)
+            return
+
+        prepared = _prepare_final_frame(frames)
+        yield TargetsSchema.validate(prepared, lazy=True)
+
     path.parent.mkdir(parents=True, exist_ok=True)
     write_csv(
-        validated,
+        _validated_stream(),
         path,
         cfg=cfg,
         sep=sep,
@@ -295,27 +376,29 @@ def _cached_chembl_fetch(
     *,
     chunk_size: int = 100,
     batch_size: int | None = None,
-) -> pd.DataFrame:
-    """Return a deterministic frame for the provided ``chunks``.
+) -> Iterator[pd.DataFrame]:
+    """Yield deterministic ChEMBL frames for the provided ``chunks``.
 
     The wrapper mimics the behaviour of the production fetcher which caches
-    results on disk.  In this trimmed-down CLI variant we lazily convert the
-    incoming chunk iterator into dataframes and concatenate them on demand
-    while keeping the API compatible with
-    :func:`library.pipeline_targets.run_pipeline`.
+    results on disk.  In this trimmed-down CLI variant we now expose a
+    streaming interface so callers can process chunks incrementally without
+    materialising the entire dataset at once.
     """
 
-    frames = _chembl_frame_stream(chunks)
-    try:
-        first = next(frames)
-    except StopIteration:
-        return pd.DataFrame(
-            {
-                "target_chembl_id": pd.Series(dtype="string"),
-                "source": pd.Series(dtype="string"),
-            }
-        )
-    return pd.concat(chain([first], frames), ignore_index=True)
+    def _stream() -> Iterator[pd.DataFrame]:
+        yielded = False
+        for frame in _chembl_frame_stream(chunks):
+            yielded = True
+            yield frame
+        if not yielded:
+            yield pd.DataFrame(
+                {
+                    "target_chembl_id": pd.Series(dtype="string"),
+                    "source": pd.Series(dtype="string"),
+                }
+            )
+
+    return _stream()
 
 
 def run(cfg: Config, options: PipelineConfig) -> int:
@@ -332,20 +415,31 @@ def run(cfg: Config, options: PipelineConfig) -> int:
     if final_path is None:
         final_path = default_output_path(options.input_csv, cfg.io)
 
-    final_df = result.chembl
-    raw_df = final_df.drop(columns=_PIPELINE_METADATA_COLUMNS, errors="ignore")
-
+    frame_iter = _frame_iterator(result.chembl)
+    raw_writer: _RawStreamWriter | None = None
     if options.raw_out is not None:
-        _raw_dump(
-            [raw_df],
+        raw_writer = _RawStreamWriter(
             options.raw_out,
             cfg=cfg,
             sep=options.sep,
             encoding=options.encoding,
         )
 
+    def _final_stream() -> Iterator[pd.DataFrame]:
+        try:
+            for chunk in frame_iter:
+                if raw_writer is not None:
+                    raw_chunk = chunk.drop(
+                        columns=_PIPELINE_METADATA_COLUMNS, errors="ignore"
+                    )
+                    raw_writer.write(raw_chunk)
+                yield chunk
+        finally:
+            if raw_writer is not None:
+                raw_writer.close()
+
     _validate_and_write(
-        final_df,
+        _final_stream(),
         final_path,
         cfg=cfg,
         sep=options.sep,

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -316,9 +316,7 @@ def test_cli_does_not_print_config_when_flag_missing(
     assert captured.out == ""
 
 
-def test_cached_chembl_fetch_uses_chunk_concatenation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_cached_chembl_fetch_streams_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     chunks = iter(
         [
             ["CHEMBL1", "CHEMBL2"],
@@ -326,23 +324,16 @@ def test_cached_chembl_fetch_uses_chunk_concatenation(
         ]
     )
 
-    recorded: dict[str, Any] = {}
-    original_concat = pd.concat
+    stream = cli._cached_chembl_fetch(chunks, Config())
+    assert hasattr(stream, "__iter__")
 
-    def spy_concat(objs: Iterable[pd.DataFrame], **kwargs: Any) -> pd.DataFrame:
-        recorded["type"] = type(objs)
-        frames = list(objs)
-        recorded["sizes"] = [len(frame) for frame in frames]
-        return original_concat(frames, **kwargs)
-
-    monkeypatch.setattr(pd, "concat", spy_concat)
-
-    df = cli._cached_chembl_fetch(chunks, Config())
-
-    assert list(df["target_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
-    assert list(df["source"]) == ["chembl", "chembl", "chembl"]
-    assert recorded["type"].__name__ == "chain"
-    assert recorded["sizes"] == [2, 1]
+    frames = list(stream)
+    assert len(frames) == 2
+    assert [list(frame["target_chembl_id"]) for frame in frames] == [
+        ["CHEMBL1", "CHEMBL2"],
+        ["CHEMBL3"],
+    ]
+    assert all((frame["source"] == "chembl").all() for frame in frames)
 
 
 # ---------------------------------------------------------------------------
@@ -416,8 +407,12 @@ def test_backward_compatibility_out_alias(
 
     recorded: dict[str, Path] = {}
 
-    def fake_validate(df: pd.DataFrame, path: Path, **_: Any) -> Path:
+    def fake_validate(
+        df: pd.DataFrame | Iterable[pd.DataFrame], path: Path, **_: Any
+    ) -> Path:
         recorded["path"] = path
+        if not isinstance(df, pd.DataFrame):
+            list(df)
         return path
 
     monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
@@ -475,3 +470,67 @@ def test_end_to_end_cli_raw_and_final_outputs(
     TargetsSchema.validate(final_df)
     assert final_df.loc[0, "uniprot_id_primary"] == ""
 
+
+def test_streaming_pipeline_keeps_chunk_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    total = 1_000
+    chunk_size = 25
+    input_csv = tmp_path / "targets.csv"
+    raw_out = tmp_path / "raw.csv"
+    final_out = tmp_path / "final.csv"
+
+    with input_csv.open("w", encoding="utf8") as handle:
+        handle.write("target_chembl_id\n")
+        for index in range(total):
+            handle.write(f"CHEMBL{index}\n")
+
+    recorded_final_sizes: list[int] = []
+    recorded_raw_sizes: list[int] = []
+
+    import library.io.writers as io_writers
+
+    original_chunks = io_writers.write_csv_chunks_deterministic
+
+    def tracking_write_chunks(
+        chunks: Iterable[pd.DataFrame], path: Path, *args: Any, **kwargs: Any
+    ) -> Path:
+        def _tracking() -> Iterator[pd.DataFrame]:
+            for chunk in chunks:
+                recorded_final_sizes.append(len(chunk))
+                yield chunk
+
+        return original_chunks(_tracking(), path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        io_writers,
+        "write_csv_chunks_deterministic",
+        tracking_write_chunks,
+    )
+
+    original_raw_write = cli._RawStreamWriter.write
+
+    def tracking_raw_write(self: cli._RawStreamWriter, chunk: pd.DataFrame) -> None:
+        recorded_raw_sizes.append(len(chunk))
+        original_raw_write(self, chunk)
+
+    monkeypatch.setattr(cli._RawStreamWriter, "write", tracking_raw_write)
+
+    options = cli.PipelineConfig(
+        input_csv=input_csv,
+        final_out=final_out,
+        raw_out=raw_out,
+        chunk_size=chunk_size,
+        batch_size=chunk_size,
+        column="target_chembl_id",
+        encoding="utf8",
+        sep=",",
+    )
+
+    exit_code = cli.run(cfg, options)
+    assert exit_code == 0
+
+    assert recorded_final_sizes
+    assert max(recorded_final_sizes) <= chunk_size
+    assert recorded_raw_sizes
+    assert max(recorded_raw_sizes) <= chunk_size


### PR DESCRIPTION
## Summary
- stream the CLI's cached ChEMBL fetcher and output writer so rows are processed chunk-by-chunk instead of materialising a single frame
- allow `library.pipeline_targets.run_pipeline` to propagate iterable chunks while still materialising data for optional downstream stages when needed
- add a regression test that runs the CLI over a large input and asserts the emitted chunk sizes stay bounded

## Testing
- pytest tests/test_pipeline_targets_cli.py
- pytest tests/test_pipeline_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68de4f8205b48324b8cc96f5aec5d541