### PR TITLE
Handle null hierarchy parents in enrichment

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -123,7 +123,7 @@ def _load_molecule_hierarchy_mapping(
     path: str,
     encoding: str,
     delimiter: str,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
     """Return cached child → parent mapping with normalised identifiers."""
 
     csv_path = Path(path)
@@ -166,21 +166,22 @@ def _load_molecule_hierarchy_mapping(
         subset[parent_column] = frame[parent_column].copy()
 
     for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = (
-            subset[column].fillna("").astype("string").str.strip().str.upper()
-        )
+        subset[column] = subset[column].astype("string").str.strip().str.upper()
 
+    subset = subset[subset["molecule_chembl_id"].notna()]
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
         subset=["molecule_chembl_id"],
         keep="first",
     )
 
-    lookup: dict[str, str] = {}
+    lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent = parent_id or ""
-        if parent == molecule_id:
-            parent = ""
+        parent: str | None
+        if pd.isna(parent_id) or parent_id == "" or parent_id == molecule_id:
+            parent = None
+        else:
+            parent = parent_id
         lookup[molecule_id] = parent
 
     return lookup
@@ -192,7 +193,7 @@ def LoadMoleculeHierarchyLookup(
     encoding: str | None = None,
     delimiter: str | None = None,
     catalog_cfg: MoleculeCatalogCfg | None = None,
-) -> dict[str, dict[str, str]]:
+) -> dict[str, dict[str, str | None]]:
     """Return cached molecule hierarchy lookup keyed by ``molecule_chembl_id``."""
 
     cfg_source = catalog_cfg or _DEFAULT_CATALOG_CFG
