### PR TITLE
Ensure optional test item columns are populated

### DIFF
--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -687,10 +687,16 @@ def finalize_output(
     rows_written = 0
     exit_code = 0
     columns_seen: set[str] = set()
+    columns_to_fill: set[str] = set()
     failure_cases = SidecarErrors()
     failure_count = 0
 
     chunk_iter = iter(chunks)
+
+    def _ensure_optional_columns(frame: pd.DataFrame) -> None:
+        for column in columns_to_fill:
+            if column not in frame.columns:
+                frame[column] = pd.Series(pd.NA, index=frame.index, dtype="string")
 
     def _process_chunk(raw: pd.DataFrame) -> pd.DataFrame:
         nonlocal rows_total, rows_written, exit_code, columns_seen, failure_count
@@ -700,6 +706,7 @@ def finalize_output(
         if "pubchem_cid" in current.columns:
             current["pubchem_cid"] = current["pubchem_cid"].astype(object)
         current = add_pipeline_metadata(current)
+        _ensure_optional_columns(current)
         columns_seen.update(current.columns)
 
         chunk_missing_required = required_cols - set(current.columns)
@@ -765,10 +772,22 @@ def finalize_output(
 
     missing_optional = optional_cols - columns_seen
     if missing_optional:
-        logger.warning(
-            "optional_columns_missing",
-            columns=sorted(missing_optional),
-        )
+        added_optional = sorted(missing_optional)
+        columns_to_fill.update(missing_optional)
+        for chunk in prepared_chunks:
+            _ensure_optional_columns(chunk)
+        columns_seen.update(columns_to_fill)
+        remaining_missing_optional = optional_cols - columns_seen
+        if remaining_missing_optional:
+            logger.warning(
+                "optional_columns_missing",
+                columns=sorted(remaining_missing_optional),
+            )
+        else:
+            logger.debug(
+                "optional_columns_filled",
+                columns=added_optional,
+            )
 
     if failure_count:
         failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -685,14 +685,35 @@ def test_finalize_output_success(
     monkeypatch.setattr(pipeline, "write_meta_yaml", capture_meta)
     monkeypatch.setattr(pipeline_cli, "write_meta_yaml", capture_meta)
     monkeypatch.setattr(pipeline, "file_sha256", lambda path: "hash")
+    monkeypatch.setattr(pipeline_cli, "file_sha256", lambda path: "hash")
     monkeypatch.setattr(
         pipeline, "analyze_table_quality", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
+        pipeline_cli, "analyze_table_quality", lambda *_args, **_kwargs: None
+    )
+
+    written_chunks: list[pd.DataFrame] = []
+
+    def capture_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        **kwargs: object,
+    ) -> Path:
+        materialized = list(chunks)
+        written_chunks.extend(materialized)
+        return path
+
+    monkeypatch.setattr(
         pipeline,
         "write_csv_chunks_deterministic",
-        lambda chunks, path, **kwargs: path,
+        capture_chunks,
         raising=False,
+    )
+    monkeypatch.setattr(
+        pipeline_cli,
+        "write_csv_chunks_deterministic",
+        capture_chunks,
     )
 
     exit_code = pipeline.finalize_output(
@@ -706,6 +727,12 @@ def test_finalize_output_success(
     assert exit_code == 0
     assert captured_stats.get("parent_lookup_failed_ids") == ["CHEMBL9"]
     assert captured_stats.get("parent_lookup_failed_count") == 1
+
+    written_columns: set[str] = set()
+    for chunk in written_chunks:
+        written_columns.update(chunk.columns)
+
+    assert written_columns == set(TestitemsSchema.columns)
 
 
 def test_finalize_output_missing_required_columns(

--- a/tests/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/scripts/get_testitem_data/test_get_testitem_data.py
@@ -29,6 +29,7 @@ from library.integration import molecule_catalog
 from library.integration import pubchem_library as pl
 import library.pipelines.testitem as pipeline
 import library.pipelines.testitem.cli as pipeline_cli
+import library.testitem_pipeline.cli as modern_pipeline_cli
 
 from library.config import ApiCfg, Config, IoCfg
 
@@ -684,15 +685,44 @@ def test_finalize_output_success(
 
     monkeypatch.setattr(pipeline, "write_meta_yaml", capture_meta)
     monkeypatch.setattr(pipeline_cli, "write_meta_yaml", capture_meta)
+    monkeypatch.setattr(modern_pipeline_cli, "write_meta_yaml", capture_meta)
     monkeypatch.setattr(pipeline, "file_sha256", lambda path: "hash")
+    monkeypatch.setattr(pipeline_cli, "file_sha256", lambda path: "hash")
+    monkeypatch.setattr(modern_pipeline_cli, "file_sha256", lambda path: "hash")
     monkeypatch.setattr(
         pipeline, "analyze_table_quality", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
+        pipeline_cli, "analyze_table_quality", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        modern_pipeline_cli,
+        "analyze_table_quality",
+        lambda *_args, **_kwargs: None,
+    )
+
+    written_chunks: list[pd.DataFrame] = []
+
+    def capture_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        **kwargs: object,
+    ) -> Path:
+        materialized = list(chunks)
+        written_chunks.extend(materialized)
+        return path
+
+    monkeypatch.setattr(
         pipeline,
         "write_csv_chunks_deterministic",
-        lambda chunks, path, **kwargs: path,
+        capture_chunks,
         raising=False,
+    )
+    monkeypatch.setattr(pipeline_cli, "write_csv_chunks_deterministic", capture_chunks)
+    monkeypatch.setattr(
+        modern_pipeline_cli,
+        "write_csv_chunks_deterministic",
+        capture_chunks,
     )
 
     exit_code = pipeline.finalize_output(
@@ -706,6 +736,12 @@ def test_finalize_output_success(
     assert exit_code == 0
     assert captured_stats.get("parent_lookup_failed_ids") == ["CHEMBL9"]
     assert captured_stats.get("parent_lookup_failed_count") == 1
+
+    written_columns: set[str] = set()
+    for chunk in written_chunks:
+        written_columns.update(chunk.columns)
+
+    assert written_columns == set(TestitemsSchema.columns)
 
 
 def test_finalize_output_missing_required_columns(


### PR DESCRIPTION
## Summary
- add NA-filled string columns for optional schema fields during finalize_output and downgrade logging when backfilling succeeds
- extend finalize_output tests to capture written chunks and assert the generated CSV includes every schema column

## Testing
- pytest tests/pipelines/test_get_testitem_data.py::test_finalize_output_success


------
https://chatgpt.com/codex/tasks/task_e_68df95f525708324b7417f6d7b932c73