### PR TITLE
Fix missing NamedTuple import in test item CLI

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Hashable, MutableMapping, Sequence, cast
+from typing import Hashable, MutableMapping, NamedTuple, Sequence, cast
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- add the missing NamedTuple import required by ParentLookupPreparedData in the test item CLI module

## Testing
- python -m compileall scripts/get_testitem_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e0074864188324bc631d6a2779f4cc