### PR TITLE
Fix PubChem compatibility exports for test item pipeline

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -8,13 +8,23 @@ Changelog
 from __future__ import annotations
 
 # ===== Modules =====
+from importlib import import_module
+from importlib.util import find_spec
+
 from .enrichment import enrich
+from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
+
 
 # ===== Compatibility Exports =====
-from library.testitem_pipeline.pubchem import (
-    PUBCHEM_CID_CACHE_ENCODING,
-    PUBCHEM_COLUMNS,
-)
+_PUBCHEM_COMPAT_MODULE = "library.testitem_pipeline.pubchem"
+
+if find_spec(_PUBCHEM_COMPAT_MODULE) is not None:
+    pubchem_module = import_module(_PUBCHEM_COMPAT_MODULE)
+    PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
+    PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
+else:
+    PUBCHEM_CID_CACHE_ENCODING = "utf-8"
+    PUBCHEM_COLUMNS = list(TESTITEM_PUBCHEM_COLUMNS)
 
 __all__ = [
     "enrich",


### PR DESCRIPTION
## Summary
- probe for the modern `library.testitem_pipeline.pubchem` module before importing its exports
- provide a deterministic fallback for PubChem encoding and columns when the integration package is unavailable

## Testing
- pytest tests/test_testitem_pipeline_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68df6b29e0648324a2ee7defb1e3ef91