### PR TITLE
Add activity pipeline CLI unit tests and emit reports

### DIFF
--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,29 +1,28 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "ebcbf5a8b0e0f6afe2823985d3c1df51a0726423",
+    "commit": "0f9600ce1405089269ec3f7708066dba90c2f052",
     "branch": "work",
-    "ts_utc": "2025-10-03T23:56:02.430565+00:00",
-    "duration_sec": 1.7036499977111816,
+    "ts_utc": "2025-10-04T00:08:16.711620+00:00",
+    "duration_sec": 2.207,
     "python": "3.11.12",
-    "pytest": "8.4.2",
-    "exit_code": 0
+    "pytest": "8.4.1"
   },
   "summary": {
-    "total": 75,
-    "passed": 75,
+    "total": 88,
+    "passed": 88,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
     "xpassed": 0,
     "error": 0,
-    "success_rate": 100.0
+    "success_rate": 1.0
   },
   "tests": [
     {
       "nodeid": "tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline",
       "status": "passed",
-      "duration_ms": 83.711,
+      "duration_ms": 114.469,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -32,25 +31,35 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
       "status": "passed",
-      "duration_ms": 51.219,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:00.929632+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:56:00.929772+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-03T23:56:00.932369+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}",
+      "duration_ms": 68.167,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.178309+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:08:15.178494+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:08:15.182167+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.178309+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:08:15.178494+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:08:15.182167+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__finalize_stage_idempotent",
       "status": "passed",
-      "duration_ms": 176.507,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:00.971043+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.015200+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.015396+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.036235+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.060817+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-03T23:56:01.073613+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.076127+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.084811+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.084964+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.105311+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.138652+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}",
+      "duration_ms": 210.816,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.236985+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.262041+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.262239+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.290088+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.324187+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T00:08:15.348769+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.352030+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.363682+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.363865+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.390608+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.438809+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.236985+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.262041+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.262239+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.290088+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.324187+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T00:08:15.348769+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.352030+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.363682+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.363865+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.390608+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.438809+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
       "status": "passed",
-      "duration_ms": 19.448,
+      "duration_ms": 24.676,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -59,34 +68,58 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
       "status": "passed",
-      "duration_ms": 18.06,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.176869+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}",
+      "duration_ms": 24.095,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.493548+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.493548+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
       "status": "passed",
-      "duration_ms": 6.065,
+      "duration_ms": 6.179,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
       "status": "passed",
-      "duration_ms": 88.825,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.191437+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.199912+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.200051+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.218620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.252242+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_c0/final.csv.meta.yaml\"}",
+      "duration_ms": 85.493,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.979784+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T00:08:15.986060+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.986222+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.009453+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.060893+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.979784+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T00:08:15.986060+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.986222+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.009453+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.060893+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
+      "status": "passed",
+      "duration_ms": 159.369,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.068382+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:16.075987+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:16.076161+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.100386+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.146458+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:16.148393+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:16.155638+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:16.155801+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.178731+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.225324+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.068382+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:16.075987+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:16.076161+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.100386+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.146458+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:16.148393+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:16.155638+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:16.155801+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:16.178731+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:08:16.225324+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__missing_required_columns_fails",
       "status": "passed",
-      "duration_ms": 3.326,
+      "duration_ms": 1.448,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -95,53 +128,78 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__optional_columns_missing_warns",
       "status": "passed",
-      "duration_ms": 58.456,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.282912+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.288293+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.305644+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.337962+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__optional0/optional.csv.meta.yaml\"}",
+      "duration_ms": 79.642,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.646907+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.654365+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.678820+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.724347+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
       "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
-      "status": "passed",
-      "duration_ms": 25.177,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.342649+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.349482+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-03T23:56:01.350653+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.362845+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__writes_f0/failures_failure_cases.csv\"}",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
-      "status": "passed",
-      "duration_ms": 107.147,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.368061+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.372844+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.372965+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.437764+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.470938+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.471862+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}",
-      "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.646907+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.654365+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.678820+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.724347+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal",
       "status": "passed",
