### PR TITLE
Handle unexpected exceptions in CLI pipeline components

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -61,6 +61,12 @@ TableQualityHook = Callable[[Path], None]
 Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
 
 
+def _callable_name(func: Callable[..., object]) -> str:
+    """Return a human readable name for ``func``."""
+
+    return getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+
+
 class PipelineError(RuntimeError):
     """Raised when a pipeline step encounters a fatal error."""
 
@@ -240,6 +246,9 @@ def run_pipeline(
         iterable = _as_iterable(fetcher())
     except PipelineError:
         return 1
+    except Exception as exc:  # pragma: no cover - exercised in integration tests
+        use_logger.error("fetch_failed", error=str(exc))
+        return 1
 
     with TemporaryDirectory() as tmpdir_name:
         tmpdir = Path(tmpdir_name)
@@ -254,7 +263,15 @@ def run_pipeline(
                 rows_total += chunk_rows_total
 
                 for hook in metadata_hooks:
-                    chunk = hook(chunk)
+                    try:
+                        chunk = hook(chunk)
+                    except Exception as exc:
+                        use_logger.error(
+                            "metadata_hook_failed",
+                            hook=_callable_name(hook),
+                            error=str(exc),
+                        )
+                        return 1
 
                 chunk_columns = set(chunk.columns)
                 present_columns.update(chunk_columns)
@@ -311,6 +328,12 @@ def run_pipeline(
                 chunk_paths.append(chunk_path)
         except PipelineError:
             return 1
+        except Exception as exc:
+            use_logger.error(
+                "chunk_processing_failed",
+                error=str(exc),
+            )
+            return 1
 
         if missing_required_columns:
             use_logger.warning(
@@ -322,7 +345,15 @@ def run_pipeline(
         if not chunk_paths:
             empty = pd.DataFrame()
             for hook in metadata_hooks:
-                empty = hook(empty)
+                try:
+                    empty = hook(empty)
+                except Exception as exc:
+                    use_logger.error(
+                        "metadata_hook_failed",
+                        hook=_callable_name(hook),
+                        error=str(exc),
+                    )
+                    return 1
             present_columns.update(empty.columns)
             all_columns.update(empty.columns)
             chunk_path = tmpdir / "chunk_0.pkl"
@@ -362,8 +393,10 @@ def run_pipeline(
                 yield df
 
         try:
-            csv_path = writer(_iter_validated(), output_path, col_order, resolved_keys)
-        except OSError as exc:
+            csv_path = writer(
+                _iter_validated(), output_path, col_order, resolved_keys
+            )
+        except Exception as exc:
             use_logger.error(
                 "write_fail",
                 error=str(exc),

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import json
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -9,6 +11,7 @@ import yaml
 
 from library.config import Config, _mask_secrets, _serialize_paths
 from library.cli_utils import build_parser, run_pipeline
+from library.logging_setup import LoggerConfig, configure_logger as setup_logger
 from schemas import AssaysSchema
 
 
@@ -21,6 +24,7 @@ def test_cli_utils_flags_and_help() -> None:
         "--log-level",
         "--input",
         "--output",
+        "--out",
         "--config",
         "--sep",
         "--encoding",
@@ -238,3 +242,123 @@ def test_run_pipeline_missing_required_columns(tmp_path: Path, cfg: Config) -> N
     assert exit_code == 1
     assert not output.exists()
     assert not failure_path.exists()
+
+
+def test_run_pipeline_metadata_hook_failure(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+    frames = [
+        pd.DataFrame(
+            {
+                "assay_chembl_id": ["A1"],
+                "document_chembl_id": ["D1"],
+            }
+        )
+    ]
+
+    def fetcher() -> list[pd.DataFrame]:
+        return frames
+
+    def hook(_: pd.DataFrame) -> pd.DataFrame:
+        raise RuntimeError("hook boom")
+
+    writer_called: list[Path] = []
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        writer_called.append(destination)
+        return destination
+
+    buf = io.StringIO()
+    logger = setup_logger(LoggerConfig(stream=buf), replace_root=False)
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[],
+        metadata_hooks=[hook],
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda path: None,
+        cfg=cfg,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    assert not writer_called
+    assert not output.exists()
+    assert not failure_path.exists()
+
+    lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+    assert lines
+    assert all("Traceback" not in line for line in lines)
+    records = [json.loads(line) for line in lines]
+    hook_errors = [record for record in records if record.get("event") == "metadata_hook_failed"]
+    assert hook_errors
+    assert hook_errors[-1]["error"] == "hook boom"
+
+
+def test_run_pipeline_writer_failure(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [
+            pd.DataFrame(
+                {
+                    "assay_chembl_id": ["A1"],
+                    "document_chembl_id": ["D1"],
+                }
+            )
+        ]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        raise RuntimeError("writer boom")
+
+    buf = io.StringIO()
+    logger = setup_logger(LoggerConfig(stream=buf), replace_root=False)
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[],
+        metadata_hooks=[lambda df: df],
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda path: None,
+        cfg=cfg,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    assert not output.exists()
+    assert not failure_path.exists()
+
+    lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+    assert lines
+    assert all("Traceback" not in line for line in lines)
+    records = [json.loads(line) for line in lines]
+    write_errors = [record for record in records if record.get("event") == "write_fail"]
+    assert write_errors
+    assert write_errors[-1]["error"] == "writer boom"


### PR DESCRIPTION
## Summary
- guard pipeline fetch, metadata hook, and writer stages so unexpected errors are logged and return a non-zero exit code
- add CLI regression tests that cover hook and writer failures and verify the error output
- update CLI flag expectations to reflect the deprecated --out passthrough option

## Testing
- pytest tests/test_cli_utils.py tests/test_activity_cli_error.py

------
https://chatgpt.com/codex/tasks/task_e_68de56dca5488324bb41035ca2aeb217