### PR TITLE
Fix CLI invocation handling and dataframe casting

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 import traceback
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -127,6 +128,16 @@ def run_cli_command(
     return exit_code
 
 
+def resolve_invocation(
+    program: str, argv: Sequence[str] | None
+) -> tuple[str, ...]:
+    """Return the effective command invocation as a tuple of strings."""
+
+    if argv is None:
+        argv = sys.argv[1:]
+    return (program, *map(str, argv))
+
+
 @overload
 def _as_iterable(source: pd.DataFrame) -> Iterator[pd.DataFrame]: ...
 
@@ -156,11 +167,12 @@ def run_pipeline(
     writer: Writer,
     output_path: Path,
     failure_path: Path,
-    command: str,
+    command: str | None = None,
     config_snapshot: Mapping[str, object],
     inputs: Mapping[str, object],
     key_columns: Sequence[str],
     table_quality: TableQualityHook,
+    invocation: Sequence[str] | None = None,
     cfg: Config | None = None,
     logger: logging.Logger | None = None,
 ) -> int:
@@ -192,7 +204,8 @@ def run_pipeline(
     failure_path:
         Path for persisting validation failure cases.
     command:
-        Command used to launch the pipeline.  Stored in metadata output.
+        Command used to launch the pipeline.  Stored in metadata output. When
+        omitted the value is derived from ``invocation`` or ``sys.argv``.
     config_snapshot:
         Mapping of configuration values persisted to metadata.
     inputs:
@@ -202,6 +215,10 @@ def run_pipeline(
         columns present in the final dataset are forwarded to ``writer``.
     table_quality:
         Callable invoked after writing the CSV to compute quality metrics.
+    invocation:
+        Optional command invocation captured as a sequence of arguments. When
+        provided it is persisted to metadata alongside the joined ``command``
+        string.
     cfg:
         Optional application configuration forwarded to sidecar metadata.
     logger:
@@ -411,13 +428,21 @@ def run_pipeline(
         "rows_dropped": rows_dropped,
         "output_sha256": file_sha256(csv_path),
     }
+    resolved_invocation = tuple(map(str, invocation)) if invocation else ()
+    resolved_command = (
+        command
+        if command is not None
+        else (" ".join(resolved_invocation) if resolved_invocation else " ".join(sys.argv))
+    )
+
     meta_path = write_meta_yaml(
         csv_path=csv_path,
-        command=command,
+        command=resolved_command,
         config_subset=config_snapshot,
         inputs=inputs,
         stats=stats,
         schema=schema_name,
+        invocation=resolved_invocation or None,
     )
 
     try:

--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -326,13 +326,13 @@ def dataframe_to_strings(
 
     skip_set = set(skip or [])
     result = df.copy()
+    dtypes = result.dtypes
     for idx, col in enumerate(result.columns):
         if col in skip_set:
             continue
-        series = result.iloc[:, idx]
-        if pd.api.types.is_numeric_dtype(series.dtype):
+        if pd.api.types.is_numeric_dtype(dtypes.iloc[idx]):
             continue
-        result.iloc[:, idx] = series.astype(str)
+        result.iloc[:, idx] = result.iloc[:, idx].astype(str)
     return result
 
 

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import platform
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
@@ -71,6 +71,8 @@ def write_meta_yaml(
     inputs: Mapping[str, Any],
     stats: Stats,
     schema: str,
+    *,
+    invocation: Sequence[str] | None = None,
 ) -> Path:
     """Write metadata for ``csv_path`` to ``<csv_path>.meta.yaml``.
 
@@ -89,6 +91,9 @@ def write_meta_yaml(
         Summary statistics about the output table.
     schema:
         Name of the schema applied to the output data.
+    invocation:
+        Optional tuple describing the exact CLI invocation. Persisted when
+        provided to aid reproducibility.
 
     Returns
     -------
@@ -123,6 +128,8 @@ def write_meta_yaml(
             "schema": schema,
         }
     )
+    if invocation:
+        metadata["invocation"] = list(invocation)
 
     with open_atomic(meta_path, encoding="utf-8") as fh:
         yaml.safe_dump(metadata, fh, sort_keys=False)

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -162,6 +162,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         extra_columns.append(action_cfg.column)
     extra_kwargs = {"extra_columns": extra_columns} if extra_columns else {}
 
+    invocation = _args_invocation(args)
+
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
 
@@ -301,7 +303,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             writer=writer,
             output_path=output,
             failure_path=failure_path,
-            invocation=_args_invocation(args),
+            command=" ".join(invocation),
+            invocation=invocation,
             config_snapshot=_serialize_paths(cfg.to_dict()),
             inputs={"input_csv": str(args.input_csv)},
             key_columns=["activity_id"],


### PR DESCRIPTION
## Summary
- add a reusable CLI invocation resolver and allow pipelines to persist invocation metadata
- extend metadata writing to record the invocation and derive the command string automatically
- fix dataframe_to_strings to inspect column dtypes without relying on Series.dtype and update the activity CLI to pass invocation details

## Testing
- pytest tests/test_get_activity_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de95e99eb483248d6e51ef6f2b3788