### PR TITLE
Add structure metrics to QA reporting

### DIFF
--- a/qa/check_document_postprocessing.py
+++ b/qa/check_document_postprocessing.py
@@ -366,6 +366,13 @@ def _render_markdown(metrics: Mapping[str, Any], diff_path: Path | None) -> str:
             parts.append(f"{column} [{value_text}]")
         return "; ".join(parts)
 
+    def _format_bool_optional(flag: Any | None) -> str:
+        if flag is None:
+            return "n/a"
+        if isinstance(flag, bool):
+            return _format_bool(flag)
+        return _format_bool(bool(flag))
+
     def _format_share_block(summary: Mapping[str, Any], total_rows: int) -> str:
         if not summary.get("available"):
             return "n/a"
@@ -379,13 +386,14 @@ def _render_markdown(metrics: Mapping[str, Any], diff_path: Path | None) -> str:
     lines.append(f"- Status: **{metrics['status']}**")
     lines.append(f"- Reference rows: {ref_rows}")
     lines.append(f"- Candidate rows: {cand_rows}")
+    structure = metrics.get("structure", {})
     lines.append(
         "- Column sets identical: "
-        + _format_bool(metrics["structure"]["columns_equal"])
+        + _format_bool_optional(structure.get("columns_equal"))
     )
     lines.append(
         "- Column order identical: "
-        + _format_bool(metrics["structure"]["column_order_equal"])
+        + _format_bool_optional(structure.get("column_order_equal"))
     )
     lines.append(
         "- Cells different: "
@@ -549,25 +557,25 @@ def run_document_postprocessing_check(
     missing_in_actual = sorted(set(all_columns) - set(actual_df.columns))
     missing_in_expected = sorted(set(all_columns) - set(expected_df.columns))
 
-    structure_metrics = {
-        "columns_equal": set(reference_df.columns) == set(candidate_df.columns),
-        "column_order_equal": list(reference_df.columns) == list(candidate_df.columns),
-    }
-
     reference_summary = _summarise_dataset(
-        frame=reference_df,
+        frame=expected_df,
         canonical=reference_canonical,
         key_columns=key_columns,
         path=str(reference_resolved),
         duplicate_count=reference_duplicates,
     )
     candidate_summary = _summarise_dataset(
-        frame=candidate_df,
+        frame=actual_df,
         canonical=candidate_canonical,
         key_columns=key_columns,
         path=str(candidate_resolved),
         duplicate_count=candidate_duplicates,
     )
+
+    structure_metrics = {
+        "columns_equal": set(expected_df.columns) == set(actual_df.columns),
+        "column_order_equal": list(expected_df.columns) == list(actual_df.columns),
+    }
 
     issues: list[str] = []
     if cells_different:
@@ -615,18 +623,9 @@ def run_document_postprocessing_check(
         "status": status,
         "date_code": resolved_date_code,
 
-        "reference": {
-            "path": str(reference_resolved),
-            "rows": int(len(expected_df)),
-            "columns": list(expected_df.columns),
-            "duplicates": reference_duplicates,
-        },
-        "candidate": {
-            "path": str(processed_path),
-            "rows": int(len(actual_df)),
-            "columns": list(actual_df.columns),
-            "duplicates": candidate_duplicates,
-        },
+        "structure": structure_metrics,
+        "reference": reference_summary,
+        "candidate": candidate_summary,
 
         "differences": {
             "cells_total": total_cells,

--- a/tests/test_document_postprocessing_qa.py
+++ b/tests/test_document_postprocessing_qa.py
@@ -92,6 +92,8 @@ def test_run_document_postprocessing_check_pass(tmp_path: Path) -> None:
 
     markdown = result.report_markdown.read_text(encoding="utf-8")
     assert "- Status: **passed**" in markdown
+    assert "- Column sets identical: ✅ yes" in markdown
+    assert "- Column order identical: ✅ yes" in markdown
     assert "- Diff excerpt: not generated" in markdown
 
 
@@ -137,27 +139,55 @@ def test_run_document_postprocessing_check_failure(
 
     markdown = result.report_markdown.read_text(encoding="utf-8")
     assert "- Status: **failed**" in markdown
+    assert "- Column sets identical:" in markdown
+    assert "- Column order identical:" in markdown
     assert result.diff_csv.name in markdown
 
 
-def test_diff_extract_limited_by_keys(tmp_path: Path) -> None:
+def test_diff_extract_limited_by_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
 
-    template = pd.read_csv(reference_path, dtype=str)
-    rows: list[pd.Series] = []
+    candidate_template = pd.read_csv(candidate_path, dtype=str)
+    candidate_rows: list[pd.Series] = []
     for idx in range(150):
-        record = template.iloc[0].copy()
-        record["PMID"] = f"{100000 + idx}"
-        record["document_chembl_id"] = f"DOC{idx:05d}"
-        record["completed"] = "2020-01-01"
-        record["doi"] = f"10.1000/{idx:03d}"
-        rows.append(record)
-    reference_df = pd.DataFrame(rows)
-    reference_df.to_csv(reference_path, index=False)
+        record = candidate_template.iloc[0].copy()
+        record["ChEMBL.document_chembl_id"] = f"DOC{idx:05d}"
+        record["ChEMBL.doi"] = f"10.1000/{idx:03d}"
+        record["ChEMBL.pubmed_id"] = f"{100000 + idx}"
+        record["PubMed.PMID"] = f"{100000 + idx}"
+        record["PubMed.YearCompleted"] = "2020"
+        record["PubMed.MonthCompleted"] = "01"
+        record["PubMed.DayCompleted"] = "01"
+        record["ChEMBL.year"] = "2020"
+        record["ChEMBL.volume"] = "1"
+        record["ChEMBL.issue"] = "1"
+        record["ChEMBL.first_page"] = "1"
+        record["ChEMBL.last_page"] = "2"
+        candidate_rows.append(record)
+    candidate_raw = pd.DataFrame(candidate_rows)
+    candidate_raw.to_csv(candidate_path, index=False)
 
-    candidate_df = reference_df.copy()
-    candidate_df["doi"] = candidate_df["doi"] + ".mismatch"
-    candidate_df.to_csv(candidate_path, index=False)
+    original = dp.postprocess_documents
+
+    def mutate(
+        frame,
+        *,
+        required_columns=None,
+        ref_document=None,
+        ref_document_path=None,
+    ):
+        processed = original(
+            frame,
+            required_columns=required_columns,
+            ref_document=ref_document,
+            ref_document_path=ref_document_path,
+        )
+        processed["doi"] = processed["doi"].astype(str) + ".mismatch"
+        return processed
+
+    monkeypatch.setattr(dp, "postprocess_documents", mutate)
 
     result = run_document_postprocessing_check(
         base_path=base_dir,
@@ -206,12 +236,8 @@ def test_cli_exit_codes(
         [
             "--base-path",
             str(base_dir),
-
-            "--ref",
-            "input\\full\\document.csv",
-            "--actual",
+            "--out",
             "output\\document\\output.document_20230101.csv",
-
         ]
     )
 


### PR DESCRIPTION
## Summary
- include the structure comparison metrics in the serialized QA payload and render them defensively in the markdown report
- exercise the markdown structure block and CLI argument handling in the document post-processing QA tests
- update the large diff scenario to mutate the processed output so that the diff export remains limited by the configured key count

## Testing
- pytest tests/test_document_postprocessing_qa.py

------
https://chatgpt.com/codex/tasks/task_e_68dea510caa08324930c15916037bf66