### PR TITLE
Handle missing optional export tuple when collecting __all__

### DIFF
--- a/library/testitem_pipeline/__init__.py
+++ b/library/testitem_pipeline/__init__.py
@@ -263,9 +263,11 @@ _EXTRA_EXPORTS = (
     "write_meta_yaml",
 )
 
+_COLLECTED_EXTRAS = globals().get("_EXTRA_EXPORTS", ())
+
 __all__ = _collect_exports(
     _CATALOG_EXPORTS,
     _CLI_EXPORTS,
     _PUBCHEM_EXPORTS,
-    extras=_EXTRA_EXPORTS,
+    extras=_COLLECTED_EXTRAS,
 )


### PR DESCRIPTION
## Summary
- guard the optional export collection against missing `_EXTRA_EXPORTS` during module initialisation

## Testing
- python - <<'PY'
import library.testitem_pipeline as pipeline
print('import_ok')
print(len(pipeline.__all__))
PY

------
https://chatgpt.com/codex/tasks/task_e_68df8711b6e0832497a02216c907860d