### PR TITLE
Update data README to reflect tracked directories

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -17,9 +17,9 @@ have predictable fixtures and can understand how local artefacts are derived.
   recreate them on demand. Commit refreshed caches only when they are required
   for deterministic tests or tutorials, and include a short note in the commit
   that explains the regeneration.
-- `run.but` – A developer convenience script that records typical command
-  invocations used during manual runs. It is not executed automatically and may
-  be adapted locally.
+- `logs/` – Checkpoints from sample ETL runs that illustrate the expected
+  console output and help troubleshoot regressions in the acquisition scripts.
+  These files are updated manually when workflows or logging formats change.
 
 ## Where to place runtime output
 


### PR DESCRIPTION
## Summary
- remove documentation for the obsolete `run.but` helper in the data directory guide
- describe the `logs/` folder so contributors know where run logs live

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfbf41bd408324ad3b3acb63f89afe