### PR TITLE
Fix circular import between document postprocessing and QA

### DIFF
--- a/library/common/text_utils.py
+++ b/library/common/text_utils.py
@@ -1,0 +1,38 @@
+"""Shared text conversion helpers used across pipelines and QA checks."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+
+UTF8_ENCODING = "utf-8"
+
+
+def to_text(value: Any, *, encoding: str = UTF8_ENCODING) -> str:
+    """Convert *value* to a string while mapping null-like values to ``""``."""
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode(encoding, errors="ignore")
+    if isinstance(value, (np.bool_, bool)):
+        return "true" if bool(value) else "false"
+    if isinstance(value, (np.integer, int)):
+        return str(int(value))
+    if isinstance(value, (np.floating, float)):
+        numeric = float(value)
+        if numeric != numeric:  # NaN check
+            return ""
+        if numeric.is_integer():
+            return str(int(numeric))
+        return str(numeric)
+    if pd.isna(cast(object, value)):
+        return ""
+    return str(value)
+
+
+__all__ = ["to_text", "UTF8_ENCODING"]

--- a/library/pipelines/document/postprocessing.py
+++ b/library/pipelines/document/postprocessing.py
@@ -17,6 +17,7 @@ import pandas as pd
 from ... import validation
 from ...config import IoCfg
 from ...common.csv_utils import write_csv_deterministic
+from ...common.text_utils import to_text
 
 
 # ===== Parameters ===========================================================
@@ -156,30 +157,6 @@ REFERENCE_REQUIRED_COLUMNS: tuple[str, ...] = (
 
 
 # ===== Helper utilities =====================================================
-
-
-def to_text(value: Any) -> str:
-    """Return *value* converted to text, mapping nulls to ``""``."""
-
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bytes):
-        return value.decode(UTF8_ENCODING, errors="ignore")
-    if isinstance(value, (np.bool_, bool)):
-        return "true" if bool(value) else "false"
-    if isinstance(value, (np.integer, int)):
-        return str(int(value))
-    if isinstance(value, (np.floating, float)):
-        if float(value) != float(value):  # NaN check
-            return ""
-        if float(value).is_integer():
-            return str(int(value))
-        return str(float(value))
-    if pd.isna(cast(object, value)):
-        return ""
-    return str(value)
 
 
 def safe_lower(value: Any) -> str:

--- a/library/qa/check_document_postprocessing.py
+++ b/library/qa/check_document_postprocessing.py
@@ -21,7 +21,7 @@ import pandas as pd
 import yaml
 
 from library.common.csv_utils import write_csv_deterministic
-from library.pipelines.document.postprocessing import to_text
+from library.common.text_utils import to_text
 
 
 # ===== Parameters ============================================================


### PR DESCRIPTION
## Summary
- extract the `to_text` conversion helper into `library/common/text_utils.py` so it can be shared without importing document postprocessing
- update the document postprocessing pipeline to consume the shared helper
- point the document QA checks at the shared helper to remove the circular dependency

## Testing
- python scripts/get_data.py --limit 10 --log-level WARNING *(fails: missing reference CSV in the sandbox environment)*
- pytest tests/test_document_postprocessing_qa.py *(fails: existing CLI signature expectations in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df684bc2f883249b4f4827cdf405fb