### PR TITLE
Handle missing legacy testitem module gracefully

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -18,11 +18,15 @@ from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
 # ===== Compatibility Exports =====
 _PUBCHEM_COMPAT_MODULE = "library.testitem_pipeline.pubchem"
 
-if find_spec(_PUBCHEM_COMPAT_MODULE) is not None:
+try:
+    if find_spec(_PUBCHEM_COMPAT_MODULE) is None:
+        raise ModuleNotFoundError(_PUBCHEM_COMPAT_MODULE)
     pubchem_module = import_module(_PUBCHEM_COMPAT_MODULE)
     PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
     PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
-else:
+except ModuleNotFoundError as exc:
+    if getattr(exc, "name", None) != _PUBCHEM_COMPAT_MODULE:
+        raise
     PUBCHEM_CID_CACHE_ENCODING = "utf-8"
     PUBCHEM_COLUMNS = list(TESTITEM_PUBCHEM_COLUMNS)
 


### PR DESCRIPTION
## Summary
- guard the legacy `library.testitem_pipeline.pubchem` import so missing packages fall back to the modern defaults

## Testing
- python - <<'PY'
from importlib import import_module
from library.pipelines import testitem
print(testitem.PUBCHEM_COLUMNS[:3])
PY

------
https://chatgpt.com/codex/tasks/task_e_68df6c8859848324abef4df0b3d258b8