### PR TITLE
Log parent catalog warm-up status before test item pipeline

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -732,10 +732,23 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
     cache_path = catalog_cfg.cache_path
     sqlite_path = catalog_cfg.sqlite_path
 
-    if cache_path.exists() and sqlite_path.exists():
+    cache_ready = cache_path.is_file()
+    sqlite_ready = sqlite_path.is_file()
+
+    if cache_ready and sqlite_ready:
+        _LOGGER.info(
+            "parent_catalog_warm_skip",
+            cache=str(cache_path),
+            sqlite=str(sqlite_path),
+        )
         return
 
     testitem_cfg = chembl_sources.pipelines.testitem
+    _LOGGER.info(
+        "parent_catalog_warm_start",
+        cache=str(cache_path),
+        sqlite=str(sqlite_path),
+    )
     with ChemblClient(
         api=chembl_sources.api,
         retry=config.system.retry,
@@ -747,6 +760,11 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
             catalog_cfg=catalog_cfg,
             timeout=testitem_cfg.timeout,
         )
+    _LOGGER.info(
+        "parent_catalog_warm_done",
+        cache=str(cache_path),
+        sqlite=str(sqlite_path),
+    )
 
 
 def run_pipeline(cfg: PipelineRunConfig) -> int:


### PR DESCRIPTION
## Summary
- add detailed cache readiness checks in `_warm_parent_catalog`
- log whether the parent catalogue warm-up reuses existing artefacts or triggers a refresh

## Testing
- python scripts/get_data.py --base-path data --limit 0 --skip-existing

------
https://chatgpt.com/codex/tasks/task_e_68df95f0b30c8324b06f2c05d3d4e142