### PR TITLE
docs: highlight --final-out as the preferred destination flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ The README is available in multiple languages:
 | Русский  | [README_RU.md](README_RU.md) |
 
  
-* Командные скрипты с унифицированными флагами `--input`, `--output`/`--out`,
+* Командные скрипты с унифицированными флагами `--input`, `--final-out`
 
+  (основной путь назначения; устаревшие алиасы `--output`/`--out`
+  сохраняются для совместимости и теперь сопровождаются предупреждением),
   `--log-level`, `--sep`, `--encoding`, `--column`, а также `--config` и
   `--print-config` для управления загрузкой настроек. Размер пакетной
   выборки задаётся параметрами `--chunk-size` или `--batch-size` в зависимости
-  от конкретного пайплайна. Новые переключатели `--raw-out`, `--final-out`,
-  `--raw-format` и `--id-cols` уже доступны в пайплайне таргетов; остальные
-  команды получат их после расширения общего CLI.
+  от конкретного пайплайна. Новые переключатели `--raw-out`, `--raw-format` и
+  `--id-cols` уже доступны в пайплайне таргетов; остальные команды получат их
+  после расширения общего CLI.
 
 * Потоковая обработка больших CSV через чанки, детерминированный вывод.
 * Отдельный «сырой» снимок (`--raw-out`) доступен для пайплайна таргетов;
@@ -155,13 +157,18 @@ Sensitive configuration such as API tokens belongs in a local ``.env`` file – 
 
   ```bash
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --out out/quality --table-name chembl_targets --log-level INFO
+      --final-out out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  Во втором примере аргумент `--out`/`--output` должен указывать на каталог, в котором
-  будут созданы файлы отчёта.
+  EN: In the reporting example above `--final-out` must point to the directory where
+  the helper writes its results. The legacy `--output`/`--out` aliases remain available
+  but now raise deprecation warnings.
+
+  RU: В примере с отчётностью `--final-out` указывает каталог, куда будут сохранены
+  результаты. Устаревшие алиасы `--output`/`--out` по-прежнему работают, но теперь
+  сопровождаются предупреждением о скором удалении.
 
 4. **Run the tests / Запустите тесты** – refer to [Tests / Тесты](#tests--тесты).
 
@@ -176,15 +183,18 @@ flowchart LR
 
 **EN.** The target pipeline already follows the staged contract with dedicated destinations for raw and cleaned artefacts. Use
 `--raw-out` (optionally with `--raw-format parquet`) to capture the raw payload, list composite keys via `--id-cols`, and direct
-the cleaned export to `--final-out` or the shorter alias `--out`. Placeholder identifiers remain in the raw snapshot and are
-counted in the metadata (`error_placeholder_counts`), while the final export includes only validated values. Other pipelines keep
-using `--output` until the shared CLI is extended.
+the cleaned export to `--final-out`. The legacy `--output`/`--out` aliases stay wired in for compatibility but now emit
+deprecation warnings when used. Placeholder identifiers remain in the raw snapshot and are counted in the metadata
+(`error_placeholder_counts`), while the final export includes only validated values. Other pipelines will surface
+`--final-out` once their shared CLI is extended; until then the deprecated aliases remain available with matching warnings.
 
 **RU.** Пайплайн таргетов уже использует поэтапный контракт с разделением «сырого» и нормализованного вывода. Флаг `--raw-out`
 (при необходимости с `--raw-format parquet`) сохраняет исходный ответ, `--id-cols` перечисляет составные ключи, а чистый экспорт
-направляется в `--final-out` либо сокращённый алиас `--out`. Временные идентификаторы остаются в «сыром» снимке и учитываются в
-метаданных (`error_placeholder_counts`), тогда как финальная таблица содержит только прошедшие валидацию значения. Прочие
-пайплайны пока используют `--output` до расширения общего CLI.
+направляется в `--final-out`. Алиасы `--output`/`--out` сохранены для совместимости, однако при их использовании CLI выводит
+предупреждение об устаревании. Временные идентификаторы остаются в «сыром» снимке и учитываются в метаданных
+(`error_placeholder_counts`), тогда как финальная таблица содержит только прошедшие валидацию значения. Прочие пайплайны
+получат `--final-out` после расширения общего CLI; до тех пор устаревшие алиасы остаются доступными и сопровождаются теми же
+предупреждениями.
 
 > **EN.** `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols` are currently exposed via `get-target-data` and
 > `library.utils.cli_tools.pipeline_targets_main`. Other commands will adopt these switches once the shared parser lands.
@@ -206,10 +216,10 @@ pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
 python -m scripts.get_data --help
 tmp_dir=$(mktemp -d) && python -m library.utils.cli_tools.pipeline_targets_main \
     --input tests/data/chembl_targets_min.csv \
-    --out "${tmp_dir}/targets.csv" --log-level INFO --limit 2
+    --final-out "${tmp_dir}/targets.csv" --log-level INFO --limit 2
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --out out/mapped.csv --log-level INFO
+    --final-out out/mapped.csv --log-level INFO
 ```
 
 Before running the smoke command, create a `chembl_ids.csv` file with a header `chembl_id` and the required identifiers. / Перед запуском smoke-команды создайте `chembl_ids.csv` со столбцом `chembl_id` и нужными идентификаторами.