-      "duration_ms": 91.695,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.475899+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-03T23:56:01.480895+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.481008+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.497860+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.530387+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.563822+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.564190+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}",
+      "duration_ms": 126.439,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.849556+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.856974+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.857135+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.881232+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.927811+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.973619+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.973988+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.849556+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.856974+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.857135+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.881232+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.927811+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.973619+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.973988+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
+        }
+      ],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
       "status": "passed",
-      "duration_ms": 58.403,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.568650+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-03T23:56:01.573229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.573342+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.589105+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.621787+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}",
+      "duration_ms": 79.144,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.766777+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.773732+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.773894+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.796783+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.842969+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.844097+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.766777+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.773732+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.773894+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.796783+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.842969+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:08:15.844097+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
+        }
+      ],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
       "status": "passed",
-      "duration_ms": 113.543,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.627229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.632229+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.632343+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.648713+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.681011+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-03T23:56:01.682562+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-03T23:56:01.687635+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-03T23:56:01.687768+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-03T23:56:01.704253+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-03T23:56:01.736981+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-12/test_finalize_output__idempote0/stable.csv.meta.yaml\"}",
+      "duration_ms": 127.385,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.513877+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.525653+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.525829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.553397+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.603802+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.513877+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:08:15.525653+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:08:15.525829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.553397+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T00:08:15.603802+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
+      "status": "passed",
+      "duration_ms": 33.325,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:15.730539+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.740579+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T00:08:15.742143+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.759849+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:15.730539+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:08:15.740579+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T00:08:15.742143+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:08:15.759849+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-8/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
+      "status": "passed",
+      "duration_ms": 0.7,
+      "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
@@ -149,7 +207,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_encoding_recovers_values",
       "status": "passed",
-      "duration_ms": 2.559,
+      "duration_ms": 1.201,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -158,25 +216,52 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_separator_emits_info",
       "status": "passed",
-      "duration_ms": 1.818,
+      "duration_ms": 0.497,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
+      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
       "status": "passed",
-      "duration_ms": 1.804,
-      "stdout": "",
+      "duration_ms": 0.625,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.287097+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.287097+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[32mINFO    \u001b[0m pubchem-test:test_pubchem_augmentation.py:357 pubchem_disabled"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
+      "status": "passed",
+      "duration_ms": 6.058,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.279280+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.279280+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[32mINFO    \u001b[0m pubchem-test:test_pubchem_augmentation.py:329 pubchem_cache_expired"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__normal_flow_populates_cache",
       "status": "passed",
-      "duration_ms": 8.23,
+      "duration_ms": 9.598,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -185,67 +270,57 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__skips_polymers_when_disallowed",
       "status": "passed",
-      "duration_ms": 7.64,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.757770+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
+      "duration_ms": 7.834,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.255580+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
-        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.255580+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[33mWARNING \u001b[0m pubchem-test:test_pubchem_augmentation.py:148 pubchem_skip_polymers"
+        }
       ],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_augment_pubchem__initialises_session_and_reuses_cache",
       "status": "passed",
-      "duration_ms": 9.918,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.764626+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.768510+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.768781+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-03T23:56:01.772166+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
-      "status": "passed",
-      "duration_ms": 5.855,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.775409+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
+      "duration_ms": 11.425,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.264207+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.269615+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.269916+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.274510+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
-        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.264207+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.269615+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.269916+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:08:16.274510+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n"
+        }
       ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
-      "status": "passed",
-      "duration_ms": 1.987,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.781061+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}",
-      "stderr": "",
-      "log": [
-        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
-      "status": "passed",
-      "duration_ms": 4.665,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
       "error": null
     },
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
       "status": "passed",
-      "duration_ms": 1.52,
+      "duration_ms": 1.105,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
+      "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
       "status": "passed",
-      "duration_ms": 1.5,
+      "duration_ms": 5.218,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
+      "status": "passed",
+      "duration_ms": 1.384,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -254,18 +329,25 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
       "status": "passed",
-      "duration_ms": 2.038,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.791925+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}",
+      "duration_ms": 1.757,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.301856+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n",
       "stderr": "",
       "log": [
-        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.301856+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
+        }
       ],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
       "status": "passed",
