### PR TITLE
Respect doc quality settings in table profiling

### DIFF
--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -329,11 +329,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             cfg=cfg,
         )
 
-    table_quality = partial(
-        analyze_table_quality,
-        table_name=str(output_path.with_suffix("")),
-        destination_dir=output_path.parent,
-    )
+    doc_quality_cfg = cfg.system.doc_quality
+    if doc_quality_cfg.enable:
+        table_quality = partial(
+            analyze_table_quality,
+            table_name=str(output_path.with_suffix("")),
+            destination_dir=output_path.parent,
+            sample_rows=doc_quality_cfg.sample_rows,
+            include_columns=doc_quality_cfg.include_columns,
+            exclude_columns=doc_quality_cfg.exclude_columns,
+        )
+    else:
+        def table_quality(_: Path) -> None:
+            return None
 
     command = " ".join(["pubmed_library"] + (list(argv) if argv else []))
     config_snapshot = _serialize_paths(cfg.to_dict())

--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections import Counter
-from collections.abc import Iterable, Sized
+from collections.abc import Iterable, Sequence, Sized
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +62,66 @@ def _load_table(table: pd.DataFrame | str | Path) -> pd.DataFrame:
             logger.debug("failed to decode %s with %s", path, enc)
             continue
     raise UnicodeDecodeError("utf-8", b"", 0, 1, "Unable to decode CSV")
+
+
+def _apply_sampling_and_filters(
+    frame: pd.DataFrame,
+    *,
+    table_name: str,
+    sample_rows: int | None,
+    include_columns: tuple[str, ...] | None,
+    exclude_columns: tuple[str, ...] | None,
+    include_warning_logged: list[bool],
+    exclude_warning_logged: list[bool],
+    no_columns_logged: list[bool],
+) -> tuple[pd.DataFrame, int | None]:
+    """Apply row sampling and column filters to ``frame``."""
+
+    remaining: int | None = sample_rows
+    filtered = frame
+    if remaining is not None:
+        if remaining <= 0:
+            return frame.iloc[0:0], 0
+        filtered = filtered.head(remaining)
+
+    if include_columns:
+        missing = sorted(set(include_columns) - set(frame.columns))
+        if missing and not include_warning_logged[0]:
+            logger.warning(
+                "include_columns_missing",
+                columns=missing,
+                table_name=table_name,
+            )
+            include_warning_logged[0] = True
+        include_set = set(include_columns)
+        filtered = filtered.loc[:, [col for col in filtered.columns if col in include_set]]
+
+    if exclude_columns:
+        missing = sorted(set(exclude_columns) - set(frame.columns))
+        if missing and not exclude_warning_logged[0]:
+            logger.warning(
+                "exclude_columns_missing",
+                columns=missing,
+                table_name=table_name,
+            )
+            exclude_warning_logged[0] = True
+        exclude_set = set(exclude_columns)
+        filtered = filtered.loc[
+            :, [col for col in filtered.columns if col not in exclude_set]
+        ]
+
+    if (
+        (include_columns or exclude_columns)
+        and filtered.shape[1] == 0
+        and not no_columns_logged[0]
+    ):
+        logger.warning("no_columns_after_filter", table_name=table_name)
+        no_columns_logged[0] = True
+
+    if remaining is not None:
+        remaining = max(remaining - len(filtered), 0)
+
+    return filtered, remaining
 
 
 def _is_isbn(value: str) -> bool:
