### PR TITLE
Add invocation support for CLI pipelines

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -17,6 +17,8 @@ from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Protocol, TypeVar, overload
 
+import shlex
+
 import pandas as pd
 from pandera.errors import SchemaErrors
 
@@ -69,6 +71,19 @@ def _callable_name(func: Callable[..., object]) -> str:
 
 class PipelineError(RuntimeError):
     """Raised when a pipeline step encounters a fatal error."""
+
+
+def resolve_invocation(
+    prog: str | None, argv: Sequence[object] | None
+) -> tuple[str, ...]:
+    """Return a normalised tuple describing the CLI invocation."""
+
+    parts: list[str] = []
+    if prog:
+        parts.append(str(prog))
+    if argv:
+        parts.extend(str(arg) for arg in argv)
+    return tuple(parts)
 
 
 def run_cli_command(
@@ -156,7 +171,8 @@ def run_pipeline(
     writer: Writer,
     output_path: Path,
     failure_path: Path,
-    command: str,
+    command: str | None = None,
+    invocation: Sequence[str] | None = None,
     config_snapshot: Mapping[str, object],
     inputs: Mapping[str, object],
     key_columns: Sequence[str],
@@ -193,6 +209,8 @@ def run_pipeline(
         Path for persisting validation failure cases.
     command:
         Command used to launch the pipeline.  Stored in metadata output.
+    invocation:
+        Normalised command invocation used when ``command`` is not provided.
     config_snapshot:
         Mapping of configuration values persisted to metadata.
     inputs:
@@ -216,6 +234,14 @@ def run_pipeline(
     """
 
     use_logger = logger or default_logger
+
+    if invocation is not None:
+        quoted = [shlex.quote(str(part)) for part in invocation]
+        command_str = " ".join(quoted)
+    else:
+        command_str = command
+    if command_str is None:
+        raise ValueError("run_pipeline requires either 'command' or 'invocation'")
 
     metadata_hooks = list(metadata_hooks or [])
     validators = list(validators or [])
@@ -413,7 +439,7 @@ def run_pipeline(
     }
     meta_path = write_meta_yaml(
         csv_path=csv_path,
-        command=command,
+        command=command_str,
         config_subset=config_snapshot,
         inputs=inputs,
         stats=stats,

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from library.config import Config, _mask_secrets, _serialize_paths
-from library.cli_utils import build_parser, run_pipeline
+from library.cli_utils import build_parser, resolve_invocation, run_pipeline
 from library.logging_setup import LoggerConfig, configure_logger as setup_logger
 from schemas import AssaysSchema
 
@@ -60,6 +60,11 @@ def test_cli_utils_flags_and_help() -> None:
     assert parser.description.startswith(
         "CLI wrapper for :func:`write_csv_deterministic`"
     )
+
+
+def test_resolve_invocation_normalises_arguments() -> None:
+    invocation = resolve_invocation("tool", ["--flag", "value with space"])
+    assert invocation == ("tool", "--flag", "value with space")
 
 
 class _ValidationResult:
@@ -213,6 +218,49 @@ def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path, cfg: Config) -> N
 
     meta_path = output.with_name(output.name + ".meta.yaml")
     assert meta_path.exists()
+
+
+def test_run_pipeline_records_invocation(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    frame = pd.DataFrame({"assay_chembl_id": ["A1"], "value": [1]})
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [frame]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        frames = list(chunks)
+        df = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        df.to_csv(destination, index=False)
+        return destination
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=None,
+        schema_name="",  # ignored when schema is None
+        validators=None,
+        metadata_hooks=None,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        invocation=("tool", "--flag", "value with space"),
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda _path: None,
+        cfg=cfg,
+    )
+
+    assert exit_code == 0
+    meta_path = output.with_name(output.name + ".meta.yaml")
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["command"] == "tool --flag 'value with space'"
 
 
 def test_run_pipeline_removes_outputs_on_table_quality_failure(


### PR DESCRIPTION
## Summary
- add a `resolve_invocation` helper to normalise CLI argument sequences
- allow `run_pipeline` to accept invocation tuples and persist quoted command strings in metadata
- extend CLI utility tests to cover invocation resolution and metadata output

## Testing
- pytest tests/test_cli_utils.py
- pytest tests/test_get_activity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de966797f88324bb3a0ee86bafecc1