### PR TITLE
Add structured logging to data acquisition scripts

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -130,9 +130,37 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error("invalid_limit", section="activity.limit", limit=limit)
         return 1
 
+    offset = getattr(args, "offset", 0)
+    workers_override = getattr(args, "workers", None)
+    configured_workers = (
+        workers_override
+        if workers_override is not None
+        else getattr(cfg.activity, "workers", 1)
+    )
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    logger.info(
+        "activity_pipeline_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=limit,
+        offset=offset,
+        batch_size=cfg.activity.batch_size,
+        timeout=cfg.activity.timeout,
+        dry_run=cfg.activity.dry_run,
+        workers=configured_workers,
+    )
+
     if cfg.activity.dry_run:
         expected = limit if limit is not None else 0
         logger.info("dry_run", limit=expected)
+        logger.info(
+            "activity_pipeline_done",
+            output=str(output_path),
+            processed=0,
+            dry_run=True,
+        )
         return 0
 
     try:
@@ -145,7 +173,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 1
 
-    offset = getattr(args, "offset", 0)
     if offset:
         ids_iter = islice(ids_iter, offset, None)
         logger.info("process_offset", offset=offset)
@@ -174,10 +201,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     invocation = _args_invocation(args)
 
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
-    fetch_failure_path = Path(output).with_name(
-        f"{Path(output).stem}_fetch_failures.csv"
+    failure_path = output_path.with_name(f"{output_path.stem}_failure_cases.csv")
+    fetch_failure_path = output_path.with_name(
+        f"{output_path.stem}_fetch_failures.csv"
     )
 
 
@@ -231,13 +257,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if doc_quality_cfg.enable:
         table_quality = partial(
             analyze_table_quality,
-            table_name=str(Path(output).with_suffix("")),
-            destination_dir=Path(output).parent,
+            table_name=str(Path(output_path).with_suffix("")),
+            destination_dir=Path(output_path).parent,
             sample_rows=doc_quality_cfg.sample_rows,
             include_columns=doc_quality_cfg.include_columns,
             exclude_columns=doc_quality_cfg.exclude_columns,
         )
     else:
+
         def table_quality(_: Path) -> None:
             return None
 
@@ -287,7 +314,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                             **log_context,
                         )
                         chunk_failures.add_failure(chunk_ids, error_message)
-                        return pd.DataFrame(columns=ACTIVITY_COLUMNS)
+                        raise PipelineError("chunk_fetch_failed")
                     delay = compute_backoff_delay(attempt, retry_cfg)
                     logger.warning(
                         "activity_fetch_retry",
@@ -347,7 +374,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 validators=validators,
                 metadata_hooks=metadata_hooks,
                 writer=writer,
-                output_path=output,
+                output_path=output_path,
                 failure_path=failure_path,
                 command=" ".join(_args_invocation(args)),
                 config_snapshot=_serialize_paths(cfg.to_dict()),
@@ -363,6 +390,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)
+
+    if exit_code == 0:
+        logger.info(
+            "activity_pipeline_done",
+            output=str(output_path),
+            processed=processed_ids,
+            dry_run=False,
+        )
+    else:
+        logger.error(
+            "activity_pipeline_failed",
+            output=str(output_path),
+            processed=processed_ids,
+            exit_code=exit_code,
+        )
 
     return exit_code
 

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -100,6 +100,18 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return 1
 
     offset = getattr(args, "offset", 0)
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    logger.info(
+        "assay_pipeline_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=limit,
+        offset=offset,
+        batch_size=cfg.assay.batch_size,
+        timeout=cfg.assay.timeout,
+    )
     if offset:
         ids_iter = islice(ids_iter, offset, None)
         logger.info("process_offset", offset=offset)
@@ -117,10 +129,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     else:
         ids_source = _iter_ids()
 
