### PR TITLE
Fix global rate limiter usage in document CLI

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1478,6 +1478,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     # Configure session for ChEMBL requests
+    global_limiter = get_global_limiter(
+        cfg.rate.global_rps, cfg.rate.global_burst
+    )
+
     with ChemblClient(
         cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
     ) as client:
@@ -1565,6 +1569,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     # Prepare shared session before performing any API calls
+    global_limiter = get_global_limiter(
+        cfg.rate.global_rps, cfg.rate.global_burst
+    )
+
     try:
         ids_iter = io.read_ids(
             args.input_csv,


### PR DESCRIPTION
## Summary
- initialize the global rate limiter within the document Chembl and combined pipelines
- ensure Chembl client sessions always receive a configured limiter

## Testing
- pytest tests/test_document_cli_limit.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de696d32ac83248cf3a020278ad907