### PR TITLE
Use shared chunked helpers in activity pipeline

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -10,15 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-import threading
 from collections.abc import Iterable, Iterator, Sequence
-from concurrent.futures import (
-    FIRST_COMPLETED,
-    Future,
-    ThreadPoolExecutor,
-    as_completed,
-    wait,
-)
 
 from functools import partial
 from itertools import islice
@@ -70,7 +62,6 @@ from library.cli_utils import (
 from library.cli_utils import (
     write_meta_yaml as _cli_write_meta_yaml,
 )
-from library.clients import ChemblClient, _chunked
 from library.config import Config, _serialize_paths
 from library.log import logger
 from library.pipeline_metadata import add_pipeline_metadata
@@ -166,172 +157,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
 
-    def fetcher() -> Iterator[pd.DataFrame]:
-
-        id_batches = list(_chunked(limited_ids, cfg.activity.batch_size))
-        if not id_batches:
-            return
-
-        id_sequence = [str(identifier) for batch in id_batches for identifier in batch]
-        id_order = {identifier: index for index, identifier in enumerate(id_sequence)}
-        id_chunks = iter(id_batches)
-        primary_key = tuple(str(identifier) for identifier in id_batches[0])
-        primary_done = threading.Event()
-        cache_lock = threading.Lock()
-        cached_chunks: dict[tuple[str, ...], list[pd.DataFrame]] = {}
-
-        global_limiter = get_global_limiter(
-            cfg.rate.global_rps, cfg.rate.global_burst
-        )
-
-        with ChemblClient(
-            cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-        ) as client:
-
-
-            def _fetch_chunk(chunk_ids: Sequence[str]) -> list[pd.DataFrame]:
-                key = tuple(str(identifier) for identifier in chunk_ids)
-                with cache_lock:
-                    cached = cached_chunks.pop(key, None)
-                if cached is not None:
-                    return cached
-                if key != primary_key and not primary_done.is_set():
-                    primary_done.wait()
-                    with cache_lock:
-                        cached = cached_chunks.pop(key, None)
-                    if cached is not None:
-                        return cached
-
-                try:
-
-                    result = cl.get_activities(
-
-                        chunk_ids,
-                        cfg=cfg.api,
-                        client=client,
-                        chunk_size=cfg.activity.batch_size,
-                        timeout=cfg.activity.timeout,
-                        **extra_kwargs,
-                    )
-                    if isinstance(result, pd.DataFrame):
-                        frames = [result]
-                    elif result is None:
-                        frames = []
-                    else:
-                        frames = [frame for frame in result]
-                    if not frames:
-                        return []
-
-                    chunk_map: dict[tuple[str, ...], list[pd.DataFrame]] = {}
-                    for frame in frames:
-                        if frame is None or frame.empty:
-                            continue
-                        if "activity_id" not in frame.columns:
-                            chunk_map.setdefault(key, []).append(frame)
-                            continue
-                        column = frame["activity_id"].astype(str)
-                        matched: set[str] = set()
-                        for value in column:
-                            if value in id_order:
-                                matched.add(value)
-                                continue
-                            for identifier in id_order:
-                                if value.endswith(identifier):
-                                    matched.add(identifier)
-                                    break
-                        if not matched:
-                            matched = set(key)
-                        matched_ids = tuple(
-                            sorted(
-                                matched,
-                                key=lambda identifier: id_order.get(identifier, len(id_order)),
-                            )
-                        )
-                        mask = column.apply(
-                            lambda value, ids=matched_ids: value in ids
-                            or any(value.endswith(identifier) for identifier in ids)
-                        )
-                        if mask.any():
-                            chunk_map.setdefault(matched_ids, []).append(frame.loc[mask])
-
-                    with cache_lock:
-                        for chunk_key, chunk_frames in chunk_map.items():
-                            cached_chunks.setdefault(chunk_key, []).extend(chunk_frames)
-                        frames_for_key = cached_chunks.pop(key, [])
-                except (requests.RequestException, ValueError) as exc:
-                    logger.error(
-                        "activity_fetch_failed",
-                        extra={
-                            "msg": str(exc),
-                            "chunk_ids": list(chunk_ids),
-                        },
-                        error=str(exc),
-                        batch_size=cfg.activity.batch_size,
-                        timeout=cfg.activity.timeout,
-                    )
-                    raise PipelineError(str(exc)) from exc
-                finally:
-                    if key == primary_key:
-                        primary_done.set()
-
-                return frames_for_key
-
-
-            workers = max(1, cfg.activity.workers)
-            if workers == 1:
-
-                for chunk_ids in id_chunks:
-                    for frame in _fetch_chunk(list(chunk_ids)):
-                        yield frame
-                return
-
-
-            pending: dict[Future[list[pd.DataFrame]], int] = {}
-            completed: dict[int, list[pd.DataFrame]] = {}
-            next_index = 0
-
-            def _cancel_pending() -> None:
-                for future in list(pending):
-                    future.cancel()
-
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-
-                try:
-                    for index, chunk_ids in enumerate(id_chunks):
-                        chunk_list = list(chunk_ids)
-                        future = executor.submit(_fetch_chunk, chunk_list)
-                        pending[future] = index
-                        if len(pending) >= workers:
-                            done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
-                            for finished in done:
-                                chunk_index = pending.pop(finished)
-                                try:
-                                    completed[chunk_index] = finished.result()
-                                except PipelineError:
-                                    _cancel_pending()
-                                    raise
-                            while next_index in completed:
-                                frames = completed.pop(next_index)
-                                for frame in frames:
-                                    yield frame
-                                next_index += 1
-
-                    for future in as_completed(list(pending)):
-                        chunk_index = pending.pop(future)
-                        try:
-                            completed[chunk_index] = future.result()
-                        except PipelineError:
-                            _cancel_pending()
-                            raise
-                        while next_index in completed:
-                            frames = completed.pop(next_index)
-                            for frame in frames:
-                                yield frame
-                            next_index += 1
-                finally:
-                    pending.clear()
-
-
     def _compute_bounds(frame: pd.DataFrame) -> pd.DataFrame:
         return compute_activity_bounds(frame, cfg.activity_bounds)
 
@@ -350,29 +175,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     ]
 
     validators = [partial(validate_activities, return_result=True)]
