### PR TITLE
Align document export post-processing with Stage output

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -18,10 +18,10 @@ from typing import Any, Mapping
 import numpy as np
 import pandas as pd
 
+from .. import document_postprocessing as stage_document_postprocessing
 from ..config import IoCfg
 from ..csv_utils import write_csv_deterministic
 from ..log import logger
-from ..validation import validate_columns
 
 # ===== Parameters ===========================================================
 UTF8_ENCODING = "utf-8"
@@ -198,7 +198,7 @@ PREPROCESSED_COLUMN_ORDER: tuple[str, ...] = (
     "date_code",
     "Index",
 )
-DEFAULT_KEY_COLUMNS: tuple[str, ...] = ("document_chembl_id",)
+DEFAULT_KEY_COLUMNS: tuple[str, ...] = ("completed", "document_chembl_id")
 
 
 # ===== Helpers ==============================================================
@@ -439,99 +439,39 @@ def _ensure_document_identifier(frame: pd.DataFrame) -> pd.DataFrame:
     return fallback
 
 
-def preprocess_document_export(df: pd.DataFrame) -> pd.DataFrame:
-    """Return analytics-oriented projection of ``df``."""
+def preprocess_document_export(
+    df: pd.DataFrame,
+    *,
+    ref_document: pd.DataFrame | None = None,
+    ref_document_path: Path | str | None = None,
+) -> pd.DataFrame:
+    """Return the Stage-aligned projection of ``df``.
 
+    This is a thin wrapper around :func:`library.document_postprocessing.postprocess_documents`
+    that preserves the legacy entry point used by :mod:`scripts.get_document_data`.
+    The resulting frame strictly follows :data:`FINAL_COLUMN_ORDER` defined in the
+    Stage port and omits analytics-only helper columns (``preferred_*``,
+    ``coverage_*`` and similar aggregates).
+    """
 
+    processed = stage_document_postprocessing.postprocess_documents(
+        df,
+        ref_document=ref_document,
+        ref_document_path=ref_document_path,
+    )
 
