### PR TITLE
Handle empty Guide-to-Pharmacology responses

### DIFF
--- a/library/integration/uniprot_library.py
+++ b/library/integration/uniprot_library.py
@@ -881,8 +881,14 @@ def _fetch_gtop_endpoint(
         session = get_uniprot_session()
         with session.get(url, timeout=timeout) as response:
             response.raise_for_status()
-            body = response.content or b""
-            if response.headers.get("Content-Length") == "0" or not body.strip():
+            body = response.content
+            if isinstance(body, (bytes, bytearray)):
+                body_is_empty = not body.strip()
+            elif isinstance(body, str):
+                body_is_empty = not body.strip()
+            else:
+                body_is_empty = not body
+            if response.headers.get("Content-Length") == "0" or body_is_empty:
                 logger.warning(
                     "gtop_json_decode_failed",
                     gtop_id=gtop_id,

--- a/tests/library/integration/test_uniprot_library.py
+++ b/tests/library/integration/test_uniprot_library.py
@@ -360,10 +360,11 @@ def test_fetch_gtop_endpoint_handles_empty_body(
 
     monkeypatch.setattr(ul, "get_uniprot_session", lambda: DummySession())
 
-    ul._fetch_gtop_endpoint("1234", "function", cfg=cfg)
+    result = ul._fetch_gtop_endpoint("1234", "function", cfg=cfg)
 
     captured = capsys.readouterr()
     assert '"event": "gtop_json_decode_failed"' in captured.out
+    assert result is None
 
 
 def test_collect_info_uses_canonical_fallback(


### PR DESCRIPTION
## Summary
- guard _fetch_gtop_endpoint against empty Guide-to-Pharmacology payloads before decoding JSON
- extend the unit test to assert the helper returns None and logs the decoding failure when the body is empty

## Testing
- pytest tests/library/integration/test_uniprot_library.py -k empty_body

------
https://chatgpt.com/codex/tasks/task_e_68df95f0684c8324b40bdd0567207f64