### PR TITLE
Update check-determinism docs to reflect current CLI

### DIFF
--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -134,8 +134,7 @@ pre-commit run --all-files
 pip check
 pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing
-python -m library.utils.cli_tools.check_determinism --log-level DEBUG \
-    --input out/latest.csv --previous out/previous.csv
+check-determinism --log-level DEBUG
 ```
 
 The QA playbook (`docs/QA_PROCESS_EN.md` / `docs/QA_PROCESS_RU.md`) documents

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -133,8 +133,7 @@ pre-commit run --all-files
 pip check
 pytest
 pytest --cov=library --cov=scripts --cov-report=term-missing
-python -m library.utils.cli_tools.check_determinism --log-level DEBUG \
-    --input out/latest.csv --previous out/previous.csv
+check-determinism --log-level DEBUG
 ```
 
 QA-плейбук (`docs/QA_PROCESS_RU.md` / `docs/QA_PROCESS_EN.md`) описывает ворота

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -163,7 +163,7 @@ Use these modules for diagnostics, QA, or offline workflows. Each exposes a
 
 | Module | Console command | Purpose |
 |--------|-----------------|---------|
-| `library.utils.cli_tools.check_determinism` | `check-determinism --input a.csv --previous b.csv` | Compare SHA-256 hashes and metadata between two exports. |
+| `library.utils.cli_tools.check_determinism` | `check-determinism --log-level INFO` | Verify deterministic CSV writers by hashing sample outputs. |
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Re-serialise CSV files in deterministic chunks. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Normalise delimiters, quoting, and ordering for arbitrary CSV files. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Inspect pandas dtypes produced by the pipelines. |

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -156,7 +156,7 @@ get-testitem-data --input seeds/molecule_ids.csv \
 
 | Модуль | Команда | Назначение |
 |--------|---------|------------|
-| `library.utils.cli_tools.check_determinism` | `check-determinism --input a.csv --previous b.csv` | Сравнение SHA-256 и метаданных разных запусков. |
+| `library.utils.cli_tools.check_determinism` | `check-determinism --log-level INFO` | Проверка детерминированности CSV через сравнение хэшей тестовых файлов. |
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Потоковое чтение/запись CSV с сохранением порядка. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Нормализация разделителей, кавычек и порядка колонок. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Диагностика типов pandas-таблиц. |


### PR DESCRIPTION
## Summary
- align helper tables to show the current check-determinism invocation and behaviour
- fix the QA command snippets to use the supported flags
- remove outdated references to --input/--previous in the documentation set

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dfda1d95cc8324a97022f21dd456cc