### PR TITLE
Simplify document QA CLI usage

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -154,16 +154,15 @@ Before running the smoke command, create a `chembl_ids.csv` file with a `chembl_
 
 ### Document post-processing QA
 
-The document pipeline now emits QA artefacts next to `preprocessed_output.document_YYYYMMDD.csv` when a legacy
-Power Query export (`input/full/ref_document.csv`) is available under the data root. The helper writes a JSON report,
+The document pipeline now emits QA artefacts next to `output.document_YYYYMMDD.csv` when a legacy
+Power Query export (`input/full/document.csv`) is available under the data root. The helper writes a JSON report,
 Markdown summary and, on divergence, a CSV diff capped at 100 rows. You can also run the checker manually:
 
 ```bash
 python -m qa.check_document_postprocessing \
     --base-path data \
-    --ref input\\full\\ref_document.csv \
-    --actual output\\document\\preprocessed_output.document_20230101.csv \
-    --out qa_reports
+    --out output\\document\\output.document_20230101.csv \
+    --reports-dir qa_reports
 ```
 
 The command exits with status code `1` when mismatches occur and stores the diff in

--- a/docs/QA_PROCESS_EN.md
+++ b/docs/QA_PROCESS_EN.md
@@ -63,9 +63,9 @@ checklist.
 
 The document export now includes an automated regression check against the legacy Power Query workbook.
 
-1. Populate `data/input/full/ref_document.csv` with the authoritative export.
+1. Populate `data/input/full/document.csv` with the authoritative export.
 2. Run the document pipeline (`python -m scripts.get_document_data ...`) and confirm it produces:
-   * `preprocessed_output.document_YYYYMMDD.csv`
+   * `output.document_YYYYMMDD.csv`
    * `qa_document_postprocessing_report_YYYYMMDD.json`
    * `qa_document_postprocessing_report_YYYYMMDD.md`
    * `qa_document_postprocessing_diff_YYYYMMDD.csv` (only when mismatches are present)
@@ -73,7 +73,6 @@ The document export now includes an automated regression check against the legac
    ```bash
    python -m qa.check_document_postprocessing \
        --base-path data \
-       --ref input\\full\\ref_document.csv \
-       --actual output\\document\\preprocessed_output.document_YYYYMMDD.csv
+       --out output\\document\\output.document_YYYYMMDD.csv
    ```
 4. Treat a non-zero exit code as a blocking failure; consult the Markdown summary and diff extract for remediation.

--- a/qa/check_document_postprocessing.py
+++ b/qa/check_document_postprocessing.py
@@ -366,20 +366,15 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--base-path",
         default=".",
-        help="Root directory for resolving relative paths",
-    )
-    parser.add_argument(
-        "--ref",
-        required=True,
-        help="Relative or absolute path to the reference (Power Query) CSV",
-    )
-    parser.add_argument(
-        "--actual",
-        required=True,
-        help="Relative or absolute path to the Python-generated CSV",
+        help="Root directory containing the Power Query reference and Python outputs",
     )
     parser.add_argument(
         "--out",
+        required=True,
+        help="Relative or absolute path to the Python-generated document CSV (output.document_*.csv)",
+    )
+    parser.add_argument(
+        "--reports-dir",
         dest="output_dir",
         help="Optional directory for QA reports (defaults to the candidate directory)",
     )
@@ -415,10 +410,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    base_dir = Path(args.base_path).resolve()
+    reference_path = _resolve_relative(base_dir, Path("input") / "full" / "document.csv")
+    candidate_path = _resolve_relative(base_dir, args.out)
+
     result = run_document_postprocessing_check(
-        base_path=args.base_path,
-        reference_path=args.ref,
-        candidate_path=args.actual,
+        base_path=base_dir,
+        reference_path=reference_path,
+        candidate_path=candidate_path,
         output_dir=args.output_dir,
         date_code=args.date_code,
         delimiter=args.delimiter,

--- a/tests/test_document_postprocessing_qa.py
+++ b/tests/test_document_postprocessing_qa.py
@@ -23,11 +23,14 @@ def _prepare_environment(tmp_path: Path) -> tuple[Path, Path, Path]:
     reference_dir.mkdir(parents=True)
     output_dir.mkdir(parents=True)
 
-    reference_path = reference_dir / "ref_document.csv"
-    candidate_path = output_dir / "preprocessed_output.document_20230101.csv"
+    reference_path = reference_dir / "document.csv"
+    candidate_path = output_dir / "output.document_20230101.csv"
 
     shutil.copy(FIXTURE_DIR / "ref_document.csv", reference_path)
-    shutil.copy(FIXTURE_DIR / "ref_document.csv", candidate_path)
+    shutil.copy(
+        FIXTURE_DIR / "preprocessed_output.document_20230101.csv",
+        candidate_path,
+    )
 
     return base_dir, reference_path, candidate_path
 
@@ -90,10 +93,8 @@ def test_cli_exit_codes(tmp_path: Path, mutate: bool) -> None:
         [
             "--base-path",
             str(base_dir),
-            "--ref",
-            "input\\full\\ref_document.csv",
-            "--actual",
-            "output\\preprocessed_output.document_20230101.csv",
+            "--out",
+            "output\\output.document_20230101.csv",
         ]
     )
 


### PR DESCRIPTION
## Summary
- require only the base data directory and document output path when running the document post-processing QA, auto-resolving the reference CSV
- refresh the regression tests and documentation snippets to reflect the streamlined CLI and artefact names

## Testing
- pytest tests/test_document_postprocessing_qa.py

------
https://chatgpt.com/codex/tasks/task_e_68de9675de808324b82002ff99d3de38