### PR TITLE
Fix parent hierarchy assignment in testitem catalog pipeline

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -635,8 +635,10 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved.astype(object)
-            existing_parent.loc[hierarchy_mask] = resolved.fillna("").astype("string")
+            df.loc[hierarchy_mask, parent_column] = resolved_values.astype(object)
+            existing_parent.loc[hierarchy_mask] = (
+                resolved_values.fillna("").astype("string")
+            )
             hierarchy_attached = int(hierarchy_mask.sum())
 
             has_parent_mask = resolved_values.notna()


### PR DESCRIPTION
## Summary
- ensure hierarchy prefills use the resolved hierarchy series when populating parent identifiers
- normalise parent cache updates after filling hierarchy-derived values

## Testing
- pytest tests/scripts/get_testitem_data/test_get_testitem_data.py -k hierarchy -q *(fails: module 'library.pipelines.testitem' has no attribute 'load_molecule_hierarchy_lookup')*


------
https://chatgpt.com/codex/tasks/task_e_68dfd00d5798832490b89a8d53b9e349