### PR TITLE
Refine document QA to run post-processing pipeline

### DIFF
--- a/docs/QA_PROCESS_EN.md
+++ b/docs/QA_PROCESS_EN.md
@@ -63,7 +63,7 @@ checklist.
 
 The document export now includes an automated regression check against the legacy Power Query workbook.
 
-1. Populate `data/input/full/ref_document.csv` with the authoritative export.
+1. Populate `data/input/full/document.csv` with the authoritative export.
 2. Run the document pipeline (`python -m scripts.get_document_data ...`) and confirm it produces:
    * `preprocessed_output.document_YYYYMMDD.csv`
    * `qa_document_postprocessing_report_YYYYMMDD.json`
@@ -73,7 +73,7 @@ The document export now includes an automated regression check against the legac
    ```bash
    python -m qa.check_document_postprocessing \
        --base-path data \
-       --ref input\\full\\ref_document.csv \
+       --ref input\\full\\document.csv \
        --actual output\\document\\preprocessed_output.document_YYYYMMDD.csv
    ```
 4. Treat a non-zero exit code as a blocking failure; consult the Markdown summary and diff extract for remediation.

--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -581,7 +581,7 @@ CSV_DELIMITER = ","
 DEFAULT_BASE_PATH = "e:\\github\\ChEMBL_data_acquisition\\data\\"
 DEFAULT_REF_RELATIVE = "input\\full\\document.csv"
 DEFAULT_OUTPUT_RELATIVE = "output\\document\\output.document_YYYYMMDD.csv"
-DEFAULT_QA_REFERENCE_RELATIVE = "input\\full\\ref_document.csv"
+DEFAULT_QA_REFERENCE_RELATIVE = "input\\full\\document.csv"
 
 
 # ---------------------------------------------------------------------------
