### PR TITLE
Fix compatibility import in testitem pipeline

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -54,11 +54,12 @@ try:
     if find_spec(_PUBCHEM_COMPAT_MODULE) is None:
         raise ModuleNotFoundError(_PUBCHEM_COMPAT_MODULE)
     pubchem_module = import_module(_PUBCHEM_COMPAT_MODULE)
-    PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
-    PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
-else:
+except ModuleNotFoundError:
     PUBCHEM_CID_CACHE_ENCODING = _PIPELINE_PUBCHEM_CID_CACHE_ENCODING
     PUBCHEM_COLUMNS = list(_PIPELINE_PUBCHEM_COLUMNS)
+else:
+    PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
+    PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
 
 __all__ = [
     "enrich",


### PR DESCRIPTION
## Summary
- fix the compatibility import for the test item pipeline fallback logic

## Testing
- python -m compileall library/pipelines/testitem/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68df6dae0f388324ac29134a23e15f78