### PR TITLE
Add unified records_dropped logging across pipelines

### DIFF
--- a/library/cli/utils.py
+++ b/library/cli/utils.py
@@ -229,6 +229,7 @@ def run_pipeline(
         Mapping[str, object] | Callable[[], Mapping[str, object]] | None
     ) = None,
     logger: Logger | None = None,
+    stats_callback: Callable[[Stats], None] | None = None,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
 
@@ -280,6 +281,10 @@ def run_pipeline(
         pipeline-specific diagnostics such as fetch failures.
     logger:
         Optional logger.  Defaults to :data:`library.common.log.logger` when omitted.
+    stats_callback:
+        Optional callable invoked with the final ``stats`` mapping prior to
+        metadata serialisation. Use this to capture summary statistics for
+        external reporting without mutating the persisted metadata.
 
     Returns
     -------
@@ -610,7 +615,13 @@ def run_pipeline(
     extra_stats = stats_extra() if callable(stats_extra) else stats_extra
     for key, value in (extra_stats or {}).items():
         stats[key] = value
- 
+
+    if stats_callback is not None:
+        try:
+            stats_callback(dict(stats))
+        except Exception:  # pragma: no cover - defensive against user callbacks
+            use_logger.exception("stats_callback_failed")
+
     resolved_invocation = invocation_tuple
 
     extra_metadata: dict[str, object] = {}

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -223,6 +223,7 @@ def run_pipeline(
         Mapping[str, object] | Callable[[], Mapping[str, object]] | None
     ) = None,
     logger: Logger | None = None,
+    stats_callback: Callable[[Stats], None] | None = None,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
 
@@ -274,6 +275,10 @@ def run_pipeline(
         pipeline-specific diagnostics such as fetch failures.
     logger:
         Optional logger.  Defaults to :data:`library.common.log.logger` when omitted.
+    stats_callback:
+        Optional callable invoked with the final ``stats`` mapping prior to
+        metadata serialisation. Use this to capture summary statistics for
+        external reporting without mutating the persisted metadata.
 
     Returns
     -------
@@ -604,7 +609,13 @@ def run_pipeline(
     extra_stats = stats_extra() if callable(stats_extra) else stats_extra
     for key, value in (extra_stats or {}).items():
         stats[key] = value
- 
+
+    if stats_callback is not None:
+        try:
+            stats_callback(dict(stats))
+        except Exception:  # pragma: no cover - defensive against user callbacks
+            use_logger.exception("stats_callback_failed")
+
     resolved_invocation = invocation_tuple
 
     extra_metadata: dict[str, object] = {}

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -821,6 +821,12 @@ def finalize_output(
         return 1
 
     rows_dropped = rows_total - rows_written
+    logger.info(
+        "records_dropped",
+        rows_total=int(rows_total),
+        rows_kept=int(rows_written),
+        rows_dropped=int(rows_dropped),
+    )
     parent_stats = parent_stats_supplier()
     missing_ids_tuple = tuple(missing_ids or ())
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 
 from functools import partial
 from itertools import islice
@@ -391,6 +391,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             csv_writer=writer_config,
         )
 
+        pipeline_stats: dict[str, object] | None = None
+
+        def _capture_stats(stats: Mapping[str, object]) -> None:
+            nonlocal pipeline_stats
+            pipeline_stats = dict(stats)
+
         try:
             exit_code = run_pipeline(
                 fetcher=fetcher,
@@ -409,12 +415,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 stats_extra=chunk_failures.stats,
                 logger=logger,
+                stats_callback=_capture_stats,
             )
         finally:
             chunk_failures.save(fetch_failure_path, cfg=cfg)
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)
+
+    if pipeline_stats is not None:
+        logger.info(
+            "records_dropped",
+            rows_total=int(pipeline_stats.get("rows_total", processed_ids)),
+            rows_kept=int(pipeline_stats.get("rows_kept", 0)),
+            rows_dropped=int(pipeline_stats.get("rows_dropped", 0)),
+        )
 
     if exit_code == 0:
         logger.info(

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from time import sleep
 
 import argparse
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import partial
 from itertools import islice
 
@@ -236,6 +236,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             csv_writer=writer_config,
         )
 
+        pipeline_stats: dict[str, object] | None = None
+
+        def _capture_stats(stats: Mapping[str, object]) -> None:
+            nonlocal pipeline_stats
+            pipeline_stats = dict(stats)
+
         try:
             exit_code = run_pipeline(
                 fetcher=fetcher,
@@ -254,6 +260,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg=cfg,
                 stats_extra=chunk_failures.stats,
                 logger=logger,
+                stats_callback=_capture_stats,
             )
         finally:
             chunk_failures.save(fetch_failure_path, cfg=cfg)
@@ -262,6 +269,14 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("process_limit", limit=processed_ids)
     else:
         logger.info("processed_count", count=processed_ids)
+
+    if pipeline_stats is not None:
+        logger.info(
+            "records_dropped",
+            rows_total=int(pipeline_stats.get("rows_total", processed_ids)),
+            rows_kept=int(pipeline_stats.get("rows_kept", 0)),
+            rows_dropped=int(pipeline_stats.get("rows_dropped", 0)),
+        )
 
     if exit_code == 0:
         logger.info(

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -1556,6 +1556,12 @@ def _finalise_export(
 
 
     rows_dropped = rows_total - rows_kept
+    logger.info(
+        "records_dropped",
+        rows_total=int(rows_total),
+        rows_kept=int(rows_kept),
+        rows_dropped=int(rows_dropped),
+    )
     if exit_code == 0:
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
         if csv_path.name.startswith("output.document_"):


### PR DESCRIPTION
## Summary
- extend `run_pipeline` with an optional `stats_callback` hook to surface final statistics to callers
- log unified `records_dropped` events for assay, activity, and document exports using the captured stats
- emit matching structured drop counts from the test item pipeline for downstream consumers

## Testing
- pytest tests/library/cli/test_cli_utils.py -k includes_extra_stats -q

------
https://chatgpt.com/codex/tasks/task_e_68dfad2a7964832483437fbed1ed53a2