### PR TITLE
Fix test item pipeline import cycle

### DIFF
--- a/library/integration/__init__.py
+++ b/library/integration/__init__.py
@@ -1,22 +1,44 @@
-"""Adapters and façade modules wrapping third-party integrations."""
+"""Adapters and façade modules wrapping third-party integrations.
+
+Changelog
+========
+* Replace eager submodule imports with lazy loading to avoid circular
+  dependencies when accessed during the test item pipeline bootstrap.
+"""
 
 from __future__ import annotations
 
-from .chembl_client import ChemblClient
-from . import (
-  chembl_library,
-  input_initialisation_library,
-  iuphar_library,
-  mapper_batch_library,
-  mapper_library,
-  molecule_catalog,
-  openalex_crossref_library,
-  pubchem_library,
-  pubmed_library,
-  semantic_scholar_library,
-  uniprot_library,
-)
+# ===== Modules =====
+from importlib import import_module
+from typing import Any
 
+from .chembl_client import ChemblClient
+
+# ===== Helpers =====
+_LAZY_SUBMODULES = {
+  "chembl_library",
+  "input_initialisation_library",
+  "iuphar_library",
+  "mapper_batch_library",
+  "mapper_library",
+  "molecule_catalog",
+  "openalex_crossref_library",
+  "pubchem_library",
+  "pubmed_library",
+  "semantic_scholar_library",
+  "uniprot_library",
+}
+
+
+def _load_submodule(name: str) -> Any:
+  """Import ``library.integration.<name>`` and memoise the module object."""
+
+  module = import_module(f"{__name__}.{name}")
+  globals()[name] = module
+  return module
+
+
+# ===== Exports =====
 __all__ = [
   "ChemblClient",
   "chembl_library",
@@ -31,3 +53,17 @@ __all__ = [
   "semantic_scholar_library",
   "uniprot_library",
 ]
+
+
+def __getattr__(name: str) -> Any:
+  """Resolve lazy integration submodules on first attribute access."""
+
+  if name in _LAZY_SUBMODULES:
+    return _load_submodule(name)
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+  """Expose eager and lazy exports for introspection tools."""
+
+  return sorted({*globals(), *__all__, *_LAZY_SUBMODULES})

--- a/library/pipelines/__init__.py
+++ b/library/pipelines/__init__.py
@@ -1,7 +1,42 @@
-"""Domain-specific data pipelines grouped by entity type."""
+"""Domain-specific data pipelines grouped by entity type.
+
+Changelog
+========
+* Replace eager imports with lazy module loaders to avoid circular
+  dependencies during initialisation.
+"""
 
 from __future__ import annotations
 
-from . import activity, assay, common, document, target, testitem
+# ===== Modules =====
+from importlib import import_module
+from typing import Any
 
+# ===== Helpers =====
+_LAZY_SUBMODULES = {"activity", "assay", "common", "document", "target", "testitem"}
+
+
+def _load_submodule(name: str) -> Any:
+  """Import ``library.pipelines.<name>`` and cache the module in globals."""
+
+  module = import_module(f"{__name__}.{name}")
+  globals()[name] = module
+  return module
+
+
+# ===== Exports =====
 __all__ = ["activity", "assay", "common", "document", "target", "testitem"]
+
+
+def __getattr__(name: str) -> Any:
+  """Expose pipeline submodules on demand to break import cycles."""
+
+  if name in _LAZY_SUBMODULES:
+    return _load_submodule(name)
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+  """Provide completion support for the exported submodules."""
+
+  return sorted({*globals(), *__all__, *_LAZY_SUBMODULES})

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 from collections import OrderedDict, deque
 from dataclasses import dataclass
+from functools import lru_cache
 from itertools import chain, islice
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Sequence
@@ -15,7 +16,6 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import io
-from library.integration import chembl_library as cl
 from library.integration.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.config import (
@@ -57,6 +57,15 @@ from .catalog import (
 )
 from . import testitem_enrichment
 from .pubchem import PUBCHEM_COLUMNS, add_pubchem_data, augment_pubchem
+
+
+@lru_cache(maxsize=1)
+def _chembl_library() -> Any:
+    """Return the lazily imported ChEMBL integration module."""
+
+    from library.integration import chembl_library
+
+    return chembl_library
 
 _FETCH_ERROR_SAMPLE_SIZE = 10
 _MISSING_IDENTIFIER_LOG_SAMPLE_SIZE = 10
@@ -293,7 +302,7 @@ def fetch_testitems(
 
     def _load_chunk(batch: Sequence[str], chunk_size: int) -> pd.DataFrame:
         try:
-            frame = cl.get_testitem(
+            frame = _chembl_library().get_testitem(
                 batch,
                 cfg=api_cfg,
                 client=client,


### PR DESCRIPTION
## Summary
- lazily load integration submodules so the test item pipeline can bootstrap without circular imports
- defer pipeline package imports until access and fetch the ChEMBL integration module on demand inside the CLI

## Testing
- python -m compileall library/integration/__init__.py library/pipelines/__init__.py library/testitem_pipeline/cli.py

------
https://chatgpt.com/codex/tasks/task_e_68df6e7f8f988324b6714269b81fc77e