### PR TITLE
Support Russian keyboard aliases in target CLI

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -120,6 +120,83 @@ RAW_SUFFIX = "_raw"
 NORMALIZED_SUFFIX = "_normalized"
 
 
+COMMAND_CHOICES: tuple[str, ...] = ("uniprot", "chembl", "iuphar", "all")
+
+_RUSSIAN_KEYBOARD_MAP: dict[str, str] = {
+    "q": "й",
+    "w": "ц",
+    "e": "у",
+    "r": "к",
+    "t": "е",
+    "y": "н",
+    "u": "г",
+    "i": "ш",
+    "o": "щ",
+    "p": "з",
+    "[": "х",
+    "]": "ъ",
+    "a": "ф",
+    "s": "ы",
+    "d": "в",
+    "f": "а",
+    "g": "п",
+    "h": "р",
+    "j": "о",
+    "k": "л",
+    "l": "д",
+    ";": "ж",
+    "'": "э",
+    "z": "я",
+    "x": "ч",
+    "c": "с",
+    "v": "м",
+    "b": "и",
+    "n": "т",
+    "m": "ь",
+    ",": "б",
+    ".": "ю",
+    "`": "ё",
+}
+
+
+def _translate_keyboard_layout(value: str) -> str:
+    """Return ``value`` as if typed with the Russian keyboard layout."""
+
+    translated: list[str] = []
+    for char in value:
+        lower = char.lower()
+        mapped = _RUSSIAN_KEYBOARD_MAP.get(lower)
+        if mapped is None:
+            translated.append(char)
+            continue
+        translated.append(mapped.upper() if char.isupper() else mapped)
+    return "".join(translated)
+
+
+def _keyboard_aliases(command: str) -> tuple[str, ...]:
+    """Return alternative spellings caused by the Russian keyboard layout."""
+
+    base = _translate_keyboard_layout(command)
+    variants: list[str] = []
+    for candidate in (base, base.capitalize(), base.upper()):
+        if candidate != command and candidate not in variants:
+            variants.append(candidate)
+    return tuple(variants)
+
+
+COMMAND_KEYBOARD_ALIASES: dict[str, tuple[str, ...]] = {}
+for _command_choice in COMMAND_CHOICES:
+    _aliases = _keyboard_aliases(_command_choice)
+    if _aliases:
+        COMMAND_KEYBOARD_ALIASES[_command_choice] = _aliases
+
+COMMAND_ALIAS_TO_CANONICAL: dict[str, str] = {
+    alias: command
+    for command, aliases in COMMAND_KEYBOARD_ALIASES.items()
+    for alias in aliases
+}
+
+
 @dataclass(frozen=True)
 class _UniprotCandidate:
     """Container describing a UniProt identifier candidate for a target row."""
@@ -601,6 +678,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "uniprot",
         parents=[shared],
         help="Extract information for UniProt accessions",
+        aliases=list(COMMAND_KEYBOARD_ALIASES.get("uniprot", ())),
     )
     uniprot.add_argument(
         "--column",
@@ -639,6 +717,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         parents=[shared],
         help="Retrieve target information from ChEMBL",
         conflict_handler="resolve",
+        aliases=list(COMMAND_KEYBOARD_ALIASES.get("chembl", ())),
     )
     # ``--id-cols`` and other export options are inherited from ``shared``.
     chembl.set_defaults(normalize_at_export=True)
@@ -683,6 +762,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "iuphar",
         parents=[shared],
         help="Map UniProt accessions to IUPHAR classifications",
+        aliases=list(COMMAND_KEYBOARD_ALIASES.get("iuphar", ())),
     )
     iuphar.add_argument(
         "--target-csv",
@@ -723,6 +803,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "all",
         parents=[shared],
         help="Run ChEMBL, UniProt and IUPHAR pipelines and merge results",
+        aliases=list(COMMAND_KEYBOARD_ALIASES.get("all", ())),
     )
     all_cmd.add_argument(
         "--chembl-out",
@@ -2452,6 +2533,14 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
 def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the selected target pipeline applying CLI policies."""
 
+    alias_token = getattr(args, "_command_keyboard_alias", None)
+    if isinstance(alias_token, str):
+        logger.info(
+            "command_alias_resolved",
+            alias=alias_token,
+            command=args.command,
+        )
+
     final_candidate = getattr(args, "final_out", None)
     if final_candidate in (None, argparse.SUPPRESS):
         final_output = Path(io.default_output_path(args.input_csv, cfg.io))
@@ -2499,6 +2588,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    command_alias = COMMAND_ALIAS_TO_CANONICAL.get(getattr(args, "command", ""))
+    if command_alias is not None:
+        setattr(args, "_command_keyboard_alias", args.command)
+        args.command = command_alias
     prepare_io_paths(
         args,
         input_default=DEFAULT_INPUT_NAME,

--- a/tests/test_get_target_data_keyboard_aliases.py
+++ b/tests/test_get_target_data_keyboard_aliases.py
@@ -1,0 +1,66 @@
+"""Tests for keyboard layout aliases in :mod:`scripts.get_target_data`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+import library.cli_utils as cli_utils
+from library.config import Config
+from scripts import get_target_data as gtd
+
+
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("фдд", "all"),
+        ("СРУЬИД", "chembl"),
+        ("гтшзкще", "uniprot"),
+        ("Шгзрфк", "iuphar"),
+    ],
+)
+def test_target_subcommand_keyboard_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: Config,
+    alias: str,
+    expected: str,
+) -> None:
+    """Running the CLI with a Russian keyboard alias resolves to the command."""
+
+    input_csv = tmp_path / "targets.csv"
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text("dummy: true\n")
+
+    resolved_command: dict[str, str] = {}
+
+    def fake_apply(
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+        cfg_path: str | Path,
+        mapping: dict[str, str] | None = None,
+        *,
+        base_parser: argparse.ArgumentParser | None = None,
+    ) -> Config:
+        return cfg
+
+    def fake_run(cfg: Config, args: argparse.Namespace) -> int:
+        resolved_command["command"] = args.command
+        return 0
+
+    monkeypatch.setattr(cli_utils, "apply_config_overrides", fake_apply)
+    monkeypatch.setattr(cli_utils, "ensure_dirs", lambda cfg: None)
+    monkeypatch.setattr(gtd, "run", fake_run)
+
+    exit_code = gtd.main([
+        "--config",
+        str(config_yaml),
+        "--input",
+        str(input_csv),
+        alias,
+    ])
+
+    assert exit_code == 0
+    assert resolved_command["command"] == expected


### PR DESCRIPTION
## Summary
- translate common Russian keyboard layout typos for get_target_data subcommands and normalise them to canonical names
- record resolved aliases in the CLI run path to retain existing configuration overrides and logging
- add unit coverage ensuring the aliases map back to the expected pipelines

## Testing
- pytest tests/test_get_target_data_keyboard_aliases.py *(fails: SyntaxError raised in library/postprocessing/document.py during module import)*

------
https://chatgpt.com/codex/tasks/task_e_68de6890becc8324b45777122376c6b6