-      "duration_ms": 1.769,
+      "duration_ms": 0.954,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -274,61 +356,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
       "status": "passed",
-      "duration_ms": 0.913,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
-      "status": "passed",
-      "duration_ms": 0.851,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
-      "status": "passed",
-      "duration_ms": 0.861,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
-      "status": "passed",
-      "duration_ms": 0.857,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
-      "status": "passed",
-      "duration_ms": 0.909,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
-      "status": "passed",
-      "duration_ms": 0.912,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
-      "status": "passed",
-      "duration_ms": 1.008,
+      "duration_ms": 0.371,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -337,7 +365,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
       "status": "passed",
-      "duration_ms": 0.826,
+      "duration_ms": 0.158,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -346,7 +374,61 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
       "status": "passed",
-      "duration_ms": 0.817,
+      "duration_ms": 0.157,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
+      "status": "passed",
+      "duration_ms": 0.157,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.119,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.125,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
+      "status": "passed",
+      "duration_ms": 0.119,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.16,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
+      "status": "passed",
+      "duration_ms": 0.118,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -355,16 +437,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
       "status": "passed",
-      "duration_ms": 2.769,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
-      "status": "passed",
-      "duration_ms": 1.975,
+      "duration_ms": 2.509,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -373,7 +446,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
       "status": "passed",
-      "duration_ms": 1.895,
+      "duration_ms": 1.835,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -382,16 +455,16 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
       "status": "passed",
-      "duration_ms": 1.942,
+      "duration_ms": 1.652,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
       "status": "passed",
-      "duration_ms": 1.78,
+      "duration_ms": 1.618,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -400,16 +473,53 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
       "status": "passed",
-      "duration_ms": 1.792,
+      "duration_ms": 1.311,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
+      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
+      "status": "passed",
+      "duration_ms": 0.162,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
+      "status": "passed",
+      "duration_ms": 1.253,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.360820+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-8/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_read_input_ids__invalid_c0/input.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.360820+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-8/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-8/test_read_input_ids__invalid_c0/input.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
+      "status": "passed",
+      "duration_ms": 1.358,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.356481+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.356481+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
+        }
+      ],
+      "error": null
+    },
+    {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
       "status": "passed",
-      "duration_ms": 3.771,
+      "duration_ms": 2.96,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -418,97 +528,21 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
       "status": "passed",
-      "duration_ms": 1.793,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.826834+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}",
+      "duration_ms": 0.349,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.352081+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
       "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
-      "status": "passed",
-      "duration_ms": 2.572,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.829722+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
-      "status": "passed",
-      "duration_ms": 2.607,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.832811+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-12/test_read_input_ids__invalid_c0/input.csv\"}",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
-      "status": "passed",
-      "duration_ms": 0.909,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
-      "status": "passed",
-      "duration_ms": 0.88,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
-      "status": "passed",
-      "duration_ms": 0.974,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
-      "status": "passed",
-      "duration_ms": 0.839,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
-      "status": "passed",
-      "duration_ms": 0.864,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
-      "status": "passed",
-      "duration_ms": 0.886,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
-      "status": "passed",
-      "duration_ms": 0.869,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.352081+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
       "status": "passed",
-      "duration_ms": 0.924,
+      "duration_ms": 0.115,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -517,7 +551,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
       "status": "passed",
-      "duration_ms": 0.964,
+      "duration_ms": 0.147,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -526,7 +560,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
       "status": "passed",
-      "duration_ms": 0.887,
+      "duration_ms": 0.126,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -535,7 +569,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
       "status": "passed",
-      "duration_ms": 1.087,
+      "duration_ms": 0.121,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -544,7 +578,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
       "status": "passed",
-      "duration_ms": 0.883,
+      "duration_ms": 0.13,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -553,16 +587,70 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
       "status": "passed",
-      "duration_ms": 0.913,
+      "duration_ms": 0.13,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
       "status": "passed",
