### PR TITLE
Avoid creating output directories during get-data dry runs

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -260,7 +260,10 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Run pipelines without writing outputs or performing side effects",
+        help=(
+            "Run pipelines without writing outputs or performing side effects, "
+            "including output directory creation"
+        ),
     )
     return parser.parse_args(argv)
 
@@ -273,6 +276,7 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
     output_dir = _resolve_path(base_path, args.output_dir)
     config_candidate = args.config or DEFAULT_CONFIG_PATH
     config_path = Path(config_candidate).expanduser().resolve()
+    dry_run = bool(getattr(args, "dry_run", False))
 
     if args.limit is not None and args.limit < 0:
         raise ValueError("--limit must be zero or a positive integer")
@@ -281,7 +285,8 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
         raise FileNotFoundError(f"input directory not found: {input_dir}")
     if not config_path.exists():
         raise FileNotFoundError(f"configuration file not found: {config_path}")
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if not dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
 
     return PipelineRunConfig(
         base_path=base_path,
@@ -293,7 +298,7 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
         limit=args.limit,
         force=args.force,
         skip_existing=args.skip_existing,
-        dry_run=bool(getattr(args, "dry_run", False)),
+        dry_run=dry_run,
     )
 
 

--- a/tests/cli/test_get_data_cli_limit.py
+++ b/tests/cli/test_get_data_cli_limit.py
@@ -37,3 +37,13 @@ def test_zero_limit_allowed(tmp_path: Path) -> None:
     args = _args(tmp_path, limit=0)
     cfg = get_data._prepare_config(args)
     assert cfg.limit == 0
+
+
+def test_dry_run_skips_output_dir_creation(tmp_path: Path) -> None:
+    args = _args(tmp_path, limit=None)
+    args.dry_run = True
+
+    cfg = get_data._prepare_config(args)
+
+    assert cfg.dry_run is True
+    assert not (tmp_path / "output").exists()

--- a/tests/scripts/get_data/test_get_data_cli_limit.py
+++ b/tests/scripts/get_data/test_get_data_cli_limit.py
@@ -37,3 +37,13 @@ def test_zero_limit_allowed(tmp_path: Path) -> None:
     args = _args(tmp_path, limit=0)
     cfg = get_data._prepare_config(args)
     assert cfg.limit == 0
+
+
+def test_dry_run_skips_output_dir_creation(tmp_path: Path) -> None:
+    args = _args(tmp_path, limit=None)
+    args.dry_run = True
+
+    cfg = get_data._prepare_config(args)
+
+    assert cfg.dry_run is True
+    assert not (tmp_path / "output").exists()


### PR DESCRIPTION
## Summary
- prevent the get-data orchestrator from creating the output directory when running with --dry-run
- document the restriction in the CLI help text
- add unit tests ensuring dry runs leave the output directory absent

## Testing
- pytest tests/cli/test_get_data_cli_limit.py tests/scripts/get_data/test_get_data_cli_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68dfa229d89c83249c14d3a28f9a3e2a