### PR TITLE
Log document all pipeline parameters before fetching data

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1926,6 +1926,18 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+    logger.info(
+        "document_all_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=limit,
+        offset=offset,
+        chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
+        workers=getattr(args, "workers", all_defaults.workers),
+        batch_size=getattr(args, "batch_size", all_defaults.batch_size),
+        sleep=getattr(args, "sleep", all_defaults.sleep),
+        timeout=getattr(args, "timeout", all_defaults.timeout),
+    )
 
     try:
         with ChemblClient(


### PR DESCRIPTION
## Summary
- log a `document_all_start` event in `run_all` to capture invocation parameters before fetching data
- align the logged fields with the existing `run_pubmed` and `run_chembl` start events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfad281c688324bcb6b90f15038369