### PR TITLE
Clarify --final-out scope across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ The README is available in multiple languages:
 | Русский  | [README_RU.md](README_RU.md) |
 
  
-* Командные скрипты с унифицированными флагами `--input`, `--final-out`
+* Командные скрипты с унифицированными флагами `--input`, `--output`
 
-  (основной путь назначения; устаревшие алиасы `--output`/`--out`
-  сохраняются для совместимости и теперь сопровождаются предупреждением),
+  (основной путь назначения; `--final-out` пока доступен только в
+  `scripts.get_target_data` и `library.utils.cli_tools.pipeline_targets_main`,
+  а устаревшие алиасы `--out` сохраняются для совместимости и теперь
+  сопровождаются предупреждением),
   `--log-level`, `--sep`, `--encoding`, `--column`, а также `--config` и
   `--print-config` для управления загрузкой настроек. Размер пакетной
   выборки задаётся параметрами `--chunk-size` или `--batch-size` в зависимости
@@ -157,18 +159,20 @@ Sensitive configuration such as API tokens belongs in a local ``.env`` file – 
 
   ```bash
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --final-out out/quality --table-name chembl_targets --log-level INFO
+      --output out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  EN: In the reporting example above `--final-out` must point to the directory where
-  the helper writes its results. The legacy `--output`/`--out` aliases remain available
-  but now raise deprecation warnings.
+  EN: In the reporting example above `--output` sets the destination. `--final-out`
+  currently exists only in `scripts.get_target_data` and
+  `library.utils.cli_tools.pipeline_targets_main`. The legacy `--out` alias remains
+  available but now raises a deprecation warning.
 
-  RU: В примере с отчётностью `--final-out` указывает каталог, куда будут сохранены
-  результаты. Устаревшие алиасы `--output`/`--out` по-прежнему работают, но теперь
-  сопровождаются предупреждением о скором удалении.
+  RU: В примере с отчётностью каталог задаёт `--output`. Флаг `--final-out`
+  реализован лишь в `scripts.get_target_data` и
+  `library.utils.cli_tools.pipeline_targets_main`. Устаревший алиас `--out`
+  сохраняется, но сопровождается предупреждением об удалении.
 
 4. **Run the tests / Запустите тесты** – refer to [Tests / Тесты](#tests--тесты).
 
@@ -219,7 +223,7 @@ tmp_dir=$(mktemp -d) && python -m library.utils.cli_tools.pipeline_targets_main 
     --final-out "${tmp_dir}/targets.csv" --log-level INFO --limit 2
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --final-out out/mapped.csv --log-level INFO
+    --output out/mapped.csv --log-level INFO
 ```
 
 Before running the smoke command, create a `chembl_ids.csv` file with a header `chembl_id` and the required identifiers. / Перед запуском smoke-команды создайте `chembl_ids.csv` со столбцом `chembl_id` и нужными идентификаторами.
@@ -305,7 +309,7 @@ solely with local files and prepared identifier batches. / **RU.**
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --final-out data/output/activities.csv --limit 10 --log-level INFO
+    --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 Команда извлекает данные из API ChEMBL, сохраняет таблицу и сопутствующий
@@ -325,13 +329,15 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 ## Usage
 
 The examples below illustrate how to run the main CLI tools with common
-options like ``--input``, ``--final-out`` (primary destination flag) and
-``--limit``. The legacy ``--output``/``--out`` aliases stay available for
-compatibility but now trigger explicit deprecation warnings. Passing
-``--limit 0`` short-circuits processing before any network or filesystem
-access, which is handy for configuration smoke tests. The target pipeline
-already exposes ``--raw-out``, ``--final-out``, ``--raw-format`` and ``--id-cols``;
-other commands will gain the staging switches once the shared CLI is extended.
+options like ``--input``, ``--output`` (primary destination flag for most
+commands; ``--final-out`` is currently restricted to ``scripts.get_target_data``
+and ``library.utils.cli_tools.pipeline_targets_main``) and ``--limit``. The
+compatibility alias ``--out`` stays available for now but triggers explicit
+deprecation warnings. Passing ``--limit 0`` short-circuits processing before any
+network or filesystem access, which is handy for configuration smoke tests. The
+target pipeline already exposes ``--raw-out``, ``--final-out``, ``--raw-format``
+and ``--id-cols``; other commands will gain the staging switches once the shared
+CLI is extended.
 
 ### scripts/get_document_data.py
 