@@ -565,6 +625,9 @@ def analyze_table_quality(
     table_name: str,
     *,
     destination_dir: Path | str | None = None,
+    sample_rows: int | None = None,
+    include_columns: Sequence[str] | None = None,
+    exclude_columns: Sequence[str] | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Profile ``table`` and compute correlations for numeric columns.
 
@@ -588,23 +651,71 @@ def analyze_table_quality(
     # level import was stripped by the execution environment.
     import pandas as pd
 
+    include_tuple: tuple[str, ...] | None = (
+        tuple(include_columns)
+        if include_columns is not None
+        else None
+    )
+    exclude_tuple: tuple[str, ...] | None = (
+        tuple(exclude_columns)
+        if exclude_columns is not None
+        else None
+    )
+
+    include_warning_logged = [False]
+    exclude_warning_logged = [False]
+    no_columns_logged = [False]
+
     profiler: TableQualityProfiler
     if isinstance(table, TableQualityProfiler):
         profiler = table
     else:
         profiler = TableQualityProfiler()
         if isinstance(table, pd.DataFrame):
-            profiler.consume(table)
+            filtered, _ = _apply_sampling_and_filters(
+                table,
+                table_name=table_name,
+                sample_rows=sample_rows,
+                include_columns=include_tuple,
+                exclude_columns=exclude_tuple,
+                include_warning_logged=include_warning_logged,
+                exclude_warning_logged=exclude_warning_logged,
+                no_columns_logged=no_columns_logged,
+            )
+            profiler.consume(filtered)
         elif isinstance(table, (str, Path)):
             df = _load_table(table)
-            profiler.consume(df)
+            filtered, _ = _apply_sampling_and_filters(
+                df,
+                table_name=table_name,
+                sample_rows=sample_rows,
+                include_columns=include_tuple,
+                exclude_columns=exclude_tuple,
+                include_warning_logged=include_warning_logged,
+                exclude_warning_logged=exclude_warning_logged,
+                no_columns_logged=no_columns_logged,
+            )
+            profiler.consume(filtered)
         elif isinstance(table, Iterable):
+            remaining = sample_rows
             for frame in table:
                 if not isinstance(frame, pd.DataFrame):
                     raise TypeError(
                         "Streaming quality analysis requires pandas DataFrame chunks"
                     )
-                profiler.consume(frame)
+                filtered, remaining = _apply_sampling_and_filters(
+                    frame,
+                    table_name=table_name,
+                    sample_rows=remaining,
+                    include_columns=include_tuple,
+                    exclude_columns=exclude_tuple,
+                    include_warning_logged=include_warning_logged,
+                    exclude_warning_logged=exclude_warning_logged,
+                    no_columns_logged=no_columns_logged,
+                )
+                profiler.consume(filtered)
+                if remaining is not None and remaining <= 0:
+                    break
         else:
             raise TypeError(
                 "Unsupported table type. Expected DataFrame, path or chunk iterable."

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -775,12 +775,17 @@ def finalize_output(
         schema="TestitemsSchema",
     )
 
+    doc_quality_cfg = cfg.system.doc_quality
     try:
-        analyze_table_quality(
-            csv_path,
-            table_name=str(output.with_suffix("")),
-            destination_dir=output.parent,
-        )
+        if doc_quality_cfg.enable:
+            analyze_table_quality(
+                csv_path,
+                table_name=str(output.with_suffix("")),
+                destination_dir=output.parent,
+                sample_rows=doc_quality_cfg.sample_rows,
+                include_columns=doc_quality_cfg.include_columns,
+                exclude_columns=doc_quality_cfg.exclude_columns,
+            )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -104,12 +104,18 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("generate_quality_reports")
         report_dir = out_dir / "data_validity_report"
         report_dir.mkdir(parents=True, exist_ok=True)
+        doc_quality_cfg = cfg.system.doc_quality
         for entity, path in paths.items():
             logger.info("profiling", entity=entity)
+            if not doc_quality_cfg.enable:
+                continue
             analyze_table_quality(
                 path,
                 table_name=path.stem,
                 destination_dir=report_dir,
+                sample_rows=doc_quality_cfg.sample_rows,
+                include_columns=doc_quality_cfg.include_columns,
+                exclude_columns=doc_quality_cfg.exclude_columns,
             )
 
         logger.info("save_done", tables=len(paths), path=str(out_dir))

--- a/library/utils/cli_tools/table_quality_main.py
+++ b/library/utils/cli_tools/table_quality_main.py
@@ -77,28 +77,6 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         if exclude_columns is None:
             exclude_columns = doc_cfg.exclude_columns
 
-        if sample_rows is not None:
-            df = df.head(sample_rows)
-
-        include_columns = tuple(include_columns) if include_columns else None
-        exclude_columns = tuple(exclude_columns) if exclude_columns else None
-
-        if include_columns is not None:
-            missing = sorted(set(include_columns) - set(df.columns))
-            if missing:
-                logger.warning("include_columns_missing", columns=missing)
-            df = df.loc[:, [col for col in df.columns if col in include_columns]]
-
-        if exclude_columns is not None:
-            missing = sorted(set(exclude_columns) - set(df.columns))
-            if missing:
-                logger.warning("exclude_columns_missing", columns=missing)
-            excluded = set(exclude_columns)
-            df = df.loc[:, [col for col in df.columns if col not in excluded]]
-
-        if df.shape[1] == 0:
-            logger.warning("no_columns_after_filter", table_name=args.table_name)
-
         output_dir = args.output_csv
 
         if output_dir.suffix:
@@ -132,6 +110,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             df,
             table_name=args.table_name,
             destination_dir=destination_dir,
+            sample_rows=sample_rows,
+            include_columns=include_columns,
+            exclude_columns=exclude_columns,
         )
         return 0
     except Exception as exc:  # pragma: no cover - defensive

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -221,11 +221,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 
-    table_quality = partial(
-        analyze_table_quality,
-        table_name=str(Path(output).with_suffix("")),
-        destination_dir=Path(output).parent,
-    )
+    doc_quality_cfg = cfg.system.doc_quality
+    if doc_quality_cfg.enable:
+        table_quality = partial(
+            analyze_table_quality,
+            table_name=str(Path(output).with_suffix("")),
+            destination_dir=Path(output).parent,
+            sample_rows=doc_quality_cfg.sample_rows,
+            include_columns=doc_quality_cfg.include_columns,
+            exclude_columns=doc_quality_cfg.exclude_columns,
+        )
+    else:
+        def table_quality(_: Path) -> None:
+            return None
 
     global_limiter = get_global_limiter(
         cfg.rate.global_rps,

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -125,11 +125,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     validators = [partial(validate_assays, return_result=True)]
 
-    table_quality = partial(
-        analyze_table_quality,
-        table_name=str(Path(output).with_suffix("")),
-        destination_dir=Path(output).parent,
-    )
+    doc_quality_cfg = cfg.system.doc_quality
+    if doc_quality_cfg.enable:
+        table_quality = partial(
+            analyze_table_quality,
+            table_name=str(Path(output).with_suffix("")),
+            destination_dir=Path(output).parent,
+            sample_rows=doc_quality_cfg.sample_rows,
+            include_columns=doc_quality_cfg.include_columns,
+            exclude_columns=doc_quality_cfg.exclude_columns,
+        )
+    else:
+        def table_quality(_: Path) -> None:
+            return None
 
     global_limiter = get_global_limiter(
         cfg.rate.global_rps,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1460,12 +1460,17 @@ def _finalise_export(
         )
         return 1
 
+    doc_quality_cfg = cfg.system.doc_quality
     try:
-        analyze_table_quality(
-            quality_profiler,
-            table_name=str(csv_path.with_suffix("")),
-            destination_dir=csv_path.parent,
-        )
+        if doc_quality_cfg.enable:
+            analyze_table_quality(
+                quality_profiler,
+                table_name=str(csv_path.with_suffix("")),
+                destination_dir=csv_path.parent,
+                sample_rows=doc_quality_cfg.sample_rows,
+                include_columns=doc_quality_cfg.include_columns,
+                exclude_columns=doc_quality_cfg.exclude_columns,
+            )
     except Exception as exc:
         logger.exception(
             "quality_report_generation_failed",

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1140,12 +1140,17 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             output=str(output),
         )
         return 1
+    doc_quality_cfg = cfg.system.doc_quality
     try:
-        analyze_table_quality(
-            out_df,
-            table_name=str(output.with_suffix("")),
-            destination_dir=output.parent,
-        )
+        if doc_quality_cfg.enable:
+            analyze_table_quality(
+                out_df,
+                table_name=str(output.with_suffix("")),
+                destination_dir=output.parent,
+                sample_rows=doc_quality_cfg.sample_rows,
+                include_columns=doc_quality_cfg.include_columns,
+                exclude_columns=doc_quality_cfg.exclude_columns,
+            )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -1548,11 +1553,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     failure_path = normalized_output.with_name(
         f"{normalized_output.stem}_failure_cases.csv"
     )
-    table_quality = partial(
-        analyze_table_quality,
-        table_name=str(final_output.with_suffix("")),
-        destination_dir=final_output.parent,
-    )
+    doc_quality_cfg = cfg.system.doc_quality
+    if doc_quality_cfg.enable:
+        table_quality = partial(
+            analyze_table_quality,
+            table_name=str(final_output.with_suffix("")),
+            destination_dir=final_output.parent,
+            sample_rows=doc_quality_cfg.sample_rows,
+            include_columns=doc_quality_cfg.include_columns,
+            exclude_columns=doc_quality_cfg.exclude_columns,
+        )
+    else:
+        def table_quality(_: Path) -> None:
+            return None
 
     metadata_hooks = [add_pipeline_metadata, _prepare_chunk]
     if not normalize_at_export:
@@ -1693,12 +1706,17 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
+    doc_quality_cfg = cfg.system.doc_quality
     try:
-        analyze_table_quality(
-            output,
-            table_name=str(output.with_suffix("")),
-            destination_dir=output.parent,
-        )
+        if doc_quality_cfg.enable:
+            analyze_table_quality(
+                output,
+                table_name=str(output.with_suffix("")),
+                destination_dir=output.parent,
+                sample_rows=doc_quality_cfg.sample_rows,
+                include_columns=doc_quality_cfg.include_columns,
+                exclude_columns=doc_quality_cfg.exclude_columns,
+            )
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -2603,12 +2621,17 @@ def validate_and_write(
             table=str(normalized_output.with_suffix("")),
         )
     else:
+        doc_quality_cfg = cfg.system.doc_quality
         try:
-            analyze_table_quality(
-                final_df,
-                table_name=str(normalized_output.with_suffix("")),
-                destination_dir=normalized_output.parent,
-            )
+            if doc_quality_cfg.enable:
+                analyze_table_quality(
+                    final_df,
+                    table_name=str(normalized_output.with_suffix("")),
+                    destination_dir=normalized_output.parent,
+                    sample_rows=doc_quality_cfg.sample_rows,
+                    include_columns=doc_quality_cfg.include_columns,
+                    exclude_columns=doc_quality_cfg.exclude_columns,
+                )
         except Exception as exc:
             logger.exception(
                 "quality_report_failed",

--- a/tests/test_activity_cli_overrides.py
+++ b/tests/test_activity_cli_overrides.py
@@ -81,7 +81,9 @@ def _run(
 
     monkeypatch.setattr(cl, "get_activities", fake_get)
     monkeypatch.setattr(io, "write_csv", fake_write)
-    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gad, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gad, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gad, "write_meta_yaml", lambda **__: None)
     rc = gad.main(["--config", str(config_path), "--input", str(input_csv), *extra])

--- a/tests/test_cli_timeout_override.py
+++ b/tests/test_cli_timeout_override.py
@@ -84,7 +84,9 @@ def test_assay_timeout_override(
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
     )
-    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gas, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gas, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gas, "write_meta_yaml", lambda **__: None)
     rc = gas.main(
@@ -143,7 +145,9 @@ def test_document_timeout_override(
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
     )
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     rc = gdd.main(
@@ -216,7 +220,9 @@ def test_testitem_timeout_override(
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
     )
-    monkeypatch.setattr(gtdt, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gtdt, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gtdt, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gtdt, "write_meta_yaml", lambda **__: None)
     rc = gtdt.main(
@@ -275,7 +281,9 @@ def test_target_timeout_override(
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
     )
-    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gtd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **__: None)
     rc = gtd.main(
@@ -335,7 +343,9 @@ def test_target_chunk_size_override(
         "write_csv",
         lambda df, path, *, cfg, sep=None, encoding=None, **k: path,
     )
-    monkeypatch.setattr(gtd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gtd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gtd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gtd, "write_meta_yaml", lambda **__: None)
     rc = gtd.main(

--- a/tests/test_document_pipeline.py
+++ b/tests/test_document_pipeline.py
@@ -638,7 +638,9 @@ def test_finalise_export_streams_single_pass(
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **_: None)
     monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     exit_code = gdd._finalise_export(
         df,
 

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -74,7 +74,9 @@ def test_run_chembl_respects_limit(
         return path
 
     monkeypatch.setattr(gad, "write_csv_chunks_deterministic", fake_write_chunks)
-    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gad, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -135,7 +137,9 @@ def test_run_chembl_column_order(
     )
 
     monkeypatch.setattr(cl, "get_activities", lambda *_, **__: df)
-    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gad, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -228,7 +232,9 @@ def test_run_chembl_streams_large_output(
         "validate_activities",
         lambda df, return_result: _Result(df),
     )
-    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gad, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -318,7 +324,9 @@ def test_run_chembl_writer_missing_output(
         lambda df, return_result: _Result(df),
     )
 
-    monkeypatch.setattr(gad, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gad, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 

--- a/tests/test_get_assay_data.py
+++ b/tests/test_get_assay_data.py
@@ -35,7 +35,9 @@ def test_run_chembl_orders_columns(
     )
     monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
     monkeypatch.setattr(gas.ap, "postprocess_assays", lambda df: df)
-    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gas, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -106,7 +108,9 @@ def test_run_chembl_streams_chunks_and_applies_hooks(
         return _Result(frame)
 
     monkeypatch.setattr(gas, "validate_assays", fake_validate)
-    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gas, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -212,7 +216,9 @@ def test_run_chembl_processes_multiple_chunks(
         return _Result(frame)
 
     monkeypatch.setattr(gas, "validate_assays", fake_validate)
-    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gas, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 
@@ -271,7 +277,9 @@ def test_run_chembl_sorts_output_deterministically(
 
     monkeypatch.setattr(cl, "get_assays", lambda *_, **__: df)
     monkeypatch.setattr(gas.ap, "postprocess_assays", lambda frame: frame)
-    monkeypatch.setattr(gas, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gas, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(cli_utils, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(cli_utils, "file_sha256", lambda p: "deadbeef")
 

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -128,7 +128,9 @@ def test_cli_uses_custom_column(
     monkeypatch.setattr(gdd, "_write_export_chunks", fake_write_export_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
     monkeypatch.setattr(gdd, "ensure_dirs", lambda cfg: None)
@@ -911,7 +913,9 @@ def test_write_csv_column_order(
     monkeypatch.setattr(gdd, "write_csv_chunks_deterministic", fake_write_csv_chunks)
     monkeypatch.setattr(gdd, "file_sha256", lambda p: "deadbeef")
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
     monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
 
@@ -2105,7 +2109,9 @@ def test_finalise_export_falls_back_to_default_key(
     monkeypatch.setattr(gdd, "write_meta_yaml", lambda **__: None)
     monkeypatch.setattr(gdd, "build_quality_report", lambda *_, **__: {})
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(gdd.DocumentsSchema, "validate", lambda frame, lazy=True: frame)
 
     exit_code = gdd._finalise_export(
@@ -2295,7 +2301,9 @@ def test_finalise_export_accepts_generator(
 
     monkeypatch.setattr(gdd, "build_quality_report", fake_build_report)
     monkeypatch.setattr(gdd, "save_quality_report", lambda report, path: path)
-    monkeypatch.setattr(gdd, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        gdd, "analyze_table_quality", lambda df, table_name, **_: None
+    )
 
     exit_code = gdd._finalise_export(
         iter(frames),

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -756,7 +756,9 @@ def test_finalize_output_streams_sorted_chunks(
     monkeypatch.setattr(pd.DataFrame, "to_csv", spy_to_csv)
     monkeypatch.setattr(pipeline, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(pipeline, "file_sha256", lambda path: "hash")
-    monkeypatch.setattr(pipeline, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        pipeline, "analyze_table_quality", lambda df, table_name, **_: None
+    )
 
     exit_code = pipeline.finalize_output(
         [df],
@@ -1682,7 +1684,9 @@ def test_run_chembl_column_order(
     monkeypatch.setattr(
         pipeline, "attach_parent_molecule_ids", fake_attach_parent_molecule_ids
     )
-    monkeypatch.setattr(pipeline, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        pipeline, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(pipeline, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(pipeline, "file_sha256", lambda p: "deadbeef")
 
@@ -1864,7 +1868,9 @@ def test_run_chembl_initialises_pubchem_session(
         "write_csv",
         lambda df, path, *, cfg, key_cols=None, col_order=None, **__: path,
     )
-    monkeypatch.setattr(pipeline, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        pipeline, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(pipeline, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(pipeline, "file_sha256", lambda path: "deadbeef")
 
@@ -2044,7 +2050,9 @@ def test_run_chembl_calls_pubchem_once(
         "write_csv",
         lambda frame, path, *, cfg, key_cols=None, col_order=None, **__: path,
     )
-    monkeypatch.setattr(pipeline, "analyze_table_quality", lambda df, table_name: None)
+    monkeypatch.setattr(
+        pipeline, "analyze_table_quality", lambda df, table_name, **_: None
+    )
     monkeypatch.setattr(pipeline, "write_meta_yaml", lambda **kwargs: None)
     monkeypatch.setattr(pipeline, "file_sha256", lambda path: "deadbeef")
 


### PR DESCRIPTION
## Summary
- extend `analyze_table_quality` to support configuration-driven sampling and column filters used by doc quality tooling
- gate pipeline table-quality callbacks on `doc_quality.enable` while forwarding sampling and filter options across CLI helpers and data pipelines

## Testing
- pytest tests/test_table_quality.py
- pytest tests/test_get_activity_data.py::test_run_chembl_integration_with_stubbed_request_json

------
https://chatgpt.com/codex/tasks/task_e_68deac6399b8832483916486b8492d23