### PR TITLE
Handle table quality failure non fatally

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -711,6 +711,11 @@
           ],
           "default": null,
           "title": "Exclude Columns"
+        },
+        "fatal_on_error": {
+          "default": false,
+          "title": "Fatal On Error",
+          "type": "boolean"
         }
       },
       "title": "DocQualityCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -330,6 +330,7 @@ system:
     sample_rows: null  # Limit profiling to the first N rows (null keeps all)
     include_columns: null  # Optional allow list of column names to analyse
     exclude_columns: null  # Optional deny list of column names to skip
+    fatal_on_error: false  # Fail the pipeline when table profiling raises
   doc_type:
     weights:
       pubmed: 4

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -355,6 +355,7 @@ Paths under `data/input/ChEMBL/*.xlsx` are placeholders included for local smoke
 |  | `sample_rows` | `null` | Limit analysis to the first `N` rows; `null` processes the full dataset. |
 |  | `include_columns` | `null` | Optional allow list of column names to profile. |
 |  | `exclude_columns` | `null` | Optional deny list of column names to skip. |
+|  | `fatal_on_error` | `false` | Treat profiling errors as fatal pipeline failures. |
 | `doc_type` | `weights` | `{pubmed: 4, openalex: 3, scholar: 2}` | Weighting applied to document sources. |
 |  | `thresholds` | `{review: 1, experimental: 1, unknown: 2}` | Minimum counts for document type classification. |
 |  | `limit` | `null` | Optional limit on classified records. |

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -33,7 +33,7 @@ from .cli import (
 )
 from .config import Config, ensure_dirs, print_config
 from .log import logger as default_logger
-from .metadata import Stats, file_sha256, write_meta_yaml
+from .metadata import Stats, file_sha256, write_meta_yaml, record_quality_failure
 from .sidecar import SidecarErrors
 from .utils.config import DEFAULT_CONFIG_PATH
 
@@ -560,21 +560,30 @@ def run_pipeline(
         invocation=resolved_invocation or None,
     )
 
+    doc_quality_cfg = getattr(getattr(cfg, "system", None), "doc_quality", None)
+    fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
+
     try:
         table_quality(csv_path)
     except Exception as exc:
-        use_logger.error(
-            "quality_report_failed",
+        tb = traceback.format_exc()
+        record_quality_failure(
+            meta_path,
             error=str(exc),
             error_type=exc.__class__.__name__,
-            path=str(csv_path),
-            traceback=traceback.format_exc(),
-
+            traceback=tb,
+            fatal=fatal_quality_error,
         )
-        if schema is not None:
-            Path(csv_path).unlink(missing_ok=True)
-        meta_path.unlink(missing_ok=True)
-        return 1
+        log_kwargs = {
+            "error": str(exc),
+            "error_type": exc.__class__.__name__,
+            "path": str(csv_path),
+            "traceback": tb,
+        }
+        if fatal_quality_error:
+            log_kwargs["fatal"] = True
+            exit_code = 1
+        use_logger.warning("quality_report_failed", **log_kwargs)
 
     if exit_code == 0:
         use_logger.info("write_done", rows=rows_kept, path=str(csv_path))

--- a/library/config.py
+++ b/library/config.py
@@ -581,6 +581,7 @@ class DocQualityCfg(_BaseModel):
     sample_rows: int | None = Field(default=None, ge=1)
     include_columns: tuple[str, ...] | None = None
     exclude_columns: tuple[str, ...] | None = None
+    fatal_on_error: bool = False
 
 
 class ResourcesCfg(_BaseModel):

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -22,6 +22,23 @@ from .git_utils import _git_sha
 from .log import logger
 from .utils.atomic import open_atomic
 
+
+def _load_metadata(meta_path: Path) -> dict[str, Any]:
+    """Return the metadata dictionary stored in ``meta_path`` if available."""
+
+    if not meta_path.exists():
+        return {}
+
+    try:
+        with meta_path.open("r", encoding="utf-8") as fh:
+            loaded = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError):
+        loaded = None
+
+    if isinstance(loaded, dict):
+        return dict(loaded)
+    return {}
+
 # ``datetime.UTC`` is only available in Python 3.11 and later.
 # ``timezone.utc`` provides the same value and works on older versions.
 UTC = timezone.utc  # noqa: UP017
