### PR TITLE
Improve UniProt fallback handling and logging

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -6,4 +6,6 @@
 - Documented the requirement to configure `api.user_agent` with a real contact, including validation behaviour and the
   `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT` environment override.
 - Downgraded ChEMBL and PubChem cache hit/miss logging to DEBUG to reduce noise in default INFO logs.
+- Added UniProt isoform fallbacks, richer cross-reference extraction (AlphaFold, PDB, Ensembl), and additional logging to
+  trace identifier coverage through the target merge pipeline.
 

--- a/library/uniprot_library.py
+++ b/library/uniprot_library.py
@@ -80,6 +80,21 @@ __all__ = [
 ]
 
 
+def _canonical_accession(accession: str) -> str | None:
+    """Return canonical accession for ``accession`` when it targets an isoform."""
+
+    if not isinstance(accession, str):
+        return None
+    head, sep, tail = accession.partition("-")
+    if not sep:
+        return None
+    head = head.strip()
+    tail = tail.strip()
+    if not head or not tail:
+        return None
+    return head
+
+
 UNIPROT_OUTPUT_COLUMNS: list[str] = [
     "uniprot_id",
     "names",
@@ -747,21 +762,24 @@ def extract_crossrefs(data: Any) -> dict[str, str]:
     Returns:
         A dictionary mapping database names to pipe-separated identifier
         strings. The returned keys include ``GuidetoPHARMACOLOGY``, ``family``,
-        ``SUPFAM``, ``PROSITE``, ``InterPro``, ``Pfam``, ``PRINTS``, and
-        ``TCDB``.
+        ``SUPFAM``, ``PROSITE``, ``InterPro``, ``Pfam``, ``PRINTS``, ``TCDB``,
+        ``xref_pdb``, ``xref_alphafold``, and ``xref_ensembl``.
 
     """
-    dbs = [
-        "GuidetoPHARMACOLOGY",
-        "family",
-        "SUPFAM",
-        "PROSITE",
-        "InterPro",
-        "Pfam",
-        "PRINTS",
-        "TCDB",
-    ]
-    result: dict[str, list[str]] = {db: [] for db in dbs}
+    db_map: dict[str, tuple[str, ...]] = {
+        "GuidetoPHARMACOLOGY": ("GuidetoPHARMACOLOGY",),
+        "family": ("family",),
+        "SUPFAM": ("SUPFAM",),
+        "PROSITE": ("PROSITE",),
+        "InterPro": ("InterPro",),
+        "Pfam": ("Pfam",),
+        "PRINTS": ("PRINTS",),
+        "TCDB": ("TCDB",),
+        "xref_pdb": ("PDB",),
+        "xref_alphafold": ("AlphaFoldDB",),
+        "xref_ensembl": ("Ensembl",),
+    }
+    result: dict[str, list[str]] = {column: [] for column in db_map}
     if isinstance(data, dict) and "results" in data:
         entries = data["results"]
     elif isinstance(data, list):
@@ -783,11 +801,16 @@ def extract_crossrefs(data: Any) -> dict[str, str]:
             if not isinstance(ref, dict):
                 continue
             db = ref.get("database")
-            if db in result:
-                ref_id = ref.get("id")
-                if isinstance(ref_id, str):
-                    result[db].append(ref_id)
-    return {db: "|".join(ids) for db, ids in result.items()}
+            if not isinstance(db, str):
+                continue
+            ref_id = ref.get("id")
+            if not isinstance(ref_id, str):
+                continue
+            for column, names in db_map.items():
+                if db in names:
+                    result[column].append(ref_id)
+                    break
+    return {column: "|".join(ids) for column, ids in result.items()}
 
 
 def extract_activity(data: Any) -> dict[str, str]:
@@ -999,6 +1022,74 @@ def _extract_audit_last_update(audit: dict[str, Any]) -> str | None:
     return None
 
 
+def _load_uniprot_entry(
+    uid: str, data_dir: Path, cfg: UniprotCfg
+) -> tuple[Any | None, str | None]:
+    """Return UniProt JSON data for ``uid`` with isoform-aware fallback."""
+
+    fallback_id = _canonical_accession(uid)
+    candidates: list[str] = [uid]
+    if fallback_id and fallback_id not in candidates:
+        candidates.append(fallback_id)
+
+    for candidate in candidates:
+        json_path = data_dir / f"{candidate}.json"
+        try:
+            with open(json_path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            continue
+        except json.JSONDecodeError:
+            logger.warning("uniprot_json_malformed", uid=candidate)
+            continue
+        else:
+            if candidate != uid:
+                logger.info(
+                    "uniprot_isoform_fallback_cache",
+                    isoform=uid,
+                    canonical=candidate,
+                )
+            return data, candidate
+
+    logger.info("uniprot_json_download", uid=uid)
+    for index, candidate in enumerate(candidates):
+        try:
+            data = fetch_uniprot(candidate, cfg=cfg)
+        except UniProtFetchError as exc:
+            if candidate == uid and fallback_id and index == 0:
+                logger.info(
+                    "uniprot_isoform_fetch_retry",
+                    isoform=uid,
+                    canonical=fallback_id,
+                    error=str(exc),
+                )
+                continue
+            logger.warning("uniprot_json_fetch_failed", uid=candidate, error=str(exc))
+            return None, None
+
+        data_dir.mkdir(parents=True, exist_ok=True)
+        persist_ids = [candidate]
+        if candidate != uid:
+            persist_ids.append(uid)
+            logger.info(
+                "uniprot_isoform_fallback_fetch",
+                isoform=uid,
+                canonical=candidate,
+            )
+        for persist_id in persist_ids:
+            json_path = data_dir / f"{persist_id}.json"
+            try:
+                with open(json_path, "w", encoding="utf-8") as handle:
+                    json.dump(data, handle)
+            except OSError as exc:  # pragma: no cover - disk I/O failure
+                logger.warning(
+                    "uniprot_json_write_failed", uid=persist_id, error=str(exc)
+                )
+        return data, candidate
+
+    return None, None
+
+
 def collect_info(
     uid: str,
     data_dir: Path | str | None = None,
@@ -1034,7 +1125,6 @@ def collect_info(
         data_dir = _DEFAULT_UNIPROT_DATA_DIR
     data_dir = Path(data_dir)
 
-    json_path = data_dir / f"{uid}.json"
     result = {
         "uniprot_id": uid,
         "names": "",
@@ -1086,25 +1176,8 @@ def collect_info(
         "timestamp_utc": "",
         "uniProtkbIdFallback": "",
     }
-    try:
-        with open(json_path, encoding="utf-8") as handle:
-            data = json.load(handle)
-    except FileNotFoundError:
-        logger.info("uniprot_json_download", uid=uid)
-        try:
-            data = fetch_uniprot(uid, cfg=cfg)
-        except UniProtFetchError as exc:
-            logger.warning("uniprot_json_fetch_failed", uid=uid, error=str(exc))
-            return result
-        data_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            with open(json_path, "w", encoding="utf-8") as handle:
-                json.dump(data, handle)
-        except OSError as exc:  # pragma: no cover - disk I/O failure
-            logger.warning("uniprot_json_write_failed", uid=uid, error=str(exc))
-            return result
-    except json.JSONDecodeError:
-        logger.warning("uniprot_json_malformed", uid=uid)
+    data, _source_id = _load_uniprot_entry(uid, data_dir, cfg)
+    if data is None:
         return result
 
     names = extract_names(data)

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -146,6 +146,7 @@ class _UniprotQueryPlan:
     unique_records: list[dict[str, str]]
     row_candidates: list[list[_UniprotCandidate]]
     row_index: list[Any]
+    candidate_columns: list[str]
 
 
 def _split_uniprot_tokens(value: str) -> Iterator[str]:
@@ -190,7 +191,9 @@ def _build_uniprot_query_plan(df: pd.DataFrame, cfg: Config) -> _UniprotQueryPla
     row_index = list(df.index)
 
     if not candidate_columns:
-        return _UniprotQueryPlan(unique_records, [[] for _ in row_index], row_index)
+        return _UniprotQueryPlan(
+            unique_records, [[] for _ in row_index], row_index, candidate_columns
+        )
 
     positions = [df.columns.get_loc(column) for column in candidate_columns]
     for row in df.itertuples(index=False, name=None):
@@ -215,7 +218,7 @@ def _build_uniprot_query_plan(df: pd.DataFrame, cfg: Config) -> _UniprotQueryPla
                     )
         row_candidates.append(candidates)
 
-    return _UniprotQueryPlan(unique_records, row_candidates, row_index)
+    return _UniprotQueryPlan(unique_records, row_candidates, row_index, candidate_columns)
 
 
 def _resolve_uniprot_matches(
@@ -1568,6 +1571,12 @@ def fetch_uniprot(
 
     logger.info("fetch_uniprot_start", output=str(output_csv))
     plan = _build_uniprot_query_plan(chembl_df, cfg)
+    logger.info(
+        "fetch_uniprot_plan",
+        rows=len(plan.row_index),
+        unique=len(plan.unique_records),
+        candidate_columns=plan.candidate_columns,
+    )
     if plan.unique_records:
         id_df = pd.DataFrame(plan.unique_records, dtype=object)
     else:
@@ -1604,6 +1613,34 @@ def fetch_uniprot(
     fetched_df = pd.read_csv(
         output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
     )
+    requested_ids = {
+        str(record.get("uniprot_id", "")).strip()
+        for record in plan.unique_records
+        if str(record.get("uniprot_id", "")).strip()
+    }
+    if "uniprot_id" in fetched_df.columns:
+        retrieved_ids = {
+            str(value).strip()
+            for value in fetched_df["uniprot_id"].dropna()
+            if str(value).strip()
+        }
+    else:
+        retrieved_ids = set()
+    missing_ids = requested_ids - retrieved_ids
+    logger.info(
+        "fetch_uniprot_coverage",
+        requested=len(requested_ids),
+        retrieved=len(retrieved_ids),
+        missing=len(missing_ids),
+    )
+    if missing_ids:
+        sample = sorted(missing_ids)[:10]
+        logger.debug(
+            "fetch_uniprot_missing_ids",
+            sample=sample,
+            sample_size=len(sample),
+            total_missing=len(missing_ids),
+        )
     if "uniprot_id" in fetched_df.columns:
         df = id_df.merge(fetched_df, on="uniprot_id", how="left", sort=False)
     else:
@@ -1998,6 +2035,26 @@ def merge_results(
     """
 
     logger.info("merge_results_start")
+    chembl_keys: set[str] = set()
+    if "uniprot_id" in combined_df.columns:
+        chembl_keys = {
+            str(value).strip()
+            for value in combined_df["uniprot_id"].dropna()
+            if str(value).strip()
+        }
+    iuphar_keys: set[str] = set()
+    if "uniprot_id" in iuphar_df.columns:
+        iuphar_keys = {
+            str(value).strip()
+            for value in iuphar_df["uniprot_id"].dropna()
+            if str(value).strip()
+        }
+    logger.info(
+        "merge_results_key_coverage",
+        chembl=len(chembl_keys),
+        iuphar=len(iuphar_keys),
+        matched=len(chembl_keys & iuphar_keys),
+    )
     merged = combined_df.merge(iuphar_df, on="uniprot_id", how="left")
     if classifier is None:
         classifier = pc.classifier_from_config(cfg)

--- a/tests/test_uniprot_library.py
+++ b/tests/test_uniprot_library.py
@@ -30,6 +30,24 @@ def test_extract_names() -> None:
     assert names == {"Protein X", "Alt Name", "GENE1", "G1"}
 
 
+def test_extract_crossrefs_includes_structural_ids() -> None:
+    sample = {
+        "uniProtKBCrossReferences": [
+            {"database": "GuidetoPHARMACOLOGY", "id": "GT123"},
+            {"database": "AlphaFoldDB", "id": "AF-P12345-F1"},
+            {"database": "PDB", "id": "1ABC"},
+            {"database": "Ensembl", "id": "ENSP000003"},
+        ]
+    }
+
+    crossrefs = ul.extract_crossrefs(sample)
+
+    assert crossrefs["GuidetoPHARMACOLOGY"] == "GT123"
+    assert crossrefs["xref_alphafold"] == "AF-P12345-F1"
+    assert crossrefs["xref_pdb"] == "1ABC"
+    assert crossrefs["xref_ensembl"] == "ENSP000003"
+
+
 @responses.activate
 def test_fetch_uniprot_network_error(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = UniprotCfg(base="https://example.org", delay=0)
@@ -294,3 +312,36 @@ def test_collect_info_enriches_gtop(tmp_path: Path) -> None:
         == "Physiological function: Regulates sample process"
     )
     assert len(responses.calls) == 3
+
+
+def test_collect_info_uses_canonical_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = UniprotCfg(base="https://example.org", delay=0)
+    isoform_id = "P12345-2"
+    canonical_id = "P12345"
+    payload = {
+        "primaryAccession": canonical_id,
+        "sequence": {"length": 42},
+        "proteinDescription": {
+            "recommendedName": {"fullName": {"value": "Canonical protein"}}
+        },
+        "genes": [{"geneName": {"value": "GENE"}}],
+    }
+    calls: list[str] = []
+
+    def fake_fetch(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, object]:
+        calls.append(uniprot_id)
+        if uniprot_id == isoform_id:
+            raise ul.UniProtFetchError("not found")
+        assert uniprot_id == canonical_id
+        return payload
+
+    monkeypatch.setattr(ul, "fetch_uniprot", fake_fetch)
+
+    result = ul.collect_info(isoform_id, data_dir=tmp_path, cfg=cfg)
+
+    assert calls == [isoform_id, canonical_id]
+    assert result["sequence_length"] == "42"
+    assert result["uniProtkbIdFallback"] == canonical_id
+    assert (tmp_path / f"{isoform_id}.json").exists()


### PR DESCRIPTION
## Summary
- load UniProt JSON with isoform-aware fallbacks and populate AlphaFold, PDB, and Ensembl cross references
- add coverage logging for UniProt fetch/merge stages and document the enhancements in the release notes
- extend unit coverage with cross-reference and isoform fallback tests

## Testing
- pytest tests/test_uniprot_library.py -k "crossrefs or canonical"

------
https://chatgpt.com/codex/tasks/task_e_68de5308d0688324acd402e3ac5b2f99