### PR TITLE
Handle missing test item fields returned from ChEMBL

### DIFF
--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -386,6 +386,17 @@ def fetch_testitems(
             )
             return _load_chunk(batch, next_chunk_size)
 
+        if fields:
+            missing_fields = [
+                column
+                for column in fields
+                if isinstance(column, str) and column not in frame.columns
+            ]
+            if missing_fields:
+                na_series = pd.Series(pd.NA, index=frame.index, dtype="object")
+                for column in missing_fields:
+                    frame[column] = na_series.copy()
+
         if "molecule_chembl_id" not in frame.columns:
             frame["molecule_chembl_id"] = pd.Series(dtype="string")
         frame["molecule_chembl_id"] = (

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -343,6 +343,17 @@ def fetch_testitems(
             )
             return _load_chunk(batch, next_chunk_size)
 
+        if fields:
+            missing_fields = [
+                column
+                for column in fields
+                if isinstance(column, str) and column not in frame.columns
+            ]
+            if missing_fields:
+                na_series = pd.Series(pd.NA, index=frame.index, dtype="object")
+                for column in missing_fields:
+                    frame[column] = na_series.copy()
+
         if "molecule_chembl_id" not in frame.columns:
             frame["molecule_chembl_id"] = pd.Series(dtype="string")
         frame["molecule_chembl_id"] = (

--- a/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
@@ -288,6 +288,53 @@ def test_fetch_testitems_passes_fields_and_limit(
     assert requested_ids == ("CHEMBL1", "CHEMBL2")
 
 
+def test_fetch_testitems_adds_missing_columns(
+    monkeypatch: pytest.MonkeyPatch, cfg: Config
+) -> None:
+    def fake_get_testitem(
+        ids: Iterable[str],
+        *,
+        cfg: ApiCfg,
+        client: object,
+        chunk_size: int,
+        timeout: float | None,
+        fields: Sequence[str] | None = None,
+        page_limit: int = 0,
+    ) -> pd.DataFrame:
+        _ = (cfg, client, chunk_size, timeout, fields, page_limit)
+        return pd.DataFrame({"molecule_chembl_id": list(ids)})
+
+    monkeypatch.setattr(cl, "get_testitem", fake_get_testitem)
+
+    fields = (
+        "molecule_chembl_id",
+        "parent_molecule_chembl_id",
+        "pubchem_cid",
+    )
+
+    status, chunks, _ = gtd.fetch_testitems(
+        iter(["CHEMBL1", "CHEMBL2"]),
+        api_cfg=cfg.api,
+        batch_size=2,
+        timeout=cfg.testitem.timeout,
+        client=SimpleNamespace(),
+        sample_ids=("CHEMBL1",),
+        fields=fields,
+        page_limit=cfg.testitem.request_limit,
+        retry_cfg=cfg.testitem.batch_retry,
+    )
+
+    assert status == 0
+    assert chunks is not None
+    frames = list(chunks)
+    assert len(frames) == 1
+    frame = frames[0]
+    for column in fields:
+        assert column in frame.columns
+    assert frame["parent_molecule_chembl_id"].isna().all()
+    assert frame["pubchem_cid"].isna().all()
+
+
 def test_fetch_testitems_logs_missing_summary(
     monkeypatch: pytest.MonkeyPatch, cfg: Config
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure missing columns requested from ChEMBL are populated with nulls during test item fetch
- apply the same safeguard to the legacy pipeline fetcher
- cover the behaviour with an integration test for the get_testitem_data CLI

## Testing
- pytest tests/integration/scripts/get_testitem_data/test_get_testitem_data.py::test_fetch_testitems_adds_missing_columns

------
https://chatgpt.com/codex/tasks/task_e_68dfe5ae2cd8832489e81a7eae9054e7