### PR TITLE
Add runtime configuration for activity schema standard types

### DIFF
--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,6 +1,6 @@
 """Convenient exports for schema definitions."""
 
-from .activities import ActivitiesSchema
+from .activities import ActivitiesSchema, configure_activity_schema
 from .assay_postprocessing import AssayPostprocessSchema
 from .assays import AssaysSchema
 from .documents import DocumentsSchema
@@ -28,4 +28,5 @@ __all__ = [
     "normalize_documents",
     "normalize_targets",
     "normalize_testitems",
+    "configure_activity_schema",
 ]

--- a/schemas/activities.py
+++ b/schemas/activities.py
@@ -6,11 +6,10 @@ expected structure of activity dataframes.
 
 from __future__ import annotations
 
-from pathlib import Path
+from collections.abc import Mapping
 from typing import cast
 
 import pandera.pandas as pa
-import yaml
 from pandera.dtypes import DataType
 
 PA_ANY = cast(DataType, None)
@@ -27,20 +26,10 @@ _ALLOWED_ACTION_TYPES = {
 }
 
 
-def _load_standard_type_values() -> tuple[str, ...]:
-    """Return configured standard type values if available."""
+def _derive_standard_type_values(metrics: Mapping[str, str] | None) -> tuple[str, ...]:
+    """Derive permissible ``standard_type`` values from *metrics* keys."""
 
-    config_path = Path(__file__).resolve().parents[1] / "config" / "config.yaml"
-    try:
-        with config_path.open("r", encoding="utf8") as handle:
-            config = yaml.safe_load(handle) or {}
-    except (FileNotFoundError, yaml.YAMLError, TypeError):
-        return ()
-
-    metrics = (
-        config.get("activity_enrichment", {}).get("action_type", {}).get("metrics", {})
-    )
-    if not isinstance(metrics, dict):
+    if not metrics:
         return ()
 
     values: set[str] = set()
@@ -60,10 +49,7 @@ def _load_standard_type_values() -> tuple[str, ...]:
     return tuple(sorted(values))
 
 
-_STANDARD_TYPE_VALUES = _load_standard_type_values()
 _STANDARD_TYPE_CHECKS: list[pa.Check] = []
-if _STANDARD_TYPE_VALUES:
-    _STANDARD_TYPE_CHECKS.append(pa.Check.isin(sorted(_STANDARD_TYPE_VALUES)))
 
 
 ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
@@ -118,3 +104,18 @@ ActivitiesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
 )
 
 """pa.DataFrameSchema: Validation schema for activities."""
+
+
+def configure_activity_schema(metrics: Mapping[str, str] | None) -> pa.DataFrameSchema:
+    """Update :data:`ActivitiesSchema` based on *metrics* configuration."""
+
+    values = _derive_standard_type_values(metrics)
+
+    _STANDARD_TYPE_CHECKS.clear()
+    if values:
+        _STANDARD_TYPE_CHECKS.append(pa.Check.isin(sorted(values)))
+
+    # ``DataFrameSchema`` stores a shallow copy of the provided list, therefore
+    # we synchronise the column checks explicitly to reflect runtime changes.
+    ActivitiesSchema.columns["standard_type"].checks = list(_STANDARD_TYPE_CHECKS)
+    return ActivitiesSchema

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -44,7 +44,7 @@ from library.processing.activity import (
     apply_activity_annotations,
     compute_activity_bounds,
 )
-from schemas import ActivitiesSchema, normalize_activities
+from schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
 
 
 DEFAULT_INPUT_NAME = "activity.csv"
@@ -119,6 +119,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     enrichment_cfg = cfg.activity_enrichment
     extra_columns: list[str] = []
     action_cfg = enrichment_cfg.action_type
+    configure_activity_schema(action_cfg.metrics)
     if action_cfg.enabled or action_cfg.log_missing or action_cfg.log_distribution:
         extra_columns.append(action_cfg.column)
     extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pandas as pd
@@ -21,8 +22,27 @@ from schemas import (
     DocumentsSchema,
     TargetsSchema,
     TestitemsSchema,
+    configure_activity_schema,
 )
 from schemas.targets import TARGETS_COLUMN_ORDER
+
+
+DEFAULT_ACTION_TYPE_METRICS = {
+    "ic50": "inhibition",
+    "ec50": "activation",
+    "ac50": "activation",
+    "ki": "binding",
+    "kd": "binding",
+}
+
+
+@pytest.fixture(autouse=True)
+def configure_default_activity_schema() -> Iterator[None]:
+    """Ensure ``ActivitiesSchema`` enforces the default metric allowlist."""
+
+    configure_activity_schema(DEFAULT_ACTION_TYPE_METRICS)
+    yield
+    configure_activity_schema(DEFAULT_ACTION_TYPE_METRICS)
 
 
 def test_activities_schema_validation() -> None:
@@ -57,6 +77,24 @@ def test_activities_schema_accepts_configured_standard_types() -> None:
             "assay_chembl_id": ["CHEMBL0", "CHEMBL0", "CHEMBL1"],
             "standard_value": [1.0, 2.0, 3.0],
             "standard_type": ["IC50", "EC50", "KD"],
+        }
+    )
+
+    ActivitiesSchema.validate(df)
+
+
+def test_configure_activity_schema_accepts_custom_metrics() -> None:
+    """Schema accepts standard types derived from custom metrics."""
+
+    configure_activity_schema({"FooIC50": "activation"})
+
+    df = pd.DataFrame(
+        {
+            "activity_id": ["1", "2"],
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "assay_chembl_id": ["CHEMBL0", "CHEMBL0"],
+            "standard_value": [5.0, 10.0],
+            "standard_type": ["FooIC50", "fooic50"],
         }
     )
 


### PR DESCRIPTION
## Summary
- refactor the activities schema to expose `configure_activity_schema` and remove the import-time YAML read
- configure the activity pipeline with the action-type metrics before running validation
- add regression coverage to verify the schema accepts custom action-type metrics

## Testing
- pytest tests/test_schemas.py

------
https://chatgpt.com/codex/tasks/task_e_68de56d8c5088324b4b562d07d71273c