### PR TITLE
Fix project root bootstrap in get_assay_data CLI

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -18,6 +18,10 @@ from itertools import islice
 import pandas as pd
 import requests
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from library.utils.bootstrap import ensure_project_root
 
 


### PR DESCRIPTION
## Summary
- ensure the get_assay_data script injects the repository root into sys.path before importing internal modules so it can run directly via ``python scripts/get_assay_data.py``

## Testing
- python scripts/get_assay_data.py --help


------
https://chatgpt.com/codex/tasks/task_e_68de66ca8b8c83249a7d79c70183dbec