### PR TITLE
Document user-writable defaults and config override workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ running `pip install .[dev]` and freezing the result with
 новое виртуальное окружение, выполните `pip install .[dev]`, а затем
 `pip freeze > requirements-lock.txt`.
 
+> **EN.** Fresh wheel installs now rely on platform-specific user directories.
+> The packaged configuration is copied to the user config home, CSV exports go
+> to the user data directory and HTTP caches live in the user cache directory.
+> Adjust these paths via the `local.io.*` keys if required or keep the defaults
+> listed below. See also the [FAQ entry on wheel vs. source usage](#faq-wheel-vs-source).
+>
+> **RU.** Новые установки wheel используют каталоги пользователя, подобранные
+> `platformdirs`: конфигурация копируется в пользовательский каталог настроек,
+> выгрузки — в пользовательский каталог данных, кэши HTTP — в пользовательский
+> каталог кэша. При необходимости меняйте их через `local.io.*` или оставляйте
+> значения по умолчанию из таблицы. Дополнительные детали собраны в
+> [FAQ про wheel и исходники](#faq-wheel-vs-source).
+
+| Platform / Платформа | Config dir / Каталог конфигурации | Output dir / Каталог выгрузки | Cache dir / Каталог кэша |
+| --------------------- | --------------------------------- | ----------------------------- | ------------------------ |
+| Linux (XDG)           | `~/.config/chembl-data-acquisition/config.yaml` | `~/.local/share/chembl-data-acquisition/output` | `~/.cache/chembl-data-acquisition` |
+| macOS                 | `~/Library/Application Support/chembl-data-acquisition/config.yaml` | `~/Library/Application Support/chembl-data-acquisition/output` | `~/Library/Caches/chembl-data-acquisition` |
+| Windows               | `%APPDATA%\chembl-data-acquisition\config.yaml` | `%LOCALAPPDATA%\chembl-data-acquisition\output` | `%LOCALAPPDATA%\chembl-data-acquisition\Cache` |
+
 Sensitive configuration such as API tokens belongs in a local ``.env`` file – see [`Конфигурация через .env`](#конфигурация-через-env) for usage guidelines.
 
 ## Quick Start / Быстрый старт
@@ -164,6 +183,34 @@ Sensitive configuration such as API tokens belongs in a local ``.env`` file – 
   python -m library.utils.cli_tools.table_quality_main --input tests/data/chembl_targets_min.csv \
       --output out/quality --table-name chembl_targets --log-level INFO
   ```
+
+   EN: Maintain a custom configuration by copying the packaged YAML into the
+   user config directory and passing it via `--config`. The loader automatically
+   merges a sibling `config.local.yaml`, keeping your overrides separate from the
+   upstream defaults. Example:
+
+  ```bash
+  python - <<'PY'
+from importlib import resources
+from pathlib import Path
+
+target = Path.home() / ".config" / "chembl-data-acquisition"
+target.mkdir(parents=True, exist_ok=True)
+source = resources.files("chembl_data_acquisition.config") / "config.yaml"
+target_cfg = target / "config.yaml"
+target_cfg.write_bytes(source.read_bytes())
+PY
+
+  get-data --config ~/.config/chembl-data-acquisition/config.yaml \
+      --output-dir ~/.local/share/chembl-data-acquisition/output
+  ```
+
+   RU: Чтобы сопровождать собственную конфигурацию, скопируйте штатный YAML в
+   пользовательский каталог настроек и передайте путь через `--config`.
+   Файл `config.local.yaml`, лежащий рядом, автоматически объединяется с базой,
+   поэтому изменения остаются отделены от стандартов. Пример выше можно
+   использовать и в Linux/macOS; в PowerShell путь будет
+   `%APPDATA%\chembl-data-acquisition\config.yaml`.
 
   EN: In the reporting example above `--output` sets the destination. `--final-out`
   currently exists only in `scripts.get_target_data` and
@@ -916,6 +963,19 @@ pytest
 ```
 
 Test datasets live in ``tests/data``; ``library.utils.cli_tools.check_determinism`` validates repeatable CSV output. / Тестовые наборы лежат в ``tests/data``; ``library.utils.cli_tools.check_determinism`` проверяет повторяемость CSV-вывода.
+
+## FAQ
+
+<a id="faq-wheel-vs-source"></a>
+### Wheel vs. source installation / Установка wheel против исходников
+
+**EN.** Install the published wheel (`pip install chembl-data-acquisition`) when you only need the pipelines: the package ships with the default configuration, dictionary resources and schema validators, and now places writable artefacts under platform-specific user directories (see the table above). Keep long-term tweaks in a sibling `config.local.yaml` or point CLI commands at a cloned copy via `--config`.
+
+**RU.** Используйте опубликованный wheel (`pip install chembl-data-acquisition`), если достаточно готовых пайплайнов: пакет включает конфигурацию по умолчанию, словари и схемы, а артефакты записывает в пользовательские каталоги (см. таблицу выше). Долгосрочные правки сохраняйте в `config.local.yaml` рядом с файлом или передавайте путь к собственной копии через `--config`.
+
+**EN.** Clone the repository when developing new features or debugging: editable installs keep tests, documentation sources and tooling such as `pre-commit` at hand, and you can pin dependencies via `requirements-lock.txt`.
+
+**RU.** Клонируйте репозиторий для разработки и отладки: так остаются доступны тесты, исходники документации и инструменты (`pre-commit` и др.), а зависимости фиксируются через `requirements-lock.txt`.
 
 ## Лицензия
 


### PR DESCRIPTION
## Summary
- describe the new platform-specific user directories for default configuration, output and cache paths
- show how to maintain a custom configuration copy and link to a wheel vs. source FAQ entry

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ded4d295e88324878ecbf1f1a985a9