-    frame = _apply_export_aliases(df)
-
-
-    validate_columns(frame, REQUIRED_INPUT_COLUMNS)
-    if frame.empty:
-        result = pd.DataFrame(columns=list(PREPROCESSED_COLUMN_ORDER))
-        return result
-
-    result = pd.DataFrame(index=frame.index)
-    result["document_chembl_id"] = _string_series(frame["document_chembl_id"])
-
-    for target, columns in COALESCE_PRIORITIES.items():
-        result[target] = _coalesce_columns(frame, columns)
-
-    if "publication_class" in frame.columns:
-        result["publication_class"] = _string_series(frame["publication_class"])
-    else:
-        result["publication_class"] = pd.Series(
-            [""] * len(frame), index=frame.index, dtype="string"
-        )
-
-    review_series = pd.Series([False] * len(frame), index=frame.index)
-    if "publication_class" in result.columns:
-        review_series = review_series | (
-            result["publication_class"].str.lower() == "review"
-        )
-    for column in REVIEW_COLUMNS:
-        if column in frame.columns:
-            review_series = review_series | _series_to_bool(frame[column])
-    result["is_review"] = review_series
-
-    metadata_series, metadata_flags = _build_metadata_flags(frame)
-    result["metadata_sources"] = metadata_series
-    result["metadata_source_count"] = metadata_flags.pop("metadata_source_count")
-    for column, mask in metadata_flags.items():
-        result[column] = mask
-
-    error_sources, has_error = _build_error_sources(frame)
-    result["error_sources"] = error_sources
-    result["has_error"] = has_error
-
-    result["coverage_score"] = result["metadata_source_count"].astype("Int64")
-    status_values = [
-        _coverage_status(int(score) if pd.notna(score) else 0, bool(error))
-        for score, error in zip(
-            result["coverage_score"].fillna(0), result["has_error"].fillna(False)
-        )
+    missing_columns = [
+        column
+        for column in stage_document_postprocessing.FINAL_COLUMN_ORDER
+        if column not in processed.columns
     ]
-    result["coverage_status"] = pd.Series(status_values, index=df.index, dtype="string")
-
-    mesh_columns = [column for column in MESH_TERM_COLUMNS if column in frame.columns]
-    result["mesh_terms"] = _aggregate_terms(frame, mesh_columns)
-
-    if "publication_year" in result.columns:
-        publication_year = result["publication_year"].replace("", pd.NA)
-        result["publication_year"] = pd.to_numeric(
-            publication_year, errors="coerce"
-        ).astype("Int64")
-    else:
-        result["publication_year"] = pd.Series(
-            [pd.NA] * len(frame), index=frame.index, dtype="Int64"
+    if missing_columns:
+        raise ValueError(
+            "Stage post-processing did not return the expected column set",
+            missing_columns,
         )
 
-    for column in PASS_THROUGH_COLUMNS:
-        if column not in frame.columns:
-            if column == "Index":
-                result[column] = pd.Series(
-                    [""] * len(frame), index=frame.index, dtype="string"
-                )
-            else:
-                result[column] = pd.Series(
-                    [""] * len(frame), index=frame.index, dtype="string"
-                )
-            continue
-        if column == "Index":
-            index_series = frame[column]
-            if pd.api.types.is_numeric_dtype(index_series):
-                padded = index_series.fillna(0).astype(int).astype(str)
-            else:
-                padded = _string_series(index_series)
-            result[column] = padded.str.zfill(INDEX_PAD_WIDTH)
-        else:
-            result[column] = _string_series(frame[column])
-
-    existing_columns = [
-        column for column in PREPROCESSED_COLUMN_ORDER if column in result.columns
-    ]
-    return result.loc[:, existing_columns]
+    return processed.loc[:, stage_document_postprocessing.FINAL_COLUMN_ORDER]
 
 
 def postprocess_export_file(
@@ -541,8 +481,10 @@ def postprocess_export_file(
     output_path: Path | None = None,
     sep: str | None = None,
     encoding: str | None = None,
+    ref_document: pd.DataFrame | None = None,
+    ref_document_path: Path | str | None = None,
 ) -> Path:
-    """Read ``input_path``, project the analytics table and write to disk."""
+    """Read ``input_path`` and materialise the Stage-aligned projection."""
 
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding or UTF8_ENCODING
@@ -553,12 +495,20 @@ def postprocess_export_file(
         dtype=str,
         keep_default_na=False,
     )
-    processed = preprocess_document_export(frame)
+    processed = preprocess_document_export(
+        frame,
+        ref_document=ref_document,
+        ref_document_path=ref_document_path,
+    )
     destination = Path(output_path) if output_path else Path(input_path).with_name(
         f"{DEFAULT_OUTPUT_PREFIX}{Path(input_path).name}"
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
-    col_order = [col for col in PREPROCESSED_COLUMN_ORDER if col in processed.columns]
+    col_order = [
+        column
+        for column in stage_document_postprocessing.FINAL_COLUMN_ORDER
+        if column in processed.columns
+    ]
     write_csv_deterministic(
         processed,
         destination,
@@ -569,6 +519,7 @@ def postprocess_export_file(
         cfg=None,
     )
     return destination
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_document_export_postprocessing.py
+++ b/tests/test_document_export_postprocessing.py
@@ -1,121 +1,85 @@
-"""Tests for :mod:`library.postprocessing.document`."""
-
-from __future__ import annotations
-
 from pathlib import Path
 
 import pandas as pd
 
+from library import document_postprocessing as dp
 from library.config import IoCfg
 from library.postprocessing import document as document_export_postprocessing
 
 
-def _sample_dataframe() -> pd.DataFrame:
-    return pd.DataFrame(
-        {
-            "document_chembl_id": ["DOC1", "DOC2"],
-            "title": ["Title A", ""],
-            "PubMed.ArticleTitle": ["", "PubMed Title"],
-            "abstract": ["", "Abstract B"],
-            "PubMed.Abstract": ["Abstract A", ""],
-            "doi_normalised": ["10.1000/foo", ""],
-            "PubMed.DOI": ["", "10.1000/bar"],
-            "pubmed_id": ["100", ""],
-            "PubMed.PMID": ["", "200"],
-            "year": ["2021", ""],
-            "PubMed.YearCompleted": ["", "2018"],
-            "journal": ["Journal A", ""],
-            "PubMed.JournalTitle": ["", "Journal B"],
-            "publication_class": ["experimental", "review"],
-            "PubMed.is_review": [False, True],
-            "OpenAlex.is_review": [False, False],
-            "scholar.is_review": [False, False],
-            "PubMed.MeSH_Descriptors": ["Term1; Term2", ""],
-            "OpenAlex.MeshDescriptors": ["", "Term3"],
-            "PubMed.MeSH_Qualifiers": ["", "Qual1"],
-            "fetch_status": ["ok", "error"],
-            "error_source": ["", "pubmed"],
-            "PubMed.Error": ["", "Timeout"],
-            "scholar.Error": ["", ""],
-            "OpenAlex.Error": ["", ""],
-            "crossref.Error": ["", ""],
-            "date_code": ["2021-01-01", "2018-05-01"],
-            "Index": ["0000", "0001"],
-            "authors": ["A; B", "C"],
-            "source": ["chembl", "chembl"],
-            "pipeline_version": ["1.0", "1.0"],
-            "timestamp_utc": ["2024-01-01T00:00:00Z", "2024-01-01T00:00:00Z"],
-        }
+FIXTURE_DIR = Path("tests/data/postprocessing_document")
+
+BOOL_COLUMNS = {
+    "review",
+    "experimental",
+    "document_contains_external_links",
+    "invalid",
+    "invalid.doi",
+    "invalid.PMID",
+    "invalid.reference",
+}
+
+
+def _frame_from_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, dtype=str)
+
+
+def _normalise_strings(df: pd.DataFrame) -> pd.DataFrame:
+    normalised = df.apply(
+        lambda col: col.map(lambda value: "" if pd.isna(value) else str(value))
+    )
+    for column in BOOL_COLUMNS.intersection(normalised.columns):
+        normalised[column] = normalised[column].str.lower()
+    return normalised
+
+
+def test_preprocess_document_export_matches_stage_projection() -> None:
+    """The export wrapper mirrors the Stage post-processing output."""
+
+    input_frame = _frame_from_csv(FIXTURE_DIR / "output.document_20230101.csv")
+    reference_frame = _frame_from_csv(FIXTURE_DIR / "document.csv")
+    expected_frame = _frame_from_csv(
+        FIXTURE_DIR / "preprocessed_output.document_20230101.csv"
+    )
+
+    result = document_export_postprocessing.preprocess_document_export(
+        input_frame,
+        ref_document=reference_frame,
+    )
+
+    assert list(result.columns) == list(dp.FINAL_COLUMN_ORDER)
+    assert "preferred_title" not in result.columns
+    assert "metadata_sources" not in result.columns
+
+    pd.testing.assert_frame_equal(
+        _normalise_strings(result),
+        _normalise_strings(expected_frame),
+        check_dtype=False,
     )
 
 
-def _chembl_namespaced_dataframe() -> pd.DataFrame:
-    mapping = {
-        "document_chembl_id": "ChEMBL.document_chembl_id",
-        "title": "ChEMBL.title",
-        "abstract": "ChEMBL.abstract",
-        "doi_normalised": "doi_normalised",
-        "pubmed_id": "ChEMBL.pubmed_id",
-        "journal": "ChEMBL.journal",
-        "authors": "ChEMBL.authors",
-        "source": "ChEMBL.source",
-    }
-    df = _sample_dataframe().rename(columns=mapping)
-    return df
+def test_postprocess_export_file_writes_stage_projection(tmp_path: Path) -> None:
+    """The CSV artefact follows the Stage column ordering."""
 
+    raw_frame = _frame_from_csv(FIXTURE_DIR / "output.document_20230101.csv")
+    input_path = tmp_path / "output.document_20240101.csv"
+    raw_frame.to_csv(input_path, index=False)
 
-def _assert_projection(result: pd.DataFrame) -> None:
-    assert result["preferred_title"].tolist() == ["Title A", "PubMed Title"]
-    assert result["preferred_abstract"].tolist() == ["Abstract A", "Abstract B"]
-    assert result["preferred_doi"].tolist() == ["10.1000/foo", "10.1000/bar"]
-    assert result["primary_pubmed_id"].tolist() == ["100", "200"]
-    assert result["preferred_journal"].tolist() == ["Journal A", "Journal B"]
-    assert result["metadata_sources"].tolist() == [
-        "chembl; pubmed",
-        "chembl; pubmed; openalex",
-    ]
-    assert result["metadata_source_count"].tolist() == [2, 3]
-    assert result["has_pubmed"].tolist() == [True, True]
-    assert result["has_openalex"].tolist() == [False, True]
-    assert result["has_semantic_scholar"].tolist() == [False, False]
-    assert result["error_sources"].tolist() == ["", "pubmed"]
-    assert result["has_error"].tolist() == [False, True]
-    assert result["mesh_terms"].tolist() == ["Term1; Term2", "Qual1; Term3"]
-    assert result["publication_year"].tolist() == [2021, 2018]
-    assert result["is_review"].tolist() == [False, True]
-
-
-def test_preprocess_document_export_derives_fields() -> None:
-    """The derived projection coalesces fields and computes coverage flags."""
-
-    df = _sample_dataframe()
-    result = document_export_postprocessing.preprocess_document_export(df)
-    _assert_projection(result)
-
-
-def test_preprocess_document_export_accepts_namespaced_columns() -> None:
-    """Namespaced ChEMBL columns are normalised before processing."""
-
-    df = _chembl_namespaced_dataframe()
-    result = document_export_postprocessing.preprocess_document_export(df)
-    _assert_projection(result)
-
-
-
-def test_postprocess_export_file_writes_csv(tmp_path: Path) -> None:
-    """``postprocess_export_file`` writes the derived projection to disk."""
-
-    df = _sample_dataframe()
     cfg = IoCfg(csv_sep=",", csv_encoding="utf-8")
-    input_path = tmp_path / "output.documents_20240101.csv"
-    df.to_csv(input_path, index=False, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
-
     output_path = document_export_postprocessing.postprocess_export_file(
         input_path,
         cfg=cfg,
+        ref_document_path=FIXTURE_DIR / "document.csv",
     )
 
     assert output_path.name == f"preprocessed_{input_path.name}"
-    processed = pd.read_csv(output_path, sep=cfg.csv_sep, encoding=cfg.csv_encoding)
-    assert "metadata_sources" in processed.columns
-    assert processed["metadata_sources"].iloc[1] == "chembl; pubmed; openalex"
+
+    produced = pd.read_csv(output_path, dtype=str)
+    expected = _frame_from_csv(FIXTURE_DIR / "preprocessed_output.document_20230101.csv")
+
+    assert list(produced.columns) == list(dp.FINAL_COLUMN_ORDER)
+    pd.testing.assert_frame_equal(
+        _normalise_strings(produced),
+        _normalise_strings(expected),
+        check_dtype=False,
+    )


### PR DESCRIPTION
## Summary
- delegate document export preprocessing to the Stage pipeline so exports follow FINAL_COLUMN_ORDER
- update CSV writing to respect Stage key ordering and optional reference inputs
- refresh regression tests to validate Stage-aligned headers and data

## Testing
- pytest tests/test_document_export_postprocessing.py tests/test_document_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68deae10bae48324b8fc485c246f4441