### PR TITLE
Gracefully handle missing parent hierarchy columns

### DIFF
--- a/library/testitem_pipeline/catalog.py
+++ b/library/testitem_pipeline/catalog.py
@@ -137,16 +137,29 @@ def _load_molecule_hierarchy_mapping(
             "Unable to read molecule hierarchy dictionary; verify the CSV format."
         ) from exc
 
-    missing_columns = [
-        column for column in _MOLECULE_HIERARCHY_COLUMNS if column not in frame.columns
-    ]
-    if missing_columns:
+    child_column, parent_column = _MOLECULE_HIERARCHY_COLUMNS
+    child_missing = child_column not in frame.columns
+    parent_missing = parent_column not in frame.columns
+
+    if child_missing:
         raise ValueError(
             "Molecule hierarchy dictionary missing required columns: "
-            + ", ".join(missing_columns)
+            + child_column
         )
 
-    subset = frame.loc[:, list(_MOLECULE_HIERARCHY_COLUMNS)].copy()
+    if parent_missing:
+        logger.warning(
+            "molecule_hierarchy_missing_parent_column",
+            column=parent_column,
+            path=str(csv_path),
+        )
+
+    subset = frame.loc[:, [child_column]].copy()
+    if parent_missing:
+        subset[parent_column] = pd.Series(pd.NA, index=subset.index, dtype="string")
+    else:
+        subset[parent_column] = frame[parent_column].copy()
+
     for column in _MOLECULE_HIERARCHY_COLUMNS:
         subset[column] = (
             subset[column].fillna("").astype("string").str.strip().str.upper()

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -140,16 +140,29 @@ def _load_molecule_hierarchy_mapping(
             "Unable to read molecule hierarchy dictionary; verify the CSV format."
         ) from exc
 
-    missing_columns = [
-        column for column in _MOLECULE_HIERARCHY_COLUMNS if column not in frame.columns
-    ]
-    if missing_columns:
+    child_column, parent_column = _MOLECULE_HIERARCHY_COLUMNS
+    child_missing = child_column not in frame.columns
+    parent_missing = parent_column not in frame.columns
+
+    if child_missing:
         raise ValueError(
             "Molecule hierarchy dictionary missing required columns: "
-            + ", ".join(missing_columns)
+            + child_column
         )
 
-    subset = frame.loc[:, list(_MOLECULE_HIERARCHY_COLUMNS)].copy()
+    if parent_missing:
+        logger.warning(
+            "molecule_hierarchy_missing_parent_column",
+            column=parent_column,
+            path=str(csv_path),
+        )
+
+    subset = frame.loc[:, [child_column]].copy()
+    if parent_missing:
+        subset[parent_column] = pd.Series(pd.NA, index=subset.index, dtype="string")
+    else:
+        subset[parent_column] = frame[parent_column].copy()
+
     for column in _MOLECULE_HIERARCHY_COLUMNS:
         subset[column] = (
             subset[column].fillna("").astype("string").str.strip().str.upper()

--- a/tests/test_get_testitem_data.py
+++ b/tests/test_get_testitem_data.py
@@ -807,7 +807,7 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
 
 
 def test_load_molecule_hierarchy_lookup_missing_columns(
-    tmp_path: Path, cfg: Config
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = tmp_path / "hierarchy_invalid.csv"
     path.write_text(
@@ -815,10 +815,20 @@ def test_load_molecule_hierarchy_lookup_missing_columns(
         encoding=cfg.io.csv_encoding,
     )
 
-    with pytest.raises(ValueError) as excinfo:
-        pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+    captured: list[tuple[str, dict[str, object]]] = []
 
-    assert "invalid hierarchy lookup" in str(excinfo.value)
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(pipeline.logger, "warning", fake_warning)
+
+    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert result == {"CHEMBL1": None}
+    assert captured
+    event, payload = captured[-1]
+    assert event == "molecule_hierarchy_missing_parent_column"
+    assert payload.get("column") == "parent_molecule_chembl_id"
 
 
 def test_prepare_pubchem_caches_primes_local_parent_cache(


### PR DESCRIPTION
## Summary
- allow the hierarchy mapping loader to warn and continue when the parent column is absent, keeping child rows usable
- mirror the graceful handling in the CLI helper and extend tests to cover the new behaviour

## Testing
- pytest tests/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup_missing_columns
- pytest tests/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup_filters_empty_rows

------
https://chatgpt.com/codex/tasks/task_e_68deac9b7fb88324b153b0a6cca9a0b2