### PR TITLE
Stop waiting on cancelled chunk workers

### DIFF
--- a/library/pipelines/common/helpers.py
+++ b/library/pipelines/common/helpers.py
@@ -72,37 +72,50 @@ def _ordered_results(
         for future in list(pending):
             future.cancel()
 
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        try:
-            for index, chunk_ids in enumerate(chunk_iter):
-                future = executor.submit(fetch_chunk, list(chunk_ids))
-                pending[future] = index
-                if len(pending) < workers:
-                    continue
-                done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
-                for finished in done:
-                    chunk_index = pending.pop(finished)
-                    try:
-                        completed[chunk_index] = finished.result()
-                    except PipelineError:
-                        _cancel_pending()
-                        raise
-                while next_index in completed:
-                    yield completed.pop(next_index)
-                    next_index += 1
+    executor = ThreadPoolExecutor(max_workers=workers)
+    shutdown_called = False
 
-            for future in as_completed(list(pending)):
-                chunk_index = pending.pop(future)
+    def _shutdown_executor(*, wait: bool, cancel_futures: bool) -> None:
+        nonlocal shutdown_called
+        if shutdown_called:
+            return
+        shutdown_called = True
+        executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    try:
+        for index, chunk_ids in enumerate(chunk_iter):
+            future = executor.submit(fetch_chunk, list(chunk_ids))
+            pending[future] = index
+            if len(pending) < workers:
+                continue
+            done, _ = wait(set(pending), return_when=FIRST_COMPLETED)
+            for finished in done:
+                chunk_index = pending.pop(finished)
                 try:
-                    completed[chunk_index] = future.result()
-                except PipelineError:
+                    completed[chunk_index] = finished.result()
+                except BaseException:
+                    _shutdown_executor(wait=False, cancel_futures=True)
                     _cancel_pending()
                     raise
-                while next_index in completed:
-                    yield completed.pop(next_index)
-                    next_index += 1
-        finally:
-            pending.clear()
+            while next_index in completed:
+                yield completed.pop(next_index)
+                next_index += 1
+
+        for future in as_completed(list(pending)):
+            chunk_index = pending.pop(future)
+            try:
+                completed[chunk_index] = future.result()
+            except BaseException:
+                _shutdown_executor(wait=False, cancel_futures=True)
+                _cancel_pending()
+                raise
+            while next_index in completed:
+                yield completed.pop(next_index)
+                next_index += 1
+    finally:
+        pending.clear()
+        completed.clear()
+        _shutdown_executor(wait=True, cancel_futures=False)
 
 
 def prepare_chunked_pipeline(

--- a/tests/test_get_activity_data.py
+++ b/tests/test_get_activity_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import threading
 import time
 from collections.abc import Iterable
 from pathlib import Path
@@ -16,6 +17,7 @@ from library import io
 from library.common import rate_limiter as rl
 from library.config import Config
 from library.schemas import ActivitiesSchema
+from library.pipelines.common import helpers
 from scripts import get_activity_data as gad
 
 
@@ -182,6 +184,35 @@ def test_run_chembl_column_order(
     expected_head = [c for c in schema_cols if c in available]
     expected_tail = sorted(available - set(schema_cols))
     assert captured["col_order"] == expected_head + expected_tail
+
+
+def test_ordered_results_shutdown_on_pipeline_error() -> None:
+    """Ensure chunk fetch failures stop outstanding workers promptly."""
+
+    sleep_duration = 1.5
+    started = threading.Event()
+
+    def fetch_chunk(ids: list[str]) -> pd.DataFrame:
+        if ids == ["error"]:
+            time.sleep(0.1)
+            raise cli_utils.PipelineError("boom")
+        started.set()
+        time.sleep(sleep_duration)
+        return pd.DataFrame()
+
+    start = time.perf_counter()
+    with pytest.raises(cli_utils.PipelineError):
+        list(
+            helpers._ordered_results(
+                chunk_iter=iter([["error"], ["slow"]]),
+                fetch_chunk=fetch_chunk,
+                workers=2,
+            )
+        )
+
+    elapsed = time.perf_counter() - start
+    assert started.is_set(), "Sleeping worker never started"
+    assert elapsed < sleep_duration / 2
 
 
 def test_run_chembl_streams_large_output(


### PR DESCRIPTION
## Summary
- stop `_ordered_results` from blocking on outstanding futures by shutting the executor down without waiting when a worker fails
- clear pending state and re-raise the original exception so chunk ordering remains deterministic
- add a regression test covering a sleeping worker that is cancelled after another raises `PipelineError`

## Testing
- pytest tests/test_get_activity_data.py::test_ordered_results_shutdown_on_pipeline_error


------
https://chatgpt.com/codex/tasks/task_e_68df65be85988324a1c5e7df807973f4