### PR TITLE
Update output filename examples to plural stems

### DIFF
--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -17,11 +17,11 @@ inject an alternate timestamp.
 
 ```
 ../data/output/
-├── output.activity_20240105.csv
-├── output.activity_20240105.csv.meta.yaml
-├── output.activity_20240105_failure_cases.csv
-├── output.activity_20240105_quality_report_table.csv
-└── output.activity_20240105_data_correlation_report_table.csv
+├── output.activities_20240105.csv
+├── output.activities_20240105.csv.meta.yaml
+├── output.activities_20240105_failure_cases.csv
+├── output.activities_20240105_quality_report_table.csv
+└── output.activities_20240105_data_correlation_report_table.csv
 ```
 
 Document-oriented pipelines (for example `scripts/get_document_data.py`) append
@@ -31,13 +31,13 @@ errors. Activity, assay and target jobs do not generate this report.
 Intermediate artefacts produced by the target `all` pipeline (`*_chembl.csv`,
 `*_uniprot.csv`, `*_iuphar.csv`) follow the same pattern. Custom `--output`
 arguments remain supported when a different layout (for example,
-`../data/output/ChEMBL/processed/activity.csv`) is required.
+`../data/output/ChEMBL/processed/activities.csv`) is required.
 
 ## Metadata sidecars (`*.csv.meta.yaml`)
 
 Each CSV export is accompanied by `<base>.csv.meta.yaml` created via
 `library.metadata.write_meta_yaml`, where `<base>` matches the CSV filename
-without the extension (for example `output.activity_20240105`). The metadata
+without the extension (for example `output.activities_20240105`). The metadata
 captures the following keys:
 
 * `generated_at` – ISO 8601 timestamp (UTC) when the file was produced.
@@ -108,7 +108,7 @@ when the signal is inconclusive.
 
 ## Activity bounds (`lower_value`, `upper_value`)
 
-The activity export (`output.activity_<date>.csv` by default) exposes canonical
+The activity export (`output.activities_<date>.csv` by default) exposes canonical
 value ranges derived from ChEMBL `standard_*`
 columns in `scripts/get_activity_data.py`. Bounds are resolved in the following
 priority order:
@@ -143,7 +143,7 @@ contains:
 
 ## Test item enrichment
 
-`scripts/get_testitem_data.py` produces `output_testitem_<date>.csv` plus the standard
+`scripts/get_testitem_data.py` produces `output.testitems_<date>.csv` plus the standard
 sidecars and quality reports. Each row merges ChEMBL molecule metadata, PubChem
 properties and pipeline bookkeeping, forming the canonical compound dimension.
 The enrichment stage relies on the molecule catalogue configured at

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -13,11 +13,11 @@ Acquisition, а также вспомогательные модули, отве
 
 ```
 ../data/output/
-├── output.activity_20240105.csv
-├── output.activity_20240105.csv.meta.yaml
-├── output.activity_20240105_failure_cases.csv
-├── output.activity_20240105_quality_report_table.csv
-└── output.activity_20240105_data_correlation_report_table.csv
+├── output.activities_20240105.csv
+├── output.activities_20240105.csv.meta.yaml
+├── output.activities_20240105_failure_cases.csv
+├── output.activities_20240105_quality_report_table.csv
+└── output.activities_20240105_data_correlation_report_table.csv
 ```
 
 Документные пайплайны (например, `scripts/get_document_data.py`) дополняют
@@ -27,13 +27,13 @@ Acquisition, а также вспомогательные модули, отве
 Промежуточные файлы таргет-пайплайна в режиме `all`
 (`*_chembl.csv`, `*_uniprot.csv`, `*_iuphar.csv`) используют тот же шаблон.
 Параметр `--output` по-прежнему позволяет задать альтернативную структуру,
-например `../data/output/ChEMBL/processed/activity.csv`.
+например `../data/output/ChEMBL/processed/activities.csv`.
 
 ## Sidecar с метаданными (`*.csv.meta.yaml`)
 
 Каждый CSV сопровождается `<base>.csv.meta.yaml`, который создаёт
 `library.metadata.write_meta_yaml`, где `<base>` совпадает с именем файла без
-расширения (например, `output.activity_20240105`). Файл содержит:
+расширения (например, `output.activities_20240105`). Файл содержит:
 
 * `generated_at` — отметку времени в формате ISO 8601 (UTC).
 * `git_sha` — хэш коммита на момент запуска.
@@ -99,7 +99,7 @@ Acquisition, а также вспомогательные модули, отве
 
 ## Границы активности (`lower_value`, `upper_value`)
 
-Выгрузка активностей (`output.activity_<date>.csv` по умолчанию) включает
+Выгрузка активностей (`output.activities_<date>.csv` по умолчанию) включает
 диапазоны значений, рассчитанные из канонических полей ChEMBL `standard_*`.
 Приоритет действий:
 
@@ -132,7 +132,7 @@ Acquisition, а также вспомогательные модули, отве
 
 ## Экспорт тест-объектов
 
-`scripts/get_testitem_data.py` формирует `output_testitem_<date>.csv` с
+`scripts/get_testitem_data.py` формирует `output.testitems_<date>.csv` с
 метаданными и отчётами качества. Каждая строка объединяет данные ChEMBL,
 обогащение PubChem и служебные
 колонки, обеспечивая опорное измерение соединений. Для работы требуется каталог


### PR DESCRIPTION
## Summary
- update the English output documentation to reference the plural `activities`/`testitems` stems in examples
- mirror the filename corrections in the Russian output guide to keep both languages in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deccaaf32c832496cbde8a04f3d2ca