### PR TITLE
Fix retry delay configuration in PubMed client

### DIFF
--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -197,7 +197,7 @@ def _do_request(
             retry_delay = (
                 header_delay
                 if header_delay is not None
-                else _retry_delay(attempt, delay, retry_cfg, timeout)
+                else _retry_delay(attempt, delay, retry_policy, timeout)
             )
             extra["delay"] = retry_delay
             logger.info(event, extra=extra)


### PR DESCRIPTION
## Summary
- ensure the PubMed client computes retry delays using the effective retry policy, even when falling back to the default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deab0fb14c8324ac561e64d910520b