### PR TITLE
Fix StageWatchdog logging conflict with structured logger

### DIFF
--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -353,7 +353,7 @@ class StageWatchdog:
         if event:
             self._logger.info(
                 f"{self.stage_name}_watchdog_progress",
-                event=event,
+                watchdog_event=event,
                 **payload,
             )
 


### PR DESCRIPTION
## Summary
- avoid passing the reserved `event` keyword to the structured logger when emitting watchdog progress updates
- ensure watchdog progress logs continue to include the related event name via a dedicated payload field

## Testing
- pytest tests/test_testitem_pipeline.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dffccab1688324966ffb38ade38da5