### PR TITLE
Increase minimum test success rate threshold to 80%

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -14,7 +14,7 @@ from typing import Any, Sequence
 import pytest
 
 
-SUCCESS_RATE_THRESHOLD = 0.75
+SUCCESS_RATE_THRESHOLD = 0.80
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -86,9 +86,67 @@ def test_main__returns_error_when_success_rate_below_threshold(
     caplog.set_level(logging.ERROR)
     exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
 
-    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.75)
+    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.80)
     assert exit_code == 1
     assert "below the required threshold" in caplog.text
 
     report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
     assert report_payload["summary"]["success_rate"] < run_test_suite.SUCCESS_RATE_THRESHOLD
+
+
+@pytest.mark.unit
+def test_main__passes_when_success_rate_meets_threshold(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
+        plugin: run_test_suite.JsonReportPlugin = plugins[0]
+        log_path = str(plugin._log_path)
+        plugin._results = {
+            "tests::pass": run_test_suite.TestResult(
+                name="tests::pass",
+                status="passed",
+                duration=0.1,
+                message="",
+                log_path=log_path,
+            ),
+            "tests::also_pass": run_test_suite.TestResult(
+                name="tests::also_pass",
+                status="passed",
+                duration=0.1,
+                message="",
+                log_path=log_path,
+            ),
+            "tests::third_pass": run_test_suite.TestResult(
+                name="tests::third_pass",
+                status="passed",
+                duration=0.1,
+                message="",
+                log_path=log_path,
+            ),
+            "tests::fourth_pass": run_test_suite.TestResult(
+                name="tests::fourth_pass",
+                status="passed",
+                duration=0.1,
+                message="",
+                log_path=log_path,
+            ),
+            "tests::skip": run_test_suite.TestResult(
+                name="tests::skip",
+                status="skipped",
+                duration=0.1,
+                message="not run",
+                log_path=log_path,
+            ),
+        }
+        return 0
+
+    monkeypatch.setattr(run_test_suite.pytest, "main", fake_pytest_main)
+
+    caplog.set_level(logging.ERROR)
+    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
+
+    assert exit_code == 0
+    assert "below the required threshold" not in caplog.text
+
+    report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
+    assert report_payload["summary"]["success_rate"] >= run_test_suite.SUCCESS_RATE_THRESHOLD

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -14,9 +15,13 @@ from typing import Any
 
 import pytest
 
+from scripts.run_test_suite import SUCCESS_RATE_THRESHOLD
+
 
 REPO_NAME = "SatoryKono/ChEMBL_data_acquisition"
 
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class TestRecord:
@@ -256,13 +261,26 @@ def main(argv: list[str] | None = None) -> int:
     if args.pytest_args:
         pytest_args.extend(args.pytest_args)
 
-    exit_code = pytest.main(pytest_args, plugins=[collector])
+    pytest_exit_code = pytest.main(pytest_args, plugins=[collector])
+    exit_code = int(pytest_exit_code)
 
     data = _build_json(collector, report_path=args.json)
     _write_markdown(args.markdown, data)
+
+    success_rate_percent = data["summary"]["success_rate"]
+    success_rate_ratio = success_rate_percent / 100.0
+    if success_rate_ratio < SUCCESS_RATE_THRESHOLD:
+        logger.error(
+            "Success rate %.2f%% is below the required threshold of %.2f%%",
+            success_rate_percent,
+            SUCCESS_RATE_THRESHOLD * 100,
+        )
+        if exit_code == 0:
+            exit_code = 1
 
     return exit_code
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- raise the success-rate enforcement threshold to 80% in the test suite runner
- adjust unit tests to cover both failing and passing scenarios under the new limit
- have the CLI test harness compute the success rate and exit non-zero when below 80%

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e057c552188324ba7e74d30047de98