### PR TITLE
Fix circular import when bootstrapping library package

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -1,17 +1,19 @@
 """Utility libraries for data acquisition and processing.
 
-This package exposes commonly used helper functions and submodules. The
-original implementation used absolute imports which fail when the package is
-executed as part of a larger project.  The imports are now explicitly relative
-so that ``python`` can resolve them correctly regardless of the working
-directory.
+The package re-exports frequently used helpers to provide a compact public
+surface.  Importing some of the underlying modules is comparatively expensive
+and can introduce circular dependencies when scripts import :mod:`library`
+before bootstrapping :data:`sys.path`.  To keep the package importable in
+minimal environments (for example when ``scripts/get_data.py`` adjusts
+``sys.path`` at runtime) we lazily resolve all heavyweight modules the first
+time their attributes are requested.
 """
 
 from __future__ import annotations
 
 from importlib import import_module
 from typing import Any
-from .config import Config, load_config
+
 from .common.csv_utils import (
     sha256_file,
     write_csv_chunks_deterministic,
@@ -19,28 +21,8 @@ from .common.csv_utils import (
 )
 from .common.logging_setup import Logger, LoggerConfig, configure_logger
 from .common.timing import log_duration
-from .pipelines.document.type_classifier import compute_scores, decide_label
-from .pipelines.document.type_terms import (
-    EXPERIMENTAL_TERMS,
-    REVIEW_TERMS,
-    UNKNOWN_TERMS,
-    parse_terms,
-)
-from .pipelines.target import organism_classification, protein_classification
-from .pipelines.target.organism_classification import (
-    TYPE_MULTICELLULAR,
-    TYPE_UNICELLULAR,
-    TYPE_VIRAL,
-    OrganismClassificationRules,
-    add_cellularity,
-    add_cellularity_smart,
-    classify_by_lineage,
-    classify_record,
-    normalize,
-)
-from .pipelines.testitem import enrichment as testitem_enrichment
+from .config import Config, load_config
 from .parser_schema import CSVExportArgs
-from .sidecar import SidecarErrors
 
 _LAZY_SUBMODULES = {
     "io",
@@ -49,24 +31,77 @@ _LAZY_SUBMODULES = {
     "validation",
 }
 
+_LAZY_EXPORTS: dict[str, tuple[str, str | None]] = {
+    "compute_scores": ("library.pipelines.document.type_classifier", "compute_scores"),
+    "decide_label": ("library.pipelines.document.type_classifier", "decide_label"),
+    "parse_terms": ("library.pipelines.document.type_terms", "parse_terms"),
+    "REVIEW_TERMS": ("library.pipelines.document.type_terms", "REVIEW_TERMS"),
+    "EXPERIMENTAL_TERMS": ("library.pipelines.document.type_terms", "EXPERIMENTAL_TERMS"),
+    "UNKNOWN_TERMS": ("library.pipelines.document.type_terms", "UNKNOWN_TERMS"),
+    "organism_classification": ("library.pipelines.target", None),
+    "protein_classification": ("library.pipelines.target", None),
+    "testitem_enrichment": ("library.pipelines.testitem.enrichment", None),
+    "OrganismClassificationRules": (
+        "library.pipelines.target.organism_classification",
+        "OrganismClassificationRules",
+    ),
+    "add_cellularity": (
+        "library.pipelines.target.organism_classification",
+        "add_cellularity",
+    ),
+    "add_cellularity_smart": (
+        "library.pipelines.target.organism_classification",
+        "add_cellularity_smart",
+    ),
+    "classify_by_lineage": (
+        "library.pipelines.target.organism_classification",
+        "classify_by_lineage",
+    ),
+    "classify_record": (
+        "library.pipelines.target.organism_classification",
+        "classify_record",
+    ),
+    "normalize": ("library.pipelines.target.organism_classification", "normalize"),
+    "TYPE_MULTICELLULAR": (
+        "library.pipelines.target.organism_classification",
+        "TYPE_MULTICELLULAR",
+    ),
+    "TYPE_UNICELLULAR": (
+        "library.pipelines.target.organism_classification",
+        "TYPE_UNICELLULAR",
+    ),
+    "TYPE_VIRAL": ("library.pipelines.target.organism_classification", "TYPE_VIRAL"),
+    "SidecarErrors": ("library.sidecar", "SidecarErrors"),
+}
+
+
+def _resolve_lazy_attribute(name: str) -> Any:
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = import_module(module_name)
+    value = module if attr_name is None else getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
 
 def __getattr__(name: str) -> Any:
-    """Dynamically import heavy submodules on first access."""
+    """Dynamically import heavy submodules or attributes on first access."""
 
     if name in _LAZY_SUBMODULES:
         module = import_module(f"{__name__}.{name}")
         globals()[name] = module
         return module
+    if name in _LAZY_EXPORTS:
+        return _resolve_lazy_attribute(name)
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 __all__ = [
+    "compute_scores",
+    "decide_label",
     "parse_terms",
     "REVIEW_TERMS",
     "EXPERIMENTAL_TERMS",
     "UNKNOWN_TERMS",
-    "compute_scores",
-    "decide_label",
     "io",
     "qa",
     "schemas",
@@ -98,6 +133,6 @@ __all__ = [
 
 
 def __dir__() -> list[str]:
-    """Return available attributes including lazily loaded submodules."""
+    """Return available attributes including lazily loaded members."""
 
-    return sorted({*globals(), *__all__, *_LAZY_SUBMODULES})
+    return sorted({*globals(), *__all__, *_LAZY_SUBMODULES, *_LAZY_EXPORTS})

--- a/library/pipelines/document/postprocessing.py
+++ b/library/pipelines/document/postprocessing.py
@@ -14,7 +14,7 @@ from typing import Any, Iterable, cast
 import numpy as np
 import pandas as pd
 
-from ... import validation
+from ...validation import validate_columns
 from ...config import IoCfg
 from ...common.csv_utils import write_csv_deterministic
 from ...common.text_utils import to_text
@@ -447,7 +447,7 @@ def postprocess_documents(
     """
 
     if required_columns is not None:
-        validation.validate_columns(df, required_columns)
+        validate_columns(df, required_columns)
 
     if df.empty:
         return pd.DataFrame(columns=FINAL_COLUMN_ORDER)


### PR DESCRIPTION
## Summary
- lazily resolve heavy pipeline exports from the `library` package so scripts can import bootstrap helpers without triggering circular imports
- import the document validation helper directly inside the postprocessing pipeline to avoid referencing a partially initialised package

## Testing
- python -m compileall library

------
https://chatgpt.com/codex/tasks/task_e_68df69691adc8324842374d7104f31c7