### PR TITLE
Provide fallback for missing testitem pipeline

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -3,6 +3,7 @@
 Changelog
 ========
 * Add compatibility re-exports for the modern test item pipeline API.
+* Provide graceful fallbacks when the optional modern pipeline is unavailable.
 """
 
 from __future__ import annotations
@@ -11,10 +12,17 @@ from __future__ import annotations
 from .enrichment import enrich
 
 # ===== Compatibility Exports =====
-from library.testitem_pipeline.pubchem import (
-    PUBCHEM_CID_CACHE_ENCODING,
-    PUBCHEM_COLUMNS,
-)
+try:  # pragma: no cover - exercised indirectly via import side effects
+    from library.testitem_pipeline.pubchem import (
+        PUBCHEM_CID_CACHE_ENCODING,
+        PUBCHEM_COLUMNS,
+    )
+except ModuleNotFoundError:  # pragma: no cover - platform specific dependency gap
+    from library.common.text_utils import UTF8_ENCODING
+    from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
+
+    PUBCHEM_CID_CACHE_ENCODING = UTF8_ENCODING
+    PUBCHEM_COLUMNS = TESTITEM_PUBCHEM_COLUMNS
 
 __all__ = [
     "enrich",


### PR DESCRIPTION
## Summary
- add fallbacks so the test item pipeline exports keep working even when the optional `library.testitem_pipeline` module cannot be imported

## Testing
- python -m compileall library/pipelines/testitem/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68df6b9c39908324a372ab931f8285f6