### PR TITLE
Prevent parent lookup full sync when parentless entries filtered

### DIFF
--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -465,6 +465,27 @@ def attach_parent_molecule_ids(
 
     needs_full_sync = catalog is None and uncovered_children > 0
 
+    parentless_filtered = False
+    if catalog is None:
+        filters_exclude_parentless = getattr(
+            molecule_catalog,
+            "_filters_exclude_parentless",
+            lambda cfg: False,
+        )
+        parentless_filtered = bool(filters_exclude_parentless(catalog_cfg))
+
+    if needs_full_sync and parentless_filtered:
+        needs_full_sync = False
+        logger.info(
+            "parent_lookup_skip_full_sync",
+            missing=len(missing_ids),
+            parentless_filtered=True,
+        )
+        if source_resolved is None and not partial_fetch_used:
+            source_resolved = (
+                PARENT_LOOKUP_SOURCE_CACHE if used_partial_cache else PARENT_LOOKUP_SOURCE_SKIPPED
+            )
+
     if missing_ids and catalog is None and needs_full_sync:
         cache_before_load = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_catalog_fn(


### PR DESCRIPTION
## Summary
- add a guard that skips triggering a full catalog synchronisation when parentless records are excluded by filters
- log the skip and keep parent lookup statistics consistent when the fallback is bypassed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfdb8a60c4832499d7abcea02efa3a