### PR TITLE
Fix default resource paths outside config directory

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -444,12 +444,12 @@
       "additionalProperties": false,
       "properties": {
         "cache_path": {
-          "default": "data/cache/molecule_parent_catalog.json",
+          "default": "../data/cache/molecule_parent_catalog.json",
           "title": "Cache Path",
           "type": "string"
         },
         "sqlite_path": {
-          "default": "data/cache/molecule_parent_catalog.sqlite",
+          "default": "../data/cache/molecule_parent_catalog.sqlite",
           "title": "Sqlite Path",
           "type": "string"
         },
@@ -477,7 +477,7 @@
               "type": "null"
             }
           ],
-          "default": "dictionary/_testitem/molecule_hierarchy.csv",
+          "default": "../dictionary/_testitem/molecule_hierarchy.csv",
           "title": "Hierarchy Lookup Path"
         },
         "hierarchy_lookup_encoding": {
@@ -941,19 +941,19 @@
       "additionalProperties": false,
       "properties": {
         "same_doc": {
-          "default": "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx",
+          "default": "../data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx",
           "format": "path",
           "title": "Same Doc",
           "type": "string"
         },
         "all_doc": {
-          "default": "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx",
+          "default": "../data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx",
           "format": "path",
           "title": "All Doc",
           "type": "string"
         },
         "output_dir": {
-          "default": "data/output/ChEMBL/processed",
+          "default": "../data/output/ChEMBL/processed",
           "format": "path",
           "title": "Output Dir",
           "type": "string"
@@ -966,7 +966,7 @@
       "additionalProperties": false,
       "properties": {
         "output_dir": {
-          "default": "data/output",
+          "default": "../data/output",
           "format": "path",
           "title": "Output Dir",
           "type": "string"
@@ -1264,7 +1264,7 @@
           ]
         },
         "cid_cache_path": {
-          "default": "data/cache/pubchem_cid_cache.json",
+          "default": "../data/cache/pubchem_cid_cache.json",
           "description": "Optional JSON cache storing PubChem CIDs by molecule_chembl_id",
           "title": "Cid Cache Path",
           "type": [
@@ -1410,25 +1410,25 @@
           "type": "string"
         },
         "iuphar_target_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Iuphar Target Csv",
           "type": "string"
         },
         "iuphar_family_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Iuphar Family Csv",
           "type": "string"
         },
         "uniprot_data_dir": {
-          "default": "dictionary/_target/_uniprot",
+          "default": "../dictionary/_target/_uniprot",
           "format": "path",
           "title": "Uniprot Data Dir",
           "type": "string"
         },
         "targets_type_csv": {
-          "default": "dictionary/_target/targets_type.csv",
+          "default": "../dictionary/_target/targets_type.csv",
           "format": "path",
           "title": "Targets Type Csv",
           "type": "string"
@@ -1576,19 +1576,19 @@
       "additionalProperties": false,
       "properties": {
         "data_dir": {
-          "default": "dictionary/_target/_uniprot",
+          "default": "../dictionary/_target/_uniprot",
           "format": "path",
           "title": "Data Dir",
           "type": "string"
         },
         "target_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Target Csv",
           "type": "string"
         },
         "family_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Family Csv",
           "type": "string"
@@ -1727,13 +1727,13 @@
       "additionalProperties": false,
       "properties": {
         "target_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Target Csv",
           "type": "string"
         },
         "family_csv": {
-          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Family Csv",
           "type": "string"
@@ -1764,7 +1764,7 @@
           "type": "string"
         },
         "data_dir": {
-          "default": "dictionary/_target/_uniprot",
+          "default": "../dictionary/_target/_uniprot",
           "format": "path",
           "title": "Data Dir",
           "type": "string"
@@ -1890,13 +1890,13 @@
       "additionalProperties": false,
       "properties": {
         "molecule_catalog_path": {
-          "default": "dictionary/molecule_catalog.csv",
+          "default": "../dictionary/molecule_catalog.csv",
           "format": "path",
           "title": "Molecule Catalog Path",
           "type": "string"
         },
         "molecule_hierarchy_path": {
-          "default": "dictionary/molecule_hierarchy.csv",
+          "default": "../dictionary/molecule_hierarchy.csv",
           "format": "path",
           "title": "Molecule Hierarchy Path",
           "type": "string"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,12 +23,12 @@ sources:
       cache_ttl: 3600  # Seconds to cache ChEMBL API responses (env: CHEMBL_DA_CACHE_TTL)
       cache_maxsize: 1024  # Max cached ChEMBL responses (env: CHEMBL_DA_CACHE_MAXSIZE)
     molecule_catalog:
-      cache_path: "data/cache/molecule_parent_catalog.json"  # Local cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_CACHE)
-      sqlite_path: "data/cache/molecule_parent_catalog.sqlite"  # SQLite cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_SQLITE)
+      cache_path: "../data/cache/molecule_parent_catalog.json"  # Local cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_CACHE)
+      sqlite_path: "../data/cache/molecule_parent_catalog.sqlite"  # SQLite cache for molecule parents (env: CHEMBL_DA_MOLECULE_CATALOG_SQLITE)
       endpoint: "molecule"  # API resource providing parent relationships
       child_field: "molecule_chembl_id"  # Column containing molecule identifiers
       parent_field: "parent_molecule_chembl_id"  # Column containing parent molecule identifiers
-      hierarchy_lookup_path: "dictionary/_testitem/molecule_hierarchy.csv"  # CSV with precomputed parent relationships
+      hierarchy_lookup_path: "../dictionary/_testitem/molecule_hierarchy.csv"  # CSV with precomputed parent relationships
       hierarchy_lookup_encoding: "utf-8-sig"  # Encoding used for the hierarchy CSV
       hierarchy_lookup_delimiter: ","  # Delimiter used for the hierarchy CSV
       page_size: 500  # Page size for catalog fetching
@@ -99,7 +99,7 @@ sources:
       target:
         uniprot:
           column: "uniprot_id"
-          data_dir: "dictionary/_target/_uniprot"
+          data_dir: "../dictionary/_target/_uniprot"
           limit: null
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers
@@ -107,13 +107,13 @@ sources:
           timeout: 30.0
           limit: null
         iuphar:
-          target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
-          family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
+          target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
+          family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           limit: null
         all:
-          data_dir: "dictionary/_target/_uniprot"
-          target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
-          family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
+          data_dir: "../dictionary/_target/_uniprot"
+          target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
+          family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           chunk_size: 5
           timeout: 30.0
           uniprot_column: "uniprot_id"
@@ -177,7 +177,7 @@ sources:
     cache_ttl: 3600  # Request cache time-to-live in seconds
     cache_maxsize: 1024  # Maximum cached PubChem responses
     cache_ttl_hours: null  # Persisted CID cache TTL in hours; null disables expiry
-    cid_cache_path: "data/cache/pubchem_cid_cache.json"
+    cid_cache_path: "../data/cache/pubchem_cid_cache.json"
     batch_size: 50
     prefer_local_smiles: false
     prefer_local_values: true
@@ -203,12 +203,12 @@ sources:
 local:
   resources:
     dictionary_dir: "dictionary"  # Directory with supplementary lookup tables
-    iuphar_target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
-    iuphar_family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
-    uniprot_data_dir: "dictionary/_target/_uniprot"  # Directory containing cached UniProt JSON files
-    targets_type_csv: "dictionary/_target/targets_type.csv"  # Target type mapping table
+    iuphar_target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
+    iuphar_family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
+    uniprot_data_dir: "../dictionary/_target/_uniprot"  # Directory containing cached UniProt JSON files
+    targets_type_csv: "../dictionary/_target/targets_type.csv"  # Target type mapping table
   io:
-    output_dir: "data/output"  # Directory for generated datasets
+    output_dir: "../data/output"  # Directory for generated datasets
     cache_dir: ".cache"  # Directory for cached HTTP responses (env: CHEMBL_DA_CACHE_DIR)
     csv_sep: ","  # CSV field separator
     csv_encoding: "utf-8-sig"  # Encoding for CSV files
@@ -221,9 +221,9 @@ local:
     keep_na_markers: false  # Preserve identifiers matching NA markers instead of dropping them
     exist_ok: true  # Create directories with ensure_dirs if missing
   init:
-    same_doc: "data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"  # Source workbook
-    all_doc: "data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
-    output_dir: "data/output/ChEMBL/processed"  # Output directory for processed files
+    same_doc: "../data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx"  # Source workbook
+    all_doc: "../data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx"
+    output_dir: "../data/output/ChEMBL/processed"  # Output directory for processed files
 
 activity_enrichment:
   action_type:
@@ -290,8 +290,8 @@ activity_enrichment:
 testitem_molecule_enrichment:
   enable: true
   sources:
-    molecule_catalog_path: "dictionary/_testitem/molecule_catalog.csv"
-    molecule_hierarchy_path: "dictionary/_testitem/molecule_hierarchy.csv"
+    molecule_catalog_path: "../dictionary/_testitem/molecule_catalog.csv"
+    molecule_hierarchy_path: "../dictionary/_testitem/molecule_hierarchy.csv"
   output:
     salt_as_null_when_absent: true
   flags:

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -44,15 +44,15 @@ Sensitive values (API tokens, personal e-mails) should be injected via environme
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `cache_path` | `data/cache/molecule_parent_catalog.json` | Location of the JSON cache storing molecule parent-child relationships reused by enrichment jobs; override via `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`). |
-| `sqlite_path` | `data/cache/molecule_parent_catalog.sqlite` | Location of the SQLite cache powering parent-child lookups; override via `CHEMBL_DA_SOURCES_CHEMBL_MOLECULE_CATALOG_SQLITE_PATH` (or the canonical `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__SQLITE_PATH`). |
+| `cache_path` | `../data/cache/molecule_parent_catalog.json` | Location of the JSON cache storing molecule parent-child relationships reused by enrichment jobs; override via `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (alias for `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`). |
+| `sqlite_path` | `../data/cache/molecule_parent_catalog.sqlite` | Location of the SQLite cache powering parent-child lookups; override via `CHEMBL_DA_SOURCES_CHEMBL_MOLECULE_CATALOG_SQLITE_PATH` (or the canonical `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__SQLITE_PATH`). |
 | `endpoint` | `molecule` | ChEMBL REST resource queried when the cache needs to be refreshed. |
 | `child_field` | `molecule_chembl_id` | JSON field containing the child molecule identifier extracted from API responses. |
 | `parent_field` | `parent_molecule_chembl_id` | JSON field containing the parent molecule identifier extracted from API responses. |
 | `force_refresh_existing` | `false` | When `true`, rebuilds parent relationships even if the incoming dataset already contains parent identifiers, ensuring the cache wins over source columns. |
 | `fields` | `['molecule_chembl_id', 'parent_molecule_chembl_id']` | List of fields requested from the ChEMBL API when populating or refreshing the catalogue; extend to retrieve extra metadata alongside identifiers. |
 | `filters` | `{'parent_molecule_chembl_id__isnull': 'false'}` | Query parameters appended to every API call; defaults keep only rows that already have parent assignments in ChEMBL. |
-| `hierarchy_lookup_path` | `dictionary/_testitem/molecule_hierarchy.csv` | Optional CSV used as an offline seed for parent-child relationships before querying ChEMBL; override when distributing a curated hierarchy snapshot or relocating the dictionary folder. |
+| `hierarchy_lookup_path` | `../dictionary/_testitem/molecule_hierarchy.csv` | Optional CSV used as an offline seed for parent-child relationships before querying ChEMBL; override when distributing a curated hierarchy snapshot or relocating the dictionary folder. |
 | `hierarchy_lookup_encoding` | `utf-8-sig` | Text encoding applied when reading the hierarchy lookup CSV; change when the snapshot is saved with a different charset (for example Latin-1 from legacy exports). |
 | `hierarchy_lookup_delimiter` | `,` | Delimiter expected by the hierarchy lookup loader; override for semicolon- or tab-separated snapshots produced by regional data teams. |
 | `page_size` | `500` | Number of records requested per API page while rebuilding the catalogue. |
@@ -188,8 +188,8 @@ applies exponential backoff between attempts before surfacing the error.
 | Key | Default | Description |
 | --- | --- | --- |
 | `enable` | `true` | Master switch for the enrichment stage that derives salt identifiers and catalogue flags. |
-| `sources.molecule_catalog_path` | `dictionary/_testitem/molecule_catalog.csv` | CSV with `molecule_chembl_id` and the `natural_product`/`prodrug`/`polymer_flag` columns. |
-| `sources.molecule_hierarchy_path` | `dictionary/_testitem/molecule_hierarchy.csv` | CSV that maps derivatives to their parent molecule (`molecule_chembl_id`, `parent_molecule_chembl_id`). |
+| `sources.molecule_catalog_path` | `../dictionary/_testitem/molecule_catalog.csv` | CSV with `molecule_chembl_id` and the `natural_product`/`prodrug`/`polymer_flag` columns. |
+| `sources.molecule_hierarchy_path` | `../dictionary/_testitem/molecule_hierarchy.csv` | CSV that maps derivatives to their parent molecule (`molecule_chembl_id`, `parent_molecule_chembl_id`). |
 | `output.salt_as_null_when_absent` | `true` | Emit `null` (or `-` when set to `false`) when the compound is not a salt. |
 | `flags.coerce_to_bool` | `true` | Normalise catalogue values such as `Y/N`, `1/0`, `yes/no` to pandas nullable booleans. |
 | `flags.parent_fallback` | `true` | Reuse parent flag values when the child entry is missing. |
@@ -222,18 +222,18 @@ applies exponential backoff between attempts before surfacing the error.
 | Sub-section | Key | Default | Description |
 | --- | --- | --- | --- |
 | `uniprot` | `column` | `uniprot_id` | Column with UniProt identifiers. |
-|  | `data_dir` | `dictionary/_target/_uniprot` | Directory holding cached UniProt JSON files. |
+|  | `data_dir` | `../dictionary/_target/_uniprot` | Directory holding cached UniProt JSON files. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
 | `chembl` | `column` | `target_chembl_id` | Column with ChEMBL target identifiers. |
 |  | `chunk_size` | `5` | Batch size for API requests. |
 |  | `timeout` | `30.0` | Request timeout in seconds. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
-| `iuphar` | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Lookup table with IUPHAR target metadata. |
-|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Lookup table with IUPHAR family metadata. |
+| `iuphar` | `target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Lookup table with IUPHAR target metadata. |
+|  | `family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Lookup table with IUPHAR family metadata. |
 |  | `limit` | `null` | Optional cap on identifiers processed. |
-| `all` | `data_dir` | `dictionary/_target/_uniprot` | Directory containing cached UniProt data. |
-|  | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target reference data. |
-|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family reference data. |
+| `all` | `data_dir` | `../dictionary/_target/_uniprot` | Directory containing cached UniProt data. |
+|  | `target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target reference data. |
+|  | `family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family reference data. |
 |  | `chunk_size` | `5` | Batch size when combining all sources. |
 |  | `timeout` | `30.0` | Request timeout in seconds. |
 
@@ -286,7 +286,7 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | `cache_ttl` | `3600` | Lifespan (seconds) of the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_maxsize` | `1024` | Maximum number of entries retained by the in-memory HTTP response cache. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_MAXSIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_MAXSIZE` |
 | `cache_ttl_hours` | `null` | Optional expiry (hours) for the persisted CID cache; `null` keeps entries indefinitely. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
-| `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
+| `cid_cache_path` | `"../data/cache/pubchem_cid_cache.json"` | Path to a JSON file storing resolved CIDs for re-use across runs. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
 | `batch_size` | `50` | Number of rows processed per PubChem batch request; concurrency never exceeds `min(batch_size, rps)`. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Skip remote lookups when local SMILES/InChIKey columns are already populated. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Preserve existing `pubchem_*` columns when lookups return empty payloads. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |
@@ -304,10 +304,10 @@ supports the short alias documented in the [Environment variable aliases](#envir
 | Key | Default | Description |
 | --- | --- | --- |
 | `dictionary_dir` | `dictionary` | Root directory with lookup tables. |
-| `iuphar_target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target mapping table. |
-| `iuphar_family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family mapping table. |
-| `uniprot_data_dir` | `dictionary/_target/_uniprot` | Cached UniProt JSON responses. |
-| `targets_type_csv` | `dictionary/_target/targets_type.csv` | Target type classification table. |
+| `iuphar_target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | IUPHAR target mapping table. |
+| `iuphar_family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | IUPHAR family mapping table. |
+| `uniprot_data_dir` | `../dictionary/_target/_uniprot` | Cached UniProt JSON responses. |
+| `targets_type_csv` | `../dictionary/_target/targets_type.csv` | Target type classification table. |
 
 
 The `dictionary/_target` folder mirrors the current repository layout; all
@@ -318,7 +318,7 @@ IUPHAR and UniProt lookups are stored there by default.
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `output_dir` | `data/output` | Base directory for generated datasets. |
+| `output_dir` | `../data/output` | Base directory for generated datasets. |
 | `cache_dir` | `.cache` | Location of the HTTP cache. |
 | `csv_sep` | `,` | Default delimiter when reading and writing CSV files. |
 | `csv_fallback_separators` | `["\t", ";"]` | Additional delimiters tried when the primary separator does not expose the requested column. |
@@ -332,9 +332,9 @@ IUPHAR and UniProt lookups are stored there by default.
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `same_doc` | `data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx` | Workbook with same-document pairs for initialisation. |
-| `all_doc` | `data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx` | Workbook with cross-document pairs for initialisation. |
-| `output_dir` | `data/output/ChEMBL/processed` | Destination for pre-processed initialisation files. |
+| `same_doc` | `../data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx` | Workbook with same-document pairs for initialisation. |
+| `all_doc` | `../data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx` | Workbook with cross-document pairs for initialisation. |
+| `output_dir` | `../data/output/ChEMBL/processed` | Destination for pre-processed initialisation files. |
 
 ## System settings (`system`)
 

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -43,15 +43,15 @@
 
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
-| `cache_path` | `data/cache/molecule_parent_catalog.json` | Путь к локальному JSON с отношениями родитель→потомок, который переиспользуется конвейерами; переопределяется через `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (алиас `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`). |
-| `sqlite_path` | `data/cache/molecule_parent_catalog.sqlite` | Путь к SQLite-кэшу для быстрых запросов по связям; используйте `CHEMBL_DA_SOURCES_CHEMBL_MOLECULE_CATALOG_SQLITE_PATH` или каноничную форму `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__SQLITE_PATH`. |
+| `cache_path` | `../data/cache/molecule_parent_catalog.json` | Путь к локальному JSON с отношениями родитель→потомок, который переиспользуется конвейерами; переопределяется через `CHEMBL_DA_MOLECULE_CATALOG_CACHE` (алиас `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__CACHE_PATH`). |
+| `sqlite_path` | `../data/cache/molecule_parent_catalog.sqlite` | Путь к SQLite-кэшу для быстрых запросов по связям; используйте `CHEMBL_DA_SOURCES_CHEMBL_MOLECULE_CATALOG_SQLITE_PATH` или каноничную форму `CHEMBL_DA__SOURCES__CHEMBL__MOLECULE_CATALOG__SQLITE_PATH`. |
 | `endpoint` | `molecule` | Ресурс REST API ChEMBL, из которого подкачиваются данные при обновлении кэша. |
 | `child_field` | `molecule_chembl_id` | Поле ответа API с идентификатором дочерней молекулы. |
 | `parent_field` | `parent_molecule_chembl_id` | Поле ответа API с идентификатором родительской молекулы. |
 | `force_refresh_existing` | `false` | При `true` пересобирает связи родитель→потомок даже для записей с уже заполненным родителем, заставляя использовать данные из кэша/ChEMBL. |
 | `fields` | `['molecule_chembl_id', 'parent_molecule_chembl_id']` | Список полей, которые запрашиваются у ChEMBL при построении или обновлении каталога; расширяйте его для дополнительных атрибутов. |
 | `filters` | `{'parent_molecule_chembl_id__isnull': 'false'}` | Набор фильтров, добавляемых ко всем запросам; по умолчанию выбирает только записи с заполненным родителем в ChEMBL. |
-| `hierarchy_lookup_path` | `dictionary/_testitem/molecule_hierarchy.csv` | Необязательный CSV с готовыми связями родитель→потомок, который используется офлайн до обращения к ChEMBL; переопределяйте при распространении собственной витрины или переносе каталога. |
+| `hierarchy_lookup_path` | `../dictionary/_testitem/molecule_hierarchy.csv` | Необязательный CSV с готовыми связями родитель→потомок, который используется офлайн до обращения к ChEMBL; переопределяйте при распространении собственной витрины или переносе каталога. |
 | `hierarchy_lookup_encoding` | `utf-8-sig` | Кодировка, применяемая при чтении CSV иерархии; меняйте, если файл сохранён в другом наборе символов (например, Latin-1 из старых выгрузок). |
 | `hierarchy_lookup_delimiter` | `,` | Разделитель столбцов, ожидаемый загрузчиком иерархии; укажите `;` или табуляцию для файлов, подготовленных региональными командами. |
 | `page_size` | `500` | Количество записей в одном запросе при перепостроении каталога. |
@@ -179,8 +179,8 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
 | `enable` | `true` | Включает стадию расчёта `salt_chembl_id` и флагов из каталога молекул. |
-| `sources.molecule_catalog_path` | `dictionary/_testitem/molecule_catalog.csv` | CSV со столбцами `molecule_chembl_id`, `natural_product`, `prodrug`, `polymer_flag`. |
-| `sources.molecule_hierarchy_path` | `dictionary/_testitem/molecule_hierarchy.csv` | CSV с соответствиями дочерней и родительской молекулы. |
+| `sources.molecule_catalog_path` | `../dictionary/_testitem/molecule_catalog.csv` | CSV со столбцами `molecule_chembl_id`, `natural_product`, `prodrug`, `polymer_flag`. |
+| `sources.molecule_hierarchy_path` | `../dictionary/_testitem/molecule_hierarchy.csv` | CSV с соответствиями дочерней и родительской молекулы. |
 | `output.salt_as_null_when_absent` | `true` | При `true` несолевые соединения дают `null`, при `false` — символ `-`. |
 | `flags.coerce_to_bool` | `true` | Нормализует значения вида `Y/N`, `1/0`, `yes/no` в булев тип pandas. |
 | `flags.parent_fallback` | `true` | Подтягивает флаги из родителя, если у дочерней записи они пусты. |
@@ -213,18 +213,18 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Подсекция | Ключ | Значение | Описание |
 | --- | --- | --- | --- |
 | `uniprot` | `column` | `uniprot_id` | Колонка с UniProt ID. |
-|  | `data_dir` | `dictionary/_target/_uniprot` | Каталог с кэшированными JSON UniProt. |
+|  | `data_dir` | `../dictionary/_target/_uniprot` | Каталог с кэшированными JSON UniProt. |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
 | `chembl` | `column` | `target_chembl_id` | Колонка с таргетами ChEMBL. |
 |  | `chunk_size` | `5` | Размер батча запросов. |
 |  | `timeout` | `30.0` | Таймаут запроса (сек.). |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
-| `iuphar` | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Справочник таргетов IUPHAR. |
-|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
+| `iuphar` | `target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Справочник таргетов IUPHAR. |
+|  | `family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
 |  | `limit` | `null` | Ограничение на число идентификаторов. |
-| `all` | `data_dir` | `dictionary/_target/_uniprot` | Каталог с данными UniProt. |
-|  | `target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Таблица таргетов IUPHAR. |
-|  | `family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Таблица семейств IUPHAR. |
+| `all` | `data_dir` | `../dictionary/_target/_uniprot` | Каталог с данными UniProt. |
+|  | `target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Таблица таргетов IUPHAR. |
+|  | `family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Таблица семейств IUPHAR. |
 |  | `chunk_size` | `5` | Размер батча при объединении источников. |
 |  | `timeout` | `30.0` | Таймаут запроса (сек.). |
 
@@ -273,7 +273,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 | `resolve_order` | `cache → smiles → inchikey → inchi → pref_name` | Очерёдность стратегий при поиске PubChem CID. | `CHEMBL_DA_SOURCES_PUBCHEM_RESOLVE_ORDER`, `CHEMBL_DA__SOURCES__PUBCHEM__RESOLVE_ORDER` |
 | `cache_ttl` | `3600` | Время жизни in-memory кэша HTTP (сек.). | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL` |
 | `cache_ttl_hours` | `null` | TTL (часы) для постоянного CID-кэша; `null` отключает истечение. | `CHEMBL_DA_SOURCES_PUBCHEM_CACHE_TTL_HOURS`, `CHEMBL_DA__SOURCES__PUBCHEM__CACHE_TTL_HOURS` |
-| `cid_cache_path` | `"data/cache/pubchem_cid_cache.json"` | Путь к JSON с сохранёнными CID для повторного использования. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
+| `cid_cache_path` | `"../data/cache/pubchem_cid_cache.json"` | Путь к JSON с сохранёнными CID для повторного использования. | `CHEMBL_DA_SOURCES_PUBCHEM_CID_CACHE_PATH`, `CHEMBL_DA__SOURCES__PUBCHEM__CID_CACHE_PATH` |
 | `batch_size` | `50` | Размер батча для обработчика PubChem; параллелизм ограничен `min(batch_size, rps)`. | `CHEMBL_DA_SOURCES_PUBCHEM_BATCH_SIZE`, `CHEMBL_DA__SOURCES__PUBCHEM__BATCH_SIZE` |
 | `prefer_local_smiles` | `false` | Пропускать запросы, если локальные SMILES/InChIKey уже заполнены. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_SMILES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_SMILES` |
 | `prefer_local_values` | `true` | Сохранять существующие колонки `pubchem_*`, если ответ пуст. | `CHEMBL_DA_SOURCES_PUBCHEM_PREFER_LOCAL_VALUES`, `CHEMBL_DA__SOURCES__PUBCHEM__PREFER_LOCAL_VALUES` |
@@ -291,10 +291,10 @@ CLI-параметры имеют приоритет над YAML и окруже
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
 | `dictionary_dir` | `dictionary` | Корневая папка словарей. |
-| `iuphar_target_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Соответствия таргетов IUPHAR. |
-| `iuphar_family_csv` | `dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
-| `uniprot_data_dir` | `dictionary/_target/_uniprot` | Кэшированные ответы UniProt. |
-| `targets_type_csv` | `dictionary/_target/targets_type.csv` | Классификация типов таргетов. |
+| `iuphar_target_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_target.csv` | Соответствия таргетов IUPHAR. |
+| `iuphar_family_csv` | `../dictionary/_target/_IUPHAR/_IUPHAR_family.csv` | Справочник семейств IUPHAR. |
+| `uniprot_data_dir` | `../dictionary/_target/_uniprot` | Кэшированные ответы UniProt. |
+| `targets_type_csv` | `../dictionary/_target/targets_type.csv` | Классификация типов таргетов. |
 
 
 Каталог `dictionary/_target` отражает текущую структуру репозитория; в нём по умолчанию лежат справочники IUPHAR и выгрузки UniProt.
@@ -306,7 +306,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
-| `output_dir` | `data/output` | Каталог для результирующих наборов данных. |
+| `output_dir` | `../data/output` | Каталог для результирующих наборов данных. |
 | `cache_dir` | `.cache` | Каталог HTTP-кэша. |
 | `csv_sep` | `,` | Разделитель CSV по умолчанию. |
 | `csv_fallback_separators` | `["\t", ";"]` | Дополнительные разделители, которые пробуются, если основной не раскрывает требуемый столбец. |
@@ -320,9 +320,9 @@ CLI-параметры имеют приоритет над YAML и окруже
 
 | Ключ | Значение по умолчанию | Описание |
 | --- | --- | --- |
-| `same_doc` | `data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx` | Источник пар «тот же документ». |
-| `all_doc` | `data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx` | Источник пар «разные документы». |
-| `output_dir` | `data/output/ChEMBL/processed` | Каталог для подготовленных файлов. |
+| `same_doc` | `../data/input/ChEMBL/ChEMBL_same_document_20_05.xlsx` | Источник пар «тот же документ». |
+| `all_doc` | `../data/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx` | Источник пар «разные документы». |
+| `output_dir` | `../data/output/ChEMBL/processed` | Каталог для подготовленных файлов. |
 
 ## Системные настройки (`system`)
 

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -6,7 +6,7 @@ creation.
 
 ## Directory layout
 
-Exports are written to `local.io.output_dir` (default `data/output`). By
+Exports are written to `local.io.output_dir` (default `../data/output`). By
 default each CLI command derives the destination file as
 `output.<stem>_<date>.csv`, where `<stem>` is the input filename without
 extension and `<date>` is the host-local calendar date in `YYYYMMDD` format.
@@ -16,7 +16,7 @@ custom `--output` value or set `local.io.output_dir` explicitly so you can
 inject an alternate timestamp.
 
 ```
-data/output/
+../data/output/
 ├── output.activity_20240105.csv
 ├── output.activity_20240105.csv.meta.yaml
 ├── output.activity_20240105_failure_cases.csv
@@ -31,7 +31,7 @@ errors. Activity, assay and target jobs do not generate this report.
 Intermediate artefacts produced by the target `all` pipeline (`*_chembl.csv`,
 `*_uniprot.csv`, `*_iuphar.csv`) follow the same pattern. Custom `--output`
 arguments remain supported when a different layout (for example,
-`data/output/ChEMBL/processed/activity.csv`) is required.
+`../data/output/ChEMBL/processed/activity.csv`) is required.
 
 ## Metadata sidecars (`*.csv.meta.yaml`)
 

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -5,14 +5,14 @@ Acquisition, а также вспомогательные модули, отве
 
 ## Структура каталогов
 
-Экспорты сохраняются в `local.io.output_dir` (по умолчанию `data/output`). По
+Экспорты сохраняются в `local.io.output_dir` (по умолчанию `../data/output`). По
 умолчанию CLI формирует имя как `output.<stem>_<date>.csv`, где `<stem>` — имя
 входного файла без расширения, а `<date>` — текущая дата в формате `YYYYMMDD`.
 Запись автоматически создаёт родительские каталоги, если `local.io.exist_ok`
 равно `true`.
 
 ```
-data/output/
+../data/output/
 ├── output.activity_20240105.csv
 ├── output.activity_20240105.csv.meta.yaml
 ├── output.activity_20240105_failure_cases.csv
@@ -27,7 +27,7 @@ data/output/
 Промежуточные файлы таргет-пайплайна в режиме `all`
 (`*_chembl.csv`, `*_uniprot.csv`, `*_iuphar.csv`) используют тот же шаблон.
 Параметр `--output` по-прежнему позволяет задать альтернативную структуру,
-например `data/output/ChEMBL/processed/activity.csv`.
+например `../data/output/ChEMBL/processed/activity.csv`.
 
 ## Sidecar с метаданными (`*.csv.meta.yaml`)
 

--- a/docs/SUMMARY.EN.md
+++ b/docs/SUMMARY.EN.md
@@ -113,7 +113,7 @@ Detailed command walkthroughs live in `docs/USAGE_EN.md` and
 
 ## Outputs
 
-* Primary CSV exports live under `local.io.output_dir` (default `data/output`).
+* Primary CSV exports live under `local.io.output_dir` (default `../data/output`).
 * Every run writes a `<name>.csv.meta.yaml` sidecar with configuration, command
   line, row counts and SHA-256 digests. Validation errors go into
   `<name>_failure_cases.csv`, and table-quality reports are produced for each

--- a/docs/SUMMARY.RU.md
+++ b/docs/SUMMARY.RU.md
@@ -112,7 +112,7 @@ add_pipeline_metadata → write_csv_deterministic →
 
 ## Результаты выгрузки
 
-* Основные CSV сохраняются в `local.io.output_dir` (по умолчанию `data/output`).
+* Основные CSV сохраняются в `local.io.output_dir` (по умолчанию `../data/output`).
 * Каждый запуск формирует `<name>.csv.meta.yaml` с конфигурацией, командой,
   статистикой строк и SHA-256 хэшем; ошибки валидации попадают в
   `<name>_failure_cases.csv`, а отчёты качества строятся автоматически.


### PR DESCRIPTION
## Summary
- adjust the shipped configuration to resolve dictionary and data resources outside of the config directory
- sync the JSON schema defaults and documentation tables with the new relative paths so guidance matches the runtime behaviour

## Testing
- `PYTHONPATH=. python - <<'PY'
from library.config import load_config
cfg = load_config('config/config.yaml')
print(cfg.local.resources.iuphar_target_csv)
print(cfg.local.resources.uniprot_data_dir)
print(cfg.io.output_dir)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68de79a5b04c83249552d98e13556e1b