### PR TITLE
Fix document pipeline run_all output path initialization

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1871,7 +1871,10 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     if limit_counter is not None:
         logger.info("process_limit", limit=limit_counter())
-    output = Path(args.output_csv or io.default_output_path(args.input_csv, cfg.io))
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    output = output_path
     if "doi" in doc_df.columns:
         doc_df["doi"] = doc_df["doi"].map(normalise_doi)
     if doc_df.empty or "pubmed_id" not in doc_df:


### PR DESCRIPTION
## Summary
- ensure the document pipeline initialises `output_path` before logging in `run_all`
- reuse the resolved path when exporting merged document data to avoid NameError crashes

## Testing
- `pytest tests/test_get_document_data.py::test_run_all_limit_zero` *(fails: dependency `responses` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5d2967308324b82652dd953f1697