### PR TITLE
Handle namespaced ChEMBL columns in document export postprocessing

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -131,6 +131,23 @@ METADATA_SOURCE_COLUMNS: Mapping[str, Sequence[str]] = {
         "crossref.Error",
     ),
 }
+
+CHEMBL_EXPORT_ALIASES: Mapping[str, str] = {
+    "ChEMBL.document_chembl_id": "document_chembl_id",
+    "ChEMBL.title": "title",
+    "ChEMBL.abstract": "abstract",
+    "ChEMBL.doi": "doi",
+    "ChEMBL.year": "year",
+    "ChEMBL.journal": "journal",
+    "ChEMBL.journal_abbrev": "journal_abbrev",
+    "ChEMBL.volume": "volume",
+    "ChEMBL.issue": "issue",
+    "ChEMBL.first_page": "first_page",
+    "ChEMBL.last_page": "last_page",
+    "ChEMBL.pubmed_id": "pubmed_id",
+    "ChEMBL.authors": "authors",
+    "ChEMBL.source": "source",
+}
 ERROR_COLUMN_MAP: Mapping[str, str] = {
     "pubmed": "PubMed.Error",
     "semantic_scholar": "scholar.Error",
@@ -208,6 +225,22 @@ def _string_series(series: pd.Series) -> pd.Series:
         return pd.Series(dtype="string")
     result = series.astype("string").fillna("").str.strip()
     return result
+
+
+def _apply_export_aliases(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with ChEMBL export aliases populated."""
+
+    frame = df.copy()
+    for source, target in CHEMBL_EXPORT_ALIASES.items():
+        if source not in frame.columns:
+            continue
+        if target in frame.columns:
+            mask = _string_series(frame[target]) == ""
+            if mask.any():
+                frame.loc[mask, target] = frame.loc[mask, source]
+        else:
+            frame[target] = frame[source]
+    return frame
 
 
 def _truthy_mask(series: pd.Series) -> pd.Series:
@@ -370,39 +403,42 @@ def _coverage_status(score: int, has_error: bool) -> str:
 def preprocess_document_export(df: pd.DataFrame) -> pd.DataFrame:
     """Return analytics-oriented projection of ``df``."""
 
-    validate_columns(df, REQUIRED_INPUT_COLUMNS)
-    if df.empty:
+    frame = _apply_export_aliases(df)
+    validate_columns(frame, REQUIRED_INPUT_COLUMNS)
+    if frame.empty:
         result = pd.DataFrame(columns=list(PREPROCESSED_COLUMN_ORDER))
         return result
 
-    result = pd.DataFrame(index=df.index)
-    result["document_chembl_id"] = _string_series(df["document_chembl_id"])
+    result = pd.DataFrame(index=frame.index)
+    result["document_chembl_id"] = _string_series(frame["document_chembl_id"])
 
     for target, columns in COALESCE_PRIORITIES.items():
-        result[target] = _coalesce_columns(df, columns)
+        result[target] = _coalesce_columns(frame, columns)
 
-    if "publication_class" in df.columns:
-        result["publication_class"] = _string_series(df["publication_class"])
+    if "publication_class" in frame.columns:
+        result["publication_class"] = _string_series(frame["publication_class"])
     else:
-        result["publication_class"] = pd.Series([""] * len(df), index=df.index, dtype="string")
+        result["publication_class"] = pd.Series(
+            [""] * len(frame), index=frame.index, dtype="string"
+        )
 
-    review_series = pd.Series([False] * len(df), index=df.index)
+    review_series = pd.Series([False] * len(frame), index=frame.index)
     if "publication_class" in result.columns:
         review_series = review_series | (
             result["publication_class"].str.lower() == "review"
         )
     for column in REVIEW_COLUMNS:
-        if column in df.columns:
-            review_series = review_series | _series_to_bool(df[column])
+        if column in frame.columns:
+            review_series = review_series | _series_to_bool(frame[column])
     result["is_review"] = review_series
 
-    metadata_series, metadata_flags = _build_metadata_flags(df)
+    metadata_series, metadata_flags = _build_metadata_flags(frame)
     result["metadata_sources"] = metadata_series
     result["metadata_source_count"] = metadata_flags.pop("metadata_source_count")
     for column, mask in metadata_flags.items():
         result[column] = mask
 
-    error_sources, has_error = _build_error_sources(df)
+    error_sources, has_error = _build_error_sources(frame)
     result["error_sources"] = error_sources
     result["has_error"] = has_error
 
@@ -415,8 +451,8 @@ def preprocess_document_export(df: pd.DataFrame) -> pd.DataFrame:
     ]
     result["coverage_status"] = pd.Series(status_values, index=df.index, dtype="string")
 
-    mesh_columns = [column for column in MESH_TERM_COLUMNS if column in df.columns]
-    result["mesh_terms"] = _aggregate_terms(df, mesh_columns)
+    mesh_columns = [column for column in MESH_TERM_COLUMNS if column in frame.columns]
+    result["mesh_terms"] = _aggregate_terms(frame, mesh_columns)
 
     if "publication_year" in result.columns:
         publication_year = result["publication_year"].replace("", pd.NA)
@@ -424,24 +460,30 @@ def preprocess_document_export(df: pd.DataFrame) -> pd.DataFrame:
             publication_year, errors="coerce"
         ).astype("Int64")
     else:
-        result["publication_year"] = pd.Series([pd.NA] * len(df), index=df.index, dtype="Int64")
+        result["publication_year"] = pd.Series(
+            [pd.NA] * len(frame), index=frame.index, dtype="Int64"
+        )
 
     for column in PASS_THROUGH_COLUMNS:
-        if column not in df.columns:
+        if column not in frame.columns:
             if column == "Index":
-                result[column] = pd.Series([""] * len(df), index=df.index, dtype="string")
+                result[column] = pd.Series(
+                    [""] * len(frame), index=frame.index, dtype="string"
+                )
             else:
-                result[column] = pd.Series([""] * len(df), index=df.index, dtype="string")
+                result[column] = pd.Series(
+                    [""] * len(frame), index=frame.index, dtype="string"
+                )
             continue
         if column == "Index":
-            index_series = df[column]
+            index_series = frame[column]
             if pd.api.types.is_numeric_dtype(index_series):
                 padded = index_series.fillna(0).astype(int).astype(str)
             else:
                 padded = _string_series(index_series)
             result[column] = padded.str.zfill(INDEX_PAD_WIDTH)
         else:
-            result[column] = _string_series(df[column])
+            result[column] = _string_series(frame[column])
 
     existing_columns = [
         column for column in PREPROCESSED_COLUMN_ORDER if column in result.columns

--- a/tests/test_document_export_postprocessing.py
+++ b/tests/test_document_export_postprocessing.py
@@ -49,12 +49,22 @@ def _sample_dataframe() -> pd.DataFrame:
     )
 
 
-def test_preprocess_document_export_derives_fields() -> None:
-    """The derived projection coalesces fields and computes coverage flags."""
+def _chembl_namespaced_dataframe() -> pd.DataFrame:
+    mapping = {
+        "document_chembl_id": "ChEMBL.document_chembl_id",
+        "title": "ChEMBL.title",
+        "abstract": "ChEMBL.abstract",
+        "doi_normalised": "doi_normalised",
+        "pubmed_id": "ChEMBL.pubmed_id",
+        "journal": "ChEMBL.journal",
+        "authors": "ChEMBL.authors",
+        "source": "ChEMBL.source",
+    }
+    df = _sample_dataframe().rename(columns=mapping)
+    return df
 
-    df = _sample_dataframe()
-    result = document_export_postprocessing.preprocess_document_export(df)
 
+def _assert_projection(result: pd.DataFrame) -> None:
     assert result["preferred_title"].tolist() == ["Title A", "PubMed Title"]
     assert result["preferred_abstract"].tolist() == ["Abstract A", "Abstract B"]
     assert result["preferred_doi"].tolist() == ["10.1000/foo", "10.1000/bar"]
@@ -73,6 +83,22 @@ def test_preprocess_document_export_derives_fields() -> None:
     assert result["mesh_terms"].tolist() == ["Term1; Term2", "Qual1; Term3"]
     assert result["publication_year"].tolist() == [2021, 2018]
     assert result["is_review"].tolist() == [False, True]
+
+
+def test_preprocess_document_export_derives_fields() -> None:
+    """The derived projection coalesces fields and computes coverage flags."""
+
+    df = _sample_dataframe()
+    result = document_export_postprocessing.preprocess_document_export(df)
+    _assert_projection(result)
+
+
+def test_preprocess_document_export_accepts_namespaced_columns() -> None:
+    """Namespaced ChEMBL columns are normalised before processing."""
+
+    df = _chembl_namespaced_dataframe()
+    result = document_export_postprocessing.preprocess_document_export(df)
+    _assert_projection(result)
 
 
 def test_postprocess_export_file_writes_csv(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- normalise ChEMBL-prefixed document columns before running the analytics export pipeline so core fields are always present
- cover the behaviour with a regression test that exercises namespaced inputs alongside the existing projection test

## Testing
- pytest tests/test_document_export_postprocessing.py
- python scripts/get_document_data.py all --limit 5 --input data/input/full/document.csv --output /tmp/test.csv

------
https://chatgpt.com/codex/tasks/task_e_68de6bf638a08324a30b30577f27f58f