### PR TITLE
Restore resolve_invocation helper for CLI metadata

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 import traceback
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -35,6 +36,17 @@ from .sidecar import SidecarErrors
 from .utils.config import DEFAULT_CONFIG_RELATIVE
 
 SchemaT = TypeVar("SchemaT")
+
+
+def resolve_invocation(prog: str, argv: Sequence[str] | None) -> tuple[str, ...]:
+    """Return a normalised tuple describing the CLI invocation."""
+
+    if argv is None:
+        return tuple(str(arg) for arg in sys.argv)
+
+    resolved = [prog]
+    resolved.extend(str(arg) for arg in argv)
+    return tuple(resolved)
 
 
 class ValidationResult(Protocol):

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -10,7 +11,7 @@ import pytest
 import yaml
 
 from library.config import Config, _mask_secrets, _serialize_paths
-from library.cli_utils import build_parser, run_pipeline
+from library.cli_utils import build_parser, resolve_invocation, run_pipeline
 from library.logging_setup import LoggerConfig, configure_logger as setup_logger
 from schemas import AssaysSchema
 
@@ -59,6 +60,20 @@ def test_cli_utils_flags_and_help() -> None:
     assert parser.description is not None
     assert parser.description.startswith(
         "CLI wrapper for :func:`write_csv_deterministic`"
+    )
+
+
+def test_resolve_invocation_defaults_to_sys_argv(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["script.py", "--foo", "bar"], raising=False)
+
+    assert resolve_invocation("ignored", None) == ("script.py", "--foo", "bar")
+
+
+def test_resolve_invocation_with_custom_argv() -> None:
+    assert resolve_invocation("cli", ["--flag", "value"]) == (
+        "cli",
+        "--flag",
+        "value",
     )
 
 


### PR DESCRIPTION
## Summary
- restore a resolve_invocation helper in library/cli_utils to normalise CLI arguments when commands run scripts
- extend CLI utility tests to cover the new helper and ensure behaviour for default and custom argv values

## Testing
- pytest tests/test_cli_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68de9511b0a083249cd21b1ab5d0be40