### PR TITLE
Clean up stale failure sidecar files after successful pipeline runs

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -381,6 +381,9 @@ def run_pipeline(
 
         if total_failures:
             errors.save(failure_path, cfg=cfg)
+        else:
+            failure_path.unlink(missing_ok=True)
+            Path(f"{failure_path}.meta.yaml").unlink(missing_ok=True)
 
         if exit_code != 0:
             return exit_code

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -143,6 +143,60 @@ def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path, cfg: Config) -> N
     assert meta_path.exists()
 
 
+def test_run_pipeline_removes_stale_failure_outputs(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+    failure_meta_path = Path(f"{failure_path}.meta.yaml")
+
+    failure_path.write_text("old", encoding="utf8")
+    failure_meta_path.write_text("old", encoding="utf8")
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [
+            pd.DataFrame(
+                {
+                    "assay_chembl_id": ["A1"],
+                    "document_chembl_id": ["D1"],
+                }
+            )
+        ]
+
+    def validator(df: pd.DataFrame) -> _ValidationResult:
+        return _ValidationResult(df, pd.DataFrame())
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str],
+        key_cols: list[str],
+    ) -> Path:
+        frames = list(chunks)
+        pd.concat(frames, ignore_index=True).to_csv(destination, index=False)
+        return destination
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[validator],
+        metadata_hooks=[lambda df: df],
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda path: None,
+        cfg=cfg,
+    )
+
+    assert exit_code == 0
+    assert output.exists()
+    assert not failure_path.exists()
+    assert not failure_meta_path.exists()
+
+
 def test_run_pipeline_writes_failure_cases(tmp_path: Path, cfg: Config) -> None:
     output = tmp_path / "assays.csv"
     failure_path = tmp_path / "assays_failure_cases.csv"


### PR DESCRIPTION
## Summary
- remove existing failure sidecar outputs when a pipeline run has no validation failures
- cover the clean-up behaviour with a CLI utils regression test

## Testing
- pytest tests/test_cli_utils.py -k failure

------
https://chatgpt.com/codex/tasks/task_e_68de698f674c832485d230b3d598286a