### PR TITLE
Fix document export column collisions

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1037,7 +1037,15 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Rename and project columns to match the export schema."""
 
     frame = df.copy()
-    rename_map = {k: v for k, v in _EXPORT_COLUMN_RENAMES.items() if k in frame.columns}
+    rename_map: dict[str, str] = {}
+    for source, target in _EXPORT_COLUMN_RENAMES.items():
+        if source not in frame.columns:
+            continue
+        if target in frame.columns and target != source:
+            frame[target] = _coalesce_columns(frame, [target, source])
+            frame = frame.drop(columns=[source])
+            continue
+        rename_map[source] = target
     if rename_map:
         frame = frame.rename(columns=rename_map)
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -3243,3 +3243,24 @@ def test_fetch_pubmed_records_uses_pending_helper_minimally(
     assert call_count == 2
     assert df["PubMed.PMID"].tolist() == pmids
 
+
+def test_prepare_export_frame_merges_prefixed_columns() -> None:
+    """Existing prefixed columns should absorb their unprefixed counterparts."""
+
+    frame = pd.DataFrame(
+        {
+            "ChEMBL.title": ["kept", ""],
+            "title": ["ignored", "fallback"],
+            "ChEMBL.abstract": ["", "pref"],
+            "abstract": ["primary", ""],
+        }
+    )
+
+    result = gdd._prepare_export_frame(frame)
+
+    assert not result.columns.duplicated().any()
+    assert result.loc[0, "ChEMBL.title"] == "kept"
+    assert result.loc[1, "ChEMBL.title"] == "fallback"
+    assert result.loc[0, "ChEMBL.abstract"] == "primary"
+    assert result.loc[1, "ChEMBL.abstract"] == "pref"
+


### PR DESCRIPTION
## Summary
- coalesce prefixed document columns with their unprefixed counterparts before renaming to the export schema
- add a regression test ensuring `_prepare_export_frame` no longer produces duplicate ChEMBL columns

## Testing
- pytest tests/test_get_document_data.py -k test_prepare_export_frame_merges_prefixed_columns (skipped: responses module missing)
- python - <<'PY' ... (pass)


------
https://chatgpt.com/codex/tasks/task_e_68de9e3544708324a0e9d61246bd5dc0