### PR TITLE
Handle read_csv failures gracefully

### DIFF
--- a/library/io/readers.py
+++ b/library/io/readers.py
@@ -257,14 +257,25 @@ def read_csv(
 
     sep = sep or cfg.csv_sep
     encoding = encoding or cfg.csv_encoding
-    df = pd.read_csv(
-        path,
-        sep=sep,
-        encoding=encoding,
-        dtype=dtype,
-        na_values=na_values,
-        parse_dates=list(parse_dates) if parse_dates is not None else None,
-    )
+    path_obj = Path(path)
+
+    try:
+        df = pd.read_csv(
+            path_obj,
+            sep=sep,
+            encoding=encoding,
+            dtype=dtype,
+            na_values=na_values,
+            parse_dates=list(parse_dates) if parse_dates is not None else None,
+        )
+    except (FileNotFoundError, pd.errors.ParserError, UnicodeError) as exc:
+        logger.error(
+            "read_fail",
+            path=str(path_obj),
+            encoding=encoding,
+            error=str(exc),
+        )
+        raise SystemExit(1) from exc
     if schema is not None:
         if pa is None:
             raise RuntimeError(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -18,6 +18,17 @@ from library.config import Config, IoCfg
 from library.logging_setup import LoggerConfig, configure_logger
 
 
+def _bind_io_logger(monkeypatch: pytest.MonkeyPatch) -> StringIO:
+    """Return a stream capturing ``library.io.readers`` log output."""
+
+    from library.io import readers as io_readers
+
+    stream = StringIO()
+    test_logger = configure_logger(LoggerConfig(level="INFO", stream=stream))
+    monkeypatch.setattr(io_readers, "logger", test_logger)
+    return stream
+
+
 def test_read_csv_validates_columns(tmp_path: Path) -> None:
     path = tmp_path / "data.csv"
     with path.open("w", newline="") as fh:
@@ -120,6 +131,46 @@ def test_read_csv_with_schema(tmp_path: Path) -> None:
     bad_schema = pa.DataFrameSchema({"a": pa.Column(int), "c": pa.Column(str)})
     with pytest.raises(pa.errors.SchemaError):
         io.read_csv(path, cfg=IoCfg(), schema=bad_schema)
+
+
+def test_read_csv_missing_file_logs_and_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = IoCfg()
+    stream = _bind_io_logger(monkeypatch)
+    missing = tmp_path / "missing.csv"
+
+    with pytest.raises(SystemExit) as exc:
+        io.read_csv(missing, cfg=cfg)
+
+    assert exc.value.code == 1
+    records = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert records, "read_csv should emit a read_fail log"
+    record = records[-1]
+    assert record["event"] == "read_fail"
+    assert record["path"] == str(missing)
+    assert record["encoding"] == cfg.csv_encoding
+
+
+def test_read_csv_parser_error_logs_and_exits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = IoCfg()
+    stream = _bind_io_logger(monkeypatch)
+    malformed = tmp_path / "malformed.csv"
+    malformed.write_text("value\n\"unterminated", encoding=cfg.csv_encoding)
+
+    with pytest.raises(SystemExit) as exc:
+        io.read_csv(malformed, cfg=cfg)
+
+    assert exc.value.code == 1
+    records = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert records, "read_csv should emit a read_fail log"
+    record = records[-1]
+    assert record["event"] == "read_fail"
+    assert record["path"] == str(malformed)
+    assert record["encoding"] == cfg.csv_encoding
+    assert "error" in record
 
 
 def test_write_csv_creates_metadata_file(tmp_path: Path, cfg: Config) -> None:


### PR DESCRIPTION
## Summary
- ensure io.readers.read_csv logs read_fail and exits on missing or malformed input
- add regression tests covering missing files and parser errors

## Testing
- pytest tests/test_io.py::test_read_csv_missing_file_logs_and_exits tests/test_io.py::test_read_csv_parser_error_logs_and_exits

------
https://chatgpt.com/codex/tasks/task_e_68ded42aad7483249a5ef39188291990