### PR TITLE
Stream ChEMBL test item requests with duplicate tracking

### DIFF
--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -6,11 +6,13 @@ import sys
 from collections import OrderedDict, deque
 from dataclasses import dataclass
 from itertools import chain, islice
+from types import MappingProxyType
 from pathlib import Path
 from typing import (
     Any,
     Iterable,
     Iterator,
+    Mapping,
     Sequence,
 )
 
@@ -219,6 +221,58 @@ def integrate_missing_identifiers(
     return ordered
 
 
+class RequestedIdsSummary:
+    """Track requested identifiers and input duplicates during streaming."""
+
+    __slots__ = ("_unique", "_duplicates", "_total")
+
+    def __init__(self) -> None:
+        self._unique: OrderedDict[str, str] = OrderedDict()
+        self._duplicates: set[str] = set()
+        self._total = 0
+
+    def record(self, identifier: object) -> tuple[str, bool]:
+        """Register *identifier* and return its text form and inclusion flag."""
+
+        self._total += 1
+        text_identifier = str(identifier)
+        normalized = text_identifier.strip()
+
+        if not normalized:
+            return text_identifier, True
+
+        upper_identifier = normalized.upper()
+        if upper_identifier in self._unique:
+            self._duplicates.add(upper_identifier)
+            return text_identifier, False
+
+        self._unique[upper_identifier] = text_identifier
+        return text_identifier, True
+
+    @property
+    def unique(self) -> Mapping[str, str]:
+        """Return a read-only, ordered view of the unique identifiers."""
+
+        return MappingProxyType(self._unique)
+
+    def iter_unique_keys(self) -> Iterator[str]:
+        """Yield normalised keys for all unique identifiers in input order."""
+
+        return iter(self._unique.keys())
+
+    def missing_originals(self, fetched_keys: set[str]) -> list[str]:
+        """Return identifiers absent from *fetched_keys* preserving order."""
+
+        return [
+            original for key, original in self._unique.items() if key not in fetched_keys
+        ]
+
+    def duplicate_keys(self) -> set[str]:
+        """Return the set of normalised duplicate identifiers from input."""
+
+        return set(self._duplicates)
+
+
 class TestitemFetchError(RuntimeError):
     """Raised when streaming retrieval of test item data fails."""
 
@@ -230,21 +284,6 @@ class TestitemPipelineStageError(RuntimeError):
         detail = message if message is not None else f"pipeline stage failed ({code})"
         super().__init__(detail)
         self.code = code
-
-
-def _batched(iterable: Iterable[str], size: int) -> Iterator[list[str]]:
-    """Yield lists of at most ``size`` elements from ``iterable``."""
-
-    chunk: list[str] = []
-    for item in iterable:
-        chunk.append(item)
-        if len(chunk) == size:
-            yield chunk
-            chunk = []
-    if chunk:
-        yield chunk
-
-
 def fetch_testitems(
     ids_iter: Iterable[str],
     *,
@@ -259,13 +298,26 @@ def fetch_testitems(
     """Retrieve ChEMBL test item records for ``ids_iter`` in chunks."""
 
     logger.info("chembl_fetch_start", batch_size=batch_size)
-    requested_ids_original: list[str] = []
+    requested_summary = RequestedIdsSummary()
 
-    for identifier in ids_iter:
-        text_identifier = str(identifier)
-        requested_ids_original.append(text_identifier)
+    def _iter_requested_batches() -> Iterator[list[str]]:
+        chunk: list[str] = []
+        chunk_limit = max(1, batch_size)
 
-    requested_iter = iter(requested_ids_original)
+        for identifier in ids_iter:
+            text_identifier, include = requested_summary.record(identifier)
+            if not include:
+                continue
+
+            chunk.append(text_identifier)
+            if len(chunk) == chunk_limit:
+                yield chunk
+                chunk = []
+
+        if chunk:
+            yield chunk
+
+    requested_iter = _iter_requested_batches()
 
     seen_ids: set[str] = set()
     duplicate_ids: set[str] = set()
@@ -332,27 +384,26 @@ def fetch_testitems(
 
         return cleaned.reset_index(drop=True)
 
-    batched_iter = _batched(requested_iter, max(1, batch_size))
-
     try:
-        first_batch = next(batched_iter)
+        first_batch = next(requested_iter)
     except StopIteration:
         logger.info("chembl_fetch_done", rows=0)
         logger.info("identifiers_retrieved", count=0)
+        duplicate_ids.update(requested_summary.duplicate_keys())
         if duplicate_ids:
             logger.warning(
                 "chembl_duplicate_identifiers",
                 duplicate_count=len(duplicate_ids),
                 duplicate_ids=sorted(duplicate_ids),
             )
-        return 0, iter(()), tuple(requested_ids_original)
+        return 0, iter(()), requested_summary
 
     prefetched: list[pd.DataFrame] = []
 
     try:
         prefetched.append(_load_chunk(first_batch))
     except TestitemFetchError:
-        return 1, None, tuple(requested_ids_original)
+        return 1, None, requested_summary
 
     rows_counter = 0
 
@@ -363,7 +414,7 @@ def fetch_testitems(
                 if not prefetched_chunk.empty:
                     rows_counter += len(prefetched_chunk)
                     yield prefetched_chunk
-            for batch in batched_iter:
+            for batch in requested_iter:
                 chunk_df = _load_chunk(batch)
                 if not chunk_df.empty:
                     rows_counter += len(chunk_df)
@@ -371,6 +422,7 @@ def fetch_testitems(
         finally:
             logger.info("chembl_fetch_done", rows=rows_counter)
             logger.info("identifiers_retrieved", count=rows_counter)
+            duplicate_ids.update(requested_summary.duplicate_keys())
             if duplicate_ids:
                 logger.warning(
                     "chembl_duplicate_identifiers",
@@ -378,7 +430,7 @@ def fetch_testitems(
                     duplicate_ids=sorted(duplicate_ids),
                 )
 
-    return 0, _chunk_stream(), tuple(requested_ids_original)
+    return 0, _chunk_stream(), requested_summary
 
 
 def apply_testitem_enrichment(
@@ -470,14 +522,6 @@ def run_testitem_pipeline(
         )
         if fetch_status != 0 or chunk_iter is None:
             return fetch_status
-
-        requested_unique: OrderedDict[str, str] = OrderedDict()
-        for identifier in requested_ids:
-            key = identifier.strip()
-            if not key:
-                continue
-            upper_key = key.upper()
-            requested_unique.setdefault(upper_key, identifier)
 
         fetched_ids: set[str] = set()
 
@@ -572,8 +616,7 @@ def run_testitem_pipeline(
             ) as exc:  # pragma: no cover - propagated network error
                 raise TestitemPipelineStageError(1, str(exc)) from exc
 
-            missing_keys = [key for key in requested_unique if key not in fetched_ids]
-            missing_ids.extend(requested_unique[key] for key in missing_keys)
+            missing_ids.extend(requested_ids.missing_originals(fetched_ids))
             if missing_ids:
                 logger.warning(
                     "chembl_missing_identifiers",

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -148,7 +148,7 @@ def test_fetch_testitems_failure(monkeypatch: pytest.MonkeyPatch, cfg: Config) -
 
     assert status == 1
     assert chunks is None
-    assert requested_ids == ()
+    assert list(requested_ids.unique.values()) == ["CHEMBL1"]
 
 
 def test_ensure_no_parant_column_raises() -> None:
@@ -204,7 +204,60 @@ def test_fetch_testitems_passes_fields_and_limit(
     assert frames[0]["molecule_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
     assert captured["fields"] == ("a", "b")
     assert captured["page_limit"] == 500
-    assert requested_ids == ("CHEMBL1", "CHEMBL2")
+    assert list(requested_ids.unique.values()) == ["CHEMBL1", "CHEMBL2"]
+
+
+def test_fetch_testitems_deduplicates_input(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    captured_batches: list[list[str]] = []
+    captured_events: list[tuple[str, dict[str, object]]] = []
+
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured_events.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(gtd.logger, "warning", fake_warning)
+
+    def fake_get_testitem(
+        ids: Iterable[str],
+        *,
+        cfg: ApiCfg,
+        client: object,
+        chunk_size: int,
+        timeout: float | None,
+        fields: Sequence[str] | None = None,
+        page_limit: int = 0,
+    ) -> pd.DataFrame:
+        batch = list(ids)
+        captured_batches.append(batch)
+        return pd.DataFrame(
+            [{"molecule_chembl_id": value.upper()} for value in batch],
+            columns=["molecule_chembl_id"],
+        )
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+
+    ids = iter(["chembl1", "CHEMBL1", "ChEmBl1", "CHEMBL2", "chembl3"])
+    status, chunks, requested_ids = gtd.fetch_testitems(
+        ids,
+        api_cfg=cfg.api,
+        batch_size=2,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        sample_ids=("chembl1",),
+        fields=cfg.testitem.fields,
+        page_limit=cfg.testitem.request_limit,
+    )
+
+    assert status == 0
+    assert chunks is not None
+    _ = list(chunks)
+    assert captured_batches == [["chembl1", "CHEMBL2"], ["chembl3"]]
+    assert list(requested_ids.unique.values()) == ["chembl1", "CHEMBL2", "chembl3"]
+    duplicate_events = [event for event in captured_events if event[0] == "chembl_duplicate_identifiers"]
+    assert duplicate_events
+    assert duplicate_events[0][1]["duplicate_count"] == 1
+    assert duplicate_events[0][1]["duplicate_ids"] == ["CHEMBL1"]
 
 
 def test_fetch_testitems_logs_missing_summary(
@@ -245,8 +298,12 @@ def test_fetch_testitems_logs_missing_summary(
 
     assert status == 0
     assert chunks is not None
-    assert requested_ids == ("CHEMBL1", "chembl2", "CHEMBL3")
     _ = list(chunks)
+    assert list(requested_ids.unique.values()) == [
+        "CHEMBL1",
+        "chembl2",
+        "CHEMBL3",
+    ]
     missing = [
         record for record in captured if record[0] == "chembl_missing_identifiers"
     ]

--- a/tests/test_testitem_pipeline_threadsafe.py
+++ b/tests/test_testitem_pipeline_threadsafe.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 from library.config import ApiCfg, PubChemCfg, RetryCfg
 import library.testitem_pipeline as pipeline
+import library.testitem_pipeline.cli as pipeline_cli
 
 
 def test_augment_pubchem_single_initialisation(monkeypatch) -> None:
@@ -88,7 +89,10 @@ def test_run_pipeline_streams_chunks(monkeypatch, tmp_path, cfg) -> None:
         )
 
     def fake_fetch(*_args, **_kwargs):
-        return 0, iter([chunk_a, chunk_b]), ("CHEMBL1", "CHEMBL2", "CHEMBL3")
+        summary = pipeline_cli.RequestedIdsSummary()
+        for value in ("CHEMBL1", "CHEMBL2", "CHEMBL3"):
+            summary.record(value)
+        return 0, iter([chunk_a, chunk_b]), summary
 
     def fake_prepare(df: pd.DataFrame, **_kwargs):
         captured_prepare.append(df.copy())
@@ -145,12 +149,19 @@ def test_run_pipeline_streams_chunks(monkeypatch, tmp_path, cfg) -> None:
             return False
 
     monkeypatch.setattr(pipeline, "read_input_ids", fake_read_ids)
+    monkeypatch.setattr(pipeline_cli, "read_input_ids", fake_read_ids)
     monkeypatch.setattr(pipeline, "fetch_testitems", fake_fetch)
+    monkeypatch.setattr(pipeline_cli, "fetch_testitems", fake_fetch)
     monkeypatch.setattr(pipeline, "prepare_parent_enrichment", fake_prepare)
+    monkeypatch.setattr(pipeline_cli, "prepare_parent_enrichment", fake_prepare)
     monkeypatch.setattr(pipeline, "run_parent_enrichment", fake_run)
+    monkeypatch.setattr(pipeline_cli, "run_parent_enrichment", fake_run)
     monkeypatch.setattr(pipeline, "augment_pubchem", fake_augment)
+    monkeypatch.setattr(pipeline_cli, "augment_pubchem", fake_augment)
     monkeypatch.setattr(pipeline, "apply_testitem_enrichment", fake_enrich)
+    monkeypatch.setattr(pipeline_cli, "apply_testitem_enrichment", fake_enrich)
     monkeypatch.setattr(pipeline, "finalize_output", fake_finalize)
+    monkeypatch.setattr(pipeline_cli, "finalize_output", fake_finalize)
     monkeypatch.setattr(pipeline, "ChemblClient", DummyClient)
     monkeypatch.setattr(pipeline.pc, "init_session", lambda *_args, **_kwargs: None)
 
@@ -189,7 +200,10 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
         )
 
     def fake_fetch(*_args, **_kwargs):
-        return 0, iter([chunk]), ("CHEMBL1", "CHEMBL2")
+        summary = pipeline_cli.RequestedIdsSummary()
+        for value in ("CHEMBL1", "CHEMBL2"):
+            summary.record(value)
+        return 0, iter([chunk]), summary
 
     def fake_prepare(df: pd.DataFrame, **_kwargs):
         lookup = pipeline.ParentLookupPreparedData(
@@ -238,12 +252,19 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
             return False
 
     monkeypatch.setattr(pipeline, "read_input_ids", fake_read_ids)
+    monkeypatch.setattr(pipeline_cli, "read_input_ids", fake_read_ids)
     monkeypatch.setattr(pipeline, "fetch_testitems", fake_fetch)
+    monkeypatch.setattr(pipeline_cli, "fetch_testitems", fake_fetch)
     monkeypatch.setattr(pipeline, "prepare_parent_enrichment", fake_prepare)
+    monkeypatch.setattr(pipeline_cli, "prepare_parent_enrichment", fake_prepare)
     monkeypatch.setattr(pipeline, "run_parent_enrichment", fake_run)
+    monkeypatch.setattr(pipeline_cli, "run_parent_enrichment", fake_run)
     monkeypatch.setattr(pipeline, "augment_pubchem", lambda df, **_: df)
+    monkeypatch.setattr(pipeline_cli, "augment_pubchem", lambda df, **_: df)
     monkeypatch.setattr(pipeline, "apply_testitem_enrichment", lambda df, **_: (0, df))
+    monkeypatch.setattr(pipeline_cli, "apply_testitem_enrichment", lambda df, **_: (0, df))
     monkeypatch.setattr(pipeline, "finalize_output", fake_finalize)
+    monkeypatch.setattr(pipeline_cli, "finalize_output", fake_finalize)
     monkeypatch.setattr(pipeline, "ChemblClient", DummyClient)
     monkeypatch.setattr(pipeline.pc, "init_session", lambda *_args, **_kwargs: None)
 


### PR DESCRIPTION
## Summary
- stream identifier batches without materialising the full request list and track duplicate inputs
- expose ordered identifier metadata for downstream missing-id handling
- update CLI pipeline tests to work with the streaming identifier summary and cover input deduplication

## Testing
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_failure
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_passes_fields_and_limit
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_deduplicates_input
- pytest tests/test_get_testitem_data.py::test_fetch_testitems_logs_missing_summary
- pytest tests/test_testitem_pipeline_threadsafe.py::test_run_pipeline_streams_chunks
- pytest tests/test_testitem_pipeline_threadsafe.py::test_run_pipeline_streams_missing
- pytest tests/test_testitem_pipeline_threadsafe.py::test_augment_pubchem_single_initialisation

------
https://chatgpt.com/codex/tasks/task_e_68de7fcb352883248d3e6767f7274ec2