-      "duration_ms": 6.882,
+      "duration_ms": 0.258,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
+      "status": "passed",
+      "duration_ms": 0.134,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
+      "status": "passed",
+      "duration_ms": 0.142,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
+      "status": "passed",
+      "duration_ms": 0.184,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
+      "status": "passed",
+      "duration_ms": 0.215,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
+      "status": "passed",
+      "duration_ms": 0.222,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
+      "status": "passed",
+      "duration_ms": 0.177,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -571,43 +659,157 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
       "status": "passed",
-      "duration_ms": 3.387,
+      "duration_ms": 3.346,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
+      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
       "status": "passed",
-      "duration_ms": 1.348,
+      "duration_ms": 8.744,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[None-expected0]",
       "status": "passed",
-      "duration_ms": 1.301,
+      "duration_ms": 0.138,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation1-expected1]",
       "status": "passed",
-      "duration_ms": 1.578,
+      "duration_ms": 0.134,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation2-expected2]",
       "status": "passed",
-      "duration_ms": 1.398,
+      "duration_ms": 0.132,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation3-expected3]",
+      "status": "passed",
+      "duration_ms": 0.125,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation4-expected4]",
+      "status": "passed",
+      "duration_ms": 0.204,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation5-expected5]",
+      "status": "passed",
+      "duration_ms": 0.123,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation6-expected6]",
+      "status": "passed",
+      "duration_ms": 0.145,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation7-expected7]",
+      "status": "passed",
+      "duration_ms": 0.124,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation8-expected8]",
+      "status": "passed",
+      "duration_ms": 0.14,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation9-expected9]",
+      "status": "passed",
+      "duration_ms": 0.124,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_respects_flags",
+      "status": "passed",
+      "duration_ms": 0.507,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.431625+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-8/test_run__skip_existing_respec0/output.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.431625+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-8/test_run__skip_existing_respec0/output.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__dry_run_short_circuits",
+      "status": "passed",
+      "duration_ms": 0.651,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.427774+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-8/test_run_chembl__dry_run_short0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-8/test_run_chembl__dry_run_short0/output.csv\", \"limit\": 7, \"offset\": 0, \"batch_size\": 5, \"timeout\": 30.0, \"dry_run\": true, \"workers\": 1}\n{\"ts\": \"2025-10-04T00:08:16.427949+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 7}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.427774+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-8/test_run_chembl__dry_run_short0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-8/test_run_chembl__dry_run_short0/output.csv\", \"limit\": 7, \"offset\": 0, \"batch_size\": 5, \"timeout\": 30.0, \"dry_run\": true, \"workers\": 1}\n{\"ts\": \"2025-10-04T00:08:16.427949+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 7}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__invalid_limit_logs_error",
+      "status": "passed",
+      "duration_ms": 0.492,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.424181+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.424181+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
+      "status": "passed",
+      "duration_ms": 0.75,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -616,7 +818,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__identifier_columns_trimmed",
       "status": "passed",
-      "duration_ms": 1.843,
+      "duration_ms": 1.723,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -625,7 +827,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__micro_sign_replaced",
       "status": "passed",
-      "duration_ms": 1.337,
+      "duration_ms": 0.607,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -634,7 +836,43 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__preserves_boolean_dtype",
       "status": "passed",
-      "duration_ms": 1.376,
+      "duration_ms": 0.826,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
+      "status": "passed",
+      "duration_ms": 1.093,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
+      "status": "passed",
+      "duration_ms": 0.733,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
+      "status": "passed",
+      "duration_ms": 0.863,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
+      "status": "passed",
+      "duration_ms": 0.802,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -643,25 +881,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__retains_missing_values",
       "status": "passed",
-      "duration_ms": 1.475,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
-      "status": "passed",
-      "duration_ms": 1.351,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
-      "status": "passed",
-      "duration_ms": 1.85,
+      "duration_ms": 1.722,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -670,7 +890,16 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
       "status": "passed",
-      "duration_ms": 1.927,
+      "duration_ms": 1.553,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
+      "status": "passed",
+      "duration_ms": 1.633,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -679,7 +908,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 1.361,
+      "duration_ms": 0.885,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -688,7 +917,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 1.124,
+      "duration_ms": 0.448,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -697,11 +926,18 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_main__downgrades_exit_code_when_threshold_not_met",
       "status": "passed",