@@ -341,7 +347,7 @@ sample file:
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --final-out out/documents.csv \
+    --output out/documents.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -354,7 +360,7 @@ You can also run the PubMed pipeline directly using the library module:
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --final-out out/documents.csv \
+    --output out/documents.csv \
     --log-level INFO
 ```
 
@@ -454,7 +460,7 @@ Refer to the [alias table](library/config.py#L1531-L1634) in
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \\
-    --final-out out/assays.csv
+    --output out/assays.csv
 ```
 
 Файл `assay_ids.csv` должен содержать столбец `assay_chembl_id` с нужными
@@ -558,7 +564,7 @@ api:
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --final-out out/assays.final.csv
+    --output out/assays.final.csv
 ```
 
 Пример строки лога:
@@ -692,12 +698,13 @@ Running the CLI saves ``data_quality_report_table.csv`` and
 
     python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 
-Use ``--final-out`` to redirect these artefacts to another directory. The value must be a directory path
-(do not include the final file name). The compatibility aliases ``--output``/``--out`` remain wired in but
-now raise deprecation warnings whenever they are invoked. When ``local.io.exist_ok`` is set to ``false``
-the directory has to exist beforehand; otherwise it is created automatically. The target pipeline uses the
-additional ``--raw-out``/``--final-out`` switches to separate staging outputs until the shared CLI is
-updated for the remaining commands.
+Use ``--output`` to redirect these artefacts to another directory. The value must be a directory path
+(do not include the final file name). The compatibility alias ``--out`` remains wired in but now raises a
+deprecation warning whenever it is invoked. ``--final-out`` is currently exclusive to
+``scripts.get_target_data`` and ``library.utils.cli_tools.pipeline_targets_main`` until the shared CLI is
+updated for the remaining commands. When ``local.io.exist_ok`` is set to ``false`` the directory has to
+exist beforehand; otherwise it is created automatically. The target pipeline uses the additional
+``--raw-out``/``--final-out`` switches to separate staging outputs.
 
 All scripts share a common set of flags:
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,12 +5,13 @@ The primary documentation and reference material live in the [docs/](docs/) dire
 ## Features
 
 
-* Unified CLI flags such as `--input`, `--final-out` (primary destination flag; the legacy `--output`/`--out`
-  aliases remain for compatibility but now emit deprecation warnings), `--log-level`, `--sep`, `--encoding`,
-  `--column`, plus `--config` and `--print-config` to manage configuration files. Batch size is controlled via
-  `--chunk-size` or `--batch-size` depending on the pipeline. The `--raw-out`, `--raw-format`, and `--id-cols`
-  switches are currently available through the target pipeline; other commands will expose them once the shared
-  CLI is extended.
+* Unified CLI flags such as `--input`, `--output` (primary destination flag; `--final-out` is currently
+  available only in `scripts.get_target_data` and `library.utils.cli_tools.pipeline_targets_main`, while the
+  legacy `--out` alias remains for compatibility but now emits a deprecation warning), `--log-level`, `--sep`,
+  `--encoding`, `--column`, plus `--config` and `--print-config` to manage configuration files. Batch size is
+  controlled via `--chunk-size` or `--batch-size` depending on the pipeline. The `--raw-out`, `--raw-format`,
+  and `--id-cols` switches are currently available through the target pipeline; other commands will expose them
+  once the shared CLI is extended.
 
 * Streaming CSV handling with deterministic output for large datasets.
 * Schema validators in [`schemas/`](schemas/) and dictionaries in [`dictionary/`](dictionary/) that enforce types,
@@ -108,29 +109,31 @@ for usage guidelines.
 
   ```bash
   get-activity-data --input tests/data/activity_ids_small.csv \
-      --final-out out/activities.csv \
+      --output out/activities.csv \
       --limit 10 --log-level INFO
   get-document-data pubmed --input tests/data/pmids.csv \
