### PR TITLE
Guard PubChem augmentation when disabled

### DIFF
--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -424,8 +424,11 @@ def run_testitem_pipeline(
         api_overrides["backoff_factor"] = cfg.testitem.backoff_factor
     api_cfg = cfg.api.model_copy(update=api_overrides) if api_overrides else cfg.api
 
-    pubchem_api_cfg = _prepare_pubchem_api_cfg(cfg, api_cfg)
-    pc.init_session(pubchem_api_cfg, cfg.retry)
+    pubchem_enabled = getattr(cfg.pubchem, "enable", True)
+    pubchem_api_cfg = api_cfg
+    if pubchem_enabled:
+        pubchem_api_cfg = _prepare_pubchem_api_cfg(cfg, api_cfg)
+        pc.init_session(pubchem_api_cfg, cfg.retry)
 
     requested_ids: tuple[str, ...] = ()
     missing_ids: list[str] = []
@@ -536,16 +539,17 @@ def run_testitem_pipeline(
                         parent_stats_holder["value"], parent_result.parent_stats
                     )
 
-                    current = augment_pubchem(
-                        current,
-                        pubchem_cfg=cfg.pubchem,
-                        api_cfg=pubchem_api_cfg,
-                        retry_cfg=cfg.retry,
-                        timeout=parent_timeout,
-                        client=client,
-                        fields=cfg.testitem.fields,
-                        request_limit=cfg.testitem.request_limit,
-                    )
+                    if pubchem_enabled:
+                        current = augment_pubchem(
+                            current,
+                            pubchem_cfg=cfg.pubchem,
+                            api_cfg=pubchem_api_cfg,
+                            retry_cfg=cfg.retry,
+                            timeout=parent_timeout,
+                            client=client,
+                            fields=cfg.testitem.fields,
+                            request_limit=cfg.testitem.request_limit,
+                        )
 
                     enrichment_status, enriched_df = apply_testitem_enrichment(
                         current,

--- a/tests/test_testitem_pipeline_threadsafe.py
+++ b/tests/test_testitem_pipeline_threadsafe.py
@@ -144,15 +144,20 @@ def test_run_pipeline_streams_chunks(monkeypatch, tmp_path, cfg) -> None:
         def __exit__(self, *_args) -> bool:
             return False
 
-    monkeypatch.setattr(pipeline, "read_input_ids", fake_read_ids)
-    monkeypatch.setattr(pipeline, "fetch_testitems", fake_fetch)
-    monkeypatch.setattr(pipeline, "prepare_parent_enrichment", fake_prepare)
-    monkeypatch.setattr(pipeline, "run_parent_enrichment", fake_run)
-    monkeypatch.setattr(pipeline, "augment_pubchem", fake_augment)
-    monkeypatch.setattr(pipeline, "apply_testitem_enrichment", fake_enrich)
-    monkeypatch.setattr(pipeline, "finalize_output", fake_finalize)
-    monkeypatch.setattr(pipeline, "ChemblClient", DummyClient)
-    monkeypatch.setattr(pipeline.pc, "init_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("library.testitem_pipeline.cli.read_input_ids", fake_read_ids)
+    monkeypatch.setattr("library.testitem_pipeline.cli.fetch_testitems", fake_fetch)
+    monkeypatch.setattr("library.testitem_pipeline.cli.prepare_parent_enrichment", fake_prepare)
+    monkeypatch.setattr("library.testitem_pipeline.cli.run_parent_enrichment", fake_run)
+    monkeypatch.setattr("library.testitem_pipeline.cli.augment_pubchem", fake_augment)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.apply_testitem_enrichment", fake_enrich
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.finalize_output", fake_finalize)
+    monkeypatch.setattr("library.testitem_pipeline.cli.ChemblClient", DummyClient)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.pc.init_session",
+        lambda *_args, **_kwargs: None,
+    )
 
     options = pipeline.TestitemPipelineOptions(
         input_csv=tmp_path / "input.csv",
@@ -237,15 +242,23 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
         def __exit__(self, *_args) -> bool:
             return False
 
-    monkeypatch.setattr(pipeline, "read_input_ids", fake_read_ids)
-    monkeypatch.setattr(pipeline, "fetch_testitems", fake_fetch)
-    monkeypatch.setattr(pipeline, "prepare_parent_enrichment", fake_prepare)
-    monkeypatch.setattr(pipeline, "run_parent_enrichment", fake_run)
-    monkeypatch.setattr(pipeline, "augment_pubchem", lambda df, **_: df)
-    monkeypatch.setattr(pipeline, "apply_testitem_enrichment", lambda df, **_: (0, df))
-    monkeypatch.setattr(pipeline, "finalize_output", fake_finalize)
-    monkeypatch.setattr(pipeline, "ChemblClient", DummyClient)
-    monkeypatch.setattr(pipeline.pc, "init_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("library.testitem_pipeline.cli.read_input_ids", fake_read_ids)
+    monkeypatch.setattr("library.testitem_pipeline.cli.fetch_testitems", fake_fetch)
+    monkeypatch.setattr("library.testitem_pipeline.cli.prepare_parent_enrichment", fake_prepare)
+    monkeypatch.setattr("library.testitem_pipeline.cli.run_parent_enrichment", fake_run)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.augment_pubchem", lambda df, **_: df
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.apply_testitem_enrichment",
+        lambda df, **_: (0, df),
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.finalize_output", fake_finalize)
+    monkeypatch.setattr("library.testitem_pipeline.cli.ChemblClient", DummyClient)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.pc.init_session",
+        lambda *_args, **_kwargs: None,
+    )
 
     options = pipeline.TestitemPipelineOptions(
         input_csv=tmp_path / "input.csv",
@@ -259,3 +272,107 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
         ["CHEMBL1"],
         ["CHEMBL2"],
     ]
+
+
+def test_run_pipeline_skips_pubchem_when_disabled(monkeypatch, tmp_path, cfg) -> None:
+    """Ensure PubChem augmentation is bypassed when disabled in configuration."""
+
+    cfg.pubchem.enable = False
+    placeholder = "chembl-da/0.1 (mailto:contact@example.org)"
+    cfg.api.user_agent = placeholder
+    cfg.pubchem.user_agent = placeholder
+
+    chunk = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    def fake_read_ids(*_args, **_kwargs):
+        return 0, pipeline.ReadInputIdsResult(
+            ids_iter=iter(["CHEMBL1"]),
+            sample_ids=("CHEMBL1",),
+        )
+
+    def fake_fetch(*_args, **_kwargs):
+        return 0, iter([chunk]), ("CHEMBL1",)
+
+    def fake_prepare(df: pd.DataFrame, **_kwargs):
+        lookup = pipeline.ParentLookupPreparedData(
+            child_ids=pd.Series(dtype="string"),
+            existing_parent_ids=pd.Series(dtype="string"),
+            need_lookup=set(),
+        )
+        prep = pipeline.ParentEnrichmentPreparation(
+            df=df,
+            lookup_data=lookup,
+            parent_catalog=None,
+            parent_catalog_source=pipeline.PARENT_LOOKUP_SOURCE_CACHE,
+            parent_stats=pipeline.ParentLookupStats(
+                source=pipeline.PARENT_LOOKUP_SOURCE_CACHE,
+                missing=0,
+                unique=len(df),
+                attached=len(df),
+                uncovered=0,
+            ),
+        )
+        return 0, prep
+
+    def fake_run(prep: pipeline.ParentEnrichmentPreparation, **_kwargs):
+        stats = pipeline.ParentLookupStats(
+            source=pipeline.PARENT_LOOKUP_SOURCE_LOOKUP,
+            missing=0,
+            unique=len(prep.df),
+            attached=len(prep.df),
+            uncovered=0,
+        )
+        return 0, pipeline.ParentEnrichmentResult(df=prep.df, parent_stats=stats)
+
+    def fake_enrich(df: pd.DataFrame, **_kwargs):
+        return 0, df
+
+    def fake_finalize(*_args, **_kwargs):
+        return 0
+
+    def fail_prepare_pubchem(*_args, **_kwargs):
+        raise AssertionError("PubChem configuration should not be prepared when disabled")
+
+    def fail_init_session(*_args, **_kwargs):
+        raise AssertionError("PubChem session should not be initialised when disabled")
+
+    def fail_augment(*_args, **_kwargs):
+        raise AssertionError("augment_pubchem should not run when disabled")
+
+    class DummyClient:
+        def __init__(self, *_args, **_kwargs) -> None:  # pragma: no cover - simple stub
+            self.client = SimpleNamespace()
+
+        def __enter__(self) -> SimpleNamespace:
+            return self.client
+
+        def __exit__(self, *_args) -> bool:
+            return False
+
+    monkeypatch.setattr("library.testitem_pipeline.cli.read_input_ids", fake_read_ids)
+    monkeypatch.setattr("library.testitem_pipeline.cli.fetch_testitems", fake_fetch)
+    monkeypatch.setattr("library.testitem_pipeline.cli.prepare_parent_enrichment", fake_prepare)
+    monkeypatch.setattr("library.testitem_pipeline.cli.run_parent_enrichment", fake_run)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.apply_testitem_enrichment", fake_enrich
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.finalize_output", fake_finalize)
+    monkeypatch.setattr("library.testitem_pipeline.cli.ChemblClient", DummyClient)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli._prepare_pubchem_api_cfg",
+        fail_prepare_pubchem,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.pc.init_session", fail_init_session
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.augment_pubchem", fail_augment)
+
+    options = pipeline.TestitemPipelineOptions(
+        input_csv=tmp_path / "input.csv",
+        output_csv=tmp_path / "output.csv",
+    )
+
+    result = pipeline.run_testitem_pipeline(cfg, options)
+
+    assert result == 0
+


### PR DESCRIPTION
## Summary
- avoid preparing the PubChem API client when the feature is disabled and skip augmentation in the CLI pipeline
- update pipeline tests to patch module-level functions and cover the disabled PubChem flow

## Testing
- pytest tests/test_testitem_pipeline_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68de811a8c5c8324805177e9fe58476f