### PR TITLE
Fix circular imports in library package

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -9,7 +9,8 @@ directory.
 
 from __future__ import annotations
 
-from . import io, qa, schemas, validation
+from importlib import import_module
+from typing import Any
 from .config import Config, load_config
 from .common.csv_utils import (
     sha256_file,
@@ -40,6 +41,24 @@ from .pipelines.target.organism_classification import (
 from .pipelines.testitem import enrichment as testitem_enrichment
 from .parser_schema import CSVExportArgs
 from .sidecar import SidecarErrors
+
+_LAZY_SUBMODULES = {
+    "io",
+    "qa",
+    "schemas",
+    "validation",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import heavy submodules on first access."""
+
+    if name in _LAZY_SUBMODULES:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 __all__ = [
     "parse_terms",
@@ -76,3 +95,9 @@ __all__ = [
     "TYPE_UNICELLULAR",
     "TYPE_VIRAL",
 ]
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazily loaded submodules."""
+
+    return sorted({*globals(), *__all__, *_LAZY_SUBMODULES})

--- a/library/common/csv_utils.py
+++ b/library/common/csv_utils.py
@@ -22,10 +22,22 @@ import numpy as np
 import pandas as pd
 from pandas.api import types as ptypes
 
+from typing import TYPE_CHECKING
+
 from ..config import Config
-from ..io.metadata import write_meta_yaml
 from .log import logger
 from ..utils.atomic import open_atomic
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..io.metadata import write_meta_yaml as _write_meta_yaml_type
+
+
+def _write_meta_yaml(*args: Any, **kwargs: Any) -> Path:
+    """Import :func:`write_meta_yaml` lazily to avoid circular imports."""
+
+    from ..io.metadata import write_meta_yaml as _write_meta_yaml_impl
+
+    return _write_meta_yaml_impl(*args, **kwargs)
 
 
 def _normalise_bool(series: pd.Series) -> pd.Series:
@@ -545,7 +557,7 @@ def write_csv_deterministic(
 
         os.replace(tmp_path, out_path)
 
-    write_meta_yaml(
+    _write_meta_yaml(
         out_path,
         cfg,
         columns=list(work.columns),
@@ -738,7 +750,7 @@ def write_csv_chunks_deterministic(
         if meta_columns is None:
             meta_columns = list(columns)
 
-    write_meta_yaml(
+    _write_meta_yaml(
         out_path,
         cfg,
         columns=meta_columns or columns,


### PR DESCRIPTION
## Summary
- lazily load heavy library submodules to avoid circular import crashes
- defer importing metadata writers in csv utilities to prevent io recursion

## Testing
- python scripts/get_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68df66eefcb08324a9f7264d69fd22ec