-      --final-out out/documents.csv \
+      --output out/documents.csv \
       --limit 5 --log-level INFO
 
   ```
 
-  The target pipeline is the only one that currently honours `--raw-out` and `--raw-format`; other pipelines ignore the flags
-  until raw snapshot support lands in their adapters.
+  The target pipeline is the only one that currently honours `--raw-out`, `--raw-format`, and `--final-out`.
+  Other pipelines should continue using `--output` (or the deprecated `--out` alias) until the shared parser is
+  extended.
 
    The console scripts accept the same options as their module counterparts, so existing `python -m …` workflows remain valid:
 
   ```bash
   python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --final-out out/quality --table-name chembl_targets --log-level INFO
+      --output out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  In the reporting example above `--final-out` must point to the directory where the report files will be created. The legacy
-  `--output`/`--out` aliases remain available for compatibility but now raise deprecation warnings when invoked.
+  In the reporting example above `--output` sets the destination. `--final-out` is currently exclusive to
+  `scripts.get_target_data` and `library.utils.cli_tools.pipeline_targets_main`. The legacy `--out` alias remains
+  available for compatibility but now raises a deprecation warning when invoked.
 
 4. **Run the tests** – see [Tests](#tests).
 
@@ -147,7 +150,7 @@ pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --final-out out/mapped.csv --log-level INFO
+    --output out/mapped.csv --log-level INFO
 ```
 
 Before running the smoke command, create a `chembl_ids.csv` file with a `chembl_id` header and the required identifiers.
@@ -187,7 +190,7 @@ Example full pipeline execution:
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --final-out data/output/activities.csv --limit 10 --log-level INFO
+    --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 The command reads data from the ChEMBL API, writes the CSV table and the accompanying `*.meta.yaml`. Development utilities are in
@@ -201,11 +204,12 @@ as a CI artifact.
 ## Usage
 
 
-The examples below demonstrate how to run the main CLI tools with common options such as `--input`, `--final-out`, and
-`--limit`. The compatibility aliases `--output`/`--out` are still recognised but now emit deprecation warnings. Using `--limit 0`
-short-circuits processing before any network or filesystem access, which is useful for smoke-testing configuration overrides.
-The target pipeline already exposes `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols`; the remaining commands will pick
-up the staged switches as the shared parser is extended.
+The examples below demonstrate how to run the main CLI tools with common options such as `--input`, `--output`, and
+`--limit`. `--final-out` is currently restricted to `scripts.get_target_data` and
+`library.utils.cli_tools.pipeline_targets_main`. The compatibility alias `--out` is still recognised but now emits a
+deprecation warning. Using `--limit 0` short-circuits processing before any network or filesystem access, which is useful for
+smoke-testing configuration overrides. The target pipeline already exposes `--raw-out`, `--final-out`, `--raw-format`, and
+`--id-cols`; the remaining commands will pick up the staged switches as the shared parser is extended.
 After installing the project with `pip install .`, the same pipelines can be started via the console scripts listed in the
 [Quick Start](#quick-start) table—for example, `get-activity-data --help` is equivalent to `python -m scripts.get_activity_data --help`.
 Both forms accept identical arguments, so feel free to swap between them depending on your environment.
@@ -224,7 +228,7 @@ Retrieve document metadata for a list of PubMed IDs using the bundled sample fil
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --final-out out/documents.csv \
+    --output out/documents.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -236,7 +240,7 @@ You can also run the PubMed pipeline directly via the library module:
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --final-out out/documents.csv \
+    --output out/documents.csv \
     --log-level INFO
 ```
 
@@ -303,8 +307,9 @@ flowchart LR
 * **Cleanup IDs** – trim, deduplicate and patch placeholder identifiers before downstream work.
 * **Normalize** – harmonise text, relations and datatypes so validation is deterministic.
 * **Validate** – run `pandera` schemas, routing failures to the sidecar files recorded in the metadata YAML.
-* **Final export** – write the cleaned table to `--final-out` alongside metadata and quality reports. Deprecated
-  aliases `--output`/`--out` continue to function but emit warnings during the migration period.
+* **Final export** – write the cleaned table to `--final-out` (target pipeline) or `--output` for commands that
+  have not yet adopted the staged switches. The deprecated `--out` alias continues to function but emits warnings
+  during the migration period.
 
 > **Note.** At the moment `--raw-out`, `--final-out`, `--raw-format`, and `--id-cols` are available through
 > `get-target-data` and `library.utils.cli_tools.pipeline_targets_main`. Other pipelines will adopt the same
@@ -356,7 +361,7 @@ Run a script with automatic configuration loading:
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \
-    --final-out out/assays.csv
+    --output out/assays.csv
 ```
 
 The `assay_ids.csv` file must contain an `assay_chembl_id` column with the required identifiers, for example:
@@ -448,7 +453,7 @@ Set the log level via the `--log-level` flag or the `CHEMBL_DA_LOG_LEVEL` enviro
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --final-out out/assays.final.csv
+    --output out/assays.final.csv
 ```
 
 Sample log entry:
@@ -503,10 +508,11 @@ All CLI scripts share a common set of flags:
 python -m library.utils.cli_tools.table_quality_main --input data.csv --table-name data
 ```
 
-`--final-out` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. The legacy
-`--output`/`--out` aliases continue to map to the same path but now emit deprecation warnings. Target pipeline invocations can
-override the raw snapshot via `--raw-out` (with optional `--raw-format parquet`) and the cleaned export via `--final-out`. For
-additional examples see [`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
+`--output` defaults to `output.<input_name>_YYYYMMDD.csv` in the directory defined by `local.io.output_dir`. The deprecated
+`--out` alias continues to map to the same path but now emits deprecation warnings. Target pipeline invocations additionally
+accept `--final-out`, which reuses the same default while enabling distinct destinations once raw snapshots are enabled. Combine
+it with `--raw-out` (and optional `--raw-format parquet`) to persist the unprocessed payload. For additional examples see
+[`docs/USAGE_EN.md`](docs/USAGE_EN.md) (Russian version:
 
 [`docs/USAGE_RU.md`](docs/USAGE_RU.md)).
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -4,9 +4,10 @@
 
 ## Особенности
 
-* Унифицированные CLI-флаги `--input`, `--final-out` (основной флаг назначения; устаревшие алиасы `--output`/`--out`
-  сохранены для совместимости и теперь сопровождаются предупреждением), `--log-level`, `--sep`, `--encoding`,
-  `--column`, а также `--config` и `--print-config` для управления конфигурацией. Размер партий задаётся параметрами
+* Унифицированные CLI-флаги `--input`, `--output` (основной флаг назначения; `--final-out` пока доступен только в
+  `scripts.get_target_data` и `library.utils.cli_tools.pipeline_targets_main`, а устаревший алиас `--out`
+  сохранён для совместимости и сопровождается предупреждением), `--log-level`, `--sep`, `--encoding`, `--column`,
+  а также `--config` и `--print-config` для управления конфигурацией. Размер партий задаётся параметрами
   `--chunk-size` или `--batch-size` в зависимости от пайплайна. Переключатели `--raw-out`, `--raw-format` и `--id-cols`
   уже доступны в пайплайне таргетов; остальные команды получат их после расширения общего CLI.
 
@@ -102,28 +103,29 @@ pre-commit install
 
   ```bash
   get-activity-data --input tests/data/activity_ids_small.csv \
-      --final-out out/activities.csv \
+      --output out/activities.csv \
       --limit 10 --log-level INFO
   get-document-data pubmed --input tests/data/pmids.csv \
-      --final-out out/documents.csv \
+      --output out/documents.csv \
       --limit 5 --log-level INFO
   ```
 
-  Выделенный «сырой» снимок сейчас поддерживает только таргет-пайплайн; остальные команды принимают `--raw-out`/`--raw-format`
-  для совместимости, но игнорируют их до появления соответствующей реализации.
+  Таргет-пайплайн остаётся единственным, кто понимает `--raw-out`, `--raw-format` и `--final-out`. Остальные команды
+  используют `--output` (или устаревший алиас `--out`) до расширения общего парсера.
 
    Консольные утилиты принимают те же аргументы, поэтому привычные сценарии `python -m …` продолжают работать:
 
   ```bash
   python -m library.utils.cli_tools.get_activities --limit 10 --log-level INFO
   python -m library.utils.cli_tools.mapper_main --input tests/data/chembl_targets_min.csv \
-      --column target_chembl_id --final-out out/targets_mapped.csv --log-level DEBUG
+      --column target_chembl_id --output out/targets_mapped.csv --log-level DEBUG
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
-      --final-out out/quality --table-name chembl_targets --log-level INFO
+      --output out/quality --table-name chembl_targets --log-level INFO
   ```
 
-  В примере с отчётностью `--final-out` задаёт каталог, где будут сохранены результаты. Устаревшие алиасы
-  `--output`/`--out` остаются для совместимости, но теперь сопровождаются предупреждением об удалении.
+  В примере с отчётностью путь задаёт `--output`. Флаг `--final-out` сейчас реализован только в
+  `scripts.get_target_data` и `library.utils.cli_tools.pipeline_targets_main`. Алиас `--out`
+  сохранён для совместимости, но сопровождается предупреждением об удалении.
 
 4. **Запустите тесты** — см. раздел [Тесты](#тесты).
 
@@ -138,7 +140,7 @@ pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing --cov-report=xml
 python -m library.utils.cli_tools.check_determinism --log-level DEBUG
 python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
-    --final-out out/mapped.csv --log-level INFO
+    --output out/mapped.csv --log-level INFO
 ```
 
 Перед запуском smoke-команды создайте `chembl_ids.csv` с заголовком `chembl_id` и нужными идентификаторами.
@@ -162,7 +164,7 @@ python -m library.utils.cli_tools.mapper_batch_main --input chembl_ids.csv \
 
 ```bash
 python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
-    --final-out data/output/activities.csv --limit 10 --log-level INFO
+    --output data/output/activities.csv --limit 10 --log-level INFO
 ```
 
 Команда обращается к API ChEMBL, сохраняет таблицу и сопровождающий `*.meta.yaml`. Утилиты разработки находятся в `library/utils/cli_tools/`; например, модуль `get_activities` предназначен лишь для демонстрационного логирования и не выполняет файловых операций. См. [`docs/CLI_TOOLS.md`](docs/CLI_TOOLS.md) для кратких описаний и типовых команд. Каталог результатов игнорируется Git и публикуется как артефакт CI.
@@ -171,7 +173,7 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 
 ## Использование
 
-Ниже приведены примеры запуска основных CLI-инструментов с типовыми флагами (`--input`, `--final-out`, `--limit`). Устаревшие алиасы `--output`/`--out` остаются доступными, но при использовании выводят предупреждения. Параметр `--limit 0` допустим: пайплайн завершится до любых сетевых и файловых операций, что удобно для быстрых smoke-тестов конфигурации. Пайплайн таргетов уже поддерживает `--raw-out`, `--final-out`, `--raw-format` и `--id-cols`; остальные команды получат эти переключатели после расширения общего парсера.
+Ниже приведены примеры запуска основных CLI-инструментов с типовыми флагами (`--input`, `--output`, `--limit`). Флаг `--final-out` сейчас реализован только в `scripts.get_target_data` и `library.utils.cli_tools.pipeline_targets_main`. Устаревший алиас `--out` остаётся доступным, но при использовании выводит предупреждение. Параметр `--limit 0` допустим: пайплайн завершится до любых сетевых и файловых операций, что удобно для быстрых smoke-тестов конфигурации. Пайплайн таргетов уже поддерживает `--raw-out`, `--final-out`, `--raw-format` и `--id-cols`; остальные команды получат эти переключатели после расширения общего парсера.
 После установки пакета через `pip install .` те же пайплайны доступны в виде консольных скриптов из таблицы в разделе
 [Быстрый старт](#быстрый-старт) — например, `get-activity-data --help` полностью эквивалентен
 `python -m scripts.get_activity_data --help`. Оба варианта принимают одинаковые аргументы, поэтому выбирайте форму, удобную
@@ -191,8 +193,7 @@ python -m scripts.get_activity_data --input tests/data/activity_ids_small.csv \
 ```bash
 python -m scripts.get_document_data pubmed \
     --input tests/data/pmids.csv \
-    --final-out out/documents.csv \
-
+    --output out/documents.csv \
     --limit 5 \
     --log-level INFO
 ```
@@ -204,7 +205,7 @@ python -m scripts.get_document_data pubmed \
 ```bash
 python -m library.pubmed_library \
     --input-csv tests/data/pmids.csv \
-    --final-out out/documents.csv \
+    --output out/documents.csv \
     --log-level INFO
 ```
 
@@ -316,7 +317,7 @@ CHEMBL_DA_BASE=https://www.ebi.ac.uk/chembl/api/data
 
 ```bash
 python -m dotenv run -- python -m scripts.get_assay_data --input assay_ids.csv \
-    --final-out out/assays.csv
+    --output out/assays.csv
 ```
 
 Файл `assay_ids.csv` должен содержать столбец `assay_chembl_id` с нужными идентификаторами, например:
@@ -405,7 +406,7 @@ CLI-хелперы настраивают структурированное JSO
 
 ```bash
 CHEMBL_DA_LOG_LEVEL=DEBUG python -m scripts.get_assay_data --input assay_ids.csv \
-    --final-out out/assays.final.csv
+    --output out/assays.final.csv
 ```
 
 Пример строки лога:
@@ -457,9 +458,10 @@ python -m library.utils.cli_tools.table_quality_main --input tests/data/activity
     --table-name activity
 ```
 
-По умолчанию `--final-out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`.
-Устаревшие алиасы `--output`/`--out` продолжают работать, но сопровождаются предупреждениями. Пайплайн таргетов может
-разделять «сырой» и чистый вывод флагами `--raw-out` (с `--raw-format`) и `--final-out`. Дополнительные примеры приведены в
+По умолчанию `--output` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге, указанном в `local.io.output_dir`.
+Устаревший алиас `--out` продолжает работать, но сопровождается предупреждениями. Таргет-пайплайн также принимает
+`--final-out`, чтобы разделять директории при наличии «сырого» снимка. Флаг `--raw-out` (с `--raw-format`) управляет
+сохранением необработанных данных. Дополнительные примеры приведены в
 [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 
@@ -568,9 +570,10 @@ python -m library.utils.cli_tools.table_quality_main \
     --table-name activity
 ```
 
-По умолчанию `--final-out` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Устаревшие алиасы
-`--output`/`--out` продолжают работать и предупреждают о грядущем удалении. Пайплайн таргетов может использовать `--raw-out` и
-`--final-out`, чтобы явно развести «сырые» и чистые артефакты (при желании указав `--raw-format`). Дополнительные примеры см. в
+По умолчанию `--output` формируется как `output.<имя_входа>_YYYYMMDD.csv` в каталоге `local.io.output_dir`. Устаревший алиас
+`--out` сохраняется для совместимости и предупреждает о грядущем удалении. Таргет-пайплайн дополнительно принимает `--final-out`,
+который использует тот же шаблон пути и позволяет разделять директории после добавления «сырого» снимка. Комбинируйте его с
+`--raw-out` (и опциональным `--raw-format parquet`), чтобы сохранять необработанный ответ. Дополнительные примеры см. в
 [`docs/USAGE_RU.md`](docs/USAGE_RU.md) (английская версия — [`docs/USAGE_EN.md`](docs/USAGE_EN.md)).
 
 ## Вывод и метаданные

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -31,8 +31,8 @@ directly.
 | `--input-dir` | Directory containing input artefacts; resolved against `--base-path` when relative. |
 | `--output-dir` | Directory receiving generated artefacts; resolved against `--base-path` when relative. |
 | `--input` | Input CSV with identifiers (default: `input.csv`). |
-| `--final-out` | Primary destination for the cleaned export. When omitted, defaults to `output.<input-stem>_<YYYYMMDD>.csv` under `--output-dir` or `--base-path`. Equivalent to the legacy `--output`/`--out`, which remain available but raise deprecation warnings. |
-| `--output` / `--out` | Deprecated aliases for `--final-out`. They keep the previous behaviour and default paths but emit warnings on each invocation and will be removed after the migration. |
+| `--final-out` | Primary destination for the cleaned export in `scripts.get_target_data` and `library.utils.cli_tools.pipeline_targets_main`. Defaults to `output.<input-stem>_<YYYYMMDD>.csv` under `--output-dir` or `--base-path`. Other commands currently rely on `--output`, which maps to the same default path. |
+| `--output` / `--out` | Destination flag for commands that have not yet adopted `--final-out`. `--out` remains as a deprecated alias and emits a warning on each invocation. |
 | `--raw-out` | Path for the raw snapshot written before cleanup and normalisation. Currently exposed by `get-target-data` and `library.utils.cli_tools.pipeline_targets_main`; other commands will surface it once the shared parser is extended. Skipped when omitted. |
 | `--raw-format` | Format of the raw snapshot. Accepts `csv` (default) or `parquet`. Available in the same entry points as `--raw-out`. |
 | `--date` | Override the auto-generated `YYYYMMDD` suffix when building default output filenames. |
@@ -161,7 +161,7 @@ Console form:
 ```bash
 get-document-data all --input path/to/documents.csv \
   --column document_chembl_id \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --batch-size 20
 ```
 
@@ -171,7 +171,7 @@ Module form:
 python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --batch-size 20
 ```
 
@@ -198,7 +198,7 @@ Console form:
 ```bash
 get-document-data pubmed --input path/to/documents.csv \
   --column PMID \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -212,7 +212,7 @@ Module form:
 python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -34,8 +34,8 @@ CLI без вложенных подкоманд.
 | `--input-dir` | Каталог с входными артефактами; относительный путь сочетается с `--base-path`. |
 | `--output-dir` | Каталог для сохранения артефактов; относительный путь сочетается с `--base-path`. |
 | `--input` | Входной CSV с идентификаторами (по умолчанию `input.csv`). |
-| `--final-out` | Основной путь финального экспорта. При отсутствии формируется `output.<stem>_<YYYYMMDD>.csv` в `--output-dir` или `--base-path`. Эквивалентен устаревшим `--output`/`--out`, которые сохраняются для совместимости, но выводят предупреждения. |
-| `--output` / `--out` | Устаревшие алиасы `--final-out`. Поведение и значения по умолчанию совпадают, однако при использовании выводятся предупреждения; после завершения миграции будут удалены. |
+| `--final-out` | Основной путь финального экспорта для `scripts.get_target_data` и `library.utils.cli_tools.pipeline_targets_main`. По умолчанию формируется `output.<stem>_<YYYYMMDD>.csv` в `--output-dir` или `--base-path`. Остальные команды используют `--output`, который указывает на тот же путь. |
+| `--output` / `--out` | Флаг назначения для команд, где `--final-out` ещё не внедрён. Алиас `--out` сохраняется для совместимости, но сопровождается предупреждением при каждом запуске. |
 | `--raw-out` | Путь для «сырого» снимка до очистки и нормализации. Сейчас флаг доступен в `get-target-data` и `library.utils.cli_tools.pipeline_targets_main`; остальные команды получат его после расширения парсера. Если флаг опущен, этап пропускается. |
 | `--raw-format` | Формат снимка: `csv` (по умолчанию) или `parquet`. Поддерживается теми же точками входа, что и `--raw-out`. |
 | `--date` | Заменяет автогенерируемый суффикс `YYYYMMDD` при формировании имени файла по умолчанию. |
@@ -158,7 +158,7 @@ python -m scripts.get_assay_data \
 ```bash
 get-document-data all --input path/to/documents.csv \
   --column document_chembl_id \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --batch-size 20
 ```
 
@@ -168,7 +168,7 @@ get-document-data all --input path/to/documents.csv \
 python -m scripts.get_document_data all \
   --input path/to/documents.csv \
   --column document_chembl_id \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --batch-size 20
 ```
 
@@ -196,7 +196,7 @@ CHEMBL_DA__SOURCES__CHEMBL__PIPELINES__DOCUMENT__PUBMED__BATCH_SIZE=20 \
 ```bash
 get-document-data pubmed --input path/to/documents.csv \
   --column PMID \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \
@@ -210,7 +210,7 @@ get-document-data pubmed --input path/to/documents.csv \
 python -m scripts.get_document_data pubmed \
   --input path/to/documents.csv \
   --column PMID \
-  --final-out out/documents.csv \
+  --output out/documents.csv \
   --openalex-rps 2.5 \
   --crossref-rps 1.5 \
   --fallback-doi-csv path/to/doi_overrides.csv \


### PR DESCRIPTION
## Summary
- update README files to steer non-target helpers toward `--output` and document that `--final-out` is limited to the target pipeline entry points
- mirror the same guidance in the English and Russian usage guides, updating examples to match the current parser behaviour

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68decca3b944832484ac1b2cdf561062