### PR TITLE
Fix parent hierarchy lookup NameError

### DIFF
--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -635,8 +635,10 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+            df.loc[hierarchy_mask, parent_column] = resolved_values.astype(object)
+            existing_parent.loc[hierarchy_mask] = (
+                resolved_values.fillna("").astype("string")
+            )
             hierarchy_attached = int(hierarchy_mask.sum())
 
             has_parent_mask = resolved_values.notna()


### PR DESCRIPTION
## Summary
- ensure the hierarchy lookup branch assigns parent values using the resolved lookup series

## Testing
- not run (tests require optional pipeline modules that are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc63499588324b49d33764e9778e0