### PR TITLE
Handle parentless filtered catalog full sync

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -656,7 +656,9 @@ def attach_parent_molecule_ids(
     partial_fetch_used = False
     full_sync_used = False
     uncovered_children = 0
-    parentless_filtered = molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    parentless_filtered = bool(
+        molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    )
     json_cache_exists = catalog_cfg.cache_path.is_file()
     sqlite_exists = catalog_cfg.sqlite_path.is_file()
 
@@ -726,6 +728,19 @@ def attach_parent_molecule_ids(
             identifiers=missing_ids,
         )
         source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
+    elif needs_full_sync and parentless_filtered:
+        needs_full_sync = False
+        logger.info(
+            "parent_lookup_skip_full_sync",
+            missing=len(missing_ids),
+            parentless_filtered=True,
+        )
+        if source_resolved is None and not partial_fetch_used:
+            source_resolved = (
+                PARENT_LOOKUP_SOURCE_CACHE
+                if used_partial_cache
+                else PARENT_LOOKUP_SOURCE_SKIPPED
+            )
     elif missing_ids and catalog is None and needs_full_sync:
         cache_before_load = _cache_state(catalog_cfg.cache_path)
         catalog_data = load_parent_catalog(

--- a/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
@@ -3144,11 +3144,17 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     logger_target = getattr(attach_module, "logger", gtd.logger)
 
     captured_warnings: list[tuple[str, dict[str, object]]] = []
+    captured_infos: list[tuple[str, dict[str, object]]] = []
 
     def fake_warning(event: str, *args: object, **kwargs: object) -> None:
         captured_warnings.append((event, dict(kwargs)))
 
     monkeypatch.setattr(logger_target, "warning", fake_warning)
+
+    def fake_info(event: str, *args: object, **kwargs: object) -> None:
+        captured_infos.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(logger_target, "info", fake_info)
 
     precomputed = (
         prepare_parent_lookup_data(df, catalog_cfg) if use_precomputed else None
@@ -3171,6 +3177,29 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     skip_events = [event for event, _ in captured_warnings]
     assert "parent_lookup_full_sync_skipped_parentless" in skip_events
     assert "parent_lookup_missing_parents" in skip_events
+
+    captured_warnings.clear()
+    captured_infos.clear()
+    catalog_cfg.cache_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_cfg.cache_path.write_text("{}", encoding="utf-8")
+
+    result, stats = attach_module.attach_parent_molecule_ids(
+        df,
+        client=object(),
+        api_cfg=cfg.sources.chembl.api,
+        catalog_cfg=catalog_cfg,
+        timeout=None,
+        precomputed=precomputed,
+    )
+
+    assert result[catalog_cfg.parent_field].tolist() == [pd.NA]
+    assert stats.source == getattr(
+        attach_module, "PARENT_LOOKUP_SOURCE_SKIPPED", pipeline.PARENT_LOOKUP_SOURCE_SKIPPED
+    )
+    assert stats.missing == 1
+    assert stats.uncovered == 1
+    info_events = [event for event, _ in captured_infos]
+    assert "parent_lookup_skip_full_sync" in info_events
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])


### PR DESCRIPTION
## Summary
- prevent redundant full sync when parentless-filtered catalogs still report missing IDs
- log the skip event and align `get_testitem_data` with the library implementation
- extend the integration test to assert the new logging behaviour

## Testing
- pytest tests/integration/scripts/get_testitem_data/test_get_testitem_data.py::test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered -q

------
https://chatgpt.com/codex/tasks/task_e_68dfef80a91c8324b6352b0ace26350b