### PR TITLE
Refactor activity and assay pipelines with chunked helper

### DIFF
--- a/library/pipeline_helpers.py
+++ b/library/pipeline_helpers.py
@@ -1,0 +1,172 @@
+"""Helpers for executing chunked data pipelines.
+
+The utilities centralise the boilerplate involved in running chunked fetchers
+with optional concurrency while streaming deterministic CSV output. Pipelines
+provide the chunk-level fetch function together with the existing
+``run_pipeline`` arguments and the helper coordinates the rest.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    as_completed,
+    wait,
+)
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pandas as pd
+
+from .cli_utils import PipelineError, run_pipeline
+from .clients import _chunked
+
+
+Chunk = TypeVar("Chunk", bound=pd.DataFrame)
+
+
+@dataclass(slots=True)
+class ChunkedFetchConfig:
+    """Configuration describing how identifiers should be chunked."""
+
+    ids: Iterable[str]
+    chunk_size: int
+    workers: int = 1
+    chunker: Callable[[Iterable[str], int], Iterable[Sequence[str]]] = _chunked
+
+
+@dataclass(slots=True)
+class CsvWriterConfig:
+    """Parameters forwarded to deterministic CSV writers."""
+
+    writer: Callable[..., Path]
+    kwargs: Mapping[str, Any]
+    ensure_destination: bool = False
+
+
+RunPipelineKwargs = Mapping[str, Any]
+
+
+def _ordered_results(
+    *,
+    chunk_iter: Iterable[Sequence[str]],
+    fetch_chunk: Callable[[Sequence[str]], Chunk],
+    workers: int,
+) -> Iterator[Chunk]:
+    """Yield fetched chunks preserving submission order."""
+
+    if workers <= 1:
+        for chunk_ids in chunk_iter:
+            yield fetch_chunk(list(chunk_ids))
+        return
+
+    pending: dict[Future[Chunk], int] = {}
+    completed: dict[int, Chunk] = {}
+    next_index = 0
+
+    def _cancel_pending() -> None:
+        for future in list(pending):
+            future.cancel()
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        try:
+            for index, chunk_ids in enumerate(chunk_iter):
+                future = executor.submit(fetch_chunk, list(chunk_ids))
+                pending[future] = index
+                if len(pending) < workers:
+                    continue
+                done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
+                for finished in done:
+                    chunk_index = pending.pop(finished)
+                    try:
+                        completed[chunk_index] = finished.result()
+                    except PipelineError:
+                        _cancel_pending()
+                        raise
+                while next_index in completed:
+                    yield completed.pop(next_index)
+                    next_index += 1
+
+            for future in as_completed(list(pending)):
+                chunk_index = pending.pop(future)
+                try:
+                    completed[chunk_index] = future.result()
+                except PipelineError:
+                    _cancel_pending()
+                    raise
+                while next_index in completed:
+                    yield completed.pop(next_index)
+                    next_index += 1
+        finally:
+            pending.clear()
+
+
+def prepare_chunked_pipeline(
+    *,
+    fetch_config: ChunkedFetchConfig,
+    fetch_chunk: Callable[[Sequence[str]], Chunk],
+    csv_writer: CsvWriterConfig,
+) -> tuple[
+    Callable[[], Iterator[Chunk]],
+    Callable[[Iterable[Chunk], Path, Sequence[str], Sequence[str]], Path],
+]:
+    """Construct fetcher and writer callables handling chunking and ordering."""
+
+    def fetcher() -> Iterator[Chunk]:
+        chunk_iterable = fetch_config.chunker(
+            fetch_config.ids,
+            fetch_config.chunk_size,
+        )
+        yield from _ordered_results(
+            chunk_iter=chunk_iterable,
+            fetch_chunk=fetch_chunk,
+            workers=max(1, fetch_config.workers),
+        )
+
+    def writer(
+        chunks: Iterable[Chunk],
+        destination: Path,
+        col_order: Sequence[str],
+        key_cols: Sequence[str],
+    ) -> Path:
+        sort_columns = list(key_cols) or sorted(col_order)
+        path = csv_writer.writer(
+            chunks,
+            destination,
+            key_cols=sort_columns,
+            col_order=col_order,
+            **csv_writer.kwargs,
+        )
+        path_obj = Path(path)
+        if csv_writer.ensure_destination and not path_obj.exists():
+            path_obj.parent.mkdir(parents=True, exist_ok=True)
+            path_obj.touch()
+        return path_obj
+
+    return fetcher, writer
+
+
+def run_chunked_pipeline(
+    *,
+    fetch_config: ChunkedFetchConfig,
+    fetch_chunk: Callable[[Sequence[str]], Chunk],
+    csv_writer: CsvWriterConfig,
+    pipeline_kwargs: RunPipelineKwargs,
+) -> int:
+    """Execute a pipeline using chunked fetching and deterministic CSV output."""
+
+    fetcher, writer = prepare_chunked_pipeline(
+        fetch_config=fetch_config,
+        fetch_chunk=fetch_chunk,
+        csv_writer=csv_writer,
+    )
+
+    return run_pipeline(
+        fetcher=fetcher,
+        writer=writer,
+        **pipeline_kwargs,
+    )

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Iterable, Iterator, Sequence
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, as_completed, wait
+from collections.abc import Iterator, Sequence
 from functools import partial
 from itertools import islice
 from pathlib import Path
@@ -27,8 +26,13 @@ import requests
 from library import chembl_library as cl
 from library import cli
 from library import io
-from library.csv_utils import write_csv_chunks_deterministic
-from library.clients import ChemblClient, _chunked
+from library.clients import ChemblClient
+from library.csv_utils import write_csv_chunks_deterministic  # re-exported for tests
+from library.pipeline_helpers import (
+    ChunkedFetchConfig,
+    CsvWriterConfig,
+    prepare_chunked_pipeline,
+)
 from library.rate_limiter import get_global_limiter
 from library.cli import (
     LoggerConfig,
@@ -138,91 +142,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
-    def fetcher() -> Iterator[pd.DataFrame]:
-        chunk_iter = _chunked(limited_ids, cfg.activity.batch_size)
-        global_limiter = get_global_limiter(
-            cfg.rate.global_rps, cfg.rate.global_burst
-        )
-
-        with ChemblClient(
-            cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-        ) as client:
-
-
-            def _fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
-                try:
-                    return cl.get_activities(
-                        ids,
-                        cfg=cfg.api,
-                        client=client,
-                        chunk_size=cfg.activity.batch_size,
-                        timeout=cfg.activity.timeout,
-                        **extra_kwargs,
-                    )
-                except (requests.RequestException, ValueError) as exc:
-                    logger.error(
-                        "activity_fetch_failed",
-                        extra={
-                            "msg": str(exc),
-                            "chunk_ids": list(chunk_ids),
-                        },
-                        error=str(exc),
-                        batch_size=cfg.activity.batch_size,
-                        timeout=cfg.activity.timeout,
-                    )
-                    raise PipelineError(str(exc)) from exc
-
-
-            workers = max(1, cfg.activity.workers)
-            if workers == 1:
-
-                for chunk_ids in id_chunks:
-                    yield _fetch_chunk(list(chunk_ids))
-                return
-
-
-            pending: dict[Future[pd.DataFrame], int] = {}
-            completed: dict[int, pd.DataFrame] = {}
-            next_index = 0
-
-            def _cancel_pending() -> None:
-                for future in list(pending):
-                    future.cancel()
-
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-
-                try:
-                    for index, chunk_ids in enumerate(id_chunks):
-                        chunk_list = list(chunk_ids)
-                        future = executor.submit(_fetch_chunk, chunk_list)
-                        pending[future] = index
-                        if len(pending) >= workers:
-                            done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
-                            for finished in done:
-                                chunk_index = pending.pop(finished)
-                                try:
-                                    completed[chunk_index] = finished.result()
-                                except PipelineError:
-                                    _cancel_pending()
-                                    raise
-                            while next_index in completed:
-                                yield completed.pop(next_index)
-                                next_index += 1
-
-                    for future in as_completed(list(pending)):
-                        chunk_index = pending.pop(future)
-                        try:
-                            completed[chunk_index] = future.result()
-                        except PipelineError:
-                            _cancel_pending()
-                            raise
-                        while next_index in completed:
-                            yield completed.pop(next_index)
-                            next_index += 1
-                finally:
-                    pending.clear()
-
-
     def _compute_bounds(frame: pd.DataFrame) -> pd.DataFrame:
         return compute_activity_bounds(frame, cfg.activity_bounds)
 
@@ -242,51 +161,88 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     validators = [partial(validate_activities, return_result=True)]
 
-    def writer(
-        chunks: Iterable[pd.DataFrame],
-        destination: Path,
-        col_order: Sequence[str],
-        key_cols: Sequence[str],
-    ) -> Path:
-        sort_columns = list(key_cols) or sorted(col_order)
-        output_path = io.write_csv(
-            chunks,
-            destination,
-            cfg=cfg,
-            key_cols=sort_columns,
-            col_order=col_order,
-            chunksize=cfg.io.csv_chunksize,
-            sep=cfg.io.csv_sep,
-            encoding=cfg.io.csv_encoding,
-        )
-        path_obj = Path(output_path)
-        if not path_obj.exists():
-            path_obj.parent.mkdir(parents=True, exist_ok=True)
-            path_obj.touch()
-        return path_obj
-
     table_quality = partial(
         analyze_table_quality,
         table_name=str(Path(output).with_suffix("")),
     )
 
-    exit_code = run_pipeline(
-        fetcher=fetcher,
-        schema=ActivitiesSchema,
-        schema_name="ActivitiesSchema",
-        validators=validators,
-        metadata_hooks=metadata_hooks,
-        writer=writer,
-        output_path=output,
-        failure_path=failure_path,
-        command=" ".join(sys.argv),
-        config_snapshot=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
-        key_columns=["activity_id"],
-        table_quality=table_quality,
-        cfg=cfg,
-        logger=logger,
+    global_limiter = get_global_limiter(
+        cfg.rate.global_rps,
+        cfg.rate.global_burst,
     )
+
+    with ChemblClient(
+        cfg.api,
+        cfg.retry,
+        cfg.chembl,
+        global_limiter=global_limiter,
+    ) as client:
+
+        def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
+            try:
+                return cl.get_activities(
+                    chunk_ids,
+                    cfg=cfg.api,
+                    client=client,
+                    chunk_size=cfg.activity.batch_size,
+                    timeout=cfg.activity.timeout,
+                    **extra_kwargs,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.error(
+                    "activity_fetch_failed",
+                    extra={
+                        "msg": str(exc),
+                        "chunk_ids": list(chunk_ids),
+                    },
+                    error=str(exc),
+                    batch_size=cfg.activity.batch_size,
+                    timeout=cfg.activity.timeout,
+                )
+                raise PipelineError(str(exc)) from exc
+
+        worker_count = getattr(cfg.activity, "workers", 1) or 1
+        fetch_config = ChunkedFetchConfig(
+            ids=limited_ids,
+            chunk_size=cfg.activity.batch_size,
+            workers=max(1, worker_count),
+        )
+
+        writer_config = CsvWriterConfig(
+            writer=write_csv_chunks_deterministic,
+            kwargs={
+                "cfg": cfg,
+                "chunksize": cfg.io.csv_chunksize,
+                "sort_chunksize": cfg.io.csv_chunksize,
+                "sep": cfg.io.csv_sep,
+                "encoding": cfg.io.csv_encoding,
+            },
+            ensure_destination=True,
+        )
+
+        fetcher, writer = prepare_chunked_pipeline(
+            fetch_config=fetch_config,
+            fetch_chunk=fetch_chunk,
+            csv_writer=writer_config,
+        )
+
+        exit_code = run_pipeline(
+            fetcher=fetcher,
+            schema=ActivitiesSchema,
+            schema_name="ActivitiesSchema",
+            validators=validators,
+            metadata_hooks=metadata_hooks,
+            writer=writer,
+            output_path=output,
+            failure_path=failure_path,
+            command=" ".join(sys.argv),
+            config_snapshot=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            key_columns=["activity_id"],
+            table_quality=table_quality,
+            cfg=cfg,
+            logger=logger,
+        )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -46,6 +46,11 @@ from library.pipeline_metadata import add_pipeline_metadata
 from library.table_quality import analyze_table_quality
 from library.validation import validate_assays
 from schemas import AssaysSchema, normalize_assays
+from library.pipeline_helpers import (
+    ChunkedFetchConfig,
+    CsvWriterConfig,
+    prepare_chunked_pipeline,
+)
 
 __all__ = ["ap", "main", "run", "run_chembl"]
 
@@ -112,35 +117,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
-    def fetcher() -> Iterable[pd.DataFrame]:
-        global_limiter = get_global_limiter(
-            cfg.rate.global_rps, cfg.rate.global_burst
-        )
-
-        with ChemblClient(
-            cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-        ) as client:
-            chunk_iter = cl._chunked(ids_source, cfg.assay.batch_size)
-            for chunk_ids in chunk_iter:
-                try:
-                    df = cl.get_assays(
-                        chunk_ids,
-                        cfg=cfg.api,
-                        client=client,
-                        chunk_size=cfg.assay.batch_size,
-                        timeout=cfg.assay.timeout,
-                    )
-                except (requests.RequestException, ValueError) as exc:
-                    logger.error(
-                        "assay_fetch_failed",
-                        extra={"msg": str(exc)},
-                        error=str(exc),
-                        batch_size=cfg.assay.batch_size,
-                        timeout=cfg.assay.timeout,
-                    )
-                    raise PipelineError(str(exc)) from exc
-                yield df
-
     metadata_hooks = [
         ap.postprocess_assays,
         normalize_assays,
@@ -149,47 +125,82 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     validators = [partial(validate_assays, return_result=True)]
 
-    def writer(
-        chunks: Iterable[pd.DataFrame],
-        destination: Path,
-        col_order: Sequence[str],
-        key_cols: Sequence[str],
-    ) -> Path:
-        sort_columns = list(key_cols) or sorted(col_order)
-        return write_csv_chunks_deterministic(
-            chunks,
-            destination,
-            key_cols=sort_columns,
-            col_order=col_order,
-            chunksize=cfg.io.csv_chunksize,
-            sort_chunksize=cfg.io.csv_chunksize,
-            sep=cfg.io.csv_sep,
-            encoding=cfg.io.csv_encoding,
-            cfg=cfg,
-        )
-
     table_quality = partial(
         analyze_table_quality,
         table_name=str(Path(output).with_suffix("")),
     )
 
-    exit_code = run_pipeline(
-        fetcher=fetcher,
-        schema=AssaysSchema,
-        schema_name="AssaysSchema",
-        validators=validators,
-        metadata_hooks=metadata_hooks,
-        writer=writer,
-        output_path=output,
-        failure_path=failure_path,
-        command=" ".join(sys.argv),
-        config_snapshot=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(args.input_csv)},
-        key_columns=["assay_chembl_id"],
-        table_quality=table_quality,
-        cfg=cfg,
-        logger=logger,
+    global_limiter = get_global_limiter(
+        cfg.rate.global_rps,
+        cfg.rate.global_burst,
     )
+
+    with ChemblClient(
+        cfg.api,
+        cfg.retry,
+        cfg.chembl,
+        global_limiter=global_limiter,
+    ) as client:
+
+        def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
+            try:
+                return cl.get_assays(
+                    chunk_ids,
+                    cfg=cfg.api,
+                    client=client,
+                    chunk_size=cfg.assay.batch_size,
+                    timeout=cfg.assay.timeout,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.error(
+                    "assay_fetch_failed",
+                    extra={"msg": str(exc)},
+                    error=str(exc),
+                    batch_size=cfg.assay.batch_size,
+                    timeout=cfg.assay.timeout,
+                )
+                raise PipelineError(str(exc)) from exc
+
+        fetch_config = ChunkedFetchConfig(
+            ids=ids_source,
+            chunk_size=cfg.assay.batch_size,
+            workers=1,
+        )
+
+        writer_config = CsvWriterConfig(
+            writer=write_csv_chunks_deterministic,
+            kwargs={
+                "chunksize": cfg.io.csv_chunksize,
+                "sort_chunksize": cfg.io.csv_chunksize,
+                "sep": cfg.io.csv_sep,
+                "encoding": cfg.io.csv_encoding,
+                "cfg": cfg,
+            },
+        )
+
+        fetcher, writer = prepare_chunked_pipeline(
+            fetch_config=fetch_config,
+            fetch_chunk=fetch_chunk,
+            csv_writer=writer_config,
+        )
+
+        exit_code = run_pipeline(
+            fetcher=fetcher,
+            schema=AssaysSchema,
+            schema_name="AssaysSchema",
+            validators=validators,
+            metadata_hooks=metadata_hooks,
+            writer=writer,
+            output_path=output,
+            failure_path=failure_path,
+            command=" ".join(sys.argv),
+            config_snapshot=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(args.input_csv)},
+            key_columns=["assay_chembl_id"],
+            table_quality=table_quality,
+            cfg=cfg,
+            logger=logger,
+        )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)


### PR DESCRIPTION
## Summary
- add a shared helper that builds chunked fetchers and deterministic CSV writers while preserving order and concurrency handling
- refactor the activity pipeline to rely on the helper, centralising rate-limited fetching and metadata hooks
- update the assay pipeline to use the same helper for chunking and CSV export to reduce duplicated code

## Testing
- pytest tests/test_get_activity_data.py tests/test_get_assay_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de69a1424c832492d63687c2e441e2