### PR TITLE
Add retry tracking and metadata for chunk fetch failures

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1484,6 +1484,15 @@
           "title": "Backoff Factor",
           "type": "number"
         },
+        "backoff_cap": {
+          "default": null,
+          "minimum": 0,
+          "title": "Backoff Cap",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "status_forcelist": {
           "items": {
             "type": "integer"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -319,6 +319,7 @@ system:
   retry:
     max_attempts: 3  # HTTP retry attempts (env: CHEMBL_DA_RETRY_MAX_ATTEMPTS)
     backoff_factor: 0.5  # Base delay multiplier (env: CHEMBL_DA_RETRY_BACKOFF_FACTOR)
+    backoff_cap: null  # Maximum backoff delay in seconds (env: CHEMBL_DA_RETRY_BACKOFF_CAP)
     status_forcelist:
       - 429  # Too Many Requests
       - 500

--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -27,6 +27,7 @@ Sensitive values (API tokens, personal e-mails) should be injected via environme
 | `timeout_read` | `30` | Read timeout in seconds. |
 | `retries` | `3` | Maximum number of attempts performed by higher-level clients; the shared HTTP adapter does not retry automatically. |
 | `backoff_factor` | `0.5` | Multiplier for exponential backoff between retries. |
+| `backoff_cap` | `null` | Maximum delay in seconds applied to exponential backoff. |
 | `rps` | `20` | Allowed requests per second for the rate limiter. |
 | `burst` | `20` | Bucket size used by the token bucket limiter. |
 | `user_agent` | `chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)` | User-Agent header. Replace the contact with your own address before production use; the validator still rejects the placeholder `contact@example.org`. Set via `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT`. |
@@ -350,6 +351,7 @@ Paths under `data/input/ChEMBL/*.xlsx` are placeholders included for local smoke
 |  | `limiter_cache_ttl` | `600` | TTL for cached limiters in seconds. |
 | `retry` | `max_attempts` | `3` | Number of retry attempts for recoverable errors. |
 |  | `backoff_factor` | `0.5` | Base multiplier for exponential backoff. |
+|  | `backoff_cap` | `null` | Maximum delay in seconds applied between retry attempts. |
 |  | `status_forcelist` | `[429, 500, 502, 503, 504]` | HTTP status codes that trigger retries. |
 | `doc_quality` | `enable` | `true` | Toggle generation of table quality reports. |
 |  | `sample_rows` | `null` | Limit analysis to the first `N` rows; `null` processes the full dataset. |
@@ -392,6 +394,7 @@ Common short aliases:
 | `CHEMBL_DA_LOG_LEVEL` | `system.log.level` |
 | `CHEMBL_DA_RETRY_MAX_ATTEMPTS` | `system.retry.max_attempts` |
 | `CHEMBL_DA_RETRY_BACKOFF_FACTOR` | `system.retry.backoff_factor` |
+| `CHEMBL_DA_RETRY_BACKOFF_CAP` | `system.retry.backoff_cap` |
 | `CHEMBL_DA_DICT_DIR` | `local.resources.dictionary_dir` |
 | `CHEMBL_DA_UNIPROT_DATA_DIR` | `local.resources.uniprot_data_dir` |
 | `CHEMBL_DA_IUPHAR_TARGET_CSV` | `local.resources.iuphar_target_csv` |

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -27,6 +27,7 @@
 | `timeout_read` | `30` | Таймаут ожидания ответа (сек.). |
 | `retries` | `3` | Максимум попыток, выполняемых клиентскими обёртками; общий HTTP-адаптер повторы не делает. |
 | `backoff_factor` | `0.5` | Множитель экспоненциального backoff между повторами. |
+| `backoff_cap` | `null` | Максимальная задержка экспоненциального backoff (сек.). |
 | `rps` | `20` | Лимит запросов в секунду для rate limiter. |
 | `burst` | `20` | Размер «ведра» токенов. |
 | `user_agent` | `chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)` | Заголовок User-Agent. Перед продакшеном замените контакт на собственный адрес; валидатор по-прежнему отвергает шаблон `contact@example.org`. Задайте через `CHEMBL_DA__SOURCES__CHEMBL__API__USER_AGENT`. |
@@ -338,6 +339,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 |  | `limiter_cache_ttl` | `600` | TTL записей кэша (сек.). |
 | `retry` | `max_attempts` | `3` | Количество повторов при ошибках. |
 |  | `backoff_factor` | `0.5` | Базовый множитель экспоненциальной задержки. |
+|  | `backoff_cap` | `null` | Максимальная задержка между повторами (сек.). |
 |  | `status_forcelist` | `[429, 500, 502, 503, 504]` | Коды HTTP, инициирующие повтор. |
 | `doc_type` | `weights` | `{pubmed: 4, openalex: 3, scholar: 2}` | Веса источников документации. |
 |  | `thresholds` | `{review: 1, experimental: 1, unknown: 2}` | Минимальные пороги классификации. |
@@ -376,6 +378,7 @@ export CHEMBL_DA__LOCAL__IO__OUTPUT_DIR=/mnt/datasets
 | `CHEMBL_DA_LOG_LEVEL` | `system.log.level` |
 | `CHEMBL_DA_RETRY_MAX_ATTEMPTS` | `system.retry.max_attempts` |
 | `CHEMBL_DA_RETRY_BACKOFF_FACTOR` | `system.retry.backoff_factor` |
+| `CHEMBL_DA_RETRY_BACKOFF_CAP` | `system.retry.backoff_cap` |
 | `CHEMBL_DA_DICT_DIR` | `local.resources.dictionary_dir` |
 | `CHEMBL_DA_UNIPROT_DATA_DIR` | `local.resources.uniprot_data_dir` |
 | `CHEMBL_DA_IUPHAR_TARGET_CSV` | `local.resources.iuphar_target_csv` |

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -200,6 +200,9 @@ def run_pipeline(
     key_columns: Sequence[str],
     table_quality: TableQualityHook,
     cfg: Config | None = None,
+    stats_extra: (
+        Mapping[str, object] | Callable[[], Mapping[str, object]] | None
+    ) = None,
     logger: Logger | None = None,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
@@ -246,6 +249,10 @@ def run_pipeline(
         Callable invoked after writing the CSV to compute quality metrics.
     cfg:
         Optional application configuration forwarded to sidecar metadata.
+    stats_extra:
+        Optional mapping or callable returning a mapping of additional
+        statistics merged into the metadata output. Intended for
+        pipeline-specific diagnostics such as fetch failures.
     logger:
         Optional logger.  Defaults to :data:`library.log.logger` when omitted.
 
@@ -544,6 +551,9 @@ def run_pipeline(
         "rows_dropped": rows_dropped,
         "output_sha256": file_sha256(csv_path),
     }
+    extra_stats = stats_extra() if callable(stats_extra) else stats_extra
+    for key, value in (extra_stats or {}).items():
+        stats[key] = value
  
     resolved_invocation = invocation_tuple
  

--- a/library/config.py
+++ b/library/config.py
@@ -690,6 +690,7 @@ class RateCfg(_BaseModel):
 class RetryCfg(_BaseModel):
     max_attempts: int = Field(3, ge=1)
     backoff_factor: float = Field(0.5, ge=0)
+    backoff_cap: float | None = Field(default=None, ge=0)
     status_forcelist: list[StrictInt] = Field(
         default_factory=lambda: [429, 500, 502, 503, 504]
     )
@@ -1779,6 +1780,7 @@ _ALIAS_OVERRIDES: dict[str, list[str]] = {
     "CHEMBL_DA_LOG_LEVEL": ["system", "log", "level"],
     "CHEMBL_DA_RETRY_MAX_ATTEMPTS": ["system", "retry", "max_attempts"],
     "CHEMBL_DA_RETRY_BACKOFF_FACTOR": ["system", "retry", "backoff_factor"],
+    "CHEMBL_DA_RETRY_BACKOFF_CAP": ["system", "retry", "backoff_cap"],
 }
 
 _ALIAS_MAP: dict[str, list[str]] = {

--- a/library/fetch_retry.py
+++ b/library/fetch_retry.py
@@ -1,0 +1,93 @@
+"""Helpers for retrying chunked fetch operations and tracking failures."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from .config import Config, RetryCfg
+from .sidecar import SidecarErrors
+
+
+@dataclass(slots=True)
+class _ChunkFailure:
+    """Internal representation of a failed chunk fetch."""
+
+    chunk_ids: list[str]
+    error: str
+
+
+_EMPTY_STATS: Final[dict[str, Any]] = {}
+
+
+class ChunkFailureTracker:
+    """Collect chunk level failures and expose aggregated statistics."""
+
+    def __init__(self) -> None:
+        self._failures: list[_ChunkFailure] = []
+        self._sidecar = SidecarErrors()
+
+    def add_failure(self, chunk_ids: Sequence[str], error: str) -> None:
+        """Record a failed chunk fetch attempt."""
+
+        ids = [str(identifier) for identifier in chunk_ids]
+        failure = _ChunkFailure(chunk_ids=ids, error=error)
+        self._failures.append(failure)
+        self._sidecar.add_error(
+            {
+                "chunk_ids": ",".join(ids),
+                "chunk_size": len(ids),
+                "error": error,
+            }
+        )
+
+    def stats(self) -> dict[str, Any]:
+        """Return aggregated statistics for persisted metadata files."""
+
+        if not self._failures:
+            return _EMPTY_STATS
+        unique_ids = sorted(
+            {
+                identifier
+                for failure in self._failures
+                for identifier in failure.chunk_ids
+            }
+        )
+        return {
+            "chunk_fetch_failure_chunks": len(self._failures),
+            "chunk_fetch_failure_ids": unique_ids,
+        }
+
+    def save(self, path: Path, *, cfg: Config | None = None) -> None:
+        """Write recorded failures to ``path`` and emit metadata sidecar."""
+
+        if self._failures:
+            self._sidecar.save(path, cfg=cfg)
+            return
+        path.unlink(missing_ok=True)
+        Path(f"{path}.meta.yaml").unlink(missing_ok=True)
+
+    def has_failures(self) -> bool:
+        """Return ``True`` when at least one failure has been recorded."""
+
+        return bool(self._failures)
+
+
+def compute_backoff_delay(attempt: int, retry_cfg: RetryCfg) -> float:
+    """Return the exponential backoff delay for ``attempt`` respecting caps."""
+
+    if attempt <= 0:
+        raise ValueError("attempt must be a positive integer")
+    factor = retry_cfg.backoff_factor
+    if factor <= 0:
+        return 0.0
+    delay = factor * (2 ** (attempt - 1))
+    cap = retry_cfg.backoff_cap
+    if cap is not None:
+        delay = min(delay, cap)
+    return delay
+
+
+__all__ = ["ChunkFailureTracker", "compute_backoff_delay"]

--- a/library/metadata.py
+++ b/library/metadata.py
@@ -41,6 +41,8 @@ class Stats(_StatsRequired, total=False):
     parent_lookup_missing: int
     missing_molecule_ids: list[str]
     missing_molecule_ids_count: int
+    chunk_fetch_failure_chunks: int
+    chunk_fetch_failure_ids: list[str]
 
 
 def file_sha256(path: Path | str) -> str:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from functools import partial
 from itertools import islice
 from pathlib import Path
+from time import sleep
 
 try:
     from library.utils.bootstrap import ensure_project_root
@@ -37,6 +38,7 @@ from library import cli
 from library import io
 from library.clients import ChemblClient
 from library.csv_utils import write_csv_chunks_deterministic  # re-exported for tests
+from library.chembl_assay import ACTIVITY_COLUMNS
 from library.pipeline_helpers import (
     ChunkedFetchConfig,
     CsvWriterConfig,
@@ -74,6 +76,7 @@ from library.rate_limiter import get_global_limiter
 from library.table_quality import analyze_table_quality
 from library.validation import validate_activities
 from schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
+from library.fetch_retry import ChunkFailureTracker, compute_backoff_delay
 
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
@@ -173,6 +176,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
+    fetch_failure_path = Path(output).with_name(
+        f"{Path(output).stem}_fetch_failures.csv"
+    )
 
 
     def _compute_bounds(frame: pd.DataFrame) -> pd.DataFrame:
@@ -247,28 +253,51 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         global_limiter=global_limiter,
     ) as client:
 
+        retry_cfg = cfg.retry
+        chunk_failures = ChunkFailureTracker()
+
         def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
-            try:
-                return cl.get_activities(
-                    chunk_ids,
-                    cfg=cfg.api,
-                    client=client,
-                    chunk_size=cfg.activity.batch_size,
-                    timeout=cfg.activity.timeout,
-                    **extra_kwargs,
-                )
-            except (requests.RequestException, ValueError) as exc:
-                logger.error(
-                    "activity_fetch_failed",
-                    extra={
-                        "msg": str(exc),
+            attempts = max(1, retry_cfg.max_attempts)
+            for attempt in range(1, attempts + 1):
+                try:
+                    return cl.get_activities(
+                        chunk_ids,
+                        cfg=cfg.api,
+                        client=client,
+                        chunk_size=cfg.activity.batch_size,
+                        timeout=cfg.activity.timeout,
+                        **extra_kwargs,
+                    )
+                except (requests.RequestException, ValueError) as exc:
+                    error_message = str(exc)
+                    context = {
                         "chunk_ids": list(chunk_ids),
-                    },
-                    error=str(exc),
-                    batch_size=cfg.activity.batch_size,
-                    timeout=cfg.activity.timeout,
-                )
-                raise PipelineError(str(exc)) from exc
+                        "chunk_size": len(chunk_ids),
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                        "batch_size": cfg.activity.batch_size,
+                        "timeout": cfg.activity.timeout,
+                    }
+                    log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
+                    if attempt >= attempts:
+                        logger.error(
+                            "activity_fetch_failed",
+                            extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                            error=error_message,
+                            **log_context,
+                        )
+                        chunk_failures.add_failure(chunk_ids, error_message)
+                        return pd.DataFrame(columns=ACTIVITY_COLUMNS)
+                    delay = compute_backoff_delay(attempt, retry_cfg)
+                    logger.warning(
+                        "activity_fetch_retry",
+                        extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                        delay=delay,
+                        **log_context,
+                    )
+                    if delay > 0:
+                        sleep(delay)
+            return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 
         worker_count = getattr(cfg.activity, "workers", 1) or 1
         fetch_config = ChunkedFetchConfig(
@@ -310,24 +339,27 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             csv_writer=writer_config,
         )
 
-        exit_code = run_pipeline(
-            fetcher=fetcher,
-            schema=ActivitiesSchema,
-            schema_name="ActivitiesSchema",
-            validators=validators,
-            metadata_hooks=metadata_hooks,
-            writer=writer,
-            output_path=output,
-            failure_path=failure_path,
-            command=" ".join(_args_invocation(args)),
-
-            config_snapshot=_serialize_paths(cfg.to_dict()),
-            inputs={"input_csv": str(args.input_csv)},
-            key_columns=["activity_id"],
-            table_quality=table_quality,
-            cfg=cfg,
-            logger=logger,
-        )
+        try:
+            exit_code = run_pipeline(
+                fetcher=fetcher,
+                schema=ActivitiesSchema,
+                schema_name="ActivitiesSchema",
+                validators=validators,
+                metadata_hooks=metadata_hooks,
+                writer=writer,
+                output_path=output,
+                failure_path=failure_path,
+                command=" ".join(_args_invocation(args)),
+                config_snapshot=_serialize_paths(cfg.to_dict()),
+                inputs={"input_csv": str(args.input_csv)},
+                key_columns=["activity_id"],
+                table_quality=table_quality,
+                cfg=cfg,
+                stats_extra=chunk_failures.stats,
+                logger=logger,
+            )
+        finally:
+            chunk_failures.save(fetch_failure_path, cfg=cfg)
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from time import sleep
 
 import argparse
 from collections.abc import Iterable, Iterator, Sequence
@@ -33,13 +34,14 @@ from library import chembl_library as cl
 from library import cli
 from library import io
 from library.csv_utils import write_csv_chunks_deterministic
+from library.chembl_assay import ASSAY_COLUMNS
 from library.clients import ChemblClient
 from library.rate_limiter import get_global_limiter
 from library.cli import (
     LoggerConfig,
 )
 from library.cli import build_parser as base_parser
-from library.cli_utils import PipelineError, run_cli_command, run_pipeline
+from library.cli_utils import run_cli_command, run_pipeline
 from library.config import Config, _serialize_paths
 from library.log import logger
 from library.pipeline_metadata import add_pipeline_metadata
@@ -51,6 +53,7 @@ from library.pipeline_helpers import (
     CsvWriterConfig,
     prepare_chunked_pipeline,
 )
+from library.fetch_retry import ChunkFailureTracker, compute_backoff_delay
 
 __all__ = ["ap", "main", "run", "run_chembl"]
 
@@ -116,6 +119,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
+    fetch_failure_path = Path(output).with_name(
+        f"{Path(output).stem}_fetch_failures.csv"
+    )
 
     metadata_hooks = [
         ap.postprocess_assays,
@@ -151,24 +157,50 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         global_limiter=global_limiter,
     ) as client:
 
+        retry_cfg = cfg.retry
+        chunk_failures = ChunkFailureTracker()
+
         def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
-            try:
-                return cl.get_assays(
-                    chunk_ids,
-                    cfg=cfg.api,
-                    client=client,
-                    chunk_size=cfg.assay.batch_size,
-                    timeout=cfg.assay.timeout,
-                )
-            except (requests.RequestException, ValueError) as exc:
-                logger.error(
-                    "assay_fetch_failed",
-                    extra={"msg": str(exc)},
-                    error=str(exc),
-                    batch_size=cfg.assay.batch_size,
-                    timeout=cfg.assay.timeout,
-                )
-                raise PipelineError(str(exc)) from exc
+            attempts = max(1, retry_cfg.max_attempts)
+            for attempt in range(1, attempts + 1):
+                try:
+                    return cl.get_assays(
+                        chunk_ids,
+                        cfg=cfg.api,
+                        client=client,
+                        chunk_size=cfg.assay.batch_size,
+                        timeout=cfg.assay.timeout,
+                    )
+                except (requests.RequestException, ValueError) as exc:
+                    error_message = str(exc)
+                    context = {
+                        "chunk_ids": list(chunk_ids),
+                        "chunk_size": len(chunk_ids),
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                        "batch_size": cfg.assay.batch_size,
+                        "timeout": cfg.assay.timeout,
+                    }
+                    log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
+                    if attempt >= attempts:
+                        logger.error(
+                            "assay_fetch_failed",
+                            extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                            error=error_message,
+                            **log_context,
+                        )
+                        chunk_failures.add_failure(chunk_ids, error_message)
+                        return pd.DataFrame(columns=ASSAY_COLUMNS)
+                    delay = compute_backoff_delay(attempt, retry_cfg)
+                    logger.warning(
+                        "assay_fetch_retry",
+                        extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                        delay=delay,
+                        **log_context,
+                    )
+                    if delay > 0:
+                        sleep(delay)
+            return pd.DataFrame(columns=ASSAY_COLUMNS)
 
         fetch_config = ChunkedFetchConfig(
             ids=ids_source,
@@ -193,23 +225,27 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             csv_writer=writer_config,
         )
 
-        exit_code = run_pipeline(
-            fetcher=fetcher,
-            schema=AssaysSchema,
-            schema_name="AssaysSchema",
-            validators=validators,
-            metadata_hooks=metadata_hooks,
-            writer=writer,
-            output_path=output,
-            failure_path=failure_path,
-            command=" ".join(sys.argv),
-            config_snapshot=_serialize_paths(cfg.to_dict()),
-            inputs={"input_csv": str(args.input_csv)},
-            key_columns=["assay_chembl_id"],
-            table_quality=table_quality,
-            cfg=cfg,
-            logger=logger,
-        )
+        try:
+            exit_code = run_pipeline(
+                fetcher=fetcher,
+                schema=AssaysSchema,
+                schema_name="AssaysSchema",
+                validators=validators,
+                metadata_hooks=metadata_hooks,
+                writer=writer,
+                output_path=output,
+                failure_path=failure_path,
+                command=" ".join(sys.argv),
+                config_snapshot=_serialize_paths(cfg.to_dict()),
+                inputs={"input_csv": str(args.input_csv)},
+                key_columns=["assay_chembl_id"],
+                table_quality=table_quality,
+                cfg=cfg,
+                stats_extra=chunk_failures.stats,
+                logger=logger,
+            )
+        finally:
+            chunk_failures.save(fetch_failure_path, cfg=cfg)
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -168,6 +168,51 @@ def test_run_pipeline_multiple_chunks(tmp_path: Path, cfg: Config) -> None:
     assert metadata["stats"]["rows_dropped"] == 0
 
 
+def test_run_pipeline_includes_extra_stats(tmp_path: Path, cfg: Config) -> None:
+    output = tmp_path / "assays.csv"
+    failure_path = tmp_path / "assays_failure_cases.csv"
+
+    frame = pd.DataFrame({"assay_chembl_id": ["A1"]})
+
+    def fetcher() -> list[pd.DataFrame]:
+        return [frame]
+
+    def writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        col_order: list[str] | None,
+        key_cols: list[str],
+    ) -> Path:
+        combined = pd.concat(list(chunks), ignore_index=True)
+        combined.to_csv(destination, index=False)
+        return destination
+
+    extra = {"chunk_fetch_failure_chunks": 3, "chunk_fetch_failure_ids": ["C1"]}
+
+    exit_code = run_pipeline(
+        fetcher=fetcher,
+        schema=None,
+        schema_name="none",
+        validators=None,
+        metadata_hooks=None,
+        writer=writer,
+        output_path=output,
+        failure_path=failure_path,
+        command="pytest",
+        config_snapshot={},
+        inputs={},
+        key_columns=["assay_chembl_id"],
+        table_quality=lambda _path: None,
+        cfg=cfg,
+        stats_extra=lambda: extra,
+    )
+
+    assert exit_code == 0
+    metadata = yaml.safe_load(output.with_name(output.name + ".meta.yaml").read_text())
+    assert metadata["stats"]["chunk_fetch_failure_chunks"] == 3
+    assert metadata["stats"]["chunk_fetch_failure_ids"] == ["C1"]
+
+
 def test_run_pipeline_applies_hooks_and_writes(tmp_path: Path, cfg: Config) -> None:
     output = tmp_path / "assays.csv"
     failure_path = tmp_path / "assays_failure_cases.csv"

--- a/tests/test_fetch_retry.py
+++ b/tests/test_fetch_retry.py
@@ -1,0 +1,45 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from library.config import RetryCfg
+from library.fetch_retry import ChunkFailureTracker, compute_backoff_delay
+
+
+def test_compute_backoff_delay_respects_cap() -> None:
+    cfg = RetryCfg(max_attempts=3, backoff_factor=0.5, backoff_cap=1.0)
+    assert compute_backoff_delay(1, cfg) == pytest.approx(0.5)
+    assert compute_backoff_delay(3, cfg) == pytest.approx(1.0)
+
+
+def test_compute_backoff_delay_raises_on_invalid_attempt() -> None:
+    cfg = RetryCfg()
+    with pytest.raises(ValueError):
+        compute_backoff_delay(0, cfg)
+
+
+def test_chunk_failure_tracker_records_stats(tmp_path: Path, cfg) -> None:
+    tracker = ChunkFailureTracker()
+    tracker.add_failure(["A1", "A2"], "boom")
+    tracker.add_failure(["A2"], "retry failed")
+
+    stats = tracker.stats()
+    assert stats["chunk_fetch_failure_chunks"] == 2
+    assert stats["chunk_fetch_failure_ids"] == ["A1", "A2"]
+
+    path = tmp_path / "fetch_failures.csv"
+    tracker.save(path, cfg=cfg)
+    assert path.exists()
+    with path.open(newline="", encoding="utf8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows and rows[0]["chunk_ids"] == "A1,A2"
+
+    # Saving again without new failures should remove the artefact.
+    empty_tracker = ChunkFailureTracker()
+    path.write_text("stale", encoding="utf8")
+    meta = Path(f"{path}.meta.yaml")
+    meta.write_text("{}", encoding="utf8")
+    empty_tracker.save(path, cfg=cfg)
+    assert not path.exists()
+    assert not meta.exists()


### PR DESCRIPTION
## Summary
- add exponential backoff retry helpers with configurable caps and track chunk fetch failures via sidecar + metadata updates
- wire assay and activity pipelines to persist failed chunk IDs while continuing processing
- expose optional metadata stats hook, extend retry config/docs, and cover the new behaviour with focused tests

## Testing
- pytest tests/test_fetch_retry.py tests/test_cli_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ded7e078e08324bb0c907490c94572