### PR TITLE
Increase test suite success rate threshold to 95%

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -14,7 +14,7 @@ from typing import Any, Sequence
 import pytest
 
 
-SUCCESS_RATE_THRESHOLD = 0.80
+SUCCESS_RATE_THRESHOLD = 0.95
 
 
 logger = logging.getLogger(__name__)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Install dependencies (see the repository `README.md`) and run the suite via the 
 python tools/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate = passed/total`), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥75% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate = passed/total`), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
 
 To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tools/run_tests.py --pytest-args -m unit`.
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -57,25 +57,21 @@ def test_main__returns_error_when_success_rate_below_threshold(
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
         log_path = str(plugin._log_path)
         plugin._results = {
-            "tests::pass": run_test_suite.TestResult(
-                name="tests::pass",
-                status="passed",
-                duration=0.1,
-                message="",
-                log_path=log_path,
-            ),
+            **{
+                f"tests::pass_{index}": run_test_suite.TestResult(
+                    name=f"tests::pass_{index}",
+                    status="passed",
+                    duration=0.1,
+                    message="",
+                    log_path=log_path,
+                )
+                for index in range(18)
+            },
             "tests::fail": run_test_suite.TestResult(
                 name="tests::fail",
                 status="failed",
                 duration=0.1,
                 message="boom",
-                log_path=log_path,
-            ),
-            "tests::skip": run_test_suite.TestResult(
-                name="tests::skip",
-                status="skipped",
-                duration=0.1,
-                message="not run",
                 log_path=log_path,
             ),
         }
@@ -86,7 +82,7 @@ def test_main__returns_error_when_success_rate_below_threshold(
     caplog.set_level(logging.ERROR)
     exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
 
-    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.80)
+    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.95)
     assert exit_code == 1
     assert "below the required threshold" in caplog.text
 
@@ -102,34 +98,16 @@ def test_main__passes_when_success_rate_meets_threshold(
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
         log_path = str(plugin._log_path)
         plugin._results = {
-            "tests::pass": run_test_suite.TestResult(
-                name="tests::pass",
-                status="passed",
-                duration=0.1,
-                message="",
-                log_path=log_path,
-            ),
-            "tests::also_pass": run_test_suite.TestResult(
-                name="tests::also_pass",
-                status="passed",
-                duration=0.1,
-                message="",
-                log_path=log_path,
-            ),
-            "tests::third_pass": run_test_suite.TestResult(
-                name="tests::third_pass",
-                status="passed",
-                duration=0.1,
-                message="",
-                log_path=log_path,
-            ),
-            "tests::fourth_pass": run_test_suite.TestResult(
-                name="tests::fourth_pass",
-                status="passed",
-                duration=0.1,
-                message="",
-                log_path=log_path,
-            ),
+            **{
+                f"tests::pass_{index}": run_test_suite.TestResult(
+                    name=f"tests::pass_{index}",
+                    status="passed",
+                    duration=0.1,
+                    message="",
+                    log_path=log_path,
+                )
+                for index in range(19)
+            },
             "tests::skip": run_test_suite.TestResult(
                 name="tests::skip",
                 status="skipped",


### PR DESCRIPTION
## Summary
- raise the run_test_suite success-rate gate to 95%
- update the unit tests to match the new threshold and keep their fabricated payloads consistent
- refresh the tests README so the documented policy cites the 95% requirement

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e05a61d02c8324882bf506ca125bab