### PR TITLE
Ensure table quality reports land in pipeline output directories

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -332,6 +332,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     table_quality = partial(
         analyze_table_quality,
         table_name=str(output_path.with_suffix("")),
+        destination_dir=output_path.parent,
     )
 
     command = " ".join(["pubmed_library"] + (list(argv) if argv else []))

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -776,7 +776,11 @@ def finalize_output(
     )
 
     try:
-        analyze_table_quality(csv_path, table_name=str(output.with_suffix("")))
+        analyze_table_quality(
+            csv_path,
+            table_name=str(output.with_suffix("")),
+            destination_dir=output.parent,
+        )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -106,7 +106,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         report_dir.mkdir(parents=True, exist_ok=True)
         for entity, path in paths.items():
             logger.info("profiling", entity=entity)
-            analyze_table_quality(path, table_name=str(report_dir / path.stem))
+            analyze_table_quality(
+                path,
+                table_name=path.stem,
+                destination_dir=report_dir,
+            )
 
         logger.info("save_done", tables=len(paths), path=str(out_dir))
         return 0

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -224,6 +224,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     table_quality = partial(
         analyze_table_quality,
         table_name=str(Path(output).with_suffix("")),
+        destination_dir=Path(output).parent,
     )
 
     global_limiter = get_global_limiter(

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -128,6 +128,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     table_quality = partial(
         analyze_table_quality,
         table_name=str(Path(output).with_suffix("")),
+        destination_dir=Path(output).parent,
     )
 
     global_limiter = get_global_limiter(

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1461,7 +1461,11 @@ def _finalise_export(
         return 1
 
     try:
-        analyze_table_quality(quality_profiler, table_name=str(csv_path.with_suffix("")))
+        analyze_table_quality(
+            quality_profiler,
+            table_name=str(csv_path.with_suffix("")),
+            destination_dir=csv_path.parent,
+        )
     except Exception as exc:
         logger.exception(
             "quality_report_generation_failed",

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1141,7 +1141,11 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 1
     try:
-        analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
+        analyze_table_quality(
+            out_df,
+            table_name=str(output.with_suffix("")),
+            destination_dir=output.parent,
+        )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -1546,8 +1550,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     )
     table_quality = partial(
         analyze_table_quality,
-
         table_name=str(final_output.with_suffix("")),
+        destination_dir=final_output.parent,
     )
 
     metadata_hooks = [add_pipeline_metadata, _prepare_chunk]
@@ -1690,7 +1694,11 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
     try:
-        analyze_table_quality(output, table_name=str(output.with_suffix("")))
+        analyze_table_quality(
+            output,
+            table_name=str(output.with_suffix("")),
+            destination_dir=output.parent,
+        )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -2557,7 +2565,9 @@ def validate_and_write(
     else:
         try:
             analyze_table_quality(
-                final_df, table_name=str(normalized_output.with_suffix(""))
+                final_df,
+                table_name=str(normalized_output.with_suffix("")),
+                destination_dir=normalized_output.parent,
             )
         except Exception as exc:
             logger.exception(

--- a/tests/smoke/test_activity_action_properties_smoke.py
+++ b/tests/smoke/test_activity_action_properties_smoke.py
@@ -44,8 +44,13 @@ def test_activity_action_properties_cli(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         "scripts.get_activity_data.cl.get_activities", lambda *_, **__: df
     )
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
     monkeypatch.setattr(
-        "scripts.get_activity_data.analyze_table_quality", lambda *_, **__: None
+        "scripts.get_activity_data.analyze_table_quality", _capture_quality
     )
     monkeypatch.setattr("scripts.get_activity_data.write_meta_yaml", lambda **__: None)
     monkeypatch.setattr("scripts.get_activity_data.file_sha256", lambda _: "deadbeef")
@@ -71,6 +76,11 @@ def test_activity_action_properties_cli(tmp_path: Path, monkeypatch) -> None:
         ]
     )
     assert exit_code == 0
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert Path(quality_args[0]) == output_csv
+    assert Path(quality_kwargs.get("destination_dir")).resolve() == output_csv.parent.resolve()
 
     result = pd.read_csv(output_csv)
     assert set(["action_type", "activity_properties", "properties_hash"]).issubset(

--- a/tests/smoke/test_get_data_scripts.py
+++ b/tests/smoke/test_get_data_scripts.py
@@ -529,9 +529,12 @@ def test_get_activity_data_smoke(
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_activities", fake_get_activities)
-    monkeypatch.setattr(
-        get_activity_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_activity_data, "analyze_table_quality", _capture_quality)
     monkeypatch.setattr(get_activity_data, "configure_logger", _capture_configure_logger)
     monkeypatch.setattr(
         get_activity_data.cli,
@@ -545,6 +548,11 @@ def test_get_activity_data_smoke(
     assert output_csv.exists()
     assert output_csv.name == f"output.activities_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert quality_args[0] == output_csv
+    assert quality_kwargs.get("destination_dir") == smoke_output_dir
 
     df = pd.read_csv(output_csv)
     assert not df.empty
@@ -599,13 +607,24 @@ def test_get_assay_data_smoke(
 
     monkeypatch.setattr(cl, "get_assays", fake_get_assays)
     monkeypatch.setattr(get_assay_data.ap, "postprocess_assays", lambda df: df)
-    monkeypatch.setattr(get_assay_data, "analyze_table_quality", lambda *_, **__: None)
+
+    assay_quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_assay_quality(*args: object, **kwargs: object) -> None:
+        assay_quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_assay_data, "analyze_table_quality", _capture_assay_quality)
 
     exit_code = get_assay_data.main(_cli_args())
     assert exit_code == 0
     assert output_csv.exists()
     assert output_csv.name == f"output.assays_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
+
+    assert assay_quality_calls, "quality profiler should be invoked"
+    assay_args, assay_kwargs = assay_quality_calls[-1]
+    assert assay_args[0] == output_csv
+    assert assay_kwargs.get("destination_dir") == smoke_output_dir
 
     df = pd.read_csv(output_csv)
     assert not df.empty
@@ -666,9 +685,12 @@ def test_get_document_data_smoke(
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_documents", fake_get_documents)
-    monkeypatch.setattr(
-        get_document_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    document_quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_document_quality(*args: object, **kwargs: object) -> None:
+        document_quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_document_data, "analyze_table_quality", _capture_document_quality)
 
     try:
         exit_code = get_document_data.main(["chembl", *_cli_args()])
@@ -680,6 +702,11 @@ def test_get_document_data_smoke(
     assert output_csv.exists()
     assert output_csv.name == f"output.documents_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
+
+    assert document_quality_calls, "quality profiler should be invoked"
+    document_args, document_kwargs = document_quality_calls[-1]
+    assert document_args[0] == output_csv
+    assert document_kwargs.get("destination_dir") == smoke_output_dir
 
     df = pd.read_csv(output_csv)
     assert not df.empty
@@ -734,7 +761,12 @@ def test_get_target_data_smoke(
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_targets", fake_get_targets)
-    monkeypatch.setattr(get_target_data, "analyze_table_quality", lambda *_, **__: None)
+    target_quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_target_quality(*args: object, **kwargs: object) -> None:
+        target_quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_target_data, "analyze_table_quality", _capture_target_quality)
 
     try:
         exit_code = get_target_data.main(["chembl", *_cli_args()])
@@ -746,6 +778,11 @@ def test_get_target_data_smoke(
     assert output_csv.exists()
     assert output_csv.name == f"output.targets_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
+
+    assert target_quality_calls, "quality profiler should be invoked"
+    target_args, target_kwargs = target_quality_calls[-1]
+    assert target_args[0] == output_csv
+    assert target_kwargs.get("destination_dir") == smoke_output_dir
 
     df = pd.read_csv(output_csv)
     assert not df.empty
@@ -851,8 +888,14 @@ def test_get_testitem_data_smoke(
         "load_parent_catalog",
         lambda **__: {"CHEMBL1": "CHEMBL1_PARENT"},
     )
+
+    testitem_quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_testitem_quality(*args: object, **kwargs: object) -> None:
+        testitem_quality_calls.append((args, kwargs))
+
     monkeypatch.setattr(
-        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
+        get_testitem_data, "analyze_table_quality", _capture_testitem_quality
     )
 
     original_apply = get_testitem_data.cli.apply_config_overrides
@@ -877,6 +920,10 @@ def test_get_testitem_data_smoke(
     assert output_csv.exists()
     assert output_csv.name == f"output.testitems_{DEFAULT_DATE}.csv"
     assert output_csv.parent == smoke_output_dir
+    assert testitem_quality_calls, "quality profiler should be invoked"
+    testitem_args, testitem_kwargs = testitem_quality_calls[-1]
+    assert testitem_args[0] == output_csv
+    assert testitem_kwargs.get("destination_dir") == smoke_output_dir
     assert polymer_smiles not in smiles_calls
     assert mixture_smiles not in smiles_calls
     assert any(event == "pubchem_skip_polymers" for event, _ in warning_events)
@@ -966,14 +1013,22 @@ def test_get_activity_data_force_overrides_skip(
         return pd.DataFrame(rows)
 
     monkeypatch.setattr(cl, "get_activities", fake_get_activities)
-    monkeypatch.setattr(
-        get_activity_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    force_quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_force_quality(*args: object, **kwargs: object) -> None:
+        force_quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_activity_data, "analyze_table_quality", _capture_force_quality)
 
     exit_code = get_activity_data.main(_cli_args("--skip-existing", "--force"))
     assert exit_code == 0
     assert output_csv.exists()
     assert output_csv.read_text() != "sentinel"
+
+    assert force_quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = force_quality_calls[-1]
+    assert quality_args[0] == output_csv
+    assert quality_kwargs.get("destination_dir") == smoke_output_dir
 
 
 def test_run_pipeline_failure_removes_outputs(

--- a/tests/smoke/test_get_testitem_parent.py
+++ b/tests/smoke/test_get_testitem_parent.py
@@ -114,9 +114,12 @@ def test_get_testitem_parent_catalog(
         "update_parent_catalog_cache",
         lambda data, cfg: None,
     )
-    monkeypatch.setattr(
-        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", _capture_quality)
     monkeypatch.setattr(
         get_testitem_data.cli,
         "apply_config_overrides",
@@ -138,6 +141,11 @@ def test_get_testitem_parent_catalog(
 
     assert exit_code == 0
     assert output_csv.exists()
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert Path(quality_args[0]) == output_csv
+    assert Path(quality_kwargs.get("destination_dir")).resolve() == output_csv.parent.resolve()
 
     df = pd.read_csv(output_csv)
     assert "parent_molecule_chembl_id" in df.columns
@@ -222,9 +230,12 @@ def test_get_testitem_skips_parent_lookup_when_present(
         cfg.pubchem.resolve_order = ("smiles",)
         return cfg
 
-    monkeypatch.setattr(
-        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", _capture_quality)
     monkeypatch.setattr(
         get_testitem_data.cli,
         "apply_config_overrides",
@@ -246,6 +257,11 @@ def test_get_testitem_skips_parent_lookup_when_present(
 
     assert exit_code == 0
     assert output_csv.exists()
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert Path(quality_args[0]) == output_csv
+    assert Path(quality_kwargs.get("destination_dir")).resolve() == output_csv.parent.resolve()
 
     df = pd.read_csv(output_csv)
     assert list(df["parent_molecule_chembl_id"]) == ["CHEMBL9001", "CHEMBL9002"]
@@ -318,9 +334,13 @@ def test_get_testitem_refreshes_outdated_parents(
         "update_parent_catalog_cache",
         lambda data, cfg: None,
     )
-    monkeypatch.setattr(
-        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
-    )
+
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", _capture_quality)
     monkeypatch.setattr(get_testitem_data, "query_parent_catalog", lambda *_, **__: {})
 
     def patched_apply_config_overrides(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
@@ -355,6 +375,11 @@ def test_get_testitem_refreshes_outdated_parents(
     assert list(df["parent_molecule_chembl_id"]) == ["CHEMBL9001", "CHEMBL9002"]
     assert fetch_calls and len(fetch_calls) == 1
     assert set(fetch_calls[0]) == {"CHEMBL1", "CHEMBL2"}
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert Path(quality_args[0]) == output_csv
+    assert Path(quality_kwargs.get("destination_dir")).resolve() == output_csv.parent.resolve()
 
 
 CONFIG_CLI_PATH = str(DEFAULT_CONFIG_RELATIVE)

--- a/tests/smoke/test_testitem_salt_flags_smoke.py
+++ b/tests/smoke/test_testitem_salt_flags_smoke.py
@@ -106,9 +106,12 @@ def test_testitem_salt_flags_smoke(
             hierarchy=hierarchy, catalog=catalog
         ),
     )
-    monkeypatch.setattr(
-        get_testitem_data, "analyze_table_quality", lambda *_, **__: None
-    )
+    quality_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _capture_quality(*args: object, **kwargs: object) -> None:
+        quality_calls.append((args, kwargs))
+
+    monkeypatch.setattr(get_testitem_data, "analyze_table_quality", _capture_quality)
 
     exit_code = get_testitem_data.main(
         [
@@ -125,6 +128,11 @@ def test_testitem_salt_flags_smoke(
 
     assert exit_code == 0
     assert output_csv.exists()
+
+    assert quality_calls, "quality profiler should be invoked"
+    quality_args, quality_kwargs = quality_calls[-1]
+    assert Path(quality_args[0]) == output_csv
+    assert Path(quality_kwargs.get("destination_dir")).resolve() == output_csv.parent.resolve()
 
     df = pd.read_csv(output_csv)
     assert {"salt_chembl_id", "natural_product"}.issubset(df.columns)


### PR DESCRIPTION
## Summary
- ensure pipeline table_quality callbacks provide the output directory so reports are colocated with CSV exports
- harden CLI pipelines and document/document activity helpers to pass destination directories to the quality profiler
- extend smoke tests to assert table-quality hooks receive the expected destinations

## Testing
- pytest tests/test_get_activity_data.py::test_run_chembl_integration_with_stubbed_request_json

------
https://chatgpt.com/codex/tasks/task_e_68dea8e01dc88324ba4becafd3c57007