### PR TITLE
Add determinism smoke test wrapper

### DIFF
--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Best-effort determinism smoke test for data acquisition pipelines."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _ensure_project_root() -> Path:
+    """Return repository root, adding it to ``sys.path`` when required."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_str = str(repo_root)
+    if repo_str not in sys.path:
+        sys.path.insert(0, repo_str)
+    return repo_root
+
+
+def _hash_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _run_activity(limit: int, destination: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.setdefault("PYTHONHASHSEED", "0")
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve().parents[0] / "get_activity_data.py"),
+        "--dry-run",
+        "--limit",
+        str(limit),
+        "--output",
+        str(destination),
+    ]
+    return subprocess.run(cmd, text=True, capture_output=True, env=env)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit", type=int, default=10, help="Number of IDs to process"
+    )
+    args = parser.parse_args(argv)
+
+    _ensure_project_root()
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="determinism_check_"))
+    try:
+        first = tmp_dir / "first.csv"
+        second = tmp_dir / "second.csv"
+
+        first_run = _run_activity(args.limit, first)
+        if first_run.returncode != 0:
+            sys.stderr.write("first run failed\n")
+            sys.stderr.write(first_run.stderr)
+            return 1
+
+        second_run = _run_activity(args.limit, second)
+        if second_run.returncode != 0:
+            sys.stderr.write("second run failed\n")
+            sys.stderr.write(second_run.stderr)
+            return 1
+
+        if not first.exists() or not second.exists():
+            print(
+                "Outputs not created; determinism check inconclusive", file=sys.stderr
+            )
+            return 1
+
+        first_hash = _hash_file(first)
+        second_hash = _hash_file(second)
+
+        if first_hash != second_hash:
+            print("Mismatch detected:")
+            print(f"  first:  {first_hash}")
+            print(f"  second: {second_hash}")
+            return 1
+
+        print("Deterministic output confirmed")
+        print(f"SHA256: {first_hash}")
+        return 0
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone `scripts/check_determinism.py` helper that runs the activity pipeline twice and compares output hashes
- ensure the helper normalises the project root on sys.path so it can import repository modules when executed directly

## Testing
- python scripts/check_determinism.py *(fails: activity CLI cannot import `resolve_invocation`)*

------
https://chatgpt.com/codex/tasks/task_e_68de94940f1c832497682bed3ec27c96