### PR TITLE
Propagate CLI IO directories to configuration

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -965,6 +965,32 @@
     "IoCfg": {
       "additionalProperties": false,
       "properties": {
+        "base_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Path"
+        },
+        "input_dir": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Input Dir"
+        },
         "output_dir": {
           "default": "../data/output",
           "format": "path",

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -8,4 +8,6 @@
 - Downgraded ChEMBL and PubChem cache hit/miss logging to DEBUG to reduce noise in default INFO logs.
 - Added UniProt isoform fallbacks, richer cross-reference extraction (AlphaFold, PDB, Ensembl), and additional logging to
   trace identifier coverage through the target merge pipeline.
+- Normalised CLI path overrides so `--base-path`, `--input-dir`, `--output-dir`, and `--cache-dir` propagate into
+  `local.io` configuration fields.
 

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -446,6 +446,10 @@ def _normalize_path(path: str) -> str:
 _DEFAULT_OVERRIDES: dict[str, str] = {
     key: _normalize_path(value)
     for key, value in {
+        "base_path": "io.base_path",
+        "input_dir": "io.input_dir",
+        "output_dir": "io.output_dir",
+        "cache_dir": "io.cache_dir",
         "sep": "io.csv_sep",
         "encoding": "io.csv_encoding",
         "log_level": "log.level",
@@ -636,6 +640,9 @@ def prepare_io_paths(
 
     output_dir = _resolve_directory(getattr(args, "output_dir", None), base=base_path)
     setattr(args, "output_dir", output_dir)
+
+    cache_dir = _resolve_directory(getattr(args, "cache_dir", None), base=base_path)
+    setattr(args, "cache_dir", cache_dir)
 
     deprecated_out = getattr(args, "_deprecated_out", argparse.SUPPRESS)
     if deprecated_out is not argparse.SUPPRESS:

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -132,6 +132,8 @@ def run_cli_command(
                 raise ValueError(msg)
             config_path = default_config
 
+        cli.prepare_io_paths(args)
+
         cfg: Config = apply_config_overrides(
             args,
             parser,

--- a/library/config.py
+++ b/library/config.py
@@ -618,6 +618,8 @@ class ResourcesCfg(_BaseModel):
 
 
 class IoCfg(_BoolModel):
+    base_path: Path | None = None
+    input_dir: Path | None = None
     output_dir: Path = Path("data/output")
     cache_dir: Path = Path(".cache")
     csv_sep: str = ","

--- a/tests/test_cli_common_args.py
+++ b/tests/test_cli_common_args.py
@@ -59,3 +59,25 @@ def test_path_argument_normalises_windows_style(tmp_path: Path) -> None:
         ["--config", str(cfg_path), "--input", "data\\input\\file.csv"]
     )
     assert args.input_csv == Path("data/input/file.csv")
+
+
+def test_output_dir_override_updates_config(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path)
+    parser = argparse.ArgumentParser()
+    add_common_arguments(parser)
+    parser.add_argument("--config", default=cfg_path, type=path_argument)
+    args = parser.parse_args(
+        [
+            "--config",
+            str(cfg_path),
+            "--base-path",
+            str(tmp_path),
+            "--output-dir",
+            "processed",
+        ]
+    )
+    cli.prepare_io_paths(args)
+    cfg = cli.apply_config_overrides(args, parser, args.config)
+    expected = (tmp_path / "processed").resolve()
+    assert args.output_dir == expected
+    assert cfg.io.output_dir == expected


### PR DESCRIPTION
## Summary
- map the common IO path flags to configuration overrides and normalise them before configuration loading
- expose optional `base_path` and `input_dir` fields in the IO configuration schema alongside documentation of the behaviour
- cover the CLI output directory override with a regression test

## Testing
- pytest tests/test_cli_common_args.py tests/test_cli_prepare_io_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68ded4092b188324bc9bb03f95d04de5