### PR TITLE
Handle non-scalar chunk sizes in document export pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -36,6 +36,7 @@ import weakref
 import heapq
 from threading import Lock, local
 
+from numbers import Integral, Real
 from typing import Any, cast, TypeVar
 
 
@@ -1071,6 +1072,50 @@ def _iter_export_chunks(
         yield _prepare_export_frame(chunk)
 
 
+def _coerce_chunk_size_value(value: object) -> int | None:
+    """Return ``value`` as an ``int`` when possible, otherwise ``None``."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        logger.warning("invalid_stream_chunk_size_bool", value=value)
+        return None
+    if isinstance(value, Integral):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            logger.warning("invalid_stream_chunk_size_string", value=value)
+            return None
+    if isinstance(value, Real):
+        if pd.isna(value):
+            return None
+        coerced = int(value)
+        if value != coerced:
+            logger.warning("invalid_stream_chunk_size_float", value=float(value))
+            return None
+        return coerced
+    if isinstance(value, pd.Series):
+        if value.empty:
+            return None
+        if len(value) == 1:
+            return _coerce_chunk_size_value(value.iloc[0])
+        logger.warning(
+            "invalid_stream_chunk_size_series",
+            length=int(len(value)),
+        )
+        return None
+    logger.warning(
+        "invalid_stream_chunk_size_type",
+        value_type=f"{type(value).__module__}.{type(value).__qualname__}",
+    )
+    return None
+
+
 def _resolve_chunk_size(value: int | None) -> int | None:
     """Return ``value`` when positive, otherwise ``None``."""
 
@@ -1080,6 +1125,16 @@ def _resolve_chunk_size(value: int | None) -> int | None:
         logger.warning("invalid_csv_chunksize", value=value)
         return None
     return value
+
+
+def _resolve_stream_chunk_size(value: object) -> int:
+    """Return a safe streaming chunk size derived from ``value``."""
+
+    coerced = _coerce_chunk_size_value(value)
+    resolved = _resolve_chunk_size(coerced)
+    if resolved is None:
+        return _EXPORT_STREAM_CHUNK_SIZE
+    return resolved
 
 
 def _write_export_chunks(
@@ -1174,7 +1229,7 @@ def _finalise_export(
     missing_required: set[str] = set(required_cols)
     missing_optional: set[str] = set(optional_cols)
 
-    stream_chunk = max(1, int(chunk_size or _EXPORT_STREAM_CHUNK_SIZE))
+    stream_chunk = _resolve_stream_chunk_size(chunk_size)
     failure_path = output.with_name(f"{output.stem}_failure_cases.csv")
     errors = SidecarErrors()
     rows_total = 0

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -2097,6 +2097,127 @@ def test_finalise_export_falls_back_to_default_key(
     assert document_export_postprocess_stub
 
 
+def test_finalise_export_accepts_series_chunk_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    document_export_postprocess_stub,
+) -> None:
+    """Chunk size provided as a scalar ``Series`` should be coerced to ``int``."""
+
+    cfg = Config()
+    df = pd.DataFrame({"document_chembl_id": ["CHEMBL1"], "PubMed.PMID": ["123"]})
+    output = tmp_path / "documents.csv"
+
+    captured: dict[str, Any] = {}
+
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        *,
+        cfg: Any,
+        key_cols: list[str] | None = None,
+        col_order: list[str] | None = None,
+        chunksize: int,
+        merge_chunksize: int,
+        sort_chunksize: int,
+        sep: str,
+        encoding: str,
+        **_: Any,
+    ) -> Path:
+        list(chunks)
+        path.write_text("data")
+        captured["chunksize"] = chunksize
+        captured["merge_chunksize"] = merge_chunksize
+        captured["sort_chunksize"] = sort_chunksize
+        captured["key_cols"] = list(key_cols or [])
+        captured["col_order"] = list(col_order or [])
+        captured["sep"] = sep
+        captured["encoding"] = encoding
+        return path
+
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
+    monkeypatch.setattr(gdd, "file_sha256", lambda path: "hash")
+    monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
+    monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
+    monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
+    monkeypatch.setattr(gdd, "analyze_table_quality", lambda profiler, table_name: None)
+    monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
+
+    exit_code = gdd._finalise_export(
+        df,
+        output,
+        cfg,
+        input_csv=tmp_path / "input.csv",
+        key_columns=None,
+        chunk_size=pd.Series([7]),
+    )
+
+    assert exit_code == 0
+    assert captured["chunksize"] == 7
+    assert captured["merge_chunksize"] == 7
+    assert captured["sort_chunksize"] == 7
+    assert captured["key_cols"] == ["ChEMBL.document_chembl_id"]
+    assert document_export_postprocess_stub
+
+
+def test_finalise_export_series_chunk_size_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    document_export_postprocess_stub,
+) -> None:
+    """Non-scalar ``Series`` chunk sizes should fall back to the default."""
+
+    cfg = Config()
+    df = pd.DataFrame({"document_chembl_id": ["CHEMBL1"], "PubMed.PMID": ["123"]})
+    output = tmp_path / "documents.csv"
+
+    captured: dict[str, Any] = {}
+
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        *,
+        cfg: Any,
+        key_cols: list[str] | None = None,
+        col_order: list[str] | None = None,
+        chunksize: int,
+        merge_chunksize: int,
+        sort_chunksize: int,
+        sep: str,
+        encoding: str,
+        **_: Any,
+    ) -> Path:
+        list(chunks)
+        path.write_text("data")
+        captured["chunksize"] = chunksize
+        captured["merge_chunksize"] = merge_chunksize
+        captured["sort_chunksize"] = sort_chunksize
+        return path
+
+    monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
+    monkeypatch.setattr(gdd, "file_sha256", lambda path: "hash")
+    monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
+    monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
+    monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
+    monkeypatch.setattr(gdd, "analyze_table_quality", lambda profiler, table_name: None)
+    monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
+
+    exit_code = gdd._finalise_export(
+        df,
+        output,
+        cfg,
+        input_csv=tmp_path / "input.csv",
+        key_columns=None,
+        chunk_size=pd.Series([5, 6]),
+    )
+
+    assert exit_code == 0
+    assert captured["chunksize"] == gdd._EXPORT_STREAM_CHUNK_SIZE
+    assert captured["merge_chunksize"] == gdd._EXPORT_STREAM_CHUNK_SIZE
+    assert captured["sort_chunksize"] == gdd._EXPORT_STREAM_CHUNK_SIZE
+    assert document_export_postprocess_stub
+
+
 def test_finalise_export_accepts_generator(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add helpers to coerce document export stream chunk sizes into valid integers
- update the export pipeline to use the normalised chunk size when writing CSV output
- add regression tests covering scalar and non-scalar pandas Series inputs for chunk size

## Testing
- pytest tests/test_get_document_data.py::test_finalise_export_accepts_series_chunk_size tests/test_get_document_data.py::test_finalise_export_series_chunk_size_fallback

------
https://chatgpt.com/codex/tasks/task_e_68de96db8e088324bcff00a06a2453c4