### PR TITLE
Add CLI flags for target pipeline raw export parity

### DIFF
--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -61,6 +61,10 @@ class PipelineConfig(BaseModel):
     encoding: str | None = None
     na_markers: list[str] | None = None
     limit: int | None = Field(default=None, ge=0)
+    raw_format: str = Field("csv")
+    id_cols: list[str] | None = None
+    no_reindex_raw: bool = False
+    normalize_at_export: bool = True
 
 
 def _non_negative_int(value: str) -> int:
@@ -132,6 +136,38 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         help="Optional CSV capturing the raw concatenated payload",
     )
     parser.add_argument(
+        "--raw-format",
+        dest="raw_format",
+        choices=("csv", "parquet"),
+        default="csv",
+        help="Format used when writing raw payload exports",
+    )
+    parser.add_argument(
+        "--id-cols",
+        dest="id_cols",
+        nargs="+",
+        default=None,
+        help="Identifier columns used for deterministic ordering",
+    )
+    parser.add_argument(
+        "--no-reindex-raw",
+        dest="no_reindex_raw",
+        action="store_true",
+        default=False,
+        help="Skip column reindexing when exporting the raw dataset",
+    )
+    parser.add_argument(
+        "--normalize-at-export",
+        "--no-normalize-at-export",
+        dest="normalize_at_export",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Apply schema alignment before writing the final output. "
+            "Use --no-normalize-at-export to persist the raw payload."
+        ),
+    )
+    parser.add_argument(
         "--final-out",
         dest="final_out",
         type=path_argument,
@@ -188,39 +224,31 @@ _PLACEHOLDER = "-"
 
 
 def _raw_dump(
-    frames: Iterable[pd.DataFrame],
+    frames: Iterable[pd.DataFrame] | pd.DataFrame,
     path: Path,
     *,
     cfg: Config,
     sep: str | None = None,
     encoding: str | None = None,
+    raw_format: str = "csv",
+    reindex_columns: bool = True,
 ) -> Path:
     """Persist ``frames`` to ``path`` preserving columns and row order."""
 
-    sep = sep or cfg.io.csv_sep
-    encoding = encoding or cfg.io.csv_encoding
-    path.parent.mkdir(parents=True, exist_ok=True)
-    iterator = iter(frames)
-    try:
-        first = next(iterator)
-    except StopIteration:
-        first = pd.DataFrame()
-    columns = list(first.columns)
-    first.to_csv(path, index=False, sep=sep, encoding=encoding)
-    for chunk in iterator:
-        if columns:
-            chunk = chunk.reindex(columns=columns)
-        else:
-            columns = list(chunk.columns)
-        chunk.to_csv(
-            path,
-            index=False,
-            sep=sep,
-            encoding=encoding,
-            mode="a",
-            header=False,
+    writer = _RawStreamWriter(
+        path,
+        cfg=cfg,
+        sep=sep,
+        encoding=encoding,
+        raw_format=raw_format,
+        reindex_columns=reindex_columns,
     )
-    return path
+    if isinstance(frames, pd.DataFrame):
+        writer.write(frames)
+    else:
+        for chunk in frames:
+            writer.write(chunk)
+    return writer.close()
 
 
 class _RawStreamWriter:
@@ -233,49 +261,91 @@ class _RawStreamWriter:
         cfg: Config,
         sep: str | None = None,
         encoding: str | None = None,
+        raw_format: str = "csv",
+        reindex_columns: bool = True,
     ) -> None:
         self.path = path
         self.sep = sep or cfg.io.csv_sep
         self.encoding = encoding or cfg.io.csv_encoding
+        normalized_format = (raw_format or "csv").lower()
+        if normalized_format not in {"csv", "parquet"}:
+            logger.warning(
+                "unsupported_raw_format",
+                format=raw_format,
+                fallback="csv",
+            )
+            normalized_format = "csv"
+        self.raw_format = normalized_format
+        self._reindex = reindex_columns
         self._columns: list[str] | None = None
-        self._written = False
+        self._rows_written = 0
+        self._frames: list[pd.DataFrame] | None = [] if self.raw_format == "parquet" else None
+        self._destination_opened = False
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def write(self, chunk: pd.DataFrame) -> None:
+        if chunk.empty and self._rows_written == 0 and self._columns is None:
+            if self._reindex:
+                self._columns = []
+            else:
+                self._columns = list(chunk.columns)
+            return
+
         if self._columns is None:
             self._columns = list(chunk.columns)
-            chunk.to_csv(
+        else:
+            new_columns = [c for c in chunk.columns if c not in self._columns]
+            if new_columns:
+                if self.raw_format == "parquet" or self._rows_written == 0:
+                    merged = list(self._columns)
+                    merged.extend(col for col in new_columns if col not in merged)
+                    self._columns = merged
+                else:
+                    raise OSError("raw_dump_inconsistent_columns")
+
+        working = chunk
+        if self._columns is not None and not working.empty:
+            working = working.reindex(columns=self._columns)
+
+        if self.raw_format == "parquet":
+            if self._frames is None:
+                self._frames = []
+            self._frames.append(working.copy())
+        else:
+            mode = "w" if self._rows_written == 0 else "a"
+            header = self._rows_written == 0
+            working.to_csv(
                 self.path,
                 index=False,
                 sep=self.sep,
                 encoding=self.encoding,
+                mode=mode,
+                header=header,
             )
-            self._written = True
-            return
-        if self._columns:
-            chunk = chunk.reindex(columns=self._columns)
-        else:
-            self._columns = list(chunk.columns)
-        chunk.to_csv(
-            self.path,
-            index=False,
-            sep=self.sep,
-            encoding=self.encoding,
-            mode="a",
-            header=False,
-        )
-        self._written = True
+            self._destination_opened = True
+
+        self._rows_written += len(working)
 
     def close(self) -> Path:
-        if not self._written:
-            empty = pd.DataFrame(columns=self._columns or None)
-            empty.to_csv(
-                self.path,
-                index=False,
-                sep=self.sep,
-                encoding=self.encoding,
-            )
-            self._written = True
+        if self.raw_format == "parquet":
+            frames = self._frames or []
+            if frames:
+                combined = pd.concat(frames, ignore_index=True)
+            else:
+                combined = pd.DataFrame(columns=self._columns or [])
+            try:
+                combined.to_parquet(self.path, index=False)
+            except (ImportError, ValueError) as exc:
+                raise OSError(f"failed_to_write_parquet: {exc}") from exc
+        else:
+            if not self._destination_opened:
+                empty = pd.DataFrame(columns=self._columns or None)
+                empty.to_csv(
+                    self.path,
+                    index=False,
+                    sep=self.sep,
+                    encoding=self.encoding,
+                )
         return self.path
 
 
@@ -318,8 +388,21 @@ def _validate_and_write(
     cfg: Config,
     sep: str | None = None,
     encoding: str | None = None,
+    id_cols: Sequence[str] | None = None,
+    normalize: bool = True,
 ) -> Path:
     """Validate ``df`` against :data:`TargetsSchema` and serialise to CSV."""
+
+    resolved_key_cols = list(id_cols) if id_cols else ["target_chembl_id"]
+
+    def _ensure_key_columns(frame: pd.DataFrame) -> pd.DataFrame:
+        if not resolved_key_cols:
+            return frame
+        missing = [col for col in resolved_key_cols if col not in frame.columns]
+        if not missing:
+            return frame
+        ordered = list(frame.columns) + missing
+        return frame.reindex(columns=ordered)
 
     def _validated_stream() -> Iterator[pd.DataFrame]:
         if not isinstance(frames, pd.DataFrame):
@@ -327,25 +410,36 @@ def _validate_and_write(
             yielded = False
             for chunk in iterator:
                 yielded = True
-                prepared = _prepare_final_frame(chunk)
-                yield TargetsSchema.validate(prepared, lazy=True)
+                if normalize:
+                    prepared = _prepare_final_frame(chunk)
+                    yield TargetsSchema.validate(prepared, lazy=True)
+                else:
+                    yield _ensure_key_columns(chunk)
             if not yielded:
-                prepared = _prepare_final_frame(pd.DataFrame())
-                yield TargetsSchema.validate(prepared, lazy=True)
+                if normalize:
+                    prepared = _prepare_final_frame(pd.DataFrame())
+                    yield TargetsSchema.validate(prepared, lazy=True)
+                else:
+                    yield pd.DataFrame(columns=resolved_key_cols)
             return
 
-        prepared = _prepare_final_frame(frames)
-        yield TargetsSchema.validate(prepared, lazy=True)
+        if normalize:
+            prepared = _prepare_final_frame(frames)
+            yield TargetsSchema.validate(prepared, lazy=True)
+        else:
+            yield _ensure_key_columns(frames)
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    key_cols = resolved_key_cols
+    col_order: Sequence[str] | None = TARGETS_COLUMN_ORDER if normalize else None
     write_csv(
         _validated_stream(),
         path,
         cfg=cfg,
         sep=sep,
         encoding=encoding,
-        key_cols=["target_chembl_id"],
-        col_order=TARGETS_COLUMN_ORDER,
+        key_cols=key_cols,
+        col_order=col_order,
     )
     return path
 
@@ -404,6 +498,13 @@ def _cached_chembl_fetch(
 def run(cfg: Config, options: PipelineConfig) -> int:
     chunk_factory = lambda: _chunk_iterator(cfg, options)
     batch_size = options.batch_size if options.batch_size is not None else 100
+    raw_format = (options.raw_format or "csv").lower()
+    if raw_format not in {"csv", "parquet"}:
+        logger.warning("unsupported_raw_format", format=raw_format, fallback="csv")
+        raw_format = "csv"
+    reindex_raw = not options.no_reindex_raw
+    id_cols = list(options.id_cols) if options.id_cols is not None else None
+    normalize = options.normalize_at_export
     result = run_pipeline(
         chunk_factory,
         cfg,
@@ -424,28 +525,42 @@ def run(cfg: Config, options: PipelineConfig) -> int:
             cfg=cfg,
             sep=options.sep,
             encoding=options.encoding,
+            raw_format=raw_format,
+            reindex_columns=reindex_raw,
         )
 
     def _final_stream() -> Iterator[pd.DataFrame]:
         try:
+            metadata_columns = list(_PIPELINE_METADATA_COLUMNS)
             for chunk in frame_iter:
+                raw_chunk = chunk.drop(columns=metadata_columns, errors="ignore")
                 if raw_writer is not None:
-                    raw_chunk = chunk.drop(
-                        columns=_PIPELINE_METADATA_COLUMNS, errors="ignore"
-                    )
                     raw_writer.write(raw_chunk)
-                yield chunk
+                yield chunk if normalize else raw_chunk
         finally:
             if raw_writer is not None:
                 raw_writer.close()
 
-    _validate_and_write(
-        _final_stream(),
-        final_path,
-        cfg=cfg,
-        sep=options.sep,
-        encoding=options.encoding,
+    stream = _final_stream()
+    skip_final_write = (
+        not normalize
+        and options.raw_out is not None
+        and final_path == options.raw_out
+        and raw_format == "parquet"
     )
+    if skip_final_write:
+        for _ in stream:
+            pass
+    else:
+        _validate_and_write(
+            stream,
+            final_path,
+            cfg=cfg,
+            sep=options.sep,
+            encoding=options.encoding,
+            id_cols=id_cols,
+            normalize=normalize,
+        )
     logger.info("write_done", extra={"path": str(final_path)})
     return 0
 
@@ -509,6 +624,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "encoding": args.encoding,
                 "na_markers": args.na_markers,
                 "limit": args.limit,
+                "raw_format": args.raw_format,
+                "id_cols": args.id_cols,
+                "no_reindex_raw": args.no_reindex_raw,
+                "normalize_at_export": args.normalize_at_export,
             }
         )
     except (ValueError, TypeError) as exc:

--- a/tests/test_pipeline_targets_cli.py
+++ b/tests/test_pipeline_targets_cli.py
@@ -260,6 +260,51 @@ def test_cli_limit_allows_zero(
     assert captured["written_df"].empty
 
 
+def test_cli_parses_output_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = tmp_path / "targets.csv"
+    input_csv.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf8")
+    output_csv = tmp_path / "out.csv"
+
+    captured: dict[str, cli.PipelineConfig] = {}
+
+    dummy_logger = _DummyLogger()
+    monkeypatch.setattr(cli, "configure_logger", lambda cfg: dummy_logger)
+    monkeypatch.setattr(cli.cli, "apply_config_overrides", lambda *a: Config())
+    monkeypatch.setattr(cli, "ensure_dirs", lambda cfg: None)
+    monkeypatch.setattr(cli, "print_config", lambda cfg: None)
+
+    def fake_run(cfg: Config, options: cli.PipelineConfig) -> int:
+        captured["options"] = options
+        return 0
+
+    monkeypatch.setattr(cli, "run", fake_run)
+
+    args = [
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--raw-format",
+        "parquet",
+        "--id-cols",
+        "target_chembl_id",
+        "pref_name",
+        "--no-reindex-raw",
+        "--no-normalize-at-export",
+    ]
+    exit_code = cli.main(args)
+
+    assert exit_code == 0
+    assert "options" in captured
+    options = captured["options"]
+    assert options.raw_format == "parquet"
+    assert options.id_cols == ["target_chembl_id", "pref_name"]
+    assert options.no_reindex_raw is True
+    assert options.normalize_at_export is False
+
+
 
 def test_cli_does_not_print_config_when_flag_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -469,6 +514,141 @@ def test_end_to_end_cli_raw_and_final_outputs(
     final_df = pd.read_csv(final_out, dtype=str, keep_default_na=False)
     TargetsSchema.validate(final_df)
     assert final_df.loc[0, "uniprot_id_primary"] == ""
+
+
+def test_run_threads_output_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    raw_out = tmp_path / "raw.csv"
+    final_out = tmp_path / "final.csv"
+
+    base_columns = ["target_chembl_id", "pref_name"]
+    metadata_columns = list(cli._PIPELINE_METADATA_COLUMNS)
+    payload = {
+        "target_chembl_id": ["CHEMBL1"],
+        "pref_name": ["Name"],
+    }
+    for column in metadata_columns:
+        payload[column] = [f"meta_{column}"]
+    frame = pd.DataFrame(payload)
+
+    def fake_run_pipeline(*_: Any, **__: Any) -> PipelineResult:
+        return PipelineResult(chembl=[frame.copy()])
+
+    captured: dict[str, Any] = {"raw_chunks": []}
+
+    class DummyWriter:
+        def __init__(
+            self,
+            path: Path,
+            *,
+            raw_format: str,
+            reindex_columns: bool,
+            **kwargs: Any,
+        ) -> None:
+            captured["writer_args"] = {
+                "path": path,
+                "raw_format": raw_format,
+                "reindex": reindex_columns,
+            }
+            self.path = path
+
+        def write(self, chunk: pd.DataFrame) -> None:
+            captured["raw_chunks"].append(chunk.copy())
+
+        def close(self) -> Path:
+            captured["writer_closed"] = True
+            return self.path
+
+    def fake_validate(
+        data: pd.DataFrame | Iterable[pd.DataFrame],
+        path: Path,
+        *,
+        id_cols: Iterable[str] | None,
+        normalize: bool,
+        **kwargs: Any,
+    ) -> Path:
+        captured["validate_path"] = path
+        captured["validate_id_cols"] = list(id_cols or [])
+        captured["validate_normalize"] = normalize
+        chunks: list[pd.DataFrame]
+        if isinstance(data, pd.DataFrame):
+            chunks = [data.copy()]
+        else:
+            chunks = [chunk.copy() for chunk in data]
+        captured["final_chunks"] = chunks
+        return path
+
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(cli, "_RawStreamWriter", DummyWriter)
+    monkeypatch.setattr(cli, "_validate_and_write", fake_validate)
+
+    options = cli.PipelineConfig(
+        input_csv=tmp_path / "targets.csv",
+        final_out=final_out,
+        raw_out=raw_out,
+        column="target_chembl_id",
+        raw_format="csv",
+        id_cols=["target_chembl_id", "pref_name"],
+        no_reindex_raw=True,
+        normalize_at_export=False,
+    )
+
+    exit_code = cli.run(cfg, options)
+    assert exit_code == 0
+    assert captured["writer_args"]["raw_format"] == "csv"
+    assert captured["writer_args"]["reindex"] is False
+    assert captured["writer_closed"] is True
+    assert captured["validate_path"] == final_out
+    assert captured["validate_id_cols"] == ["target_chembl_id", "pref_name"]
+    assert captured["validate_normalize"] is False
+    assert captured["raw_chunks"]
+    raw_columns = [list(chunk.columns) for chunk in captured["raw_chunks"]]
+    assert raw_columns == [base_columns for _ in raw_columns]
+    assert captured["final_chunks"]
+    final_columns = [list(chunk.columns) for chunk in captured["final_chunks"]]
+    assert final_columns == [base_columns for _ in final_columns]
+
+
+def test_run_skips_validate_for_parquet_raw_final_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    destination = tmp_path / "targets.parquet"
+    frame = pd.DataFrame({"target_chembl_id": ["CHEMBL1"]})
+
+    def fake_run_pipeline(*_: Any, **__: Any) -> PipelineResult:
+        return PipelineResult(chembl=[frame.copy()])
+
+    class DummyWriter:
+        def __init__(self, path: Path, **_: Any) -> None:
+            self.path = path
+            self.written: list[pd.DataFrame] = []
+
+        def write(self, chunk: pd.DataFrame) -> None:
+            self.written.append(chunk.copy())
+
+        def close(self) -> Path:
+            return self.path
+
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(cli, "_RawStreamWriter", DummyWriter)
+
+    def fail_validate(*_: Any, **__: Any) -> Path:
+        raise AssertionError("_validate_and_write should not be invoked")
+
+    monkeypatch.setattr(cli, "_validate_and_write", fail_validate)
+
+    options = cli.PipelineConfig(
+        input_csv=tmp_path / "targets.csv",
+        final_out=destination,
+        raw_out=destination,
+        column="target_chembl_id",
+        raw_format="parquet",
+        normalize_at_export=False,
+    )
+
+    exit_code = cli.run(cfg, options)
+    assert exit_code == 0
 
 
 def test_streaming_pipeline_keeps_chunk_bound(


### PR DESCRIPTION
## Summary
- extend the target pipeline CLI configuration and parser to accept raw format, identifier columns, raw reindexing, and export normalisation flags
- update raw export helpers and pipeline run orchestration to respect the new options and align raw/final outputs accordingly
- expand pipeline CLI tests to cover the new switches and ensure the threaded parameters influence raw and final data

## Testing
- `pytest tests/test_pipeline_targets_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68def165026c8324827bb43985c6f246