### PR TITLE
Fix config path resolution for default filename

### DIFF
--- a/library/utils/config.py
+++ b/library/utils/config.py
@@ -23,7 +23,26 @@ def resolve_config_path(path: str | Path | None = None) -> Path:
 
     if path is None:
         return DEFAULT_CONFIG_PATH
-    return Path(path).expanduser()
+
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+
+    # When the caller supplies a bare filename (e.g. ``config.yaml``) allow
+    # resolving it relative to common project roots. This matches the
+    # documentation which references ``config/config.yaml`` yet keeps backward
+    # compatibility with direct paths when they exist.
+    for base in (Path.cwd(), _PACKAGE_ROOT):
+        base_candidate = (base / candidate).resolve()
+        if base_candidate.exists():
+            return base_candidate
+
+    if candidate.parent == Path(".") and candidate.name == _DEFAULT_CONFIG_NAME:
+        default_candidate = (_PACKAGE_ROOT / DEFAULT_CONFIG_RELATIVE).resolve()
+        if default_candidate.exists():
+            return default_candidate
+
+    return (Path.cwd() / candidate).resolve()
 
 
 def load_yaml_config(path: str | Path | None = None) -> tuple[dict[str, Any], Path]:

--- a/tests/library/utils/test_config_utils.py
+++ b/tests/library/utils/test_config_utils.py
@@ -1,0 +1,18 @@
+"""Tests for configuration file discovery helpers."""
+
+from __future__ import annotations
+
+from library.utils import config
+
+
+def test_resolve_config_path_prefers_repository_default(monkeypatch, tmp_path):
+    """Bare config names fall back to the repository config directory."""
+
+    # Simulate running outside the repository tree where ``config.yaml`` is
+    # not present in the working directory.
+    monkeypatch.chdir(tmp_path)
+
+    resolved = config.resolve_config_path("config.yaml")
+
+    assert resolved == config.DEFAULT_CONFIG_PATH.resolve()
+    assert resolved.exists(), "Default configuration must be available"


### PR DESCRIPTION
## Summary
- fall back to the repository config directory when callers pass only `config.yaml`
- add a regression test covering bare filename resolution behaviour

## Testing
- pytest tests/library/utils/test_config_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd3c7764883248b6b7c3b6719286d