### PR TITLE
Update success rate reporting

### DIFF
--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,188 +1,37 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "675016ce1fc32844dd004eca20750737fe7fb3aa",
+    "commit": "faf1604505269289f643da003fdd43d411a7edd3",
     "branch": "work",
-    "ts_utc": "2025-10-03T22:20:15.015519+00:00",
-    "duration_sec": 0.645,
+    "ts_utc": "2025-10-03T23:10:41.514087+00:00",
+    "duration_sec": 0.021,
     "python": "3.11.12",
     "pytest": "8.4.1"
   },
   "summary": {
-    "total": 16,
-    "passed": 16,
+    "total": 2,
+    "passed": 2,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
     "xpassed": 0,
     "error": 0,
-    "success_rate": 100.0
+    "success_rate": 1.0
   },
   "tests": [
     {
-      "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
+      "nodeid": "tests/unit/test_tools_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 54.84,
-      "stdout": "{\"ts\": \"2025-10-03T22:20:14.689860+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T22:20:14.689996+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T22:20:14.692678+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T22:20:14.689860+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T22:20:14.689996+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T22:20:14.692678+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
-      "status": "passed",
-      "duration_ms": 20.178,
+      "duration_ms": 2.396,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
+      "nodeid": "tests/unit/test_tools_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 17.321,
-      "stdout": "{\"ts\": \"2025-10-03T22:20:14.765943+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T22:20:14.765943+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
-      "status": "passed",
-      "duration_ms": 4.293,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
-      "status": "passed",
-      "duration_ms": 0.869,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
-      "status": "passed",
-      "duration_ms": 15.131,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
-      "status": "passed",
-      "duration_ms": 2.338,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
-      "status": "passed",
-      "duration_ms": 1.318,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
-      "status": "passed",
-      "duration_ms": 1.035,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
-      "status": "passed",
-      "duration_ms": 0.122,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
-      "status": "passed",
-      "duration_ms": 0.545,
-      "stdout": "{\"ts\": \"2025-10-03T22:20:14.815454+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T22:20:14.815454+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv\"}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
-      "status": "passed",
-      "duration_ms": 1.524,
-      "stdout": "{\"ts\": \"2025-10-03T22:20:14.812601+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T22:20:14.812601+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
-      "status": "passed",
-      "duration_ms": 0.406,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
-      "status": "passed",
-      "duration_ms": 0.265,
-      "stdout": "{\"ts\": \"2025-10-03T22:20:14.809587+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T22:20:14.809587+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
-      "status": "passed",
-      "duration_ms": 1.435,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
-      "status": "passed",
-      "duration_ms": 1.36,
+      "duration_ms": 0.378,
       "stdout": "",
       "stderr": "",
       "log": [],

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: 675016ce1fc32844dd004eca20750737fe7fb3aa
+- Commit: faf1604505269289f643da003fdd43d411a7edd3
 - Branch: work
-- Timestamp (UTC): 2025-10-03T22:20:15.015519+00:00
-- Duration: 0.645 s
-- Success rate: 100.0%
+- Timestamp (UTC): 2025-10-03T23:10:41.514087+00:00
+- Duration: 0.021 s
+- Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|    16 |    16 |     0 |      0 |      0 |      0 |     0 |
+|     2 |     2 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
 - none

--- a/tests/unit/test_tools_run_tests.py
+++ b/tests/unit/test_tools_run_tests.py
@@ -1,0 +1,80 @@
+"""Unit tests for :mod:`tools.run_tests`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools import run_tests
+
+
+def _stub_git_output(_: list[str]) -> str:
+    return "stub"
+
+
+def _make_record(nodeid: str, status: str) -> run_tests.TestRecord:
+    return run_tests.TestRecord(
+        nodeid=nodeid,
+        status=status,
+        duration_ms=12.3,
+        stdout="",
+        stderr="",
+    )
+
+
+@pytest.mark.unit
+def test_build_json__stores_fractional_success_rate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
+
+    collector = run_tests.ReportCollector()
+    collector.start_time = 100.0
+    collector.end_time = 100.5
+    collector.tests = {
+        "tests/test_demo.py::test_pass": _make_record(
+            "tests/test_demo.py::test_pass", "passed"
+        ),
+        "tests/test_demo.py::test_fail": _make_record(
+            "tests/test_demo.py::test_fail", "failed"
+        ),
+    }
+
+    report_path = tmp_path / "report.json"
+    payload = run_tests._build_json(collector, report_path=report_path)
+
+    assert report_path.exists()
+    saved = json.loads(report_path.read_text(encoding="utf-8"))
+
+    for data in (payload, saved):
+        assert data["summary"]["success_rate"] == pytest.approx(0.5)
+
+    summary_path = tmp_path / "summary.md"
+    run_tests._write_markdown(summary_path, payload)
+    summary_text = summary_path.read_text(encoding="utf-8")
+
+    assert "Success rate: 50.00%" in summary_text
+
+
+@pytest.mark.unit
+def test_build_json__uses_full_success_for_empty_suite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
+
+    collector = run_tests.ReportCollector()
+    collector.start_time = 50.0
+    collector.end_time = 50.0
+
+    report_path = tmp_path / "report.json"
+    payload = run_tests._build_json(collector, report_path=report_path)
+
+    assert payload["summary"]["success_rate"] == pytest.approx(1.0)
+
+    summary_path = tmp_path / "summary.md"
+    run_tests._write_markdown(summary_path, payload)
+    summary_text = summary_path.read_text(encoding="utf-8")
+
+    assert "Success rate: 100.00%" in summary_text

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -147,9 +147,9 @@ def _build_json(
     summary = collector.summary
     duration_sec = collector.duration()
     if summary["total"]:
-        success_rate = round(100.0 * summary["passed"] / summary["total"], 2)
+        success_rate = summary["passed"] / summary["total"]
     else:
-        success_rate = 100.0
+        success_rate = 1.0
 
     repo = _git_output(["config", "--get", "remote.origin.url"]) or REPO_NAME
     payload = {
@@ -196,7 +196,7 @@ def _write_markdown(summary_path: Path, data: dict[str, Any]) -> None:
         f"- Branch: {meta['branch']}",
         f"- Timestamp (UTC): {meta['ts_utc']}",
         f"- Duration: {meta['duration_sec']} s",
-        f"- Success rate: {summary['success_rate']}%",
+        f"- Success rate: {summary['success_rate'] * 100:.2f}%",
         "",
         "| total | passed | failed | skipped | xfailed | xpassed | error |",
         "|------:|-------:|-------:|--------:|--------:|--------:|------:|",


### PR DESCRIPTION
## Summary
- store the JSON success rate as a fraction and derive the markdown percentage from it
- add unit tests around `_build_json` and `_write_markdown`
- regenerate the reference reports with the new format

## Testing
- pytest tests/unit/test_tools_run_tests.py -q
- python tools/run_tests.py --pytest-args tests/unit/test_tools_run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e0579d40f08324a7b45e9de1ca0a31