### PR TITLE
Fix NameError when running document pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -343,7 +343,7 @@ def fetch_pubmed_records(
     if pubmed_cfg is None:
         pubmed_cfg = settings.pubmed
 
-    global_limiter = get_global_limiter(
+    system_limiter = get_global_limiter(
         rate_cfg.global_rps, rate_cfg.global_burst
     )
 
@@ -388,10 +388,13 @@ def fetch_pubmed_records(
     )
 
     def _acquire_documents(
-        limiter: RateLimiter | None, *, use_global: bool = True
+        limiter: RateLimiter | None,
+        *,
+        use_global: bool = True,
+        global_rate_limiter: RateLimiter | None = system_limiter,
     ) -> None:
-        if use_global and global_limiter is not None:
-            global_limiter.acquire()
+        if use_global and global_rate_limiter is not None:
+            global_rate_limiter.acquire()
         if limiter is not None:
             limiter.acquire()
 


### PR DESCRIPTION
## Summary
- capture the system rate limiter when building PubMed document fetch helpers to avoid undefined-name errors during CLI execution

## Testing
- pytest tests/test_document_cli_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68de6ae3e72c832485f2a0580874353a