### PR TITLE
Improve QA CLI path defaults and tests

### DIFF
--- a/qa/check_document_postprocessing.py
+++ b/qa/check_document_postprocessing.py
@@ -49,6 +49,8 @@ INVARIANT_LABELS: Mapping[str, str] = {
     "completed_format": "completed date format",
     "completed_order": "completed order monotonicity",
 }
+DEFAULT_REFERENCE_RELATIVE = Path("input") / "full" / "document.csv"
+DEFAULT_ACTUAL_RELATIVE = Path("output") / "document" / "output.document.csv"
 
 
 # ===== Data classes ==========================================================
@@ -550,19 +552,19 @@ def run_document_postprocessing_check(
     missing_in_expected = sorted(set(all_columns) - set(expected_df.columns))
 
     structure_metrics = {
-        "columns_equal": set(reference_df.columns) == set(candidate_df.columns),
-        "column_order_equal": list(reference_df.columns) == list(candidate_df.columns),
+        "columns_equal": set(expected_df.columns) == set(actual_df.columns),
+        "column_order_equal": list(expected_df.columns) == list(actual_df.columns),
     }
 
     reference_summary = _summarise_dataset(
-        frame=reference_df,
+        frame=expected_df,
         canonical=reference_canonical,
         key_columns=key_columns,
         path=str(reference_resolved),
         duplicate_count=reference_duplicates,
     )
     candidate_summary = _summarise_dataset(
-        frame=candidate_df,
+        frame=actual_df,
         canonical=candidate_canonical,
         key_columns=key_columns,
         path=str(candidate_resolved),
@@ -614,19 +616,10 @@ def run_document_postprocessing_check(
     metrics: dict[str, Any] = {
         "status": status,
         "date_code": resolved_date_code,
+        "structure": structure_metrics,
 
-        "reference": {
-            "path": str(reference_resolved),
-            "rows": int(len(expected_df)),
-            "columns": list(expected_df.columns),
-            "duplicates": reference_duplicates,
-        },
-        "candidate": {
-            "path": str(processed_path),
-            "rows": int(len(actual_df)),
-            "columns": list(actual_df.columns),
-            "duplicates": candidate_duplicates,
-        },
+        "reference": reference_summary,
+        "candidate": candidate_summary,
 
         "differences": {
             "cells_total": total_cells,
@@ -697,11 +690,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Root directory containing the Power Query reference and Python outputs",
     )
     parser.add_argument(
+        "--ref",
+        default=str(DEFAULT_REFERENCE_RELATIVE),
+        help="Relative or absolute path to the Power Query reference CSV",
+    )
+    parser.add_argument(
+        "--actual",
         "--out",
-        required=True,
-
-        help="Relative or absolute path to the unprocessed out_document CSV",
-
+        dest="actual",
+        default=str(DEFAULT_ACTUAL_RELATIVE),
+        help="Relative or absolute path to the Python-generated CSV",
     )
     parser.add_argument(
         "--reports-dir",
@@ -741,8 +739,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     base_dir = Path(args.base_path).resolve()
-    reference_path = _resolve_relative(base_dir, Path("input") / "full" / "document.csv")
-    candidate_path = _resolve_relative(base_dir, args.out)
+    reference_path = _resolve_relative(base_dir, args.ref)
+    candidate_path = _resolve_relative(base_dir, args.actual)
 
     result = run_document_postprocessing_check(
         base_path=base_dir,

--- a/tests/test_document_postprocessing_qa.py
+++ b/tests/test_document_postprocessing_qa.py
@@ -12,6 +12,7 @@ import pytest
 
 from library import document_postprocessing as dp
 
+import qa.check_document_postprocessing as qa_module
 from qa.check_document_postprocessing import MAX_DIFF_KEY_EXPORT
 
 from qa.check_document_postprocessing import main as qa_main
@@ -41,10 +42,12 @@ def _prepare_environment(tmp_path: Path) -> tuple[Path, Path, Path]:
 
     legacy_reference_path = reference_dir / "ref_document.csv"
     candidate_path = output_dir / "output.document_20230101.csv"
+    default_candidate_path = output_dir / "output.document.csv"
 
     shutil.copy(FIXTURE_DIR / "document.csv", reference_path)
     shutil.copy(FIXTURE_DIR / "document.csv", legacy_reference_path)
     shutil.copy(FIXTURE_DIR / "output.document_20230101.csv", candidate_path)
+    shutil.copy(FIXTURE_DIR / "output.document_20230101.csv", default_candidate_path)
 
 
     return base_dir, reference_path, candidate_path
@@ -140,24 +143,45 @@ def test_run_document_postprocessing_check_failure(
     assert result.diff_csv.name in markdown
 
 
-def test_diff_extract_limited_by_keys(tmp_path: Path) -> None:
+def test_diff_extract_limited_by_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
 
-    template = pd.read_csv(reference_path, dtype=str)
-    rows: list[pd.Series] = []
+    rows: list[dict[str, str]] = []
     for idx in range(150):
-        record = template.iloc[0].copy()
-        record["PMID"] = f"{100000 + idx}"
-        record["document_chembl_id"] = f"DOC{idx:05d}"
-        record["completed"] = "2020-01-01"
-        record["doi"] = f"10.1000/{idx:03d}"
-        rows.append(record)
+        pmid = f"{100000 + idx}"
+        chembl_id = f"DOC{idx:05d}"
+        doi_value = f"10.1000/{idx:03d}"
+        rows.append(
+            {
+                "PMID": pmid,
+                "document_chembl_id": chembl_id,
+                "completed": "2020-01-01",
+                "doi": doi_value,
+            }
+        )
+
     reference_df = pd.DataFrame(rows)
     reference_df.to_csv(reference_path, index=False)
 
     candidate_df = reference_df.copy()
     candidate_df["doi"] = candidate_df["doi"] + ".mismatch"
     candidate_df.to_csv(candidate_path, index=False)
+
+    expected = reference_df.copy()
+    actual = candidate_df.copy()
+
+    def fake_power_query(ref_doc: pd.DataFrame, out_doc: pd.DataFrame) -> pd.DataFrame:
+        return expected
+
+    def fake_postprocess(candidate: Path, destination_dir: Path, **_: object) -> Path:
+        output_path = Path(destination_dir) / f"preprocessed_{Path(candidate).name}"
+        actual.to_csv(output_path, index=False)
+        return output_path
+
+    monkeypatch.setattr(qa_module, "_power_query_expected", fake_power_query)
+    monkeypatch.setattr(dp, "postprocess_file", fake_postprocess)
 
     result = run_document_postprocessing_check(
         base_path=base_dir,
@@ -173,12 +197,10 @@ def test_diff_extract_limited_by_keys(tmp_path: Path) -> None:
     assert set(diff_df["column"]) == {"doi"}
 
 
-@pytest.mark.parametrize(
-    "mutate",
-    [False, True],
-)
+@pytest.mark.parametrize("mutate", [False, True])
+@pytest.mark.parametrize("use_defaults", [False, True])
 def test_cli_exit_codes(
-    tmp_path: Path, mutate: bool, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, mutate: bool, use_defaults: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     base_dir, reference_path, candidate_path = _prepare_environment(tmp_path)
     if mutate:
@@ -202,18 +224,18 @@ def test_cli_exit_codes(
 
         monkeypatch.setattr(dp, "postprocess_documents", mutate_fn)
 
-    exit_code = qa_main(
-        [
-            "--base-path",
-            str(base_dir),
+    args = ["--base-path", str(base_dir)]
+    if not use_defaults:
+        args.extend(
+            [
+                "--ref",
+                "input\\full\\document.csv",
+                "--actual",
+                "output\\document\\output.document_20230101.csv",
+            ]
+        )
 
-            "--ref",
-            "input\\full\\document.csv",
-            "--actual",
-            "output\\document\\output.document_20230101.csv",
-
-        ]
-    )
+    exit_code = qa_main(args)
 
     if mutate:
         assert exit_code == 1


### PR DESCRIPTION
## Summary
- add `--ref`/`--actual` options with sensible defaults while keeping the legacy `--out` alias
- surface richer structure metrics in the QA report data
- extend QA tests to cover defaulted CLI paths and simulate large diff extracts

## Testing
- pytest tests/test_document_postprocessing_qa.py

------
https://chatgpt.com/codex/tasks/task_e_68dea512f6048324aebe409a281dc12c