### PR TITLE
Fix CLI overrides referencing removed IoCfg attributes

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -446,8 +446,6 @@ def _normalize_path(path: str) -> str:
 _DEFAULT_OVERRIDES: dict[str, str] = {
     key: _normalize_path(value)
     for key, value in {
-        "base_path": "io.base_path",
-        "input_dir": "io.input_dir",
         "output_dir": "io.output_dir",
         "cache_dir": "io.cache_dir",
         "sep": "io.csv_sep",


### PR DESCRIPTION
## Summary
- stop mapping CLI overrides for `--base-path` and `--input-dir` to non-existent `IoCfg` attributes to avoid AttributeError when loading configuration
- keep overrides for supported IO settings so CLI defaults continue to hydrate configuration fields

## Testing
- pytest tests/test_cli_common_args.py

------
https://chatgpt.com/codex/tasks/task_e_68dee1e04d248324ae710e6568e7cde0