### PR TITLE
Restore legacy testitem pipeline exports

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -3,6 +3,8 @@
 Changelog
 ========
 * Add compatibility re-exports for the modern test item pipeline API.
+* Re-export public helpers from :mod:`library.testitem_pipeline` for legacy
+  imports.
 """
 
 from __future__ import annotations
@@ -13,6 +15,36 @@ from importlib.util import find_spec
 
 from .enrichment import enrich
 from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
+from library.testitem_pipeline import (
+    PARENT_LOOKUP_SOURCE_CACHE,
+    PARENT_LOOKUP_SOURCE_LOOKUP,
+    PARENT_LOOKUP_SOURCE_PARTIAL,
+    PARENT_LOOKUP_SOURCE_SKIPPED,
+    PARENT_LOOKUP_SOURCE_SYNC,
+    ReadInputIdsResult,
+    TestitemPipelineOptions,
+    _DEFAULT_CATALOG_CFG,
+    _FETCH_ERROR_SAMPLE_SIZE,
+    _MOLECULE_HIERARCHY_COLUMNS,
+    _PUBCHEM_CACHE_SCHEMA_VERSION,
+    _TYPO_PARENT_COLUMN,
+    analyze_table_quality,
+    ensure_no_parant_column,
+    file_sha256,
+    fetch_testitems,
+    integrate_missing_identifiers,
+    load_parent_catalog,
+    query_parent_catalog,
+    read_input_ids,
+    run_testitem_pipeline,
+    update_parent_catalog_cache,
+    write_meta_yaml,
+    write_parent_catalog_cache,
+    _prepare_pubchem_api_cfg,
+    _write_pubchem_cid_cache,
+    PUBCHEM_CID_CACHE_ENCODING as _PIPELINE_PUBCHEM_CID_CACHE_ENCODING,
+    PUBCHEM_COLUMNS as _PIPELINE_PUBCHEM_COLUMNS,
+)
 
 
 # ===== Compatibility Exports =====
@@ -23,11 +55,37 @@ if find_spec(_PUBCHEM_COMPAT_MODULE) is not None:
     PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
     PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
 else:
-    PUBCHEM_CID_CACHE_ENCODING = "utf-8"
-    PUBCHEM_COLUMNS = list(TESTITEM_PUBCHEM_COLUMNS)
+    PUBCHEM_CID_CACHE_ENCODING = _PIPELINE_PUBCHEM_CID_CACHE_ENCODING
+    PUBCHEM_COLUMNS = list(_PIPELINE_PUBCHEM_COLUMNS)
 
 __all__ = [
     "enrich",
     "PUBCHEM_CID_CACHE_ENCODING",
     "PUBCHEM_COLUMNS",
+    "PARENT_LOOKUP_SOURCE_CACHE",
+    "PARENT_LOOKUP_SOURCE_LOOKUP",
+    "PARENT_LOOKUP_SOURCE_PARTIAL",
+    "PARENT_LOOKUP_SOURCE_SKIPPED",
+    "PARENT_LOOKUP_SOURCE_SYNC",
+    "ReadInputIdsResult",
+    "TestitemPipelineOptions",
+    "_DEFAULT_CATALOG_CFG",
+    "_FETCH_ERROR_SAMPLE_SIZE",
+    "_MOLECULE_HIERARCHY_COLUMNS",
+    "_PUBCHEM_CACHE_SCHEMA_VERSION",
+    "_TYPO_PARENT_COLUMN",
+    "_prepare_pubchem_api_cfg",
+    "_write_pubchem_cid_cache",
+    "analyze_table_quality",
+    "ensure_no_parant_column",
+    "file_sha256",
+    "fetch_testitems",
+    "integrate_missing_identifiers",
+    "load_parent_catalog",
+    "query_parent_catalog",
+    "read_input_ids",
+    "run_testitem_pipeline",
+    "update_parent_catalog_cache",
+    "write_meta_yaml",
+    "write_parent_catalog_cache",
 ]


### PR DESCRIPTION
## Summary
- re-export the modern test item pipeline helpers from the legacy compatibility module
- fall back to the new pipeline defaults when the historical pubchem module is unavailable

## Testing
- python scripts/get_data.py --limit 1 --log-level WARNING

------
https://chatgpt.com/codex/tasks/task_e_68df6c1752c483248677750313e4fab0