@@ -295,7 +305,7 @@ solely with local files and prepared identifier batches. / **RU.**
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --output data/output/activities.csv --limit 10 --log-level INFO
+    --final-out data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 Команда извлекает данные из API ChEMBL, сохраняет таблицу и сопутствующий
@@ -315,11 +325,13 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 ## Usage
 
 The examples below illustrate how to run the main CLI tools with common
-options like ``--input``, ``--out``/``--output`` and ``--limit``. Passing
+options like ``--input``, ``--final-out`` (primary destination flag) and
+``--limit``. The legacy ``--output``/``--out`` aliases stay available for
+compatibility but now trigger explicit deprecation warnings. Passing
 ``--limit 0`` short-circuits processing before any network or filesystem
 access, which is handy for configuration smoke tests. The target pipeline
 already exposes ``--raw-out``, ``--final-out``, ``--raw-format`` and ``--id-cols``;
-other commands will gain them once the shared CLI is extended.
+other commands will gain the staging switches once the shared CLI is extended.
 
 ### scripts/get_document_data.py
 
@@ -329,7 +341,7 @@ sample file:
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -342,7 +354,7 @@ You can also run the PubMed pipeline directly using the library module:
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
     --log-level INFO
 ```
 
@@ -353,7 +365,7 @@ Fetch basic target information from ChEMBL:
 ```bash
 python -m scripts.get_target_data chembl \
     --input path/to/targets.csv \
-    --output out/targets.csv \
+    --final-out out/targets.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -372,7 +384,7 @@ target pipeline without contacting remote services:
 ```bash
 python -m library.utils.cli_tools.pipeline_targets_main \
     --input tests/data/chembl_targets_min.csv \
-    --output out/targets_cached.csv \
+    --final-out out/targets_cached.csv \
     --chunk-size 25 \
     --batch-size 25 \
     --limit 100
@@ -442,7 +454,7 @@ Refer to the [alias table](library/config.py#L1531-L1634) in
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \\
-    --output out/assays.csv
+    --final-out out/assays.csv
 ```
 
 Файл `assay_ids.csv` должен содержать столбец `assay_chembl_id` с нужными
@@ -546,7 +558,7 @@ api:
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --out out/assays.final.csv
+    --final-out out/assays.final.csv
 ```
 
 Пример строки лога:
@@ -680,9 +692,10 @@ Running the CLI saves ``data_quality_report_table.csv`` and
 
     python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 
-Use ``--output``/``--out`` to redirect these artefacts to another directory. The value must be a
-directory path (do not include the final file name). When ``local.io.exist_ok`` is set to ``false`` the
-directory has to exist beforehand; otherwise it is created automatically. The target pipeline uses the
+Use ``--final-out`` to redirect these artefacts to another directory. The value must be a directory path
+(do not include the final file name). The compatibility aliases ``--output``/``--out`` remain wired in but
+now raise deprecation warnings whenever they are invoked. When ``local.io.exist_ok`` is set to ``false``
+the directory has to exist beforehand; otherwise it is created automatically. The target pipeline uses the
 additional ``--raw-out``/``--final-out`` switches to separate staging outputs until the shared CLI is
 updated for the remaining commands.
 
@@ -832,8 +845,10 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-`--output`/`--out` по умолчанию формируется как `output.<имя_входа>_YYYYMMDD.csv`
-в каталоге, заданном `local.io.output_dir`. Пайплайн таргетов может использовать
+`--final-out` по умолчанию формируется как `output.<имя_входа>_YYYYMMDD.csv`
+в каталоге, заданном `local.io.output_dir`. Устаревшие алиасы
+`--output`/`--out` по-прежнему работают, но сопровождаются предупреждением и будут
+удалены после миграции всех пайплайнов. Пайплайн таргетов может использовать
 `--raw-out` и `--final-out` (с `--raw-format`) для разведения «сырого» снимка и
 финального экспорта. Для дополнительных примеров см. [`docs/USAGE_RU.md`](docs/USAGE_RU.md)
 и английскую версию [`docs/USAGE_EN.md`](docs/USAGE_EN.md).

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,9 +5,10 @@ The primary documentation and reference material live in the [docs/](docs/) dire
 ## Features
 
 
-* Unified CLI flags such as `--input`, `--output`/`--out`, `--log-level`, `--sep`, `--encoding`, `--column`, plus
-  `--config` and `--print-config` to manage configuration files. Batch size is controlled via `--chunk-size` or
-  `--batch-size` depending on the pipeline. The new `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols`
+* Unified CLI flags such as `--input`, `--final-out` (primary destination flag; the legacy `--output`/`--out`
+  aliases remain for compatibility but now emit deprecation warnings), `--log-level`, `--sep`, `--encoding`,
+  `--column`, plus `--config` and `--print-config` to manage configuration files. Batch size is controlled via
+  `--chunk-size` or `--batch-size` depending on the pipeline. The `--raw-out`, `--raw-format`, and `--id-cols`
   switches are currently available through the target pipeline; other commands will expose them once the shared
   CLI is extended.
 
@@ -107,11 +108,10 @@ for usage guidelines.
 
   ```bash
   get-activity-data --input tests/data/activity_ids_small.csv \
