### PR TITLE
Enhance document post-processing QA reporting

### DIFF
--- a/qa/check_document_postprocessing.py
+++ b/qa/check_document_postprocessing.py
@@ -27,6 +27,7 @@ CP1252_ENCODING = "cp1252"
 UTF8_ENCODING = "utf-8"
 CSV_DELIMITER = ","
 DEFAULT_MAX_DIFF_ROWS = 100
+MAX_DIFF_KEY_EXPORT = 100
 KEY_COLUMNS: tuple[str, str, str] = ("PMID", "document_chembl_id", "completed")
 REPORT_PREFIX = "qa_document_postprocessing_report_"
 DIFF_PREFIX = "qa_document_postprocessing_diff_"
@@ -36,6 +37,15 @@ DIFF_SUFFIX = ".csv"
 DATE_PATTERN = re.compile(r"(20\d{6})")
 SUCCESS_STATUS = "passed"
 FAILURE_STATUS = "failed"
+BOOLEAN_TRUE_VALUES = frozenset({"true", "1", "yes"})
+BOOLEAN_FALSE_VALUES = frozenset({"false", "0", "no", ""})
+COMPLETED_FORMAT_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+INVARIANT_SAMPLE_LIMIT = 5
+INVARIANT_LABELS: Mapping[str, str] = {
+    "invalid_formula": "invalid flag formula",
+    "completed_format": "completed date format",
+    "completed_order": "completed order monotonicity",
+}
 
 
 # ===== Data classes ==========================================================
