### PR TITLE
Handle table quality failures with diagnostics

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -424,11 +424,12 @@ def run_pipeline(
 
     try:
         table_quality(csv_path)
-    except ValueError as exc:
-        use_logger.error(
+    except Exception as exc:  # pragma: no cover - exercised via dedicated test
+        use_logger.exception(
             "quality_report_failed",
             error=str(exc),
             path=str(output_path),
+            exc=exc,
         )
         return 1
 

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -773,8 +773,13 @@ def finalize_output(
 
     try:
         analyze_table_quality(csv_path, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error("quality_report_failed", error=str(exc), path=str(output))
+    except Exception as exc:
+        logger.exception(
+            "quality_report_failed",
+            error=str(exc),
+            path=str(output),
+            exc=exc,
+        )
         return 1
 
     return exit_code

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1340,8 +1340,12 @@ def _finalise_export(
 
     try:
         analyze_table_quality(quality_profiler, table_name=str(csv_path.with_suffix("")))
-    except ValueError as exc:
-        logger.error("quality_report_generation_failed", error=str(exc))
+    except Exception as exc:
+        logger.exception(
+            "quality_report_generation_failed",
+            error=str(exc),
+            exc=exc,
+        )
         return 1
     return exit_code
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1047,11 +1047,12 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     try:
         analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
+    except Exception as exc:
+        logger.exception(
             "quality_report_failed",
             error=str(exc),
             path=str(output),
+            exc=exc,
         )
         return 1
     return 0
@@ -1592,11 +1593,12 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
             tmp_path.unlink(missing_ok=True)
     try:
         analyze_table_quality(output, table_name=str(output.with_suffix("")))
-    except ValueError as exc:
-        logger.error(
+    except Exception as exc:
+        logger.exception(
             "quality_report_failed",
             error=str(exc),
             path=str(output),
+            exc=exc,
         )
         return 1
     return 0
@@ -2459,11 +2461,12 @@ def validate_and_write(
             analyze_table_quality(
                 final_df, table_name=str(normalized_output.with_suffix(""))
             )
-        except ValueError as exc:
-            logger.error(
+        except Exception as exc:
+            logger.exception(
                 "quality_report_failed",
                 error=str(exc),
                 path=str(normalized_output),
+                exc=exc,
             )
             return 1
     logger.info("validate_write_done", rows=len(final_df))

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -416,3 +416,73 @@ def test_run_pipeline_writer_failure(tmp_path: Path, cfg: Config) -> None:
     write_errors = [record for record in records if record.get("event") == "write_fail"]
     assert write_errors
     assert write_errors[-1]["error"] == "writer boom"
+
+
+def test_run_pipeline_table_quality_failure(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    frames = [
+        pd.DataFrame(
+            {
+                "assay_chembl_id": ["A1"],
+                "document_chembl_id": ["D1"],
+            }
+        )
+    ]
+
+    def fetcher() -> list[pd.DataFrame]:
+        return frames
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        collected = list(chunks)
+        if collected:
+            df = pd.concat(collected, ignore_index=True)
+        else:
+            df = pd.DataFrame(columns=col_order or [])
+        df.to_csv(destination, index=False)
+        return destination
+
+    buf = io.StringIO()
+    logger = setup_logger(LoggerConfig(stream=buf), replace_root=False)
+
+    def failing_quality(_: Path) -> None:
+        raise RuntimeError("quality boom")
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=None,
+        schema_name="",
+        validators=[],
+        metadata_hooks=None,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=[],
+        table_quality=failing_quality,
+        cfg=cfg,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    assert output.exists()
+    assert not failure_path.exists()
+
+    lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+    assert lines
+    records = [json.loads(line) for line in lines]
+    quality_errors = [
+        record for record in records if record.get("event") == "quality_report_failed"
+    ]
+    assert quality_errors
+    last_record = quality_errors[-1]
+    assert last_record["error"] == "quality boom"
+    assert last_record.get("traceback")


### PR DESCRIPTION
## Summary
- log table quality hook failures with full diagnostics across pipelines
- ensure downstream commands capture exception tracebacks instead of dropping them
- add regression coverage for table quality exceptions bubbling out of `run_pipeline`

## Testing
- pytest tests/test_cli_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68de7fd448a08324926cdb2c620958fe