### PR TITLE
Fix circular imports in test item pipeline

### DIFF
--- a/library/integration/__init__.py
+++ b/library/integration/__init__.py
@@ -2,32 +2,42 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+
 from .chembl_client import ChemblClient
-from . import (
-  chembl_library,
-  input_initialisation_library,
-  iuphar_library,
-  mapper_batch_library,
-  mapper_library,
-  molecule_catalog,
-  openalex_crossref_library,
-  pubchem_library,
-  pubmed_library,
-  semantic_scholar_library,
-  uniprot_library,
-)
+
+_LAZY_MODULES = {
+  "chembl_library": "library.integration.chembl_library",
+  "input_initialisation_library": "library.integration.input_initialisation_library",
+  "iuphar_library": "library.integration.iuphar_library",
+  "mapper_batch_library": "library.integration.mapper_batch_library",
+  "mapper_library": "library.integration.mapper_library",
+  "molecule_catalog": "library.integration.molecule_catalog",
+  "openalex_crossref_library": "library.integration.openalex_crossref_library",
+  "pubchem_library": "library.integration.pubchem_library",
+  "pubmed_library": "library.integration.pubmed_library",
+  "semantic_scholar_library": "library.integration.semantic_scholar_library",
+  "uniprot_library": "library.integration.uniprot_library",
+}
 
 __all__ = [
   "ChemblClient",
-  "chembl_library",
-  "input_initialisation_library",
-  "iuphar_library",
-  "mapper_batch_library",
-  "mapper_library",
-  "molecule_catalog",
-  "openalex_crossref_library",
-  "pubchem_library",
-  "pubmed_library",
-  "semantic_scholar_library",
-  "uniprot_library",
+  *_LAZY_MODULES,
 ]
+
+
+def __getattr__(name: str) -> Any:
+  """Dynamically import integration submodules on first access."""
+
+  if name in _LAZY_MODULES:
+    module = import_module(_LAZY_MODULES[name])
+    globals()[name] = module
+    return module
+  raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+  """Return available attributes including lazily loaded submodules."""
+
+  return sorted({*globals(), *__all__})

--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -63,40 +63,6 @@ class _LazyModuleProxy:
 testitem_enrichment = _LazyModuleProxy("library.pipelines.testitem.enrichment")
 
 
-from .cli import (
-    ReadInputIdsResult,
-    TestitemFetchError,
-    TestitemPipelineOptions,
-    TestitemPipelineStageError,
-    _FETCH_ERROR_SAMPLE_SIZE,
-    _log_missing_identifier_summary,
-    _prepare_pubchem_api_cfg,
-    apply_testitem_enrichment,
-    fetch_testitems,
-    finalize_output,
-    integrate_missing_identifiers,
-    read_input_ids,
-    run_testitem_pipeline,
-)
-from .pubchem import (
-    PUBCHEM_CID_CACHE_ENCODING,
-    PUBCHEM_COLUMNS,
-    _CID_CACHE_MISSING,
-    _PUBCHEM_CACHE_SCHEMA_VERSION,
-    _PUBCHEM_SESSION_LOCK,
-    _PUBCHEM_SESSION_SIGNATURE,
-    _load_pubchem_cid_cache,
-    _merge_pubchem_properties,
-    _prepare_pubchem_caches,
-    _prefetch_parents,
-    _pubchem_session_signature,
-    _resolve_pubchem_cids,
-    _write_pubchem_cid_cache,
-    add_pubchem_data,
-    augment_pubchem,
-    resolve_pubchem_cid,
-)
-from library.integration import pubchem_library as pl
 from library.integration.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.common.csv_utils import write_csv_chunks_deterministic as write_csv_deterministic
