### PR TITLE
Update target UniProt merge column default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -120,7 +120,7 @@ sources:
           family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           chunk_size: 5
           timeout: 30.0
-          uniprot_column: uniprot_id  # Column containing primary UniProt accession used for merges
+          uniprot_column: mapping_uniprot_id  # Column containing primary UniProt accession used for merges
           chembl_out: null
           uniprot_out: null
           iuphar_out: null


### PR DESCRIPTION
## Summary
- point the target pipeline configuration at mapping_uniprot_id so the merge step can use the column that is present in recent ChEMBL exports

## Testing
- pytest tests/scripts/get_target_data/test_get_target_data_fetch.py::test_fetch_iuphar_aliases_missing_uniprot_column
- pytest tests/scripts/get_target_data/test_get_target_data_fetch.py::test_run_all_preserves_reaction_ec_numbers

------
https://chatgpt.com/codex/tasks/task_e_68dfa04ef4dc8324be20ca62e472a52e