### PR TITLE
Fix run_pipeline invocation handling

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -40,13 +40,18 @@ from .utils.config import DEFAULT_CONFIG_RELATIVE
 SchemaT = TypeVar("SchemaT")
 
 
-def resolve_invocation(prog: str, argv: Sequence[str] | None) -> tuple[str, ...]:
+def resolve_invocation(
+    prog: str | None,
+    argv: Sequence[object] | None,
+) -> tuple[str, ...]:
     """Return a normalised tuple describing the CLI invocation."""
 
     if argv is None:
         return tuple(str(arg) for arg in sys.argv)
 
-    resolved = [prog]
+    resolved: list[str] = []
+    if prog:
+        resolved.append(str(prog))
     resolved.extend(str(arg) for arg in argv)
     return tuple(resolved)
 
@@ -83,21 +88,6 @@ def _callable_name(func: Callable[..., object]) -> str:
 
 class PipelineError(RuntimeError):
     """Raised when a pipeline step encounters a fatal error."""
-
-
-def resolve_invocation(
-
-    prog: str | None, argv: Sequence[object] | None
-) -> tuple[str, ...]:
-    """Return a normalised tuple describing the CLI invocation."""
-
-    parts: list[str] = []
-    if prog:
-        parts.append(str(prog))
-    if argv:
-        parts.extend(str(arg) for arg in argv)
-    return tuple(parts)
-
 
 
 def run_cli_command(
@@ -196,8 +186,6 @@ def run_pipeline(
     output_path: Path,
     failure_path: Path,
     command: str | None = None,
-    invocation: Sequence[str] | None = None,
-
     config_snapshot: Mapping[str, object],
     inputs: Mapping[str, object],
     key_columns: Sequence[str],
@@ -235,9 +223,6 @@ def run_pipeline(
         Path for persisting validation failure cases.
     command:
         Command used to launch the pipeline.  Stored in metadata output.
-    invocation:
-        Normalised command invocation used when ``command`` is not provided.
-
     config_snapshot:
         Mapping of configuration values persisted to metadata.
     inputs:
@@ -266,12 +251,15 @@ def run_pipeline(
 
     use_logger = logger or default_logger
 
+    invocation_tuple: tuple[str, ...] = ()
     if invocation is not None:
-        quoted = [shlex.quote(str(part)) for part in invocation]
-        command_str = " ".join(quoted)
-    else:
+        invocation_tuple = tuple(str(part) for part in invocation)
+
+    if command is not None:
         command_str = command
-    if command_str is None:
+    elif invocation_tuple:
+        command_str = " ".join(shlex.quote(part) for part in invocation_tuple)
+    else:
         raise ValueError("run_pipeline requires either 'command' or 'invocation'")
 
     metadata_hooks = list(metadata_hooks or [])
@@ -468,12 +456,7 @@ def run_pipeline(
         "rows_dropped": rows_dropped,
         "output_sha256": file_sha256(csv_path),
     }
-    resolved_invocation = tuple(map(str, invocation)) if invocation else ()
-    resolved_command = (
-        command
-        if command is not None
-        else (" ".join(resolved_invocation) if resolved_invocation else " ".join(sys.argv))
-    )
+    resolved_invocation = invocation_tuple
 
     meta_path = write_meta_yaml(
         csv_path=csv_path,


### PR DESCRIPTION
## Summary
- deduplicate the resolve_invocation helper and allow optional program names
- ensure run_pipeline validates command/invocation arguments consistently and records invocation metadata

## Testing
- pytest tests/test_cli_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68de9864404083249212d4f72298ae41