### PR TITLE
Handle missing UniProt merge column for target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -312,6 +312,37 @@ def _collect_uniprot_candidate_columns(df: pd.DataFrame, cfg: Config) -> list[st
     return ordered
 
 
+def _ensure_merge_column_present(
+    df: pd.DataFrame, merge_column: str, cfg: Config
+) -> pd.DataFrame:
+    """Return ``df`` ensuring that ``merge_column`` exists or fall back to aliases."""
+
+    if merge_column in df.columns:
+        return df
+
+    candidate_columns = [
+        column
+        for column in _collect_uniprot_candidate_columns(df, cfg)
+        if column != merge_column and column in df.columns
+    ]
+
+    for source in candidate_columns:
+        series = df[source]
+        cleaned = series.fillna("").astype(str).map(str.strip)
+        if cleaned.replace("", pd.NA).dropna().empty:
+            continue
+        logger.warning(
+            "uniprot_merge_column_alias",
+            configured=merge_column,
+            alias=source,
+        )
+        aliased = df.copy()
+        aliased[merge_column] = cleaned.astype(object)
+        return aliased
+
+    return df
+
+
 def _build_uniprot_query_plan(df: pd.DataFrame, cfg: Config) -> _UniprotQueryPlan:
     """Create a deterministic plan for querying UniProt based on ``df``."""
 
@@ -2026,6 +2057,7 @@ def fetch_iuphar(
 
     logger.info("fetch_iuphar_start", output=str(output_csv))
     merge_column = cfg.target.all.uniprot_column
+    chembl_df = _ensure_merge_column_present(chembl_df, merge_column, cfg)
     if merge_column not in chembl_df.columns:
         logger.error(
             "invalid_uniprot_column",

--- a/tests/scripts/get_target_data/test_get_target_data_fetch.py
+++ b/tests/scripts/get_target_data/test_get_target_data_fetch.py
@@ -513,6 +513,46 @@ def test_fetch_iuphar_invalid_uniprot_column(
     assert "invalid_uniprot_column" in error_events
 
 
+def test_fetch_iuphar_aliases_missing_uniprot_column(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    cfg: Config,
+) -> None:
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["C1"],
+            "target_uniprot_id": ["P12345"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {"uniprot_id": ["P12345"], "original_id": ["P12345"], "names": ["Protein"]}
+    )
+    out = tmp_path / "iuphar.csv"
+
+    def fake_run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
+        pd.DataFrame({"uniprot_id": ["P12345"], "IUPHAR_class": ["Enzyme"]}).to_csv(
+            args.output_csv, index=False
+        )
+        return 0
+
+    monkeypatch.setattr(gtd, "run_iuphar", fake_run_iuphar)
+
+    warning_events: list[str] = []
+    original_warning = gtd.logger.warning
+
+    def tracking_warning(event: str, *args: object, **kwargs: object) -> object:
+        warning_events.append(event)
+        return original_warning(event, *args, **kwargs)
+
+    monkeypatch.setattr(gtd.logger, "warning", tracking_warning)
+
+    combined_df, iuphar_df = gtd.fetch_iuphar(cfg, chembl_df, uniprot_df, out)
+
+    assert "uniprot_merge_column_alias" in warning_events
+    assert combined_df.loc[0, "uniprot_id"] == "P12345"
+    assert iuphar_df.loc[0, "IUPHAR_class"] == "Enzyme"
+
+
 def test_fetch_iuphar_uses_mapping_when_uniprot_empty(
     monkeypatch: MonkeyPatch, tmp_path: Path, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- add a helper that aliases the configured UniProt merge column from available fallback columns when it is missing
- integrate the new helper into the target IUPHAR fetch step so pipelines can proceed with renamed UniProt columns
- cover the behaviour with a regression test that exercises the alias pathway

## Testing
- pytest tests/scripts/get_target_data/test_get_target_data_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68df9ed850708324a9dc14ae22f747f0