-
-
-    def writer(
-        chunks: Iterable[pd.DataFrame],
-        destination: Path,
-        col_order: Sequence[str],
-        key_cols: Sequence[str],
-    ) -> Path:
-        sort_columns = list(key_cols) or sorted(col_order)
-        output_path = io.write_csv(
-            chunks,
-            destination,
-            cfg=cfg,
-            key_cols=sort_columns,
-            col_order=col_order,
-            chunksize=cfg.io.csv_chunksize,
-            sep=cfg.io.csv_sep,
-            encoding=cfg.io.csv_encoding,
-        )
-        path_obj = Path(output_path)
-        if not path_obj.exists():
-            raise PipelineError(f"writer failed to create output: {path_obj}")
-        return path_obj
 
 
     table_quality = partial(
@@ -422,16 +224,36 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             workers=max(1, worker_count),
         )
 
+        def _write_chunks(
+            chunks: Iterable[pd.DataFrame],
+            destination: Path,
+            *,
+            col_order: Sequence[str] | None,
+            key_cols: Sequence[str] | None,
+            **kwargs,
+        ) -> Path:
+            path = write_csv_chunks_deterministic(
+                chunks,
+                destination,
+                col_order=col_order,
+                key_cols=key_cols,
+                **kwargs,
+            )
+            path_obj = Path(path)
+            if not path_obj.exists():
+                raise PipelineError(f"writer failed to create output: {path_obj}")
+            return path_obj
+
         writer_config = CsvWriterConfig(
-            writer=write_csv_chunks_deterministic,
+            writer=_write_chunks,
             kwargs={
                 "cfg": cfg,
                 "chunksize": cfg.io.csv_chunksize,
                 "sort_chunksize": cfg.io.csv_chunksize,
                 "sep": cfg.io.csv_sep,
                 "encoding": cfg.io.csv_encoding,
+                "merge_chunksize": cfg.io.csv_chunksize,
             },
-            ensure_destination=True,
         )
 
         fetcher, writer = prepare_chunked_pipeline(

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -322,20 +322,21 @@ def test_run_chembl_writer_missing_output(
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
-    def fake_write_csv(
+    def fake_write_csv_chunks(
         chunks,
         destination,
         *,
-        cfg,
-        key_cols,
         col_order,
-        chunksize,
-        sep,
-        encoding,
+        key_cols,
+        **kwargs,
     ):
         return destination
 
-    monkeypatch.setattr(gad.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(
+        gad,
+        "write_csv_chunks_deterministic",
+        fake_write_csv_chunks,
+    )
 
     rc = gad.run_chembl(cfg, args)
 

--- a/tests/test_get_activity_data_cli.py
+++ b/tests/test_get_activity_data_cli.py
@@ -66,22 +66,19 @@ def test_get_activity_data_cli_workers_order(
 
     captured = {"chunks": [], "workers": None, "calls": []}
 
-    frames = [
-        pd.DataFrame({"activity_id": ["chunk0_A1", "chunk0_A2"]}),
-        pd.DataFrame({"activity_id": ["chunk1_A3", "chunk1_A4"]}),
-    ]
-    delays = [0.05, 0.0]
+    frames = {
+        ("A1", "A2"): pd.DataFrame({"activity_id": ["chunk0_A1", "chunk0_A2"]}),
+        ("A3", "A4"): pd.DataFrame({"activity_id": ["chunk1_A3", "chunk1_A4"]}),
+    }
+    delays = {("A1", "A2"): 0.05, ("A3", "A4"): 0.0}
 
     def fake_get_activities(ids, *, cfg, client, chunk_size, timeout, **kwargs):
-        captured["calls"].append((tuple(ids), chunk_size, timeout))
-
-        def _iter():
-            for delay, frame in zip(delays, frames):
-                if delay:
-                    time.sleep(delay)
-                yield frame
-
-        return _iter()
+        key = tuple(ids)
+        captured["calls"].append((key, chunk_size, timeout))
+        delay = delays.get(key, 0.0)
+        if delay:
+            time.sleep(delay)
+        return frames[key]
 
     class DummyClient:
         def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
@@ -139,4 +136,7 @@ def test_get_activity_data_cli_workers_order(
         ["chunk0_A1", "chunk0_A2"],
         ["chunk1_A3", "chunk1_A4"],
     ]
-    assert captured["calls"] == [(("A1", "A2"), 2, 30.0)]
+    assert captured["calls"] == [
+        (("A1", "A2"), 2, 30.0),
+        (("A3", "A4"), 2, 30.0),
+    ]


### PR DESCRIPTION
## Summary
- remove the bespoke activity fetcher implementation in favour of prepare_chunked_pipeline
- wrap the shared deterministic writer to preserve output verification
- update activity CLI tests to match the shared pipeline behaviour

## Testing
- pytest tests/test_get_activity_data_cli.py tests/test_get_activity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de8113448c8324924382d1a9cd76e7