### PR TITLE
Remove duplicate _run_pipeline_with_meta helper

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -120,17 +120,6 @@ RAW_SUFFIX = "_raw"
 NORMALIZED_SUFFIX = "_normalized"
 
 
-def _run_pipeline_with_meta(**kwargs: object) -> int:
-    """Execute :func:`run_pipeline` with metadata writer override."""
-
-    original_cli_write_meta = cli_utils_module.write_meta_yaml
-    cli_utils_module.write_meta_yaml = write_meta_yaml
-    try:
-        return run_pipeline(**kwargs)
-    finally:
-        cli_utils_module.write_meta_yaml = original_cli_write_meta
-
-
 @dataclass(frozen=True)
 class _UniprotCandidate:
     """Container describing a UniProt identifier candidate for a target row."""


### PR DESCRIPTION
## Summary
- remove the redundant second definition of `_run_pipeline_with_meta` so the context-managed implementation remains the single source of truth

## Testing
- pytest tests/test_get_target_data_all.py *(fails: FileNotFoundError when reading /tmp/pytest-of-root/pytest-0/test_run_all_uses_local_inputs0/out.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68de6303930883249b014bbd74814262