### PR TITLE
Fix circular QA import and stabilize SidecarErrors access

### DIFF
--- a/library/pipelines/document/postprocessing.py
+++ b/library/pipelines/document/postprocessing.py
@@ -14,11 +14,9 @@ from typing import Any, Iterable, cast
 import numpy as np
 import pandas as pd
 
-from ... import validation
 from ...config import IoCfg
 from ...common.csv_utils import write_csv_deterministic
 from ...common.text_utils import to_text
-
 
 # ===== Parameters ===========================================================
 
@@ -447,7 +445,9 @@ def postprocess_documents(
     """
 
     if required_columns is not None:
-        validation.validate_columns(df, required_columns)
+        from ... import validation as validation_module
+
+        validation_module.validate_columns(df, required_columns)
 
     if df.empty:
         return pd.DataFrame(columns=FINAL_COLUMN_ORDER)

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -38,7 +38,7 @@ from library.metadata import (
 )
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
 from library.schemas import TestitemsSchema, normalize_testitems

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -125,7 +125,7 @@ from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.postprocessing.document import preprocess_documents_csv
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import RateLimiter, get_global_limiter, get_limiter
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 from library.table_quality import TableQualityProfiler, analyze_table_quality
 from library.schemas import DocumentsSchema, normalize_documents
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -102,7 +102,7 @@ from library.common.csv_utils import write_csv_deterministic
 from library.common.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipelines.common import add_pipeline_metadata
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import ValidationResult
 from library.schemas import TargetsSchema, normalize_targets

--- a/tests/test_activity_schema_sidecar.py
+++ b/tests/test_activity_schema_sidecar.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 from pandera.errors import SchemaErrors
 
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 from library.schemas import ActivitiesSchema
 
 

--- a/tests/test_meta_yaml.py
+++ b/tests/test_meta_yaml.py
@@ -8,7 +8,7 @@ import yaml
 
 from library.config import Config
 from library.io.writers import write_csv
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 from library.schemas import CsvMetaSchema
 
 

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -6,7 +6,7 @@ import yaml
 from library.config import Config
 from library.config import _mask_secrets, _serialize_paths
 
-from library.sidecar import SidecarErrors
+from library import SidecarErrors
 
 
 def test_sidecar_writes_rows(


### PR DESCRIPTION
## Summary
- defer document post-processing validation imports to avoid circular QA dependencies
- import SidecarErrors via the library package to prevent module resolution issues
- update tests to match the new import path

## Testing
- pytest tests/test_sidecar.py -q
- pytest tests/test_meta_yaml.py -q
- pytest tests/test_activity_schema_sidecar.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df6ada47dc8324964c4692cb28ee04