### PR TITLE
Use absolute default config paths in CLI tools

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -35,7 +35,7 @@ from .config import Config, ensure_dirs, print_config
 from .log import logger as default_logger
 from .metadata import Stats, file_sha256, write_meta_yaml
 from .sidecar import SidecarErrors
-from .utils.config import DEFAULT_CONFIG_RELATIVE
+from .utils.config import DEFAULT_CONFIG_PATH
 
 SchemaT = TypeVar("SchemaT")
 
@@ -614,8 +614,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--config",
         dest="config",
         type=path_argument,
-        default=DEFAULT_CONFIG_RELATIVE,
-        help="YAML configuration file",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"YAML configuration file (default: {DEFAULT_CONFIG_PATH})",
     )
     parser.add_argument(
         "--print-config",

--- a/library/utils/cli_tools/chunk_io_main.py
+++ b/library/utils/cli_tools/chunk_io_main.py
@@ -16,7 +16,7 @@ from library.cli import (
     path_argument,
 )
 from library.config import Config, ensure_dirs, print_config
-from library.utils.config import DEFAULT_CONFIG_RELATIVE
+from library.utils.config import DEFAULT_CONFIG_PATH
 from library.io.paths import default_output_path
 from library.log import logger
 
@@ -49,8 +49,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--config",
         dest="config",
         type=path_argument,
-        default=DEFAULT_CONFIG_RELATIVE,
-        help="YAML configuration file",
+        default=DEFAULT_CONFIG_PATH,
+        help=f"YAML configuration file (default: {DEFAULT_CONFIG_PATH})",
     )
     parser.add_argument(
         "--print-config",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,14 +4,14 @@ from pathlib import Path
 import pytest
 
 from library import cli
-from library.utils.config import DEFAULT_CONFIG_RELATIVE
+from library.utils.config import DEFAULT_CONFIG_PATH
 
 
 def test_apply_config_overrides_missing_config(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default=str(DEFAULT_CONFIG_RELATIVE))
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
     args = parser.parse_args(["--config", str(tmp_path / "missing.yaml")])
     with pytest.raises(SystemExit) as excinfo:
         cli.apply_config_overrides(args, parser, args.config)

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 
 from library.utils.config import DEFAULT_CONFIG_PATH
 from library.utils.cli_tools import mapper_batch_main
+from library.utils.cli_tools import chunk_io_main
+from library.utils.cli_tools import csv_utils_main
 from library.utils.cli_tools.table_quality_main import main
 
 
@@ -54,6 +56,105 @@ def test_mapper_batch_default_config_outside_repo(tmp_path: Path, monkeypatch) -
     monkeypatch.chdir(tmp_path)
 
     rc = mapper_batch_main.main([])
+
+    assert rc == 0
+    assert recorded["config_path"] == DEFAULT_CONFIG_PATH
+
+
+def test_chunk_io_default_config_outside_repo(tmp_path: Path, monkeypatch) -> None:
+    recorded: dict[str, Path] = {}
+
+    def fake_apply_config_overrides(
+        args,
+        parser,
+        config_path,
+        mapping=None,
+        **kwargs,
+    ):
+        recorded["config_path"] = Path(config_path)
+        return SimpleNamespace(io=SimpleNamespace(exist_ok=True))
+
+    monkeypatch.setattr(
+        chunk_io_main.cli,
+        "apply_config_overrides",
+        fake_apply_config_overrides,
+    )
+    monkeypatch.setattr(chunk_io_main, "ensure_dirs", lambda cfg: None)
+    monkeypatch.setattr(chunk_io_main, "process_csv_chunks", lambda *args, **kwargs: 0)
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id\n1\n")
+    output_csv = tmp_path / "output.csv"
+
+    monkeypatch.chdir(tmp_path)
+
+    rc = chunk_io_main.main([
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--log-level",
+        "ERROR",
+    ])
+
+    assert rc == 0
+    assert recorded["config_path"] == DEFAULT_CONFIG_PATH
+
+
+def test_csv_utils_default_config_outside_repo(tmp_path: Path, monkeypatch) -> None:
+    recorded: dict[str, Path] = {}
+
+    io_cfg = SimpleNamespace(
+        exist_ok=True,
+        csv_sep=",",
+        csv_encoding="utf8",
+        csv_chunksize=10,
+        csv_dtype=str,
+    )
+
+    def fake_apply_config_overrides(
+        args,
+        parser,
+        config_path,
+        mapping=None,
+        **kwargs,
+    ):
+        recorded["config_path"] = Path(config_path)
+        return SimpleNamespace(io=io_cfg)
+
+    monkeypatch.setattr(
+        csv_utils_main.cli,
+        "apply_config_overrides",
+        fake_apply_config_overrides,
+    )
+    monkeypatch.setattr(csv_utils_main, "ensure_dirs", lambda cfg: None)
+
+    def fake_writer(reader, output, **kwargs):
+        list(reader)
+        output.write_text("done\n")
+
+    monkeypatch.setattr(
+        csv_utils_main,
+        "write_csv_chunks_deterministic",
+        fake_writer,
+    )
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id,value\n1,2\n")
+    output_csv = tmp_path / "output.csv"
+
+    monkeypatch.chdir(tmp_path)
+
+    rc = csv_utils_main.main([
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--key-cols",
+        "id",
+        "--log-level",
+        "ERROR",
+    ])
 
     assert rc == 0
     assert recorded["config_path"] == DEFAULT_CONFIG_PATH


### PR DESCRIPTION
## Summary
- update the chunk_io and csv_utils CLI defaults to use the packaged config.yaml
- document the new absolute default in CLI help output
- add smoke tests that exercise the updated defaults outside the repository tree

## Testing
- pytest tests/test_cli_config_integration.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ded4095f088324a84f7fb45273800a