### PR TITLE
Improve error when optional test item catalog module is missing

### DIFF
--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -50,12 +50,26 @@ def _load_local_module(module_name: str) -> ModuleType:
     package_name = __name__
     qualified_name = f"{package_name}.{module_name}"
     module_path = Path(__file__).with_name(f"{module_name}.py")
+    if not module_path.is_file():
+        msg = (
+            f"Optional module '{qualified_name}' is not available. "
+            f"Expected file '{module_path}' is missing from this installation."
+        )
+        raise ModuleNotFoundError(msg)
     spec = spec_from_file_location(qualified_name, module_path)
     if spec is None or spec.loader is None:
         raise ModuleNotFoundError(qualified_name)
     module = module_from_spec(spec)
-    sys.modules[qualified_name] = module
-    spec.loader.exec_module(module)
+    try:
+        sys.modules[qualified_name] = module
+        spec.loader.exec_module(module)
+    except FileNotFoundError as exc:
+        sys.modules.pop(qualified_name, None)
+        msg = (
+            f"Optional module '{qualified_name}' could not be loaded. "
+            f"Ensure '{module_path}' is included in your environment."
+        )
+        raise ModuleNotFoundError(msg) from exc
     return module
 
 

--- a/tests/test_testitem_pipeline_imports.py
+++ b/tests/test_testitem_pipeline_imports.py
@@ -1,0 +1,29 @@
+"""Tests covering import helpers for :mod:`library.testitem_pipeline`."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def test_load_local_module_missing_file() -> None:
+    """Provide a clear error when the optional catalog module is absent."""
+
+    module = importlib.import_module("library.testitem_pipeline")
+    missing_name = "missing_catalog"
+    qualified = f"{module.__name__}.{missing_name}"
+    module_path = Path(module.__file__).with_name(f"{missing_name}.py")
+    assert not module_path.exists()
+
+    sys_modules_before = set(sys.modules)
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        module._load_local_module(missing_name)
+
+    assert qualified in str(excinfo.value)
+    assert f"{module_path}" in str(excinfo.value)
+    assert qualified not in sys.modules
+    assert sys_modules_before <= set(sys.modules)


### PR DESCRIPTION
## Summary
- add explicit checks when the local catalog fallback module is absent
- avoid leaving partially loaded modules in sys.modules and raise a clearer ModuleNotFoundError
- cover the failure mode with a regression test for the import helper

## Testing
- pytest tests/test_testitem_pipeline_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68df6e95e6248324a3be7cbd838123d3