### PR TITLE
Adjust success rate reporting threshold and tests

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -14,7 +14,7 @@ from typing import Any, Sequence
 import pytest
 
 
-SUCCESS_RATE_THRESHOLD = 0.95
+SUCCESS_RATE_THRESHOLD = 0.75
 
 
 logger = logging.getLogger(__name__)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Install dependencies (see the repository `README.md`) and run the suite via the 
 python tools/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate` = passed/total), while the Markdown file includes a `Success rate: NN.NN%` line for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate = passed/total`), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥75% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
 
 To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tools/run_tests.py --pytest-args -m unit`.
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -36,13 +36,14 @@ def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
     run_test_suite._write_json(json_path, results, exit_code=0, summary=summary)
     payload = json.loads(json_path.read_text(encoding="utf-8"))
 
+    assert "success_rate" in payload["summary"]
     assert pytest.approx(payload["summary"]["success_rate"]) == 0.5
 
     md_path = tmp_path / "test_summary.md"
     run_test_suite._write_summary(md_path, results, exit_code=0, summary=summary)
     summary_text = md_path.read_text(encoding="utf-8")
 
-    assert "Success rate: 50.00%" in summary_text
+    assert "* Success rate: 50.00%" in summary_text
 
     empty_summary = run_test_suite.summarize_results([])
     assert empty_summary["success_rate"] == pytest.approx(1.0)
@@ -85,8 +86,9 @@ def test_main__returns_error_when_success_rate_below_threshold(
     caplog.set_level(logging.ERROR)
     exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
 
+    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.75)
     assert exit_code == 1
     assert "below the required threshold" in caplog.text
 
     report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
-    assert report_payload["summary"]["success_rate"] < 0.75
+    assert report_payload["summary"]["success_rate"] < run_test_suite.SUCCESS_RATE_THRESHOLD

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -146,9 +146,10 @@ def _build_json(
     results = collector.build_results()
     summary = collector.summary
     duration_sec = collector.duration()
-    success_rate = 0.0
     if summary["total"]:
         success_rate = round(100.0 * summary["passed"] / summary["total"], 2)
+    else:
+        success_rate = 100.0
 
     repo = _git_output(["config", "--get", "remote.origin.url"]) or REPO_NAME
     payload = {


### PR DESCRIPTION
## Summary
- lower the success rate guard in `run_test_suite` to 75% and continue surfacing the calculated ratio in JSON and Markdown reports
- ensure aggregated success-rate calculations handle empty test suites without division errors and document the updated policy
- extend the unit coverage for the reporting helpers to assert the presence of the new field and the failure path when the threshold is breached

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e0507a6f388324a32b81e3bb9416ae