### PR TITLE
Fix parentless full sync short-circuit

### DIFF
--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -412,7 +412,12 @@ def attach_parent_molecule_ids(
     partial_fetch_used = False
     full_sync_used = False
     uncovered_children = 0
-    parentless_filtered = molecule_catalog._filters_exclude_parentless(catalog_cfg)
+    filters_exclude_parentless = getattr(
+        molecule_catalog,
+        "_filters_exclude_parentless",
+        lambda cfg: False,
+    )
+    parentless_filtered = bool(filters_exclude_parentless(catalog_cfg))
     json_cache_exists = catalog_cfg.cache_path.is_file()
     sqlite_exists = catalog_cfg.sqlite_path.is_file()
 
@@ -479,13 +484,7 @@ def attach_parent_molecule_ids(
     needs_full_sync = catalog is None and uncovered_children > 0
 
     # Определяем, нужно ли фильтровать parentless элементы
-    parentless_filtered = False
     if catalog is None:
-        filters_exclude_parentless = getattr(
-            molecule_catalog,
-            "_filters_exclude_parentless",
-            lambda cfg: False,
-        )
         parentless_filtered = bool(filters_exclude_parentless(catalog_cfg))
 
     skip_full_sync = (
@@ -502,6 +501,7 @@ def attach_parent_molecule_ids(
             count=len(missing_ids),
             identifiers=missing_ids,
         )
+        needs_full_sync = False
         source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
     elif needs_full_sync and parentless_filtered:
         needs_full_sync = False

--- a/tests/integration/pipelines/test_get_testitem_data.py
+++ b/tests/integration/pipelines/test_get_testitem_data.py
@@ -3205,10 +3205,13 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     catalog_cfg.cache_path = tmp_path / "catalog.json"
     catalog_cfg.sqlite_path = tmp_path / "catalog.sqlite"
 
-    def unexpected_load_parent_catalog(**_: object) -> dict[str, str]:
-        raise AssertionError("load_parent_catalog should not be called")
+    load_calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(pipeline, "load_parent_catalog", unexpected_load_parent_catalog)
+    def tracking_load_parent_catalog(**kwargs: object) -> dict[str, str]:
+        load_calls.append(dict(kwargs))
+        return {}
+
+    monkeypatch.setattr(pipeline, "load_parent_catalog", tracking_load_parent_catalog)
     monkeypatch.setattr(pipeline, "query_parent_catalog", lambda *_, **__: {})
     monkeypatch.setattr(
         pipeline.molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
@@ -3237,9 +3240,28 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     assert stats.source == pipeline.PARENT_LOOKUP_SOURCE_SKIPPED
     assert stats.missing == 1
     assert stats.uncovered == 1
+    assert not load_calls
     skip_events = [event for event, _ in captured_warnings]
     assert "parent_lookup_full_sync_skipped_parentless" in skip_events
     assert "parent_lookup_missing_parents" in skip_events
+    skipped_payload = next(
+        payload
+        for event, payload in captured_warnings
+        if event == "parent_lookup_full_sync_skipped_parentless"
+    )
+    missing_payload = next(
+        payload
+        for event, payload in captured_warnings
+        if event == "parent_lookup_missing_parents"
+    )
+    assert skipped_payload == {
+        "count": 1,
+        "identifiers": ["CHEMBL_NO_PARENT"],
+    }
+    assert missing_payload == {
+        "count": 1,
+        "identifiers": ["CHEMBL_NO_PARENT"],
+    }
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])

--- a/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
@@ -3132,10 +3132,13 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     if not hasattr(attach_module, "attach_parent_molecule_ids"):
         attach_module = gtd
 
-    def unexpected_load_parent_catalog(**_: object) -> dict[str, str]:
-        raise AssertionError("load_parent_catalog should not be called")
+    load_calls: list[dict[str, object]] = []
 
-    monkeypatch.setattr(attach_module, "load_parent_catalog", unexpected_load_parent_catalog)
+    def tracking_load_parent_catalog(**kwargs: object) -> dict[str, str]:
+        load_calls.append(dict(kwargs))
+        return {}
+
+    monkeypatch.setattr(attach_module, "load_parent_catalog", tracking_load_parent_catalog)
     monkeypatch.setattr(attach_module, "query_parent_catalog", lambda *_, **__: {})
     monkeypatch.setattr(
         molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
@@ -3168,9 +3171,28 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     )
     assert stats.missing == 1
     assert stats.uncovered == 1
+    assert not load_calls
     skip_events = [event for event, _ in captured_warnings]
     assert "parent_lookup_full_sync_skipped_parentless" in skip_events
     assert "parent_lookup_missing_parents" in skip_events
+    skipped_payload = next(
+        payload
+        for event, payload in captured_warnings
+        if event == "parent_lookup_full_sync_skipped_parentless"
+    )
+    missing_payload = next(
+        payload
+        for event, payload in captured_warnings
+        if event == "parent_lookup_missing_parents"
+    )
+    assert skipped_payload == {
+        "count": 1,
+        "identifiers": ["CHEMBL_NO_PARENT"],
+    }
+    assert missing_payload == {
+        "count": 1,
+        "identifiers": ["CHEMBL_NO_PARENT"],
+    }
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])


### PR DESCRIPTION
## Summary
- ensure `attach_parent_molecule_ids` short-circuits full synchronisation when parentless filters are active and no cache exists
- capture the skip event in regression tests and assert warning payloads and statistics stay in sync across pipeline and CLI helpers

## Testing
- pytest tests/integration/pipelines/test_get_testitem_data.py -k "skips_full_sync_when_parentless_filtered" -q
- pytest tests/integration/scripts/get_testitem_data/test_get_testitem_data.py -k "skips_full_sync_when_parentless_filtered" -q

------
https://chatgpt.com/codex/tasks/task_e_68dfee4833948324a55d7cc4111bbca2