### PR TITLE
Add integration coverage for PubChem augmentation flows

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,10 @@ The test suite is organised around the key scenarios of the ChEMBL data acquisit
 
 Shared fixtures live in `tests/conftest.py`. They configure a deterministic environment, disable outbound HTTP calls and expose helpers such as `sample_input_csv` and `snapshot_resource`.
 
+## Integration enrichment checklist
+
+- [x] PubChem augmentation: cache hits/misses, polymer handling and TTL expiry (`tests/integration/test_pubchem_augmentation.py`).
+
 ## Running tests and generating reports
 
 Install dependencies (see the repository `README.md`) and run the suite via the reporting wrapper:

--- a/tests/integration/test_pubchem_augmentation.py
+++ b/tests/integration/test_pubchem_augmentation.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.config import PubChemCfg
+import library.testitem_pipeline.pubchem as pubchem
+
+
+@pytest.mark.integration
+def test_add_pubchem_data__normal_flow_populates_cache(
+    tmp_path: Path, cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pubchem_cfg = cfg.pubchem
+    pubchem_cfg.enable = True
+    pubchem_cfg.cid_cache_path = tmp_path / "cid_cache.json"
+    pubchem_cfg.cache_ttl_hours = None
+
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "molecule_type": ["Small molecule", "Small molecule"],
+        }
+    )
+
+    cid_cache: dict[str, str | None] = {}
+    resolution_cache: dict[str, object] = {}
+    parent_record_cache: dict[str, pd.Series | None] = {}
+
+    def fake_resolve(
+        frame_arg: pd.DataFrame,
+        cfg_arg: PubChemCfg,
+        *,
+        cid_cache: dict[str, str | None],
+        resolution_cache: dict[str, object],
+        load_parent_record,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> tuple[pd.Series, set[str], bool]:
+        assert frame_arg.equals(frame)
+        assert skip_mask.tolist() == [False, False]
+        assert prefer_local_mask.tolist() == [False, False]
+        cid_series = pd.Series(["CID1", "CID2"], index=frame.index, dtype="string")
+        cid_cache["CHEMBL1"] = "CID1"
+        cid_cache["CHEMBL2"] = "CID2"
+        return cid_series, {"CID1", "CID2"}, True
+
+    def fake_merge(
+        frame_arg: pd.DataFrame,
+        cid_series: pd.Series,
+        lookup_cids: set[str],
+        *,
+        cfg: PubChemCfg,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> pd.DataFrame:
+        assert lookup_cids == {"CID1", "CID2"}
+        assert skip_mask.tolist() == [False, False]
+        return pd.DataFrame(
+            {
+                "pubchem_cid": cid_series.astype("string"),
+                "pubchem_iupac_name": ["Name1", "Name2"],
+                "pubchem_canonical_smiles": ["SMILES1", "SMILES2"],
+            },
+            index=frame.index,
+        )
+
+    monkeypatch.setattr(pubchem, "_resolve_pubchem_cids", fake_resolve)
+    monkeypatch.setattr(pubchem, "_merge_pubchem_properties", fake_merge)
+
+    result = pubchem.add_pubchem_data(
+        frame,
+        pubchem_cfg,
+        cid_cache=cid_cache,
+        resolution_cache=resolution_cache,
+        parent_record_cache=parent_record_cache,
+    )
+
+    assert result["pubchem_cid"].tolist() == ["CID1", "CID2"]
+    assert result["pubchem_iupac_name"].tolist() == ["Name1", "Name2"]
+    assert cid_cache == {"CHEMBL1": "CID1", "CHEMBL2": "CID2"}
+    assert pubchem_cfg.cid_cache_path is not None
+    cache_payload = json.loads(pubchem_cfg.cid_cache_path.read_text(encoding="utf-8"))
+    assert cache_payload["values"] == {"CHEMBL1": "CID1", "CHEMBL2": "CID2"}
+
+
+@pytest.mark.integration
+def test_add_pubchem_data__skips_polymers_when_disallowed(
+    tmp_path: Path, cfg, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pubchem_cfg = cfg.pubchem
+    pubchem_cfg.enable = True
+    pubchem_cfg.allow_polymer = False
+    pubchem_cfg.cid_cache_path = tmp_path / "cid_cache.json"
+
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+            "molecule_type": ["Polymer", "Mixture", "Small molecule"],
+        }
+    )
+
+    def fake_resolve(
+        frame_arg: pd.DataFrame,
+        cfg_arg: PubChemCfg,
+        *,
+        cid_cache: dict[str, str | None],
+        resolution_cache: dict[str, object],
+        load_parent_record,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> tuple[pd.Series, set[str], bool]:
+        assert skip_mask.tolist() == [True, True, False]
+        assert prefer_local_mask.tolist() == [False, False, False]
+        cid_series = pd.Series([pd.NA, pd.NA, "CID3"], index=frame.index, dtype="string")
+        cid_cache.update({})
+        return cid_series, {"CID3"}, False
+
+    def fake_merge(
+        frame_arg: pd.DataFrame,
+        cid_series: pd.Series,
+        lookup_cids: set[str],
+        *,
+        cfg: PubChemCfg,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> pd.DataFrame:
+        assert lookup_cids == {"CID3"}
+        assert skip_mask.tolist() == [True, True, False]
+        return pd.DataFrame(
+            {
+                "pubchem_cid": cid_series,
+                "pubchem_iupac_name": [pd.NA, pd.NA, "Name3"],
+            },
+            index=frame.index,
+        )
+
+    monkeypatch.setattr(pubchem, "_resolve_pubchem_cids", fake_resolve)
+    monkeypatch.setattr(pubchem, "_merge_pubchem_properties", fake_merge)
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(event: str, **fields: object) -> None:
+        logging.getLogger("pubchem-test").warning(event)
+        events.append((event, fields))
+
+    monkeypatch.setattr(pubchem.logger, "warning", capture_warning)
+    caplog.set_level("WARNING", logger="pubchem-test")
+    result = pubchem.add_pubchem_data(frame, pubchem_cfg)
+
+    assert pd.isna(result.loc[0, "pubchem_cid"])
+    assert pd.isna(result.loc[1, "pubchem_cid"])
+    assert result.loc[2, "pubchem_cid"] == "CID3"
+    assert any(event == "pubchem_skip_polymers" for event, _ in events)
+    assert any(
+        record.message == "pubchem_skip_polymers"
+        for record in caplog.records
+        if record.name == "pubchem-test"
+    )
+
+
+@pytest.mark.integration
+def test_augment_pubchem__initialises_session_and_reuses_cache(
+    tmp_path: Path, cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pubchem_cfg = cfg.pubchem
+    pubchem_cfg.enable = True
+    pubchem_cfg.cache_ttl_hours = None
+    pubchem_cfg.cid_cache_path = tmp_path / "cid_cache.json"
+
+    initial_payload = {
+        "metadata": {"version": 1, "updated_at": "2020-01-01T00:00:00+00:00"},
+        "values": {"CHEMBL1": "CID1"},
+    }
+    pubchem_cfg.cid_cache_path.write_text(
+        json.dumps(initial_payload, indent=2), encoding="utf-8"
+    )
+
+    init_calls: list[tuple[object, object]] = []
+
+    def record_init(api_cfg: object, retry_cfg: object) -> None:
+        init_calls.append((api_cfg, retry_cfg))
+
+    monkeypatch.setattr(pubchem.pl, "init_session", record_init)
+    monkeypatch.setattr(pubchem, "_PUBCHEM_SESSION_SIGNATURE", None)
+
+    frame = pd.DataFrame(
+        {"molecule_chembl_id": ["CHEMBL1", "CHEMBL2"]}, index=[0, 1]
+    )
+
+    call_count = 0
+
+    def fake_resolve(
+        frame_arg: pd.DataFrame,
+        cfg_arg: PubChemCfg,
+        *,
+        cid_cache: dict[str, str | None],
+        resolution_cache: dict[str, object],
+        load_parent_record,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> tuple[pd.Series, set[str], bool]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            assert cid_cache.get("CHEMBL1") == "CID1"
+            assert "CHEMBL2" not in cid_cache
+            cid_cache["CHEMBL2"] = "CID2"
+            series = pd.Series(["CID1", "CID2"], index=frame.index, dtype="string")
+            return series, {"CID2"}, True
+        assert cid_cache.get("CHEMBL1") == "CID1"
+        assert cid_cache.get("CHEMBL2") == "CID2"
+        series = pd.Series(["CID1", "CID2"], index=frame.index, dtype="string")
+        return series, set(), False
+
+    def fake_merge(
+        frame_arg: pd.DataFrame,
+        cid_series: pd.Series,
+        lookup_cids: set[str],
+        *,
+        cfg: PubChemCfg,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "pubchem_cid": cid_series,
+                "pubchem_iupac_name": ["Name1", "Name2"],
+            },
+            index=frame.index,
+        )
+
+    monkeypatch.setattr(pubchem, "_resolve_pubchem_cids", fake_resolve)
+    monkeypatch.setattr(pubchem, "_merge_pubchem_properties", fake_merge)
+
+    client = object()
+    first = pubchem.augment_pubchem(
+        frame,
+        pubchem_cfg=pubchem_cfg,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.system.retry,
+        timeout=5.0,
+        client=client,
+        fields=None,
+        request_limit=10,
+    )
+    second = pubchem.augment_pubchem(
+        frame,
+        pubchem_cfg=pubchem_cfg,
+        api_cfg=cfg.api,
+        retry_cfg=cfg.system.retry,
+        timeout=5.0,
+        client=client,
+        fields=None,
+        request_limit=10,
+    )
+
+    assert first["pubchem_cid"].tolist() == ["CID1", "CID2"]
+    assert second["pubchem_cid"].tolist() == ["CID1", "CID2"]
+    assert len(init_calls) == 1
+    cache_payload = json.loads(pubchem_cfg.cid_cache_path.read_text(encoding="utf-8"))
+    assert cache_payload["values"] == {"CHEMBL1": "CID1", "CHEMBL2": "CID2"}
+
+
+@pytest.mark.integration
+def test_add_pubchem_data__expires_stale_cache(
+    tmp_path: Path,
+    cfg,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pubchem_cfg = cfg.pubchem
+    pubchem_cfg.enable = True
+    pubchem_cfg.cache_ttl_hours = 1
+    pubchem_cfg.cid_cache_path = tmp_path / "cid_cache.json"
+
+    stale_payload = {
+        "metadata": {"version": 1, "updated_at": "2019-12-30T00:00:00+00:00"},
+        "values": {"CHEMBL1": "CID1"},
+    }
+    pubchem_cfg.cid_cache_path.write_text(
+        json.dumps(stale_payload, indent=2), encoding="utf-8"
+    )
+
+    frame = pd.DataFrame({"molecule_chembl_id": ["CHEMBL2"]})
+
+    def fake_resolve(
+        frame_arg: pd.DataFrame,
+        cfg_arg: PubChemCfg,
+        *,
+        cid_cache: dict[str, str | None],
+        resolution_cache: dict[str, object],
+        load_parent_record,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> tuple[pd.Series, set[str], bool]:
+        assert cid_cache == {}
+        series = pd.Series(["CID2"], index=frame.index, dtype="string")
+        cid_cache["CHEMBL2"] = "CID2"
+        return series, {"CID2"}, True
+
+    def fake_merge(
+        frame_arg: pd.DataFrame,
+        cid_series: pd.Series,
+        lookup_cids: set[str],
+        *,
+        cfg: PubChemCfg,
+        skip_mask: pd.Series,
+        prefer_local_mask: pd.Series,
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "pubchem_cid": cid_series,
+                "pubchem_iupac_name": ["Name2"],
+            },
+            index=frame.index,
+        )
+
+    monkeypatch.setattr(pubchem, "_resolve_pubchem_cids", fake_resolve)
+    monkeypatch.setattr(pubchem, "_merge_pubchem_properties", fake_merge)
+
+    info_events: list[str] = []
+
+    def capture_info(event: str, **fields: object) -> None:
+        logging.getLogger("pubchem-test").info(event)
+        info_events.append(event)
+
+    monkeypatch.setattr(pubchem.logger, "info", capture_info)
+    caplog.set_level("INFO", logger="pubchem-test")
+    result = pubchem.add_pubchem_data(frame, pubchem_cfg)
+
+    assert result["pubchem_cid"].tolist() == ["CID2"]
+    assert "pubchem_cache_expired" in info_events
+    assert any(
+        record.message == "pubchem_cache_expired"
+        for record in caplog.records
+        if record.name == "pubchem-test"
+    )
+
+
+@pytest.mark.integration
+def test_add_pubchem_data__disabled_mode_passthrough(
+    cfg, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pubchem_cfg = cfg.pubchem
+    pubchem_cfg.enable = False
+
+    frame = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+
+    info_events: list[str] = []
+
+    def capture_info(event: str, **fields: object) -> None:
+        logging.getLogger("pubchem-test").info(event)
+        info_events.append(event)
+
+    monkeypatch.setattr(pubchem.logger, "info", capture_info)
+    caplog.set_level("INFO", logger="pubchem-test")
+    result = pubchem.add_pubchem_data(frame, pubchem_cfg)
+
+    assert result is frame
+    assert "pubchem_disabled" in info_events
+    assert any(
+        record.message == "pubchem_disabled"
+        for record in caplog.records
+        if record.name == "pubchem-test"
+    )


### PR DESCRIPTION
## Summary
- add deterministic integration tests that exercise PubChem augmentation caches, polymer filtering, TTL expiry and disabled mode
- document the PubChem coverage in the integration enrichment checklist

## Testing
- pytest tests/integration/test_pubchem_augmentation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e05a6176ac83248ccc4d8f7a990d77