@@ -224,7 +225,7 @@ def load_molecule_hierarchy_lookup(
     encoding: str | None = None,
     delimiter: str | None = None,
     catalog_cfg: MoleculeCatalogCfg | None = None,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
     """Return child → parent mapping loaded from a local hierarchy file."""
 
     cfg_source = catalog_cfg or _DEFAULT_CATALOG_CFG
@@ -260,7 +261,7 @@ def load_molecule_hierarchy_lookup(
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value)
+    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -590,33 +591,41 @@ def prepare_parent_enrichment(
     else:
         hierarchy_lookup = {}
 
+    dictionary_resolved_children: set[str] = set()
     if hierarchy_lookup:
-        hierarchy_values = {
-            key: value for key, value in hierarchy_lookup.items() if value is not None
-        }
-    else:
-        hierarchy_values = {}
-
-    if hierarchy_values:
+        missing_sentinel = object()
         hierarchy_series = normalised_ids.map(
-            lambda value: hierarchy_values.get(value) if value else None
+            lambda value: hierarchy_lookup.get(value, missing_sentinel)
+            if value
+            else missing_sentinel
         )
-        hierarchy_mask = hierarchy_series.notna()
+        hierarchy_series = pd.Series(hierarchy_series, index=df.index, dtype="object")
+        hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
-            resolved = hierarchy_series[hierarchy_mask].astype("string")
+            resolved_values = hierarchy_series[hierarchy_mask]
+            dictionary_resolved_children = set(
+                normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
+            )
             if parent_column in df.columns:
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+
+            has_parent_mask = resolved_values.notna()
+            if has_parent_mask.any():
+                parent_updates = resolved_values[has_parent_mask].astype("string")
+                df.loc[parent_updates.index, parent_column] = parent_updates
+                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
 
     if getattr(catalog_cfg, "force_refresh_existing", False):
         need_lookup_mask = normalised_ids != ""
     else:
         need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
     initial_need_lookup = set(normalised_ids[need_lookup_mask])
-    need_lookup = set(initial_need_lookup)
+    if dictionary_resolved_children:
+        need_lookup = initial_need_lookup - dictionary_resolved_children
+    else:
+        need_lookup = set(initial_need_lookup)
 
     cache_before = _cache_state(catalog_cfg.cache_path)
     cache_after = cache_before

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -123,7 +123,7 @@ def _load_molecule_hierarchy_mapping(
     path: str,
     encoding: str,
     delimiter: str,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
     """Return cached child → parent mapping with normalised identifiers."""
 
     csv_path = Path(path)
@@ -166,21 +166,22 @@ def _load_molecule_hierarchy_mapping(
         subset[parent_column] = frame[parent_column].copy()
 
     for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = (
-            subset[column].fillna("").astype("string").str.strip().str.upper()
-        )
+        subset[column] = subset[column].astype("string").str.strip().str.upper()
 
+    subset = subset[subset["molecule_chembl_id"].notna()]
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
         subset=["molecule_chembl_id"],
         keep="first",
     )
 
-    lookup: dict[str, str] = {}
+    lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent = parent_id or ""
-        if parent == molecule_id:
-            parent = ""
+        parent: str | None
+        if pd.isna(parent_id) or parent_id == "" or parent_id == molecule_id:
+            parent = None
+        else:
+            parent = parent_id
         lookup[molecule_id] = parent
 
     return lookup
@@ -192,7 +193,7 @@ def LoadMoleculeHierarchyLookup(
     encoding: str | None = None,
     delimiter: str | None = None,
     catalog_cfg: MoleculeCatalogCfg | None = None,
-) -> dict[str, dict[str, str]]:
+) -> dict[str, dict[str, str | None]]:
     """Return cached molecule hierarchy lookup keyed by ``molecule_chembl_id``."""
 
     cfg_source = catalog_cfg or _DEFAULT_CATALOG_CFG
@@ -224,7 +225,7 @@ def load_molecule_hierarchy_lookup(
     encoding: str | None = None,
     delimiter: str | None = None,
     catalog_cfg: MoleculeCatalogCfg | None = None,
-) -> dict[str, str]:
+) -> dict[str, str | None]:
     """Return child → parent mapping loaded from a local hierarchy file."""
 
     cfg_source = catalog_cfg or _DEFAULT_CATALOG_CFG
@@ -260,7 +261,7 @@ def load_molecule_hierarchy_lookup(
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value)
+    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -590,33 +591,41 @@ def prepare_parent_enrichment(
     else:
         hierarchy_lookup = {}
 
+    dictionary_resolved_children: set[str] = set()
     if hierarchy_lookup:
-        hierarchy_values = {
-            key: value for key, value in hierarchy_lookup.items() if value is not None
-        }
-    else:
-        hierarchy_values = {}
-
-    if hierarchy_values:
+        missing_sentinel = object()
         hierarchy_series = normalised_ids.map(
-            lambda value: hierarchy_values.get(value) if value else None
+            lambda value: hierarchy_lookup.get(value, missing_sentinel)
+            if value
+            else missing_sentinel
         )
-        hierarchy_mask = hierarchy_series.notna()
+        hierarchy_series = pd.Series(hierarchy_series, index=df.index, dtype="object")
+        hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
-            resolved = hierarchy_series[hierarchy_mask].astype("string")
+            resolved_values = hierarchy_series[hierarchy_mask]
+            dictionary_resolved_children = set(
+                normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
+            )
             if parent_column in df.columns:
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+
+            has_parent_mask = resolved_values.notna()
+            if has_parent_mask.any():
+                parent_updates = resolved_values[has_parent_mask].astype("string")
+                df.loc[parent_updates.index, parent_column] = parent_updates
+                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
 
     if getattr(catalog_cfg, "force_refresh_existing", False):
         need_lookup_mask = normalised_ids != ""
     else:
         need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
     initial_need_lookup = set(normalised_ids[need_lookup_mask])
-    need_lookup = set(initial_need_lookup)
+    if dictionary_resolved_children:
+        need_lookup = initial_need_lookup - dictionary_resolved_children
+    else:
+        need_lookup = set(initial_need_lookup)
 
     cache_before = _cache_state(catalog_cfg.cache_path)
     cache_after = cache_before

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -30,7 +30,7 @@ from library.integration import pubchem_library as pl
 import library.testitem_pipeline as pipeline
 import library.testitem_pipeline.cli as pipeline_cli
 
-from library.config import ApiCfg, Config, IoCfg
+from library.config import ApiCfg, Config, IoCfg, MoleculeCatalogCfg
 
 from library.schemas import TestitemsSchema
 from scripts import get_testitem_data as gtd
@@ -459,7 +459,8 @@ def test_prepare_parent_enrichment_uses_lookup_path(
         captured_path = path
         return {"CHEMBL1": "CHEMBL999"}
 
-    monkeypatch.setattr(pipeline, "load_molecule_hierarchy_lookup", fake_lookup)
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(target, "load_molecule_hierarchy_lookup", fake_lookup)
     monkeypatch.setattr(pipeline, "query_parent_catalog", lambda *_, **__: {})
     monkeypatch.setattr(
         pipeline.molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
@@ -480,6 +481,129 @@ def test_prepare_parent_enrichment_uses_lookup_path(
     assert prep is not None
     assert captured_path == hierarchy_path
     assert list(prep.lookup_data.child_ids) == ["CHEMBL1"]
+
+
+def test_prepare_parent_enrichment_dictionary_sets_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    child_field = cfg.molecule_catalog.child_field
+    parent_field = cfg.molecule_catalog.parent_field
+    df = pd.DataFrame({child_field: ["CHEMBL1"], parent_field: [pd.NA]})
+    cfg.molecule_catalog.cache_path = tmp_path / "cache.json"
+    cfg.molecule_catalog.cache_path.write_text("{}")
+    cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
+
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(
+            target,
+            "load_molecule_hierarchy_lookup",
+            lambda *_, **__: {"CHEMBL1": "CHEMBL999"},
+        )
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(target, "query_parent_catalog", lambda *_, **__: pytest.fail("no fallback"))
+        monkeypatch.setattr(target, "load_parent_catalog", lambda *_, **__: {})
+        monkeypatch.setattr(target, "update_parent_catalog_cache", lambda *_, **__: None)
+        monkeypatch.setattr(target, "write_parent_catalog_cache", lambda *_, **__: None)
+
+    status, prep = pipeline.prepare_parent_enrichment(
+        df.copy(),
+        catalog_cfg=cfg.molecule_catalog,
+        io_cfg=cfg.io,
+        api_cfg=cfg.api,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        hierarchy_lookup_path=None,
+    )
+
+    assert status == 0
+    assert prep is not None
+    assert prep.lookup_data.need_lookup == set()
+    assert prep.parent_stats.missing == 0
+    assert prep.parent_stats.attached == 1
+    assert prep.df[parent_field].tolist() == ["CHEMBL999"]
+
+
+def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    child_field = cfg.molecule_catalog.child_field
+    parent_field = cfg.molecule_catalog.parent_field
+    df = pd.DataFrame({child_field: ["CHEMBL1"], parent_field: [pd.NA]})
+    cfg.molecule_catalog.cache_path = tmp_path / "cache.json"
+    cfg.molecule_catalog.cache_path.write_text("{}")
+    cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
+
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(
+            target,
+            "load_molecule_hierarchy_lookup",
+            lambda *_, **__: {"CHEMBL1": None},
+        )
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(target, "query_parent_catalog", lambda *_, **__: pytest.fail("no fallback"))
+        monkeypatch.setattr(target, "load_parent_catalog", lambda *_, **__: {})
+        monkeypatch.setattr(target, "update_parent_catalog_cache", lambda *_, **__: None)
+        monkeypatch.setattr(target, "write_parent_catalog_cache", lambda *_, **__: None)
+
+    status, prep = pipeline.prepare_parent_enrichment(
+        df.copy(),
+        catalog_cfg=cfg.molecule_catalog,
+        io_cfg=cfg.io,
+        api_cfg=cfg.api,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        hierarchy_lookup_path=None,
+    )
+
+    assert status == 0
+    assert prep is not None
+    assert prep.lookup_data.need_lookup == set()
+    assert prep.parent_stats.missing == 0
+    assert prep.parent_stats.attached == 1
+    assert pd.isna(prep.df[parent_field].iloc[0])
+
+
+def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    child_field = cfg.molecule_catalog.child_field
+    parent_field = cfg.molecule_catalog.parent_field
+    df = pd.DataFrame({child_field: ["CHEMBL1"], parent_field: [pd.NA]})
+    cfg.molecule_catalog.cache_path = tmp_path / "cache.json"
+    cfg.molecule_catalog.cache_path.write_text("{}")
+    cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
+
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(target, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
+
+    captured: dict[str, set[str]] = {"need": set()}
+
+    def fake_query(values: set[str], *, catalog_cfg: MoleculeCatalogCfg) -> dict[str, str]:
+        captured["need"] = set(values)
+        return {}
+
+    for target in (pipeline, pipeline.catalog):
+        monkeypatch.setattr(target, "query_parent_catalog", fake_query)
+        monkeypatch.setattr(target, "load_parent_catalog", lambda *_, **__: {})
+        monkeypatch.setattr(target, "update_parent_catalog_cache", lambda *_, **__: None)
+        monkeypatch.setattr(target, "write_parent_catalog_cache", lambda *_, **__: None)
+
+    status, prep = pipeline.prepare_parent_enrichment(
+        df.copy(),
+        catalog_cfg=cfg.molecule_catalog,
+        io_cfg=cfg.io,
+        api_cfg=cfg.api,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        hierarchy_lookup_path=None,
+    )
+
+    assert status == 0
+    assert prep is not None
+    assert prep.lookup_data.need_lookup == {"CHEMBL1"}
+    assert captured["need"] == {"CHEMBL1"}
+    assert prep.parent_stats.missing == 1
+    assert prep.parent_stats.attached == 0
 
 
 def test_run_parent_enrichment_failure(


### PR DESCRIPTION
## Summary
- preserve explicit null parents in the hierarchy mapping and propagate that through parent enrichment
- treat dictionary-resolved children as satisfied so fallback lookups skip rows flagged with null parents
- extend parent enrichment tests to cover dictionary hits, explicit nulls, and fallback behaviour

## Testing
- pytest tests/pipelines/test_get_testitem_data.py -k "prepare_parent_enrichment_dictionary" -q
- pytest tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary -q

------
https://chatgpt.com/codex/tasks/task_e_68dfbf300b688324b8b8d3c1cf570788