### PR TITLE
Fix duplicate column merge logic to avoid pandas FutureWarning

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1073,6 +1073,31 @@ def _collapse_duplicate_columns(frame: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(collapsed_columns, index=frame.index)
 
 
+def _merge_preferred_series(target_series: pd.Series, source_series: pd.Series) -> pd.Series:
+    """Return ``target_series`` with missing entries populated from ``source_series``."""
+
+    if target_series.empty and source_series.empty:
+        return target_series.copy()
+
+    if not target_series.index.equals(source_series.index):
+        source_series = source_series.reindex(target_series.index)
+
+    combined = target_series.copy()
+
+    missing_mask = target_series.isna()
+    if missing_mask.any():
+        combined.loc[missing_mask] = source_series.loc[missing_mask]
+
+    if pd.api.types.is_object_dtype(target_series.dtype) or pd.api.types.is_string_dtype(
+        target_series.dtype
+    ):
+        empty_mask = target_series.fillna("").eq("")
+        if empty_mask.any():
+            combined.loc[empty_mask] = source_series.loc[empty_mask]
+
+    return combined
+
+
 def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Rename and project columns to match the export schema."""
 
@@ -1089,15 +1114,7 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
         if target in frame.columns:
             target_series = _resolve_duplicate_column(frame, target)
             source_series = _resolve_duplicate_column(frame, source)
-            combined = target_series.combine_first(source_series)
-            if pd.api.types.is_object_dtype(target_series.dtype) or pd.api.types.is_string_dtype(
-                target_series.dtype
-            ):
-                mask = target_series.fillna("").eq("")
-                if mask.any():
-                    combined.loc[mask] = source_series.loc[mask]
-
-            frame[target] = combined
+            frame[target] = _merge_preferred_series(target_series, source_series)
             frame = frame.drop(columns=[source])
             continue
         rename_map[source] = target

--- a/tests/test_get_document_data.py
+++ b/tests/test_get_document_data.py
@@ -953,6 +953,30 @@ def test_prepare_export_frame_merges_duplicate_columns() -> None:
     assert result.loc[1, "ChEMBL.abstract"] == "fallback abstract"
 
 
+def test_merge_preferred_series_prioritizes_existing_values() -> None:
+    """Preferred-series merge should keep existing data before falling back."""
+
+    target = pd.Series(["keep", None, ""], dtype=object)
+    source = pd.Series(["alt", "fallback", "replacement"], dtype=object)
+
+    result = gdd._merge_preferred_series(target, source)
+
+    assert result.tolist() == ["keep", "fallback", "replacement"]
+
+
+def test_merge_preferred_series_aligns_on_index() -> None:
+    """Preferred-series merge should respect the target index order."""
+
+    target = pd.Series([1.5, float("nan")], index=[0, 1], dtype=float)
+    source = pd.Series([7.7], index=[1], dtype=float)
+
+    result = gdd._merge_preferred_series(target, source)
+
+    assert result.index.tolist() == [0, 1]
+    assert result.iloc[0] == pytest.approx(1.5)
+    assert result.iloc[1] == pytest.approx(7.7)
+
+
 def test_fetch_pubmed_records_handles_generic_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- replace the duplicate column merge step with a helper that does not rely on pandas combine_first
- ensure export preparation reuses the helper and extend coverage for the new behavior

## Testing
- pytest tests/test_get_document_data.py -k "merge_preferred_series or prepare_export_frame_merges_duplicate_columns"

------
https://chatgpt.com/codex/tasks/task_e_68deaeda9de0832489b12d7579745860