### PR TITLE
Fix rate limiter cache import in config loader

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1658,13 +1658,12 @@ def load_config(
             raise ConfigError(message) from exc
         raise
 
+    from .common.rate_limiter import configure_limiter_cache
+
     if not cfg.io.exist_ok:
         for p in (cfg.io.output_dir, cfg.io.cache_dir):
             if not p.exists():
                 raise FileNotFoundError(p)
-
-        from .common.rate_limiter import configure_limiter_cache
-
     configure_limiter_cache(cfg.rate.limiter_cache_maxsize, cfg.rate.limiter_cache_ttl)
     return cfg
 


### PR DESCRIPTION
## Summary
- import the rate limiter cache helper before checking io.exist_ok to ensure availability
- prevent UnboundLocalError when configuring the limiter cache

## Testing
- pytest tests/test_rate_limiter_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68df5b494b6c8324a26831e3b1e6306a