### PR TITLE
Add compatibility re-exports to legacy testitem pipeline module

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -1,7 +1,23 @@
-"""Test item pipeline orchestration helpers."""
+"""Test item pipeline orchestration helpers.
+
+Changelog
+========
+* Add compatibility re-exports for the modern test item pipeline API.
+"""
 
 from __future__ import annotations
 
+# ===== Modules =====
 from .enrichment import enrich
 
-__all__ = ["enrich"]
+# ===== Compatibility Exports =====
+from library.testitem_pipeline.pubchem import (
+    PUBCHEM_CID_CACHE_ENCODING,
+    PUBCHEM_COLUMNS,
+)
+
+__all__ = [
+    "enrich",
+    "PUBCHEM_CID_CACHE_ENCODING",
+    "PUBCHEM_COLUMNS",
+]


### PR DESCRIPTION
## Summary
- add compatibility re-exports for PubChem cache metadata to the legacy `library.pipelines.testitem` package

## Testing
- pytest tests/test_testitem_enrichment.py

------
https://chatgpt.com/codex/tasks/task_e_68df6a536bf08324ba6dd413cd2628cf