### PR TITLE
Update logging documentation links to common module paths

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -370,7 +370,7 @@ Paths under `data/input/ChEMBL/*.xlsx` are placeholders included for local smoke
 
 | Sub-section | Key | Default | Description |
 | --- | --- | --- | --- |
-| `log` | `level` | `INFO` | Default logging level. Structured JSON output keeps a fixed schema handled by [`library/logging_setup.py`](../library/logging_setup.py), so message and timestamp formatting are not configurable here. |
+| `log` | `level` | `INFO` | Default logging level. Structured JSON output keeps a fixed schema handled by [`library/common/logging_setup.py`](../library/common/logging_setup.py), so message and timestamp formatting are not configurable here. |
 | `rate` | `global_rps` | `100` | Global requests-per-second budget shared across clients. |
 |  | `global_burst` | `100` | Global token bucket burst capacity. |
 |  | `limiter_cache_maxsize` | `128` | Maximum cached limiter instances. |
@@ -442,7 +442,7 @@ Common short aliases:
 
 Any other key can be targeted using the long `CHEMBL_DA__...` form.
 
-> Structured logging details live in [`library/log.py`](../library/log.py) and [`library/logging_setup.py`](../library/logging_setup.py), explaining why the JSON layout (including date formatting) cannot be overridden via `config.yaml`.
+> Structured logging details live in [`library/common/log.py`](../library/common/log.py) and [`library/common/logging_setup.py`](../library/common/logging_setup.py), explaining why the JSON layout (including date formatting) cannot be overridden via `config.yaml`.
 
 ## CLI overrides
 

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -358,7 +358,7 @@ CLI-параметры имеют приоритет над YAML и окруже
 
 | Подсекция | Ключ | Значение | Описание |
 | --- | --- | --- | --- |
-| `log` | `level` | `INFO` | Уровень логирования по умолчанию. Структурированный JSON-вывод использует фиксированную схему из [`library/logging_setup.py`](../library/logging_setup.py), поэтому формат сообщения и таймстемпа через конфигурацию не меняется. |
+| `log` | `level` | `INFO` | Уровень логирования по умолчанию. Структурированный JSON-вывод использует фиксированную схему из [`library/common/logging_setup.py`](../library/common/logging_setup.py), поэтому формат сообщения и таймстемпа через конфигурацию не меняется. |
 | `rate` | `global_rps` | `100` | Глобальный лимит запросов в секунду. |
 |  | `global_burst` | `100` | Ёмкость глобального токен-бакета. |
 |  | `limiter_cache_maxsize` | `128` | Максимум кэшированных лимитеров. |
@@ -425,7 +425,7 @@ export CHEMBL_DA__LOCAL__IO__OUTPUT_DIR=/mnt/datasets
 
 Любой другой ключ можно задать в длинной форме `CHEMBL_DA__...`.
 
-> Детали JSON-формата описаны в [`library/log.py`](../library/log.py) и [`library/logging_setup.py`](../library/logging_setup.py); из-за этого `config.yaml` не позволяет переопределить формат сообщений и дату.
+> Детали JSON-формата описаны в [`library/common/log.py`](../library/common/log.py) и [`library/common/logging_setup.py`](../library/common/logging_setup.py); из-за этого `config.yaml` не позволяет переопределить формат сообщений и дату.
 
 ## CLI-переопределения
 


### PR DESCRIPTION
## Summary
- update the logging module references in both configuration guides to point at the common package implementation
- ensure the English and Russian docs share the same library/common log and logging_setup links

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfbf47abb88324b816e791c4b4d4b4