### PR TITLE
Handle mapper batch config and setup errors

### DIFF
--- a/library/utils/cli_tools/mapper_batch_main.py
+++ b/library/utils/cli_tools/mapper_batch_main.py
@@ -122,8 +122,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     log_cfg.level = args.log_level
     logger = configure_logger(log_cfg)
     logger.info("pipeline_start", run_id=log_cfg.run_id)
-    cfg = cli.apply_config_overrides(args, parser, args.config)
-    ensure_dirs(cfg)
+    try:
+        cfg = cli.apply_config_overrides(args, parser, args.config)
+    except (TypeError, ValueError, FileNotFoundError) as exc:
+        logger.error(
+            "config_error",
+            error=str(exc),
+            config=str(args.config),
+        )
+        logger.info("pipeline_end", exit_code=1)
+        return 1
+    try:
+        ensure_dirs(cfg)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        logger.error("directory_setup_failed", error=str(exc))
+        logger.info("pipeline_end", exit_code=1)
+        return 1
     logger = configure_logger(log_cfg)
     if args.print_config:
         print_config(cfg)

--- a/tests/test_mapper_batch_main.py
+++ b/tests/test_mapper_batch_main.py
@@ -18,6 +18,9 @@ class DummyLogger:
     def info(self, event: str, **payload: object) -> None:
         self.events.append((event, payload))
 
+    def error(self, event: str, **payload: object) -> None:
+        self.events.append((event, payload))
+
 
 def _configure_logger_factory(loggers: list[DummyLogger]):
     def _configure_logger(
@@ -134,4 +137,99 @@ def test_main_prints_config_when_requested(
     assert any(
         event == "pipeline_end" and payload.get("exit_code") == 0
         for event, payload in configured_loggers[-1].events
+    )
+
+
+def test_main_missing_config_path_logs_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing configuration paths should be reported gracefully."""
+
+    configured_loggers: list[DummyLogger] = []
+    monkeypatch.setattr(
+        cli, "configure_logger", _configure_logger_factory(configured_loggers)
+    )
+
+    def fake_apply_config_overrides(*_: object, **__: object) -> Config:
+        raise FileNotFoundError("configuration file not found: missing.yaml")
+
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", fake_apply_config_overrides)
+    monkeypatch.setattr(cli, "ensure_dirs", lambda *_: None)
+    def fail_run(*_: object, **__: object) -> int:
+        raise AssertionError("run should not execute")
+
+    monkeypatch.setattr(cli, "run", fail_run)
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    exit_code = cli.main(
+        [
+            "--config",
+            "missing.yaml",
+            "--input",
+            str(input_csv),
+            "--column",
+            "chembl_id",
+            "--chunk-size",
+            "2",
+        ]
+    )
+
+    assert exit_code == 1
+    assert configured_loggers, "logger should be configured"
+    last_logger = configured_loggers[-1]
+    assert any(event == "config_error" for event, _ in last_logger.events)
+    assert any(
+        event == "pipeline_end" and payload.get("exit_code") == 1
+        for event, payload in last_logger.events
+    )
+
+
+def test_main_directory_setup_failure_logs_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Directory preparation failures should be reported before exiting."""
+
+    configured_loggers: list[DummyLogger] = []
+    monkeypatch.setattr(
+        cli, "configure_logger", _configure_logger_factory(configured_loggers)
+    )
+
+    cfg = Config()
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *_, **__: cfg)
+
+    def fail_dirs(*_: object, **__: object) -> None:
+        raise NotADirectoryError("output is not a directory")
+
+    monkeypatch.setattr(cli, "ensure_dirs", fail_dirs)
+
+    def fail_run(*_: object, **__: object) -> int:
+        raise AssertionError("run should not execute")
+
+    monkeypatch.setattr(cli, "run", fail_run)
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    exit_code = cli.main(
+        [
+            "--input",
+            str(input_csv),
+            "--column",
+            "chembl_id",
+            "--chunk-size",
+            "2",
+        ]
+    )
+
+    assert exit_code == 1
+    assert configured_loggers, "logger should be configured"
+    last_logger = configured_loggers[-1]
+    assert any(
+        event == "directory_setup_failed" for event, _ in last_logger.events
+    )
+    assert any(
+        event == "pipeline_end" and payload.get("exit_code") == 1
+        for event, payload in last_logger.events
     )


### PR DESCRIPTION
## Summary
- wrap mapper_batch_main configuration loading in defensive error handling that mirrors mapper_main
- emit config_error and directory_setup_failed events before exiting early when configuration or directory setup fails
- extend the mapper_batch_main tests to cover missing configuration paths and directory setup failures

## Testing
- pytest tests/test_mapper_batch_main.py

------
https://chatgpt.com/codex/tasks/task_e_68ded426a0908324b093c20915adcba1