### PR TITLE
Support local config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,9 +774,12 @@ executed at runtime and should not be passed to ``jsonschema``.
 
 Command line flags have the highest priority. All utilities accept ``--config``
 to point at a configuration file and ``--print-config`` to show the effective
-values after all overrides have been applied. The final precedence is::
+values after all overrides have been applied. When a ``config.local.yaml`` file
+is present next to the primary configuration (including custom paths provided to
+``--config``) it is deep-merged after the base YAML to allow per-environment
+defaults. The final precedence is::
 
-    YAML < environment variables < CLI options
+    YAML < config.local.yaml < environment variables < CLI options
 
 Only the top-level command line scripts read the configuration file. Modules
 under ``library/`` expect a :class:`Config` (or one of its subsections) to be

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -4,7 +4,7 @@
 
 * All command-line tools load their defaults from [`config/config.yaml`](../config/config.yaml) in the project root.
 * Values are validated by `library.config.load_config`, which calls `Config.model_validate` from Pydantic. [`config.schema.json`](../config.schema.json) documents the same structure for tooling but is not executed during start-up.
-* Settings can be overridden via environment variables and CLI flags. Precedence is: `config/config.yaml` < environment variables < CLI arguments.
+* Settings can be overridden via a `config.local.yaml` placed next to the primary configuration (including custom paths supplied via `--config`), environment variables and CLI flags. Precedence is: `config/config.yaml` < `config.local.yaml` < environment variables < CLI arguments.
 
 ## Layout of `config/config.yaml`
 

--- a/library/config.py
+++ b/library/config.py
@@ -4,7 +4,7 @@ This module provides a typed wrapper around ``config/config.yaml``. Configuratio
 values are loaded from a YAML file and can be overridden by environment
 variables or command line options. The order of precedence is::
 
-    YAML < environment variables < CLI overrides
+    YAML < config.local.yaml < environment variables < CLI overrides
 
 Environment variables follow the ``CHEMBL_DA__SECTION__KEY`` naming pattern
 where sections and keys are joined by double underscores. A number of short
@@ -1364,6 +1364,16 @@ def load_config(
         data, resolved_path = load_yaml_config(path)
     except ConfigLoaderError as exc:
         raise ConfigError(str(exc)) from exc
+
+    local_path = resolved_path.with_name(
+        f"{resolved_path.stem}.local{resolved_path.suffix}"
+    )
+    if local_path != resolved_path and local_path.exists():
+        try:
+            local_data, _ = load_yaml_config(local_path)
+        except ConfigLoaderError as exc:
+            raise ConfigError(str(exc)) from exc
+        _merge_mapping(data, local_data)
 
     data = _coerce_integral_numbers(data)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,6 +142,33 @@ def test_alias_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert cfg.api.rps == 5
 
 
+def test_local_config_merges(tmp_path: Path) -> None:
+    base = tmp_path / "cfg.yaml"
+    base.write_text(
+        "sources:\n"
+        "  chembl:\n"
+        "    api:\n"
+        "      rps: 7\n"
+        "      timeout_read: 10\n"
+    )
+
+    local = base.with_name("cfg.local.yaml")
+    local.write_text(
+        "sources:\n"
+        "  chembl:\n"
+        "    api:\n"
+        "      timeout_read: 15\n"
+        "  openalex:\n"
+        "    rps: 9\n"
+    )
+
+    cfg = load_config(base)
+
+    assert cfg.api.rps == 7
+    assert cfg.api.timeout_read == 15
+    assert cfg.openalex.rps == 9
+
+
 def test_retry_and_log_aliases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """New environment variable aliases should override retry and log defaults."""
 


### PR DESCRIPTION
## Summary
- merge a sibling `config.local.yaml` into the primary configuration before applying environment or CLI overrides
- document the updated configuration precedence chain in the README and configuration reference
- add a regression test confirming values from both YAML files are visible in the resulting `Config`

## Testing
- pytest tests/test_config.py::test_local_config_merges

------
https://chatgpt.com/codex/tasks/task_e_68de570d62f08324a1bf6f3b8a0f7548