### PR TITLE
Fix bootstrap to purge conflicting library package

### DIFF
--- a/library/utils/bootstrap.py
+++ b/library/utils/bootstrap.py
@@ -9,12 +9,62 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Iterable
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _iter_module_paths(module: ModuleType) -> Iterable[Path]:
+    """Yield filesystem paths that define ``module``."""
+
+    file_attr = getattr(module, "__file__", None)
+    if file_attr:
+        yield Path(file_attr).resolve()
+
+    package_paths = getattr(module, "__path__", None)
+    if package_paths is not None:
+        for package_path in package_paths:
+            yield Path(package_path).resolve()
+
+
+def _is_within_project(path: Path) -> bool:
+    """Return ``True`` when ``path`` belongs to the repository tree."""
+
+    try:
+        path.relative_to(_PROJECT_ROOT)
+    except ValueError:
+        return False
+    return True
+
+
+def _should_purge_existing(module: ModuleType | None) -> bool:
+    """Check whether ``module`` was loaded from outside the project."""
+
+    if module is None:
+        return False
+    for module_path in _iter_module_paths(module):
+        if _is_within_project(module_path):
+            return False
+    return True
+
+
+def _purge_conflicting_modules() -> None:
+    """Remove third-party ``library`` modules shadowing the local package."""
+
+    existing = sys.modules.get("library")
+    if not _should_purge_existing(existing):
+        return
+
+    for name in list(sys.modules):
+        if name == "library" or name.startswith("library."):
+            del sys.modules[name]
+
+
 def ensure_project_root() -> None:
-    """Insert the project root into :data:`sys.path` if missing."""
+    """Insert the project root into :data:`sys.path` and purge conflicts."""
+
     project_root = str(_PROJECT_ROOT)
     if project_root not in sys.path:
         sys.path.insert(0, project_root)
+    _purge_conflicting_modules()

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -20,12 +20,39 @@ from time import sleep
 try:
     from library.utils.bootstrap import ensure_project_root
 except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
+    def _is_within(path: Path, root: Path) -> bool:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            return False
+        return True
+
     def ensure_project_root() -> None:
         """Add the repository root to ``sys.path`` when executed as a script."""
 
-        project_root = str(Path(__file__).resolve().parent.parent)
-        if project_root not in sys.path:
-            sys.path.insert(0, project_root)
+        project_root = Path(__file__).resolve().parent.parent
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
+
+        existing = sys.modules.get("library")
+        if existing is None:
+            return
+
+        module_paths: list[Path] = []
+        file_attr = getattr(existing, "__file__", None)
+        if file_attr:
+            module_paths.append(Path(file_attr).resolve())
+        package_paths = getattr(existing, "__path__", None)
+        if package_paths is not None:
+            module_paths.extend(Path(p).resolve() for p in package_paths)
+
+        if any(_is_within(path, project_root) for path in module_paths):
+            return
+
+        for name in list(sys.modules):
+            if name == "library" or name.startswith("library."):
+                del sys.modules[name]
 
 if __package__ in {None, ""}:
     ensure_project_root()

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -48,8 +48,32 @@ try:
     from library.utils.bootstrap import ensure_project_root
 except ModuleNotFoundError:  # pragma: no cover - environment bootstrap
     project_root = Path(__file__).resolve().parents[1]
-    if str(project_root) not in sys.path:
-        sys.path.insert(0, str(project_root))
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+
+    existing = sys.modules.get("library")
+    if existing is not None:
+        module_paths: list[Path] = []
+        file_attr = getattr(existing, "__file__", None)
+        if file_attr:
+            module_paths.append(Path(file_attr).resolve())
+        package_paths = getattr(existing, "__path__", None)
+        if package_paths is not None:
+            module_paths.extend(Path(p).resolve() for p in package_paths)
+
+        def _is_within(path: Path) -> bool:
+            try:
+                path.relative_to(project_root)
+            except ValueError:
+                return False
+            return True
+
+        if not any(_is_within(path) for path in module_paths):
+            for name in list(sys.modules):
+                if name == "library" or name.startswith("library."):
+                    del sys.modules[name]
+
     from library.utils.bootstrap import ensure_project_root
 
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -32,12 +32,39 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
     import sys
     from pathlib import Path
 
+    def _is_within(path: Path, root: Path) -> bool:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            return False
+        return True
+
     def ensure_project_root() -> None:
         """Add the repository root to ``sys.path`` when the package is missing."""
 
-        project_root = str(Path(__file__).resolve().parent.parent)
-        if project_root not in sys.path:
-            sys.path.insert(0, project_root)
+        project_root = Path(__file__).resolve().parent.parent
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
+
+        existing = sys.modules.get("library")
+        if existing is None:
+            return
+
+        module_paths: list[Path] = []
+        file_attr = getattr(existing, "__file__", None)
+        if file_attr:
+            module_paths.append(Path(file_attr).resolve())
+        package_paths = getattr(existing, "__path__", None)
+        if package_paths is not None:
+            module_paths.extend(Path(p).resolve() for p in package_paths)
+
+        if any(_is_within(path, project_root) for path in module_paths):
+            return
+
+        for name in list(sys.modules):
+            if name == "library" or name.startswith("library."):
+                del sys.modules[name]
 
 
 if __package__ in {None, ""}:


### PR DESCRIPTION
## Summary
- ensure the bootstrap helper removes third-party `library` packages that shadow the project modules
- extend script-level fallbacks to drop conflicting imports when run directly from the repository

## Testing
- python scripts/get_target_data.py --help
- python scripts/get_activity_data.py --help
- python scripts/get_document_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68df69a8bff88324a7fb3a10d17e2685