### PR TITLE
Handle paginated activity retrieval

### DIFF
--- a/library/chembl_assay.py
+++ b/library/chembl_assay.py
@@ -409,11 +409,21 @@ def get_activities(
         logger.info(
             "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
         )
-        url = f"{base}&activity_id__in={chunk_key}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("activities") or data.get("activity") or []
-        if items:
-            records.append(json_normalize_pyarrow(items))
+        url = f"{base}&activity_id__in={chunk_key}&limit={len(chunk)}"
+        chunk_frames: list[pd.DataFrame] = []
+        next_url: str | None = url
+        while next_url:
+            data = client.request_json(next_url, cfg=cfg, timeout=effective_timeout)
+            items = data.get("activities") or data.get("activity") or []
+            if items:
+                df_chunk = json_normalize_pyarrow(items)
+                if not df_chunk.empty:
+                    chunk_frames.append(df_chunk)
+            page_meta = data.get("page_meta") or {}
+            next_token = page_meta.get("next")
+            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+        if chunk_frames:
+            records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(
                 "chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key}
             )

--- a/tests/test_chembl_assay.py
+++ b/tests/test_chembl_assay.py
@@ -12,6 +12,7 @@ from library.chembl_assay import (
     MAX_TESTITEM_URL_LENGTH,
     TESTITEM_QUERY_FIELDS,
     _split_chunk_for_url,
+    get_activities,
     get_assays,
     get_testitem,
 )
@@ -25,6 +26,15 @@ def _response_page(
 
     page_meta: dict[str, object] = {"next": next_path}
     return {"assays": items, "page_meta": page_meta}
+
+
+def _activity_response_page(
+    items: list[dict[str, str]], next_path: str | None
+) -> dict[str, object]:
+    """Return a fake paginated response payload for activities."""
+
+    page_meta: dict[str, object] = {"next": next_path}
+    return {"activities": items, "page_meta": page_meta}
 
 
 class DummyClient:
@@ -126,6 +136,42 @@ def test_get_assays_fetches_all_pages() -> None:
     assert "offset=2" in client.calls[1]
     assert isinstance(df, pd.DataFrame)
     assert list(df["assay_chembl_id"]) == ids
+
+
+def test_get_activities_fetches_all_pages() -> None:
+    """Pagination should be followed when activity responses are truncated."""
+
+    cfg = ApiCfg()
+    ids = ["AC1", "AC2", "AC3"]
+    next_path = (
+        "/chembl/api/data/activity.json?format=json&activity_id__in=AC1,AC2,AC3&limit=3&offset=2"
+    )
+    responses = iter(
+        [
+            _activity_response_page(
+                [
+                    {"activity_id": "AC1", "assay_chembl_id": "A1"},
+                    {"activity_id": "AC2", "assay_chembl_id": "A2"},
+                ],
+                next_path,
+            ),
+            _activity_response_page(
+                [
+                    {"activity_id": "AC3", "assay_chembl_id": "A3"},
+                ],
+                None,
+            ),
+        ]
+    )
+    client = DummyClient(responses)
+
+    df = get_activities(ids, cfg=cfg, client=client, chunk_size=3)
+
+    assert len(client.calls) == 2
+    assert "limit=3" in client.calls[0]
+    assert "offset=2" in client.calls[1]
+    assert isinstance(df, pd.DataFrame)
+    assert list(df["activity_id"]) == ids
 
 
 def test_get_testitem_splits_requests_when_url_would_exceed_limit() -> None:


### PR DESCRIPTION
## Summary
- ensure `get_activities` requests include chunk-specific limits and follow pagination tokens
- add unit coverage for multi-page activity responses alongside existing assay pagination tests

## Testing
- pytest tests/test_chembl_assay.py

------
https://chatgpt.com/codex/tasks/task_e_68de7fc18dd48324acd95aaec71d71ac