### PR TITLE
Improve parent lookup fallback concurrency

### DIFF
--- a/library/molecule_catalog.py
+++ b/library/molecule_catalog.py
@@ -354,14 +354,25 @@ def _fetch_parent_catalog_via_helper(
 
         if outstanding:
             single_requests = len(outstanding)
-            if retry_chunk_size:
-                max_workers = max(
-                    1, min(len(outstanding), _PARENT_LOOKUP_SINGLE_CONCURRENCY)
-                )
-            else:
-                max_workers = 1
+            max_workers = max(
+                1,
+                min(
+                    len(outstanding),
+                    _PARENT_LOOKUP_SINGLE_CONCURRENCY,
+                    max(1, api_cfg.rps),
+                ),
+            )
+
+            resolution_cache: dict[str, tuple[str, str] | None] = {}
+            resolution_lock = threading.Lock()
+            resolved: dict[str, tuple[str, str] | None] = {}
 
             def _fetch_with_retry(chembl_id: str) -> tuple[str, str] | None:
+                with resolution_lock:
+                    if chembl_id in resolution_cache:
+                        return resolution_cache[chembl_id]
+
+                pair: tuple[str, str] | None = None
                 for attempt in range(1, attempts + 1):
                     try:
                         pair = fetch_parent_for_id(
@@ -377,14 +388,16 @@ def _fetch_parent_catalog_via_helper(
                                 "parent_lookup_single_failed",
                                 extra={"chembl_id": chembl_id, "error": str(exc)},
                             )
-                            return None
+                            pair = None
+                            break
                         if delay:
                             sleep(delay * (2 ** (attempt - 1)))
                         continue
-                    if pair is None:
-                        return None
-                    return pair
-                return None
+                    break
+
+                with resolution_lock:
+                    resolution_cache[chembl_id] = pair
+                return pair
 
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_map = {
@@ -392,21 +405,24 @@ def _fetch_parent_catalog_via_helper(
                     for chembl_id in outstanding
                 }
                 for future in as_completed(future_map):
+                    chembl_id = future_map[future]
                     try:
-                        pair = future.result()
+                        resolved[chembl_id] = future.result()
                     except Exception as exc:  # pragma: no cover - defensive logging
                         logger.warning(
                             "parent_lookup_single_failed",
-                            extra={
-                                "chembl_id": future_map[future],
-                                "error": str(exc),
-                            },
+                            extra={"chembl_id": chembl_id, "error": str(exc)},
                         )
-                        continue
-                    if not pair:
-                        continue
-                    child_id, parent_id = pair
-                    result[child_id] = parent_id
+                        with resolution_lock:
+                            resolution_cache.setdefault(chembl_id, None)
+                        resolved[chembl_id] = None
+
+            for chembl_id in outstanding:
+                pair = resolved.get(chembl_id)
+                if not pair:
+                    continue
+                child_id, parent_id = pair
+                result[child_id] = parent_id
     finally:
         elapsed = perf_counter() - fallback_start
         logger.info(

--- a/tests/test_molecule_catalog_threadsafe.py
+++ b/tests/test_molecule_catalog_threadsafe.py
@@ -112,3 +112,55 @@ def test_helper_skips_catalog_refresh_when_lock_held(monkeypatch) -> None:
 
     assert result == {}
     assert load_calls == []
+
+
+def test_fetch_parent_catalog_for_preserves_order(monkeypatch) -> None:
+    """Fallback single lookups should keep deterministic ordering."""
+
+    api_cfg = ApiCfg(user_agent="chembl-da-tests (mailto:test@example.org)")
+    cfg = MoleculeCatalogCfg(filters={})
+
+    monkeypatch.setattr(
+        molecule_catalog,
+        "_fetch_parent_catalog_chunk",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(molecule_catalog, "query_parent_catalog", lambda *_, **__: {})
+    monkeypatch.setattr(molecule_catalog, "load_parent_catalog", lambda **_: {})
+
+    completion_order: list[str] = []
+    release_first = threading.Event()
+
+    def fake_fetch_parent_for_id(chembl_id: str, **_: object) -> tuple[str, str]:
+        if chembl_id == "CHEMBL1":
+            if not release_first.wait(timeout=1):
+                raise RuntimeError("second lookup did not complete in time")
+            parent = "CHEMBL10"
+        else:
+            release_first.set()
+            parent = "CHEMBL20"
+        completion_order.append(chembl_id)
+        return chembl_id, parent
+
+    monkeypatch.setattr(
+        molecule_catalog, "fetch_parent_for_id", fake_fetch_parent_for_id
+    )
+
+    class NoRequestClient:
+        def request_json(self, *args, **kwargs):  # pragma: no cover - defensive
+            raise AssertionError("unexpected network call")
+
+    client = NoRequestClient()
+
+    result = molecule_catalog.fetch_parent_catalog_for(
+        ["CHEMBL1", "CHEMBL2"],
+        client=client,
+        api_cfg=api_cfg,
+        catalog_cfg=cfg,
+    )
+
+    assert completion_order == ["CHEMBL2", "CHEMBL1"]
+    assert list(result.items()) == [
+        ("CHEMBL1", "CHEMBL10"),
+        ("CHEMBL2", "CHEMBL20"),
+    ]


### PR DESCRIPTION
## Summary
- resolve outstanding parent lookups through a ThreadPoolExecutor constrained by the API rate limit while sharing a thread-safe resolution cache to preserve insertion order
- add an integration test covering deterministic ordering when concurrent fallback requests complete out of order

## Testing
- pytest tests/test_molecule_catalog_threadsafe.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ded7f09da08324a8d514a117eac2f4