-
-      --output out/activities.csv \
+      --final-out out/activities.csv \
       --limit 10 --log-level INFO
   get-document-data pubmed --input tests/data/pmids.csv \
-      --output out/documents.csv \
+      --final-out out/documents.csv \
       --limit 5 --log-level INFO
 
   ```
@@ -121,15 +121,16 @@ for usage guidelines.
 
    The console scripts accept the same options as their module counterparts, so existing `python -m …` workflows remain valid:
 
-   ```bash
-   python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
+  ```bash
+  python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --out out/quality --table-name chembl_targets --log-level INFO
+      --final-out out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  In the reporting example above the `--out`/`--output` argument must point to a directory where the report files will be created.
+  In the reporting example above `--final-out` must point to the directory where the report files will be created. The legacy
+  `--output`/`--out` aliases remain available for compatibility but now raise deprecation warnings when invoked.
 
 4. **Run the tests** – see [Tests](#tests).
 
@@ -146,7 +147,7 @@ pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --output out/mapped.csv --log-level INFO
+    --final-out out/mapped.csv --log-level INFO
 ```
 
 Before running the smoke command, create a `chembl_ids.csv` file with a `chembl_id` header and the required identifiers.
@@ -170,7 +171,7 @@ Example full pipeline execution:
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --output data/output/activities.csv --limit 10 --log-level INFO
+    --final-out data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 The command reads data from the ChEMBL API, writes the CSV table and the accompanying `*.meta.yaml`. Development utilities are in
@@ -184,19 +185,20 @@ as a CI artifact.
 ## Usage
 
 
