### PR TITLE
Fix circular imports in library package initialization

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from typing import Any
-from .config import Config, load_config
+
 from .common.csv_utils import (
     sha256_file,
     write_csv_chunks_deterministic,
@@ -19,28 +19,8 @@ from .common.csv_utils import (
 )
 from .common.logging_setup import Logger, LoggerConfig, configure_logger
 from .common.timing import log_duration
-from .pipelines.document.type_classifier import compute_scores, decide_label
-from .pipelines.document.type_terms import (
-    EXPERIMENTAL_TERMS,
-    REVIEW_TERMS,
-    UNKNOWN_TERMS,
-    parse_terms,
-)
-from .pipelines.target import organism_classification, protein_classification
-from .pipelines.target.organism_classification import (
-    TYPE_MULTICELLULAR,
-    TYPE_UNICELLULAR,
-    TYPE_VIRAL,
-    OrganismClassificationRules,
-    add_cellularity,
-    add_cellularity_smart,
-    classify_by_lineage,
-    classify_record,
-    normalize,
-)
-from .pipelines.testitem import enrichment as testitem_enrichment
+from .config import Config, load_config
 from .parser_schema import CSVExportArgs
-from .sidecar import SidecarErrors
 
 _LAZY_SUBMODULES = {
     "io",
@@ -49,14 +29,43 @@ _LAZY_SUBMODULES = {
     "validation",
 }
 
+_EXPORTS: dict[str, str] = {
+    "parse_terms": "library.pipelines.document.type_terms:parse_terms",
+    "REVIEW_TERMS": "library.pipelines.document.type_terms:REVIEW_TERMS",
+    "EXPERIMENTAL_TERMS": "library.pipelines.document.type_terms:EXPERIMENTAL_TERMS",
+    "UNKNOWN_TERMS": "library.pipelines.document.type_terms:UNKNOWN_TERMS",
+    "compute_scores": "library.pipelines.document.type_classifier:compute_scores",
+    "decide_label": "library.pipelines.document.type_classifier:decide_label",
+    "organism_classification": "library.pipelines.target:organism_classification",
+    "protein_classification": "library.pipelines.target:protein_classification",
+    "testitem_enrichment": "library.pipelines.testitem.enrichment",
+    "OrganismClassificationRules": "library.pipelines.target.organism_classification:OrganismClassificationRules",
+    "add_cellularity": "library.pipelines.target.organism_classification:add_cellularity",
+    "add_cellularity_smart": "library.pipelines.target.organism_classification:add_cellularity_smart",
+    "classify_by_lineage": "library.pipelines.target.organism_classification:classify_by_lineage",
+    "classify_record": "library.pipelines.target.organism_classification:classify_record",
+    "normalize": "library.pipelines.target.organism_classification:normalize",
+    "TYPE_MULTICELLULAR": "library.pipelines.target.organism_classification:TYPE_MULTICELLULAR",
+    "TYPE_UNICELLULAR": "library.pipelines.target.organism_classification:TYPE_UNICELLULAR",
+    "TYPE_VIRAL": "library.pipelines.target.organism_classification:TYPE_VIRAL",
+    "SidecarErrors": "library.sidecar:SidecarErrors",
+}
+
 
 def __getattr__(name: str) -> Any:
-    """Dynamically import heavy submodules on first access."""
+    """Dynamically import exposed helpers and submodules on first access."""
 
     if name in _LAZY_SUBMODULES:
         module = import_module(f"{__name__}.{name}")
         globals()[name] = module
         return module
+    if name in _EXPORTS:
+        target = _EXPORTS[name]
+        module_name, _, attribute = target.partition(":")
+        module = import_module(module_name)
+        value = getattr(module, attribute) if attribute else module
+        globals()[name] = value
+        return value
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 


### PR DESCRIPTION
## Summary
- avoid eager imports in `library.__init__` that triggered document QA circular dependencies
- add a lazy export registry so helper modules are loaded on first access while keeping the public API stable

## Testing
- python scripts/get_document_data.py --help
- python scripts/get_data.py --help
- python scripts/get_target_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68df69797d0c83248ec460048af34e54