### PR TITLE
Stabilize test fixtures for deterministic execution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import csv
-import json
+import datetime as dt
 import os
 import random
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
@@ -22,8 +23,18 @@ import pytest
 from library.config import Config
 
 
-def _fix_seed(seed: int = 42) -> None:
-    os.environ["PYTHONHASHSEED"] = str(seed)
+FROZEN_UTC = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+FROZEN_TIMESTAMP = FROZEN_UTC.timestamp()
+FROZEN_NAIVE = FROZEN_UTC.replace(tzinfo=None)
+
+
+def _fix_seed(
+    seed: int = 42, *, monkeypatch: pytest.MonkeyPatch | None = None
+) -> None:
+    if monkeypatch is None:
+        os.environ["PYTHONHASHSEED"] = str(seed)
+    else:
+        monkeypatch.setenv("PYTHONHASHSEED", str(seed))
     random.seed(seed)
     np.random.seed(seed)
 
@@ -32,9 +43,28 @@ def _fix_seed(seed: int = 42) -> None:
 def deterministic_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Provide deterministic environment defaults for every test."""
 
-    _fix_seed()
+    _fix_seed(monkeypatch=monkeypatch)
     monkeypatch.setenv("TZ", "UTC")
     monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FrozenDateTime(dt.datetime):
+        @classmethod
+        def now(cls, tz: dt.tzinfo | None = None) -> dt.datetime:
+            if tz is None:
+                return FROZEN_NAIVE
+            return FROZEN_UTC.astimezone(tz)
+
+        @classmethod
+        def utcnow(cls) -> dt.datetime:
+            return FROZEN_NAIVE
+
+        @classmethod
+        def today(cls) -> dt.datetime:
+            return cls.now()
+
+    monkeypatch.setattr(time, "time", lambda: FROZEN_TIMESTAMP)
+    monkeypatch.setattr(dt, "datetime", FrozenDateTime)
+    monkeypatch.setattr("datetime.datetime", FrozenDateTime)
 
 
 @pytest.fixture(autouse=True)
@@ -90,4 +120,4 @@ def make_dataframe() -> Iterable[pd.DataFrame]:
 
 @pytest.fixture()
 def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return FROZEN_UTC.isoformat()

--- a/tests/unit/test_cli_read_input.py
+++ b/tests/unit/test_cli_read_input.py
@@ -1,4 +1,3 @@
-import csv
 from pathlib import Path
 
 import pandas as pd
@@ -7,16 +6,14 @@ from library.pipelines.testitem import cli
 
 
 @pytest.mark.unit
-def test_read_input_ids__load_and_validate(tmp_path: Path, cfg) -> None:
-    input_path = tmp_path / "input.csv"
-    with input_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.writer(handle)
-        writer.writerow(["molecule_chembl_id", "value"])
-        writer.writerow([" CHEMBL1 ", "10"])
-        writer.writerow(["CHEMBL2", "20"])
+def test_read_input_ids__load_and_validate(sample_input_csv: Path, cfg) -> None:
+    frame = pd.read_csv(sample_input_csv)
+    frame["value"] = [10, 20]
+    frame.loc[0, "molecule_chembl_id"] = " CHEMBL1 "
+    frame.to_csv(sample_input_csv, index=False)
 
     rc, result = cli.read_input_ids(
-        input_path,
+        sample_input_csv,
         column="molecule_chembl_id",
         io_cfg=cfg.io,
         limit=None,
@@ -45,18 +42,17 @@ def test_read_input_ids__missing_file(cfg) -> None:
 
 
 @pytest.mark.unit
-def test_read_input_ids__limit_and_offset(tmp_path: Path, cfg) -> None:
+def test_read_input_ids__limit_and_offset(sample_input_csv: Path, cfg) -> None:
     frame = pd.DataFrame(
         {
             "molecule_chembl_id": [f"CHEMBL{i}" for i in range(6)],
             "value": range(6),
         }
     )
-    input_path = tmp_path / "input.csv"
-    frame.to_csv(input_path, index=False)
+    frame.to_csv(sample_input_csv, index=False)
 
     rc, result = cli.read_input_ids(
-        input_path,
+        sample_input_csv,
         column="molecule_chembl_id",
         io_cfg=cfg.io,
         limit=2,
@@ -71,15 +67,12 @@ def test_read_input_ids__limit_and_offset(tmp_path: Path, cfg) -> None:
 
 
 @pytest.mark.unit
-def test_read_input_ids__invalid_column(tmp_path: Path, cfg) -> None:
-    input_path = tmp_path / "input.csv"
-    with input_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.writer(handle)
-        writer.writerow(["other_column"])
-        writer.writerow(["CHEMBL1"])
+def test_read_input_ids__invalid_column(sample_input_csv: Path, cfg) -> None:
+    frame = pd.DataFrame({"other_column": ["CHEMBL1"]})
+    frame.to_csv(sample_input_csv, index=False)
 
     rc, result = cli.read_input_ids(
-        input_path,
+        sample_input_csv,
         column="molecule_chembl_id",
         io_cfg=cfg.io,
         limit=None,


### PR DESCRIPTION
## Summary
- extend the deterministic test environment to freeze RNG seeds and time-dependent APIs
- reuse the shared sample_input_csv fixture across CLI input tests to avoid ad-hoc CSV setup

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e04e1b0408832481d395047ef854d7