### PR TITLE
Handle non-JSON responses and cache GToP decode failures

### DIFF
--- a/library/integration/uniprot_library.py
+++ b/library/integration/uniprot_library.py
@@ -152,6 +152,9 @@ UNIPROT_OUTPUT_COLUMNS: list[str] = [
 ]
 
 
+_GTOP_JSON_FAILURE_CACHE: set[tuple[str, str]] = set()
+
+
 def _collect_name_fields(name_obj: dict[str, Any]) -> Iterable[str]:
     """Yield all full and short names from a UniProt name object."""
     if not isinstance(name_obj, dict):
@@ -871,6 +874,10 @@ def _fetch_gtop_endpoint(
 ) -> Any:
     """Return JSON payload for ``endpoint`` of a Guide-to-Pharmacology target."""
 
+    cache_key = (gtop_id, endpoint)
+    if cache_key in _GTOP_JSON_FAILURE_CACHE:
+        return None
+
     limiter = get_limiter("iuphar", cfg.rps, cfg.burst)
     base = cfg.base.rstrip("/")
     path = f"/{endpoint.lstrip('/')}" if endpoint else ""
@@ -881,6 +888,16 @@ def _fetch_gtop_endpoint(
         session = get_uniprot_session()
         with session.get(url, timeout=timeout) as response:
             response.raise_for_status()
+            raw_content_type = response.headers.get("Content-Type")
+            content_type = raw_content_type if isinstance(raw_content_type, str) else ""
+            if "json" not in content_type.lower():
+                logger.warning(
+                    "gtop_non_json_response",
+                    gtop_id=gtop_id,
+                    endpoint=endpoint,
+                    content_type=raw_content_type,
+                )
+                return None
             body = response.content
             if isinstance(body, (bytes, bytearray)):
                 body_is_empty = not body.strip()
@@ -895,6 +912,7 @@ def _fetch_gtop_endpoint(
                     endpoint=endpoint,
                     error="empty response body",
                 )
+                _GTOP_JSON_FAILURE_CACHE.add(cache_key)
                 return None
             return response.json()
     except (json.JSONDecodeError, ValueError) as exc:
@@ -904,6 +922,7 @@ def _fetch_gtop_endpoint(
             endpoint=endpoint,
             error=str(exc),
         )
+        _GTOP_JSON_FAILURE_CACHE.add(cache_key)
     except requests.RequestException as exc:  # pragma: no cover - network failures
         logger.warning(
             "gtop_request_failed", gtop_id=gtop_id, endpoint=endpoint, error=str(exc)

--- a/tests/pipelines/test_uniprot_library.py
+++ b/tests/pipelines/test_uniprot_library.py
@@ -18,6 +18,13 @@ from library.clients import uniprot as uniprot_client  # noqa: E402
 from library.config import ApiCfg, IupharCfg, RetryCfg, UniprotCfg  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def clear_gtop_json_failure_cache() -> None:
+    ul._GTOP_JSON_FAILURE_CACHE.clear()
+    yield
+    ul._GTOP_JSON_FAILURE_CACHE.clear()
+
+
 def test_extract_names() -> None:
     sample = {
         "proteinDescription": {
@@ -313,6 +320,65 @@ def test_collect_info_enriches_gtop(tmp_path: Path) -> None:
     )
     assert len(responses.calls) == 3
 
+
+@responses.activate
+def test_fetch_gtop_endpoint_logs_non_json_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gtop_cfg = IupharCfg(base="https://gtop.example.org/services", rps=10, burst=10)
+    recorded: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, **payload: object) -> None:
+        recorded.append((event, dict(payload)))
+
+    monkeypatch.setattr(ul.logger, "warning", capture)
+
+    responses.add(
+        responses.GET,
+        "https://gtop.example.org/services/targets/1234/function",
+        body="<html></html>",
+        status=200,
+        content_type="text/html",
+    )
+
+    result = ul._fetch_gtop_endpoint("1234", "function", cfg=gtop_cfg)
+
+    assert result is None
+    events = [event for event, _payload in recorded]
+    assert "gtop_non_json_response" in events
+    non_json_records = [payload for event, payload in recorded if event == "gtop_non_json_response"]
+    assert non_json_records and non_json_records[0]["content_type"] == "text/html"
+    assert "gtop_json_decode_failed" not in events
+
+
+@responses.activate
+def test_fetch_gtop_endpoint_caches_json_decode_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gtop_cfg = IupharCfg(base="https://gtop.example.org/services", rps=10, burst=10)
+    recorded: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, **payload: object) -> None:
+        recorded.append((event, dict(payload)))
+
+    monkeypatch.setattr(ul.logger, "warning", capture)
+
+    responses.add(
+        responses.GET,
+        "https://gtop.example.org/services/targets/1234/interactions",
+        body="not json",
+        status=200,
+        content_type="application/json",
+    )
+
+    first = ul._fetch_gtop_endpoint("1234", "interactions", cfg=gtop_cfg)
+    second = ul._fetch_gtop_endpoint("1234", "interactions", cfg=gtop_cfg)
+
+    assert first is None
+    assert second is None
+    events = [event for event, _payload in recorded]
+    assert events.count("gtop_json_decode_failed") == 1
+    assert len(responses.calls) == 1
 
 def test_collect_info_uses_canonical_fallback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- validate Guide-to-Pharmacology responses before decoding and emit a warning for non-JSON payloads
- cache JSON decode failures per endpoint to avoid repeat network requests
- extend the UniProt integration tests to cover the new logging paths

## Testing
- pytest tests/pipelines/test_uniprot_library.py

------
https://chatgpt.com/codex/tasks/task_e_68dfbf6d2f9c83249905f8e551047e81