### PR TITLE
Fix configure_limiter_cache import in config loader

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -39,6 +39,8 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from .common.rate_limiter import configure_limiter_cache
+
 from .common.log import logger
 from .utils.config import ConfigLoaderError, load_yaml_config
 
@@ -1662,8 +1664,6 @@ def load_config(
         for p in (cfg.io.output_dir, cfg.io.cache_dir):
             if not p.exists():
                 raise FileNotFoundError(p)
-
-        from .common.rate_limiter import configure_limiter_cache
 
     configure_limiter_cache(cfg.rate.limiter_cache_maxsize, cfg.rate.limiter_cache_ttl)
     return cfg


### PR DESCRIPTION
## Summary
- import configure_limiter_cache at module scope so it is always defined
- ensure configuration loading always configures the rate limiter cache

## Testing
- pytest tests/test_rate_limiter_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68df5b33fb20832497e67fc5e25f450d