### PR TITLE
Fix fetcher context management in assay data pipeline

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -109,11 +109,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
     def fetcher() -> Iterable[pd.DataFrame]:
-    global_limiter = get_global_limiter(cfg.rate.global_rps, cfg.rate.global_burst)
+        global_limiter = get_global_limiter(
+            cfg.rate.global_rps, cfg.rate.global_burst
+        )
 
-    with ChemblClient(
-        cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-    ) as client:
+        with ChemblClient(
+            cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
+        ) as client:
             chunk_iter = cl._chunked(ids_source, cfg.assay.batch_size)
             for chunk_ids in chunk_iter:
                 try:


### PR DESCRIPTION
## Summary
- indent the assay fetcher implementation so that the rate limiter, client context, and chunk iterator run inside the generator

## Testing
- pytest tests/test_get_assay_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de62ff2c708324ab9978569c6e9c7d