-    output = args.output_csv or io.default_output_path(args.input_csv, cfg.io)
-    failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")
-    fetch_failure_path = Path(output).with_name(
-        f"{Path(output).stem}_fetch_failures.csv"
+    failure_path = output_path.with_name(f"{output_path.stem}_failure_cases.csv")
+    fetch_failure_path = output_path.with_name(
+        f"{output_path.stem}_fetch_failures.csv"
     )
 
     metadata_hooks = [
@@ -135,8 +146,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if doc_quality_cfg.enable:
         table_quality = partial(
             analyze_table_quality,
-            table_name=str(Path(output).with_suffix("")),
-            destination_dir=Path(output).parent,
+            table_name=str(output_path.with_suffix("")),
+            destination_dir=output_path.parent,
             sample_rows=doc_quality_cfg.sample_rows,
             include_columns=doc_quality_cfg.include_columns,
             exclude_columns=doc_quality_cfg.exclude_columns,
@@ -233,7 +244,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 validators=validators,
                 metadata_hooks=metadata_hooks,
                 writer=writer,
-                output_path=output,
+                output_path=output_path,
                 failure_path=failure_path,
                 command=" ".join(sys.argv),
                 config_snapshot=_serialize_paths(cfg.to_dict()),
@@ -251,6 +262,20 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("process_limit", limit=processed_ids)
     else:
         logger.info("processed_count", count=processed_ids)
+
+    if exit_code == 0:
+        logger.info(
+            "assay_pipeline_done",
+            output=str(output_path),
+            processed=processed_ids,
+        )
+    else:
+        logger.error(
+            "assay_pipeline_failed",
+            output=str(output_path),
+            processed=processed_ids,
+            exit_code=exit_code,
+        )
 
     return exit_code
 

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1569,6 +1569,21 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             limit=limit,
         )
         return 1
+    offset = getattr(args, "offset", 0)
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    logger.info(
+        "document_pubmed_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=limit,
+        offset=offset,
+        workers=getattr(args, "workers", pubmed_defaults.workers),
+        batch_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
+        sleep=getattr(args, "sleep", pubmed_defaults.sleep),
+        fallback_doi=bool(getattr(args, "fallback_doi_csv", None)),
+    )
     try:
         pmids_iter = io.read_ids(
             args.input_csv,
@@ -1582,7 +1597,6 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             path=str(args.input_csv),
         )
         return 1
-    offset = getattr(args, "offset", 0)
     if offset:
         pmids_iter = islice(pmids_iter, offset, None)
         logger.info("process_offset", offset=offset)
@@ -1634,7 +1648,7 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             fallback_doi_map=fallback_doi_map,
             return_generator=True,
         )
-        output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
+        output = output_path
         normalised_frames = (normalize_documents(frame) for frame in frame_iter)
         exit_code = _finalise_export(
             normalised_frames,
@@ -1645,10 +1659,22 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
             chunk_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
-        logger.error("pubmed_pipeline_failed", error=str(exc))
+        logger.error(
+            "pubmed_pipeline_failed",
+            error=str(exc),
+            output=str(output_path),
+        )
         return 1
     if limit_counter is not None:
         logger.info("process_limit", limit=limit_counter())
+    if exit_code == 0:
+        logger.info("document_pubmed_done", output=str(output_path))
+    else:
+        logger.error(
+            "document_pubmed_failed",
+            output=str(output_path),
+            exit_code=exit_code,
+        )
     return exit_code
 
 
@@ -1675,6 +1701,19 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if limit is not None and limit < 0:
         logger.error("invalid_limit", section="document.chembl", limit=limit)
         return 1
+    offset = getattr(args, "offset", 0)
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    logger.info(
+        "document_chembl_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=limit,
+        offset=offset,
+        chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
+        timeout=getattr(args, "timeout", chembl_defaults.timeout),
+    )
 
     # Configure session for ChEMBL requests
     rate_cfg = cfg.rate
@@ -1699,7 +1738,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             return 1
 
-        offset = getattr(args, "offset", 0)
         if offset:
             ids_iter = islice(ids_iter, offset, None)
             logger.info("process_offset", offset=offset)
@@ -1727,7 +1765,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             return 1
         if "doi" in df.columns:
             df["doi"] = df["doi"].map(normalise_doi)
-        output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
+        output = output_path
         df = normalize_documents(df)
         exit_code = _finalise_export(
             df,
@@ -1737,6 +1775,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
         )
+        if exit_code == 0:
+            logger.info("document_chembl_done", output=str(output_path))
+        else:
+            logger.error(
+                "document_chembl_failed",
+                output=str(output_path),
+                exit_code=exit_code,
+            )
         return exit_code
 
 
@@ -1846,6 +1892,14 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
         )
+        if exit_code == 0:
+            logger.info("document_all_done", output=str(output_path))
+        else:
+            logger.error(
+                "document_all_failed",
+                output=str(output_path),
+                exit_code=exit_code,
+            )
         return exit_code
 
     # Normalise PubMed identifiers to strings to avoid dtype mismatches
@@ -1909,7 +1963,11 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
                 metadata_iter = iter(())
             merged = merge_with_chembl(doc_df, metadata_iter)
     except (FileNotFoundError, ValueError, OSError) as exc:
-        logger.error("pubmed_pipeline_failed", error=str(exc))
+        logger.error(
+            "pubmed_pipeline_failed",
+            error=str(exc),
+            output=str(output_path),
+        )
         return 1
     processed = dp.postprocess_documents(merged)
     extra_cols = [c for c in merged.columns if c not in processed.columns]
@@ -1928,6 +1986,14 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         key_columns=["document_chembl_id"],
         chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
     )
+    if exit_code == 0:
+        logger.info("document_all_done", output=str(output_path))
+    else:
+        logger.error(
+            "document_all_failed",
+            output=str(output_path),
+            exit_code=exit_code,
+        )
     return exit_code
 
 

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -29,8 +29,6 @@ from typing import (
     cast,
 )
 
-import logging
-
 import pandas as pd
 import requests
 
@@ -837,7 +835,25 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     if args.skip_existing and output_path.exists() and not args.force:
         logger.info("pipeline_skip_existing", output=str(output_path))
         return 0
-    return run_chembl(cfg, args)
+    logger.info(
+        "testitem_pipeline_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=getattr(cfg.testitem, "limit", None),
+        offset=getattr(args, "offset", getattr(cfg.testitem, "offset", None)),
+        batch_size=getattr(cfg.testitem, "batch_size", None),
+        timeout=getattr(cfg.testitem, "timeout", None),
+    )
+    exit_code = run_chembl(cfg, args)
+    if exit_code == 0:
+        logger.info("testitem_pipeline_done", output=str(output_path))
+    else:
+        logger.error(
+            "testitem_pipeline_failed",
+            output=str(output_path),
+            exit_code=exit_code,
+        )
+    return exit_code
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
@@ -933,7 +949,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         log_cfg=log_cfg,
         mapping=mapping,
         run=run,
-        logger=cast(logging.Logger, logger),
+        logger=logger,
     )
 
 


### PR DESCRIPTION
## Summary
- emit structured start and completion events in the assay pipeline, including output bookkeeping for reuse in downstream logging
- extend the activity pipeline with start/done logging, worker metadata, and explicit chunk failure signalling
- add consistent start/end logging for PubMed, ChEMBL, and combined document retrieval flows, plus align test item CLI logging with the other scripts

## Testing
- `pytest tests/test_get_assay_data.py tests/test_get_activity_data.py tests/test_get_document_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68dee0151b288324b6065a24b2d55e35