### PR TITLE
Fix circular import between testitem pipelines

### DIFF
--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
 import requests
 
 from .catalog import (
@@ -31,6 +35,34 @@ from .catalog import (
     update_parent_catalog_cache,
     write_parent_catalog_cache,
 )
+
+
+class _LazyModuleProxy:
+    """Lazily import *module_name* on first attribute access."""
+
+    __slots__ = ("_module", "_module_name")
+
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: ModuleType | None = None
+
+    def _ensure_loaded(self) -> ModuleType:
+        if self._module is None:
+            self._module = import_module(self._module_name)
+        return self._module
+
+    def __getattr__(self, name: str) -> Any:  # noqa: D401 - behave like the target module
+        module = self._ensure_loaded()
+        return getattr(module, name)
+
+    def __dir__(self) -> list[str]:
+        module = self._ensure_loaded()
+        return sorted(set(dir(module)))
+
+
+testitem_enrichment = _LazyModuleProxy("library.pipelines.testitem.enrichment")
+
+
 from .cli import (
     ReadInputIdsResult,
     TestitemFetchError,
@@ -65,7 +97,6 @@ from .pubchem import (
     resolve_pubchem_cid,
 )
 from library.integration import pubchem_library as pl
-from library.pipelines.testitem import enrichment as testitem_enrichment
 from library.integration.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.common.csv_utils import write_csv_chunks_deterministic as write_csv_deterministic

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -15,7 +15,6 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import io
-from library.pipelines.testitem import enrichment as testitem_enrichment
 from library.integration import chembl_library as cl
 from library.integration.chembl_client import ChemblClient
 from library.clients import pubchem as pc
@@ -56,6 +55,7 @@ from .catalog import (
     prepare_parent_enrichment,
     run_parent_enrichment,
 )
+from . import testitem_enrichment
 from .pubchem import PUBCHEM_COLUMNS, add_pubchem_data, augment_pubchem
 
 _FETCH_ERROR_SAMPLE_SIZE = 10


### PR DESCRIPTION
## Summary
- add a lazy module proxy in `library/testitem_pipeline/__init__.py` so the legacy enrichment module only loads on demand and no longer triggers circular imports
- update the CLI to rely on the local proxy export when invoking the enrichment helpers

## Testing
- pytest tests/test_testitem_enrichment.py tests/test_testitem_pipeline_threadsafe.py

------
https://chatgpt.com/codex/tasks/task_e_68df6b73b4a483248fa3b96e58d1c253