### PR TITLE
Clarify documentation input template locations

### DIFF
--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -102,9 +102,12 @@ platform-specific user directories listed in [`docs/CONFIG_EN.md`](./CONFIG_EN.m
 
 ## Quick start
 
-1. **Prepare identifier lists.** Use the templates in `data/input` or export
-   fresh ID lists from your warehouse. Each pipeline expects one identifier per
-   row; see [`docs/DATA_SCHEMA_EN.md`](./DATA_SCHEMA_EN.md) for column names.
+1. **Prepare identifier lists.** Use the templates in `data/input` (for
+   example `document.csv`, `target.csv`, `assay.csv`, `activity.csv`,
+   `testitem.csv`) or export fresh ID lists from your warehouse. A richer
+   showcase lives in `data/input/full`. Each pipeline expects one identifier per
+   row; see [`docs/DATA_SCHEMA_EN.md`](./DATA_SCHEMA_EN.md) for column names and
+   required headers.
 2. **Review configuration.** Copy `config/config.yaml` if you need to override
    API limits, output directories, or staging flags. Environment variable
    overrides follow the `CHEMBL_DA__SECTION__KEY` pattern. Details live in
@@ -113,7 +116,7 @@ platform-specific user directories listed in [`docs/CONFIG_EN.md`](./CONFIG_EN.m
 
    ```bash
    get-document-data all \
-       --input data/input/document_ids.csv \
+       --input data/input/document.csv \
        --final-out output.documents_$(date +%Y%m%d).csv \
        --config config/config.yaml \
        --log-level INFO

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -103,8 +103,10 @@ pre-commit install
 ## Быстрый старт
 
 1. **Подготовьте списки идентификаторов.** Используйте шаблоны из `data/input`
-   или выгрузите свежие списки из своей системы. Пайплайны ожидают по одному ID
-   в строке; имена колонок перечислены в [`docs/DATA_SCHEMA_RU.md`](./DATA_SCHEMA_RU.md).
+   (например, `document.csv`, `target.csv`, `assay.csv`, `activity.csv`,
+   `testitem.csv`) или выгрузите свежие списки из своей системы. Расширенный
+   набор примеров лежит в `data/input/full`. Пайплайны ожидают по одному ID в
+   строке; имена колонок перечислены в [`docs/DATA_SCHEMA_RU.md`](./DATA_SCHEMA_RU.md).
 2. **Проверьте конфигурацию.** Скопируйте `config/config.yaml`, если нужно
    переопределить лимиты API, каталоги вывода или стадийные флаги. Паттерн
    переменных окружения — `CHEMBL_DA__РАЗДЕЛ__КЛЮЧ`. Полное описание — в
@@ -113,7 +115,7 @@ pre-commit install
 
    ```bash
    get-document-data all \
-       --input data/input/document_ids.csv \
+       --input data/input/document.csv \
        --final-out output.documents_$(date +%Y%m%d).csv \
        --config config/config.yaml \
        --log-level INFO

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -34,21 +34,32 @@ three tiers:
 All commands exit with a non-zero status on validation errors, IO issues, or
 upstream API failures.
 
+### Input templates
+
+The repository ships minimal CSV templates under `data/input` (one file per
+pipeline: `document.csv`, `target.csv`, `assay.csv`, `activity.csv`,
+`testitem.csv`) and extended samples under `data/input/full`. Copy the relevant
+file, fill in your identifiers, and point `--input` to the new location. If you
+maintain your own seed lists, place them anywhere accessible to the CLI and
+ensure the headers match [`docs/DATA_SCHEMA_EN.md`](./DATA_SCHEMA_EN.md).
+
 ## Orchestrator (`get-data`)
 
 ```
 get-data --base-path /data/chembl \
-    --input-dir seeds --output-dir exports \
+    --input-dir input --output-dir exports \
     --config /data/chembl/config.yaml \
     --date 20250101 --limit 100 --log-level INFO
 ```
 
 The orchestrator resolves shared directories, prepares arguments, and invokes the
 pipelines in the following order: documents (`all` sub-command), targets (`all`),
-assays, test items, activities. Each delegated CLI receives `--final-out` so the
-individual pipelines write to the canonical destination without relying on
-deprecated aliases. `--limit 0` skips execution, `--dry-run` prints scheduled
-steps without touching the filesystem.
+assays, test items, activities. With the sample arguments above, inputs are
+loaded from `/data/chembl/input`—copy the templates there or provide your own
+directory. Each delegated CLI receives `--final-out` so the individual pipelines
+write to the canonical destination without relying on deprecated aliases.
+`--limit 0` skips execution, `--dry-run` prints scheduled steps without touching
+the filesystem.
 
 ## Document pipeline (`get-document-data`)
 
@@ -64,7 +75,7 @@ Typical command:
 
 ```
 get-document-data all \
-    --input seeds/document_ids.csv \
+    --input data/input/document.csv \
     --final-out output/documents_$(date +%Y%m%d).csv \
     --config config/config.yaml \
     --limit 500 --log-level INFO
@@ -111,7 +122,7 @@ Example with raw snapshot:
 
 ```
 get-target-data all \
-    --input seeds/target_ids.csv \
+    --input data/input/target.csv \
     --final-out output/targets_$(date +%Y%m%d).csv \
     --raw-out output/targets_raw_$(date +%Y%m%d).parquet \
     --raw-format parquet --id-cols target_chembl_id uniprot_id \
@@ -124,7 +135,7 @@ Cached replay of the production pipeline is available through
 ## Assay pipeline (`get-assay-data`)
 
 ```
-get-assay-data --input seeds/assay_ids.csv \
+get-assay-data --input data/input/assay.csv \
     --final-out output/assays_$(date +%Y%m%d).csv \
     --batch-size 100 --timeout 60 --limit 200
 ```
@@ -135,7 +146,7 @@ validates the table, then emits the standard CSV + sidecar + quality reports.
 ## Activity pipeline (`get-activity-data`)
 
 ```
-get-activity-data --input seeds/activity_ids.csv \
+get-activity-data --input data/input/activity.csv \
     --final-out output/activities_$(date +%Y%m%d).csv \
     --batch-size 50 --workers 4 --timeout 60 --limit 500
 ```
@@ -148,7 +159,7 @@ post-processing derives `lower_value`/`upper_value` using the rules described in
 ## Test item pipeline (`get-testitem-data`)
 
 ```
-get-testitem-data --input seeds/molecule_ids.csv \
+get-testitem-data --input data/input/testitem.csv \
     --final-out output/testitems_$(date +%Y%m%d).csv \
     --batch-size 1000 --timeout 60 --limit 400
 ```

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -32,20 +32,30 @@
 Любая команда возвращает ненулевой код при ошибках валидации, проблемах с IO или
 неудачных запросах к внешним сервисам.
 
+### Шаблоны входных файлов
+
+В репозитории лежат минимальные CSV-шаблоны в `data/input` (по одному на каждый
+пайплайн: `document.csv`, `target.csv`, `assay.csv`, `activity.csv`,
+`testitem.csv`) и расширенные примеры в `data/input/full`. Скопируйте нужный
+файл, заполните идентификаторы и передайте путь через `--input`. Если вы
+используете собственные списки, разместите их в любом доступном каталоге и
+убедитесь, что заголовки соответствуют [`docs/DATA_SCHEMA_RU.md`](./DATA_SCHEMA_RU.md).
+
 ## Оркестратор (`get-data`)
 
 ```
 get-data --base-path /data/chembl \
-    --input-dir seeds --output-dir exports \
+    --input-dir input --output-dir exports \
     --config /data/chembl/config.yaml \
     --date 20250101 --limit 100 --log-level INFO
 ```
 
 Оркестратор готовит аргументы и запускает пайплайны в порядке: документы (`all`),
-таргеты (`all`), ассайи, тест-объекты, активности. Каждая команда получает
-параметр `--final-out`, поэтому выгрузки создаются в целевых каталогах без
-устаревших алиасов. Значение `--limit 0` пропускает выполнение, а `--dry-run`
-выводит план без записи файлов.
+таргеты (`all`), ассайи, тест-объекты, активности. В примере выше входные CSV
+читаются из каталога `/data/chembl/input` — скопируйте туда шаблоны или укажите
+собственный путь. Каждая команда получает параметр `--final-out`, поэтому
+выгрузки создаются в целевых каталогах без устаревших алиасов. Значение
+`--limit 0` пропускает выполнение, а `--dry-run` выводит план без записи файлов.
 
 ## Пайплайн документов (`get-document-data`)
 
@@ -61,7 +71,7 @@ get-data --base-path /data/chembl \
 
 ```
 get-document-data all \
-    --input seeds/document_ids.csv \
+    --input data/input/document.csv \
     --final-out output/documents_$(date +%Y%m%d).csv \
     --config config/config.yaml \
     --limit 500 --log-level INFO
@@ -105,7 +115,7 @@ get-document-data all \
 
 ```
 get-target-data all \
-    --input seeds/target_ids.csv \
+    --input data/input/target.csv \
     --final-out output/targets_$(date +%Y%m%d).csv \
     --raw-out output/targets_raw_$(date +%Y%m%d).parquet \
     --raw-format parquet --id-cols target_chembl_id uniprot_id \
@@ -118,7 +128,7 @@ get-target-data all \
 ## Пайплайн ассайев (`get-assay-data`)
 
 ```
-get-assay-data --input seeds/assay_ids.csv \
+get-assay-data --input data/input/assay.csv \
     --final-out output/assays_$(date +%Y%m%d).csv \
     --batch-size 100 --timeout 60 --limit 200
 ```
@@ -129,7 +139,7 @@ get-assay-data --input seeds/assay_ids.csv \
 ## Пайплайн активностей (`get-activity-data`)
 
 ```
-get-activity-data --input seeds/activity_ids.csv \
+get-activity-data --input data/input/activity.csv \
     --final-out output/activities_$(date +%Y%m%d).csv \
     --batch-size 50 --workers 4 --timeout 60 --limit 500
 ```
@@ -141,7 +151,7 @@ get-activity-data --input seeds/activity_ids.csv \
 ## Пайплайн тест-объектов (`get-testitem-data`)
 
 ```
-get-testitem-data --input seeds/molecule_ids.csv \
+get-testitem-data --input data/input/testitem.csv \
     --final-out output/testitems_$(date +%Y%m%d).csv \
     --batch-size 1000 --timeout 60 --limit 400
 ```


### PR DESCRIPTION
## Summary
- replace references to non-existent `*_ids.csv` seeds with the shipped `data/input/*.csv` templates in both English and Russian guides
- document where to find minimal and full input CSV samples and explain the orchestrator directory expectations

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dfda1f01688324b54ad5b78456f50f