### PR TITLE
Normalize document export basename handling

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -477,6 +477,17 @@ def preprocess_document_export(
     return processed.loc[:, stage_document_postprocessing.FINAL_COLUMN_ORDER]
 
 
+def _normalise_export_basename(source: Path | str) -> str:
+    """Return the ``source`` basename without leading dot or ``.tmp`` suffix."""
+
+    name = Path(source).name
+    if name.startswith("."):
+        name = name[1:]
+    if name.endswith(".tmp"):
+        name = name[: -len(".tmp")]
+    return name
+
+
 def postprocess_export_file(
     input_path: Path | str,
     *,
@@ -503,8 +514,12 @@ def postprocess_export_file(
         ref_document=ref_document,
         ref_document_path=ref_document_path,
     )
-    destination = Path(output_path) if output_path else Path(input_path).with_name(
-        f"{DEFAULT_OUTPUT_PREFIX}{Path(input_path).name}"
+    destination = (
+        Path(output_path)
+        if output_path
+        else Path(input_path).with_name(
+            f"{DEFAULT_OUTPUT_PREFIX}{_normalise_export_basename(input_path)}"
+        )
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
     col_order = [

--- a/tests/library/postprocessing/test_postprocessing_document.py
+++ b/tests/library/postprocessing/test_postprocessing_document.py
@@ -1,0 +1,45 @@
+"""Tests for document post-processing helpers.
+
+Changelog
+~~~~~~~~
+- 2025-02-??: Added regression test for ``postprocess_export_file`` basename
+  normalisation when dealing with temporary export artefacts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.config import IoCfg
+from library.postprocessing import document as document_postprocessing
+
+
+def test_postprocess_export_file_strips_tmp_suffix(monkeypatch, tmp_path: Path) -> None:
+    """Temporary exports lose the leading dot and ``.tmp`` suffix when saved."""
+
+    source_path = tmp_path / ".output.documents_test.csv.tmp"
+    source_path.write_text("document_chembl_id\nCHEMBL:TEST\n", encoding="utf-8")
+
+    processed_frame = pd.DataFrame(
+        {
+            "document_chembl_id": ["CHEMBL:TEST"],
+            "completed": ["true"],
+        }
+    )
+    monkeypatch.setattr(
+        document_postprocessing,
+        "preprocess_document_export",
+        lambda *_, **__: processed_frame,
+    )
+
+    cfg = IoCfg(csv_sep=",", csv_encoding="utf-8")
+
+    destination = document_postprocessing.postprocess_export_file(
+        source_path,
+        cfg=cfg,
+    )
+
+    assert destination.name == "preprocessed_output.documents_test.csv"
+    assert destination.exists()


### PR DESCRIPTION
## Summary
- normalise document export basenames by stripping temporary markers before generating the preprocessed output name
- add a regression test ensuring `.tmp` inputs materialise as `.csv` outputs without the leading dot

## Testing
- pytest tests/unit/library/pipelines/document/test_document_export_postprocessing.py tests/library/postprocessing/test_postprocessing_document.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe2f131a483248783b9daebce7e58