### PR TITLE
Fix test item pipeline circular imports

### DIFF
--- a/library/integration/__init__.py
+++ b/library/integration/__init__.py
@@ -2,23 +2,10 @@
 
 from __future__ import annotations
 
-from .chembl_client import ChemblClient
-from . import (
-  chembl_library,
-  input_initialisation_library,
-  iuphar_library,
-  mapper_batch_library,
-  mapper_library,
-  molecule_catalog,
-  openalex_crossref_library,
-  pubchem_library,
-  pubmed_library,
-  semantic_scholar_library,
-  uniprot_library,
-)
+from importlib import import_module
+from typing import Any
 
-__all__ = [
-  "ChemblClient",
+_LAZY_MODULES = {
   "chembl_library",
   "input_initialisation_library",
   "iuphar_library",
@@ -30,4 +17,30 @@ __all__ = [
   "pubmed_library",
   "semantic_scholar_library",
   "uniprot_library",
+}
+
+__all__ = [
+  "ChemblClient",
+  *_LAZY_MODULES,
 ]
+
+
+def __getattr__(name: str) -> Any:
+  """Lazily import integration helpers on first access."""
+
+  if name == "ChemblClient":
+    from .chembl_client import ChemblClient as _ChemblClient
+
+    globals()[name] = _ChemblClient
+    return _ChemblClient
+  if name in _LAZY_MODULES:
+    module = import_module(f"{__name__}.{name}")
+    globals()[name] = module
+    return module
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+  """Return available attributes including lazily loaded modules."""
+
+  return sorted({*globals(), *__all__, *_LAZY_MODULES})

--- a/library/integration/chembl_library.py
+++ b/library/integration/chembl_library.py
@@ -1,38 +1,46 @@
-"""Compatibility layer aggregating ChEMBL helpers.
-
-This module re-exports selected public functions from :mod:`chembl_assay` and
-:mod:`chembl_target` as a convenient façade.  The functions are imported
-explicitly rather than via ``import *`` to make the exported API clear and to
-keep linters happy.
-"""
+"""Compatibility layer aggregating ChEMBL helpers."""
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+
 from library.clients import _chunked
-from ..pipelines.assay import get_activities, get_assay, get_assays, get_testitem
-from ..pipelines.document import get_documents
-from ..pipelines.target.chembl_target import (
-    extend_target,
-    get_target_payload,
-    get_target,
-    get_targets,
-    get_targets_payloads,
-    get_targets_raw_frame,
-    iter_target_batches,
-)
+
+_PIPELINE_EXPORTS = {
+  "get_assay": ("library.pipelines.assay", "get_assay"),
+  "get_assays": ("library.pipelines.assay", "get_assays"),
+  "get_activities": ("library.pipelines.assay", "get_activities"),
+  "get_testitem": ("library.pipelines.assay", "get_testitem"),
+  "get_documents": ("library.pipelines.document", "get_documents"),
+  "get_target": ("library.pipelines.target.chembl_target", "get_target"),
+  "get_target_payload": ("library.pipelines.target.chembl_target", "get_target_payload"),
+  "get_targets": ("library.pipelines.target.chembl_target", "get_targets"),
+  "get_targets_payloads": ("library.pipelines.target.chembl_target", "get_targets_payloads"),
+  "get_targets_raw_frame": ("library.pipelines.target.chembl_target", "get_targets_raw_frame"),
+  "iter_target_batches": ("library.pipelines.target.chembl_target", "iter_target_batches"),
+  "extend_target": ("library.pipelines.target.chembl_target", "extend_target"),
+}
 
 __all__ = [
-    "get_assay",
-    "get_assays",
-    "get_activities",
-    "get_testitem",
-    "get_documents",
-    "get_target",
-    "get_target_payload",
-    "get_targets",
-    "get_targets_payloads",
-    "get_targets_raw_frame",
-    "iter_target_batches",
-    "extend_target",
-    "_chunked",
+  *_PIPELINE_EXPORTS,
+  "_chunked",
 ]
+
+
+def __getattr__(name: str) -> Any:
+  """Return lazily imported pipeline helpers."""
+
+  if name in _PIPELINE_EXPORTS:
+    module_name, attribute = _PIPELINE_EXPORTS[name]
+    module = import_module(module_name)
+    value = getattr(module, attribute)
+    globals()[name] = value
+    return value
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+  """Return available attributes for introspection tools."""
+
+  return sorted({*globals(), *__all__})

--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -11,57 +11,11 @@ from __future__ import annotations
 
 # ===== Modules =====
 from importlib import import_module
-from importlib.util import find_spec
+from typing import Any
 
 from .enrichment import enrich
-from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
-from library.testitem_pipeline import (
-    PARENT_LOOKUP_SOURCE_CACHE,
-    PARENT_LOOKUP_SOURCE_LOOKUP,
-    PARENT_LOOKUP_SOURCE_PARTIAL,
-    PARENT_LOOKUP_SOURCE_SKIPPED,
-    PARENT_LOOKUP_SOURCE_SYNC,
-    ReadInputIdsResult,
-    TestitemPipelineOptions,
-    _DEFAULT_CATALOG_CFG,
-    _FETCH_ERROR_SAMPLE_SIZE,
-    _MOLECULE_HIERARCHY_COLUMNS,
-    _PUBCHEM_CACHE_SCHEMA_VERSION,
-    _TYPO_PARENT_COLUMN,
-    analyze_table_quality,
-    ensure_no_parant_column,
-    file_sha256,
-    fetch_testitems,
-    integrate_missing_identifiers,
-    load_parent_catalog,
-    query_parent_catalog,
-    read_input_ids,
-    run_testitem_pipeline,
-    update_parent_catalog_cache,
-    write_meta_yaml,
-    write_parent_catalog_cache,
-    _prepare_pubchem_api_cfg,
-    _write_pubchem_cid_cache,
-    PUBCHEM_CID_CACHE_ENCODING as _PIPELINE_PUBCHEM_CID_CACHE_ENCODING,
-    PUBCHEM_COLUMNS as _PIPELINE_PUBCHEM_COLUMNS,
-)
 
-
-# ===== Compatibility Exports =====
-_PUBCHEM_COMPAT_MODULE = "library.testitem_pipeline.pubchem"
-
-if find_spec(_PUBCHEM_COMPAT_MODULE) is not None:
-    pubchem_module = import_module(_PUBCHEM_COMPAT_MODULE)
-    PUBCHEM_CID_CACHE_ENCODING = pubchem_module.PUBCHEM_CID_CACHE_ENCODING
-    PUBCHEM_COLUMNS = list(pubchem_module.PUBCHEM_COLUMNS)
-else:
-    PUBCHEM_CID_CACHE_ENCODING = _PIPELINE_PUBCHEM_CID_CACHE_ENCODING
-    PUBCHEM_COLUMNS = list(_PIPELINE_PUBCHEM_COLUMNS)
-
-__all__ = [
-    "enrich",
-    "PUBCHEM_CID_CACHE_ENCODING",
-    "PUBCHEM_COLUMNS",
+_PIPELINE_EXPORTS = {
     "PARENT_LOOKUP_SOURCE_CACHE",
     "PARENT_LOOKUP_SOURCE_LOOKUP",
     "PARENT_LOOKUP_SOURCE_PARTIAL",
@@ -88,4 +42,40 @@ __all__ = [
     "update_parent_catalog_cache",
     "write_meta_yaml",
     "write_parent_catalog_cache",
+}
+
+_PUBCHEM_EXPORTS = {
+    "PUBCHEM_CID_CACHE_ENCODING": "PUBCHEM_CID_CACHE_ENCODING",
+    "PUBCHEM_COLUMNS": "PUBCHEM_COLUMNS",
+}
+
+__all__ = [
+    "enrich",
+    "PUBCHEM_CID_CACHE_ENCODING",
+    "PUBCHEM_COLUMNS",
+    *sorted(_PIPELINE_EXPORTS),
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Proxy access to the modern test item pipeline helpers."""
+
+    if name in _PIPELINE_EXPORTS:
+        module = import_module("library.testitem_pipeline")
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    if name in _PUBCHEM_EXPORTS:
+        module = import_module("library.testitem_pipeline.pubchem")
+        value = getattr(module, _PUBCHEM_EXPORTS[name])
+        if name == "PUBCHEM_COLUMNS":
+            value = list(value)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    """Expose lazily loaded pipeline exports for introspection."""
+
+    return sorted({*globals(), *__all__, *_PIPELINE_EXPORTS, *_PUBCHEM_EXPORTS})

--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -63,21 +63,6 @@ class _LazyModuleProxy:
 testitem_enrichment = _LazyModuleProxy("library.pipelines.testitem.enrichment")
 
 
-from .cli import (
-    ReadInputIdsResult,
-    TestitemFetchError,
-    TestitemPipelineOptions,
-    TestitemPipelineStageError,
-    _FETCH_ERROR_SAMPLE_SIZE,
-    _log_missing_identifier_summary,
-    _prepare_pubchem_api_cfg,
-    apply_testitem_enrichment,
-    fetch_testitems,
-    finalize_output,
-    integrate_missing_identifiers,
-    read_input_ids,
-    run_testitem_pipeline,
-)
 from .pubchem import (
     PUBCHEM_CID_CACHE_ENCODING,
     PUBCHEM_COLUMNS,
@@ -172,3 +157,37 @@ __all__ = [
     "write_csv_deterministic",
     "write_parent_catalog_cache",
 ]
+
+
+_CLI_EXPORTS = {
+    "ReadInputIdsResult",
+    "TestitemFetchError",
+    "TestitemPipelineOptions",
+    "TestitemPipelineStageError",
+    "_FETCH_ERROR_SAMPLE_SIZE",
+    "_log_missing_identifier_summary",
+    "_prepare_pubchem_api_cfg",
+    "apply_testitem_enrichment",
+    "fetch_testitems",
+    "finalize_output",
+    "integrate_missing_identifiers",
+    "read_input_ids",
+    "run_testitem_pipeline",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import CLI helpers to avoid circular dependencies."""
+
+    if name in _CLI_EXPORTS:
+        module = import_module("library.testitem_pipeline.cli")
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    """Expose lazily loaded CLI symbols for introspection."""
+
+    return sorted({*globals(), *__all__, *_CLI_EXPORTS})

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -35,7 +35,6 @@ from library.metadata import (
     write_meta_yaml,
     record_quality_failure,
 )
-from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -148,6 +147,14 @@ def read_input_ids(
         ids_iter=ids_iter,
         sample_ids=sample_ids,
     )
+
+
+def _add_pipeline_metadata(df: pd.DataFrame) -> pd.DataFrame:
+    """Attach acquisition metadata using the legacy pipeline helper."""
+
+    from library.pipelines.common import add_pipeline_metadata as _add_pipeline_metadata
+
+    return _add_pipeline_metadata(df)
 
 
 def _log_missing_identifier_summary(identifiers: Sequence[str]) -> None:
@@ -690,7 +697,7 @@ def finalize_output(
         current = normalize_testitems(raw)
         if "pubchem_cid" in current.columns:
             current["pubchem_cid"] = current["pubchem_cid"].astype(object)
-        current = add_pipeline_metadata(current)
+        current = _add_pipeline_metadata(current)
         columns_seen.update(current.columns)
 
         chunk_missing_required = required_cols - set(current.columns)


### PR DESCRIPTION
## Summary
- lazily load integration modules to avoid pulling the full pipeline graph during import
- convert the test item pipeline exports to defer CLI and PubChem access until they are used
- load pipeline metadata helpers inside the CLI to break remaining circular imports

## Testing
- `python scripts/get_data.py --limit 1 --log-level WARNING` *(fails: Reference document CSV not found in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df6d70f17083248c53fa1d715117b0