### PR TITLE
Handle missing parent identifiers during PubChem lookup

### DIFF
--- a/library/testitem_pipeline/pubchem.py
+++ b/library/testitem_pipeline/pubchem.py
@@ -276,9 +276,10 @@ def resolve_pubchem_cid(
             cache[chembl_id] = None
         return None
 
-    parent_id = _normalise_identifier(
-        row.get("parent_molecule_chembl_id"), uppercase=True
-    )
+    parent_raw = None
+    if isinstance(row, pd.Series) and "parent_molecule_chembl_id" in row.index:
+        parent_raw = row.get("parent_molecule_chembl_id")
+    parent_id = _normalise_identifier(parent_raw, uppercase=True)
     if not parent_id:
         if chembl_id and chembl_id not in cache:
             cache[chembl_id] = None

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -403,9 +403,10 @@ def resolve_pubchem_cid(
             cache[chembl_id] = None
         return None
 
-    parent_id = _normalise_identifier(
-        row.get("parent_molecule_chembl_id"), uppercase=True
-    )
+    parent_raw = None
+    if isinstance(row, pd.Series) and "parent_molecule_chembl_id" in row.index:
+        parent_raw = row.get("parent_molecule_chembl_id")
+    parent_id = _normalise_identifier(parent_raw, uppercase=True)
     if not parent_id:
         if chembl_id and chembl_id not in cache:
             cache[chembl_id] = None

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -1438,6 +1438,25 @@ def test_resolve_pubchem_cid_uses_parent_when_enabled(
     assert calls == ["CHEMBL2", "CHEMBL1"]
 
 
+def test_resolve_pubchem_cid_handles_missing_parent_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = pd.Series({"molecule_chembl_id": "CHEMBL2"})
+    cache: dict[str, str | None] = {}
+    cfg = pl.PubChemCfg(delay=0, use_parent_for_salts=True)
+
+    monkeypatch.setattr(
+        pl,
+        "resolve_pubchem_record",
+        lambda *args, **kwargs: pl.PubChemResolution(cid=None, source=None),
+    )
+
+    cid = pipeline.resolve_pubchem_cid(row, cache, cfg, resolution_cache={})
+
+    assert cid is None
+    assert cache["CHEMBL2"] is None
+
+
 def test_resolve_pubchem_cid_logs_when_parent_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- guard PubChem CID resolution against missing parent identifier columns
- mirror the defensive handling in the CLI script entry point
- cover the regression with a unit test exercising frames without parent data

## Testing
- pytest tests/test_get_testitem_data.py::test_resolve_pubchem_cid_handles_missing_parent_column

------
https://chatgpt.com/codex/tasks/task_e_68de94d13e0c8324996ce79968d694f9