### PR TITLE
Improve error handling for missing testitem pipeline modules

### DIFF
--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -15,36 +15,52 @@ from importlib.util import find_spec
 
 from .enrichment import enrich
 from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
-from library.testitem_pipeline import (
-    PARENT_LOOKUP_SOURCE_CACHE,
-    PARENT_LOOKUP_SOURCE_LOOKUP,
-    PARENT_LOOKUP_SOURCE_PARTIAL,
-    PARENT_LOOKUP_SOURCE_SKIPPED,
-    PARENT_LOOKUP_SOURCE_SYNC,
-    ReadInputIdsResult,
-    TestitemPipelineOptions,
-    _DEFAULT_CATALOG_CFG,
-    _FETCH_ERROR_SAMPLE_SIZE,
-    _MOLECULE_HIERARCHY_COLUMNS,
-    _PUBCHEM_CACHE_SCHEMA_VERSION,
-    _TYPO_PARENT_COLUMN,
-    analyze_table_quality,
-    ensure_no_parant_column,
-    file_sha256,
-    fetch_testitems,
-    integrate_missing_identifiers,
-    load_parent_catalog,
-    query_parent_catalog,
-    read_input_ids,
-    run_testitem_pipeline,
-    update_parent_catalog_cache,
-    write_meta_yaml,
-    write_parent_catalog_cache,
-    _prepare_pubchem_api_cfg,
-    _write_pubchem_cid_cache,
-    PUBCHEM_CID_CACHE_ENCODING as _PIPELINE_PUBCHEM_CID_CACHE_ENCODING,
-    PUBCHEM_COLUMNS as _PIPELINE_PUBCHEM_COLUMNS,
-)
+
+try:
+    from library.testitem_pipeline import (
+        PARENT_LOOKUP_SOURCE_CACHE,
+        PARENT_LOOKUP_SOURCE_LOOKUP,
+        PARENT_LOOKUP_SOURCE_PARTIAL,
+        PARENT_LOOKUP_SOURCE_SKIPPED,
+        PARENT_LOOKUP_SOURCE_SYNC,
+        ReadInputIdsResult,
+        TestitemPipelineOptions,
+        _DEFAULT_CATALOG_CFG,
+        _FETCH_ERROR_SAMPLE_SIZE,
+        _MOLECULE_HIERARCHY_COLUMNS,
+        _PUBCHEM_CACHE_SCHEMA_VERSION,
+        _TYPO_PARENT_COLUMN,
+        analyze_table_quality,
+        ensure_no_parant_column,
+        file_sha256,
+        fetch_testitems,
+        integrate_missing_identifiers,
+        load_parent_catalog,
+        query_parent_catalog,
+        read_input_ids,
+        run_testitem_pipeline,
+        update_parent_catalog_cache,
+        write_meta_yaml,
+        write_parent_catalog_cache,
+        _prepare_pubchem_api_cfg,
+        _write_pubchem_cid_cache,
+        PUBCHEM_CID_CACHE_ENCODING as _PIPELINE_PUBCHEM_CID_CACHE_ENCODING,
+        PUBCHEM_COLUMNS as _PIPELINE_PUBCHEM_COLUMNS,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - environment specific
+    _PIPELINE_IMPORT_ERROR = exc
+else:
+    _PIPELINE_IMPORT_ERROR = None
+
+if _PIPELINE_IMPORT_ERROR is not None:  # pragma: no cover - environment specific
+    missing_detail = str(_PIPELINE_IMPORT_ERROR)
+    msg = (
+        "library.pipelines.testitem requires optional modules from "
+        "library.testitem_pipeline. Ensure your installation includes "
+        "'library.testitem_pipeline.cli' and related files. "
+        f"Original error: {missing_detail}"
+    )
+    raise ModuleNotFoundError(msg) from _PIPELINE_IMPORT_ERROR
 
 
 # ===== Compatibility Exports =====


### PR DESCRIPTION
## Summary
- guard the compatibility shim against missing optional library.testitem_pipeline modules
- provide a clearer ModuleNotFoundError message that preserves the original detail

## Testing
- pytest tests/test_testitem_enrichment.py

------
https://chatgpt.com/codex/tasks/task_e_68df72d065448324a0ebd7f06e14c852