### PR TITLE
Ensure pipeline invocations are recorded in metadata

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -61,6 +61,7 @@ from library.cli import (
 )
 from library.cli_utils import (
     PipelineError,
+    resolve_invocation,
     run_cli_command,
     run_pipeline,
 )
@@ -85,6 +86,14 @@ from schemas import ActivitiesSchema, configure_activity_schema, normalize_activ
 
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
+PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
+    invocation = getattr(args, "invocation", None)
+    if invocation is None:
+        return (PROGRAM_NAME,)
+    return tuple(str(arg) for arg in invocation)
 
 
 file_sha256 = _cli_file_sha256
@@ -359,15 +368,16 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         key_cols: Sequence[str],
     ) -> Path:
         sort_columns = list(key_cols) or sorted(col_order)
-        output_path = io.write_csv(
+        output_path = write_csv_chunks_deterministic(
             chunks,
             destination,
-            cfg=cfg,
             key_cols=sort_columns,
-            col_order=col_order,
+            col_order=list(col_order),
             chunksize=cfg.io.csv_chunksize,
+            sort_chunksize=cfg.io.csv_chunksize,
             sep=cfg.io.csv_sep,
             encoding=cfg.io.csv_encoding,
+            cfg=cfg,
         )
         path_obj = Path(output_path)
         if not path_obj.exists():
@@ -423,15 +433,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
 
         writer_config = CsvWriterConfig(
-            writer=write_csv_chunks_deterministic,
-            kwargs={
-                "cfg": cfg,
-                "chunksize": cfg.io.csv_chunksize,
-                "sort_chunksize": cfg.io.csv_chunksize,
-                "sep": cfg.io.csv_sep,
-                "encoding": cfg.io.csv_encoding,
-            },
-            ensure_destination=True,
+            writer=writer,
+            kwargs={},
+            ensure_destination=False,
         )
 
         fetcher, writer = prepare_chunked_pipeline(
@@ -449,7 +453,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             writer=writer,
             output_path=output,
             failure_path=failure_path,
-            command=" ".join(sys.argv),
+            invocation=_args_invocation(args),
             config_snapshot=_serialize_paths(cfg.to_dict()),
             inputs={"input_csv": str(args.input_csv)},
             key_columns=["activity_id"],
@@ -493,6 +497,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_option="--batch-size",
         size_dest="batch_size",
     )
+    parser.prog = PROGRAM_NAME
     parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
     parser.add_argument(
         "--timeout",
@@ -551,6 +556,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
     parser, log_cfg = build_parser()
     args = parser.parse_args(argv)
+    args.invocation = resolve_invocation(parser.prog, argv)
     cli.prepare_io_paths(
         args,
         input_default=DEFAULT_INPUT_NAME,

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -322,20 +322,25 @@ def test_run_chembl_writer_missing_output(
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
-    def fake_write_csv(
+    def fake_write_csv_chunks(
         chunks,
         destination,
         *,
-        cfg,
         key_cols,
         col_order,
         chunksize,
+        sort_chunksize,
         sep,
         encoding,
+        cfg,
     ):
         return destination
 
-    monkeypatch.setattr(gad.io, "write_csv", fake_write_csv)
+    monkeypatch.setattr(
+        gad,
+        "write_csv_chunks_deterministic",
+        fake_write_csv_chunks,
+    )
 
     rc = gad.run_chembl(cfg, args)
 


### PR DESCRIPTION
## Summary
- Added invocation plumbing to CLI pipelines and metadata writers to record accurate command strings across orchestrated and standalone usage.
- Replaced direct command reconstruction via ``" ".join(sys.argv)`` with invocation-aware helpers throughout the scripts and metadata utilities.
- Updated the ChEMBL activity pipeline writer to call the deterministic CSV helper so tests can observe chunk ordering and failure handling, and refreshed the corresponding tests for the new hook.

## Testing
- pytest tests/test_cli_utils.py tests/test_metadata.py
- pytest tests/test_get_activity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de811c84348324a3ad4e97171a7115