### PR TITLE
Respect doc quality settings in pipeline table quality hooks

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import argparse
 from collections.abc import Iterable, Iterator, Sequence
 from copy import deepcopy
-from functools import partial
 from datetime import date
 from pathlib import Path
 
@@ -49,7 +48,7 @@ from .pubmed import (
 )
 from .rate_limiter import RateLimiter, get_limiter
 from .cli_utils import run_pipeline
-from .table_quality import analyze_table_quality
+from .table_quality import analyze_table_quality, build_pipeline_table_quality_hook
 from .pipeline_metadata import add_pipeline_metadata
 from .normalization import normalize_documents
 from .validation import ValidationResult as SchemaValidationResult
@@ -329,9 +328,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             cfg=cfg,
         )
 
-    table_quality = partial(
-        analyze_table_quality,
+    table_quality = build_pipeline_table_quality_hook(
         table_name=str(output_path.with_suffix("")),
+        output_path=output_path,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
     )
 
     command = " ".join(["pubmed_library"] + (list(argv) if argv else []))

--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -13,13 +13,16 @@ import warnings
 from collections import Counter
 from collections.abc import Iterable, Sized
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from pandas.errors import DtypeWarning
 
 from .log import logger
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from .config import DocQualityCfg, IoCfg
 
 # Precompiled regular expressions for pattern coverage
 _DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
@@ -611,6 +614,84 @@ def analyze_table_quality(
             )
 
     return profiler.build(table_name, destination_dir=destination_dir)
+
+
+def build_pipeline_table_quality_hook(
+    *,
+    table_name: str,
+    output_path: Path | str,
+    doc_quality_cfg: "DocQualityCfg",
+    io_cfg: "IoCfg",
+    analyze_fn: Callable[..., tuple[pd.DataFrame, pd.DataFrame]] = analyze_table_quality,
+) -> Callable[[Path | str | pd.DataFrame | TableQualityProfiler], None]:
+    """Return a pipeline callback for table quality analysis."""
+
+    if not doc_quality_cfg.enable:
+        return lambda *_args, **_kwargs: None
+
+    destination_dir = Path(output_path).resolve().parent
+    sample_rows = doc_quality_cfg.sample_rows
+    include_columns = tuple(doc_quality_cfg.include_columns or ())
+    exclude_columns = tuple(doc_quality_cfg.exclude_columns or ())
+
+    include_set = set(include_columns) if include_columns else None
+    exclude_set = set(exclude_columns) if exclude_columns else None
+
+    def _callback(table: Path | str | pd.DataFrame | TableQualityProfiler) -> None:
+        if isinstance(table, TableQualityProfiler):
+            table_input: pd.DataFrame | Path | str | TableQualityProfiler = table
+            if any((sample_rows, include_set, exclude_set)):
+                logger.warning(
+                    "doc_quality_profiler_filters_ignored",
+                    table_name=table_name,
+                )
+        elif isinstance(table, pd.DataFrame):
+            frame = table.copy()
+            if include_set is not None:
+                missing = sorted(include_set - set(frame.columns))
+                if missing:
+                    logger.warning("include_columns_missing", columns=missing)
+                frame = frame.loc[:, [col for col in frame.columns if col in include_set]]
+            if exclude_set is not None:
+                missing = sorted(exclude_set - set(frame.columns))
+                if missing:
+                    logger.warning("exclude_columns_missing", columns=missing)
+                frame = frame.loc[:, [col for col in frame.columns if col not in exclude_set]]
+            if frame.shape[1] == 0:
+                logger.warning("no_columns_after_filter", table_name=table_name)
+            if sample_rows is not None:
+                frame = frame.head(sample_rows)
+            table_input = frame
+        else:
+            if sample_rows is None and include_set is None and exclude_set is None:
+                table_input = table
+            else:
+                from . import io
+
+                frame = io.read_csv(table, cfg=io_cfg, dtype=str)
+                if include_set is not None:
+                    missing = sorted(include_set - set(frame.columns))
+                    if missing:
+                        logger.warning("include_columns_missing", columns=missing)
+                    frame = frame.loc[:, [col for col in frame.columns if col in include_set]]
+                if exclude_set is not None:
+                    missing = sorted(exclude_set - set(frame.columns))
+                    if missing:
+                        logger.warning("exclude_columns_missing", columns=missing)
+                    frame = frame.loc[:, [col for col in frame.columns if col not in exclude_set]]
+                if frame.shape[1] == 0:
+                    logger.warning("no_columns_after_filter", table_name=table_name)
+                if sample_rows is not None:
+                    frame = frame.head(sample_rows)
+                table_input = frame
+
+        analyze_fn(
+            table_input,
+            table_name=table_name,
+            destination_dir=destination_dir,
+        )
+
+    return _callback
 
 
 if __name__ == "__main__":  # pragma: no cover - illustrative usage

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -34,7 +34,7 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
 from library.rate_limiter import get_global_limiter
 from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.table_quality import analyze_table_quality, build_pipeline_table_quality_hook
 from library.validation import validate_testitems
 from schemas import TestitemsSchema, normalize_testitems
 
@@ -775,8 +775,15 @@ def finalize_output(
         schema="TestitemsSchema",
     )
 
+    table_quality = build_pipeline_table_quality_hook(
+        table_name=str(output.with_suffix("")),
+        output_path=output,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
+    )
     try:
-        analyze_table_quality(csv_path, table_name=str(output.with_suffix("")))
+        table_quality(csv_path)
     except Exception as exc:
         logger.exception(
             "quality_report_failed",

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -71,7 +71,7 @@ from library.processing.activity import (
     compute_activity_bounds,
 )
 from library.rate_limiter import get_global_limiter
-from library.table_quality import analyze_table_quality
+from library.table_quality import analyze_table_quality, build_pipeline_table_quality_hook
 from library.validation import validate_activities
 from schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
 
@@ -221,9 +221,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 
-    table_quality = partial(
-        analyze_table_quality,
+    doc_quality_cfg = cfg.system.doc_quality
+    table_quality = build_pipeline_table_quality_hook(
         table_name=str(Path(output).with_suffix("")),
+        output_path=output,
+        doc_quality_cfg=doc_quality_cfg,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
     )
 
     global_limiter = get_global_limiter(

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -43,7 +43,7 @@ from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.config import Config, _serialize_paths
 from library.log import logger
 from library.pipeline_metadata import add_pipeline_metadata
-from library.table_quality import analyze_table_quality
+from library.table_quality import analyze_table_quality, build_pipeline_table_quality_hook
 from library.validation import validate_assays
 from schemas import AssaysSchema, normalize_assays
 from library.pipeline_helpers import (
@@ -125,9 +125,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     validators = [partial(validate_assays, return_result=True)]
 
-    table_quality = partial(
-        analyze_table_quality,
+    table_quality = build_pipeline_table_quality_hook(
         table_name=str(Path(output).with_suffix("")),
+        output_path=output,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
     )
 
     global_limiter = get_global_limiter(

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -102,7 +102,11 @@ from library.postprocessing.document import preprocess_documents_csv
 from library.pipeline_metadata import add_pipeline_metadata
 from library.rate_limiter import RateLimiter, get_global_limiter, get_limiter
 from library.sidecar import SidecarErrors
-from library.table_quality import TableQualityProfiler, analyze_table_quality
+from library.table_quality import (
+    TableQualityProfiler,
+    analyze_table_quality,
+    build_pipeline_table_quality_hook,
+)
 from schemas import DocumentsSchema, normalize_documents
 
 
@@ -1460,8 +1464,15 @@ def _finalise_export(
         )
         return 1
 
+    table_quality = build_pipeline_table_quality_hook(
+        table_name=str(csv_path.with_suffix("")),
+        output_path=csv_path,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
+    )
     try:
-        analyze_table_quality(quality_profiler, table_name=str(csv_path.with_suffix("")))
+        table_quality(quality_profiler)
     except Exception as exc:
         logger.exception(
             "quality_report_generation_failed",

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -73,7 +73,7 @@ from library.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipeline_metadata import add_pipeline_metadata
 from library.sidecar import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.table_quality import analyze_table_quality, build_pipeline_table_quality_hook
 from library.validation import ValidationResult
 from schemas import TargetsSchema, normalize_targets
 from schemas.targets import TARGETS_COLUMN_ORDER
@@ -1140,8 +1140,15 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             output=str(output),
         )
         return 1
+    table_quality = build_pipeline_table_quality_hook(
+        table_name=str(Path(output).with_suffix("")),
+        output_path=output,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
+    )
     try:
-        analyze_table_quality(out_df, table_name=str(output.with_suffix("")))
+        table_quality(out_df)
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -1544,10 +1551,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     failure_path = normalized_output.with_name(
         f"{normalized_output.stem}_failure_cases.csv"
     )
-    table_quality = partial(
-        analyze_table_quality,
-
+    table_quality = build_pipeline_table_quality_hook(
         table_name=str(final_output.with_suffix("")),
+        output_path=final_output,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
     )
 
     metadata_hooks = [add_pipeline_metadata, _prepare_chunk]
@@ -1689,8 +1698,15 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
+    table_quality = build_pipeline_table_quality_hook(
+        table_name=str(Path(output).with_suffix("")),
+        output_path=output,
+        doc_quality_cfg=cfg.system.doc_quality,
+        io_cfg=cfg.io,
+        analyze_fn=analyze_table_quality,
+    )
     try:
-        analyze_table_quality(output, table_name=str(output.with_suffix("")))
+        table_quality(output)
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -2555,10 +2571,15 @@ def validate_and_write(
             table=str(normalized_output.with_suffix("")),
         )
     else:
+        table_quality = build_pipeline_table_quality_hook(
+            table_name=str(normalized_output.with_suffix("")),
+            output_path=normalized_output,
+            doc_quality_cfg=cfg.system.doc_quality,
+            io_cfg=cfg.io,
+            analyze_fn=analyze_table_quality,
+        )
         try:
-            analyze_table_quality(
-                final_df, table_name=str(normalized_output.with_suffix(""))
-            )
+            table_quality(final_df)
         except Exception as exc:
             logger.exception(
                 "quality_report_failed",


### PR DESCRIPTION
## Summary
- add a helper that builds pipeline table quality callbacks honoring doc_quality configuration
- update activity, assay, document, target, test item, and pubmed flows to use the helper and respect sampling/filter options

## Testing
- pytest tests/test_table_quality.py
- pytest tests/test_get_activity_data.py::test_run_chembl_integration_with_stubbed_request_json

------
https://chatgpt.com/codex/tasks/task_e_68dea8e46c688324bca72ce0b7a0a222