### PR TITLE
Refactor document fetching to stream IDs

### DIFF
--- a/library/chembl_document.py
+++ b/library/chembl_document.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pandas as pd
 
-from library.clients import ChemblClient, _chunked
+from library.clients import ChemblClient
 from .config import ApiCfg
 
 DOCUMENT_COLUMNS = [
@@ -26,6 +26,8 @@ DOCUMENT_COLUMNS = [
     "authors",
     "source",
 ]
+
+INVALID_DOCUMENT_IDS = {"", "#N/A"}
 
 
 def get_documents(
@@ -57,19 +59,14 @@ def get_documents(
         Data frame containing the retrieved document metadata. Missing
         identifiers result in an empty frame.
     """
-    # Filter out empty placeholders and deduplicate to avoid redundant HTTP
-    # requests for the same identifier.
-    valid = [i for i in ids if i not in {"", "#N/A"}]
-    unique_ids = list(dict.fromkeys(valid))
-    if not unique_ids:
-        return pd.DataFrame(columns=DOCUMENT_COLUMNS)
-
     base = f"{cfg.chembl_base.rstrip('/')}/document.json?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    chunk: list[str] = []
 
-    for chunk in _chunked(unique_ids, chunk_size):
-        url = f"{base}&document_chembl_id__in={','.join(chunk)}"
+    def fetch_chunk(chunk_ids: list[str]) -> None:
+        url = f"{base}&document_chembl_id__in={','.join(chunk_ids)}"
         data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
         items = data.get("documents") or data.get("document") or []
         for item in items:
@@ -91,7 +88,21 @@ def get_documents(
             }
             records.append(record)
 
-    if not records:
+    for identifier in ids:
+        if identifier in INVALID_DOCUMENT_IDS:
+            continue
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        chunk.append(identifier)
+        if len(chunk) >= chunk_size:
+            fetch_chunk(chunk)
+            chunk = []
+
+    if chunk:
+        fetch_chunk(chunk)
+
+    if not seen or not records:
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
     df = pd.DataFrame(records)

--- a/tests/test_chembl_document.py
+++ b/tests/test_chembl_document.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from library.chembl_document import get_documents
 from library.config import ApiCfg
 
@@ -11,12 +13,14 @@ class FakeClient:
 
     def __init__(self) -> None:
         self.called: list[tuple[str, float | None]] = []
+        self.chunks: list[list[str]] = []
 
     def request_json(
         self, url: str, *, cfg: ApiCfg, timeout: float | None = None
     ) -> dict[str, object]:
         self.called.append((url, timeout))
         ids = url.split("document_chembl_id__in=")[-1].split("&")[0].split(",")
+        self.chunks.append(ids)
         docs = [
             {
                 "document_chembl_id": i,
@@ -82,3 +86,21 @@ def test_get_documents_deduplicates_ids(
 
     assert df["document_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
     assert len(client.called) == len({"CHEMBL1", "CHEMBL2"})
+
+
+def test_get_documents_handles_large_iterable() -> None:
+    cfg = ApiCfg(
+        chembl_base="https://example.com",
+        user_agent="test/0.1 (mailto:test@example.com)",
+    )
+    client = FakeClient()
+
+    def id_source() -> Iterable[str]:
+        for index in range(20):
+            yield f"CHEMBL{index // 2}"
+
+    df = get_documents(id_source(), cfg=cfg, client=client, chunk_size=3)
+
+    assert df["document_chembl_id"].tolist() == [f"CHEMBL{i}" for i in range(10)]
+    assert all(len(chunk) <= 3 for chunk in client.chunks)
+    assert sum(len(chunk) for chunk in client.chunks) == 10


### PR DESCRIPTION
## Summary
- stream document identifiers lazily and deduplicate them with a set while chunking requests
- ensure remaining identifiers are fetched after the main loop and avoid unnecessary chunk materialisation
- extend document tests to cover large iterables and verify chunk sizing

## Testing
- pytest tests/test_chembl_document.py

------
https://chatgpt.com/codex/tasks/task_e_68de7fbe7b1c8324ac9754f8bb5e3322