### PR TITLE
Skip parent catalog fetch when parentless records are filtered

### DIFF
--- a/library/testitem_pipeline/catalog/__init__.py
+++ b/library/testitem_pipeline/catalog/__init__.py
@@ -458,28 +458,35 @@ def attach_parent_molecule_ids(
 
     fetched: dict[str, str] = {}
     if missing_ids and catalog is None:
-        try:
-            fetched = molecule_catalog.fetch_parent_catalog_for(
-                missing_ids,
-                client=client,
-                api_cfg=api_cfg,
-                timeout=timeout,
-                catalog_cfg=catalog_cfg,
+        if parentless_filtered:
+            logger.info(
+                "parent_lookup_partial_fetch_skipped_parentless",
+                missing=len(missing_ids),
+                identifiers=missing_ids,
             )
-        except (requests.RequestException, ValueError) as exc:
-            logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
-            fetched = {}
-        if fetched:
-            partial_fetch_used = True
-            catalog_data.update(fetched)
-            parent_map.update(fetched)
-            missing_ids = [key for key in unique_children if key not in parent_map]
-            uncovered_children = len(missing_ids)
-            if used_partial_cache:
-                update_cache_fn(fetched, catalog_cfg)
-            else:
-                write_cache_fn(catalog_data, catalog_cfg)
-                used_partial_cache = True
+        else:
+            try:
+                fetched = molecule_catalog.fetch_parent_catalog_for(
+                    missing_ids,
+                    client=client,
+                    api_cfg=api_cfg,
+                    timeout=timeout,
+                    catalog_cfg=catalog_cfg,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
+                fetched = {}
+            if fetched:
+                partial_fetch_used = True
+                catalog_data.update(fetched)
+                parent_map.update(fetched)
+                missing_ids = [key for key in unique_children if key not in parent_map]
+                uncovered_children = len(missing_ids)
+                if used_partial_cache:
+                    update_cache_fn(fetched, catalog_cfg)
+                else:
+                    write_cache_fn(catalog_data, catalog_cfg)
+                    used_partial_cache = True
 
     needs_full_sync = catalog is None and uncovered_children > 0
 

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -700,28 +700,35 @@ def attach_parent_molecule_ids(
 
     fetched: dict[str, str] = {}
     if missing_ids and catalog is None:
-        try:
-            fetched = molecule_catalog.fetch_parent_catalog_for(
-                missing_ids,
-                client=client,
-                api_cfg=api_cfg,
-                timeout=timeout,
-                catalog_cfg=catalog_cfg,
+        if parentless_filtered:
+            logger.info(
+                "parent_lookup_partial_fetch_skipped_parentless",
+                missing=len(missing_ids),
+                identifiers=missing_ids,
             )
-        except (requests.RequestException, ValueError) as exc:
-            logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
-            fetched = {}
-        if fetched:
-            partial_fetch_used = True
-            catalog_data.update(fetched)
-            parent_map.update(fetched)
-            missing_ids = [key for key in unique_children if key not in parent_map]
-            uncovered_children = len(missing_ids)
-            if used_partial_cache:
-                update_cache_fn(fetched, catalog_cfg)
-            else:
-                write_cache_fn(catalog_data, catalog_cfg)
-                used_partial_cache = True
+        else:
+            try:
+                fetched = molecule_catalog.fetch_parent_catalog_for(
+                    missing_ids,
+                    client=client,
+                    api_cfg=api_cfg,
+                    timeout=timeout,
+                    catalog_cfg=catalog_cfg,
+                )
+            except (requests.RequestException, ValueError) as exc:
+                logger.warning("parent_lookup_partial_fetch_failed", error=str(exc))
+                fetched = {}
+            if fetched:
+                partial_fetch_used = True
+                catalog_data.update(fetched)
+                parent_map.update(fetched)
+                missing_ids = [key for key in unique_children if key not in parent_map]
+                uncovered_children = len(missing_ids)
+                if used_partial_cache:
+                    update_cache_fn(fetched, catalog_cfg)
+                else:
+                    write_cache_fn(catalog_data, catalog_cfg)
+                    used_partial_cache = True
 
     needs_full_sync = catalog is None and uncovered_children > 0
 

--- a/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
+++ b/tests/integration/scripts/get_testitem_data/test_get_testitem_data.py
@@ -3140,8 +3140,15 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
 
     monkeypatch.setattr(attach_module, "load_parent_catalog", tracking_load_parent_catalog)
     monkeypatch.setattr(attach_module, "query_parent_catalog", lambda *_, **__: {})
+
+    fetch_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def tracking_fetch(*args: object, **kwargs: object) -> dict[str, str]:
+        fetch_calls.append((args, dict(kwargs)))
+        return {}
+
     monkeypatch.setattr(
-        molecule_catalog, "fetch_parent_catalog_for", lambda *_, **__: {}
+        molecule_catalog, "fetch_parent_catalog_for", tracking_fetch
     )
 
     logger_target = getattr(attach_module, "logger", gtd.logger)
@@ -3177,6 +3184,7 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     )
     assert stats.missing == 1
     assert stats.uncovered == 1
+    assert not fetch_calls
     assert not load_calls
     skip_events = [event for event, _ in captured_warnings]
     assert "parent_lookup_full_sync_skipped_parentless" in skip_events
@@ -3220,8 +3228,10 @@ def test_attach_parent_molecule_ids_skips_full_sync_when_parentless_filtered(
     )
     assert stats.missing == 1
     assert stats.uncovered == 1
+    assert not fetch_calls
     info_events = [event for event, _ in captured_infos]
     assert "parent_lookup_skip_full_sync" in info_events
+    assert "parent_lookup_partial_fetch_skipped_parentless" in info_events
 
 
 @pytest.mark.parametrize("use_precomputed", [False, True])


### PR DESCRIPTION
## Summary
- skip partial parent catalog fetches when the catalog configuration filters parentless records and log the skip
- apply the same logic in the CLI entry point so both code paths align
- extend the integration test to verify the fetch helper is not invoked and logs the new event

## Testing
- pytest tests/integration/scripts/get_testitem_data/test_get_testitem_data.py -k parentless_filtered

------
https://chatgpt.com/codex/tasks/task_e_68dffa88ce508324bc1e0ea4bd303186