### PR TITLE
Add developer documentation index

### DIFF
--- a/docs/index_developer.md
+++ b/docs/index_developer.md
@@ -1,0 +1,33 @@
+# Developer Documentation Index
+
+Use this directory to locate maintainer-focused resources covering contribution
+policies, coding standards, ownership of core modules, and the automated quality
+gates required before releases.
+
+## Contribution workflow
+
+- English
+  - [Dependency pinning policy](processes/en/CONTRIBUTING.md)
+- Русский
+  - [Политика закрепления зависимостей](processes/ru/CONTRIBUTING.md)
+
+## Code standards & tooling
+
+- English
+  - [Development and testing guidelines](guides/en/README.md#development-and-testing)
+- Русский
+  - [Разработка и тестирование](guides/ru/README.md#%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D0%B8-%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)
+
+## Module ownership & architecture
+
+- English
+  - [Repository layout overview](guides/en/SUMMARY.md#repository-layout)
+- Русский
+  - [Структура репозитория](guides/ru/SUMMARY.md#%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D1%83%D1%80%D0%B0-%D1%80%D0%B5%D0%BF%D0%BE%D0%B7%D0%B8%D1%82%D0%BE%D1%80%D0%B8%D1%8F)
+
+## Quality assurance & release automation
+
+- English
+  - [Living QA checklist for release certification](processes/en/QA_PROCESS.md)
+- Русский
+  - [Живой чек-лист QA перед релизом](processes/ru/QA_PROCESS.md)


### PR DESCRIPTION
## Summary
- add a developer-focused documentation index alongside the end-user index
- surface links for contribution policies, coding standards, module ownership, and QA/release automation in both languages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df64ed01408324b2775846c9c524c0