-      "duration_ms": 2.303,
-      "stdout": "{\"ts\": \"2025-10-03T23:56:01.887651+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}",
+      "duration_ms": 1.359,
+      "stdout": "{\"ts\": \"2025-10-04T00:08:16.470189+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n",
       "stderr": "",
       "log": [
-        "name\nmsg\nargs\nlevelname\nlevelno\npathname\nfilename\nmodule\nexc_info\nexc_text\nstack_info\nlineno\nfuncName\ncreated\nmsecs\nrelativeCreated\nthread\nthreadName\nprocessName\nprocess"
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T00:08:16.470189+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m tools.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
+        }
       ],
       "error": null
     }

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: ebcbf5a8b0e0f6afe2823985d3c1df51a0726423
+- Commit: 0f9600ce1405089269ec3f7708066dba90c2f052
 - Branch: work
-- Timestamp (UTC): 2025-10-03T23:56:02.430565+00:00
-- Duration: 1.70 s
+- Timestamp (UTC): 2025-10-04T00:08:16.711620+00:00
+- Duration: 2.207 s
 - Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|    75 |    75 |     0 |      0 |      0 |      0 |     0 |
+|    88 |    88 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
-- None
+- none

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -1,0 +1,92 @@
+"""Unit tests for :mod:`scripts.get_activity_data`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from scripts import get_activity_data
+
+
+def _make_args(tmp_path: Path) -> argparse.Namespace:
+    """Return an :class:`argparse.Namespace` populated with sane defaults."""
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("activity_id\nA1\n", encoding="utf-8")
+    return argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=tmp_path / "output.csv",
+        offset=0,
+        workers=None,
+        skip_existing=False,
+        force=False,
+        dry_run=False,
+        invocation=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "invocation, expected",
+    [
+        (None, (get_activity_data.PROGRAM_NAME,)),
+        ((), ()),
+        ([], ()),
+        (["run"], ("run",)),
+        (("fetch", 2), ("fetch", "2")),
+        ([Path("/tmp/file.csv")], ("/tmp/file.csv",)),
+        ([""], ("",)),
+        (["--limit", 5], ("--limit", "5")),
+        (["Σ", Path("relative")], ("Σ", "relative")),
+        ([42.0, 0], ("42.0", "0")),
+    ],
+)
+def test_args_invocation__cases(invocation: Iterable[object] | None, expected: tuple[str, ...]) -> None:
+    namespace = argparse.Namespace(invocation=invocation)
+    assert get_activity_data._args_invocation(namespace) == expected
+
+
+def test_run_chembl__invalid_limit_logs_error(cfg, tmp_path, caplog) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.limit = -5
+
+    caplog.set_level("ERROR")
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 1
+
+
+def test_run_chembl__dry_run_short_circuits(cfg, tmp_path, caplog) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.dry_run = True
+    cfg.activity.limit = 7
+
+    caplog.set_level("INFO")
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+
+
+def test_run__skip_existing_respects_flags(cfg, tmp_path, monkeypatch) -> None:
+    args = _make_args(tmp_path)
+    args.output_csv = None
+    args.skip_existing = True
+    args.force = False
+
+    calls: list[str] = []
+
+    def fake_default_output_path(input_path: Path, _io_cfg) -> Path:  # pragma: no cover - exercised via tests
+        assert input_path == args.input_csv
+        destination = tmp_path / "output.csv"
+        destination.write_text("existing", encoding="utf-8")
+        return destination
+
+    monkeypatch.setattr(get_activity_data.io, "default_output_path", fake_default_output_path)
+    monkeypatch.setattr(get_activity_data, "run_chembl", lambda *_: calls.append("run") or 0)
+
+    exit_code = get_activity_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert calls == []


### PR DESCRIPTION
## Summary
- add targeted unit coverage for the get_activity_data CLI helpers, including invocation handling and skip-existing logic
- regenerate the aggregated pytest JSON and Markdown reports with the latest run metadata

## Testing
- python tools/run_tests.py --pytest-args ""


------
https://chatgpt.com/codex/tasks/task_e_68e064390734832484027aceb1c8dfe6