### PR TITLE
Normalize hierarchy parent markers and extend parent lookup tests

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -29,7 +29,7 @@ _MOLECULE_HIERARCHY_COLUMNS = (
     "molecule_chembl_id",
     "parent_molecule_chembl_id",
 )
-_NO_PARENT_MARKERS = {"", "NULL"}
+_NO_PARENT_MARKERS = {"", "NULL", "NO PARENT"}
 
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
 PARENT_LOOKUP_SOURCE_LOOKUP = "lookup"
@@ -125,6 +125,22 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
         )
 
 
+def _normalise_parent_identifier(value: object, *, child_id: str) -> str | None:
+    """Return normalised parent identifier or ``None`` for missing markers."""
+
+    if value is None or pd.isna(value):
+        return None
+
+    normalised_parent = str(value).strip().upper()
+    if not normalised_parent:
+        return None
+    if normalised_parent in _NO_PARENT_MARKERS:
+        return None
+    if normalised_parent == child_id:
+        return None
+    return normalised_parent
+
+
 @lru_cache(maxsize=None)
 def _load_molecule_hierarchy_mapping(
     path: str,
@@ -184,18 +200,7 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent: str | None
-        if pd.isna(parent_id):
-            parent = None
-        else:
-            normalised_parent = str(parent_id)
-            if (
-                normalised_parent in _NO_PARENT_MARKERS
-                or normalised_parent == molecule_id
-            ):
-                parent = None
-            else:
-                parent = normalised_parent
+        parent = _normalise_parent_identifier(parent_id, child_id=molecule_id)
         lookup[molecule_id] = parent
 
     return lookup
@@ -226,7 +231,10 @@ def LoadMoleculeHierarchyLookup(
     return {
         key: {
             "molecule_chembl_id": key,
-            "parent_molecule_chembl_id": value,
+            "parent_molecule_chembl_id": _normalise_parent_identifier(
+                value,
+                child_id=key,
+            ),
         }
         for key, value in cached.items()
     }
@@ -271,7 +279,10 @@ def load_molecule_hierarchy_lookup(
     except ValueError as exc:
         raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
 
-    lookup = dict(raw_lookup)
+    lookup = {
+        child_id: _normalise_parent_identifier(parent_id, child_id=child_id)
+        for child_id, parent_id in raw_lookup.items()
+    }
     if not lookup:
         return {}
 
@@ -636,8 +647,13 @@ def prepare_parent_enrichment(
         hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
             resolved_values = hierarchy_series[hierarchy_mask]
-            resolved_as_string = resolved_values.astype("string")
-            dictionary_resolved_children = set(
+            resolved_series = pd.Series(resolved_values, dtype="object")
+            resolved_series = resolved_series.where(
+                ~resolved_series.isna(),
+                None,
+            )
+            resolved_as_string = resolved_series.astype("string")
+            dictionary_resolved_children.update(
                 normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
             )
             if parent_column in df.columns:

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -29,7 +29,7 @@ _MOLECULE_HIERARCHY_COLUMNS = (
     "molecule_chembl_id",
     "parent_molecule_chembl_id",
 )
-_NO_PARENT_MARKERS = {"", "NULL"}
+_NO_PARENT_MARKERS = {"", "NULL", "NO PARENT"}
 
 PARENT_LOOKUP_SOURCE_CACHE = "cache"
 PARENT_LOOKUP_SOURCE_LOOKUP = "lookup"
@@ -125,6 +125,22 @@ def ensure_no_parant_column(df: pd.DataFrame) -> None:
         )
 
 
+def _normalise_parent_identifier(value: object, *, child_id: str) -> str | None:
+    """Return normalised parent identifier or ``None`` for missing markers."""
+
+    if value is None or pd.isna(value):
+        return None
+
+    normalised_parent = str(value).strip().upper()
+    if not normalised_parent:
+        return None
+    if normalised_parent in _NO_PARENT_MARKERS:
+        return None
+    if normalised_parent == child_id:
+        return None
+    return normalised_parent
+
+
 @lru_cache(maxsize=None)
 def _load_molecule_hierarchy_mapping(
     path: str,
@@ -184,18 +200,7 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent: str | None
-        if pd.isna(parent_id):
-            parent = None
-        else:
-            normalised_parent = str(parent_id)
-            if (
-                normalised_parent in _NO_PARENT_MARKERS
-                or normalised_parent == molecule_id
-            ):
-                parent = None
-            else:
-                parent = normalised_parent
+        parent = _normalise_parent_identifier(parent_id, child_id=molecule_id)
         lookup[molecule_id] = parent
 
     return lookup
@@ -226,7 +231,10 @@ def LoadMoleculeHierarchyLookup(
     return {
         key: {
             "molecule_chembl_id": key,
-            "parent_molecule_chembl_id": value,
+            "parent_molecule_chembl_id": _normalise_parent_identifier(
+                value,
+                child_id=key,
+            ),
         }
         for key, value in cached.items()
     }
@@ -271,7 +279,10 @@ def load_molecule_hierarchy_lookup(
     except ValueError as exc:
         raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
 
-    lookup = dict(raw_lookup)
+    lookup = {
+        child_id: _normalise_parent_identifier(parent_id, child_id=child_id)
+        for child_id, parent_id in raw_lookup.items()
+    }
     if not lookup:
         return {}
 
@@ -636,8 +647,13 @@ def prepare_parent_enrichment(
         hierarchy_mask = hierarchy_series.ne(missing_sentinel)
         if hierarchy_mask.any():
             resolved_values = hierarchy_series[hierarchy_mask]
-            resolved_as_string = resolved_values.astype("string")
-            dictionary_resolved_children = set(
+            resolved_series = pd.Series(resolved_values, dtype="object")
+            resolved_series = resolved_series.where(
+                ~resolved_series.isna(),
+                None,
+            )
+            resolved_as_string = resolved_series.astype("string")
+            dictionary_resolved_children.update(
                 normalised_ids.loc[hierarchy_mask & normalised_ids.ne("")].tolist()
             )
             if parent_column in df.columns:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -98,7 +98,7 @@ from library.testitem_pipeline import (
     PARENT_LOOKUP_SOURCE_SYNC,
 )
 
-_NO_PARENT_MARKERS = {"", "NULL"}
+_NO_PARENT_MARKERS = {"", "NULL", "NO PARENT"}
 
 def _normalise_identifier(value: Any, *, uppercase: bool = False) -> str | None:
     """Return ``value`` normalised for PubChem lookup."""
@@ -114,6 +114,22 @@ def _normalise_identifier(value: Any, *, uppercase: bool = False) -> str | None:
     if not normalised:
         return None
     return normalised.upper() if uppercase else normalised
+
+
+def _normalise_parent_identifier(value: object, *, child_id: str) -> str | None:
+    """Return normalised parent identifier or ``None`` for missing markers."""
+
+    if value is None or pd.isna(value):
+        return None
+
+    normalised_parent = str(value).strip().upper()
+    if not normalised_parent:
+        return None
+    if normalised_parent in _NO_PARENT_MARKERS:
+        return None
+    if normalised_parent == child_id:
+        return None
+    return normalised_parent
 
 
 @lru_cache(maxsize=None)
@@ -175,18 +191,7 @@ def _load_molecule_hierarchy_mapping(
 
     lookup: dict[str, str | None] = {}
     for molecule_id, parent_id in subset.itertuples(index=False, name=None):
-        parent: str | None
-        if pd.isna(parent_id):
-            parent = None
-        else:
-            normalised_parent = str(parent_id)
-            if (
-                normalised_parent in _NO_PARENT_MARKERS
-                or normalised_parent == molecule_id
-            ):
-                parent = None
-            else:
-                parent = normalised_parent
+        parent = _normalise_parent_identifier(parent_id, child_id=molecule_id)
         lookup[molecule_id] = parent
 
     return lookup
@@ -217,7 +222,10 @@ def LoadMoleculeHierarchyLookup(
     return {
         key: {
             "molecule_chembl_id": key,
-            "parent_molecule_chembl_id": value,
+            "parent_molecule_chembl_id": _normalise_parent_identifier(
+                value,
+                child_id=key,
+            ),
         }
         for key, value in cached.items()
     }
@@ -539,7 +547,10 @@ def load_molecule_hierarchy_lookup(
     except ValueError as exc:
         raise ValueError(f"invalid hierarchy lookup: {exc}") from exc
 
-    lookup = dict(raw_lookup)
+    lookup = {
+        child_id: _normalise_parent_identifier(parent_id, child_id=child_id)
+        for child_id, parent_id in raw_lookup.items()
+    }
     if not lookup:
         return {}
 

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -524,6 +524,10 @@ def test_prepare_parent_enrichment_dictionary_sets_parent(
     assert prep.parent_stats.missing == 0
     assert prep.parent_stats.attached == 1
     assert prep.df[parent_field].tolist() == ["CHEMBL999"]
+    assert (
+        prep.lookup_data.existing_parent_ids.iloc[0]
+        == "CHEMBL999"
+    )
 
 
 def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
@@ -565,6 +569,7 @@ def test_prepare_parent_enrichment_dictionary_null_parent_skips_fallback(
     assert prep.parent_stats.missing == 0
     assert prep.parent_stats.attached == 1
     assert pd.isna(prep.df[parent_field].iloc[0])
+    assert prep.lookup_data.existing_parent_ids.isna().iloc[0]
 
 
 def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
@@ -613,6 +618,7 @@ def test_prepare_parent_enrichment_falls_back_when_missing_from_dictionary(
     assert captured["need"] == {"CHEMBL1"}
     assert prep.parent_stats.missing == 1
     assert prep.parent_stats.attached == 0
+    assert prep.lookup_data.existing_parent_ids.iloc[0] == ""
 
 
 def test_run_parent_enrichment_failure(
@@ -1079,6 +1085,21 @@ def test_load_molecule_hierarchy_lookup_missing_columns(
     event, payload = captured[-1]
     assert event == "molecule_hierarchy_missing_parent_column"
     assert payload.get("column") == "parent_molecule_chembl_id"
+
+
+def test_load_molecule_hierarchy_lookup_normalises_no_parent(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "hierarchy.csv"
+    path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\n"
+        "CHEMBL1,NO PARENT\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert result == {"CHEMBL1": None}
 
 
 def test_prepare_pubchem_caches_primes_local_parent_cache(

--- a/tests/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/scripts/get_testitem_data/test_get_testitem_data.py
@@ -957,6 +957,21 @@ def test_load_molecule_hierarchy_lookup_missing_columns(
     assert payload.get("column") == "parent_molecule_chembl_id"
 
 
+def test_load_molecule_hierarchy_lookup_normalises_no_parent(
+    tmp_path: Path, cfg: Config
+) -> None:
+    path = tmp_path / "hierarchy.csv"
+    path.write_text(
+        "molecule_chembl_id,parent_molecule_chembl_id\n"
+        "CHEMBL1,NO PARENT\n",
+        encoding=cfg.io.csv_encoding,
+    )
+
+    result = pipeline.load_molecule_hierarchy_lookup(path, io_cfg=cfg.io)
+
+    assert result == {"CHEMBL1": None}
+
+
 def test_prepare_pubchem_caches_primes_local_parent_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- normalise hierarchy dictionary values so missing parents map to None across CLI and pipeline loaders
- ensure dictionary-derived parents, including explicit null markers, mark rows as resolved during parent enrichment
- expand test coverage for hierarchy lookups and enrichment to cover parent hits, explicit nulls, and missing dictionary entries

## Testing
- pytest tests/pipelines/test_get_testitem_data.py -k "load_molecule_hierarchy_lookup_normalises_no_parent or dictionary_sets_parent or dictionary_null_parent_skips_fallback or falls_back_when_missing_from_dictionary" -q
- pytest tests/scripts/get_testitem_data/test_get_testitem_data.py -k "load_molecule_hierarchy_lookup_normalises_no_parent" -q

------
https://chatgpt.com/codex/tasks/task_e_68dfdaf3e20c8324817903235f636f80