### PR TITLE
Improve missing input diagnostics

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -215,7 +215,11 @@ def _build_missing_input_context(path: Path) -> dict[str, object]:
     names = [p.name for p in entries]
     matches = difflib.get_close_matches(path.name, names, n=5, cutoff=0.55)
     if matches:
-        info["suggestions"] = [str(parent / name) for name in matches]
+        suggestions = [parent / name for name in matches]
+        info["suggestions"] = [str(path) for path in suggestions]
+        best_match = suggestions[0]
+        info["did_you_mean"] = str(best_match)
+        info["cli_hint"] = f"--input \"{best_match}\""
         return info
 
     same_suffix = [str(p) for p in entries if p.suffix == path.suffix and p.suffix]

--- a/tests/test_get_document_data_missing_input.py
+++ b/tests/test_get_document_data_missing_input.py
@@ -1,0 +1,22 @@
+"""Tests for missing input diagnostics in :mod:`scripts.get_document_data`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import get_document_data as gdd
+
+
+def test_missing_input_context_includes_cli_hint(tmp_path: Path) -> None:
+    """Ensure the missing input context provides actionable CLI guidance."""
+
+    parent = tmp_path / "inputs"
+    parent.mkdir()
+    candidate = parent / "document1.csv"
+    candidate.write_text("", encoding="utf-8")
+
+    context = gdd._build_missing_input_context(parent / "document.csv")
+
+    assert context["did_you_mean"] == str(candidate)
+    assert context["cli_hint"] == f"--input \"{candidate}\""
+    assert context["suggestions"] == [str(candidate)]


### PR DESCRIPTION
## Summary
- enrich the missing input context with a ready-to-use CLI hint when close matches exist
- cover the enhanced diagnostics with a focused regression test

## Testing
- pytest tests/test_get_document_data_missing_input.py

------
https://chatgpt.com/codex/tasks/task_e_68df87be24a48324a0909954ad4fb866