### PR TITLE
Handle tmp suffix when postprocessing document export

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -503,8 +503,12 @@ def postprocess_export_file(
         ref_document=ref_document,
         ref_document_path=ref_document_path,
     )
-    destination = Path(output_path) if output_path else Path(input_path).with_name(
-        f"{DEFAULT_OUTPUT_PREFIX}{Path(input_path).name}"
+    destination = (
+        Path(output_path)
+        if output_path
+        else Path(input_path).with_name(
+            f"{DEFAULT_OUTPUT_PREFIX}{_derive_output_basename(Path(input_path).name)}"
+        )
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
     col_order = [
@@ -522,6 +526,13 @@ def postprocess_export_file(
         cfg=None,
     )
     return destination
+
+
+def _derive_output_basename(source_name: str) -> str:
+    """Normalise ``source_name`` for the generated artefact."""
+
+    normalised = source_name.lstrip(".")
+    return normalised[:-4] if normalised.endswith(".tmp") else normalised
 
 
 

--- a/tests/library/postprocessing/test_postprocessing_document.py
+++ b/tests/library/postprocessing/test_postprocessing_document.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pandas as pd
+
+from library.config import IoCfg
+from library.postprocessing import document as document_export_postprocessing
+
+
+FIXTURE_DIR = Path("tests/data/postprocessing_document")
+
+
+def test_postprocess_export_file_strips_tmp_suffix(tmp_path: Path) -> None:
+    """Temporary suffixes are removed when deriving the output path."""
+
+    source = FIXTURE_DIR / "output.document_20230101.csv"
+    input_path = tmp_path / ".output.documents_test.csv.tmp"
+    input_path.write_bytes(source.read_bytes())
+
+    cfg = IoCfg(csv_sep=",", csv_encoding="utf-8")
+    output_path = document_export_postprocessing.postprocess_export_file(
+        input_path,
+        cfg=cfg,
+        ref_document_path=FIXTURE_DIR / "document.csv",
+    )
+
+    assert output_path.name == "preprocessed_output.documents_test.csv"
+    assert output_path.exists()
+
+    produced = pd.read_csv(output_path, dtype=str)
+    assert not produced.empty


### PR DESCRIPTION
## Summary
- normalise the derived document export output filename to strip leading dots and temporary suffixes
- keep the explicit output path handling untouched while adjusting the helper
- add a regression test covering the `.tmp` suffixed input file scenario

## Testing
- pytest tests/unit/library/pipelines/document/test_document_export_postprocessing.py tests/library/postprocessing/test_postprocessing_document.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe16bd33c83248caf31b67ecebb1c