@@ -122,7 +132,13 @@ def _differences_to_frame(
 
     records: list[dict[str, Any]] = []
     columns = list(mask.columns)
-    for row_idx, column_idx in zip(*mask.to_numpy().nonzero(), strict=False):
+    key_count = 0
+    for row_idx, row_mask in enumerate(mask.to_numpy()):
+        if not row_mask.any():
+            continue
+        key_count += 1
+        if key_count > limit:
+            break
         index_value = mask.index[row_idx]
         if isinstance(index_value, tuple):
             key_map = dict(zip(key_columns, index_value, strict=False))
@@ -130,15 +146,16 @@ def _differences_to_frame(
             key_map = {key_columns[0]: index_value}
             for extra in key_columns[1:]:
                 key_map.setdefault(extra, "")
-        record = {
-            **key_map,
-            "column": columns[column_idx],
-            "expected": to_text(expected.iloc[row_idx, column_idx]),
-            "actual": to_text(actual.iloc[row_idx, column_idx]),
-        }
-        records.append(record)
-        if len(records) >= limit:
-            break
+        for column_idx, has_difference in enumerate(row_mask):
+            if not has_difference:
+                continue
+            record = {
+                **key_map,
+                "column": columns[column_idx],
+                "expected": to_text(expected.iloc[row_idx, column_idx]),
+                "actual": to_text(actual.iloc[row_idx, column_idx]),
+            }
+            records.append(record)
     return pd.DataFrame.from_records(records, columns=[*key_columns, "column", "expected", "actual"])
 
 
@@ -148,34 +165,290 @@ def _differences_by_column(mask: pd.DataFrame) -> dict[str, int]:
     return {column: int(mask[column].sum()) for column in mask.columns}
 
 
+def _normalise_boolish(value: Any) -> bool | None:
+    """Return a tri-state boolean for ``value`` supporting textual truthy forms."""
+
+    text = to_text(value).strip().lower()
+    if text in BOOLEAN_TRUE_VALUES:
+        return True
+    if text in BOOLEAN_FALSE_VALUES:
+        return False
+    return None
+
+
+def _value_counts(series: pd.Series) -> Mapping[str, int]:
+    """Return deterministic value counts for ``series`` as a mapping."""
+
+    counts = series.fillna("").map(to_text).value_counts(sort=False)
+    sorted_items = sorted(counts.items(), key=lambda item: item[0])
+    return {str(key): int(value) for key, value in sorted_items}
+
+
+def _summarise_invalid_flags(frame: pd.DataFrame) -> Mapping[str, Mapping[str, int]]:
+    """Return per-column distributions for invalid flags within ``frame``."""
+
+    columns = [column for column in frame.columns if column == "invalid" or column.startswith("invalid.")]
+    summary: dict[str, Mapping[str, int]] = {}
+    for column in sorted(columns):
+        summary[column] = _value_counts(frame[column])
+    return summary
+
+
+def _boolean_share(series: pd.Series | None) -> Mapping[str, Any]:
+    """Return counts and share of truthy values within ``series``."""
+
+    if series is None:
+        return {"available": False, "true": 0, "false": 0, "other": 0, "share_true": 0.0}
+
+    values = series.fillna("").map(to_text)
+    true_count = int(sum(1 for item in values if _normalise_boolish(item) is True))
+    false_count = int(sum(1 for item in values if _normalise_boolish(item) is False))
+    other_count = int(len(values) - true_count - false_count)
+    total_rows = int(len(values))
+    share_true = true_count / total_rows if total_rows else 0.0
+    return {
+        "available": True,
+        "true": true_count,
+        "false": false_count,
+        "other": other_count,
+        "share_true": share_true,
+    }
+
+
+def _collect_key_sample(index: pd.Index, key_columns: Sequence[str], limit: int = INVARIANT_SAMPLE_LIMIT) -> list[Mapping[str, Any]]:
+    """Return a deterministic sample of key combinations from ``index``."""
+
+    sample: list[Mapping[str, Any]] = []
+    for value in index[:limit]:
+        if isinstance(value, tuple):
+            sample.append({column: element for column, element in zip(key_columns, value, strict=False)})
+        else:
+            row = {key_columns[0]: value}
+            for extra in key_columns[1:]:
+                row.setdefault(extra, "")
+            sample.append(row)
+    return sample
+
+
+def _check_invalid_formula(frame: pd.DataFrame, key_columns: Sequence[str]) -> Mapping[str, Any]:
+    """Return invariant status ensuring ``invalid`` equals the OR of component flags."""
+
+    if "invalid" not in frame.columns:
+        return {"available": False, "passed": True, "violations": 0, "failing_keys": []}
+
+    detail_columns = [column for column in frame.columns if column.startswith("invalid.")]
+    invalid_true = frame["invalid"].map(_normalise_boolish).eq(True)
+    if detail_columns:
+        detail_true = frame[detail_columns].map(_normalise_boolish).eq(True)
+        expected_true = detail_true.any(axis=1)
+    else:
+        expected_true = pd.Series(False, index=frame.index)
+    violations_mask = invalid_true != expected_true
+    violations = int(violations_mask.sum())
+    failing_keys = _collect_key_sample(frame.index[violations_mask], key_columns)
+    return {
+        "available": True,
+        "passed": violations == 0,
+        "violations": violations,
+        "failing_keys": failing_keys,
+    }
+
+
+def _check_completed_format(frame: pd.DataFrame, key_columns: Sequence[str]) -> Mapping[str, Any]:
+    """Return invariant status confirming ``completed`` follows the canonical pattern."""
+
+    if "completed" not in frame.columns:
+        return {"available": False, "passed": True, "violations": 0, "failing_keys": []}
+
+    completed_values = frame["completed"].map(to_text)
+    valid_mask = completed_values.str.fullmatch(COMPLETED_FORMAT_PATTERN) | completed_values.eq("")
+    violations_mask = ~valid_mask
+    violations = int(violations_mask.sum())
+    failing_keys = _collect_key_sample(frame.index[violations_mask], key_columns)
+    return {
+        "available": True,
+        "passed": violations == 0,
+        "violations": violations,
+        "failing_keys": failing_keys,
+    }
+
+
+def _parse_completed_tuple(value: str) -> tuple[int, int, int] | None:
+    """Return a sortable tuple extracted from ``value`` when formatted correctly."""
+
+    if not COMPLETED_FORMAT_PATTERN.fullmatch(value):
+        return None
+    parts = value.split("-")
+    return tuple(int(part) for part in parts)
+
+
+def _check_completed_order(frame: pd.DataFrame, key_columns: Sequence[str]) -> Mapping[str, Any]:
+    """Return invariant status ensuring completed dates are non-decreasing by sort order."""
+
+    if "completed" not in frame.columns or "sortorder.document" not in frame.columns:
+        return {"available": False, "passed": True, "violations": 0, "failing_keys": []}
+
+    ordered = frame[["completed", "sortorder.document"]].copy()
+    ordered["completed"] = ordered["completed"].map(to_text)
+    ordered["sortorder.document"] = ordered["sortorder.document"].map(to_text)
+    ordered = ordered.sort_values("sortorder.document", kind="stable")
+
+    previous: tuple[int, int, int] | None = None
+    violating_labels: list[Any] = []
+    for label, value in ordered["completed"].items():
+        parsed = _parse_completed_tuple(value)
+        if parsed is None:
+            continue
+        if previous is None:
+            previous = parsed
+            continue
+        if parsed < previous:
+            violating_labels.append(label)
+        else:
+            previous = parsed
+    violations = len(violating_labels)
+    failing_keys = _collect_key_sample(pd.Index(violating_labels), key_columns)
+    return {
+        "available": True,
+        "passed": violations == 0,
+        "violations": violations,
+        "failing_keys": failing_keys,
+    }
+
+
+def _summarise_dataset(
+    *,
+    frame: pd.DataFrame,
+    canonical: pd.DataFrame,
+    key_columns: Sequence[str],
+    path: str,
+    duplicate_count: int,
+) -> Mapping[str, Any]:
+    """Return derived metrics for ``frame`` and ``canonical`` representations."""
+
+    review_summary = _boolean_share(canonical.get("review"))
+    experimental_summary = _boolean_share(canonical.get("experimental"))
+    invariants = {
+        "invalid_formula": _check_invalid_formula(canonical, key_columns),
+        "completed_format": _check_completed_format(canonical, key_columns),
+        "completed_order": _check_completed_order(canonical, key_columns),
+    }
+    return {
+        "path": path,
+        "rows": int(len(frame)),
+        "columns": list(frame.columns),
+        "column_count": int(len(frame.columns)),
+        "duplicates": duplicate_count,
+        "invalid_flags": _summarise_invalid_flags(canonical),
+        "review": review_summary,
+        "experimental": experimental_summary,
+        "invariants": invariants,
+    }
+
+
 def _render_markdown(metrics: Mapping[str, Any], diff_path: Path | None) -> str:
     """Return a Markdown summary of the QA run."""
 
+    def _format_bool(flag: bool) -> str:
+        return "✅ yes" if flag else "❌ no"
+
+    def _format_invalid(summary: Mapping[str, Mapping[str, int]]) -> str:
+        if not summary:
+            return "n/a"
+        parts = []
+        for column, values in summary.items():
+            value_text = ", ".join(
+                f"{name or '""'}={count}" for name, count in values.items()
+            )
+            parts.append(f"{column} [{value_text}]")
+        return "; ".join(parts)
+
+    def _format_share_block(summary: Mapping[str, Any], total_rows: int) -> str:
+        if not summary.get("available"):
+            return "n/a"
+        true_count = summary["true"]
+        percentage = summary["share_true"] * 100
+        return f"{percentage:.2f}% ({true_count}/{total_rows})"
+
+    ref_rows = metrics["reference"]["rows"]
+    cand_rows = metrics["candidate"]["rows"]
     lines = ["# Document post-processing QA report", ""]
-    lines.append(f"*Status*: **{metrics['status']}**")
-    lines.append(f"*Reference rows*: {metrics['reference']['rows']}")
-    lines.append(f"*Candidate rows*: {metrics['candidate']['rows']}")
+    lines.append(f"- Status: **{metrics['status']}**")
+    lines.append(f"- Reference rows: {ref_rows}")
+    lines.append(f"- Candidate rows: {cand_rows}")
     lines.append(
-        f"*Cells different*: {metrics['differences']['cells_different']} / "
-        f"{metrics['differences']['cells_total']}"
+        "- Column sets identical: "
+        + _format_bool(metrics["structure"]["columns_equal"])
     )
-    lines.append(f"*Rows with differences*: {metrics['differences']['rows_with_differences']}")
-    lines.append(f"*Issues detected*: {len(metrics['issues'])}")
+    lines.append(
+        "- Column order identical: "
+        + _format_bool(metrics["structure"]["column_order_equal"])
+    )
+    lines.append(
+        "- Cells different: "
+        f"{metrics['differences']['cells_different']} / {metrics['differences']['cells_total']} "
+        f"(rows impacted: {metrics['differences']['rows_with_differences']} of {metrics['differences']['rows_compared']})"
+    )
+    lines.append(
+        "- Missing keys: "
+        f"reference-only {metrics['missing_rows']['reference_only']['count']}, "
+        f"candidate-only {metrics['missing_rows']['candidate_only']['count']}"
+    )
+    lines.append(
+        "- Invalid flags (reference): "
+        + _format_invalid(metrics["reference"]["invalid_flags"])
+    )
+    lines.append(
+        "- Invalid flags (candidate): "
+        + _format_invalid(metrics["candidate"]["invalid_flags"])
+    )
+    lines.append(
+        "- Review share: reference "
+        + _format_share_block(metrics["reference"]["review"], ref_rows)
+        + "; candidate "
+        + _format_share_block(metrics["candidate"]["review"], cand_rows)
+    )
+    lines.append(
+        "- Experimental share: reference "
+        + _format_share_block(metrics["reference"]["experimental"], ref_rows)
+        + "; candidate "
+        + _format_share_block(metrics["candidate"]["experimental"], cand_rows)
+    )
+    invariants = metrics["candidate"]["invariants"]
+    ref_invariants = metrics["reference"]["invariants"]
+    lines.append(
+        "- Invariants: "
+        f"invalid formula ref {_format_bool(ref_invariants['invalid_formula']['passed'])} / "
+        f"cand {_format_bool(invariants['invalid_formula']['passed'])}; "
+        f"completed format ref {_format_bool(ref_invariants['completed_format']['passed'])} / "
+        f"cand {_format_bool(invariants['completed_format']['passed'])}; "
+        f"order ref {_format_bool(ref_invariants['completed_order']['passed'])} / "
+        f"cand {_format_bool(invariants['completed_order']['passed'])}"
+    )
+    lines.append(f"- Issues detected: {len(metrics['issues'])}")
+    if diff_path is not None:
+        lines.append(
+            f"- Diff excerpt: [{diff_path.name}]({diff_path.name})"
+        )
+    else:
+        lines.append("- Diff excerpt: not generated")
+
     if metrics["issues"]:
         lines.append("")
         lines.append("## Issues")
         for issue in metrics["issues"]:
             lines.append(f"- {issue}")
-    lines.append("")
-    lines.append("## Differences by column")
-    lines.append("| Column | Differences |")
-    lines.append("| --- | ---: |")
-    for column, count in metrics["differences"]["by_column"].items():
-        lines.append(f"| {column} | {count} |")
-    if diff_path is not None:
+
+    if metrics["differences"]["by_column"]:
         lines.append("")
-        lines.append(f"Diff excerpt written to `{diff_path.name}`.")
-    return "\n".join(lines) + "\n"
+        lines.append("## Differences by column")
+        lines.append("| Column | Differences |")
+        lines.append("| --- | ---: |")
+        for column, count in metrics["differences"]["by_column"].items():
+            lines.append(f"| {column} | {count} |")
+
+    lines.append("")
+    return "\n".join(lines)
 
 
 # ===== Core functionality ====================================================
@@ -258,6 +531,26 @@ def run_document_postprocessing_check(
     missing_reference_columns = sorted(set(all_columns) - set(candidate_df.columns))
     missing_candidate_columns = sorted(set(all_columns) - set(reference_df.columns))
 
+    structure_metrics = {
+        "columns_equal": set(reference_df.columns) == set(candidate_df.columns),
+        "column_order_equal": list(reference_df.columns) == list(candidate_df.columns),
+    }
+
+    reference_summary = _summarise_dataset(
+        frame=reference_df,
+        canonical=reference_canonical,
+        key_columns=key_columns,
+        path=str(reference_resolved),
+        duplicate_count=reference_duplicates,
+    )
+    candidate_summary = _summarise_dataset(
+        frame=candidate_df,
+        canonical=candidate_canonical,
+        key_columns=key_columns,
+        path=str(candidate_resolved),
+        duplicate_count=candidate_duplicates,
+    )
+
     issues: list[str] = []
     if cells_different:
         issues.append(f"Detected {cells_different} mismatched cells")
@@ -283,6 +576,19 @@ def run_document_postprocessing_check(
             "Candidate missing columns present in reference: "
             + ", ".join(missing_candidate_columns)
         )
+    if structure_metrics["columns_equal"] and not structure_metrics["column_order_equal"]:
+        issues.append("Column order differs between reference and candidate outputs")
+
+    for dataset_name, dataset_summary in (
+        ("reference", reference_summary),
+        ("candidate", candidate_summary),
+    ):
+        for invariant_key, invariant in dataset_summary["invariants"].items():
+            if invariant.get("available") and not invariant.get("passed"):
+                label = INVARIANT_LABELS.get(invariant_key, invariant_key.replace("_", " "))
+                issues.append(
+                    f"{dataset_name.title()} {label} violated for {invariant['violations']} rows"
+                )
 
     status = SUCCESS_STATUS if not issues else FAILURE_STATUS
     resolved_date_code = _extract_date_code(candidate_resolved, date_code)
@@ -290,21 +596,13 @@ def run_document_postprocessing_check(
     metrics: dict[str, Any] = {
         "status": status,
         "date_code": resolved_date_code,
-        "reference": {
-            "path": str(reference_resolved),
-            "rows": int(len(reference_df)),
-            "columns": list(reference_df.columns),
-            "duplicates": reference_duplicates,
-        },
-        "candidate": {
-            "path": str(candidate_resolved),
-            "rows": int(len(candidate_df)),
-            "columns": list(candidate_df.columns),
-            "duplicates": candidate_duplicates,
-        },
+        "reference": reference_summary,
+        "candidate": candidate_summary,
+        "structure": structure_metrics,
         "differences": {
             "cells_total": total_cells,
             "cells_different": cells_different,
+            "rows_compared": int(len(mask.index)),
             "rows_with_differences": rows_with_differences,
             "by_column": by_column,
         },
@@ -326,12 +624,13 @@ def run_document_postprocessing_check(
 
     diff_path: Path | None = None
     if issues:
+        diff_limit = min(max_diff_rows, MAX_DIFF_KEY_EXPORT)
         diff_df = _differences_to_frame(
             mask,
             reference_aligned,
             candidate_aligned,
             key_columns=key_columns,
-            limit=max_diff_rows,
+            limit=diff_limit,
         )
         if not diff_df.empty:
             diff_name = f"{DIFF_PREFIX}{resolved_date_code}{DIFF_SUFFIX}"

--- a/tests/test_document_postprocessing_qa.py
+++ b/tests/test_document_postprocessing_qa.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from qa.check_document_postprocessing import MAX_DIFF_KEY_EXPORT
 from qa.check_document_postprocessing import main as qa_main
 from qa.check_document_postprocessing import run_document_postprocessing_check
 
@@ -47,6 +48,14 @@ def test_run_document_postprocessing_check_pass(tmp_path: Path) -> None:
     with result.report_json.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     assert payload["status"] == "passed"
+    assert payload["structure"]["columns_equal"] is True
+    assert payload["structure"]["column_order_equal"] is True
+    assert payload["reference"]["review"]["share_true"] == pytest.approx(2 / 3)
+    assert payload["candidate"]["invariants"]["invalid_formula"]["passed"] is True
+
+    markdown = result.report_markdown.read_text(encoding="utf-8")
+    assert "- Status: **passed**" in markdown
+    assert "- Diff excerpt: not generated" in markdown
 
 
 def test_run_document_postprocessing_check_failure(tmp_path: Path) -> None:
@@ -73,6 +82,44 @@ def test_run_document_postprocessing_check_failure(tmp_path: Path) -> None:
     with result.report_json.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     assert payload["status"] == "failed"
+    assert payload["differences"]["rows_with_differences"] >= 1
+
+    markdown = result.report_markdown.read_text(encoding="utf-8")
+    assert "- Status: **failed**" in markdown
+    assert result.diff_csv.name in markdown
+
+
+def test_diff_extract_limited_by_keys(tmp_path: Path) -> None:
+    base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
+
+    template = pd.read_csv(reference_path, dtype=str)
+    rows: list[pd.Series] = []
+    for idx in range(150):
+        record = template.iloc[0].copy()
+        record["PMID"] = f"{100000 + idx}"
+        record["document_chembl_id"] = f"DOC{idx:05d}"
+        record["completed"] = "2020-01-01"
+        record["doi"] = f"10.1000/{idx:03d}"
+        rows.append(record)
+    reference_df = pd.DataFrame(rows)
+    reference_df.to_csv(reference_path, index=False)
+
+    candidate_df = reference_df.copy()
+    candidate_df["doi"] = candidate_df["doi"] + ".mismatch"
+    candidate_df.to_csv(candidate_path, index=False)
+
+    result = run_document_postprocessing_check(
+        base_path=base_dir,
+        reference_path=reference_path,
+        candidate_path=candidate_path,
+    )
+
+    assert result.passed is False
+    assert result.diff_csv is not None
+
+    diff_df = pd.read_csv(result.diff_csv, dtype=str)
+    assert diff_df["PMID"].nunique() == MAX_DIFF_KEY_EXPORT
+    assert set(diff_df["column"]) == {"doi"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- expand the document QA metrics to cover column structure, invalid flag distributions, review/experimental shares, invariants, and cap diff exports to the first 100 keys
- refresh the markdown report to follow the prescribed bullet template and link to the diff extract when present
- extend the regression tests to validate the enriched metrics, markdown output, and key-based diff limiting

## Testing
- pytest tests/test_document_postprocessing_qa.py

------
https://chatgpt.com/codex/tasks/task_e_68de96764acc8324b748e63d0d06e996