### PR TITLE
Add structured pytest reporting and expand pipeline tests

### DIFF
--- a/docs/ru/QA_PROCESS.md
+++ b/docs/ru/QA_PROCESS.md
@@ -37,10 +37,18 @@ mypy --strict
    ```
 2. Для сертификационных прогонов формируйте агрегированные отчёты (JSON + Markdown + логи):
    ```bash
-   make test-report
+   python scripts/run_tests.py
    ```
-   Команда оборачивает `python -m scripts.run_test_suite`, прогоняет весь набор и складывает артефакты в `reports/`.
-3. При локальной отладке допускается запускать «чистый» `pytest` с нужной детализацией (`-q` или `-vv`).
+   Скрипт сам вызывает `pytest` (эквивалентен `make test`), фиксирует stdout/stderr в `reports/test_run.log`,
+   сохраняет исходный отчёт плагина в `reports/pytest_raw_report.json` и публикует нормализованные артефакты
+   `reports/test_report.json` и `reports/test_summary.md`.
+3. Если требуется жёстко задать детерминированные параметры запуска, предварительно экспортируйте переменные окружения:
+   ```bash
+   PYTHONHASHSEED=${PYTHONHASHSEED:-0} \
+   CHEMBL_DA_BASE_PATH=$(pwd)/tests/data \
+   python scripts/run_tests.py
+   ```
+4. При локальной отладке допускается запускать «чистый» `pytest` с нужной детализацией (`-q` или `-vv`).
 
 ## 4. Проверка детерминизма и smoke-тесты CLI
 
@@ -60,9 +68,10 @@ mypy --strict
 
 Раннер по умолчанию создаёт три артефакта:
 
-- `reports/test_report.json` — машиночитаемый список тестов. Для каждого указаны идентификатор, итоговый статус, суммарная длительность, сообщение об ошибке/skip и путь до общего лог-файла.
+- `reports/test_report.json` — машиночитаемый список тестов. Для каждого указаны идентификатор, итоговый статус, суммарная длительность, агрегированные stdout/stderr, логи шага и текст ошибки (если был).
 - `reports/test_summary.md` — Markdown-дайджест с агрегированными счётчиками и перечнем проваленных/пропущенных тестов.
-- `reports/logs/<suite>.log` — совмещённый лог pytest-сеанса.
+- `reports/test_run.log` — совмещённый лог pytest-сеанса (stdout+stderr).
+- `reports/pytest_raw_report.json` — необработанный отчёт `pytest-json-report` (оставлен для пост-анализа и отладки) и по умолчанию добавлен в `.gitignore`.
 
 Подробная схема и пример Markdown приведены в `tests/README.md`.
 

--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,28 +1,29 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "b5a97fc2541b9eda41c3689a4721444bab9ccbc7",
+    "commit": "ebcbf5a8b0e0f6afe2823985d3c1df51a0726423",
     "branch": "work",
-    "ts_utc": "2025-10-03T23:33:35.418868+00:00",
-    "duration_sec": 1.17,
+    "ts_utc": "2025-10-03T23:56:02.430565+00:00",
+    "duration_sec": 1.7036499977111816,
     "python": "3.11.12",
-    "pytest": "8.4.1"
+    "pytest": "8.4.2",
+    "exit_code": 0
   },
   "summary": {
-    "total": 33,
-    "passed": 33,
+    "total": 75,
+    "passed": 75,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
     "xpassed": 0,
     "error": 0,
-    "success_rate": 1.0
+    "success_rate": 100.0
   },
   "tests": [
     {
       "nodeid": "tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline",
       "status": "passed",
-      "duration_ms": 121.971,
+      "duration_ms": 83.711,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -31,21 +32,25 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
       "status": "passed",
-      "duration_ms": 73.258,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:34.852378+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:33:34.852575+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:33:34.856578+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 51.219,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:00.929632+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:56:00.929772+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:56:00.932369+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}",
       "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:34.852378+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:33:34.852575+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:33:34.856578+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
-        }
-      ],
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__finalize_stage_idempotent",
+      "status": "passed",
+      "duration_ms": 176.507,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:00.971043+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.015200+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.015396+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.036235+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.060817+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-03T23:56:01.073613+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.076127+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.084811+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.084964+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.105311+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.138652+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}",
+      "stderr": "",
+      "log": [],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
       "status": "passed",
-      "duration_ms": 25.972,
+      "duration_ms": 19.448,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -54,31 +59,89 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
       "status": "passed",
-      "duration_ms": 25.417,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:34.959456+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 18.06,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.176869+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}",
       "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:34.959456+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
-        }
-      ],
+      "log": [],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
       "status": "passed",
-      "duration_ms": 6.172,
+      "duration_ms": 6.065,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
       "status": "passed",
-      "duration_ms": 0.36,
+      "duration_ms": 88.825,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.191437+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.199912+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.200051+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.218620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.252242+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_c0/final.csv.meta.yaml\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__missing_required_columns_fails",
+      "status": "passed",
+      "duration_ms": 3.326,
       "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__optional_columns_missing_warns",
+      "status": "passed",
+      "duration_ms": 58.456,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.282912+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.288293+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.305644+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.337962+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__optional0/optional.csv.meta.yaml\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
+      "status": "passed",
+      "duration_ms": 25.177,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.342649+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.349482+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-03T23:56:01.350653+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.362845+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_f0/failures_failure_cases.csv\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
+      "status": "passed",
+      "duration_ms": 107.147,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.368061+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.372844+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.372965+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.437764+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.470938+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.471862+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal",
+      "status": "passed",
+      "duration_ms": 91.695,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.475899+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.480895+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.481008+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.497860+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.530387+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.563822+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.564190+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
+      "status": "passed",
+      "duration_ms": 58.403,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.568650+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-03T23:56:01.573229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.573342+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.589105+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.621787+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
+      "status": "passed",
+      "duration_ms": 113.543,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.627229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.632229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.632343+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.648713+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.681011+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.682562+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.687635+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.687768+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.704253+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.736981+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv.meta.yaml\"}",
       "stderr": "",
       "log": [],
       "error": null
@@ -86,7 +149,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_encoding_recovers_values",
       "status": "passed",
-      "duration_ms": 1.245,
+      "duration_ms": 2.559,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -95,52 +158,25 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_separator_emits_info",
       "status": "passed",
-      "duration_ms": 0.604,
+      "duration_ms": 1.818,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
+      "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
       "status": "passed",
-      "duration_ms": 0.72,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.041694+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 1.804,
+      "stdout": "",
       "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.041694+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[32mINFO    \u001b[0m pubchem-test:test_pubchem_augmentation.py:357 pubchem_disabled"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
-      "status": "passed",
-      "duration_ms": 6.596,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.032748+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.032748+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[32mINFO    \u001b[0m pubchem-test:test_pubchem_augmentation.py:329 pubchem_cache_expired"
-        }
-      ],
+      "log": [],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__normal_flow_populates_cache",
       "status": "passed",
-      "duration_ms": 9.657,
+      "duration_ms": 8.23,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -149,57 +185,67 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__skips_polymers_when_disallowed",
       "status": "passed",
-      "duration_ms": 9.697,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.004628+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 7.64,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.757770+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
       "stderr": "",
       "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.004628+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[33mWARNING \u001b[0m pubchem-test:test_pubchem_augmentation.py:148 pubchem_skip_polymers"
-        }
+        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
       ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_augment_pubchem__initialises_session_and_reuses_cache",
       "status": "passed",
-      "duration_ms": 13.717,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.015239+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.021423+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.021920+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.027445+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 9.918,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.764626+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.768510+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.768781+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.772166+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
+      "status": "passed",
+      "duration_ms": 5.855,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.775409+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
       "stderr": "",
       "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.015239+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.021423+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.021920+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:33:35.027445+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n"
-        }
+        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
       ],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
+      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
       "status": "passed",
-      "duration_ms": 1.293,
-      "stdout": "",
+      "duration_ms": 1.987,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.781061+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
       "stderr": "",
-      "log": [],
+      "log": [
+        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
       "status": "passed",
-      "duration_ms": 22.256,
+      "duration_ms": 4.665,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
+      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
       "status": "passed",
-      "duration_ms": 1.697,
+      "duration_ms": 1.52,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
+      "status": "passed",
+      "duration_ms": 1.5,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -208,25 +254,99 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
       "status": "passed",
-      "duration_ms": 2.105,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.075712+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n",
+      "duration_ms": 2.038,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.791925+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}",
       "stderr": "",
       "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.075712+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
-        }
+        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
       ],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
       "status": "passed",
-      "duration_ms": 0.83,
+      "duration_ms": 1.769,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
+      "status": "passed",
+      "duration_ms": 0.913,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.851,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.861,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.857,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.909,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
+      "status": "passed",
+      "duration_ms": 0.912,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
+      "status": "passed",
+      "duration_ms": 1.008,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
+      "status": "passed",
+      "duration_ms": 0.826,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
+      "status": "passed",
+      "duration_ms": 0.817,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -235,7 +355,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
       "status": "passed",
-      "duration_ms": 3.106,
+      "duration_ms": 2.769,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -244,16 +364,25 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
       "status": "passed",
-      "duration_ms": 1.971,
+      "duration_ms": 1.975,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
       "status": "passed",
-      "duration_ms": 1.487,
+      "duration_ms": 1.895,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
+      "status": "passed",
+      "duration_ms": 1.942,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -262,44 +391,25 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
       "status": "passed",
-      "duration_ms": 0.167,
+      "duration_ms": 1.78,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
+      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
       "status": "passed",
-      "duration_ms": 1.347,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.114172+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-3/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-3/test_read_input_ids__invalid_c0/input.csv\"}\n",
+      "duration_ms": 1.792,
+      "stdout": "",
       "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.114172+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-3/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-3/test_read_input_ids__invalid_c0/input.csv\"}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
-      "status": "passed",
-      "duration_ms": 1.902,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.109646+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.109646+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
-        }
-      ],
+      "log": [],
       "error": null
     },
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
       "status": "passed",
-      "duration_ms": 3.051,
+      "duration_ms": 3.771,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -308,21 +418,142 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
       "status": "passed",
-      "duration_ms": 0.462,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.104475+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
+      "duration_ms": 1.793,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.826834+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}",
       "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.104475+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
-        }
-      ],
+      "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
       "status": "passed",
-      "duration_ms": 4.034,
+      "duration_ms": 2.572,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.829722+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
+      "status": "passed",
+      "duration_ms": 2.607,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.832811+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv\"}",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
+      "status": "passed",
+      "duration_ms": 0.909,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
+      "status": "passed",
+      "duration_ms": 0.88,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
+      "status": "passed",
+      "duration_ms": 0.974,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
+      "status": "passed",
+      "duration_ms": 0.839,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
+      "status": "passed",
+      "duration_ms": 0.864,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
+      "status": "passed",
+      "duration_ms": 0.886,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
+      "status": "passed",
+      "duration_ms": 0.869,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
+      "status": "passed",
+      "duration_ms": 0.924,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
+      "status": "passed",
+      "duration_ms": 0.964,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
+      "status": "passed",
+      "duration_ms": 0.887,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
+      "status": "passed",
+      "duration_ms": 1.087,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
+      "status": "passed",
+      "duration_ms": 0.883,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
+      "status": "passed",
+      "duration_ms": 0.913,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -331,16 +562,97 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
       "status": "passed",
-      "duration_ms": 9.625,
+      "duration_ms": 6.882,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
+      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
       "status": "passed",
-      "duration_ms": 1.501,
+      "duration_ms": 3.387,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
+      "status": "passed",
+      "duration_ms": 1.348,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
+      "status": "passed",
+      "duration_ms": 1.301,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
+      "status": "passed",
+      "duration_ms": 1.578,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
+      "status": "passed",
+      "duration_ms": 1.398,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__identifier_columns_trimmed",
+      "status": "passed",
+      "duration_ms": 1.843,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__micro_sign_replaced",
+      "status": "passed",
+      "duration_ms": 1.337,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__preserves_boolean_dtype",
+      "status": "passed",
+      "duration_ms": 1.376,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__retains_missing_values",
+      "status": "passed",
+      "duration_ms": 1.475,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
+      "status": "passed",
+      "duration_ms": 1.351,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -349,7 +661,16 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
       "status": "passed",
-      "duration_ms": 1.72,
+      "duration_ms": 1.85,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
+      "status": "passed",
+      "duration_ms": 1.927,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -358,7 +679,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 0.737,
+      "duration_ms": 1.361,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -367,7 +688,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 0.553,
+      "duration_ms": 1.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -376,18 +697,11 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_main__downgrades_exit_code_when_threshold_not_met",
       "status": "passed",
-      "duration_ms": 1.787,
-      "stdout": "{\"ts\": \"2025-10-03T23:33:35.146242+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n",
+      "duration_ms": 2.303,
+      "stdout": "{\"ts\": \"2025-10-03T23:56:01.887651+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}",
       "stderr": "",
       "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-03T23:33:35.146242+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m tools.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
-        }
+        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
       ],
       "error": null
     }

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: b5a97fc2541b9eda41c3689a4721444bab9ccbc7
+- Commit: ebcbf5a8b0e0f6afe2823985d3c1df51a0726423
 - Branch: work
-- Timestamp (UTC): 2025-10-03T23:33:35.418868+00:00
-- Duration: 1.17 s
+- Timestamp (UTC): 2025-10-03T23:56:02.430565+00:00
+- Duration: 1.70 s
 - Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|    33 |    33 |     0 |      0 |      0 |      0 |     0 |
+|    75 |    75 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
-- none
+- None

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,18 +1,23 @@
-"""Run the test suite and produce machine- and human-readable reports."""
+"""Run the test suite and produce structured JSON and Markdown reports."""
 from __future__ import annotations
 
 import json
+import platform
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+import pytest
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 REPORTS_DIR = ROOT_DIR / "reports"
+RAW_REPORT_FILE = REPORTS_DIR / "pytest_raw_report.json"
 REPORT_FILE = REPORTS_DIR / "test_report.json"
 LOG_FILE = REPORTS_DIR / "test_run.log"
 SUMMARY_FILE = REPORTS_DIR / "test_summary.md"
+REPO_SLUG = "SatoryKono/ChEMBL_data_acquisition"
 
 PYTEST_COMMAND: tuple[str, ...] = (
     sys.executable,
@@ -20,20 +25,20 @@ PYTEST_COMMAND: tuple[str, ...] = (
     "pytest",
     "--json-report",
     "--json-report-file",
-    str(REPORT_FILE),
+    str(RAW_REPORT_FILE),
     "--durations=0",
     "-vv",
 )
 
 
 def ensure_reports_directory() -> None:
-    """Ensure that the reports directory exists."""
+    """Ensure the reports directory exists."""
 
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def run_pytest() -> int:
-    """Execute pytest and capture its combined stdout/stderr into a log file."""
+    """Execute pytest and capture combined output in the log file."""
 
     with LOG_FILE.open("w", encoding="utf-8") as log_file:
         result = subprocess.run(
@@ -45,20 +50,16 @@ def run_pytest() -> int:
     return result.returncode
 
 
-def load_report() -> dict[str, Any]:
-    """Load the JSON report produced by pytest-json-report, if available."""
-
-    if not REPORT_FILE.exists():
+def _load_raw_report() -> dict[str, Any]:
+    if not RAW_REPORT_FILE.exists():
         return {}
     try:
-        return json.loads(REPORT_FILE.read_text(encoding="utf-8"))
+        return json.loads(RAW_REPORT_FILE.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return {}
 
 
 def _normalise_message(raw: Any) -> str:
-    """Convert values from the report into a compact string."""
-
     if raw is None:
         return ""
     if isinstance(raw, str):
@@ -70,8 +71,6 @@ def _normalise_message(raw: Any) -> str:
 
 
 def _extract_section_message(section: dict[str, Any]) -> str:
-    """Extract a meaningful message from a report section."""
-
     for key in ("longrepr", "message"):
         if key in section:
             message = _normalise_message(section[key])
@@ -88,131 +87,207 @@ def _extract_section_message(section: dict[str, Any]) -> str:
     return ""
 
 
-def collect_notable_failures(report: dict[str, Any], limit: int = 5) -> list[dict[str, str]]:
-    """Return a concise list of failing test cases for the summary."""
+def _git_output(*args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ("git", *args),
+            cwd=ROOT_DIR,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
 
-    tests = report.get("tests", [])
-    if not isinstance(tests, list):
+
+def _collect_phase_output(section: dict[str, Any], field: str) -> list[str]:
+    if not isinstance(section, dict):
         return []
+    value = section.get(field)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [_normalise_message(item) for item in value if _normalise_message(item)]
+    text = _normalise_message(value)
+    return [text] if text else []
 
-    failures: list[dict[str, str]] = []
-    for test in tests:
+
+def _build_test_entry(test: dict[str, Any]) -> dict[str, Any]:
+    nodeid = str(test.get("nodeid", "<unknown>"))
+    status = str(test.get("outcome", "unknown")).lower()
+    duration = 0.0
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    log_entries: list[str] = []
+
+    for phase_name in ("setup", "call", "teardown"):
+        section = test.get(phase_name)
+        if not isinstance(section, dict):
+            continue
+        duration += float(section.get("duration", 0.0) or 0.0)
+        stdout_parts.extend(_collect_phase_output(section, "stdout"))
+        stderr_parts.extend(_collect_phase_output(section, "stderr"))
+        log_entries.extend(_collect_phase_output(section, "log"))
+
+    error_message = ""
+    if status not in {"passed", "skipped", "xfailed", "xpassed"}:
+        for phase_name in ("setup", "call", "teardown"):
+            section = test.get(phase_name)
+            if isinstance(section, dict):
+                error_message = _extract_section_message(section)
+            if error_message:
+                break
+        if not error_message:
+            error_message = _normalise_message(test.get("longrepr"))
+
+    entry = {
+        "nodeid": nodeid,
+        "status": status or "unknown",
+        "duration_ms": round(duration * 1000.0, 3),
+        "stdout": "\n".join(stdout_parts),
+        "stderr": "\n".join(stderr_parts),
+        "log": log_entries,
+        "error": error_message or None,
+    }
+    return entry
+
+
+def build_structured_report(raw: dict[str, Any], exit_code: int) -> dict[str, Any]:
+    tests_raw = raw.get("tests", [])
+    tests: list[dict[str, Any]] = []
+    summary = {
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0,
+        "error": 0,
+    }
+
+    if isinstance(tests_raw, list):
+        iterable = tests_raw
+    else:
+        iterable = []
+
+    for test in iterable:
         if not isinstance(test, dict):
             continue
-        outcome = test.get("outcome")
-        if outcome in {"passed", "skipped", "xfailed"}:
-            continue
-        nodeid = str(test.get("nodeid", "<unknown>"))
-        message = ""
-        for phase in ("setup", "call", "teardown"):
-            section = test.get(phase)
-            if isinstance(section, dict):
-                message = _extract_section_message(section)
-            if message:
-                break
-        if not message:
-            message = _normalise_message(test.get("longrepr"))
-        if not message:
-            message = "See test_run.log for details."
-        truncated = message if len(message) <= 500 else f"{message[:497]}..."
-        failures.append({
-            "nodeid": nodeid,
-            "outcome": str(outcome),
-            "message": truncated,
-        })
-        if len(failures) >= limit:
-            break
-    return failures
+        entry = _build_test_entry(test)
+        tests.append(entry)
+        summary["total"] += 1
+        status = entry["status"]
+        if status in summary:
+            summary[status] += 1
+        elif status.startswith("xfail"):
+            summary["xfailed"] += 1
+        elif status.startswith("xpass"):
+            summary["xpassed"] += 1
+        else:
+            summary["error"] += 1
+
+    success_rate = (
+        (summary["passed"] / summary["total"] * 100.0)
+        if summary["total"]
+        else 0.0
+    )
+    summary["success_rate"] = round(success_rate, 2)
+
+    meta = {
+        "repo": REPO_SLUG,
+        "commit": _git_output("rev-parse", "HEAD"),
+        "branch": _git_output("rev-parse", "--abbrev-ref", "HEAD"),
+        "ts_utc": datetime.now(timezone.utc).isoformat(),
+        "duration_sec": float(raw.get("duration", 0.0) or 0.0),
+        "python": platform.python_version(),
+        "pytest": pytest.__version__,
+        "exit_code": exit_code,
+    }
+
+    return {
+        "meta": meta,
+        "summary": summary,
+        "tests": tests,
+    }
 
 
-def build_summary(report: dict[str, Any], exit_code: int) -> str:
-    """Create a Markdown summary for the test run."""
-
-    summary = report.get("summary", {}) if isinstance(report, dict) else {}
-    total = int(summary.get("total", 0)) if summary else 0
-    passed = int(summary.get("passed", 0)) if summary else 0
-    failed = int(summary.get("failed", 0)) if summary else 0
-    errors = int(summary.get("error", 0)) if summary else 0
-    skipped = int(summary.get("skipped", 0)) if summary else 0
-    xfailed = int(summary.get("xfailed", 0)) if summary else 0
-    xpassed = int(summary.get("xpassed", 0)) if summary else 0
-
-    success_rate = (passed / total * 100) if total else 0.0
-
-    timestamp = datetime.now(timezone.utc).isoformat()
-
-    lines = [
-        "# Test Run Summary",
-        "",
-        f"- Timestamp (UTC): {timestamp}",
-        f"- Exit code: {exit_code}",
-        f"- JSON report: `{REPORT_FILE.relative_to(ROOT_DIR)}`",
-        f"- Log file: `{LOG_FILE.relative_to(ROOT_DIR)}`",
-    ]
-
-    if report:
-        duration = report.get("duration")
-        if duration is not None:
-            lines.append(f"- Duration: {duration:.2f}s")
-    lines.extend(
-        [
-            "",
-            "## Overview",
-            "",
-            "| Metric | Value |",
-            "| --- | --- |",
-            f"| Total tests | {total} |",
-            f"| Passed | {passed} |",
-            f"| Failed | {failed} |",
-            f"| Errors | {errors} |",
-            f"| Skipped | {skipped} |",
-            f"| XFailed | {xfailed} |",
-            f"| XPassed | {xpassed} |",
-            f"| Success rate | {success_rate:.1f}% |",
-        ]
+def write_json_report(report: dict[str, Any]) -> None:
+    REPORT_FILE.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False),
+        encoding="utf-8",
     )
 
-    failures = collect_notable_failures(report)
-    lines.append("")
-    if failures:
-        lines.append("## Notable failures")
-        lines.append("")
-        for item in failures:
-            lines.append(f"- `{item['nodeid']}` ({item['outcome']})")
-            sanitized_message = item['message'].replace('\n', ' ')
-            lines.append(f"  - {sanitized_message}")
-        if len(failures) == 5:
-            lines.append("")
-            lines.append("_Only the first five failures are shown. Consult the log for full output._")
+
+def build_summary_markdown(report: dict[str, Any]) -> str:
+    meta = report.get("meta", {})
+    summary = report.get("summary", {})
+    tests = report.get("tests", [])
+
+    repo = meta.get("repo", REPO_SLUG)
+    commit = meta.get("commit", "unknown")
+    branch = meta.get("branch", "unknown")
+    timestamp = meta.get("ts_utc", datetime.now(timezone.utc).isoformat())
+    duration = float(meta.get("duration_sec", 0.0) or 0.0)
+    success_rate = summary.get("success_rate", 0.0)
+
+    lines = [
+        "# Test Summary",
+        "",
+        f"- Repo: `{repo}`",
+        f"- Commit: {commit}",
+        f"- Branch: {branch}",
+        f"- Timestamp (UTC): {timestamp}",
+        f"- Duration: {duration:.2f} s",
+        f"- Success rate: {success_rate:.2f}%",
+        "",
+        "| total | passed | failed | skipped | xfailed | xpassed | error |",
+        "|------:|-------:|-------:|--------:|--------:|--------:|------:|",
+        "| {total:5d} | {passed:5d} | {failed:5d} | {skipped:6d} | {xfailed:6d} | {xpassed:6d} | {error:5d} |".format(
+            total=summary.get("total", 0),
+            passed=summary.get("passed", 0),
+            failed=summary.get("failed", 0),
+            skipped=summary.get("skipped", 0),
+            xfailed=summary.get("xfailed", 0),
+            xpassed=summary.get("xpassed", 0),
+            error=summary.get("error", 0),
+        ),
+        "",
+        "## Failed / Error details",
+    ]
+
+    failure_rows = [
+        (test["nodeid"], (test.get("error") or "See reports/test_run.log"))
+        for test in tests
+        if test.get("status") in {"failed", "error"}
+    ]
+
+    if not failure_rows:
+        lines.append("- None")
     else:
-        if exit_code == 0:
-            lines.append("All tests passed.")
-        else:
-            lines.append("No failure details captured. Check the log file for diagnostics.")
+        for nodeid, message in failure_rows:
+            compact_message = message.replace("\n", " ").strip()
+            lines.append(f"- `{nodeid}`: {compact_message}")
 
     lines.append("")
     return "\n".join(lines)
 
 
-def write_summary(report: dict[str, Any], exit_code: int) -> None:
-    """Persist the Markdown summary to disk."""
-
-    SUMMARY_FILE.write_text(build_summary(report, exit_code), encoding="utf-8")
+def write_summary(report: dict[str, Any]) -> None:
+    SUMMARY_FILE.write_text(build_summary_markdown(report), encoding="utf-8")
 
 
 def main() -> int:
-    """Run pytest, create artefacts, and forward the exit status."""
-
     ensure_reports_directory()
     exit_code = run_pytest()
-    report = load_report()
-    write_summary(report, exit_code)
+    raw_report = _load_raw_report()
+    structured = build_structured_report(raw_report, exit_code)
+    write_json_report(structured)
+    write_summary(structured)
+
     print(f"Pytest finished with exit code {exit_code}.")
     print(f"Log saved to {LOG_FILE.relative_to(ROOT_DIR)}.")
-    if REPORT_FILE.exists():
-        print(f"JSON report available at {REPORT_FILE.relative_to(ROOT_DIR)}.")
-    else:
-        print("JSON report was not created. See log for details.")
+    if RAW_REPORT_FILE.exists():
+        print(f"Raw report available at {RAW_REPORT_FILE.relative_to(ROOT_DIR)}.")
+    print(f"Structured report written to {REPORT_FILE.relative_to(ROOT_DIR)}.")
     print(f"Summary written to {SUMMARY_FILE.relative_to(ROOT_DIR)}.")
     return exit_code
 

--- a/tests/e2e/test_testitem_pipeline.py
+++ b/tests/e2e/test_testitem_pipeline.py
@@ -7,6 +7,7 @@ import pytest
 
 from library.common.csv_utils import sha256_file, write_csv_deterministic
 from library.pipelines.testitem import cli, enrichment
+from library.pipelines.testitem.catalog import ParentLookupStats
 from library.schemas.normalize import normalize_testitems
 
 
@@ -68,3 +69,57 @@ def test_testitem_pipeline_e2e__deterministic_output(
     assert list(reloaded["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL2", "CHEMBL999"]
     assert pd.isna(reloaded.loc[2, "parent_molecule_chembl_id"])
     assert pd.isna(reloaded.loc[2, "natural_product"])
+
+
+@pytest.mark.e2e
+def test_testitem_pipeline_e2e__finalize_stage_idempotent(
+    tmp_path: Path, sample_input_csv: Path, cfg
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series(["CHEMBL1", "CHEMBL2"], dtype="string"),
+            "parent_molecule_chembl_id": pd.Series(["CHEMBL10", pd.NA], dtype="string"),
+            "natural_product": pd.Series([True, False], dtype="boolean"),
+            "salt_chembl_id": pd.Series(["CHEMBL1", "CHEMBL2"], dtype="string"),
+        }
+    )
+
+    stats = ParentLookupStats(
+        source="lookup",
+        missing=0,
+        unique=2,
+        attached=2,
+        uncovered=0,
+    )
+
+    def supplier() -> ParentLookupStats:
+        return stats
+
+    output_path = tmp_path / "finalized.csv"
+
+    first_exit = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=supplier,
+        input_csv=sample_input_csv,
+    )
+    assert first_exit == 0
+    first_hash = sha256_file(output_path)
+
+    second_exit = cli.finalize_output(
+        [chunk.copy()],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=supplier,
+        input_csv=sample_input_csv,
+    )
+    assert second_exit == 0
+    second_hash = sha256_file(output_path)
+
+    assert first_hash == second_hash
+
+    final_frame = pd.read_csv(output_path)
+    assert list(final_frame["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]

--- a/tests/integration/test_finalize_output.py
+++ b/tests/integration/test_finalize_output.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from library.common.csv_utils import sha256_file
+from library.pipelines.testitem import cli
+from library.pipelines.testitem.catalog import ParentLookupStats
+
+
+class _StatsSupplier:
+    """Callable wrapper returning a predetermined :class:`ParentLookupStats`."""
+
+    def __init__(self, stats: ParentLookupStats) -> None:
+        self._stats = stats
+
+    def __call__(self) -> ParentLookupStats:
+        return self._stats
+
+
+def _base_stats() -> ParentLookupStats:
+    return ParentLookupStats(
+        source="lookup",
+        missing=0,
+        unique=2,
+        attached=2,
+        uncovered=0,
+        failed_ids=(),
+        hierarchy_attached=1,
+        fallback_attached=1,
+        no_parent=0,
+    )
+
+
+@pytest.mark.integration
+def test_finalize_output__writes_csv_and_metadata(
+    tmp_path: Path, sample_input_csv: Path, cfg
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series([" CHEMBL1 ", "CHEMBL2"], dtype="string"),
+            "parent_molecule_chembl_id": pd.Series(["CHEMBL10", pd.NA], dtype="string"),
+            "natural_product": pd.Series([True, False], dtype="boolean"),
+            "salt_chembl_id": pd.Series(["CHEMBL1", pd.NA], dtype="string"),
+            "pubchem_cid": pd.Series([123, 456], dtype="Int64"),
+        }
+    )
+    output_path = tmp_path / "final.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+        missing_ids=["CHEMBL999"],
+    )
+
+    assert exit_code == 0
+    assert output_path.exists()
+
+    final = pd.read_csv(output_path)
+    assert list(final.columns[:3]) == [
+        "molecule_chembl_id",
+        "parent_molecule_chembl_id",
+        "salt_chembl_id",
+    ]
+    assert list(final["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    assert "pipeline_version" in final.columns
+    assert "timestamp_utc" in final.columns
+
+    meta_path = output_path.with_name("final.csv.meta.yaml")
+    assert meta_path.exists()
+    meta = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert meta["stats"]["rows_total"] == 2
+    assert meta["stats"]["rows_kept"] == 2
+    assert meta["inputs"]["input_csv"].endswith("input.csv")
+
+
+@pytest.mark.integration
+def test_finalize_output__missing_required_columns_fails(
+    tmp_path: Path, sample_input_csv: Path, cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame({"other": [1]})
+    output_path = tmp_path / "invalid.csv"
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(event: str, **fields: object) -> None:
+        warnings.append((event, fields))
+
+    monkeypatch.setattr(cli.logger, "warning", capture_warning)
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 1
+    assert ("validation_skipped", {"missing_columns": ["molecule_chembl_id"]}) in warnings
+
+
+@pytest.mark.integration
+def test_finalize_output__optional_columns_missing_warns(
+    tmp_path: Path, sample_input_csv: Path, cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+    output_path = tmp_path / "optional.csv"
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(event: str, **fields: object) -> None:
+        warnings.append((event, fields))
+
+    monkeypatch.setattr(cli.logger, "warning", capture_warning)
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 0
+    assert any(event == "optional_columns_missing" for event, _ in warnings)
+
+
+@pytest.mark.integration
+def test_finalize_output__writes_failure_cases(tmp_path: Path, sample_input_csv: Path, cfg) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1"],
+            "natural_product": ["unexpected"],
+        }
+    )
+    output_path = tmp_path / "failures.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 1
+    failure_path = tmp_path / "failures_failure_cases.csv"
+    assert failure_path.exists()
+    failure_contents = pd.read_csv(failure_path)
+    assert not failure_contents.empty
+    assert "natural_product" in failure_contents["column"].tolist()
+
+
+@pytest.mark.integration
+def test_finalize_output__quality_report_failure_non_fatal(
+    tmp_path: Path,
+    sample_input_csv: Path,
+    cfg,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg.system.doc_quality.enable = True
+    cfg.system.doc_quality.fatal_on_error = False
+
+    chunk = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+    output_path = tmp_path / "quality.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+    recorded: list[dict[str, object]] = []
+
+    def fake_analyze(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("quality failed")
+
+    def capture_failure(*_args: object, **kwargs: object) -> None:
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(cli, "analyze_table_quality", fake_analyze)
+    monkeypatch.setattr(cli, "record_quality_failure", capture_failure)
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 0
+    assert recorded and recorded[0]["error"] == "quality failed"
+
+
+@pytest.mark.integration
+def test_finalize_output__quality_report_failure_fatal(
+    tmp_path: Path,
+    sample_input_csv: Path,
+    cfg,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg.system.doc_quality.enable = True
+    cfg.system.doc_quality.fatal_on_error = True
+
+    chunk = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+    output_path = tmp_path / "quality_fatal.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    def fake_analyze(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("quality failed")
+
+    monkeypatch.setattr(cli, "analyze_table_quality", fake_analyze)
+
+    exit_code = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+def test_finalize_output__empty_input_produces_placeholder(
+    tmp_path: Path, sample_input_csv: Path, cfg
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    output_path = tmp_path / "empty.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 0
+    frame = pd.read_csv(output_path)
+    assert list(frame.columns[:1]) == ["molecule_chembl_id"]
+    assert frame.empty
+
+
+@pytest.mark.integration
+def test_finalize_output__idempotent_results(tmp_path: Path, sample_input_csv: Path, cfg) -> None:
+    cfg.system.doc_quality.enable = False
+
+    chunk = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1", "CHEMBL2"]})
+    output_path = tmp_path / "stable.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    first_exit = cli.finalize_output(
+        [chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+    first_hash = sha256_file(output_path)
+
+    second_exit = cli.finalize_output(
+        [chunk.copy()],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+    second_hash = sha256_file(output_path)
+
+    assert first_exit == 0 == second_exit
+    assert first_hash == second_hash

--- a/tests/unit/test_catalog_utils.py
+++ b/tests/unit/test_catalog_utils.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.pipelines.testitem import catalog
+
+
+@pytest.mark.unit
+def test_ensure_no_parant_column__raises() -> None:
+    frame = pd.DataFrame({"parant_molecule_id": ["CHEMBL1"]})
+    with pytest.raises(ValueError):
+        catalog.ensure_no_parant_column(frame)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value, child_id, expected",
+    [
+        (None, "CHEMBL1", None),
+        ("", "CHEMBL1", None),
+        ("NULL", "CHEMBL1", None),
+        ("CHEMBL1", "CHEMBL1", None),
+        ("NO PARENT", "CHEMBL2", None),
+        (" chembl2 ", "CHEMBL1", "CHEMBL2"),
+    ],
+)
+def test_normalise_parent_identifier__cases(value: object, child_id: str, expected: str | None) -> None:
+    assert catalog._normalise_parent_identifier(value, child_id=child_id) == expected
+
+
+@pytest.mark.unit
+def test_merge_parent_stats__accumulates_counts() -> None:
+    base = catalog.ParentLookupStats(
+        source=catalog.PARENT_LOOKUP_SOURCE_CACHE,
+        missing=1,
+        unique=2,
+        attached=1,
+        uncovered=0,
+        failed_ids=("CHEMBL1",),
+        hierarchy_attached=1,
+        fallback_attached=0,
+        no_parent=0,
+    )
+    update = catalog.ParentLookupStats(
+        source=catalog.PARENT_LOOKUP_SOURCE_LOOKUP,
+        missing=2,
+        unique=1,
+        attached=1,
+        uncovered=1,
+        failed_ids=("CHEMBL2", "CHEMBL1"),
+        hierarchy_attached=0,
+        fallback_attached=1,
+        no_parent=1,
+    )
+
+    merged = catalog._merge_parent_stats(base, update)
+
+    assert merged.source == catalog.PARENT_LOOKUP_SOURCE_LOOKUP
+    assert merged.missing == 3
+    assert merged.unique == 3
+    assert merged.attached == 2
+    assert merged.uncovered == 1
+    assert merged.hierarchy_attached == 1
+    assert merged.fallback_attached == 1
+    assert merged.no_parent == 1
+    assert merged.failed_ids == ("CHEMBL1", "CHEMBL2")
+
+
+@pytest.mark.unit
+def test_merge_parent_stats__keeps_higher_priority_source() -> None:
+    base = catalog.ParentLookupStats(
+        source=catalog.PARENT_LOOKUP_SOURCE_SYNC,
+        missing=0,
+        unique=0,
+        attached=0,
+        uncovered=0,
+    )
+    update = catalog.ParentLookupStats(
+        source=catalog.PARENT_LOOKUP_SOURCE_CACHE,
+        missing=0,
+        unique=0,
+        attached=0,
+        uncovered=0,
+    )
+
+    merged = catalog._merge_parent_stats(base, update)
+    assert merged.source == catalog.PARENT_LOOKUP_SOURCE_SYNC

--- a/tests/unit/test_cli_integrate_missing.py
+++ b/tests/unit/test_cli_integrate_missing.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas as pd
 import pytest
 
 from library.pipelines.testitem import cli
@@ -43,3 +42,27 @@ def test_integrate_missing_identifiers__restores_requested_order() -> None:
     )
 
     assert list(result["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL3"]
+
+
+@pytest.mark.unit
+def test_integrate_missing_identifiers__ignores_blank_requested_ids() -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL1"]})
+    result = cli.integrate_missing_identifiers(
+        df,
+        missing_ids=["CHEMBL2"],
+        requested_ids=["", None, "CHEMBL1", "CHEMBL2"],
+    )
+
+    assert list(result["molecule_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+
+
+@pytest.mark.unit
+def test_integrate_missing_identifiers__missing_ids_appended_at_end() -> None:
+    df = pd.DataFrame({"molecule_chembl_id": ["CHEMBL3"]})
+    result = cli.integrate_missing_identifiers(
+        df,
+        missing_ids=["CHEMBL1"],
+        requested_ids=["CHEMBL3"],
+    )
+
+    assert list(result["molecule_chembl_id"]) == ["CHEMBL3", "CHEMBL1"]

--- a/tests/unit/test_cli_stage_controls.py
+++ b/tests/unit/test_cli_stage_controls.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from library.testitem_pipeline import cli
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, dict[str, object]]] = []
+
+    def info(self, event: str, **payload: object) -> None:
+        self.messages.append(("info", event, dict(payload)))
+
+    def warning(self, event: str, **payload: object) -> None:
+        self.messages.append(("warning", event, dict(payload)))
+
+    def error(self, event: str, **payload: object) -> None:
+        self.messages.append(("error", event, dict(payload)))
+
+
+@pytest.mark.unit
+def test_stage_execution_budget__start_logs_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_calls = [0.0]
+
+    def fake_monotonic() -> float:
+        return monotonic_calls[0]
+
+    monkeypatch.setattr(cli.time, "monotonic", fake_monotonic)
+    logger = DummyLogger()
+
+    budget = cli.StageExecutionBudget("fetch", minutes=1, logger=logger)
+    budget.start()
+
+    assert ("info", "fetch_execution_budget_started", {"budget_seconds": 60}) in logger.messages
+
+
+@pytest.mark.unit
+def test_stage_execution_budget__enforce_within_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [0.0]
+
+    def fake_monotonic() -> float:
+        return now[0]
+
+    monkeypatch.setattr(cli.time, "monotonic", fake_monotonic)
+    logger = DummyLogger()
+
+    budget = cli.StageExecutionBudget("stage", minutes=1, logger=logger)
+    budget.start()
+    now[0] = 30.0
+    budget.enforce("chunk")
+
+    assert all(level != "error" for level, _, _ in logger.messages)
+
+
+@pytest.mark.unit
+def test_stage_execution_budget__enforce_after_budget_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [0.0]
+
+    def fake_monotonic() -> float:
+        return now[0]
+
+    monkeypatch.setattr(cli.time, "monotonic", fake_monotonic)
+    logger = DummyLogger()
+
+    budget = cli.StageExecutionBudget("stage", minutes=1 / 60, logger=logger)
+    budget.start()
+    now[0] = 5.0
+
+    with pytest.raises(cli.TestitemPipelineStageError):
+        budget.enforce("batch")
+
+    assert any(event == "stage_execution_budget_exhausted" for _, event, _ in logger.messages)
+
+
+@pytest.mark.unit
+def test_stage_watchdog__start_without_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.time, "monotonic", lambda: 0.0)
+    logger = DummyLogger()
+
+    watchdog = cli.StageWatchdog("stage", idle_minutes=0, logger=logger)
+    watchdog.start()
+
+    assert watchdog._thread is None  # noqa: SLF001 - internal state asserted for determinism
+
+
+@pytest.mark.unit
+def test_stage_watchdog__ping_logs_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = [0.0]
+
+    def fake_monotonic() -> float:
+        return monotonic_values[0]
+
+    monkeypatch.setattr(cli.time, "monotonic", fake_monotonic)
+    logger = DummyLogger()
+
+    class FakeThread:
+        def __init__(self, *_, **__):
+            self.started = False
+
+        def start(self) -> None:
+            self.started = True
+
+        def join(self, timeout: float | None = None) -> None:  # noqa: ARG002
+            self.started = False
+
+    monkeypatch.setattr(cli.threading, "Thread", FakeThread)
+
+    watchdog = cli.StageWatchdog("stage", idle_minutes=1, logger=logger)
+    watchdog.start()
+    monotonic_values[0] = 1.0
+    watchdog.ping("chunk", processed=10)
+
+    assert ("info", "stage_watchdog_progress", {"watchdog_event": "chunk", "processed": 10}) in logger.messages
+
+
+@pytest.mark.unit
+def test_stage_watchdog__raise_if_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.time, "monotonic", lambda: 0.0)
+    logger = DummyLogger()
+
+    watchdog = cli.StageWatchdog("stage", idle_minutes=1, logger=logger)
+    watchdog._timed_out.set()
+
+    with pytest.raises(cli.TestitemPipelineStageError):
+        watchdog.raise_if_timed_out()
+
+
+@pytest.mark.unit
+def test_stage_watchdog__monitor_emits_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = [0.0, 120.0]
+
+    def fake_monotonic() -> float:
+        return monotonic_values.pop(0)
+
+    monkeypatch.setattr(cli.time, "monotonic", fake_monotonic)
+    logger = DummyLogger()
+
+    watchdog = cli.StageWatchdog("stage", idle_minutes=2, logger=logger, check_interval=1)
+    watchdog._idle_timeout_seconds = 60
+    watchdog._effective_interval = 1
+    watchdog._last_activity = 0.0
+
+    class StubEvent:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.flag = False
+
+        def wait(self, _timeout: float) -> bool:
+            self.calls += 1
+            return self.calls > 1
+
+        def set(self) -> None:
+            self.flag = True
+
+        def clear(self) -> None:
+            self.flag = False
+
+        def is_set(self) -> bool:
+            return self.flag
+
+    watchdog._stop_event = StubEvent()
+    watchdog._timed_out = StubEvent()
+
+    watchdog._monitor()
+
+    assert any(event == "stage_watchdog_timeout" for _, event, _ in logger.messages)
+    assert watchdog._timed_out.flag is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "items, size, expected",
+    [
+        ([], 3, []),
+        (["a"], 2, [["a"]]),
+        (["a", "b", "c", "d"], 2, [["a", "b"], ["c", "d"]]),
+        (["a", "b", "c"], 5, [["a", "b", "c"]]),
+    ],
+)
+def test_batched__yields_expected_groups(items: list[str], size: int, expected: list[list[str]]) -> None:
+    batches = list(cli._batched(items, size))
+    assert batches == expected
+
+
+@pytest.mark.unit
+def test_log_missing_identifier_summary__emits_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = DummyLogger()
+    monkeypatch.setattr(cli, "logger", logger)
+
+    cli._log_missing_identifier_summary(["CHEMBL1", "CHEMBL2"])
+
+    assert (
+        "warning",
+        "chembl_missing_identifiers",
+        {"total": 2, "sample": ["CHEMBL1", "CHEMBL2"]},
+    ) in logger.messages
+
+
+@pytest.mark.unit
+def test_log_missing_identifier_summary__skips_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = DummyLogger()
+    monkeypatch.setattr(cli, "logger", logger)
+
+    cli._log_missing_identifier_summary([])
+
+    assert not logger.messages

--- a/tests/unit/test_normalize_rules.py
+++ b/tests/unit/test_normalize_rules.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.schemas.normalize import normalize_testitems
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "relation, expected",
+    [("<", "<="), (">", ">="), ("<=", "<="), ("invalid", "invalid")],
+)
+def test_normalize_testitems__relation_mapping(relation: str, expected: str) -> None:
+    frame = pd.DataFrame({"relation": [relation]})
+    normalised = normalize_testitems(frame)
+    assert normalised.loc[0, "relation"] == expected
+
+
+@pytest.mark.unit
+def test_normalize_testitems__identifier_columns_trimmed() -> None:
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": [" cheMBL1 "],
+            "parent_molecule_chembl_id": ["  chembl2"],
+        }
+    )
+    normalised = normalize_testitems(frame)
+    assert normalised.loc[0, "molecule_chembl_id"] == "cheMBL1"
+    assert normalised["molecule_chembl_id"].dtype == "string"
+    assert normalised.loc[0, "parent_molecule_chembl_id"] == "chembl2"
+
+
+@pytest.mark.unit
+def test_normalize_testitems__micro_sign_replaced() -> None:
+    frame = pd.DataFrame({"units": ["5 μM", "10 uM"]})
+    normalised = normalize_testitems(frame)
+    assert list(normalised["units"]) == ["5 uM", "10 uM"]
+
+
+@pytest.mark.unit
+def test_normalize_testitems__preserves_boolean_dtype() -> None:
+    frame = pd.DataFrame({"natural_product": pd.Series([True, pd.NA], dtype="boolean")})
+    normalised = normalize_testitems(frame)
+    assert normalised["natural_product"].dtype == "boolean"
+    assert normalised["natural_product"].tolist() == [True, pd.NA]
+
+
+@pytest.mark.unit
+def test_normalize_testitems__retains_missing_values() -> None:
+    frame = pd.DataFrame({"molecule_chembl_id": [pd.NA]})
+    normalised = normalize_testitems(frame)
+    assert pd.isna(normalised.loc[0, "molecule_chembl_id"])
+
+
+@pytest.mark.unit
+def test_normalize_testitems__does_not_mutate_original() -> None:
+    frame = pd.DataFrame({"relation": ["<"]})
+    _ = normalize_testitems(frame)
+    assert frame.loc[0, "relation"] == "<"


### PR DESCRIPTION
## Summary
- replace the pytest runner script with a structured reporting pipeline that emits machine-readable and human-readable artefacts
- document the deterministic test workflow and artefacts in the Russian QA process guide
- add integration, end-to-end, and unit tests covering finalize_output, stage controls, normalization, and catalog utilities

## Testing
- python scripts/run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e05f2c6d9883249ab1c558793889e9