### PR TITLE
Run determinism check without dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         run: mypy --strict library
       - name: Run tests
         run: pytest
+      - name: Determinism smoke test
+        run: python scripts/check_determinism.py --limit 5
       - name: Smoke test get_data orchestrator
         run: pytest -k "get_data_main_smoke"
       - name: Smoke CLI entry points

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -37,7 +37,6 @@ def _run_activity(limit: int, destination: Path) -> subprocess.CompletedProcess[
     cmd = [
         sys.executable,
         str(Path(__file__).resolve().parents[0] / "get_activity_data.py"),
-        "--dry-run",
         "--limit",
         str(limit),
         "--output",

--- a/tests/test_check_determinism.py
+++ b/tests/test_check_determinism.py
@@ -1,16 +1,46 @@
+"""Regression tests for :mod:`scripts.check_determinism`."""
+
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
-from library.utils.cli_tools.check_determinism import run_check
+import pytest
+
+from scripts import check_determinism
 
 
-def test_run_check_repeatable(tmp_path: Path) -> None:
-    """Running the determinism check twice yields consistent results."""
+class _DummyCompletedProcess(subprocess.CompletedProcess[str]):
+    """Helper providing a string-specialised :class:`CompletedProcess`."""
 
-    workdir = tmp_path / "check"
-    workdir.mkdir()
+    def __init__(self) -> None:
+        super().__init__(args=["python", "scripts/get_activity_data.py"], returncode=0)
 
-    assert run_check(workdir)
-    # Re-run in the same directory to ensure files are overwritten deterministically.
-    assert run_check(workdir)
+
+def _render_csv(limit: int) -> str:
+    """Return deterministic CSV content for ``limit`` identifiers."""
+
+    rows = "\n".join(str(index) for index in range(limit))
+    return f"activity_id\n{rows}\n"
+
+
+def test_main_succeeds(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Check that the determinism probe exits successfully."""
+
+    outputs: dict[str, str] = {}
+
+    def _fake_run_activity(limit: int, destination: Path) -> subprocess.CompletedProcess[str]:
+        assert limit == 3
+        content = _render_csv(limit)
+        destination.write_text(content)
+        outputs[destination.name] = content
+        return _DummyCompletedProcess()
+
+    monkeypatch.setattr(check_determinism, "_run_activity", _fake_run_activity)
+    monkeypatch.setattr(check_determinism.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+
+    exit_code = check_determinism.main(["--limit", "3"])
+
+    assert exit_code == 0
+    assert outputs["first.csv"] == outputs["second.csv"]
+


### PR DESCRIPTION
## Summary
- remove the dry-run flag from the determinism smoke test so it produces CSV output
- add a regression test that stubs the activity runner and verifies the check succeeds
- execute the determinism probe in CI to guard against regressions

## Testing
- pytest tests/test_check_determinism.py


------
https://chatgpt.com/codex/tasks/task_e_68dea8ea2af483248cc1318da6019737