### PR TITLE
Add watchdogs, metrics, and tests for parentless parent lookup

### DIFF
--- a/library/common/watchdog.py
+++ b/library/common/watchdog.py
@@ -1,0 +1,76 @@
+"""Utility helpers for logging stage SLA breaches."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from threading import Event, Timer
+from time import perf_counter
+from typing import Any, Mapping
+
+from .log import logger
+
+
+@dataclass(slots=True)
+class StageWatchdog(AbstractContextManager["StageWatchdog"]):
+    """Monitor execution time for long running stages.
+
+    The watchdog starts a background timer that emits a warning when the
+    configured SLA threshold is exceeded. The caller can inspect the elapsed
+    time and whether the SLA was breached once the monitored block finishes.
+    """
+
+    stage: str
+    event: str
+    sla_seconds: float
+    context: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.sla_seconds < 0:
+            raise ValueError("sla_seconds must be non-negative")
+        self._timer: Timer | None = None
+        self._start = 0.0
+        self._elapsed = 0.0
+        self._breached = Event()
+
+    def __enter__(self) -> "StageWatchdog":
+        self._start = perf_counter()
+        if self.sla_seconds:
+            self._timer = Timer(self.sla_seconds, self._trigger)
+            self._timer.daemon = True
+            self._timer.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool | None:
+        self.cancel()
+        self._elapsed = perf_counter() - self._start
+        return None
+
+    def cancel(self) -> None:
+        """Cancel the watchdog timer if it is running."""
+
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    def _trigger(self) -> None:
+        self._breached.set()
+        payload = {"stage": self.stage, "sla_seconds": self.sla_seconds}
+        if self.context:
+            payload.update(self.context)
+        logger.warning(self.event, **payload)
+
+    @property
+    def breached(self) -> bool:
+        """Return ``True`` when the SLA threshold was exceeded."""
+
+        return self._breached.is_set()
+
+    @property
+    def elapsed(self) -> float:
+        """Return the elapsed time in seconds for the monitored block."""
+
+        return self._elapsed
+
+
+__all__ = ["StageWatchdog"]

--- a/library/config.py
+++ b/library/config.py
@@ -393,6 +393,20 @@ class MoleculeCatalogCfg(_BaseModel):
     )
     page_size: int = Field(500, ge=1)
     fallback_single_limit: int | None = Field(default=None, ge=1)
+    enable_full_sync_for_parentless: bool = Field(
+        True,
+        description="Allow loading the full parent catalogue when parent lookups fail",
+    )
+    parent_lookup_sla_seconds: float = Field(
+        300.0,
+        ge=0,
+        description="SLA threshold for parent lookup enrichment in seconds",
+    )
+    full_sync_progress_page_interval: int = Field(
+        25,
+        ge=1,
+        description="Emit informational progress logs every N pages during full sync",
+    )
 
 
 class OpenAlexCfg(_BaseModel):
@@ -557,6 +571,11 @@ class PubChemCfg(_BaseModel):
         None,
         ge=0,
         description="Optional TTL for the persisted CID cache in hours",
+    )
+    augment_sla_seconds: float = Field(
+        300.0,
+        ge=0,
+        description="SLA threshold for augmenting PubChem data in seconds",
     )
     cid_cache_path: Path | None = Field(
         default_factory=lambda: _default_base_path()

--- a/library/integration/molecule_catalog.py
+++ b/library/integration/molecule_catalog.py
@@ -561,6 +561,9 @@ def fetch_parent_catalog(
     next_url: str | None = url
     result: dict[str, str] = {}
     effective_timeout = timeout if timeout is not None else api_cfg.timeout_read
+    start_time = perf_counter()
+    page_count = 0
+    progress_interval = getattr(catalog_cfg, "full_sync_progress_page_interval", 0)
 
     while next_url:
         logger.debug("parent_catalog_page", url=next_url, collected=len(result))
@@ -591,6 +594,15 @@ def fetch_parent_catalog(
         page_meta = data.get("page_meta") or {}
         next_token = page_meta.get("next")
         next_url = urljoin(api_cfg.chembl_base, next_token) if next_token else None
+        page_count += 1
+        if progress_interval and page_count % progress_interval == 0:
+            elapsed = perf_counter() - start_time
+            logger.info(
+                "parent_catalog_progress",
+                pages=page_count,
+                entries=len(result),
+                elapsed_seconds=elapsed,
+            )
 
     return result
 

--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import ChainMap
 from dataclasses import dataclass
 from functools import lru_cache
+from time import perf_counter
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, NamedTuple, Sequence
 
@@ -15,6 +16,7 @@ from library.integration import molecule_catalog
 from library.integration.chembl_client import ChemblClient
 from library.config import ApiCfg, IoCfg, MoleculeCatalogCfg
 from library.common.log import logger
+from library.common.watchdog import StageWatchdog
 from library.integration.molecule_catalog import (
     load_parent_catalog,
     query_parent_catalog,
@@ -78,6 +80,8 @@ class ParentLookupStats:
     hierarchy_attached: int = 0
     fallback_attached: int = 0
     no_parent: int = 0
+    remaining_before_full_sync: int = 0
+    full_sync_duration_seconds: float = 0.0
 
 
 class ParentLookupPreparedData(NamedTuple):
@@ -113,6 +117,10 @@ def _merge_parent_stats(base: ParentLookupStats, update: ParentLookupStats) -> P
         hierarchy_attached=base.hierarchy_attached + update.hierarchy_attached,
         fallback_attached=base.fallback_attached + update.fallback_attached,
         no_parent=base.no_parent + update.no_parent,
+        remaining_before_full_sync=
+            base.remaining_before_full_sync + update.remaining_before_full_sync,
+        full_sync_duration_seconds=
+            base.full_sync_duration_seconds + update.full_sync_duration_seconds,
     )
 
 
@@ -464,29 +472,52 @@ def attach_parent_molecule_ids(
                 used_partial_cache = True
 
     needs_full_sync = catalog is None and uncovered_children > 0
+    full_sync_remaining_before = 0
+    full_sync_duration = 0.0
+    full_sync_enabled = getattr(catalog_cfg, "enable_full_sync_for_parentless", True)
 
     if missing_ids and catalog is None and needs_full_sync:
-        cache_before_load = _cache_state(catalog_cfg.cache_path)
-        catalog_data = load_catalog_fn(
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-        )
-        cache_after_load = _cache_state(catalog_cfg.cache_path)
-        full_sync_used = True
-        source_resolved = _resolve_catalog_load_source(
-            cache_before_load, cache_after_load
-        )
-        if partial_fetch_used:
-            catalog_data.update(fetched)
-        parent_map = {
-            key: catalog_data.get(key, parent_map.get(key, ""))
-            for key in unique_children
-            if key in catalog_data or key in parent_map
-        }
-        missing_ids = [key for key in unique_children if key not in parent_map]
-        uncovered_children = len(missing_ids)
+        if not full_sync_enabled:
+            logger.info(
+                "parent_lookup_full_sync_skipped",
+                missing=len(missing_ids),
+                reason="disabled_for_parentless",
+            )
+        else:
+            cache_before_load = _cache_state(catalog_cfg.cache_path)
+            logger.info(
+                "parent_lookup_full_sync_start",
+                remaining=uncovered_children,
+            )
+            sync_start = perf_counter()
+            catalog_data = load_catalog_fn(
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+            )
+            full_sync_duration = perf_counter() - sync_start
+            cache_after_load = _cache_state(catalog_cfg.cache_path)
+            full_sync_used = True
+            full_sync_remaining_before = uncovered_children
+            source_resolved = _resolve_catalog_load_source(
+                cache_before_load, cache_after_load
+            )
+            if partial_fetch_used:
+                catalog_data.update(fetched)
+            parent_map = {
+                key: catalog_data.get(key, parent_map.get(key, ""))
+                for key in unique_children
+                if key in catalog_data or key in parent_map
+            }
+            missing_ids = [key for key in unique_children if key not in parent_map]
+            uncovered_children = len(missing_ids)
+            logger.info(
+                "parent_lookup_full_sync_done",
+                remaining_before=full_sync_remaining_before,
+                elapsed_seconds=full_sync_duration,
+                catalog_size=len(catalog_data),
+            )
 
     if missing_ids:
         logger.warning(
@@ -552,6 +583,8 @@ def attach_parent_molecule_ids(
         failed_ids=tuple(missing_ids),
         fallback_attached=int(fallback_attached),
         no_parent=int(no_parent_count),
+        remaining_before_full_sync=int(full_sync_remaining_before),
+        full_sync_duration_seconds=float(full_sync_duration),
     )
 
     logger.info(
@@ -564,6 +597,8 @@ def attach_parent_molecule_ids(
         hierarchy_attached=stats.hierarchy_attached,
         fallback_attached=stats.fallback_attached,
         no_parent=stats.no_parent,
+        full_sync_duration_seconds=stats.full_sync_duration_seconds,
+        remaining_before_full_sync=stats.remaining_before_full_sync,
     )
 
     return result, stats
@@ -739,20 +774,28 @@ def run_parent_enrichment(
     """Attach parent molecule identifiers using the prepared context."""
 
     logger.info("parent_lookup_start")
-    try:
-        df, attach_stats = attach_parent_molecule_ids(
-            prep.df,
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-            catalog=prep.parent_catalog,
-            source=prep.parent_catalog_source,
-            precomputed=prep.lookup_data,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("parent_lookup_failed", error=str(exc))
-        return 1, None
+    sla_seconds = getattr(catalog_cfg, "parent_lookup_sla_seconds", 0.0)
+    with StageWatchdog(
+        stage="parent_lookup",
+        event="parent_lookup_sla_breached",
+        sla_seconds=float(sla_seconds),
+        context={"rows": int(len(prep.df))},
+    ) as watchdog:
+        try:
+            df, attach_stats = attach_parent_molecule_ids(
+                prep.df,
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+                catalog=prep.parent_catalog,
+                source=prep.parent_catalog_source,
+                precomputed=prep.lookup_data,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("parent_lookup_failed", error=str(exc))
+            return 1, None
+    elapsed_seconds = watchdog.elapsed
 
     combined_stats = _merge_parent_stats(prep.parent_stats, attach_stats)
 
@@ -766,6 +809,11 @@ def run_parent_enrichment(
         hierarchy_attached=combined_stats.hierarchy_attached,
         fallback_attached=combined_stats.fallback_attached,
         no_parent=combined_stats.no_parent,
+        elapsed_seconds=elapsed_seconds,
+        sla_seconds=sla_seconds,
+        sla_breached=watchdog.breached,
+        full_sync_duration_seconds=combined_stats.full_sync_duration_seconds,
+        remaining_before_full_sync=combined_stats.remaining_before_full_sync,
     )
 
     return 0, ParentEnrichmentResult(df=df, parent_stats=combined_stats)

--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -859,6 +859,8 @@ def finalize_output(
         "parent_lookup_hierarchy_attached": parent_stats.hierarchy_attached,
         "parent_lookup_fallback_attached": parent_stats.fallback_attached,
         "parent_lookup_no_parent": parent_stats.no_parent,
+        "parent_lookup_remaining_before_full_sync": parent_stats.remaining_before_full_sync,
+        "parent_lookup_full_sync_seconds": parent_stats.full_sync_duration_seconds,
     }
     if missing_ids_tuple:
         stats["missing_molecule_ids"] = list(missing_ids_tuple)

--- a/library/pipelines/testitem/pubchem.py
+++ b/library/pipelines/testitem/pubchem.py
@@ -17,6 +17,7 @@ import requests
 from library.integration.chembl_client import ChemblClient
 from library.config import ApiCfg, PubChemCfg, RetryCfg
 from library.common.log import logger
+from library.common.watchdog import StageWatchdog
 from library.utils.atomic import open_atomic
 
 if TYPE_CHECKING:
@@ -846,20 +847,33 @@ def augment_pubchem(
         pubchem_resolution_cache = cast(ResolutionCache, {})
         pubchem_parent_record_cache = {}
 
-    logger.info("pubchem_augment_start")
-    result = add_pubchem_data(
-        df,
-        pubchem_cfg,
-        client=client,
-        api_cfg=api_cfg,
-        timeout=timeout,
-        cid_cache=pubchem_cid_cache,
-        resolution_cache=pubchem_resolution_cache,
-        parent_record_cache=pubchem_parent_record_cache,
-        testitem_fields=fields,
-        request_limit=request_limit,
+    logger.info("pubchem_augment_start", rows=int(len(df)))
+    sla_seconds = getattr(pubchem_cfg, "augment_sla_seconds", 0.0)
+    with StageWatchdog(
+        stage="pubchem",
+        event="pubchem_sla_breached",
+        sla_seconds=float(sla_seconds),
+        context={"rows": int(len(df))},
+    ) as watchdog:
+        result = add_pubchem_data(
+            df,
+            pubchem_cfg,
+            client=client,
+            api_cfg=api_cfg,
+            timeout=timeout,
+            cid_cache=pubchem_cid_cache,
+            resolution_cache=pubchem_resolution_cache,
+            parent_record_cache=pubchem_parent_record_cache,
+            testitem_fields=fields,
+            request_limit=request_limit,
+        )
+    logger.info(
+        "pubchem_augment_done",
+        elapsed_seconds=watchdog.elapsed,
+        sla_seconds=sla_seconds,
+        sla_breached=watchdog.breached,
+        rows=int(len(result)),
     )
-    logger.info("pubchem_augment_done")
     return result
 
 

--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import ChainMap
 from dataclasses import dataclass
 from functools import lru_cache
+from time import perf_counter
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, NamedTuple, Sequence
 
@@ -15,6 +16,7 @@ from library.integration import molecule_catalog
 from library.integration.chembl_client import ChemblClient
 from library.config import ApiCfg, IoCfg, MoleculeCatalogCfg
 from library.common.log import logger
+from library.common.watchdog import StageWatchdog
 from library.integration.molecule_catalog import (
     load_parent_catalog,
     query_parent_catalog,
@@ -78,6 +80,8 @@ class ParentLookupStats:
     hierarchy_attached: int = 0
     fallback_attached: int = 0
     no_parent: int = 0
+    remaining_before_full_sync: int = 0
+    full_sync_duration_seconds: float = 0.0
 
 
 class ParentLookupPreparedData(NamedTuple):
@@ -113,6 +117,10 @@ def _merge_parent_stats(base: ParentLookupStats, update: ParentLookupStats) -> P
         hierarchy_attached=base.hierarchy_attached + update.hierarchy_attached,
         fallback_attached=base.fallback_attached + update.fallback_attached,
         no_parent=base.no_parent + update.no_parent,
+        remaining_before_full_sync=
+            base.remaining_before_full_sync + update.remaining_before_full_sync,
+        full_sync_duration_seconds=
+            base.full_sync_duration_seconds + update.full_sync_duration_seconds,
     )
 
 
@@ -464,29 +472,52 @@ def attach_parent_molecule_ids(
                 used_partial_cache = True
 
     needs_full_sync = catalog is None and uncovered_children > 0
+    full_sync_remaining_before = 0
+    full_sync_duration = 0.0
+    full_sync_enabled = getattr(catalog_cfg, "enable_full_sync_for_parentless", True)
 
     if missing_ids and catalog is None and needs_full_sync:
-        cache_before_load = _cache_state(catalog_cfg.cache_path)
-        catalog_data = load_catalog_fn(
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-        )
-        cache_after_load = _cache_state(catalog_cfg.cache_path)
-        full_sync_used = True
-        source_resolved = _resolve_catalog_load_source(
-            cache_before_load, cache_after_load
-        )
-        if partial_fetch_used:
-            catalog_data.update(fetched)
-        parent_map = {
-            key: catalog_data.get(key, parent_map.get(key, ""))
-            for key in unique_children
-            if key in catalog_data or key in parent_map
-        }
-        missing_ids = [key for key in unique_children if key not in parent_map]
-        uncovered_children = len(missing_ids)
+        if not full_sync_enabled:
+            logger.info(
+                "parent_lookup_full_sync_skipped",
+                missing=len(missing_ids),
+                reason="disabled_for_parentless",
+            )
+        else:
+            cache_before_load = _cache_state(catalog_cfg.cache_path)
+            logger.info(
+                "parent_lookup_full_sync_start",
+                remaining=uncovered_children,
+            )
+            sync_start = perf_counter()
+            catalog_data = load_catalog_fn(
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+            )
+            full_sync_duration = perf_counter() - sync_start
+            cache_after_load = _cache_state(catalog_cfg.cache_path)
+            full_sync_used = True
+            full_sync_remaining_before = uncovered_children
+            source_resolved = _resolve_catalog_load_source(
+                cache_before_load, cache_after_load
+            )
+            if partial_fetch_used:
+                catalog_data.update(fetched)
+            parent_map = {
+                key: catalog_data.get(key, parent_map.get(key, ""))
+                for key in unique_children
+                if key in catalog_data or key in parent_map
+            }
+            missing_ids = [key for key in unique_children if key not in parent_map]
+            uncovered_children = len(missing_ids)
+            logger.info(
+                "parent_lookup_full_sync_done",
+                remaining_before=full_sync_remaining_before,
+                elapsed_seconds=full_sync_duration,
+                catalog_size=len(catalog_data),
+            )
 
     if missing_ids:
         logger.warning(
@@ -552,6 +583,8 @@ def attach_parent_molecule_ids(
         failed_ids=tuple(missing_ids),
         fallback_attached=int(fallback_attached),
         no_parent=int(no_parent_count),
+        remaining_before_full_sync=int(full_sync_remaining_before),
+        full_sync_duration_seconds=float(full_sync_duration),
     )
 
     logger.info(
@@ -564,6 +597,8 @@ def attach_parent_molecule_ids(
         hierarchy_attached=stats.hierarchy_attached,
         fallback_attached=stats.fallback_attached,
         no_parent=stats.no_parent,
+        full_sync_duration_seconds=stats.full_sync_duration_seconds,
+        remaining_before_full_sync=stats.remaining_before_full_sync,
     )
 
     return result, stats
@@ -739,20 +774,28 @@ def run_parent_enrichment(
     """Attach parent molecule identifiers using the prepared context."""
 
     logger.info("parent_lookup_start")
-    try:
-        df, attach_stats = attach_parent_molecule_ids(
-            prep.df,
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-            catalog=prep.parent_catalog,
-            source=prep.parent_catalog_source,
-            precomputed=prep.lookup_data,
-        )
-    except (requests.RequestException, ValueError) as exc:
-        logger.error("parent_lookup_failed", error=str(exc))
-        return 1, None
+    sla_seconds = getattr(catalog_cfg, "parent_lookup_sla_seconds", 0.0)
+    with StageWatchdog(
+        stage="parent_lookup",
+        event="parent_lookup_sla_breached",
+        sla_seconds=float(sla_seconds),
+        context={"rows": int(len(prep.df))},
+    ) as watchdog:
+        try:
+            df, attach_stats = attach_parent_molecule_ids(
+                prep.df,
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+                catalog=prep.parent_catalog,
+                source=prep.parent_catalog_source,
+                precomputed=prep.lookup_data,
+            )
+        except (requests.RequestException, ValueError) as exc:
+            logger.error("parent_lookup_failed", error=str(exc))
+            return 1, None
+    elapsed_seconds = watchdog.elapsed
 
     combined_stats = _merge_parent_stats(prep.parent_stats, attach_stats)
 
@@ -766,6 +809,11 @@ def run_parent_enrichment(
         hierarchy_attached=combined_stats.hierarchy_attached,
         fallback_attached=combined_stats.fallback_attached,
         no_parent=combined_stats.no_parent,
+        elapsed_seconds=elapsed_seconds,
+        sla_seconds=sla_seconds,
+        sla_breached=watchdog.breached,
+        full_sync_duration_seconds=combined_stats.full_sync_duration_seconds,
+        remaining_before_full_sync=combined_stats.remaining_before_full_sync,
     )
 
     return 0, ParentEnrichmentResult(df=df, parent_stats=combined_stats)

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -840,6 +840,8 @@ def finalize_output(
         "parent_lookup_hierarchy_attached": parent_stats.hierarchy_attached,
         "parent_lookup_fallback_attached": parent_stats.fallback_attached,
         "parent_lookup_no_parent": parent_stats.no_parent,
+        "parent_lookup_remaining_before_full_sync": parent_stats.remaining_before_full_sync,
+        "parent_lookup_full_sync_seconds": parent_stats.full_sync_duration_seconds,
     }
     if missing_ids_tuple:
         stats["missing_molecule_ids"] = list(missing_ids_tuple)

--- a/library/testitem_pipeline/pubchem.py
+++ b/library/testitem_pipeline/pubchem.py
@@ -19,6 +19,7 @@ from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
 from library.integration.chembl_client import ChemblClient
 from library.config import ApiCfg, PubChemCfg, RetryCfg
 from library.common.log import logger
+from library.common.watchdog import StageWatchdog
 from library.utils.atomic import open_atomic
 
 UTC = timezone.utc  # noqa: UP017
@@ -812,20 +813,33 @@ def augment_pubchem(
         pubchem_resolution_cache = cast(ResolutionCache, {})
         pubchem_parent_record_cache = {}
 
-    logger.info("pubchem_augment_start")
-    result = add_pubchem_data(
-        df,
-        pubchem_cfg,
-        client=client,
-        api_cfg=api_cfg,
-        timeout=timeout,
-        cid_cache=pubchem_cid_cache,
-        resolution_cache=pubchem_resolution_cache,
-        parent_record_cache=pubchem_parent_record_cache,
-        testitem_fields=fields,
-        request_limit=request_limit,
+    logger.info("pubchem_augment_start", rows=int(len(df)))
+    sla_seconds = getattr(pubchem_cfg, "augment_sla_seconds", 0.0)
+    with StageWatchdog(
+        stage="pubchem",
+        event="pubchem_sla_breached",
+        sla_seconds=float(sla_seconds),
+        context={"rows": int(len(df))},
+    ) as watchdog:
+        result = add_pubchem_data(
+            df,
+            pubchem_cfg,
+            client=client,
+            api_cfg=api_cfg,
+            timeout=timeout,
+            cid_cache=pubchem_cid_cache,
+            resolution_cache=pubchem_resolution_cache,
+            parent_record_cache=pubchem_parent_record_cache,
+            testitem_fields=fields,
+            request_limit=request_limit,
+        )
+    logger.info(
+        "pubchem_augment_done",
+        elapsed_seconds=watchdog.elapsed,
+        sla_seconds=sla_seconds,
+        sla_breached=watchdog.breached,
+        rows=int(len(result)),
     )
-    logger.info("pubchem_augment_done")
     return result
 
 

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -16,6 +16,7 @@ from collections import ChainMap
 from dataclasses import dataclass
 from functools import lru_cache
 from datetime import UTC, datetime, timedelta
+from time import perf_counter
 from pathlib import Path
 from typing import (
     Any,
@@ -459,6 +460,8 @@ class ParentLookupStats:
     hierarchy_attached: int = 0
     fallback_attached: int = 0
     no_parent: int = 0
+    remaining_before_full_sync: int = 0
+    full_sync_duration_seconds: float = 0.0
 
 
 def _cache_state(path: Path) -> tuple[bool, float | None]:
@@ -697,29 +700,52 @@ def attach_parent_molecule_ids(
                 used_partial_cache = True
 
     needs_full_sync = catalog is None and uncovered_children > 0
+    full_sync_remaining_before = 0
+    full_sync_duration = 0.0
+    full_sync_enabled = getattr(catalog_cfg, "enable_full_sync_for_parentless", True)
 
     if missing_ids and catalog is None and needs_full_sync:
-        cache_before_load = _cache_state(catalog_cfg.cache_path)
-        catalog_data = load_parent_catalog(
-            client=client,
-            api_cfg=api_cfg,
-            catalog_cfg=catalog_cfg,
-            timeout=timeout,
-        )
-        cache_after_load = _cache_state(catalog_cfg.cache_path)
-        full_sync_used = True
-        source_resolved = _resolve_catalog_load_source(
-            cache_before_load, cache_after_load
-        )
-        if partial_fetch_used:
-            catalog_data.update(fetched)
-        parent_map = {
-            key: catalog_data.get(key, parent_map.get(key, ""))
-            for key in unique_children
-            if key in catalog_data or key in parent_map
-        }
-        missing_ids = [key for key in unique_children if key not in parent_map]
-        uncovered_children = len(missing_ids)
+        if not full_sync_enabled:
+            logger.info(
+                "parent_lookup_full_sync_skipped",
+                missing=len(missing_ids),
+                reason="disabled_for_parentless",
+            )
+        else:
+            cache_before_load = _cache_state(catalog_cfg.cache_path)
+            logger.info(
+                "parent_lookup_full_sync_start",
+                remaining=uncovered_children,
+            )
+            sync_start = perf_counter()
+            catalog_data = load_parent_catalog(
+                client=client,
+                api_cfg=api_cfg,
+                catalog_cfg=catalog_cfg,
+                timeout=timeout,
+            )
+            full_sync_duration = perf_counter() - sync_start
+            cache_after_load = _cache_state(catalog_cfg.cache_path)
+            full_sync_used = True
+            full_sync_remaining_before = uncovered_children
+            source_resolved = _resolve_catalog_load_source(
+                cache_before_load, cache_after_load
+            )
+            if partial_fetch_used:
+                catalog_data.update(fetched)
+            parent_map = {
+                key: catalog_data.get(key, parent_map.get(key, ""))
+                for key in unique_children
+                if key in catalog_data or key in parent_map
+            }
+            missing_ids = [key for key in unique_children if key not in parent_map]
+            uncovered_children = len(missing_ids)
+            logger.info(
+                "parent_lookup_full_sync_done",
+                remaining_before=full_sync_remaining_before,
+                elapsed_seconds=full_sync_duration,
+                catalog_size=len(catalog_data),
+            )
 
     refreshed_parent = normalised_child.map(parent_map).astype("string")
     refreshed_normalised = refreshed_parent.fillna("").astype("string")
@@ -776,6 +802,8 @@ def attach_parent_molecule_ids(
         failed_ids=tuple(missing_ids),
         fallback_attached=int(fallback_attached),
         no_parent=int(no_parent_count),
+        remaining_before_full_sync=int(full_sync_remaining_before),
+        full_sync_duration_seconds=float(full_sync_duration),
     )
 
     logger.info(
@@ -788,6 +816,8 @@ def attach_parent_molecule_ids(
         hierarchy_attached=stats.hierarchy_attached,
         fallback_attached=stats.fallback_attached,
         no_parent=stats.no_parent,
+        full_sync_duration_seconds=stats.full_sync_duration_seconds,
+        remaining_before_full_sync=stats.remaining_before_full_sync,
     )
 
     return result, stats

--- a/tests/library/testitem_pipeline/test_testitem_pipeline_threadsafe.py
+++ b/tests/library/testitem_pipeline/test_testitem_pipeline_threadsafe.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import threading
+from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from types import SimpleNamespace
 
-from library.config import ApiCfg, PubChemCfg, RetryCfg
+from library.config import ApiCfg, Config, PubChemCfg, RetryCfg
 import library.pipelines.testitem as pipeline
 
 
@@ -273,6 +275,114 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
         ["CHEMBL2"],
     ]
 
+
+def test_run_pipeline_parentless_skips_full_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    """Legacy wrapper also honours parentless full sync flag."""
+
+    cfg.molecule_catalog.enable_full_sync_for_parentless = False
+    cfg.molecule_catalog.hierarchy_lookup_path = None
+    cfg.molecule_catalog.cache_path = tmp_path / "catalog.json"
+    cfg.molecule_catalog.sqlite_path = tmp_path / "catalog.sqlite"
+    cfg.pubchem.enable = False
+
+    chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            cfg.molecule_catalog.parent_field: [pd.NA, pd.NA],
+        }
+    )
+
+    def fake_read_ids(*_args, **_kwargs):
+        return 0, pipeline.ReadInputIdsResult(
+            ids_iter=iter(["CHEMBL1", "CHEMBL2"]),
+            sample_ids=("CHEMBL1",),
+        )
+
+    def fake_fetch(*_args, **_kwargs):
+        return 0, iter([chunk]), ("CHEMBL1", "CHEMBL2")
+
+    captured_stats: dict[str, pipeline.ParentLookupStats] = {}
+
+    def fake_finalize(chunks, **kwargs):
+        for _chunk in chunks:
+            pass
+        captured_stats["parent"] = kwargs["parent_stats_supplier"]()
+        return 0
+
+    def fail_full_sync(*_args, **_kwargs):
+        raise AssertionError("full sync should be disabled for parentless identifiers")
+
+    class DummyClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.client = SimpleNamespace()
+
+        def __enter__(self) -> SimpleNamespace:
+            return self.client
+
+        def __exit__(self, *_args) -> bool:
+            return False
+
+    monkeypatch.setattr("library.testitem_pipeline.cli.read_input_ids", fake_read_ids)
+    monkeypatch.setattr("library.testitem_pipeline.cli.fetch_testitems", fake_fetch)
+    monkeypatch.setattr("library.testitem_pipeline.cli.finalize_output", fake_finalize)
+    monkeypatch.setattr("library.testitem_pipeline.cli.augment_pubchem", lambda df, **_: df)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.apply_testitem_enrichment", lambda df, **_: (0, df)
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.ChemblClient", DummyClient)
+    monkeypatch.setattr(
+        "library.pipelines.testitem.catalog.molecule_catalog.fetch_parent_catalog_for",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "library.pipelines.testitem.catalog.load_parent_catalog",
+        fail_full_sync,
+    )
+    monkeypatch.setattr(
+        "library.pipelines.testitem.catalog.query_parent_catalog", lambda *_args, **_kwargs: {}
+    )
+    monkeypatch.setattr(
+        "library.pipelines.testitem.catalog.update_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "library.pipelines.testitem.catalog.write_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.molecule_catalog.fetch_parent_catalog_for",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.load_parent_catalog",
+        fail_full_sync,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.query_parent_catalog", lambda *_args, **_kwargs: {}
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.update_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.write_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+
+    options = pipeline.TestitemPipelineOptions(
+        input_csv=tmp_path / "input.csv",
+        output_csv=tmp_path / "output.csv",
+    )
+
+    result = pipeline.run_testitem_pipeline(cfg, options)
+
+    assert result == 0
+    parent_stats = captured_stats.get("parent")
+    assert parent_stats is not None
+    assert parent_stats.full_sync_duration_seconds == 0.0
+    assert parent_stats.remaining_before_full_sync == 0
 
 def test_run_pipeline_skips_pubchem_when_disabled(monkeypatch, tmp_path, cfg) -> None:
     """Ensure PubChem augmentation is bypassed when disabled in configuration."""

--- a/tests/pipelines/test_testitem_pipeline_threadsafe.py
+++ b/tests/pipelines/test_testitem_pipeline_threadsafe.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import threading
+from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from types import SimpleNamespace
 
-from library.config import ApiCfg, PubChemCfg, RetryCfg
+from library.config import ApiCfg, Config, PubChemCfg, RetryCfg
 import library.testitem_pipeline as pipeline
 
 
@@ -273,6 +275,95 @@ def test_run_pipeline_streams_missing(monkeypatch, tmp_path, cfg) -> None:
         ["CHEMBL2"],
     ]
 
+
+def test_run_pipeline_parentless_skips_full_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    """Disabling parentless full sync prevents catalogue loading."""
+
+    cfg.molecule_catalog.enable_full_sync_for_parentless = False
+    cfg.molecule_catalog.hierarchy_lookup_path = None
+    cfg.molecule_catalog.cache_path = tmp_path / "catalog.json"
+    cfg.molecule_catalog.sqlite_path = tmp_path / "catalog.sqlite"
+    cfg.pubchem.enable = False
+
+    chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            cfg.molecule_catalog.parent_field: [pd.NA, pd.NA],
+        }
+    )
+
+    def fake_read_ids(*_args, **_kwargs):
+        return 0, pipeline.ReadInputIdsResult(
+            ids_iter=iter(["CHEMBL1", "CHEMBL2"]),
+            sample_ids=("CHEMBL1",),
+        )
+
+    def fake_fetch(*_args, **_kwargs):
+        return 0, iter([chunk]), ("CHEMBL1", "CHEMBL2")
+
+    captured_stats: dict[str, pipeline.ParentLookupStats] = {}
+
+    def fake_finalize(chunks, **kwargs):
+        for _chunk in chunks:
+            pass
+        captured_stats["parent"] = kwargs["parent_stats_supplier"]()
+        return 0
+
+    def fail_full_sync(*_args, **_kwargs):
+        raise AssertionError("full sync should be disabled for parentless identifiers")
+
+    class DummyClient:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.client = SimpleNamespace()
+
+        def __enter__(self) -> SimpleNamespace:
+            return self.client
+
+        def __exit__(self, *_args) -> bool:
+            return False
+
+    monkeypatch.setattr("library.testitem_pipeline.cli.read_input_ids", fake_read_ids)
+    monkeypatch.setattr("library.testitem_pipeline.cli.fetch_testitems", fake_fetch)
+    monkeypatch.setattr("library.testitem_pipeline.cli.finalize_output", fake_finalize)
+    monkeypatch.setattr("library.testitem_pipeline.cli.augment_pubchem", lambda df, **_: df)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.cli.apply_testitem_enrichment", lambda df, **_: (0, df)
+    )
+    monkeypatch.setattr("library.testitem_pipeline.cli.ChemblClient", DummyClient)
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.molecule_catalog.fetch_parent_catalog_for",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.load_parent_catalog",
+        fail_full_sync,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.query_parent_catalog", lambda *_args, **_kwargs: {}
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.update_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "library.testitem_pipeline.catalog.write_parent_catalog_cache",
+        lambda *_args, **_kwargs: None,
+    )
+
+    options = pipeline.TestitemPipelineOptions(
+        input_csv=tmp_path / "input.csv",
+        output_csv=tmp_path / "output.csv",
+    )
+
+    result = pipeline.run_testitem_pipeline(cfg, options)
+
+    assert result == 0
+    parent_stats = captured_stats.get("parent")
+    assert isinstance(parent_stats, pipeline.ParentLookupStats)
+    assert parent_stats.full_sync_duration_seconds == 0.0
+    assert parent_stats.remaining_before_full_sync == 0
 
 def test_run_pipeline_skips_pubchem_when_disabled(monkeypatch, tmp_path, cfg) -> None:
     """Ensure PubChem augmentation is bypassed when disabled in configuration."""


### PR DESCRIPTION
## Summary
- add a reusable StageWatchdog helper and use it to log SLA breaches for parent lookup and PubChem enrichment
- expose configuration toggles for parentless full sync, progress logging, and SLA thresholds while recording new full-sync metrics in stats
- extend parent lookup metadata and tests to verify full sync is skipped for parentless identifiers

## Testing
- pytest tests/pipelines/test_testitem_pipeline_threadsafe.py::test_run_pipeline_parentless_skips_full_sync
- pytest tests/library/testitem_pipeline/test_testitem_pipeline_threadsafe.py::test_run_pipeline_parentless_skips_full_sync

------
https://chatgpt.com/codex/tasks/task_e_68dfdac09cc083248ac97fcd84f16e61