@@ -104,6 +70,52 @@ from library.common.log import logger
 from library.metadata import file_sha256, write_meta_yaml
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
+
+_LAZY_EXPORTS: dict[str, str] = {
+    "ReadInputIdsResult": "library.testitem_pipeline.cli:ReadInputIdsResult",
+    "TestitemFetchError": "library.testitem_pipeline.cli:TestitemFetchError",
+    "TestitemPipelineOptions": "library.testitem_pipeline.cli:TestitemPipelineOptions",
+    "TestitemPipelineStageError": "library.testitem_pipeline.cli:TestitemPipelineStageError",
+    "_FETCH_ERROR_SAMPLE_SIZE": "library.testitem_pipeline.cli:_FETCH_ERROR_SAMPLE_SIZE",
+    "_log_missing_identifier_summary": "library.testitem_pipeline.cli:_log_missing_identifier_summary",
+    "_prepare_pubchem_api_cfg": "library.testitem_pipeline.cli:_prepare_pubchem_api_cfg",
+    "apply_testitem_enrichment": "library.testitem_pipeline.cli:apply_testitem_enrichment",
+    "fetch_testitems": "library.testitem_pipeline.cli:fetch_testitems",
+    "finalize_output": "library.testitem_pipeline.cli:finalize_output",
+    "integrate_missing_identifiers": "library.testitem_pipeline.cli:integrate_missing_identifiers",
+    "read_input_ids": "library.testitem_pipeline.cli:read_input_ids",
+    "run_testitem_pipeline": "library.testitem_pipeline.cli:run_testitem_pipeline",
+    "PUBCHEM_CID_CACHE_ENCODING": "library.testitem_pipeline.pubchem:PUBCHEM_CID_CACHE_ENCODING",
+    "PUBCHEM_COLUMNS": "library.testitem_pipeline.pubchem:PUBCHEM_COLUMNS",
+    "_CID_CACHE_MISSING": "library.testitem_pipeline.pubchem:_CID_CACHE_MISSING",
+    "_PUBCHEM_CACHE_SCHEMA_VERSION": "library.testitem_pipeline.pubchem:_PUBCHEM_CACHE_SCHEMA_VERSION",
+    "_PUBCHEM_SESSION_LOCK": "library.testitem_pipeline.pubchem:_PUBCHEM_SESSION_LOCK",
+    "_PUBCHEM_SESSION_SIGNATURE": "library.testitem_pipeline.pubchem:_PUBCHEM_SESSION_SIGNATURE",
+    "_load_pubchem_cid_cache": "library.testitem_pipeline.pubchem:_load_pubchem_cid_cache",
+    "_merge_pubchem_properties": "library.testitem_pipeline.pubchem:_merge_pubchem_properties",
+    "_prepare_pubchem_caches": "library.testitem_pipeline.pubchem:_prepare_pubchem_caches",
+    "_prefetch_parents": "library.testitem_pipeline.pubchem:_prefetch_parents",
+    "_pubchem_session_signature": "library.testitem_pipeline.pubchem:_pubchem_session_signature",
+    "_resolve_pubchem_cids": "library.testitem_pipeline.pubchem:_resolve_pubchem_cids",
+    "_write_pubchem_cid_cache": "library.testitem_pipeline.pubchem:_write_pubchem_cid_cache",
+    "add_pubchem_data": "library.testitem_pipeline.pubchem:add_pubchem_data",
+    "augment_pubchem": "library.testitem_pipeline.pubchem:augment_pubchem",
+    "resolve_pubchem_cid": "library.testitem_pipeline.pubchem:resolve_pubchem_cid",
+    "pl": "library.integration.pubchem_library",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import CLI and PubChem helpers on first access."""
+
+    if name in _LAZY_EXPORTS:
+        module_name, _, attribute = _LAZY_EXPORTS[name].partition(":")
+        module = import_module(module_name)
+        value = getattr(module, attribute) if attribute else module
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 __all__ = [
     "ChemblClient",
@@ -172,3 +184,9 @@ __all__ = [
     "write_csv_deterministic",
     "write_parent_catalog_cache",
 ]
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazily loaded helpers."""
+
+    return sorted({*globals(), *__all__, *_LAZY_EXPORTS})

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 from collections import OrderedDict, deque
 from dataclasses import dataclass
+from functools import lru_cache
 from itertools import chain, islice
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Sequence
@@ -15,7 +16,6 @@ import requests
 from pandera.errors import SchemaErrors
 
 from library import io
-from library.integration import chembl_library as cl
 from library.integration.chembl_client import ChemblClient
 from library.clients import pubchem as pc
 from library.config import (
@@ -35,12 +35,10 @@ from library.metadata import (
     write_meta_yaml,
     record_quality_failure,
 )
-from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library import SidecarErrors
 from library.table_quality import analyze_table_quality
 from library.validation import validate_testitems
-from library.schemas import TestitemsSchema, normalize_testitems
 
 from .catalog import (
     PARENT_LOOKUP_SOURCE_CACHE,
@@ -56,7 +54,6 @@ from .catalog import (
     run_parent_enrichment,
 )
 from . import testitem_enrichment
-from .pubchem import PUBCHEM_COLUMNS, add_pubchem_data, augment_pubchem
 
 _FETCH_ERROR_SAMPLE_SIZE = 10
 _MISSING_IDENTIFIER_LOG_SAMPLE_SIZE = 10
@@ -237,6 +234,42 @@ class TestitemPipelineStageError(RuntimeError):
         self.code = code
 
 
+@lru_cache(maxsize=1)
+def _load_chembl_library():
+    """Return the ChemBL integration module without creating import cycles."""
+
+    from library.integration import chembl_library as chembl_lib
+
+    return chembl_lib
+
+
+@lru_cache(maxsize=1)
+def _load_pipeline_metadata_adder():
+    """Return the pipeline metadata helper lazily to avoid circular imports."""
+
+    from library.pipelines.common import add_pipeline_metadata as add_metadata
+
+    return add_metadata
+
+
+@lru_cache(maxsize=1)
+def _load_testitem_schema():
+    """Return the schema model and normalizer lazily to avoid circular imports."""
+
+    from library.schemas import TestitemsSchema, normalize_testitems
+
+    return TestitemsSchema, normalize_testitems
+
+
+@lru_cache(maxsize=1)
+def _load_pubchem_augmenter():
+    """Return the PubChem augmentation helper lazily to avoid circular imports."""
+
+    from .pubchem import augment_pubchem as _augment
+
+    return _augment
+
+
 def _batched(iterable: Iterable[str], size: int) -> Iterator[list[str]]:
     """Yield lists of at most ``size`` elements from ``iterable``."""
 
@@ -265,6 +298,7 @@ def fetch_testitems(
     """Retrieve ChEMBL test item records for ``ids_iter`` in chunks."""
 
     logger.info("chembl_fetch_start", batch_size=batch_size)
+    chembl_lib = _load_chembl_library()
     requested_ids_original: list[str] = []
 
     for identifier in ids_iter:
@@ -293,7 +327,7 @@ def fetch_testitems(
 
     def _load_chunk(batch: Sequence[str], chunk_size: int) -> pd.DataFrame:
         try:
-            frame = cl.get_testitem(
+            frame = chembl_lib.get_testitem(
                 batch,
                 cfg=api_cfg,
                 client=client,
@@ -582,7 +616,7 @@ def run_testitem_pipeline(
                     )
 
                     if pubchem_enabled:
-                        current = augment_pubchem(
+                        current = _load_pubchem_augmenter()(
                             current,
                             pubchem_cfg=cfg.pubchem,
                             api_cfg=pubchem_api_cfg,
@@ -665,11 +699,12 @@ def finalize_output(
 ) -> int:
     """Normalise, validate, and persist the final dataset from ``chunks``."""
 
-    schema_cols = list(TestitemsSchema.columns)
+    schema_model, normalizer = _load_testitem_schema()
+    schema_cols = list(schema_model.columns)
     required_cols = {
-        name for name, col in TestitemsSchema.columns.items() if col.required
+        name for name, col in schema_model.columns.items() if col.required
     }
-    optional_cols = set(TestitemsSchema.columns) - required_cols
+    optional_cols = set(schema_model.columns) - required_cols
     col_order = schema_cols
     key_cols = ["molecule_chembl_id"]
     csv_chunksize = cfg.io.csv_chunksize
@@ -687,10 +722,10 @@ def finalize_output(
         nonlocal rows_total, rows_written, exit_code, columns_seen, failure_count
 
         rows_total += len(raw)
-        current = normalize_testitems(raw)
+        current = normalizer(raw)
         if "pubchem_cid" in current.columns:
             current["pubchem_cid"] = current["pubchem_cid"].astype(object)
-        current = add_pipeline_metadata(current)
+        current = _load_pipeline_metadata_adder()(current)
         columns_seen.update(current.columns)
 
         chunk_missing_required = required_cols - set(current.columns)

--- a/library/testitem_pipeline/pubchem.py
+++ b/library/testitem_pipeline/pubchem.py
@@ -7,24 +7,34 @@ import threading
 from collections.abc import Collection, Hashable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, MutableMapping, Sequence, TypeAlias, cast
 
 import pandas as pd
 import requests
 
-from library.integration import chembl_library as cl
-from library.integration import pubchem_library as pl
-from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
 from library.integration.chembl_client import ChemblClient
 from library.config import ApiCfg, PubChemCfg, RetryCfg
 from library.common.log import logger
 from library.utils.atomic import open_atomic
 
+if TYPE_CHECKING:
+    from library.integration.pubchem_library import Properties, PubChemResolution
+
 UTC = timezone.utc  # noqa: UP017
 ENCODING_UTF8 = "utf-8"
 PUBCHEM_CID_CACHE_ENCODING = ENCODING_UTF8
-PUBCHEM_COLUMNS = list(TESTITEM_PUBCHEM_COLUMNS)
+_TESTITEM_PUBCHEM_COLUMNS = (
+    "pubchem_cid",
+    "pubchem_iupac_name",
+    "pubchem_molecular_formula",
+    "pubchem_isomeric_smiles",
+    "pubchem_canonical_smiles",
+    "pubchem_inchi",
+    "pubchem_inchikey",
+)
+PUBCHEM_COLUMNS = list(_TESTITEM_PUBCHEM_COLUMNS)
 
 _CID_CACHE_MISSING = object()
 _PUBCHEM_CACHE_SCHEMA_VERSION = 1
@@ -32,8 +42,26 @@ _PUBCHEM_CACHE_SCHEMA_VERSION = 1
 _PUBCHEM_SESSION_SIGNATURE: str | None = None
 
 
-ResolutionCache: TypeAlias = MutableMapping[Hashable, pl.PubChemResolution]
+ResolutionCache: TypeAlias = MutableMapping[Hashable, "PubChemResolution"]
 _PUBCHEM_SESSION_LOCK = threading.Lock()
+
+
+@lru_cache(maxsize=1)
+def _load_chembl_library():
+    """Return the ChemBL integration module without triggering circular imports."""
+
+    from library.integration import chembl_library as chembl_lib
+
+    return chembl_lib
+
+
+@lru_cache(maxsize=1)
+def _load_pubchem_library():
+    """Return the PubChem integration module without triggering circular imports."""
+
+    from library.integration import pubchem_library as pubchem_lib
+
+    return pubchem_lib
 
 
 def _pubchem_session_signature(api_cfg: ApiCfg, retry_cfg: RetryCfg) -> str:
@@ -260,7 +288,9 @@ def resolve_pubchem_cid(
             return None
         visited.add(chembl_id)
 
-    resolution = pl.resolve_pubchem_record(
+    pubchem_lib = _load_pubchem_library()
+
+    resolution = pubchem_lib.resolve_pubchem_record(
         identifiers,
         cfg,
         cid_cache=cache,
@@ -444,8 +474,10 @@ def _prefetch_parents(
         count=len(parent_ids),
         batch_size=getattr(cfg, "batch_size", 0),
     )
+    chembl_lib = _load_chembl_library()
+
     try:
-        fetched = cl.get_testitem(
+        fetched = chembl_lib.get_testitem(
             parent_ids,
             cfg=api_cfg,
             client=client,
@@ -572,8 +604,10 @@ def _merge_pubchem_properties(
         max_workers = max(1, min(configured_batch_size, rps_limit))
         batch_size = configured_batch_size
 
-        def _fetch_properties(cid: str) -> pl.Properties:
-            return pl.get_properties(cid, cfg)
+        pubchem_lib = _load_pubchem_library()
+
+        def _fetch_properties(cid: str) -> Properties:
+            return pubchem_lib.get_properties(cid, cfg)
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for start in range(0, len(lookup_order), batch_size):
@@ -588,7 +622,7 @@ def _merge_pubchem_properties(
                         logger.warning(
                             "pubchem_properties_failed", cid=cid, error=str(exc)
                         )
-                        props = pl.Properties(None, None, None, None, None, None)
+                        props = pubchem_lib.Properties(None, None, None, None, None, None)
                     properties_records[cid] = {
                         "pubchem_iupac_name": _value_or_na(props.IUPACName),
                         "pubchem_molecular_formula": _value_or_na(
@@ -803,7 +837,7 @@ def augment_pubchem(
         session_signature = _pubchem_session_signature(api_cfg, retry_cfg)
         with _PUBCHEM_SESSION_LOCK:
             if session_signature != _PUBCHEM_SESSION_SIGNATURE:
-                pl.init_session(api_cfg, retry_cfg)
+                _load_pubchem_library().init_session(api_cfg, retry_cfg)
                 _PUBCHEM_SESSION_SIGNATURE = session_signature
         pubchem_cid_cache = _load_pubchem_cid_cache(
             getattr(pubchem_cfg, "cid_cache_path", None),


### PR DESCRIPTION
## Summary
- lazily load integration submodules to avoid importing the full pipelines package on module import
- break circular dependencies in the test item pipeline by deferring CLI/pubchem helpers and reworking cache loaders
- add local PubChem column constants and cached accessors to keep schema/augment helpers available without eager imports

## Testing
- python scripts/get_data.py --limit 1 --log-level WARNING


------
https://chatgpt.com/codex/tasks/task_e_68df6e473254832496e11eda3b8f995d