### PR TITLE
Enforce success rate threshold in test suite runner

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import pytest
+
+
+SUCCESS_RATE_THRESHOLD = 0.95
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,22 +72,46 @@ def _format_longrepr(longrepr: Any) -> str:
     return str(longrepr)
 
 
-def _write_json(report_path: Path, plugin: JsonReportPlugin, exit_code: int) -> None:
-    payload = {
-        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        "exit_code": exit_code,
-        "tests": [asdict(result) for result in plugin.results],
-    }
-    report_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-
-
-def _write_summary(summary_path: Path, plugin: JsonReportPlugin, exit_code: int) -> None:
-    results = plugin.results
+def summarize_results(results: Sequence[TestResult]) -> dict[str, Any]:
     total = len(results)
     passed = sum(1 for item in results if item.status == "passed")
     failed = sum(1 for item in results if item.status == "failed")
     skipped = sum(1 for item in results if item.status == "skipped")
     duration = sum(item.duration for item in results)
+    success_rate = 1.0 if total == 0 else passed / total
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "duration": duration,
+        "success_rate": success_rate,
+    }
+
+
+def _write_json(report_path: Path, results: Sequence[TestResult], exit_code: int, summary: dict[str, Any]) -> None:
+    payload = {
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "exit_code": exit_code,
+        "summary": summary,
+        "tests": [asdict(result) for result in results],
+    }
+    report_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _write_summary(
+    summary_path: Path,
+    results: Sequence[TestResult],
+    exit_code: int,
+    summary: dict[str, Any],
+) -> None:
+    total = summary["total"]
+    passed = summary["passed"]
+    failed = summary["failed"]
+    skipped = summary["skipped"]
+    duration = summary["duration"]
+    success_rate = summary["success_rate"] * 100
 
     lines = [
         "# Test suite summary",
@@ -92,6 +123,7 @@ def _write_summary(summary_path: Path, plugin: JsonReportPlugin, exit_code: int)
         f"* Failed: {failed}",
         f"* Skipped: {skipped}",
         f"* Cumulative duration: {duration:.2f}s",
+        f"* Success rate: {success_rate:.2f}%",
         "",
         "## Failing tests" if failed else "## Failing tests",
     ]
@@ -168,12 +200,25 @@ def main(argv: list[str] | None = None) -> int:
         pytest_args.extend(args.pytest_args)
 
     plugin = JsonReportPlugin(log_path)
-    exit_code = pytest.main(pytest_args, plugins=[plugin])
+    pytest_exit_code = pytest.main(pytest_args, plugins=[plugin])
+    exit_code = int(pytest_exit_code)
+
+    results = plugin.results
+    summary = summarize_results(results)
+
+    if summary["success_rate"] < SUCCESS_RATE_THRESHOLD:
+        logger.error(
+            "Success rate %.2f%% is below the required threshold of %.2f%%",
+            summary["success_rate"] * 100,
+            SUCCESS_RATE_THRESHOLD * 100,
+        )
+        if exit_code == 0:
+            exit_code = 1
 
     json_path = report_dir / "test_report.json"
     summary_path = report_dir / "test_summary.md"
-    _write_json(json_path, plugin, exit_code)
-    _write_summary(summary_path, plugin, exit_code)
+    _write_json(json_path, results, exit_code, summary)
+    _write_summary(summary_path, results, exit_code, summary)
 
     return int(exit_code)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Install dependencies (see the repository `README.md`) and run the suite via the 
 python tools/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The run fails if any test errors or fails, and the expected success-rate threshold is ≥95%.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate` = passed/total), while the Markdown file includes a `Success rate: NN.NN%` line for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
 
 To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tools/run_tests.py --pytest-args -m unit`.
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -1,0 +1,92 @@
+"""Unit tests for the scripts.run_test_suite helper."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from scripts import run_test_suite
+
+
+def _make_result(name: str, status: str, *, duration: float = 0.1, message: str = "") -> run_test_suite.TestResult:
+    return run_test_suite.TestResult(
+        name=name,
+        status=status,
+        duration=duration,
+        message=message,
+        log_path=None,
+    )
+
+
+@pytest.mark.unit
+def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
+    plugin = run_test_suite.JsonReportPlugin(tmp_path / "suite.log")
+    plugin._results = {
+        "tests::passed": _make_result("tests::passed", "passed"),
+        "tests::failed": _make_result("tests::failed", "failed", message="boom"),
+    }
+
+    results = plugin.results
+    summary = run_test_suite.summarize_results(results)
+
+    json_path = tmp_path / "test_report.json"
+    run_test_suite._write_json(json_path, results, exit_code=0, summary=summary)
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+
+    assert pytest.approx(payload["summary"]["success_rate"]) == 0.5
+
+    md_path = tmp_path / "test_summary.md"
+    run_test_suite._write_summary(md_path, results, exit_code=0, summary=summary)
+    summary_text = md_path.read_text(encoding="utf-8")
+
+    assert "Success rate: 50.00%" in summary_text
+
+    empty_summary = run_test_suite.summarize_results([])
+    assert empty_summary["success_rate"] == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_main__returns_error_when_success_rate_below_threshold(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
+        plugin: run_test_suite.JsonReportPlugin = plugins[0]
+        log_path = str(plugin._log_path)
+        plugin._results = {
+            "tests::pass": run_test_suite.TestResult(
+                name="tests::pass",
+                status="passed",
+                duration=0.1,
+                message="",
+                log_path=log_path,
+            ),
+            "tests::fail": run_test_suite.TestResult(
+                name="tests::fail",
+                status="failed",
+                duration=0.1,
+                message="boom",
+                log_path=log_path,
+            ),
+            "tests::skip": run_test_suite.TestResult(
+                name="tests::skip",
+                status="skipped",
+                duration=0.1,
+                message="not run",
+                log_path=log_path,
+            ),
+        }
+        return 0
+
+    monkeypatch.setattr(run_test_suite.pytest, "main", fake_pytest_main)
+
+    caplog.set_level(logging.ERROR)
+    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
+
+    assert exit_code == 1
+    assert "below the required threshold" in caplog.text
+
+    report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
+    assert report_payload["summary"]["success_rate"] < 0.75


### PR DESCRIPTION
## Summary
- compute the pytest success rate in the reporting helper and persist it to JSON/Markdown outputs
- enforce the 95% success rate threshold while gracefully handling empty result sets
- cover the new behaviour with dedicated unit tests and document the reporting policy update

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e04e4680308324a3e124c917a44fc8