### PR TITLE
Normalize hierarchy parent values and extend enrichment tests

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -30,6 +30,8 @@ _MOLECULE_HIERARCHY_COLUMNS = (
     "parent_molecule_chembl_id",
 )
 
+_MOLECULE_HIERARCHY_NULL_VALUES = frozenset({"NULL"})
+
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
 PARENT_LOOKUP_SOURCE_LOOKUP = "lookup"
 PARENT_LOOKUP_SOURCE_PARTIAL = "partial"
@@ -169,12 +171,24 @@ def _load_molecule_hierarchy_mapping(
     if parent_missing:
         subset[parent_column] = pd.Series(pd.NA, index=subset.index, dtype="string")
     else:
-        subset[parent_column] = frame[parent_column].copy()
+        subset[parent_column] = frame[parent_column].astype("string")
 
-    for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = subset[column].astype("string").str.strip().str.upper()
+    child_series = (
+        subset[child_column].astype("string").fillna("").str.strip().str.upper()
+    )
+    parent_series = subset[parent_column].astype("string")
+    parent_series = parent_series.str.strip()
+    parent_upper = parent_series.str.upper()
+    null_mask = (
+        parent_series.isna()
+        | parent_series.eq("")
+        | parent_upper.isin(_MOLECULE_HIERARCHY_NULL_VALUES)
+    )
+    parent_series = parent_upper.mask(null_mask, pd.NA)
 
-    subset = subset[subset["molecule_chembl_id"].notna()]
+    subset[child_column] = child_series
+    subset[parent_column] = parent_series
+
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
         subset=["molecule_chembl_id"],
@@ -267,7 +281,7 @@ def load_molecule_hierarchy_lookup(
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
+    attached_rows = sum(1 for value in lookup.values() if value is not None)
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -628,6 +642,7 @@ def prepare_parent_enrichment(
         hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
             resolved_values = hierarchy_series[hierarchy_mask]
+            resolved_series = resolved_values.astype("string")
             dictionary_resolved_children = set(
                 normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
             )
@@ -635,27 +650,22 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved_values.astype(object)
-            existing_parent.loc[hierarchy_mask] = (
-                resolved_values.fillna("").astype("string")
-            )
+            df.loc[resolved_series.index, parent_column] = resolved_series
+            existing_parent.loc[resolved_series.index] = resolved_series
             hierarchy_attached = int(hierarchy_mask.sum())
 
-            has_parent_mask = resolved_values.notna()
-            if has_parent_mask.any():
-                parent_updates = resolved_values[has_parent_mask].astype("string")
-                df.loc[parent_updates.index, parent_column] = parent_updates
-                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
-
     if getattr(catalog_cfg, "force_refresh_existing", False):
-        need_lookup_mask = normalised_ids != ""
+        lookup_candidates = normalised_ids[normalised_ids != ""]
     else:
-        need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
-    initial_need_lookup = set(normalised_ids[need_lookup_mask])
+        lookup_mask = (normalised_ids != "") & (
+            existing_parent.isna() | existing_parent.eq("")
+        )
+        lookup_candidates = normalised_ids[lookup_mask]
+    initial_need_lookup = set(lookup_candidates.tolist())
     if dictionary_resolved_children:
-        need_lookup = initial_need_lookup - dictionary_resolved_children
-    else:
-        need_lookup = set(initial_need_lookup)
+        initial_need_lookup -= dictionary_resolved_children
+
+    need_lookup = set(initial_need_lookup)
 
     cache_before = _cache_state(catalog_cfg.cache_path)
     cache_after = cache_before

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -30,6 +30,8 @@ _MOLECULE_HIERARCHY_COLUMNS = (
     "parent_molecule_chembl_id",
 )
 
+_MOLECULE_HIERARCHY_NULL_VALUES = frozenset({"NULL"})
+
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
 PARENT_LOOKUP_SOURCE_LOOKUP = "lookup"
 PARENT_LOOKUP_SOURCE_PARTIAL = "partial"
@@ -169,12 +171,24 @@ def _load_molecule_hierarchy_mapping(
     if parent_missing:
         subset[parent_column] = pd.Series(pd.NA, index=subset.index, dtype="string")
     else:
-        subset[parent_column] = frame[parent_column].copy()
+        subset[parent_column] = frame[parent_column].astype("string")
 
-    for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = subset[column].astype("string").str.strip().str.upper()
+    child_series = (
+        subset[child_column].astype("string").fillna("").str.strip().str.upper()
+    )
+    parent_series = subset[parent_column].astype("string")
+    parent_series = parent_series.str.strip()
+    parent_upper = parent_series.str.upper()
+    null_mask = (
+        parent_series.isna()
+        | parent_series.eq("")
+        | parent_upper.isin(_MOLECULE_HIERARCHY_NULL_VALUES)
+    )
+    parent_series = parent_upper.mask(null_mask, pd.NA)
 
-    subset = subset[subset["molecule_chembl_id"].notna()]
+    subset[child_column] = child_series
+    subset[parent_column] = parent_series
+
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
         subset=["molecule_chembl_id"],
@@ -267,7 +281,7 @@ def load_molecule_hierarchy_lookup(
     if not lookup:
         return {}
 
-    attached_rows = sum(1 for value in lookup.values() if value is not None and value != "")
+    attached_rows = sum(1 for value in lookup.values() if value is not None)
 
     logger.info(
         "molecule_hierarchy_lookup_loaded",
@@ -628,6 +642,7 @@ def prepare_parent_enrichment(
         hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
             resolved_values = hierarchy_series[hierarchy_mask]
+            resolved_series = resolved_values.astype("string")
             dictionary_resolved_children = set(
                 normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
             )
@@ -635,27 +650,22 @@ def prepare_parent_enrichment(
                 df[parent_column] = df[parent_column].astype("string")
             else:
                 df[parent_column] = pd.Series(pd.NA, index=df.index, dtype="string")
-            df.loc[hierarchy_mask, parent_column] = resolved_values.astype(object)
-            existing_parent.loc[hierarchy_mask] = (
-                resolved_values.fillna("").astype("string")
-            )
+            df.loc[resolved_series.index, parent_column] = resolved_series
+            existing_parent.loc[resolved_series.index] = resolved_series
             hierarchy_attached = int(hierarchy_mask.sum())
 
-            has_parent_mask = resolved_values.notna()
-            if has_parent_mask.any():
-                parent_updates = resolved_values[has_parent_mask].astype("string")
-                df.loc[parent_updates.index, parent_column] = parent_updates
-                existing_parent.loc[parent_updates.index] = parent_updates.astype("string")
-
     if getattr(catalog_cfg, "force_refresh_existing", False):
-        need_lookup_mask = normalised_ids != ""
+        lookup_candidates = normalised_ids[normalised_ids != ""]
     else:
-        need_lookup_mask = (normalised_ids != "") & (existing_parent == "")
-    initial_need_lookup = set(normalised_ids[need_lookup_mask])
+        lookup_mask = (normalised_ids != "") & (
+            existing_parent.isna() | existing_parent.eq("")
+        )
+        lookup_candidates = normalised_ids[lookup_mask]
+    initial_need_lookup = set(lookup_candidates.tolist())
     if dictionary_resolved_children:
-        need_lookup = initial_need_lookup - dictionary_resolved_children
-    else:
-        need_lookup = set(initial_need_lookup)
+        initial_need_lookup -= dictionary_resolved_children
+
+    need_lookup = set(initial_need_lookup)
 
     cache_before = _cache_state(catalog_cfg.cache_path)
     cache_after = cache_before

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -39,6 +39,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_NAME = "testitem.csv"
 DEFAULT_OUTPUT_STEM = "testitems"
 
+MOLECULE_HIERARCHY_NULL_VALUES = frozenset({"NULL"})
+
 
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -159,12 +161,23 @@ def _load_molecule_hierarchy_mapping(
     if parent_missing:
         subset[parent_column] = pd.Series(pd.NA, index=subset.index, dtype="string")
     else:
-        subset[parent_column] = frame[parent_column].copy()
+        subset[parent_column] = frame[parent_column].astype("string")
 
-    for column in _MOLECULE_HIERARCHY_COLUMNS:
-        subset[column] = (
-            subset[column].fillna("").astype("string").str.strip().str.upper()
-        )
+    child_series = (
+        subset[child_column].astype("string").fillna("").str.strip().str.upper()
+    )
+    parent_series = subset[parent_column].astype("string")
+    parent_series = parent_series.str.strip()
+    parent_upper = parent_series.str.upper()
+    null_mask = (
+        parent_series.isna()
+        | parent_series.eq("")
+        | parent_upper.isin(MOLECULE_HIERARCHY_NULL_VALUES)
+    )
+    parent_series = parent_upper.mask(null_mask, pd.NA)
+
+    subset[child_column] = child_series
+    subset[parent_column] = parent_series
 
     subset = subset[subset["molecule_chembl_id"] != ""]
     subset = subset.drop_duplicates(
@@ -174,7 +187,10 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent = parent_id or None
+        if pd.isna(parent_id) or parent_id == "":
+            parent: str | None = None
+        else:
+            parent = parent_id
         if parent is not None and parent == molecule_id:
             parent = None
         lookup[molecule_id] = parent

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -495,12 +495,13 @@ def test_prepare_parent_enrichment_dictionary_sets_parent(
     cfg.molecule_catalog.cache_path.write_text("{}")
     cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
 
-    for target in (pipeline, pipeline.catalog):
-        monkeypatch.setattr(
-            target,
-            "load_molecule_hierarchy_lookup",
-            lambda *_, **__: {"CHEMBL1": "CHEMBL999"},
-        )
+    hierarchy_path = tmp_path / "hierarchy.csv"
+    hierarchy_path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\nCHEMBL1,CHEMBL999\n",
+        encoding=cfg.io.csv_encoding,
+    )
+    pipeline.catalog._load_molecule_hierarchy_mapping.cache_clear()
+
     for target in (pipeline, pipeline.catalog):
         monkeypatch.setattr(target, "query_parent_catalog", lambda *_, **__: pytest.fail("no fallback"))
         monkeypatch.setattr(target, "load_parent_catalog", lambda *_, **__: {})
@@ -514,7 +515,7 @@ def test_prepare_parent_enrichment_dictionary_sets_parent(
         api_cfg=cfg.api,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
-        hierarchy_lookup_path=None,
+        hierarchy_lookup_path=hierarchy_path,
     )
 
     assert status == 0
@@ -535,12 +536,13 @@ def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
     cfg.molecule_catalog.cache_path.write_text("{}")
     cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
 
-    for target in (pipeline, pipeline.catalog):
-        monkeypatch.setattr(
-            target,
-            "load_molecule_hierarchy_lookup",
-            lambda *_, **__: {"CHEMBL1": None},
-        )
+    hierarchy_path = tmp_path / "hierarchy_null.csv"
+    hierarchy_path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\nCHEMBL1,NULL\n",
+        encoding=cfg.io.csv_encoding,
+    )
+    pipeline.catalog._load_molecule_hierarchy_mapping.cache_clear()
+
     for target in (pipeline, pipeline.catalog):
         monkeypatch.setattr(target, "query_parent_catalog", lambda *_, **__: pytest.fail("no fallback"))
         monkeypatch.setattr(target, "load_parent_catalog", lambda *_, **__: {})
@@ -554,7 +556,7 @@ def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
         api_cfg=cfg.api,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
-        hierarchy_lookup_path=None,
+        hierarchy_lookup_path=hierarchy_path,
     )
 
     assert status == 0
@@ -575,8 +577,12 @@ def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
     cfg.molecule_catalog.cache_path.write_text("{}")
     cfg.molecule_catalog.sqlite_path = tmp_path / "cache.sqlite"
 
-    for target in (pipeline, pipeline.catalog):
-        monkeypatch.setattr(target, "load_molecule_hierarchy_lookup", lambda *_, **__: {})
+    hierarchy_path = tmp_path / "hierarchy_missing.csv"
+    hierarchy_path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\nCHEMBL2,CHEMBL3\n",
+        encoding=cfg.io.csv_encoding,
+    )
+    pipeline.catalog._load_molecule_hierarchy_mapping.cache_clear()
 
     captured: dict[str, set[str]] = {"need": set()}
 
@@ -597,7 +603,7 @@ def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
         api_cfg=cfg.api,
         timeout=cfg.testitem.timeout,
         client=SimpleNamespace(),
-        hierarchy_lookup_path=None,
+        hierarchy_lookup_path=hierarchy_path,
     )
 
     assert status == 0
@@ -1024,6 +1030,7 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
     tmp_path: Path, cfg: Config
 ) -> None:
     path = tmp_path / "hierarchy.csv"
+    pipeline.catalog._load_molecule_hierarchy_mapping.cache_clear()
     path.write_text(
         "\n".join(
             [
@@ -1032,6 +1039,7 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
                 "CHEMBL3,",
                 ",CHEMBL4",
                 " chembl5 , chembl6 ",
+                "CHEMBL8,NULL",
                 "CHEMBL1,CHEMBL7",
             ]
         ),
@@ -1044,6 +1052,7 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
         "CHEMBL1": "CHEMBL2",
         "CHEMBL3": None,
         "CHEMBL5": "CHEMBL6",
+        "CHEMBL8": None,
     }
 
 

--- a/tests/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/scripts/get_testitem_data/test_get_testitem_data.py
@@ -898,7 +898,7 @@ def test_finalize_output_streams_sorted_chunks(
 def test_load_molecule_hierarchy_lookup_missing(tmp_path: Path, cfg: Config) -> None:
     path = tmp_path / "missing.csv"
 
-    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+    result = gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
 
     assert result == {}
 
@@ -907,6 +907,7 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
     tmp_path: Path, cfg: Config
 ) -> None:
     path = tmp_path / "hierarchy.csv"
+    gtd._load_molecule_hierarchy_mapping.cache_clear()
     path.write_text(
         "\n".join(
             [
@@ -915,18 +916,20 @@ def test_load_molecule_hierarchy_lookup_filters_empty_rows(
                 "CHEMBL3,",
                 ",CHEMBL4",
                 " chembl5 , chembl6 ",
+                "CHEMBL8,NULL",
                 "CHEMBL1,CHEMBL7",
             ]
         ),
         encoding=cfg.io.csv_encoding,
     )
 
-    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+    result = gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
 
     assert result == {
         "CHEMBL1": "CHEMBL2",
         "CHEMBL3": None,
         "CHEMBL5": "CHEMBL6",
+        "CHEMBL8": None,
     }
 
 
@@ -946,7 +949,7 @@ def test_load_molecule_hierarchy_lookup_missing_columns(
 
     monkeypatch.setattr(pipeline.logger, "warning", fake_warning)
 
-    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+    result = gtd.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
 
     assert result == {"CHEMBL1": None}
     assert captured


### PR DESCRIPTION
## Summary
- normalize molecule hierarchy CSV loading to treat explicit NULL tokens as missing
- ensure prepare_parent_enrichment preserves pd.NA parents and skips fallback lookups for dictionary hits
- expand pipeline and script tests to cover dictionary hits, explicit NULL values, and fallback behaviour

## Testing
- pytest tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_dictionary_sets_parent tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback tests/pipelines/test_get_testitem_data.py::test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary tests/pipelines/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup_filters_empty_rows tests/scripts/get_testitem_data/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup_filters_empty_rows

------
https://chatgpt.com/codex/tasks/task_e_68dfd5abecd88324b19cbe93223720b5