### PR TITLE
Ensure configured UniProt column must exist

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -120,7 +120,7 @@ sources:
           family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           chunk_size: 5
           timeout: 30.0
-          uniprot_column: "uniprot_id"  # Column containing primary UniProt accession used for merges
+          uniprot_column: uniprot_id  # Column containing primary UniProt accession used for merges
           chembl_out: null
           uniprot_out: null
           iuphar_out: null

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -2333,10 +2333,15 @@ def fetch_iuphar(
     if merge_column in combined_df.columns:
         existing_merge = combined_df[merge_column].astype(object)
     else:
-        existing_merge = pd.Series(
-            UNIPROT_MISSING_VALUE, index=combined_df.index, dtype=object
+        logger.error(
+            "missing_configured_uniprot_column",
+            configured=merge_column,
+            available=sorted(combined_df.columns.tolist()),
         )
-        combined_df[merge_column] = existing_merge
+        raise PipelineError(
+            "Configured UniProt column "
+            f"'{merge_column}' is not present in the merged target data."
+        )
 
     if merge_column == "uniprot_id":
         if "mapping_uniprot_id" in combined_df.columns:

--- a/tests/scripts/get_target_data/test_get_target_data_merge.py
+++ b/tests/scripts/get_target_data/test_get_target_data_merge.py
@@ -6,11 +6,13 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
+import pytest
 from pytest import MonkeyPatch
 
 import library.pipelines.target.postprocessing as tp
 from library.pipelines.target import protein_classification as pc
 from library.config import Config
+from library.cli_utils import PipelineError
 from scripts import get_target_data as gtd
 
 
@@ -171,3 +173,59 @@ def test_fetch_iuphar_prioritises_uniprot_columns(
         )
     ]
     assert not disallowed_processed
+
+
+def test_fetch_iuphar_missing_configured_uniprot_column(
+    monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    """Ensure fetch step aborts when the configured column disappears."""
+
+    cfg.target.all.uniprot_column = "unexpected_column"
+
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P12345"],
+            "unexpected_column": ["P12345"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P12345"],
+            "original_id": ["P12345"],
+        }
+    )
+    out = tmp_path / "iuphar.csv"
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        pd.DataFrame({"uniprot_id": ["P12345"], "IUPHAR_class": ["Enzyme"]}).to_csv(
+            args.output_csv,
+            index=False,
+        )
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+
+    original_merge = pd.merge
+
+    def dropping_merge(*args: object, **kwargs: object) -> pd.DataFrame:
+        result = original_merge(*args, **kwargs)
+        if "unexpected_column" in result.columns:
+            result = result.drop(columns=["unexpected_column"])
+        return result
+
+    monkeypatch.setattr(pd, "merge", dropping_merge)
+
+    error_events: list[str] = []
+    original_error = gtd.logger.error
+
+    def tracking_error(event: str, *args: object, **kwargs: object) -> object:
+        error_events.append(event)
+        return original_error(event, *args, **kwargs)
+
+    monkeypatch.setattr(gtd.logger, "error", tracking_error)
+
+    with pytest.raises(PipelineError, match="unexpected_column"):
+        gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
+
+    assert "missing_configured_uniprot_column" in error_events


### PR DESCRIPTION
## Summary
- validate that the configured UniProt column is present before inserting placeholders during the target pipeline
- set the default `target.all.uniprot_column` to `uniprot_id`
- add a regression test covering the failure path when the configured column disappears

## Testing
- pytest tests/scripts/get_target_data/test_get_target_data_merge.py::test_fetch_iuphar_missing_configured_uniprot_column

------
https://chatgpt.com/codex/tasks/task_e_68df95f08eb48324b0d1da233f7f7d4f