### PR TITLE
Enforce 95% success rate threshold in test runner

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Install dependencies (see the repository `README.md`) and run the suite via the 
 python tools/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and `success_rate = passed/total`), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥75% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `passed / total`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
 
 To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tools/run_tests.py --pytest-args -m unit`.
 

--- a/tests/unit/tools/test_run_tests.py
+++ b/tests/unit/tools/test_run_tests.py
@@ -78,3 +78,48 @@ def test_build_json__uses_full_success_for_empty_suite(
     summary_text = summary_path.read_text(encoding="utf-8")
 
     assert "Success rate: 100.00%" in summary_text
+
+
+@pytest.mark.unit
+def test_main__downgrades_exit_code_when_threshold_not_met(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
+
+    def _fake_pytest_main(pytest_args: list[str], plugins: list[object]) -> int:
+        assert plugins, "Collector plugin must be provided"
+        collector = plugins[0]
+        assert isinstance(collector, run_tests.ReportCollector)
+
+        collector.start_time = 0.0
+        collector.end_time = 0.5
+        collector.tests = {
+            "tests/test_demo.py::test_pass": _make_record(
+                "tests/test_demo.py::test_pass", "passed"
+            ),
+            "tests/test_demo.py::test_fail": _make_record(
+                "tests/test_demo.py::test_fail", "failed"
+            ),
+        }
+        collector.tests["tests/test_demo.py::test_fail"].error = "boom"
+        return 0
+
+    monkeypatch.setattr(run_tests.pytest, "main", _fake_pytest_main)
+
+    json_path = tmp_path / "report.json"
+    markdown_path = tmp_path / "summary.md"
+
+    exit_code = run_tests.main([
+        "--json",
+        str(json_path),
+        "--markdown",
+        str(markdown_path),
+    ])
+
+    assert exit_code == 1
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["success_rate"] == pytest.approx(0.5)
+
+    markdown_text = markdown_path.read_text(encoding="utf-8")
+    assert "Success rate: 50.00%" in markdown_text

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -15,10 +15,10 @@ from typing import Any
 
 import pytest
 
-from scripts.run_test_suite import SUCCESS_RATE_THRESHOLD
-
 
 REPO_NAME = "SatoryKono/ChEMBL_data_acquisition"
+
+SUCCESS_RATE_THRESHOLD = 0.95
 
 
 logger = logging.getLogger(__name__)
@@ -193,6 +193,7 @@ def _build_json(
 def _write_markdown(summary_path: Path, data: dict[str, Any]) -> None:
     summary = data["summary"]
     meta = data["meta"]
+    success_rate_ratio = summary["success_rate"]
     lines = [
         "# Test Summary",
         "",
@@ -201,7 +202,7 @@ def _write_markdown(summary_path: Path, data: dict[str, Any]) -> None:
         f"- Branch: {meta['branch']}",
         f"- Timestamp (UTC): {meta['ts_utc']}",
         f"- Duration: {meta['duration_sec']} s",
-        f"- Success rate: {summary['success_rate'] * 100:.2f}%",
+        f"- Success rate: {success_rate_ratio * 100:.2f}%",
         "",
         "| total | passed | failed | skipped | xfailed | xpassed | error |",
         "|------:|-------:|-------:|--------:|--------:|--------:|------:|",
@@ -267,12 +268,11 @@ def main(argv: list[str] | None = None) -> int:
     data = _build_json(collector, report_path=args.json)
     _write_markdown(args.markdown, data)
 
-    success_rate_percent = data["summary"]["success_rate"]
-    success_rate_ratio = success_rate_percent / 100.0
+    success_rate_ratio = data["summary"]["success_rate"]
     if success_rate_ratio < SUCCESS_RATE_THRESHOLD:
         logger.error(
             "Success rate %.2f%% is below the required threshold of %.2f%%",
-            success_rate_percent,
+            success_rate_ratio * 100,
             SUCCESS_RATE_THRESHOLD * 100,
         )
         if exit_code == 0:


### PR DESCRIPTION
## Summary
- store the success rate ratio in `tools/run_tests.py` and guard it with an in-module 95% threshold
- keep the markdown summary formatted as a percentage and document the ratio-based field in `tests/README.md`
- add regression coverage for the wrapper to ensure a 50% run flips the exit code and reports the correct numbers

## Testing
- pytest tests/unit/tools/test_run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e05a621aac8324b6a58988b1f3560d