### PR TITLE
Handle duplicate columns in dataframe_to_strings

### DIFF
--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -326,13 +326,13 @@ def dataframe_to_strings(
 
     skip_set = set(skip or [])
     result = df.copy()
-    for col in result.columns:
+    for idx, col in enumerate(result.columns):
         if col in skip_set:
             continue
-        series = result[col]
+        series = result.iloc[:, idx]
         if pd.api.types.is_numeric_dtype(series.dtype):
             continue
-        result[col] = series.astype(str)
+        result.iloc[:, idx] = series.astype(str)
     return result
 
 


### PR DESCRIPTION
## Summary
- ensure `dataframe_to_strings` works correctly when DataFrames contain duplicate column names by iterating by column index

## Testing
- pytest *(fails: ImportError: cannot import name 'resolve_invocation' from 'library.cli_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68de957a0f0c832484956a7f678e0762