### PR TITLE
Add CLI test verifying worker chunk order

### DIFF
--- a/tests/test_get_activity_data_cli.py
+++ b/tests/test_get_activity_data_cli.py
@@ -1,6 +1,14 @@
 """Smoke tests for :mod:`scripts.get_activity_data`."""
 
 from importlib import import_module
+from pathlib import Path
+import time
+
+import pandas as pd
+import pytest
+import yaml
+
+from library import cli_utils
 
 
 def test_get_activity_data_cli_exposes_main() -> None:
@@ -13,3 +21,122 @@ def test_get_activity_data_cli_print_config() -> None:
     # ``--print-config`` ensures the pipeline stops before network or IO work.
     exit_code = module.main(["--print-config"])
     assert exit_code == 0
+
+
+def test_get_activity_data_cli_workers_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = import_module("scripts.get_activity_data")
+
+    output_dir = tmp_path / "output"
+    cache_dir = tmp_path / "cache"
+    config_path = tmp_path / "config.yaml"
+    input_path = tmp_path / "activity.csv"
+    output_path = tmp_path / "activities.csv"
+
+    config_data = {
+        "sources": {
+            "chembl": {
+                "pipelines": {
+                    "activity": {
+                        "workers": 2,
+                        "batch_size": 2,
+                    }
+                }
+            }
+        },
+        "local": {
+            "io": {
+                "output_dir": str(output_dir),
+                "cache_dir": str(cache_dir),
+                "exist_ok": True,
+            }
+        },
+    }
+
+    config_path.write_text(yaml.safe_dump(config_data))
+    input_path.write_text("activity_id\nA1\nA2\nA3\nA4\n")
+
+    monkeypatch.setattr(cli_utils, "ensure_dirs", lambda cfg: None)
+    monkeypatch.setattr(
+        module.io,
+        "read_ids",
+        lambda *args, **kwargs: iter(["A1", "A2", "A3", "A4"]),
+    )
+
+    captured = {"chunks": [], "workers": None, "calls": []}
+
+    frames = [
+        pd.DataFrame({"activity_id": ["chunk0_A1", "chunk0_A2"]}),
+        pd.DataFrame({"activity_id": ["chunk1_A3", "chunk1_A4"]}),
+    ]
+    delays = [0.05, 0.0]
+
+    def fake_get_activities(ids, *, cfg, client, chunk_size, timeout, **kwargs):
+        captured["calls"].append((tuple(ids), chunk_size, timeout))
+
+        def _iter():
+            for delay, frame in zip(delays, frames):
+                if delay:
+                    time.sleep(delay)
+                yield frame
+
+        return _iter()
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+            pass
+
+        def __enter__(self):  # pragma: no cover - trivial
+            return self
+
+        def __exit__(self, *args):  # pragma: no cover - trivial
+            return False
+
+    monkeypatch.setattr(module.cl, "get_activities", fake_get_activities)
+    monkeypatch.setattr(module, "ChemblClient", lambda *args, **kwargs: DummyClient())
+    monkeypatch.setattr(module, "get_global_limiter", lambda *args, **kwargs: None)
+
+    def _normalize_chunks(source):
+        if source is None:
+            return []
+        if isinstance(source, pd.DataFrame):
+            return [source]
+        return list(source)
+
+    def fake_run_pipeline(*, fetcher, cfg, **kwargs):
+        captured["workers"] = cfg.activity.workers
+        iterator = fetcher()
+        collected: list[pd.DataFrame] = []
+        while True:
+            try:
+                chunk = next(iterator)
+            except StopIteration as stop:
+                collected.extend(_normalize_chunks(stop.value))
+                break
+            else:
+                collected.append(chunk)
+        for frame in collected:
+            captured["chunks"].append(list(frame["activity_id"]))
+        return 0
+
+    monkeypatch.setattr(module, "run_pipeline", fake_run_pipeline)
+
+    exit_code = module.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["workers"] == 2
+    assert captured["chunks"] == [
+        ["chunk0_A1", "chunk0_A2"],
+        ["chunk1_A3", "chunk1_A4"],
+    ]
+    assert captured["calls"] == [(("A1", "A2"), 2, 30.0)]


### PR DESCRIPTION
## Summary
- add a CLI integration test that loads a temporary YAML config with two activity workers
- stub Chembl interactions to return deterministic chunks and assert they are emitted in order

## Testing
- pytest tests/test_get_activity_data_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68de6309e30883249b1523c81223e69a