-The examples below demonstrate how to run the main CLI tools with common options such as `--input`, `--out`/`--output`, and
-`--limit`. Using `--limit 0` now short-circuits processing before any network or filesystem access, which is useful for
-smoke-testing configuration overrides. The target pipeline already exposes `--raw-out`, `--final-out`, `--raw-format`, and
-`--id-cols`; the remaining commands continue to rely on `--output` until the shared parser is extended.
+The examples below demonstrate how to run the main CLI tools with common options such as `--input`, `--final-out`, and
+`--limit`. The compatibility aliases `--output`/`--out` are still recognised but now emit deprecation warnings. Using `--limit 0`
+short-circuits processing before any network or filesystem access, which is useful for smoke-testing configuration overrides.
+The target pipeline already exposes `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols`; the remaining commands will pick
+up the staged switches as the shared parser is extended.
 After installing the project with `pip install .`, the same pipelines can be started via the console scripts listed in the
 [Quick Start](#quick-start) table—for example, `get-activity-data --help` is equivalent to `python -m scripts.get_activity_data --help`.
 Both forms accept identical arguments, so feel free to swap between them depending on your environment.
 
 Within the target pipeline the staged export surfaces separate destinations for raw payloads and cleaned tables. Use
 `--raw-out` to persist the unprocessed API response, optionally changing the `--raw-format` between `csv` (default) and
-`parquet`, and `--final-out` to override the normalised export while keeping the metadata sidecars. When you only need a
-single output switch, `--out` acts as a short alias for `--output`. Multi-identifier payloads accept multiple columns via
-`--id-cols`, allowing you to keep composite keys in the raw snapshot before the cleanup step runs.
+`parquet`, and `--final-out` to override the normalised export while keeping the metadata sidecars. The legacy
+`--output`/`--out` aliases act as compatibility shims for now but emit a warning on each invocation. Multi-identifier payloads
+accept multiple columns via `--id-cols`, allowing you to keep composite keys in the raw snapshot before the cleanup step runs.
 
 
 ### `scripts/get_document_data.py`
@@ -206,7 +208,7 @@ Retrieve document metadata for a list of PubMed IDs using the bundled sample fil
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -218,7 +220,7 @@ You can also run the PubMed pipeline directly via the library module:
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
     --log-level INFO
 ```
 
@@ -232,15 +234,15 @@ Fetch basic target information from ChEMBL:
 ```bash
 python -m scripts.get_target_data chembl \
     --input path/to/targets.csv \
-    --out out/targets.final.csv \
+    --final-out out/targets.final.csv \
     --raw-out out/targets.raw.csv \
     --limit 5 \
     --log-level INFO
 ```
 
 Replace `path/to/targets.csv` with a CSV containing a `target_chembl_id` column. The `--raw-out` switch keeps the
-pre-normalised snapshot for debugging, while `--out` (alias for `--output`) produces the cleaned export aligned with the
-validation schemas.
+pre-normalised snapshot for debugging, while `--final-out` produces the cleaned export aligned with the validation schemas.
+The compatibility aliases `--output`/`--out` remain for migration support and issue warnings when used.
 
 ### `library.utils.cli_tools.pipeline_targets_main`
 
@@ -249,7 +251,7 @@ Exercise the chunking and batch configuration used by the production target pipe
 ```bash
 python -m library.utils.cli_tools.pipeline_targets_main \
     --input tests/data/chembl_targets_min.csv \
-    --output out/targets_cached.csv \
+    --final-out out/targets_cached.csv \
     --chunk-size 25 \
     --batch-size 25 \
     --limit 100
@@ -285,7 +287,8 @@ flowchart LR
 * **Cleanup IDs** – trim, deduplicate and patch placeholder identifiers before downstream work.
 * **Normalize** – harmonise text, relations and datatypes so validation is deterministic.
 * **Validate** – run `pandera` schemas, routing failures to the sidecar files recorded in the metadata YAML.
-* **Final export** – write the cleaned table to `--final-out`/`--out` alongside metadata and quality reports.
+* **Final export** – write the cleaned table to `--final-out` alongside metadata and quality reports. Deprecated
+  aliases `--output`/`--out` continue to function but emit warnings during the migration period.
 
 > **Note.** At the moment `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols` are available through
 > `get-target-data` and `library.utils.cli_tools.pipeline_targets_main`. Other pipelines will adopt the same
@@ -337,7 +340,7 @@ Run a script with automatic configuration loading:
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \
-    --output out/assays.csv
+    --final-out out/assays.csv
 ```
 
 The `assay_ids.csv` file must contain an `assay_chembl_id` column with the required identifiers, for example:
@@ -429,7 +432,7 @@ Set the log level via the `--log-level` flag or the `CHEMBL_DA_LOG_LEVEL` enviro
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --out out/assays.final.csv
+    --final-out out/assays.final.csv
 ```
 
 Sample log entry:
@@ -484,9 +487,10 @@ All CLI scripts share a common set of flags:
 python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 ```
 
-`--output`/`--out` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. Target
-pipeline invocations can override the raw snapshot via `--raw-out` (with optional `--raw-format parquet`) and the cleaned
-export via `--final-out`. For additional examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
+`--final-out` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. The legacy
+`--output`/`--out` aliases continue to map to the same path but now emit deprecation warnings. Target pipeline invocations can
+override the raw snapshot via `--raw-out` (with optional `--raw-format parquet`) and the cleaned export via `--final-out`. For
+additional examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
 
 [`docs/USAGE_RU.md`](docs/USAGE_RU.md)).
 
@@ -608,9 +612,10 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-`--output`/`--out` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory specified by `local.io.output_dir`.
-Target pipeline invocations can use `--raw-out` and `--final-out` when the raw snapshot and the cleaned export must be
-separated explicitly. For additional examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
+`--final-out` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory specified by `local.io.output_dir`. Legacy
+aliases `--output`/`--out` continue to resolve to the same path but issue a deprecation warning. Target pipeline invocations can
+use `--raw-out` and `--final-out` when the raw snapshot and the cleaned export must be separated explicitly. For additional
+examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
 [`docs/USAGE_RU.md`](docs/USAGE_RU.md)).
 
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -4,10 +4,11 @@
 
 ## Особенности
 
-* Унифицированные CLI-флаги `--input`, `--output`/`--out`, `--log-level`, `--sep`, `--encoding`, `--column`, а также
-  `--config` и `--print-config` для управления конфигурацией. Размер партий задаётся параметрами `--chunk-size`
-  или `--batch-size` в зависимости от пайплайна. Новые переключатели `--raw-out`, `--final-out`, `--raw-format` и
-  `--id-cols` уже доступны в пайплайне таргетов; остальные команды получат их после расширения общего CLI.
+* Унифицированные CLI-флаги `--input`, `--final-out` (основной флаг назначения; устаревшие алиасы `--output`/`--out`
+  сохранены для совместимости и теперь сопровождаются предупреждением), `--log-level`, `--sep`, `--encoding`,
+  `--column`, а также `--config` и `--print-config` для управления конфигурацией. Размер партий задаётся параметрами
+  `--chunk-size` или `--batch-size` в зависимости от пайплайна. Переключатели `--raw-out`, `--raw-format` и `--id-cols`
+  уже доступны в пайплайне таргетов; остальные команды получат их после расширения общего CLI.
 
 * Потоковая обработка крупных CSV-файлов с детерминированным выводом.
 * Валидаторы схем в [`schemas/`](schemas/) и словари в [`dictionary/`](dictionary/) для проверки типов, диапазонов и справочных данных.
@@ -101,10 +102,10 @@ pre-commit install
 
   ```bash
   get-activity-data --input tests/data/activity_ids_small.csv \
-      --output out/activities.csv \
+      --final-out out/activities.csv \
       --limit 10 --log-level INFO
   get-document-data pubmed --input tests/data/pmids.csv \
-      --output out/documents.csv \
+      --final-out out/documents.csv \
       --limit 5 --log-level INFO
   ```
 
@@ -113,15 +114,16 @@ pre-commit install
 
    Консольные утилиты принимают те же аргументы, поэтому привычные сценарии `python -m …` продолжают работать:
 
-   ```bash
-   python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
+  ```bash
+  python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --out out/quality --table-name chembl_targets --log-level INFO
+      --final-out out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  В примере с отчётностью аргумент `--out`/`--output` должен указывать на каталог, где будут сохранены результаты.
+  В примере с отчётностью `--final-out` задаёт каталог, где будут сохранены результаты. Устаревшие алиасы
+  `--output`/`--out` остаются для совместимости, но теперь сопровождаются предупреждением об удалении.
 
 4. **Запустите тесты** — см. раздел [Тесты](#тесты).
 
@@ -136,7 +138,7 @@ pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --output out/mapped.csv --log-level INFO
+    --final-out out/mapped.csv --log-level INFO
 ```
 
 Перед запуском smoke-команды создайте `chembl_ids.csv` с заголовком `chembl_id` и нужными идентификаторами.
@@ -160,7 +162,7 @@ python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --output data/output/activities.csv --limit 10 --log-level INFO
+    --final-out data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 Команда обращается к API ChEMBL, сохраняет таблицу и сопровождающий `*.meta.yaml`. Утилиты разработки находятся в `library/utils/cli_tools/`; например, модуль `get_activities` предназначен лишь для демонстрационного логирования и не выполняет файловых операций. См. [`docs/CLI_TOOLS.md`](docs/CLI_TOOLS.md) для кратких описаний и типовых команд. Каталог результатов игнорируется Git и публикуется как артефакт CI.
@@ -169,7 +171,7 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 
 ## Использование
 
-Ниже приведены примеры запуска основных CLI-инструментов с типовыми флагами (`--input`, `--out`/`--output`, `--limit`). Параметр `--limit 0` допустим: пайплайн завершится до любых сетевых и файловых операций, что удобно для быстрых smoke-тестов конфигурации. Пайплайн таргетов уже поддерживает `--raw-out`, `--final-out`, `--raw-format` и `--id-cols`; остальные команды будут полагаться на `--output` до расширения общего парсера.
+Ниже приведены примеры запуска основных CLI-инструментов с типовыми флагами (`--input`, `--final-out`, `--limit`). Устаревшие алиасы `--output`/`--out` остаются доступными, но при использовании выводят предупреждения. Параметр `--limit 0` допустим: пайплайн завершится до любых сетевых и файловых операций, что удобно для быстрых smoke-тестов конфигурации. Пайплайн таргетов уже поддерживает `--raw-out`, `--final-out`, `--raw-format` и `--id-cols`; остальные команды получат эти переключатели после расширения общего парсера.
 После установки пакета через `pip install .` те же пайплайны доступны в виде консольных скриптов из таблицы в разделе
 [Быстрый старт](#быстрый-старт) — например, `get-activity-data --help` полностью эквивалентен
 `python -m scripts.get_activity_data --help`. Оба варианта принимают одинаковые аргументы, поэтому выбирайте форму, удобную
@@ -177,9 +179,9 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 
 Обновлённая конвейерная обработка в пайплайне таргетов разделяет необработанные и нормализованные артефакты. Параметр
 `--raw-out` сохраняет ответы API до любых преобразований, формат задаётся через `--raw-format` (`csv` по умолчанию, либо
-`parquet`). Опция `--final-out` переопределяет путь нормализованного экспорта, сохраняя побочные файлы метаданных. Для
-одиночного переключателя подойдёт короткий алиас `--out`, полностью эквивалентный `--output`. Пайплайны с составными
-ключами принимают список столбцов через `--id-cols`, чтобы фиксировать исходные идентификаторы в «сыром» снимке до очистки.
+`parquet`). Опция `--final-out` переопределяет путь нормализованного экспорта, сохраняя побочные файлы метаданных. Алиасы
+`--output`/`--out` по-прежнему работают, но сопровождаются предупреждениями. Пайплайны с составными ключами принимают список
+столбцов через `--id-cols`, чтобы фиксировать исходные идентификаторы в «сыром» снимке до очистки.
 
 
 ### `scripts/get_document_data.py`
@@ -189,7 +191,7 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
 
     --limit 5 \
     --log-level INFO
@@ -202,7 +204,7 @@ python -m scripts.get_document_data pubmed \
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --output out/documents.csv \
+    --final-out out/documents.csv \
     --log-level INFO
 ```
 
@@ -216,14 +218,15 @@ python -m library.pubmed_library \
 ```bash
 python -m scripts.get_target_data chembl \
     --input path/to/targets.csv \
-    --out out/targets.final.csv \
+    --final-out out/targets.final.csv \
     --raw-out out/targets.raw.csv \
     --limit 5 \
     --log-level INFO
 ```
 
 Замените `path/to/targets.csv` на CSV со столбцом `target_chembl_id`. `--raw-out` фиксирует снимок до нормализации для
-диагностики, а `--out` (`--output`) формирует чистый экспорт, согласованный со схемами валидации.
+диагностики, а `--final-out` формирует чистый экспорт, согласованный со схемами валидации. Устаревшие алиасы
+`--output`/`--out` сохраняются для совместимости и выводят предупреждения.
 
 ### `library.utils.cli_tools.pipeline_targets_main`
 
@@ -232,7 +235,7 @@ python -m scripts.get_target_data chembl \
 ```bash
 python -m library.utils.cli_tools.pipeline_targets_main \
     --input tests/data/chembl_targets_min.csv \
-    --output out/targets_cached.csv \
+    --final-out out/targets_cached.csv \
     --chunk-size 25 \
     --batch-size 25 \
     --limit 100
@@ -265,7 +268,8 @@ flowchart LR
 * **Очистка идентификаторов** — обрезка пробелов, дедупликация и пометка заглушек до дальнейшей обработки.
 * **Normalize** — выравнивание текста, операторов и типов для детерминированной валидации.
 * **Validate** — применение схем `pandera`, перенос ошибочных строк в sidecar-файлы, описанные в YAML метаданных.
-* **Финальный экспорт** — запись очищенной таблицы в `--final-out`/`--out` вместе с метаданными и отчётами о качестве.
+* **Финальный экспорт** — запись очищенной таблицы в `--final-out` вместе с метаданными и отчётами о качестве. Устаревшие алиасы
+  `--output`/`--out` временно сохраняются и сопровождаются предупреждениями.
 
 > **Примечание.** Сейчас флаги `--raw-out`, `--final-out`, `--raw-format` и `--id-cols` доступны в `get-target-data`
 > и `library.utils.cli_tools.pipeline_targets_main`. Остальные точки входа получат их после расширения общего CLI.
@@ -312,7 +316,7 @@ CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \
-    --output out/assays.csv
+    --final-out out/assays.csv
 ```
 
 Файл `assay_ids.csv` должен содержать столбец `assay_chembl_id` с нужными идентификаторами, например:
@@ -401,7 +405,7 @@ CLI-хелперы настраивают структурированное JSO
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --out out/assays.final.csv
+    --final-out out/assays.final.csv
 ```
 
 Пример строки лога:
@@ -453,9 +457,10 @@ python -m library.utils.cli_tools.table_quality_main --input tests/data/activity
     --table-name activity
 ```
 
-По умолчанию `--output`/`--out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`.
-Пайплайн таргетов может разделять «сырой» и чистый вывод флагами `--raw-out` (с `--raw-format`) и `--final-out`. Дополнительные
-примеры приведены в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
+По умолчанию `--final-out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`.
+Устаревшие алиасы `--output`/`--out` продолжают работать, но сопровождаются предупреждениями. Пайплайн таргетов может
+разделять «сырой» и чистый вывод флагами `--raw-out` (с `--raw-format`) и `--final-out`. Дополнительные примеры приведены в
+[`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 
 ## Структура проекта
@@ -563,10 +568,10 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-По умолчанию `--output`/`--out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Пайплайн
-таргетов может использовать `--raw-out` и `--final-out`, чтобы явно развести «сырые» и чистые артефакты (при желании указав
-`--raw-format`). Дополнительные примеры см. в [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия —
-[`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
+По умолчанию `--final-out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Устаревшие алиасы
+`--output`/`--out` продолжают работать и предупреждают о грядущем удалении. Пайплайн таргетов может использовать `--raw-out` и
+`--final-out`, чтобы явно развести «сырые» и чистые артефакты (при желании указав `--raw-format`). Дополнительные примеры см. в
+[`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 ## Вывод и метаданные
 

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -31,10 +31,10 @@ directly.
 | `--input-dir` | Directory containing input artefacts; resolved against `--base-path` when relative. |
 | `--output-dir` | Directory receiving generated artefacts; resolved against `--base-path` when relative. |
 | `--input` | Input CSV with identifiers (default: `input.csv`). |
-| `--output` / `--out` | Destination CSV. When omitted, a file named `output.<input-stem>_<YYYYMMDD>.csv` is created inside `--output-dir` or `--base-path`. |
+| `--final-out` | Primary destination for the cleaned export. When omitted, defaults to `output.<input-stem>_<YYYYMMDD>.csv` under `--output-dir` or `--base-path`. Equivalent to the legacy `--output`/`--out`, which remain available but raise deprecation warnings. |
+| `--output` / `--out` | Deprecated aliases for `--final-out`. They keep the previous behaviour and default paths but emit warnings on each invocation and will be removed after the migration. |
 | `--raw-out` | Path for the raw snapshot written before cleanup and normalisation. Currently exposed by `get-target-data` and `library.utils.cli_tools.pipeline_targets_main`; other commands will surface it once the shared parser is extended. Skipped when omitted. |
 | `--raw-format` | Format of the raw snapshot. Accepts `csv` (default) or `parquet`. Available in the same entry points as `--raw-out`. |
-| `--final-out` | Path for the final cleaned export. When omitted, falls back to `--output` / `--out`. Currently exposed by the target pipeline helpers. |
 | `--date` | Override the auto-generated `YYYYMMDD` suffix when building default output filenames. |
 | `--force` | Overwrite outputs even when they already exist. |
 | `--skip-existing` | Skip processing if the destination file is already present. |
@@ -66,7 +66,7 @@ flowchart LR
   Fetch --> Raw["Raw CSV / Parquet"] --> Cleanup["Cleanup IDs"] --> Normalize --> Validate --> Final["Final export"]
 ```
 
-In the target pipeline `--raw-out` (with optional `--raw-format parquet`) captures the untouched payload, `--id-cols` keeps composite identifiers in that snapshot, and `--final-out`/`--out` writes the cleaned table after normalisation and validation. If `--raw-out` is omitted the raw dump stage is skipped for backward compatibility, while other pipelines continue to rely on `--output` until the shared parser is extended.
+In the target pipeline `--raw-out` (with optional `--raw-format parquet`) captures the untouched payload, `--id-cols` keeps composite identifiers in that snapshot, and `--final-out` writes the cleaned table after normalisation and validation. The legacy `--output`/`--out` switches remain wired in for compatibility but emit deprecation warnings. If `--raw-out` is omitted the raw dump stage is skipped for backward compatibility, while other pipelines will add the staged switches once the shared parser is extended.
 
 > **Note.** `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols` are currently exposed by `get-target-data` and `library.utils.cli_tools.pipeline_targets_main`. Other entry points will adopt them once the shared CLI grows the staging switches.
 
@@ -161,7 +161,7 @@ Console form:
 ```bash
 get-document-data all --input path/to/documents.csv \
   --column document_chembl_id \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --batch-size 20
 ```
 
@@ -171,7 +171,7 @@ Module form:
 python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --batch-size 20
 ```
 
@@ -198,7 +198,7 @@ Console form:
 ```bash
 get-document-data pubmed --input path/to/documents.csv \
   --column PMID \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -212,7 +212,7 @@ Module form:
 python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -231,7 +231,7 @@ Console form:
 get-target-data chembl --input path/to/targets.csv \
   --column target_chembl_id \
   --raw-out out/targets.raw.csv \
-  --out out/targets.final.csv
+  --final-out out/targets.final.csv
 ```
 
 Module form:
@@ -241,7 +241,7 @@ python -m scripts.get_target_data chembl \
   --input path/to/targets.csv \
   --column target_chembl_id \
   --raw-out out/targets.raw.csv \
-  --out out/targets.final.csv
+  --final-out out/targets.final.csv
 ```
 
 Combines ChEMBL, UniProt and IUPHAR sources according to `sources.chembl.pipelines.target.*`. Create a CSV with a `target_chembl_id` header (one identifier per row) to execute the pipeline; no fixture ships with the repository. Swap `chembl` in the example for `uniprot`, `iuphar` or `all` to choose a different source mix.
@@ -253,7 +253,7 @@ Combines ChEMBL, UniProt and IUPHAR sources according to `sources.chembl.pipelin
 ```bash
 python -m library.utils.cli_tools.pipeline_targets_main \
   --input tests/data/chembl_targets_min.csv \
-  --out out/targets_cached.csv \
+  --final-out out/targets_cached.csv \
   --chunk-size 50 \
   --batch-size 50 \
   --limit 200

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -34,10 +34,10 @@ CLI без вложенных подкоманд.
 | `--input-dir` | Каталог с входными артефактами; относительный путь сочетается с `--base-path`. |
 | `--output-dir` | Каталог для сохранения артефактов; относительный путь сочетается с `--base-path`. |
 | `--input` | Входной CSV с идентификаторами (по умолчанию `input.csv`). |
-| `--output` / `--out` | Выходной CSV. Если не указан, создаётся `output.<stem>_<YYYYMMDD>.csv` в `--output-dir` или `--base-path`. |
+| `--final-out` | Основной путь финального экспорта. При отсутствии формируется `output.<stem>_<YYYYMMDD>.csv` в `--output-dir` или `--base-path`. Эквивалентен устаревшим `--output`/`--out`, которые сохраняются для совместимости, но выводят предупреждения. |
+| `--output` / `--out` | Устаревшие алиасы `--final-out`. Поведение и значения по умолчанию совпадают, однако при использовании выводятся предупреждения; после завершения миграции будут удалены. |
 | `--raw-out` | Путь для «сырого» снимка до очистки и нормализации. Сейчас флаг доступен в `get-target-data` и `library.utils.cli_tools.pipeline_targets_main`; остальные команды получат его после расширения парсера. Если флаг опущен, этап пропускается. |
 | `--raw-format` | Формат снимка: `csv` (по умолчанию) или `parquet`. Поддерживается теми же точками входа, что и `--raw-out`. |
-| `--final-out` | Путь финального нормализованного экспорта. При отсутствии использует `--output` / `--out`. На данный момент флаг реализован в пайплайне таргетов. |
 | `--date` | Заменяет автогенерируемый суффикс `YYYYMMDD` при формировании имени файла по умолчанию. |
 | `--force` | Перезаписывать выходные файлы, даже если они уже существуют. |
 | `--skip-existing` | Пропускать выполнение, если целевой файл уже существует. |
@@ -68,7 +68,7 @@ flowchart LR
   Fetch --> Raw["Raw CSV / Parquet"] --> Cleanup["Очистка идентификаторов"] --> Normalize --> Validate --> Final["Финальный экспорт"]
 ```
 
-В пайплайне таргетов `--raw-out` (совместно с `--raw-format parquet` при необходимости) сохраняет необработанный ответ, `--id-cols` удерживает составные ключи в этом снимке, а `--final-out`/`--out` записывает нормализованную таблицу после валидации. Если `--raw-out` не указан, этап выгрузки «сырых» данных пропускается для совместимости со старыми сценариями. Остальные скрипты пока используют `--output` до расширения общего парсера.
+В пайплайне таргетов `--raw-out` (совместно с `--raw-format parquet` при необходимости) сохраняет необработанный ответ, `--id-cols` удерживает составные ключи в этом снимке, а `--final-out` формирует нормализованную таблицу после валидации. Устаревшие алиасы `--output`/`--out` пока остаются для совместимости, но сопровождаются предупреждениями. Если `--raw-out` не указан, этап выгрузки «сырых» данных пропускается. Остальные скрипты получат аналогичные стадии после обновления общего парсера.
 
 > **Примечание.** Флаги `--raw-out`, `--final-out`, `--raw-format` и `--id-cols` реализованы в `get-target-data` и `library.utils.cli_tools.pipeline_targets_main`. Остальные CLI получат их после обновления общего интерфейса.
 
@@ -158,7 +158,7 @@ python -m scripts.get_assay_data \
 ```bash
 get-document-data all --input path/to/documents.csv \
   --column document_chembl_id \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --batch-size 20
 ```
 
@@ -168,7 +168,7 @@ get-document-data all --input path/to/documents.csv \
 python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --batch-size 20
 ```
 
@@ -196,7 +196,7 @@ CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
 ```bash
 get-document-data pubmed --input path/to/documents.csv \
   --column PMID \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -210,7 +210,7 @@ get-document-data pubmed --input path/to/documents.csv \
 python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
-  --output out/documents.csv \
+  --final-out out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -230,7 +230,7 @@ python -m scripts.get_document_data pubmed \
 get-target-data chembl --input path/to/targets.csv \
   --column target_chembl_id \
   --raw-out out/targets.raw.csv \
-  --out out/targets.final.csv
+  --final-out out/targets.final.csv
 ```
 
 Запуск через модуль:
@@ -240,7 +240,7 @@ python -m scripts.get_target_data chembl \
   --input path/to/targets.csv \
   --column target_chembl_id \
   --raw-out out/targets.raw.csv \
-  --out out/targets.final.csv
+  --final-out out/targets.final.csv
 ```
 
 Комбинирует данные ChEMBL, UniProt и IUPHAR согласно разделу `sources.chembl.pipelines.target.*`. Соберите CSV с колонкой `target_chembl_id` (по одной записи в строке); готовый smoke-набор отсутствует.
@@ -250,7 +250,7 @@ python -m scripts.get_target_data chembl \
 ```bash
 python -m library.utils.cli_tools.pipeline_targets_main \
   --input tests/data/chembl_targets_min.csv \
-  --out out/targets_cached.csv \
+  --final-out out/targets_cached.csv \
   --chunk-size 50 \
   --batch-size 50 \
   --limit 200


### PR DESCRIPTION
## Summary
- update README variants to describe `--final-out` as the primary destination flag and note the deprecation warnings on `--output`/`--out`
- refresh quick-start steps and CLI examples across English and Russian docs to use `--final-out`
- rewrite the shared options tables to list `--final-out` first and mark the legacy aliases as deprecated

## Testing
- python -m markdown README_EN.md
- python -m markdown README_RU.md
- python -m markdown docs/USAGE_EN.md
- python -m markdown docs/USAGE_RU.md

------
https://chatgpt.com/codex/tasks/task_e_68de7d6562a883249dec030d965ea5aa