### PR TITLE
Align document QA CLI references with package module path

### DIFF
--- a/docs/QA_PROCESS_EN.md
+++ b/docs/QA_PROCESS_EN.md
@@ -71,7 +71,7 @@ The document export now includes an automated regression check against the legac
    * `qa_document_postprocessing_diff_YYYYMMDD.csv` (only when mismatches are present)
 3. Alternatively execute the QA script directly:
    ```bash
-   python -m qa.check_document_postprocessing \
+   python -m library.qa.check_document_postprocessing \
        --base-path data \
 
        --ref input\\full\\document.csv \

--- a/docs/QA_PROCESS_RU.md
+++ b/docs/QA_PROCESS_RU.md
@@ -70,7 +70,7 @@ mypy --strict
    * `qa_document_postprocessing_diff_YYYYMMDD.csv` (только при наличии расхождений)
 3. Либо выполните QA-скрипт напрямую:
    ```bash
-   python -m qa.check_document_postprocessing \
+   python -m library.qa.check_document_postprocessing \
        --base-path data \
 
        --ref input\\full\\document.csv \


### PR DESCRIPTION
## Summary
- update the document QA CLI example in the English checklist to use the package-qualified module path
- mirror the module path update in the Russian checklist and remove any stray outdated references

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dfbf4aec308324a9ee03e7900a45de