@@ -104,15 +121,7 @@ def write_meta_yaml(
     path = Path(csv_path)
     meta_path = path.with_name(path.name + ".meta.yaml")
 
-    existing: dict[str, Any] = {}
-    if meta_path.exists():
-        try:
-            with meta_path.open("r", encoding="utf-8") as fh:
-                loaded = yaml.safe_load(fh)
-        except (OSError, yaml.YAMLError):
-            loaded = None
-        if isinstance(loaded, dict):
-            existing = dict(loaded)
+    existing = _load_metadata(meta_path)
 
     metadata: dict[str, Any] = dict(existing)
     metadata.update(
@@ -136,3 +145,36 @@ def write_meta_yaml(
         logger.info("metadata_written", path=str(meta_path))
 
     return meta_path
+
+
+def record_quality_failure(
+    meta_path: Path | str,
+    *,
+    error: str,
+    error_type: str,
+    traceback: str | None = None,
+    fatal: bool = False,
+) -> Path:
+    """Persist table quality failure details alongside existing metadata."""
+
+    path = Path(meta_path)
+    metadata = _load_metadata(path)
+
+    failure: dict[str, Any] = {
+        "status": "failed",
+        "error": error,
+        "error_type": error_type,
+        "captured_at": datetime.now(UTC).isoformat(),
+    }
+    if traceback:
+        failure["traceback"] = traceback
+    if fatal:
+        failure["fatal"] = True
+
+    metadata["quality_report"] = failure
+
+    with open_atomic(path, encoding="utf-8") as fh:
+        yaml.safe_dump(metadata, fh, sort_keys=False)
+        logger.info("metadata_quality_status", path=str(path), status="failed")
+
+    return path

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import traceback
 from collections import OrderedDict, deque
 from dataclasses import dataclass
 from itertools import chain, islice
@@ -26,7 +27,12 @@ from library.config import (
 )
 from library.csv_utils import write_csv_chunks_deterministic
 from library.log import logger
-from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.metadata import (
+    Stats,
+    file_sha256,
+    write_meta_yaml,
+    record_quality_failure,
+)
 from library.pipeline_metadata import add_pipeline_metadata
 from library.rate_limiter import get_global_limiter
 from library.sidecar import SidecarErrors
@@ -763,7 +769,7 @@ def finalize_output(
         stats["missing_molecule_ids"] = list(missing_ids_tuple)
         stats["missing_molecule_ids_count"] = len(missing_ids_tuple)
 
-    write_meta_yaml(
+    meta_path = write_meta_yaml(
         csv_path=csv_path,
         command=" ".join(sys.argv),
         config_subset=_serialize_paths(cfg.to_dict()),
@@ -773,6 +779,7 @@ def finalize_output(
     )
 
     doc_quality_cfg = cfg.system.doc_quality
+    fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
     try:
         if doc_quality_cfg.enable:
             analyze_table_quality(
@@ -784,12 +791,24 @@ def finalize_output(
                 exclude_columns=doc_quality_cfg.exclude_columns,
             )
     except Exception as exc:
-        logger.exception(
-            "quality_report_failed",
+        tb = traceback.format_exc()
+        record_quality_failure(
+            meta_path,
             error=str(exc),
-            path=str(output),
-            exc=exc,
+            error_type=exc.__class__.__name__,
+            traceback=tb,
+            fatal=fatal_quality_error,
         )
-        return 1
+        log_kwargs = {
+            "error": str(exc),
+            "error_type": exc.__class__.__name__,
+            "path": str(output),
+            "traceback": tb,
+        }
+        if fatal_quality_error:
+            log_kwargs["fatal"] = True
+        logger.warning("quality_report_failed", **log_kwargs)
+        if fatal_quality_error:
+            return 1
 
     return exit_code

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -342,10 +342,12 @@ def test_run_pipeline_removes_outputs_on_table_quality_failure(
 
     meta_path = output.with_name(output.name + ".meta.yaml")
 
-    assert exit_code == 1
+    assert exit_code == 0
     assert quality_calls == [output]
-    assert not output.exists()
-    assert not meta_path.exists()
+    assert output.exists()
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["quality_report"]["status"] == "failed"
 
 
 def test_run_pipeline_removes_stale_failure_outputs(tmp_path: Path, cfg: Config) -> None:
@@ -677,9 +679,21 @@ def test_run_pipeline_table_quality_failure(tmp_path: Path, cfg: Config) -> None
         logger=logger,
     )
 
-    assert exit_code == 1
+    assert exit_code == 0
     assert output.exists()
     assert not failure_path.exists()
+
+    meta_path = output.with_name(f"{output.name}.meta.yaml")
+    assert meta_path.exists()
+    with meta_path.open("r", encoding="utf-8") as fh:
+        metadata = yaml.safe_load(fh)
+    assert metadata
+    quality = metadata.get("quality_report")
+    assert quality
+    assert quality["status"] == "failed"
+    assert quality["error"] == "quality boom"
+    assert quality["error_type"] == "RuntimeError"
+    assert "captured_at" in quality
 
     lines = [line for line in buf.getvalue().splitlines() if line.strip()]
     assert lines
@@ -691,3 +705,71 @@ def test_run_pipeline_table_quality_failure(tmp_path: Path, cfg: Config) -> None
     last_record = quality_errors[-1]
     assert last_record["error"] == "quality boom"
     assert last_record.get("traceback")
+
+
+def test_run_pipeline_table_quality_failure_fatal(tmp_path: Path, cfg: Config) -> None:
+    cfg.system.doc_quality.fatal_on_error = True
+
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    frames = [
+        pd.DataFrame(
+            {
+                "assay_chembl_id": ["A1"],
+                "document_chembl_id": ["D1"],
+            }
+        )
+    ]
+
+    def fetcher() -> list[pd.DataFrame]:
+        return frames
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        collected = list(chunks)
+        if collected:
+            df = pd.concat(collected, ignore_index=True)
+        else:
+            df = pd.DataFrame(columns=col_order or [])
+        df.to_csv(destination, index=False)
+        return destination
+
+    buf = io.StringIO()
+    logger = setup_logger(LoggerConfig(stream=buf), replace_root=False)
+
+    def failing_quality(_: Path) -> None:
+        raise RuntimeError("quality boom")
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=None,
+        schema_name="",
+        validators=[],
+        metadata_hooks=None,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=[],
+        table_quality=failing_quality,
+        cfg=cfg,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    assert output.exists()
+    meta_path = output.with_name(f"{output.name}.meta.yaml")
+    assert meta_path.exists()
+    with meta_path.open("r", encoding="utf-8") as fh:
+        metadata = yaml.safe_load(fh)
+    quality = metadata.get("quality_report")
+    assert quality
+    assert quality["status"] == "failed"
+    assert quality["fatal"] is True


### PR DESCRIPTION
## Summary
- preserve CSV outputs and annotate metadata when table quality generation fails
- add a `system.doc_quality.fatal_on_error` flag to optionally treat profiling errors as fatal
- update documentation, config wiring, and CLI tests to cover the new behaviour

## Testing
- pytest tests/test_cli_utils.py
- pytest tests/test_testitem_pipeline_exports.py
- pytest tests/test_testitem_pipeline_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68ded7de09088324b485b0585c62a7a5