### PR TITLE
Use shared default config path for get-data CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Sensitive configuration such as API tokens belongs in a local ``.env`` file – 
    ознакомления с опциями можно запускать полный экспорт, указав реальные
    каталоги.
 
+   EN: Without ``--config`` the orchestrator now falls back to the packaged
+   ``config/config.yaml`` via ``library.utils.config.DEFAULT_CONFIG_PATH``. Pass
+   an explicit path whenever you maintain a local override.
+
+   RU: При запуске без ``--config`` оркестратор использует встроенный
+   ``config/config.yaml`` через ``library.utils.config.DEFAULT_CONFIG_PATH``.
+   Собственный YAML укажите явным путём.
+
    For lightweight smoke checks you can still call individual helpers, for
    example:
 

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -52,6 +52,7 @@ from scripts import (
 )
 
 from library.logging_setup import Logger, LoggerConfig, configure_logger
+from library.utils.config import DEFAULT_CONFIG_PATH
 
 
 _LOGGER: Logger = Logger(LoggerConfig())
@@ -218,7 +219,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument(
         "--config",
         type=Path,
-        default=Path("config/config.yaml"),
+        default=DEFAULT_CONFIG_PATH,
         help="YAML configuration shared by all pipelines",
     )
     parser.add_argument(
@@ -265,7 +266,8 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
     base_path = args.base_path.expanduser().resolve()
     input_dir = _resolve_path(base_path, args.input_dir)
     output_dir = _resolve_path(base_path, args.output_dir)
-    config_path = args.config.expanduser().resolve()
+    config_candidate = args.config or DEFAULT_CONFIG_PATH
+    config_path = Path(config_candidate).expanduser().resolve()
 
     if args.limit is not None and args.limit < 0:
         raise ValueError("--limit must be zero or a positive integer")
@@ -286,7 +288,7 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
         limit=args.limit,
         force=args.force,
         skip_existing=args.skip_existing,
-        dry_run=args.dry_run,
+        dry_run=bool(getattr(args, "dry_run", False)),
     )
 
 

--- a/tests/test_csv_utils_main_args.py
+++ b/tests/test_csv_utils_main_args.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from library.utils.cli_tools import csv_utils_main as cli
+from library.utils.config import DEFAULT_CONFIG_PATH
 
 
 def _fd_count() -> int:
@@ -99,6 +100,8 @@ def test_cli_arguments_passed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
             "3",
             "--log-level",
             "INFO",
+            "--config",
+            str(DEFAULT_CONFIG_PATH),
         ]
     )
     assert rc == 0
@@ -133,6 +136,8 @@ def test_cli_writes_with_custom_separator_and_encoding(tmp_path: Path) -> None:
             "id",
             "--log-level",
             "INFO",
+            "--config",
+            str(DEFAULT_CONFIG_PATH),
         ]
     )
 
@@ -207,7 +212,18 @@ def test_cli_generates_output_path(
 
     monkeypatch.setattr(cli.logger, "info", fake_info)
 
-    rc = cli.main(["--input", str(input_csv), "--key-cols", "a"])
+    rc = cli.main(
+        [
+            "--input",
+            str(input_csv),
+            "--key-cols",
+            "a",
+            "--date",
+            "20240102",
+            "--config",
+            str(DEFAULT_CONFIG_PATH),
+        ]
+    )
     assert rc == 0
     expected = input_csv.with_name("output.input_20240102.csv")
     assert called["output"] == expected
@@ -220,7 +236,9 @@ def test_cli_uses_configured_delimiter(
     input_csv = tmp_path / "in.csv"
     input_csv.write_text("a,b\n1,2\n", encoding="utf8")
     config_path = tmp_path / "cfg.yaml"
-    config_data = yaml.safe_load(Path("config/config.yaml").read_text(encoding="utf8"))
+    config_data = yaml.safe_load(
+        DEFAULT_CONFIG_PATH.read_text(encoding="utf8")
+    )
     config_data["local"]["io"]["csv_sep"] = ";"
     config_data["local"]["io"]["csv_encoding"] = "latin1"
     config_data["local"]["io"]["csv_chunksize"] = 256
@@ -338,6 +356,8 @@ def test_cli_resolves_paths_with_base_path(
             "20240203",
             "--key-cols",
             "a",
+            "--config",
+            str(DEFAULT_CONFIG_PATH),
         ]
     )
 
@@ -359,6 +379,8 @@ def test_cli_does_not_leak_file_descriptors(tmp_path: Path) -> None:
         "id",
         "--chunk-size",
         "1",
+        "--config",
+        str(DEFAULT_CONFIG_PATH),
     ]
 
     for run in range(3):


### PR DESCRIPTION
## Summary
- import and reuse `DEFAULT_CONFIG_PATH` for the `get-data` CLI defaults
- update csv utility tests to supply explicit configuration paths and deterministic arguments
- document the orchestrator fallback behaviour in the README quick-start section

## Testing
- pytest tests/test_csv_utils_main_args.py tests/test_get_data_cli_limit.py tests/smoke/test_get_data_scripts.py

------
https://chatgpt.com/codex/tasks/task_e_68ded5cabc708324a582447461a3f175