@@ -1270,7 +1270,7 @@ def preprocess_documents_csv(
                 qa_result = run_document_postprocessing_check(
                     base_path=base_dir,
                     reference_path=qa_reference_path,
-                    candidate_path=target_path,
+                    candidate_path=out_path,
                     output_dir=target_path.parent,
                     delimiter=CSV_DELIMITER,
                 )

--- a/qa/check_document_postprocessing.py
+++ b/qa/check_document_postprocessing.py
@@ -14,10 +14,13 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
+import numpy as np
 import pandas as pd
 
+from library import document_postprocessing as dp
+from library.config import IoCfg
 from library.csv_utils import write_csv_deterministic
 from library.postprocessing.document import to_text
 
@@ -192,7 +195,7 @@ def run_document_postprocessing_check(
     max_diff_rows: int = DEFAULT_MAX_DIFF_ROWS,
     key_columns: Sequence[str] = KEY_COLUMNS,
 ) -> QaResult:
-    """Compare Power Query reference output with the Python post-processing result."""
+    """Compare the Power Query reproduction with the Python post-processing result."""
 
     if max_diff_rows <= 0:
         msg = "max_diff_rows must be positive"
@@ -208,26 +211,41 @@ def run_document_postprocessing_check(
         output_directory = _resolve_relative(base_dir, output_dir)
     output_directory.mkdir(parents=True, exist_ok=True)
 
-    reference_df = pd.read_csv(
+    ref_source = _load_csv(
         reference_resolved,
-        dtype="string",
         encoding=reference_encoding,
-        sep=delimiter,
-        keep_default_na=False,
+        delimiter=delimiter,
+        keep_default_na=True,
     )
-    candidate_df = pd.read_csv(
+    out_source = _load_csv(
         candidate_resolved,
-        dtype="string",
         encoding=candidate_encoding,
-        sep=delimiter,
+        delimiter=delimiter,
+        keep_default_na=True,
+    )
+
+    expected_df = _power_query_expected(ref_source, out_source)
+
+    cfg = IoCfg(csv_sep=delimiter, csv_encoding=candidate_encoding)
+    processed_path = dp.postprocess_file(
+        candidate_resolved,
+        candidate_resolved.parent,
+        cfg=cfg,
+        ref_document_path=reference_resolved,
+    )
+
+    actual_df = _load_csv(
+        processed_path,
+        encoding=dp.UTF8_ENCODING,
+        delimiter=delimiter,
         keep_default_na=False,
     )
 
-    reference_df = _ensure_columns(reference_df, key_columns)
-    candidate_df = _ensure_columns(candidate_df, key_columns)
+    expected_df = _ensure_columns(expected_df, key_columns)
+    actual_df = _ensure_columns(actual_df, key_columns)
 
-    reference_canonical = _canonicalise(reference_df)
-    candidate_canonical = _canonicalise(candidate_df)
+    reference_canonical = _canonicalise(expected_df)
+    candidate_canonical = _canonicalise(actual_df)
 
     reference_index = _build_index(reference_canonical, key_columns)
     candidate_index = _build_index(candidate_canonical, key_columns)
@@ -255,8 +273,8 @@ def run_document_postprocessing_check(
     reference_duplicates = int(reference_index.duplicated().sum())
     candidate_duplicates = int(candidate_index.duplicated().sum())
 
-    missing_reference_columns = sorted(set(all_columns) - set(candidate_df.columns))
-    missing_candidate_columns = sorted(set(all_columns) - set(reference_df.columns))
+    missing_in_actual = sorted(set(all_columns) - set(actual_df.columns))
+    missing_in_expected = sorted(set(all_columns) - set(expected_df.columns))
 
     issues: list[str] = []
     if cells_different:
@@ -273,33 +291,33 @@ def run_document_postprocessing_check(
         issues.append(f"Reference contains {reference_duplicates} duplicate key rows")
     if candidate_duplicates:
         issues.append(f"Candidate contains {candidate_duplicates} duplicate key rows")
-    if missing_reference_columns:
+    if missing_in_expected:
         issues.append(
             "Reference missing columns present in candidate: "
-            + ", ".join(missing_reference_columns)
+            + ", ".join(missing_in_expected)
         )
-    if missing_candidate_columns:
+    if missing_in_actual:
         issues.append(
             "Candidate missing columns present in reference: "
-            + ", ".join(missing_candidate_columns)
+            + ", ".join(missing_in_actual)
         )
 
     status = SUCCESS_STATUS if not issues else FAILURE_STATUS
-    resolved_date_code = _extract_date_code(candidate_resolved, date_code)
+    resolved_date_code = _extract_date_code(processed_path, date_code)
 
     metrics: dict[str, Any] = {
         "status": status,
         "date_code": resolved_date_code,
         "reference": {
             "path": str(reference_resolved),
-            "rows": int(len(reference_df)),
-            "columns": list(reference_df.columns),
+            "rows": int(len(expected_df)),
+            "columns": list(expected_df.columns),
             "duplicates": reference_duplicates,
         },
         "candidate": {
-            "path": str(candidate_resolved),
-            "rows": int(len(candidate_df)),
-            "columns": list(candidate_df.columns),
+            "path": str(processed_path),
+            "rows": int(len(actual_df)),
+            "columns": list(actual_df.columns),
             "duplicates": candidate_duplicates,
         },
         "differences": {
@@ -376,7 +394,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--actual",
         required=True,
-        help="Relative or absolute path to the Python-generated CSV",
+        help="Relative or absolute path to the unprocessed out_document CSV",
     )
     parser.add_argument(
         "--out",
@@ -432,3 +450,365 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+# ===== Helpers ===============================================================
+def _load_csv(
+    path: Path,
+    *,
+    encoding: str,
+    delimiter: str,
+    keep_default_na: bool,
+) -> pd.DataFrame:
+    """Return a DataFrame loaded from ``path`` with consistent options."""
+
+    return pd.read_csv(
+        path,
+        dtype="string",
+        encoding=encoding,
+        sep=delimiter,
+        keep_default_na=keep_default_na,
+    )
+
+
+def _prepare_reference_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return ``frame`` shaped like the Power Query ``ref_document`` table."""
+
+    reference = frame.copy()
+
+    if "classification" in reference.columns:
+        classification = (
+            pd.to_numeric(reference["classification"], errors="coerce")
+            .fillna(0)
+            .astype(int)
+        )
+        reference["doctype_review"] = classification.astype(bool)
+    elif "doctype_review" not in reference.columns:
+        reference["doctype_review"] = False
+
+    drop_columns = [
+        "abstract",
+        "authors",
+        "DOI",
+        "first_page",
+        "issue",
+        "journal",
+        "last_page",
+        "month",
+        "postcodes",
+        "title",
+        "volume",
+        "year",
+        "classification",
+    ]
+    reference = reference.drop(columns=[c for c in drop_columns if c in reference.columns])
+
+    reference["document_chembl_id"] = reference["document_chembl_id"].map(to_text)
+
+    return reference
+
+
+def _series_from_column(
+    frame: pd.DataFrame,
+    column: str,
+    *,
+    transform: Callable[[Any], Any] | None = to_text,
+    default: str = "",
+) -> pd.Series:
+    """Return ``column`` mapped through ``transform`` with ``default`` fallback."""
+
+    if column in frame.columns:
+        series = frame[column]
+    else:
+        series = pd.Series([default] * len(frame), index=frame.index)
+    if transform is None:
+        return series
+    return series.map(transform)
+
+
+def _power_query_expected(
+    ref_document: pd.DataFrame,
+    out_document: pd.DataFrame,
+) -> pd.DataFrame:
+    """Return the expected Power Query output for ``out_document``."""
+
+    if out_document.empty:
+        return pd.DataFrame(columns=list(dp.FINAL_COLUMN_ORDER))
+
+    frame = out_document.copy()
+
+    for column in frame.columns:
+        frame[column] = frame[column].map(to_text)
+
+    for column in dp.PUBMED_NUMERIC_TEXT_COLUMNS:
+        frame[column] = _series_from_column(frame, column).replace("", "0")
+
+    for column in dp.CHEMBL_NUMERIC_TEXT_COLUMNS + dp.PUBMED_NUMERIC_TEXT_COLUMNS:
+        frame[column] = _series_from_column(frame, column)
+
+    frame["ChEMBL.journal"] = _series_from_column(
+        frame, "ChEMBL.journal", transform=dp.normalize_journal
+    )
+    frame["PubMed.JournalTitle"] = _series_from_column(
+        frame, "PubMed.JournalTitle", transform=dp.normalize_journal
+    )
+
+    ref_doi = _series_from_column(frame, "ChEMBL.doi")
+    doi_agree: list[pd.Series] = []
+    doi_conflict: list[pd.Series] = []
+    for column in dp.EXTERNAL_DOI_COLUMNS:
+        external = _series_from_column(frame, column)
+        valid = ~external.isin(("", "0"))
+        doi_agree.append(valid & (external == ref_doi))
+        doi_conflict.append(valid & (external != ref_doi))
+    agree_any = dp._series_any(doi_agree) if doi_agree else pd.Series(False, index=frame.index)
+    conflict_any = (
+        dp._series_any(doi_conflict)
+        if doi_conflict
+        else pd.Series(False, index=frame.index)
+    )
+    frame["invalid.doi"] = (~agree_any) & conflict_any
+
+    ref_pmid_numbers = _series_from_column(frame, "ChEMBL.pubmed_id").map(dp.try_parse_int)
+    ref_valid = ref_pmid_numbers.notna()
+    pmid_agree: list[pd.Series] = []
+    pmid_conflict: list[pd.Series] = []
+    for column in dp.EXTERNAL_PMID_COLUMNS:
+        external_text = _series_from_column(frame, column)
+        external_numbers = external_text.map(dp.try_parse_int)
+        external_valid = external_numbers.notna()
+        match = ref_valid & external_valid & (external_numbers == ref_pmid_numbers)
+        pmid_agree.append(match)
+
+        non_empty = external_text != ""
+        mismatch = (
+            non_empty & ref_valid & external_valid & (external_numbers != ref_pmid_numbers)
+        )
+        pmid_conflict.append(mismatch)
+    agree_pmid_any = (
+        dp._series_any(pmid_agree)
+        if pmid_agree
+        else pd.Series(False, index=frame.index)
+    )
+    conflict_pmid_any = (
+        dp._series_any(pmid_conflict)
+        if pmid_conflict
+        else pd.Series(False, index=frame.index)
+    )
+    frame["invalid.PMID"] = (~agree_pmid_any) & conflict_pmid_any
+
+    review_columns = (
+        "PubMed.PublicationType",
+        "scholar.PublicationTypes",
+        "OpenAlex.PublicationTypes",
+        "OpenAlex.TypeCrossref",
+        "crossref.Type",
+    )
+    review_series = [
+        _series_from_column(frame, column)
+        .astype("string")
+        .fillna("")
+        .str.lower()
+        .str.contains("review", na=False)
+        for column in review_columns
+    ]
+    frame["review"] = dp._series_any(review_series) if review_series else pd.Series(False, index=frame.index)
+
+    journal_match = (
+        frame["PubMed.JournalTitle"] == frame["ChEMBL.journal"]
+    ) & (frame["ChEMBL.journal"] != "")
+    volume_match = (
+        frame["PubMed.Volume"] == frame["ChEMBL.volume"]
+    ) & (frame["ChEMBL.volume"] != "")
+    issue_match = (
+        frame["PubMed.Issue"] == frame["ChEMBL.issue"]
+    ) & (frame["ChEMBL.issue"] != "")
+    start_match = (
+        frame["PubMed.StartPage"] == frame["ChEMBL.first_page"]
+    ) & (frame["ChEMBL.first_page"] != "")
+    end_match = (
+        frame["PubMed.EndPage"] == frame["ChEMBL.last_page"]
+    ) & (frame["ChEMBL.last_page"] != "")
+
+    journal_value = np.where(journal_match, frame["ChEMBL.journal"], "unknown")
+    volume_value = np.where(volume_match, frame["ChEMBL.volume"], "unknown")
+    issue_value = np.where(issue_match, frame["ChEMBL.issue"], "unknown")
+    start_value = np.where(start_match, frame["ChEMBL.first_page"], "unknown")
+    end_value = np.where(end_match, frame["ChEMBL.last_page"], "unknown")
+
+    frame["reference"] = (
+        pd.Series(journal_value, index=frame.index)
+        + ", "
+        + pd.Series(volume_value, index=frame.index)
+        + "("
+        + pd.Series(issue_value, index=frame.index)
+        + "), p."
+        + pd.Series(start_value, index=frame.index)
+        + "-"
+        + pd.Series(end_value, index=frame.index)
+    )
+
+    frame["invalid.reference"] = frame["reference"].str.contains("unknown", na=False)
+
+    year_completed = _series_from_column(frame, "PubMed.YearCompleted")
+    year_revised = _series_from_column(frame, "PubMed.YearRevised")
+    chembl_year = _series_from_column(frame, "ChEMBL.year")
+    frame["year"] = np.where(
+        ~year_completed.map(dp.null_or_empty),
+        year_completed.map(dp.pad4),
+        np.where(
+            ~year_revised.map(dp.null_or_empty),
+            year_revised.map(dp.pad4),
+            chembl_year.map(dp.pad4),
+        ),
+    )
+
+    month_completed = _series_from_column(frame, "PubMed.MonthCompleted")
+    month_revised = _series_from_column(frame, "PubMed.MonthRevised")
+    frame["month"] = np.where(
+        ~month_completed.map(dp.null_or_empty),
+        month_completed.map(dp.pad2),
+        np.where(
+            ~month_revised.map(dp.null_or_empty),
+            month_revised.map(dp.pad2),
+            "00",
+        ),
+    )
+
+    day_completed = _series_from_column(frame, "PubMed.DayCompleted")
+    day_revised = _series_from_column(frame, "PubMed.DayRevised")
+    frame["day"] = np.where(
+        ~day_completed.map(dp.null_or_empty),
+        day_completed.map(dp.pad2),
+        np.where(
+            ~day_revised.map(dp.null_or_empty),
+            day_revised.map(dp.pad2),
+            "00",
+        ),
+    )
+
+    frame["completed"] = (
+        pd.Series(frame["year"], index=frame.index)
+        + "-"
+        + pd.Series(frame["month"], index=frame.index)
+        + "-"
+        + pd.Series(frame["day"], index=frame.index)
+    )
+
+    frame["ChEMBL.pubmed_id"] = _series_from_column(frame, "ChEMBL.pubmed_id").map(
+        dp.pad_pmid8
+    )
+    frame["sortorder.document"] = (
+        _series_from_column(frame, "PubMed.ISSN")
+        + ":"
+        + frame["completed"]
+        + ":"
+        + frame["ChEMBL.pubmed_id"].map(to_text)
+    )
+
+    frame = frame.rename(columns={"PubMed.PMID": "PMID", "ChEMBL.doi": "doi"})
+    frame["PMID"] = frame["PMID"].map(to_text)
+    frame["doi"] = frame["doi"].map(to_text)
+
+    frame["invalid"] = (
+        frame["invalid.doi"] | frame["invalid.PMID"] | frame["invalid.reference"]
+    )
+
+    drop_candidates = [
+        column for column in dp.STAGE_REMOVED_COLUMNS if column in frame.columns
+    ]
+    frame = frame.drop(columns=drop_candidates)
+
+    rename_map = {
+        "ChEMBL.document_chembl_id": "document_chembl_id",
+        "PubMed.DOI": "doi",
+        "PubMed.ArticleTitle": "title",
+        "PubMed.Abstract": "abstract",
+        "PubMed.MeSH_Descriptors": "mesh.descriptors",
+        "PubMed.MeSH_Qualifiers": "mesh.qualifiers",
+        "PubMed.ChemicalList": "chemical_list",
+        "OpenAlex.MeshDescriptors": "OpenAlex.mesh.descriptors",
+    }
+    frame = frame.rename(columns=rename_map)
+    frame["doi"] = frame["doi"].map(to_text)
+
+    secondary_rename = {
+        "chemical_list": "PubMed.chemical.list",
+        "mesh.qualifiers": "PubMed.mesh.qualifiers",
+        "mesh.descriptors": "PubMed.mesh.descriptors",
+    }
+    frame = frame.rename(columns=secondary_rename)
+
+    for column in dp.LOWERCASE_LIST_COLUMNS:
+        if column in frame.columns:
+            frame[column] = frame[column].map(dp.safe_lower)
+
+    harmonised_reference = _prepare_reference_frame(ref_document)
+
+    frame = frame.merge(harmonised_reference, on="document_chembl_id", how="left")
+
+    if "document_contains_external_links" in frame.columns:
+        def _normalize_bool(value: Any) -> Any:
+            if pd.isna(value):
+                return pd.NA
+            text = to_text(value).strip().lower()
+            if text in {"", "nan"}:
+                return pd.NA
+            if text in {"true", "1", "yes"}:
+                return True
+            if text in {"false", "0", "no"}:
+                return False
+            return bool(value)
+
+        frame["document_contains_external_links"] = frame[
+            "document_contains_external_links"
+        ].map(_normalize_bool)
+
+    review_values: list[Any] = []
+    for current, doctype in zip(frame["review"], frame["doctype_review"]):
+        current_value = None if pd.isna(current) else bool(current)
+        doctype_value = None if pd.isna(doctype) else bool(doctype)
+        if current_value is True or doctype_value is True:
+            review_values.append(True)
+        elif current_value is False and doctype_value is False:
+            review_values.append(False)
+        else:
+            review_values.append(pd.NA)
+    frame["review"] = pd.Series(review_values, index=frame.index, dtype="boolean")
+
+    experimental_values: list[Any] = []
+    for value in frame["review"]:
+        if value is pd.NA or pd.isna(value):
+            experimental_values.append(pd.NA)
+        else:
+            experimental_values.append(not bool(value))
+    frame["experimental"] = pd.Series(
+        experimental_values, index=frame.index, dtype="boolean"
+    )
+
+    frame = frame.drop(columns=["is_experimental_doc"], errors="ignore")
+
+    boolean_columns = [
+        "review",
+        "experimental",
+        "invalid",
+        "invalid.doi",
+        "invalid.PMID",
+        "invalid.reference",
+        "document_contains_external_links",
+    ]
+    for column in boolean_columns:
+        if column in frame.columns:
+            frame[column] = frame[column].map(
+                lambda value: ""
+                if pd.isna(value)
+                else str(bool(value)).lower()
+            )
+
+    missing = [column for column in dp.FINAL_COLUMN_ORDER if column not in frame.columns]
+    if missing:
+        raise ValueError(f"Missing expected columns after harmonisation: {missing}")
+
+    frame = frame.loc[:, dp.FINAL_COLUMN_ORDER]
+    frame = frame.sort_values("completed", ascending=True, kind="mergesort")
+    frame.reset_index(drop=True, inplace=True)
+
+    return frame

--- a/tests/test_document_postprocessing_qa.py
+++ b/tests/test_document_postprocessing_qa.py
@@ -9,25 +9,37 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from library import document_postprocessing as dp
 from qa.check_document_postprocessing import main as qa_main
 from qa.check_document_postprocessing import run_document_postprocessing_check
 
 
 FIXTURE_DIR = Path("tests/data/postprocessing_document")
+BOOL_COLUMNS = {
+    "review",
+    "experimental",
+    "document_contains_external_links",
+    "invalid",
+    "invalid.doi",
+    "invalid.PMID",
+    "invalid.reference",
+}
 
 
 def _prepare_environment(tmp_path: Path) -> tuple[Path, Path, Path]:
     base_dir = tmp_path / "data"
     reference_dir = base_dir / "input" / "full"
-    output_dir = base_dir / "output"
+    output_dir = base_dir / "output" / "document"
     reference_dir.mkdir(parents=True)
     output_dir.mkdir(parents=True)
 
-    reference_path = reference_dir / "ref_document.csv"
-    candidate_path = output_dir / "preprocessed_output.document_20230101.csv"
+    reference_path = reference_dir / "document.csv"
+    legacy_reference_path = reference_dir / "ref_document.csv"
+    candidate_path = output_dir / "output.document_20230101.csv"
 
-    shutil.copy(FIXTURE_DIR / "ref_document.csv", reference_path)
-    shutil.copy(FIXTURE_DIR / "ref_document.csv", candidate_path)
+    shutil.copy(FIXTURE_DIR / "document.csv", reference_path)
+    shutil.copy(FIXTURE_DIR / "document.csv", legacy_reference_path)
+    shutil.copy(FIXTURE_DIR / "output.document_20230101.csv", candidate_path)
 
     return base_dir, reference_path, candidate_path
 
@@ -44,17 +56,51 @@ def test_run_document_postprocessing_check_pass(tmp_path: Path) -> None:
     assert result.passed is True
     assert result.diff_csv is None
 
+    produced_path = candidate_path.with_name(
+        f"preprocessed_{candidate_path.name}"
+    )
+    assert produced_path.exists()
+
+    produced_df = pd.read_csv(produced_path, dtype=str)
+    expected_df = pd.read_csv(
+        FIXTURE_DIR / "preprocessed_output.document_20230101.csv", dtype=str
+    )
+    for column in BOOL_COLUMNS:
+        if column in produced_df.columns:
+            produced_df[column] = produced_df[column].str.lower()
+    for column in BOOL_COLUMNS:
+        if column in expected_df.columns:
+            expected_df[column] = expected_df[column].str.lower()
+
+    pd.testing.assert_frame_equal(
+        produced_df.fillna(""), expected_df.fillna(""), check_dtype=False
+    )
+
     with result.report_json.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
     assert payload["status"] == "passed"
 
 
-def test_run_document_postprocessing_check_failure(tmp_path: Path) -> None:
+def test_run_document_postprocessing_check_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
 
-    mutated = pd.read_csv(candidate_path, dtype=str)
-    mutated.loc[0, "doi"] = "10.9999/incorrect"
-    mutated.to_csv(candidate_path, index=False)
+    original = dp.postprocess_documents
+
+    def mutate(
+        frame, *, required_columns=None, ref_document=None, ref_document_path=None
+    ):
+        processed = original(
+            frame,
+            required_columns=required_columns,
+            ref_document=ref_document,
+            ref_document_path=ref_document_path,
+        )
+        processed.loc[0, "doi"] = "10.9999/incorrect"
+        return processed
+
+    monkeypatch.setattr(dp, "postprocess_documents", mutate)
 
     result = run_document_postprocessing_check(
         base_path=base_dir,
@@ -79,21 +125,39 @@ def test_run_document_postprocessing_check_failure(tmp_path: Path) -> None:
     "mutate",
     [False, True],
 )
-def test_cli_exit_codes(tmp_path: Path, mutate: bool) -> None:
+def test_cli_exit_codes(
+    tmp_path: Path, mutate: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
     base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
     if mutate:
-        mutated = pd.read_csv(candidate_path, dtype=str)
-        mutated.loc[0, "doi"] = "bad-doi"
-        mutated.to_csv(candidate_path, index=False)
+        original = dp.postprocess_documents
+
+        def mutate_fn(
+            frame,
+            *,
+            required_columns=None,
+            ref_document=None,
+            ref_document_path=None,
+        ):
+            processed = original(
+                frame,
+                required_columns=required_columns,
+                ref_document=ref_document,
+                ref_document_path=ref_document_path,
+            )
+            processed.loc[0, "doi"] = "bad-doi"
+            return processed
+
+        monkeypatch.setattr(dp, "postprocess_documents", mutate_fn)
 
     exit_code = qa_main(
         [
             "--base-path",
             str(base_dir),
             "--ref",
-            "input\\full\\ref_document.csv",
+            "input\\full\\document.csv",
             "--actual",
-            "output\\preprocessed_output.document_20230101.csv",
+            "output\\document\\output.document_20230101.csv",
         ]
     )
 

--- a/tests/test_postprocessing_document.py
+++ b/tests/test_postprocessing_document.py
@@ -10,6 +10,24 @@ from library.postprocessing import document as doc
 
 
 FIXTURE_DIR = Path("tests/data/postprocessing_document")
+BOOL_COLUMNS = {
+    "review",
+    "experimental",
+    "document_contains_external_links",
+    "invalid",
+    "invalid.doi",
+    "invalid.PMID",
+    "invalid.reference",
+}
+
+
+def _normalise_strings(df: pd.DataFrame) -> pd.DataFrame:
+    normalised = df.apply(
+        lambda col: col.map(lambda value: "" if pd.isna(value) else str(value))
+    )
+    for column in BOOL_COLUMNS.intersection(normalised.columns):
+        normalised[column] = normalised[column].str.lower()
+    return normalised
 
 
 def test_normalize_journal_and_padding_functions() -> None:
@@ -104,7 +122,11 @@ def test_preprocess_documents_csv_integration(tmp_path: Path) -> None:
 
     assert result.name == "preprocessed_output.document_20230101.csv"
     assert list(produced_df.columns) == list(doc.FINAL_COLUMN_ORDER)
-    pd.testing.assert_frame_equal(produced_df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(
+        _normalise_strings(produced_df),
+        _normalise_strings(expected_df),
+        check_dtype=False,
+    )
 
     completed = produced_df["completed"].tolist()
     assert completed == sorted(completed)


### PR DESCRIPTION
## Summary
- update the document QA script to regenerate the Python output, rebuild the expected Power Query result in-memory, and align reporting with the new workflow
- point the pipeline helper and documentation to the raw document reference file and refresh the QA/unit tests accordingly

## Testing
- pytest tests/test_postprocessing_document.py tests/test_document_postprocessing_qa.py

------
https://chatgpt.com/codex/tasks/task_e_68de9674365c83249fe91714583772ce