### PR TITLE
Unify documentation landing page with role-based navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,12 @@
 # Documentation Index
 
-Use the sections below to browse manuals, reference sheets, operational processes, and release history. Each link points to the corresponding language variant.
+Quick navigation: [Users](#users) · [Developers](#developers) · [Quality Assurance](#quality-assurance)
 
-## Guides
+Use the role-based sections below to locate manuals, policies, and process documentation. Each link points to the corresponding language variant.
+
+## Users
+
+### Guides
 
 - English
   - [Quickstart checklist](guides/en/QUICKSTART.md)
@@ -15,7 +19,7 @@ Use the sections below to browse manuals, reference sheets, operational processe
   - [Руководство по использованию](guides/ru/USAGE.md)
   - [Сводка компонентов](guides/ru/SUMMARY.md)
 
-## Reference
+### Reference
 
 - English
   - [Configuration matrix](reference/en/CONFIG.md)
@@ -28,25 +32,16 @@ Use the sections below to browse manuals, reference sheets, operational processe
   - [Схема данных](reference/ru/DATA_SCHEMA.md)
   - [Структура выходных данных](reference/ru/OUTPUT.md)
 
-## Architecture
+### Operations
 
 - English
-  - [Architecture overview](architecture/index.md)
-
-## Processes
-
-- English
-  - [Contribution workflow](processes/en/CONTRIBUTING.md)
   - [ETL process](processes/en/ETL_PROCESS.md)
   - [ETL data flow](processes/en/ETL_DATA_FLOW.md)
-  - [QA process](processes/en/QA_PROCESS.md)
 - Русский
-  - [Процесс контрибуции](processes/ru/CONTRIBUTING.md)
   - [ETL-процесс](processes/ru/ETL_PROCESS.md)
   - [Поток данных ETL](processes/ru/ETL_DATA_FLOW.md)
-  - [QA-процесс](processes/ru/QA_PROCESS.md)
 
-## Release Notes
+### Release Notes
 
 - English
   - [Release notes](release-notes/en/RELEASE_NOTES.md)
@@ -54,3 +49,31 @@ Use the sections below to browse manuals, reference sheets, operational processe
 - Русский
   - [Примечания к релизу](release-notes/ru/RELEASE_NOTES.md)
   - [История изменений](release-notes/ru/CHANGELOG.md)
+
+## Developers
+
+### Contribution & Policies
+
+- English
+  - [Contribution workflow](processes/en/CONTRIBUTING.md)
+  - [Development and testing guidelines](guides/en/README.md#development-and-testing)
+- Русский
+  - [Процесс контрибуции](processes/ru/CONTRIBUTING.md)
+  - [Разработка и тестирование](guides/ru/README.md#%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D0%B8-%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)
+
+### Architecture & Ownership
+
+- English
+  - [Repository layout overview](guides/en/SUMMARY.md#repository-layout)
+  - [Architecture overview](architecture/index.md)
+- Русский
+  - [Структура репозитория](guides/ru/SUMMARY.md#%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D1%83%D1%80%D0%B0-%D1%80%D0%B5%D0%BF%D0%BE%D0%B7%D0%B8%D1%82%D0%BE%D1%80%D0%B8%D1%8F)
+
+## Quality Assurance
+
+### QA Playbooks
+
+- English
+  - [QA process](processes/en/QA_PROCESS.md)
+- Русский
+  - [QA-процесс](processes/ru/QA_PROCESS.md)

--- a/docs/index_developer.md
+++ b/docs/index_developer.md
@@ -1,33 +1,5 @@
 # Developer Documentation Index
 
-Use this directory to locate maintainer-focused resources covering contribution
-policies, coding standards, ownership of core modules, and the automated quality
-gates required before releases.
+The developer-specific starting point has moved to the unified [Documentation Index](index.md#developers).
 
-## Contribution workflow
-
-- English
-  - [Dependency pinning policy](processes/en/CONTRIBUTING.md)
-- Русский
-  - [Политика закрепления зависимостей](processes/ru/CONTRIBUTING.md)
-
-## Code standards & tooling
-
-- English
-  - [Development and testing guidelines](guides/en/README.md#development-and-testing)
-- Русский
-  - [Разработка и тестирование](guides/ru/README.md#%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-%D0%B8-%D1%82%D0%B5%D1%81%D1%82%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5)
-
-## Module ownership & architecture
-
-- English
-  - [Repository layout overview](guides/en/SUMMARY.md#repository-layout)
-- Русский
-  - [Структура репозитория](guides/ru/SUMMARY.md#%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D1%83%D1%80%D0%B0-%D1%80%D0%B5%D0%BF%D0%BE%D0%B7%D0%B8%D1%82%D0%BE%D1%80%D0%B8%D1%8F)
-
-## Quality assurance & release automation
-
-- English
-  - [Living QA checklist for release certification](processes/en/QA_PROCESS.md)
-- Русский
-  - [Живой чек-лист QA перед релизом](processes/ru/QA_PROCESS.md)
+Use the role navigation there to access contribution policies, coding standards, and QA gates alongside user and QA references.


### PR DESCRIPTION
## Summary
- reorganized the main documentation index into role-based sections for users, developers, and QA with quick navigation
- redirected the developer index to the unified landing page to remove duplicated link lists

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df69fc45848324931518c60647f9ff