### PR TITLE
Optimize sidecar discovery traversal

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -25,8 +25,10 @@ import argparse
 import sys
 import time
 import uuid
+from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Callable, Sequence
 
@@ -334,7 +336,13 @@ class SidecarArtefact:
     working_path: Path | None = None
 
 
-def _discover_sidecars(final_output: Path, working_output: Path) -> dict[Path, SidecarArtefact]:
+def _discover_sidecars(
+    final_output: Path,
+    working_output: Path,
+    *,
+    max_depth: int | None = None,
+    include_patterns: Sequence[str] | None = None,
+) -> dict[Path, SidecarArtefact]:
     """Return all auxiliary files derived from ``final_output`` and ``working_output``."""
 
     final_dir = final_output.parent
@@ -346,11 +354,25 @@ def _discover_sidecars(final_output: Path, working_output: Path) -> dict[Path, S
         working_output.name,
         working_output.with_suffix("").name,
     }
+    prefix_candidates: set[str] = set()
+    for candidate in (final_output, working_output):
+        current = candidate
+        while True:
+            prefix_candidates.add(current.name)
+            if not current.suffix:
+                break
+            current = current.with_suffix("")
     replacements = (
         (working_output.name, final_output.name),
         (working_output.with_suffix("").name, final_output.with_suffix("").name),
     )
     main_outputs = {final_output.resolve(), working_output.resolve()}
+
+    def _matches_explicit_patterns(rel_path: Path, name: str) -> bool:
+        if include_patterns is None:
+            return False
+        rel_value = rel_path.as_posix()
+        return any(fnmatch(rel_value, pattern) or fnmatch(name, pattern) for pattern in include_patterns)
 
     def _normalise_relative(path: Path) -> Path:
         parts: list[str] = []
@@ -367,22 +389,39 @@ def _discover_sidecars(final_output: Path, working_output: Path) -> dict[Path, S
         collected: dict[Path, Path] = {}
         if not base_dir.exists():
             return collected
-        for candidate in base_dir.rglob("*"):
-            if not candidate.is_file():
-                continue
+        queue: deque[tuple[Path, int, bool]] = deque([(base_dir, 0, False)])
+        while queue:
+            current, depth, within_branch = queue.popleft()
             try:
-                resolved = candidate.resolve()
+                entries = list(current.iterdir())
             except OSError:  # pragma: no cover - filesystem race protection
                 continue
-            if resolved in main_outputs:
-                continue
-            name = candidate.name
-            if name == sentinel_name:
-                continue
-            if not any(name.startswith(pattern) for pattern in patterns):
-                continue
-            rel_path = candidate.relative_to(base_dir)
-            collected[rel_path] = candidate
+            for entry in entries:
+                rel_path = entry.relative_to(base_dir)
+                name = entry.name
+                if entry.is_dir():
+                    next_depth = depth + 1
+                    if max_depth is not None and next_depth > max_depth:
+                        continue
+                    matches_prefix = any(name.startswith(prefix) for prefix in prefix_candidates)
+                    matches_pattern = _matches_explicit_patterns(rel_path, name)
+                    next_within = within_branch or matches_prefix or matches_pattern
+                    if next_within:
+                        queue.append((entry, next_depth, next_within))
+                    continue
+                matches_default = any(name.startswith(pattern) for pattern in patterns)
+                matches_explicit = _matches_explicit_patterns(rel_path, name)
+                if not matches_default and not matches_explicit:
+                    continue
+                if name == sentinel_name:
+                    continue
+                try:
+                    resolved = entry.resolve()
+                except OSError:  # pragma: no cover - filesystem race protection
+                    continue
+                if resolved in main_outputs:
+                    continue
+                collected[rel_path] = entry
         return collected
 
     sidecars: dict[Path, SidecarArtefact] = {}

--- a/tests/test_sidecar_discovery.py
+++ b/tests/test_sidecar_discovery.py
@@ -1,0 +1,74 @@
+"""Regression tests for sidecar discovery pruning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import get_data
+
+
+def test_discover_sidecars_skips_irrelevant_directories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Large unrelated directories should not be traversed during discovery."""
+
+    final_dir = tmp_path / "outputs"
+    final_dir.mkdir()
+    final_output = final_dir / "output.activities_20240101.csv"
+    final_output.touch()
+    working_output = final_dir / ".output.activities_20240101.csv.tmp"
+    working_output.touch()
+
+    quality_dir = final_dir / f"{final_output.stem}_quality"
+    reports_dir = quality_dir / "reports"
+    reports_dir.mkdir(parents=True)
+    quality_file = reports_dir / f"{final_output.name}.quality.json"
+    quality_file.write_text("{}", encoding="utf-8")
+
+    unrelated_root = final_dir / "unrelated"
+    for idx in range(5):
+        branch = unrelated_root / f"branch_{idx}"
+        nested = branch / "payload"
+        nested.mkdir(parents=True, exist_ok=True)
+        for part in range(10):
+            artifact = nested / f"artifact_{idx}_{part}.txt"
+            artifact.write_text("payload", encoding="utf-8")
+
+    path_type = type(final_dir)
+    original_iterdir = path_type.iterdir
+
+    def guarded_iterdir(self: Path):  # type: ignore[override]
+        if self == unrelated_root:
+            raise AssertionError("discover_sidecars should not scan unrelated trees")
+        return original_iterdir(self)
+
+    monkeypatch.setattr(path_type, "iterdir", guarded_iterdir)
+
+    sidecars = get_data._discover_sidecars(final_output, working_output)
+
+    rel_quality = quality_file.relative_to(final_dir)
+    assert rel_quality in sidecars
+    assert sidecars[rel_quality].destination == final_dir / rel_quality
+
+
+def test_discover_sidecars_respects_depth_limit(tmp_path: Path) -> None:
+    """Depth limits restrict traversal to the configured hierarchy."""
+
+    final_dir = tmp_path / "outputs"
+    final_dir.mkdir()
+    final_output = final_dir / "output.targets_20240101.csv"
+    final_output.touch()
+    working_output = final_dir / ".output.targets_20240101.csv.tmp"
+    working_output.touch()
+
+    nested_dir = final_dir / f"{final_output.stem}_quality" / "nested" / "leaf"
+    nested_dir.mkdir(parents=True)
+    nested_file = nested_dir / f"{final_output.name}.quality.json"
+    nested_file.write_text("{}", encoding="utf-8")
+
+    shallow_sidecars = get_data._discover_sidecars(final_output, working_output, max_depth=1)
+    nested_rel = nested_file.relative_to(final_dir)
+    assert nested_rel not in shallow_sidecars
+
+    deep_sidecars = get_data._discover_sidecars(final_output, working_output, max_depth=5)
+    assert nested_rel in deep_sidecars


### PR DESCRIPTION
## Summary
- prune sidecar discovery to walk only directories tied to the target output while supporting optional depth and pattern filters
- add regression coverage to ensure unrelated trees are skipped and depth limits work

## Testing
- pytest tests/test_sidecar_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68ded4c7162c83248f5e7d8715866af7