### PR TITLE
Handle non-numeric pagination fields in reference documents

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -811,17 +811,17 @@ REF_DTYPE = {
     "classification": "string",
     "document_contains_external_links": "boolean",
     "DOI": "string",
-    "first_page": "Int64",
+    "first_page": "string",
     "is_experimental_doc": "boolean",
-    "issue": "Int64",
+    "issue": "string",
     "journal": "string",
-    "last_page": "Int64",
-    "month": "Int64",
+    "last_page": "string",
+    "month": "string",
     "postcodes": "string",
     "pubmed_id": "Int64",
     "title": "string",
-    "volume": "Int64",
-    "year": "Int64",
+    "volume": "string",
+    "year": "string",
 }
 
 


### PR DESCRIPTION
## Summary
- allow pagination-related columns in the reference document CSV to be read as strings so that alphanumeric values no longer break parsing

## Testing
- pytest tests/library/postprocessing -k document -q

------
https://chatgpt.com/codex/tasks/task_e_68df98ea76308324b7a8e0e14584730f