### PR TITLE
Refine pandas merge utilities to avoid FutureWarning

### DIFF
--- a/library/document_pipeline.py
+++ b/library/document_pipeline.py
@@ -23,6 +23,7 @@ import pandas as pd
 from .chembl_document import DOCUMENT_COLUMNS as _CHEMBL_COLUMNS
 from .document_type_classifier import compute_scores, decide_label
 from .document_type_terms import parse_terms
+from .pandas_utils import merge_series_prefer_left
 
 # ---------------------------------------------------------------------------
 # Column declarations
@@ -303,7 +304,7 @@ def merge_with_chembl(
                 )
             if column not in metadata_columns and column not in left_columns:
                 metadata_columns.append(column)
-            result[column] = result[column].combine_first(right[column])
+            result[column] = merge_series_prefer_left(result[column], right[column])
 
     result = result.sort_values("__merge_order").drop(columns=["__merge_order"])
     result = result.reset_index(drop=True)

--- a/library/pandas_utils.py
+++ b/library/pandas_utils.py
@@ -95,4 +95,40 @@ def read_csv_pyarrow(
         return cast(pd.DataFrame, read_csv(*args, **kwargs))
 
 
-__all__ = ["json_normalize_pyarrow", "read_csv_pyarrow"]
+def merge_series_prefer_left(left: pd.Series, right: pd.Series) -> pd.Series:
+    """Return ``left`` with missing entries populated from ``right``.
+
+    The function mirrors :meth:`pandas.Series.combine_first` for the subset of
+    behaviour relied upon in the codebase while avoiding the deprecated
+    concatenation of empty arrays that triggers a ``FutureWarning`` in pandas
+    2.2+. Only missing values (``NaN``/``NA``) are replaced, preserving the
+    existing handling of empty strings for object columns.
+
+    Parameters
+    ----------
+    left:
+        Primary series whose non-missing values take precedence.
+    right:
+        Fallback series used to fill missing entries in ``left``.
+
+    Returns
+    -------
+    pandas.Series
+        A copy of ``left`` with missing positions filled from ``right`` where
+        possible.
+    """
+
+    if left.empty and right.empty:
+        return left.copy()
+
+    if not left.index.equals(right.index):
+        right = right.reindex(left.index)
+
+    result = left.copy()
+    missing_mask = result.isna()
+    if missing_mask.any():
+        result.loc[missing_mask] = right.loc[missing_mask]
+    return result
+
+
+__all__ = ["json_normalize_pyarrow", "merge_series_prefer_left", "read_csv_pyarrow"]

--- a/library/processing/activity/bounds.py
+++ b/library/processing/activity/bounds.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from ...config import ActivityBoundsCfg
 from ...log import logger
+from ...pandas_utils import merge_series_prefer_left
 
 __all__ = ["compute_activity_bounds"]
 
@@ -245,8 +246,8 @@ def compute_activity_bounds(
     std_upper = _to_numeric(result, "standard_upper_value")
     std_values = _to_numeric(result, "standard_value")
 
-    lower = std_lower.combine_first(lower)
-    upper = std_upper.combine_first(upper)
+    lower = merge_series_prefer_left(lower, std_lower)
+    upper = merge_series_prefer_left(upper, std_upper)
 
     range_mask = std_values.notna() & std_upper.notna()
     if range_mask.any():
@@ -329,4 +330,8 @@ def compute_activity_bounds(
 
     result["lower_value"] = lower
     result["upper_value"] = upper
+    if "activity_id" in result.columns and pd.api.types.is_string_dtype(
+        result["activity_id"].dtype
+    ):
+        result["activity_id"] = result["activity_id"].astype("object")
     return result


### PR DESCRIPTION
## Summary
- add a reusable `merge_series_prefer_left` helper that mirrors the relevant `combine_first` behaviour without triggering the pandas FutureWarning
- replace direct `combine_first` usage in the document metadata merge and activity bounds logic with the new helper and normalise `activity_id` dtype stability

## Testing
- pytest tests/processing/test_activity_bounds.py
- pytest tests/test_document_pipeline.py *(fails: test harness references undefined `fake_info` helper before exercising code paths)*

------
https://chatgpt.com/codex/tasks/task_e_68deb065265c8324ab5988ec5a5d4b2a