### PR TITLE
Normalize hierarchy parents to avoid fallback lookups

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -183,7 +183,8 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent: str | None
+        if pd.isna(molecule_id) or molecule_id == "":
+            continue
         if pd.isna(parent_id) or parent_id == "" or parent_id == molecule_id:
             parent = None
         else:
@@ -263,11 +264,21 @@ def load_molecule_hierarchy_lookup(
     except ValueError as exc:
         raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
 
-    lookup = dict(raw_lookup)
+    lookup: dict[str, str | None] = {}
+    for key, value in raw_lookup.items():
+        if value is None:
+            lookup[key] = None
+            continue
+        if isinstance(value, str):
+            trimmed = value.strip()
+            lookup[key] = trimmed or None
+            continue
+        lookup[key] = None
+
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
+    attached_rows = sum(1 for value in lookup.values() if value is not None)
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -635,20 +646,22 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+            resolved_strings = resolved_values.astype("string")
+            df.loc[resolved_strings.index, parent_column] = resolved_strings
+            existing_parent.loc[resolved_strings.index] = resolved_strings
             hierarchy_attached = int(hierarchy_mask.sum())
 
-            has_parent_mask = resolved_values.notna()
+            has_parent_mask = resolved_strings.notna()
             if has_parent_mask.any():
-                parent_updates = resolved_values[has_parent_mask].astype("string")
+                parent_updates = resolved_strings[has_parent_mask]
                 df.loc[parent_updates.index, parent_column] = parent_updates
-                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
+                existing_parent.loc[parent_updates.index] = parent_updates
 
     if getattr(catalog_cfg, "force_refresh_existing", False):
         need_lookup_mask = normalised_ids != ""
     else:
-        need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
+        empty_parent_mask = existing_parent.isna() | existing_parent.eq("")
+        need_lookup_mask = (normalised_ids != "") & empty_parent_mask
     initial_need_lookup = set(normalised_ids[need_lookup_mask])
     if dictionary_resolved_children:
         need_lookup = initial_need_lookup - dictionary_resolved_children

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -183,7 +183,8 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent: str | None
+        if pd.isna(molecule_id) or molecule_id == "":
+            continue
         if pd.isna(parent_id) or parent_id == "" or parent_id == molecule_id:
             parent = None
         else:
@@ -263,11 +264,21 @@ def load_molecule_hierarchy_lookup(
     except ValueError as exc:
         raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
 
-    lookup = dict(raw_lookup)
+    lookup: dict[str, str | None] = {}
+    for key, value in raw_lookup.items():
+        if value is None:
+            lookup[key] = None
+            continue
+        if isinstance(value, str):
+            trimmed = value.strip()
+            lookup[key] = trimmed or None
+            continue
+        lookup[key] = None
+
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
+    attached_rows = sum(1 for value in lookup.values() if value is not None)
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -635,20 +646,22 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+            resolved_strings = resolved_values.astype("string")
+            df.loc[resolved_strings.index, parent_column] = resolved_strings
+            existing_parent.loc[resolved_strings.index] = resolved_strings
             hierarchy_attached = int(hierarchy_mask.sum())
 
-            has_parent_mask = resolved_values.notna()
+            has_parent_mask = resolved_strings.notna()
             if has_parent_mask.any():
-                parent_updates = resolved_values[has_parent_mask].astype("string")
+                parent_updates = resolved_strings[has_parent_mask]
                 df.loc[parent_updates.index, parent_column] = parent_updates
-                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
+                existing_parent.loc[parent_updates.index] = parent_updates
 
     if getattr(catalog_cfg, "force_refresh_existing", False):
         need_lookup_mask = normalised_ids != ""
     else:
-        need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
+        empty_parent_mask = existing_parent.isna() | existing_parent.eq("")
+        need_lookup_mask = (normalised_ids != "") & empty_parent_mask
     initial_need_lookup = set(normalised_ids[need_lookup_mask])
     if dictionary_resolved_children:
         need_lookup = initial_need_lookup - dictionary_resolved_children

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -162,10 +162,9 @@ def _load_molecule_hierarchy_mapping(
         subset[parent_column] = frame[parent_column].copy()
 
     for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = (
-            subset[column].fillna("").astype("string").str.strip().str.upper()
-        )
+        subset[column] = subset[column].astype("string").str.strip().str.upper()
 
+    subset = subset[subset["molecule_chembl_id"].notna()]
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
         subset=["molecule_chembl_id"],
@@ -174,9 +173,12 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent = parent_id or None
-        if parent is not None and parent == molecule_id:
+        if pd.isna(molecule_id) or molecule_id == "":
+            continue
+        if pd.isna(parent_id) or parent_id == "" or parent_id == molecule_id:
             parent = None
+        else:
+            parent = parent_id
         lookup[molecule_id] = parent
 
     return lookup

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -523,6 +523,7 @@ def test_prepare_parent_enrichment_dictionary_sets_parent(
     assert prep.parent_stats.missing == 0
     assert prep.parent_stats.attached == 1
     assert prep.df[parent_field].tolist() == ["CHEMBL999"]
+    assert prep.lookup_data.existing_parent_ids.iloc[0] == "CHEMBL999"
 
 
 def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
@@ -563,6 +564,7 @@ def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
     assert prep.parent_stats.missing == 0
     assert prep.parent_stats.attached == 1
     assert pd.isna(prep.df[parent_field].iloc[0])
+    assert pd.isna(prep.lookup_data.existing_parent_ids.iloc[0])
 
 
 def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
@@ -606,6 +608,7 @@ def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
     assert captured["need"] == {"CHEMBL1"}
     assert prep.parent_stats.missing == 1
     assert prep.parent_stats.attached == 0
+    assert prep.lookup_data.existing_parent_ids.iloc[0] == ""
 
 
 def test_run_parent_enrichment_failure(

--- a/tests/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/scripts/get_testitem_data/test_get_testitem_data.py
@@ -930,6 +930,22 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
     }
 
 
+def test_load_molecule_hierarchy_mapping_preserves_null(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "hierarchy.csv"
+    path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\nCHEMBL1,\nCHEMBL2,CHEMBL3\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    mapping = gtd._load_molecule_hierarchy_mapping(
+        str(path), cfg.io.csv_encoding, cfg.io.csv_sep
+    )
+
+    assert mapping == {"CHEMBL1": None, "CHEMBL2": "CHEMBL3"}
+
+
 def test_load_molecule_hierarchy_lookup_missing_columns(
     tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- normalise molecule hierarchy CSV loading so missing parents become None across both pipeline entry points
- ensure parent enrichment uses the normalised hierarchy results and treats dictionary-only children as resolved
- add regression coverage for hierarchy mapping and enrichment scenarios with missing parents

## Testing
- pytest tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_dictionary_sets_parent tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary tests/scripts/get_testitem_data/test_get_testitem_data.py::test_load_molecule_hierarchy_mapping_preserves_null

------
https://chatgpt.com/codex/tasks/task_e_68dfc67500348324b7b79bd64fd89366