### PR TITLE
Normalize document export tmp basenames

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -488,6 +488,14 @@ def _normalise_export_basename(source: Path | str) -> str:
     return name
 
 
+def _build_default_destination(source: Path | str) -> Path:
+    """Return the default output path for ``source``."""
+
+    source_path = Path(source)
+    base_name = _normalise_export_basename(source_path)
+    return source_path.with_name(f"{DEFAULT_OUTPUT_PREFIX}{base_name}")
+
+
 def postprocess_export_file(
     input_path: Path | str,
     *,
@@ -514,13 +522,7 @@ def postprocess_export_file(
         ref_document=ref_document,
         ref_document_path=ref_document_path,
     )
-    destination = (
-        Path(output_path)
-        if output_path
-        else Path(input_path).with_name(
-            f"{DEFAULT_OUTPUT_PREFIX}{_normalise_export_basename(input_path)}"
-        )
-    )
+    destination = Path(output_path) if output_path else _build_default_destination(input_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     col_order = [
         column

--- a/tests/library/postprocessing/test_postprocessing_document.py
+++ b/tests/library/postprocessing/test_postprocessing_document.py
@@ -41,5 +41,7 @@ def test_postprocess_export_file_strips_tmp_suffix(monkeypatch, tmp_path: Path) 
         cfg=cfg,
     )
 
-    assert destination.name == "preprocessed_output.documents_test.csv"
+    expected_path = tmp_path / "preprocessed_output.documents_test.csv"
+
+    assert destination == expected_path
     assert destination.exists()


### PR DESCRIPTION
## Summary
- reuse a helper to normalise document export basenames before building the default output path
- cover the tmp suffix scenario with a regression test for postprocess_export_file

## Testing
- pytest tests/library/postprocessing/test_postprocessing_document.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe5febaa08324b87f7a5f3f3231c6