### PR TITLE
Skip parent catalog full sync when parentless IDs are filtered

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -401,6 +401,9 @@ def attach_parent_molecule_ids(
     partial_fetch_used = False
     full_sync_used = False
     uncovered_children = 0
+    parentless_filtered = molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    json_cache_exists = catalog_cfg.cache_path.is_file()
+    sqlite_exists = catalog_cfg.sqlite_path.is_file()
 
     from library.pipelines import testitem as pipeline_module
 
@@ -426,7 +429,6 @@ def attach_parent_molecule_ids(
                 if source_resolved is None:
                     source_resolved = PARENT_LOOKUP_SOURCE_CACHE
             else:
-                sqlite_exists = catalog_cfg.sqlite_path.is_file()
                 used_partial_cache = sqlite_exists
                 if sqlite_exists:
                     if source_resolved is None:
@@ -465,7 +467,22 @@ def attach_parent_molecule_ids(
 
     needs_full_sync = catalog is None and uncovered_children > 0
 
-    if missing_ids and catalog is None and needs_full_sync:
+    skip_full_sync = (
+        missing_ids
+        and catalog is None
+        and needs_full_sync
+        and parentless_filtered
+        and not (json_cache_exists or sqlite_exists)
+    )
+
+    if skip_full_sync:
+        logger.warning(
+            "parent_lookup_full_sync_skipped_parentless",
+            count=len(missing_ids),
+            identifiers=missing_ids,
+        )
+        source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
+    elif missing_ids and catalog is None and needs_full_sync:
         cache_before_load = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_catalog_fn(
             client=client,

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -401,6 +401,9 @@ def attach_parent_molecule_ids(
     partial_fetch_used = False
     full_sync_used = False
     uncovered_children = 0
+    parentless_filtered = molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    json_cache_exists = catalog_cfg.cache_path.is_file()
+    sqlite_exists = catalog_cfg.sqlite_path.is_file()
 
     from library import testitem_pipeline as pipeline_module
 
@@ -426,7 +429,6 @@ def attach_parent_molecule_ids(
                 if source_resolved is None:
                     source_resolved = PARENT_LOOKUP_SOURCE_CACHE
             else:
-                sqlite_exists = catalog_cfg.sqlite_path.is_file()
                 used_partial_cache = sqlite_exists
                 if sqlite_exists:
                     if source_resolved is None:
@@ -465,7 +467,22 @@ def attach_parent_molecule_ids(
 
     needs_full_sync = catalog is None and uncovered_children > 0
 
-    if missing_ids and catalog is None and needs_full_sync:
+    skip_full_sync = (
+        missing_ids
+        and catalog is None
+        and needs_full_sync
+        and parentless_filtered
+        and not (json_cache_exists or sqlite_exists)
+    )
+
+    if skip_full_sync:
+        logger.warning(
+            "parent_lookup_full_sync_skipped_parentless",
+            count=len(missing_ids),
+            identifiers=missing_ids,
+        )
+        source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
+    elif missing_ids and catalog is None and needs_full_sync:
         cache_before_load = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_catalog_fn(
             client=client,

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -645,6 +645,9 @@ def attach_parent_molecule_ids(
     partial_fetch_used = False
     full_sync_used = False
     uncovered_children = 0
+    parentless_filtered = molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    json_cache_exists = catalog_cfg.cache_path.is_file()
+    sqlite_exists = catalog_cfg.sqlite_path.is_file()
 
     if catalog is not None:
         base_view = {key: catalog[key] for key in unique_children if key in catalog}
@@ -659,7 +662,6 @@ def attach_parent_molecule_ids(
                 if source_resolved is None:
                     source_resolved = PARENT_LOOKUP_SOURCE_CACHE
             else:
-                sqlite_exists = catalog_cfg.sqlite_path.is_file()
                 used_partial_cache = sqlite_exists
                 if sqlite_exists:
                     if source_resolved is None:
@@ -698,7 +700,22 @@ def attach_parent_molecule_ids(
 
     needs_full_sync = catalog is None and uncovered_children > 0
 
-    if missing_ids and catalog is None and needs_full_sync:
+    skip_full_sync = (
+        missing_ids
+        and catalog is None
+        and needs_full_sync
+        and parentless_filtered
+        and not (json_cache_exists or sqlite_exists)
+    )
+
+    if skip_full_sync:
+        logger.warning(
+            "parent_lookup_full_sync_skipped_parentless",
+            count=len(missing_ids),
+            identifiers=missing_ids,
+        )
+        source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
+    elif missing_ids and catalog is None and needs_full_sync:
         cache_before_load = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_parent_catalog(
             client=client,
@@ -720,6 +737,13 @@ def attach_parent_molecule_ids(
         }
         missing_ids = [key for key in unique_children if key not in parent_map]
         uncovered_children = len(missing_ids)
+
+    if missing_ids:
+        logger.warning(
+            "parent_lookup_missing_parents",
+            count=len(missing_ids),
+            identifiers=missing_ids,
+        )
 
     refreshed_parent = normalised_child.map(parent_map).astype("string")
     refreshed_normalised = refreshed_parent.fillna("").astype("string")

--- a/tests/pipelines/test_get_testitem_data.py
+++ b/tests/pipelines/test_get_testitem_data.py
@@ -3171,6 +3171,57 @@ def test_attach_parent_molecule_ids_handles_partial_remote_success(
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])
+def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: Config,
+    use_precomputed: bool,
+) -> None:
+    child_field = cfg.sources.chembl.molecule_catalog.child_field
+    df = pd.DataFrame({child_field: ["CHEMBL_NO_PARENT"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    def unexpected_load_parent_catalog(**_: object) -> dict[str, str]:
+        raise AssertionError("load_parent_catalog should not be called")
+
+    monkeypatch.setattr(pipeline, "load_parent_catalog", unexpected_load_parent_catalog)
+    monkeypatch.setattr(pipeline, "query_parent_catalog", lambda *_, **__: {})
+    monkeypatch.setattr(
+        pipeline.molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
+    )
+
+    captured_warnings: list[tuple[str, dict[str, object]]] = []
+
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured_warnings.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(pipeline.logger, "warning", fake_warning)
+
+    precomputed = (
+        prepare_parent_lookup_data(df, catalog_cfg) if use_precomputed else None
+    )
+    result, stats = pipeline.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+        precomputed=precomputed,
+    )
+
+    assert result[catalog_cfg.parent_field].tolist() == [pd.NA]
+    assert stats.source == pipeline.PARENT_LOOKUP_SOURCE_SKIPPED
+    assert stats.missing == 1
+    assert stats.uncovered == 1
+    skip_events = [event for event, _ in captured_warnings]
+    assert "parent_lookup_full_sync_skipped_parentless" in skip_events
+    assert "parent_lookup_missing_parents" in skip_events
+
+
+@pytest.mark.parametrize("use_precomputed", [False, True])
 def test_attach_parent_molecule_ids_updates_cache_for_reuse(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/scripts/get_testitem_data/test_get_testitem_data.py
@@ -71,7 +71,11 @@ def prepare_parent_lookup_data(
     need_lookup_mask = (normalised_child != "") & (existing_parent == "")
     need_lookup = set(normalised_child[need_lookup_mask])
 
-    return pipeline.ParentLookupPreparedData(
+    parent_lookup_cls = getattr(
+        pipeline, "ParentLookupPreparedData", gtd.ParentLookupPreparedData
+    )
+
+    return parent_lookup_cls(
         child_ids=normalised_child,
         existing_parent_ids=existing_parent,
         need_lookup=need_lookup,
@@ -463,7 +467,7 @@ def test_prepare_parent_enrichment_uses_lookup_path(
     monkeypatch.setattr(pipeline, "load_molecule_hierarchy_lookup", fake_lookup)
     monkeypatch.setattr(pipeline, "query_parent_catalog", lambda *_, **__: {})
     monkeypatch.setattr(
-        pipeline.molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
+        molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
     )
     monkeypatch.setattr(pipeline, "load_parent_catalog", lambda *_, **__: {})
 
@@ -3044,6 +3048,65 @@ def test_attach_parent_molecule_ids_handles_partial_remote_success(
     assert stats.attached == 1
     assert stats.missing == 1
     assert stats.source == pipeline.PARENT_LOOKUP_SOURCE_SYNC
+
+
+@pytest.mark.parametrize("use_precomputed", [False, True])
+def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: Config,
+    use_precomputed: bool,
+) -> None:
+    child_field = cfg.sources.chembl.molecule_catalog.child_field
+    df = pd.DataFrame({child_field: ["CHEMBL_NO_PARENT"]})
+
+    catalog_cfg = cfg.sources.chembl.molecule_catalog.model_copy(deep=True)
+    catalog_cfg.cache_path = tmp_path / "catalog.json"
+    catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
+
+    attach_module = pipeline
+    if not hasattr(attach_module, "attach_parent_molecule_ids"):
+        attach_module = gtd
+
+    def unexpected_load_parent_catalog(**_: object) -> dict[str, str]:
+        raise AssertionError("load_parent_catalog should not be called")
+
+    monkeypatch.setattr(attach_module, "load_parent_catalog", unexpected_load_parent_catalog)
+    monkeypatch.setattr(attach_module, "query_parent_catalog", lambda *_, **__: {})
+    monkeypatch.setattr(
+        molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
+    )
+
+    logger_target = getattr(attach_module, "logger", gtd.logger)
+
+    captured_warnings: list[tuple[str, dict[str, object]]] = []
+
+    def fake_warning(event: str, *args: object, **kwargs: object) -> None:
+        captured_warnings.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(logger_target, "warning", fake_warning)
+
+    precomputed = (
+        prepare_parent_lookup_data(df, catalog_cfg) if use_precomputed else None
+    )
+    result, stats = attach_module.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+        precomputed=precomputed,
+    )
+
+    assert result[catalog_cfg.parent_field].tolist() == [pd.NA]
+    assert stats.source == getattr(
+        attach_module, "PARENT_LOOKUP_SOURCE_SKIPPED", pipeline.PARENT_LOOKUP_SOURCE_SKIPPED
+    )
+    assert stats.missing == 1
+    assert stats.uncovered == 1
+    skip_events = [event for event, _ in captured_warnings]
+    assert "parent_lookup_full_sync_skipped_parentless" in skip_events
+    assert "parent_lookup_missing_parents" in skip_events
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])


### PR DESCRIPTION
## Summary
- avoid triggering the expensive parent catalog sync when parentless identifiers are filtered out and no cache is present
- log the skipped sync and missing parents in all catalog helpers, including the CLI script implementation
- add regression coverage to ensure both pipeline variants log the skip and maintain stats when the sync is bypassed

## Testing
- pytest tests/pipelines/test_get_testitem_data.py -k "skips_full_sync_when_parentless_filtered"
- pytest tests/scripts/get_testitem_data/test_get_testitem_data.py -k "skips_full_sync_when_parentless_filtered"

------
https://chatgpt.com/codex/tasks/task_e_68dfdb53aeb08324ac679296dfdb9fc5