### PR TITLE
Sanitize table-quality report filenames

### DIFF
--- a/library/table_quality.py
+++ b/library/table_quality.py
@@ -606,7 +606,11 @@ class TableQualityProfiler:
         if destination_dir is not None:
             destination.mkdir(parents=True, exist_ok=True)
 
-        quality_path = destination / f"{table_name}_quality_report_table.csv"
+        table_label = Path(str(table_name)).name
+        if not table_label:
+            raise ValueError("table_name must contain at least one non-separator character")
+
+        quality_path = destination / f"{table_label}_quality_report_table.csv"
         quality_report.to_csv(quality_path, index=False, encoding="utf-8-sig")
 
         if numeric_candidates:
@@ -614,7 +618,7 @@ class TableQualityProfiler:
         else:
             corr_report = pd.DataFrame()
 
-        corr_path = destination / f"{table_name}_data_correlation_report_table.csv"
+        corr_path = destination / f"{table_label}_data_correlation_report_table.csv"
         corr_report.reset_index().to_csv(corr_path, index=False, encoding="utf-8-sig")
 
         return quality_report, corr_report

--- a/tests/test_table_quality.py
+++ b/tests/test_table_quality.py
@@ -33,6 +33,20 @@ def test_analyze_table_quality(tmp_path: Path) -> None:
     assert corr.shape == (2, 2)
 
 
+def test_profiler_build_sanitizes_table_name(tmp_path: Path) -> None:
+    profiler = TableQualityProfiler()
+    profiler.consume(pd.DataFrame({"value": [1, 2]}))
+
+    nested_name = "nested/dir/output.csv"
+    profiler.build(table_name=nested_name, destination_dir=tmp_path)
+
+    expected_quality = tmp_path / "output.csv_quality_report_table.csv"
+    expected_corr = tmp_path / "output.csv_data_correlation_report_table.csv"
+
+    assert expected_quality.exists()
+    assert expected_corr.exists()
+
+
 def test_analyze_table_quality_supports_relative_destination(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure table quality outputs strip any directory components from the table name before writing files
- guard against empty table labels when generating quality reports
- add a regression test covering nested table-name inputs

## Testing
- pytest tests/test_table_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68df611aab288324abcc0bd3a160295b