### PR TITLE
Add streaming metadata tests for target pipeline

### DIFF
--- a/tests/unit/library/pipelines/target/test_pipeline_targets.py
+++ b/tests/unit/library/pipelines/target/test_pipeline_targets.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Iterator
 from typing import Any
 
 import pandas as pd
+import pytest
 
 from library.pipelines.target.pipeline import PipelineResult, run_pipeline
 
@@ -98,3 +99,100 @@ def test_optional_stages_receive_dataframe() -> None:
     # Mapping interface exposes the stored frames.
     assert result["chembl"].equals(result.chembl)
     assert result.as_dict()["uniprot"].equals(result.uniprot)
+
+
+def test_run_pipeline_streams_frames_with_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Streaming results preserve chunk order and inject metadata lazily."""
+
+    call_sequence: list[int] = []
+
+    def marker(frame: pd.DataFrame) -> pd.DataFrame:
+        call_index = len(call_sequence) + 1
+        call_sequence.append(call_index)
+        # Provide deterministic metadata for assertions.
+        return frame.assign(pipeline_marker=call_index)
+
+    monkeypatch.setattr(
+        "library.pipelines.target.pipeline.add_pipeline_metadata", marker
+    )
+
+    def chunk_iterator() -> Iterator[Iterable[str]]:
+        yield ["CHEMBL10", "CHEMBL11"]
+        yield ["CHEMBL12"]
+
+    def chembl_fetcher(
+        chunks: Iterator[Iterable[str]], cfg: object, *, batch_size: int
+    ) -> Iterator[pd.DataFrame]:
+        assert batch_size == 100  # default propagated value
+
+        def stream() -> Iterator[pd.DataFrame]:
+            for chunk in chunks:
+                yield pd.DataFrame({"target_chembl_id": list(chunk)})
+
+        return stream()
+
+    result = run_pipeline(
+        chunk_iterator,
+        chembl_cfg=object(),
+        chembl_fetcher=chembl_fetcher,
+    )
+
+    assert isinstance(result.chembl, Iterator)
+
+    streamed_frames = list(result.chembl)
+    assert len(streamed_frames) == 2
+    assert [
+        list(frame["target_chembl_id"])
+        for frame in streamed_frames
+    ] == [["CHEMBL10", "CHEMBL11"], ["CHEMBL12"]]
+
+    for idx, frame in enumerate(streamed_frames, start=1):
+        assert set(frame["pipeline_marker"]) == {idx}
+
+    # Generator is exhausted after a single pass.
+    assert list(result.chembl) == []
+    assert call_sequence == [1, 2]
+
+
+def test_run_pipeline_streams_empty_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no chunks are emitted a single empty frame is yielded with metadata."""
+
+    call_sequence: list[int] = []
+
+    def marker(frame: pd.DataFrame) -> pd.DataFrame:
+        call_index = len(call_sequence) + 1
+        call_sequence.append(call_index)
+        return frame.assign(pipeline_marker=call_index)
+
+    monkeypatch.setattr(
+        "library.pipelines.target.pipeline.add_pipeline_metadata", marker
+    )
+
+    def chunk_iterator() -> Iterator[Iterable[str]]:
+        return iter(())
+
+    def chembl_fetcher(
+        chunks: Iterator[Iterable[str]], cfg: object, *, batch_size: int
+    ) -> Iterator[pd.DataFrame]:
+
+        def stream() -> Iterator[pd.DataFrame]:
+            for chunk in chunks:
+                yield pd.DataFrame({"target_chembl_id": list(chunk)})
+
+        return stream()
+
+    result = run_pipeline(
+        chunk_iterator,
+        chembl_cfg=object(),
+        chembl_fetcher=chembl_fetcher,
+    )
+
+    assert isinstance(result.chembl, Iterator)
+    streamed_frames = list(result.chembl)
+    assert len(streamed_frames) == 1
+
+    empty_frame = streamed_frames[0]
+    assert empty_frame.empty
+    assert list(empty_frame.columns) == ["pipeline_marker"]
+    assert list(result.chembl) == []
+    assert call_sequence == [1]


### PR DESCRIPTION
## Summary
- add coverage for streaming ChEMBL fetchers to ensure metadata injection on each chunk
- test the empty-stream path to confirm the pipeline yields a single metadata-enhanced frame

## Testing
- pytest tests/unit/library/pipelines/target/test_pipeline_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68e02e0f77a48324a047662abde40c54