### PR TITLE
Respect Retry-After headers when retrying PubMed requests

### DIFF
--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -192,8 +192,13 @@ def _do_request(
         extra = {"stage": event, "url": url, "attempt": attempt + 1}
 
         if attempt:
-
-            retry_delay = _retry_delay(attempt, delay, retry_cfg, timeout)
+            header_delay = retry_after_delay
+            retry_after_delay = None
+            retry_delay = (
+                header_delay
+                if header_delay is not None
+                else _retry_delay(attempt, delay, retry_cfg, timeout)
+            )
             extra["delay"] = retry_delay
             logger.info(event, extra=extra)
             if retry_delay > 0:

--- a/tests/test_pubmed_library_main_smoke.py
+++ b/tests/test_pubmed_library_main_smoke.py
@@ -170,12 +170,14 @@ def test_pubmed_client_retry_logging(monkeypatch: pytest.MonkeyPatch) -> None:
 
     responses = iter(
         [
-            (429, "Too Many Requests", None, ""),
-            (200, "<xml/>", "<xml/>", ""),
+            (429, "Too Many Requests", None, "", {"Retry-After": "1.7"}),
+            (200, "<xml/>", "<xml/>", "", {}),
         ]
     )
 
-    def fake_make_request(*_args: Any, **_kwargs: Any) -> tuple[int, str, Any, str]:
+    def fake_make_request(
+        *_args: Any, **_kwargs: Any
+    ) -> tuple[int, str, Any, str, dict[str, str]]:
         try:
             return next(responses)
         except StopIteration:  # pragma: no cover - defensive
@@ -219,7 +221,7 @@ def test_pubmed_client_retry_logging(monkeypatch: pytest.MonkeyPatch) -> None:
     assert error == ""
 
     base = retry_cfg.backoff_factor * (2 ** (1 - 1))
-    expected_delay = pytest.approx(max(0.3, base + 0.2))
+    expected_delay = pytest.approx(1.7)
     assert sleep_calls == [expected_delay]
 
     retry_records = [r for r in fake_logger.records if r[1] == "request_retry"]

--- a/tests/test_pubmed_query.py
+++ b/tests/test_pubmed_query.py
@@ -157,7 +157,13 @@ def test_do_request_retry_after_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pc, "_make_request", fake_make_request)
     monkeypatch.setattr(pc, "sleep", lambda value: sleeps.append(value))
 
-    data, err = pc._do_request(requests.Session(), "http://example.org", delay=0.1, retries=1)
+    data, err = pc._do_request(
+        requests.Session(),
+        "http://example.org",
+        delay=3.0,
+        retries=1,
+        retry_cfg=RetryCfg(backoff_factor=2.0),
+    )
 
     assert data == {"ok": True}
     assert err == ""


### PR DESCRIPTION
## Summary
- honor Retry-After headers when computing PubMed retry sleep delays
- extend PubMed retry tests to cover Retry-After driven waits and logging

## Testing
- pytest tests/test_pubmed_library_main_smoke.py::test_pubmed_client_retry_logging

------
https://chatgpt.com/codex/tasks/task_e_68dea8d2a0d88324af80d6e59eee95db