### PR TITLE
Allow disabling global rate limiter

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1374,15 +1374,21 @@
       "properties": {
         "global_rps": {
           "default": 8,
-          "minimum": 1,
+          "minimum": 0,
           "title": "Global Rps",
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "global_burst": {
           "default": 8,
-          "minimum": 1,
+          "minimum": 0,
           "title": "Global Burst",
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "limiter_cache_maxsize": {
           "default": 128,

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -133,12 +133,17 @@ class ChemblClient:
 
     def _get_session(self) -> Session:
         session_attr = getattr(self._session_local, "session", None)
-        session = session_attr if isinstance(session_attr, Session) else None
+        session = (
+            session_attr
+            if isinstance(session_attr, Session)
+            or (hasattr(session_attr, "get") and hasattr(session_attr, "close"))
+            else None
+        )
         if session is None:
             session = self._session_factory()
             self._register_session(session)
             setattr(self._session_local, "session", session)
-        return session
+        return cast(Session, session)
 
     @property
     def session(self) -> Session:

--- a/library/config.py
+++ b/library/config.py
@@ -663,10 +663,26 @@ class InitCfg(_BaseModel):
 
 
 class RateCfg(_BaseModel):
-    global_rps: int = Field(8, ge=1)
-    global_burst: int = Field(8, ge=1)
+    global_rps: int | None = Field(8, ge=0)
+    global_burst: int | None = Field(8, ge=0)
     limiter_cache_maxsize: int = Field(128, ge=1)
     limiter_cache_ttl: int = Field(600, ge=1)
+
+    @field_validator("global_rps", "global_burst", mode="before")
+    @classmethod
+    def _allow_zero_or_none(cls, value: Any) -> Any:
+        """Normalise disabled limiter values."""
+
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            lowered = stripped.lower()
+            if lowered in {"none", "null"}:
+                return None
+        return value
 
 
 class RetryCfg(_BaseModel):

--- a/library/dtype_inspector.py
+++ b/library/dtype_inspector.py
@@ -70,7 +70,10 @@ def inspect_dtypes(
     # ``ChemblClient`` manages HTTP connections and retries.  The context
     # manager ensures the underlying ``requests.Session`` is properly closed
     # even if one of the retrieval functions fails.
-    global_limiter = get_global_limiter(cfg.rate.global_rps, cfg.rate.global_burst)
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     with ChemblClient(
         cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter

--- a/library/pubmed_library.py
+++ b/library/pubmed_library.py
@@ -265,8 +265,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
 
-    pubmed_rps = cfg.pubmed.rps or cfg.rate.global_rps
-    pubmed_burst = cfg.pubmed.burst or cfg.rate.global_burst
+    global_rps = cfg.rate.global_rps
+    if global_rps is None:
+        global_rps = 0
+    pubmed_rps = cfg.pubmed.rps if cfg.pubmed.rps is not None else global_rps
+    if pubmed_rps is None:
+        pubmed_rps = 0
+    pubmed_burst = cfg.pubmed.burst if cfg.pubmed.burst is not None else cfg.rate.global_burst
+    if pubmed_burst is not None and pubmed_burst <= 0:
+        pubmed_burst = None
     limiter = get_limiter("pubmed", pubmed_rps, pubmed_burst)
     delay = 1.0 / pubmed_rps if pubmed_rps > 0 else 0.0
 

--- a/library/rate_limiter.py
+++ b/library/rate_limiter.py
@@ -110,18 +110,25 @@ def get_limiter(name: str, rps: float, burst: int | None = None) -> RateLimiter:
         return limiter
 
 
-def get_global_limiter(rps: float, burst: int) -> RateLimiter:
-    """Return the shared system-wide :class:`RateLimiter`.
+def get_global_limiter(
+    rps: float | None, burst: int | None = None
+) -> RateLimiter | None:
+    """Return the shared system-wide :class:`RateLimiter` if enabled.
 
     Parameters
     ----------
     rps:
-        Allowed requests per second for the entire pipeline.
+        Allowed requests per second for the entire pipeline.  A value ``<= 0``
+        disables the limiter.
     burst:
-        Maximum burst size for the global limiter.
+        Maximum burst size for the global limiter.  Non-positive values are
+        treated as ``None``.
     """
 
-    return get_limiter(GLOBAL_LIMITER_NAME, rps, burst)
+    if rps is None or rps <= 0:
+        return None
+    burst_value = burst if burst is not None and burst > 0 else None
+    return get_limiter(GLOBAL_LIMITER_NAME, rps, burst_value)
 
 
 def sleep(delay: float) -> None:

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -440,9 +440,10 @@ def run_testitem_pipeline(
     output_csv = Path(options.output_csv) if options.output_csv is not None else None
     offset = options.offset if options.offset is not None else cfg.testitem.offset
 
-    global_limiter = get_global_limiter(
-        cfg.rate.global_rps, cfg.rate.global_burst
-    )
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     with ChemblClient(
         api_cfg, cfg.retry, cfg.chembl, global_limiter=global_limiter

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -235,10 +235,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         def table_quality(_: Path) -> None:
             return None
 
-    global_limiter = get_global_limiter(
-        cfg.rate.global_rps,
-        cfg.rate.global_burst,
-    )
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     with ChemblClient(
         cfg.api,

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -139,10 +139,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         def table_quality(_: Path) -> None:
             return None
 
-    global_limiter = get_global_limiter(
-        cfg.rate.global_rps,
-        cfg.rate.global_burst,
-    )
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     with ChemblClient(
         cfg.api,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -344,9 +344,9 @@ def fetch_pubmed_records(
     if pubmed_cfg is None:
         pubmed_cfg = settings.pubmed
 
-    system_limiter = get_global_limiter(
-        rate_cfg.global_rps, rate_cfg.global_burst
-    )
+    system_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        system_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     def _service_limiter(
         name: str,
@@ -356,12 +356,18 @@ def fetch_pubmed_records(
     ) -> RateLimiter | None:
         effective_rps = rps if rps is not None else rate_cfg.global_rps
         effective_burst = burst if burst is not None else rate_cfg.global_burst
+        if effective_rps is None or effective_rps <= 0:
+            return None
+        if effective_burst is not None and effective_burst <= 0:
+            effective_burst = None
         if (
-            rps is None
-            and burst is None
-            or (
-                effective_rps == rate_cfg.global_rps
-                and effective_burst == rate_cfg.global_burst
+            system_limiter is not None
+            and (
+                (rps is None and burst is None)
+                or (
+                    effective_rps == rate_cfg.global_rps
+                    and effective_burst == rate_cfg.global_burst
+                )
             )
         ):
             return None
@@ -1635,9 +1641,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     # Configure session for ChEMBL requests
-    global_limiter = get_global_limiter(
-        cfg.rate.global_rps, cfg.rate.global_burst
-    )
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     with ChemblClient(
         cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
@@ -1726,9 +1733,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     # Prepare shared session before performing any API calls
-    global_limiter = get_global_limiter(
-        cfg.rate.global_rps, cfg.rate.global_burst
-    )
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     try:
         ids_iter = io.read_ids(

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1258,7 +1258,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     reindex_raw = not bool(getattr(args, "no_reindex_raw", False))
 
 
-    global_limiter = get_global_limiter(cfg.rate.global_rps, cfg.rate.global_burst)
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
     fetched_rows_total = 0
     raw_dump_rows_total = 0

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -42,3 +42,16 @@ def test_rate_limiter_combined_throttling(monkeypatch) -> None:
         request.acquire()
 
     assert fake_time.sleeps == [0.1, 0.25, 0.5, 0.5]
+
+
+def test_get_global_limiter_disabled_returns_none() -> None:
+    """Zero rates should avoid creating a cached global limiter."""
+
+    with rl._limiters_lock:
+        rl._limiters.clear()
+
+    limiter = rl.get_global_limiter(0, 0)
+
+    assert limiter is None
+    with rl._limiters_lock:
+        assert rl.GLOBAL_LIMITER_NAME not in rl._limiters


### PR DESCRIPTION
## Summary
- allow configuring `system.rate` global limits to accept `0`/`null` values and normalise disabled inputs
- skip creation of the shared limiter when disabled and extend coverage to assert no limiter is cached
- update Chembl client helpers and downstream scripts to only request a global limiter when enabled and to normalise PubMed fallbacks

## Testing
- pytest tests/test_rate_limiter.py
- pytest tests/test_chembl_client_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68deb741138083249ecc4b4b6d4651f5