### PR TITLE
Handle missing document identifiers during export post-processing

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -367,16 +367,49 @@ def _coverage_status(score: int, has_error: bool) -> str:
 
 
 # ===== Modules ==============================================================
+def _ensure_document_identifier(frame: pd.DataFrame) -> pd.DataFrame:
+    """Ensure ``frame`` exposes a ``document_chembl_id`` column."""
+
+    if "document_chembl_id" in frame.columns:
+        return frame
+
+    # Normalise alternative representations (case differences, stray spacing)
+    for column in frame.columns:
+        if column.strip().lower() == "document_chembl_id":
+            if column == "document_chembl_id":
+                return frame
+            renamed = frame.copy()
+            renamed = renamed.rename(columns={column: "document_chembl_id"})
+            logger.warning(
+                "document_id_column_renamed",
+                original=column,
+                normalised="document_chembl_id",
+            )
+            return renamed
+
+    if "ChEMBL.document_chembl_id" in frame.columns:
+        duplicated = frame.copy()
+        duplicated["document_chembl_id"] = duplicated["ChEMBL.document_chembl_id"]
+        logger.warning(
+            "document_id_column_duplicated",
+            source="ChEMBL.document_chembl_id",
+            target="document_chembl_id",
+        )
+        return duplicated
+
+    fallback = frame.copy()
+    fallback["document_chembl_id"] = ""
+    logger.error(
+        "document_id_column_missing",
+        columns=list(frame.columns),
+    )
+    return fallback
+
+
 def preprocess_document_export(df: pd.DataFrame) -> pd.DataFrame:
     """Return analytics-oriented projection of ``df``."""
 
-    frame = df
-    if (
-        "document_chembl_id" not in frame.columns
-        and "ChEMBL.document_chembl_id" in frame.columns
-    ):
-        frame = frame.copy()
-        frame["document_chembl_id"] = frame["ChEMBL.document_chembl_id"]
+    frame = _ensure_document_identifier(df)
 
     validate_columns(frame, REQUIRED_INPUT_COLUMNS)
     if frame.empty:

--- a/tests/test_document_export_postprocessing.py
+++ b/tests/test_document_export_postprocessing.py
@@ -75,6 +75,27 @@ def test_preprocess_document_export_derives_fields() -> None:
     assert result["is_review"].tolist() == [False, True]
 
 
+def test_preprocess_document_export_restores_identifier_from_prefixed_column() -> None:
+    """The export projection rehydrates ``document_chembl_id`` when prefixed."""
+
+    df = _sample_dataframe().drop(columns=["document_chembl_id"])
+    df["ChEMBL.document_chembl_id"] = ["DOC1", "DOC2"]
+
+    result = document_export_postprocessing.preprocess_document_export(df)
+
+    assert result["document_chembl_id"].tolist() == ["DOC1", "DOC2"]
+
+
+def test_preprocess_document_export_injects_empty_identifier_when_missing() -> None:
+    """An empty identifier column is created when no source column exists."""
+
+    df = _sample_dataframe().drop(columns=["document_chembl_id"])
+
+    result = document_export_postprocessing.preprocess_document_export(df)
+
+    assert result["document_chembl_id"].tolist() == ["", ""]
+
+
 def test_postprocess_export_file_writes_csv(tmp_path: Path) -> None:
     """``postprocess_export_file`` writes the derived projection to disk."""
 


### PR DESCRIPTION
## Summary
- ensure the document export post-processing stage always exposes `document_chembl_id`, even when the CSV only contains a prefixed column or lacks the identifier entirely
- add regression coverage for recovering and synthesising the identifier column in the export pipeline tests

## Testing
- pytest tests/test_document_export_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68de6c8f950c83249b16ecb6078ca032