### PR TITLE
Gracefully handle metadata hook failures

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -200,6 +200,7 @@ def run_pipeline(
     key_columns: Sequence[str],
     table_quality: TableQualityHook,
     cfg: Config | None = None,
+    strict_mode: bool = False,
     logger: Logger | None = None,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
@@ -246,6 +247,9 @@ def run_pipeline(
         Callable invoked after writing the CSV to compute quality metrics.
     cfg:
         Optional application configuration forwarded to sidecar metadata.
+    strict_mode:
+        When ``True`` metadata hook failures abort the pipeline mimicking the
+        legacy behaviour used in CI environments.
     logger:
         Optional logger.  Defaults to :data:`library.log.logger` when omitted.
 
@@ -306,6 +310,7 @@ def run_pipeline(
     missing_required_columns: set[str] = set()
     all_columns: set[str] = set()
     validation_enabled = True
+    failed_metadata_hooks: set[str] = set()
 
     try:
         iterable = _as_iterable(fetcher())
@@ -353,26 +358,36 @@ def run_pipeline(
 
         chunks_emitted = False
         aborted = False
+        chunk_index = 0
 
         try:
             for chunk in iterable:
                 if chunk is None:
                     continue
 
+                chunk_index += 1
                 chunk_rows_total = len(chunk)
                 rows_total += chunk_rows_total
 
                 for hook in metadata_hooks:
+                    hook_name = _callable_name(hook)
                     try:
                         chunk = hook(chunk)
                     except Exception as exc:
                         use_logger.error(
                             "metadata_hook_failed",
-                            hook=_callable_name(hook),
+                            hook=hook_name,
                             error=str(exc),
+                            error_type=exc.__class__.__name__,
+                            context="chunk",
+                            chunk_index=chunk_index,
+                            rows=chunk_rows_total,
+                            strict_mode=strict_mode,
                         )
-                        aborted = True
-                        raise _AbortPipeline(1) from exc
+                        failed_metadata_hooks.add(hook_name)
+                        if strict_mode:
+                            aborted = True
+                            raise _AbortPipeline(1) from exc
 
                 _refresh_column_tracking(chunk)
 
@@ -447,15 +462,21 @@ def run_pipeline(
             if not aborted and not chunks_emitted and not missing_required_columns:
                 empty = pd.DataFrame()
                 for hook in metadata_hooks:
+                    hook_name = _callable_name(hook)
                     try:
                         empty = hook(empty)
                     except Exception as exc:  # pragma: no cover - rare failure path
                         use_logger.error(
                             "metadata_hook_failed",
-                            hook=_callable_name(hook),
+                            hook=hook_name,
                             error=str(exc),
+                            error_type=exc.__class__.__name__,
+                            context="empty_frame",
+                            strict_mode=strict_mode,
                         )
-                        raise _AbortPipeline(1) from exc
+                        failed_metadata_hooks.add(hook_name)
+                        if strict_mode:
+                            raise _AbortPipeline(1) from exc
                 _refresh_column_tracking(empty)
                 yield empty.reindex(columns=col_order) if col_order else empty
 
@@ -546,9 +567,10 @@ def run_pipeline(
     }
  
     resolved_invocation = invocation_tuple
- 
- 
- 
+
+    extra_metadata: dict[str, object] = {}
+    if failed_metadata_hooks:
+        extra_metadata["metadata_hook_failures"] = sorted(failed_metadata_hooks)
 
     meta_path = write_meta_yaml(
         csv_path=csv_path,
@@ -558,6 +580,7 @@ def run_pipeline(
         stats=stats,
         schema=schema_name,
         invocation=resolved_invocation or None,
+        extra_metadata=extra_metadata or None,
     )
 
     try:

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -73,6 +73,7 @@ def write_meta_yaml(
     schema: str,
     *,
     invocation: Sequence[str] | None = None,
+    extra_metadata: Mapping[str, Any] | None = None,
 ) -> Path:
     """Write metadata for ``csv_path`` to ``<csv_path>.meta.yaml``.
 
@@ -94,6 +95,9 @@ def write_meta_yaml(
     invocation:
         Optional tuple describing the exact CLI invocation. Persisted when
         provided to aid reproducibility.
+    extra_metadata:
+        Optional mapping merged into the generated metadata prior to
+        serialisation.
 
     Returns
     -------
@@ -130,6 +134,8 @@ def write_meta_yaml(
     )
     if invocation:
         metadata["invocation"] = list(invocation)
+    if extra_metadata:
+        metadata.update(dict(extra_metadata))
 
     with open_atomic(meta_path, encoding="utf-8") as fh:
         yaml.safe_dump(metadata, fh, sort_keys=False)

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -530,6 +530,10 @@ def test_run_pipeline_metadata_hook_failure(tmp_path: Path, cfg: Config) -> None
         key_cols: list[str],
     ) -> Path:
         writer_called.append(destination)
+        destination.write_text(
+            "assay_chembl_id,document_chembl_id\nA1,D1\n",
+            encoding="utf-8",
+        )
         return destination
 
     buf = io.StringIO()
@@ -553,9 +557,9 @@ def test_run_pipeline_metadata_hook_failure(tmp_path: Path, cfg: Config) -> None
         logger=logger,
     )
 
-    assert exit_code == 1
-    assert not writer_called
-    assert not output.exists()
+    assert exit_code == 0
+    assert writer_called
+    assert output.exists()
     assert not failure_path.exists()
 
     lines = [line for line in buf.getvalue().splitlines() if line.strip()]
@@ -565,6 +569,84 @@ def test_run_pipeline_metadata_hook_failure(tmp_path: Path, cfg: Config) -> None
     hook_errors = [record for record in records if record.get("event") == "metadata_hook_failed"]
     assert hook_errors
     assert hook_errors[-1]["error"] == "hook boom"
+    assert hook_errors[-1]["context"] == "chunk"
+    assert hook_errors[-1]["strict_mode"] is False
+
+    meta_path = output.with_name(output.name + ".meta.yaml")
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    failures = metadata.get("metadata_hook_failures")
+    assert failures
+    assert any(str(name).endswith(".hook") for name in failures)
+
+
+def test_run_pipeline_metadata_hook_failure_strict(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [
+            pd.DataFrame(
+                {
+                    "assay_chembl_id": ["A1"],
+                    "document_chembl_id": ["D1"],
+                }
+            )
+        ]
+
+    def hook(_: pd.DataFrame) -> pd.DataFrame:
+        raise RuntimeError("hook boom")
+
+    writer_called: list[Path] = []
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        writer_called.append(destination)
+        destination.write_text(
+            "assay_chembl_id,document_chembl_id\nA1,D1\n",
+            encoding="utf-8",
+        )
+        return destination
+
+    buf = io.StringIO()
+    logger = setup_logger(LoggerConfig(stream=buf), replace_root=False)
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=AssaysSchema,
+        schema_name="AssaysSchema",
+        validators=[],
+        metadata_hooks=[hook],
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda path: None,
+        cfg=cfg,
+        strict_mode=True,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    assert not writer_called
+    assert not output.exists()
+    assert not failure_path.exists()
+
+    lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+    assert lines
+    records = [json.loads(line) for line in lines]
+    hook_errors = [record for record in records if record.get("event") == "metadata_hook_failed"]
+    assert hook_errors
+    assert hook_errors[-1]["strict_mode"] is True
 
 
 def test_run_pipeline_writer_failure(tmp_path: Path, cfg: Config) -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -92,6 +92,31 @@ def test_write_meta_yaml_preserves_existing_columns(tmp_path: Path) -> None:
     assert data["stats"] == stats
 
 
+def test_write_meta_yaml_includes_extra_metadata(tmp_path: Path) -> None:
+    csv_path = tmp_path / "output.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+
+    stats: Stats = {
+        "rows_total": 1,
+        "rows_kept": 1,
+        "rows_dropped": 0,
+        "output_sha256": "feedface",
+    }
+
+    meta_path = write_meta_yaml(
+        csv_path=csv_path,
+        command="unit-test",
+        config_subset={},
+        inputs={},
+        stats=stats,
+        schema="Schema",
+        extra_metadata={"metadata_hook_failures": ["hook"]},
+    )
+
+    data = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert data["metadata_hook_failures"] == ["hook"]
+
+
 def test_write_meta_yaml_failure_preserves_original(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- stop aborting pipelines when metadata hooks fail unless strict mode is enabled
- log additional context for hook errors and persist failing hook names in the metadata sidecar
- extend metadata writing utilities and tests to cover the new behaviour and strict-mode path

## Testing
- pytest tests/test_cli_utils.py tests/test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68ded7de29748324a864095725790f90