### PR TITLE
Fix limiter cache configuration import to avoid UnboundLocalError

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -40,6 +40,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .common.log import logger
+from .common.rate_limiter import configure_limiter_cache
 from .utils.config import ConfigLoaderError, load_yaml_config
 
 
@@ -1662,8 +1663,6 @@ def load_config(
         for p in (cfg.io.output_dir, cfg.io.cache_dir):
             if not p.exists():
                 raise FileNotFoundError(p)
-
-        from .common.rate_limiter import configure_limiter_cache
 
     configure_limiter_cache(cfg.rate.limiter_cache_maxsize, cfg.rate.limiter_cache_ttl)
     return cfg


### PR DESCRIPTION
## Summary
- import configure_limiter_cache at module scope in library/config.py
- ensure limiter cache configuration is always available when loading configs

## Testing
- pytest tests/test_rate_limiter_cache.py *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68df5b1f1c74832481d93d93b9ad088a