### PR TITLE
Fix get_document_data bootstrap import

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -43,7 +43,13 @@ import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
 
-from library.utils.bootstrap import ensure_project_root
+try:
+    from library.utils.bootstrap import ensure_project_root
+except ModuleNotFoundError:  # pragma: no cover - environment bootstrap
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+    from library.utils.bootstrap import ensure_project_root
 
 
 if __package__ in {None, ""}:


### PR DESCRIPTION
## Summary
- ensure `scripts/get_document_data.py` can import the project packages when executed directly by inserting the repository root on ModuleNotFoundError

## Testing
- python scripts/get_document_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68de66e96754832486a369833c4204f3