### PR TITLE
Handle duplicate export columns in document pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1037,9 +1037,16 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Rename and project columns to match the export schema."""
 
     frame = df.copy()
-    rename_map = {k: v for k, v in _EXPORT_COLUMN_RENAMES.items() if k in frame.columns}
-    if rename_map:
-        frame = frame.rename(columns=rename_map)
+
+    # ===== Normalise ChEMBL column aliases =====
+    for source, target in _EXPORT_COLUMN_RENAMES.items():
+        if source not in frame.columns:
+            continue
+        if target in frame.columns:
+            frame[target] = _coalesce_columns(frame, [target, source])
+            frame = frame.drop(columns=[source])
+        else:
+            frame = frame.rename(columns={source: target})
 
     for target, sources in _EXPORT_COALESCE_SOURCES.items():
         frame[target] = _coalesce_columns(frame, sources)


### PR DESCRIPTION
## Summary
- coalesce values when both ChEMBL export aliases are present to avoid duplicate column names
- keep export coalescing behaviour unchanged after normalising the column set

## Testing
- pytest tests/test_get_document_data.py -k export

------
https://chatgpt.com/codex/tasks/task_e_68de9da3fbc483249717e00015193d99