### PR TITLE
Centralize CLI logging setup across scripts

### DIFF
--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -1,5 +1,6 @@
 """Command-line interface utilities."""
 
+from .logging import setup_cli_logging
 from .parser import (
     Logger,
     LoggerConfig,
@@ -23,6 +24,7 @@ __all__ = [
     "build_root_parser",
     "configure_logger",
     "create_logger_config",
+    "setup_cli_logging",
     "prepare_io_paths",
     "path_argument",
     "positive_int",

--- a/library/cli/logging.py
+++ b/library/cli/logging.py
@@ -1,0 +1,106 @@
+"""Helpers for configuring structured logging in CLI scripts."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Iterator
+import sys
+
+from ..common.logging_setup import LoggerConfig
+
+_DEFAULT_LOG_DIR = Path("data") / "logs"
+
+
+class _TeeStream:
+    """Mirror writes to multiple text streams without closing them."""
+
+    def __init__(self, *streams: IO[str] | None) -> None:
+        unique_streams: list[IO[str]] = []
+        for stream in streams:
+            if stream is None:
+                continue
+            if any(stream is existing for existing in unique_streams):
+                continue
+            unique_streams.append(stream)
+        self._streams: tuple[IO[str], ...] = tuple(unique_streams)
+
+    def write(self, data: str) -> int:  # pragma: no cover - direct delegation
+        for stream in self._streams:
+            stream.write(data)
+        return len(data)
+
+    def flush(self) -> None:  # pragma: no cover - direct delegation
+        for stream in self._streams:
+            flush = getattr(stream, "flush", None)
+            if callable(flush):
+                flush()
+
+    def writable(self) -> bool:  # pragma: no cover - interface helper
+        if not self._streams:
+            return False
+        return all(getattr(stream, "writable", lambda: True)() for stream in self._streams)
+
+    def isatty(self) -> bool:  # pragma: no cover - interface helper
+        return any(getattr(stream, "isatty", lambda: False)() for stream in self._streams)
+
+
+def _current_date_str() -> str:
+    """Return the current UTC date formatted as ``YYYYMMDD``."""
+
+    return datetime.now(timezone.utc).strftime("%Y%m%d")
+
+
+@dataclass(slots=True)
+class CLILoggingContext:
+    """Container returned by :func:`setup_cli_logging`."""
+
+    log_path: Path
+    log_cfg: LoggerConfig
+    console_stream: IO[str]
+
+
+@contextmanager
+def setup_cli_logging(
+    script_name: str,
+    log_cfg: LoggerConfig,
+    date_str: str | None = None,
+    *,
+    log_dir: Path | None = None,
+) -> Iterator[CLILoggingContext]:
+    """Configure logging to mirror structured output to a file and the console."""
+
+    resolved_dir = Path(log_dir) if log_dir is not None else _DEFAULT_LOG_DIR
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+
+    if date_str:
+        suffix = date_str
+    else:
+        suffix = _current_date_str()
+
+    log_path = resolved_dir / f"{script_name}_{suffix}.log"
+
+    original_stream = getattr(log_cfg, "stream", None)
+    with log_path.open("a", encoding="utf-8") as log_stream:
+        tee_stream = _TeeStream(log_stream, original_stream)
+        updated_cfg = LoggerConfig(
+            level=log_cfg.level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=tee_stream,
+        )
+        console_stream = original_stream or sys.stdout
+        if console_stream is None:  # pragma: no cover - defensive fallback
+            console_stream = sys.stdout
+        print(
+            f"[INFO] Structured logs are mirrored to '{log_path}'.",
+            file=console_stream,
+            flush=True,
+        )
+        yield CLILoggingContext(
+            log_path=log_path,
+            log_cfg=updated_cfg,
+            console_stream=console_stream,
+        )

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -80,6 +80,7 @@ from library.cli import (
 from library.cli import (
     build_parser as base_parser,
 )
+from library.cli.logging import setup_cli_logging
 from library.cli_utils import (
     PipelineError,
     resolve_invocation,
@@ -602,22 +603,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--limit must be zero or a positive integer")
     if args.offset < 0:
         parser.error("--offset must be zero or a positive integer")
-    return run_cli_command(
-        args=args,
-        parser=parser,
-        log_cfg=log_cfg,
-        mapping={
-            "timeout": "activity.timeout",
-            "column": "activity.column",
-            "batch_size": "activity.batch_size",
-            "limit": "activity.limit",
-            "offset": "activity.offset",
-            "dry_run": "activity.dry_run",
-            "workers": "activity.workers",
-        },
-        run=run,
-        logger=logger,
-    )
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name, log_cfg, getattr(args, "date", None)
+    ) as logging_ctx:
+        exit_code = run_cli_command(
+            args=args,
+            parser=parser,
+            log_cfg=logging_ctx.log_cfg,
+            mapping={
+                "timeout": "activity.timeout",
+                "column": "activity.column",
+                "batch_size": "activity.batch_size",
+                "limit": "activity.limit",
+                "offset": "activity.offset",
+                "dry_run": "activity.dry_run",
+                "workers": "activity.workers",
+            },
+            run=run,
+            logger=logger,
+        )
+    configure_logger(log_cfg)
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -39,9 +39,11 @@ from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
 from library.cli import (
     LoggerConfig,
+    configure_logger,
 )
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command, run_pipeline
+from library.cli.logging import setup_cli_logging
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.pipelines.common import add_pipeline_metadata
@@ -383,19 +385,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--limit must be zero or a positive integer")
     if args.offset < 0:
         parser.error("--offset must be zero or a positive integer")
-    return run_cli_command(
-        args=args,
-        parser=parser,
-        log_cfg=log_cfg,
-        mapping={
-            "timeout": "assay.timeout",
-            "column": "assay.column",
-            "batch_size": "assay.batch_size",
-            "limit": "assay.limit",
-        },
-        run=run,
-        logger=logger,
-    )
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name, log_cfg, getattr(args, "date", None)
+    ) as logging_ctx:
+        exit_code = run_cli_command(
+            args=args,
+            parser=parser,
+            log_cfg=logging_ctx.log_cfg,
+            mapping={
+                "timeout": "assay.timeout",
+                "column": "assay.column",
+                "batch_size": "assay.batch_size",
+                "limit": "assay.limit",
+            },
+            run=run,
+            logger=logger,
+        )
+    configure_logger(log_cfg)
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -94,10 +94,12 @@ from library.clients import ChemblClient, _chunked
 from library.cli import (
     LoggerConfig,
     build_root_parser,
+    configure_logger,
     path_argument,
     positive_int,
     prepare_io_paths,
 )
+from library.cli.logging import setup_cli_logging
 from library.cli.utils import run_cli_command
 from library.config import (
     Config,
@@ -2374,15 +2376,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         "openalex_rps": "openalex.rps",
         "crossref_rps": "crossref.rps",
     }
-    return run_cli_command(
-        args=args,
-        parser=subparser,
-        base_parser=parser,
-        log_cfg=log_cfg,
-        mapping=mapping,
-        run=run,
-        logger=logger,
-    )
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name, log_cfg, getattr(args, "date", None)
+    ) as logging_ctx:
+        exit_code = run_cli_command(
+            args=args,
+            parser=subparser,
+            base_parser=parser,
+            log_cfg=logging_ctx.log_cfg,
+            mapping=mapping,
+            run=run,
+            logger=logger,
+        )
+    configure_logger(log_cfg)
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -94,6 +94,7 @@ from library.cli import (
     positive_int,
     prepare_io_paths,
 )
+from library.cli.logging import setup_cli_logging
 from library.config import (
     Config,
     _serialize_paths,
@@ -148,9 +149,6 @@ DEFAULT_INPUT_NAME = "target.csv"
 DEFAULT_OUTPUT_STEM = "targets"
 RAW_SUFFIX = "_raw"
 NORMALIZED_SUFFIX = "_normalized"
-DEFAULT_LOG_DIR = Path("data") / "logs"
-
-
 COMMAND_CHOICES: tuple[str, ...] = ("uniprot", "chembl", "iuphar", "all")
 
 _RUSSIAN_KEYBOARD_MAP: dict[str, str] = {
@@ -227,38 +225,6 @@ COMMAND_ALIAS_TO_CANONICAL: dict[str, str] = {
     for alias in aliases
 }
 
-
-class _TeeStream:
-    """Mirror writes to multiple text streams without closing them."""
-
-    def __init__(self, *streams: IO[str] | None) -> None:
-        unique_streams: list[IO[str]] = []
-        for stream in streams:
-            if stream is None:
-                continue
-            if any(stream is existing for existing in unique_streams):
-                continue
-            unique_streams.append(stream)
-        self._streams: tuple[IO[str], ...] = tuple(unique_streams)
-
-    def write(self, data: str) -> int:  # pragma: no cover - direct delegation
-        for stream in self._streams:
-            stream.write(data)
-        return len(data)
-
-    def flush(self) -> None:  # pragma: no cover - direct delegation
-        for stream in self._streams:
-            flush = getattr(stream, "flush", None)
-            if callable(flush):
-                flush()
-
-    def writable(self) -> bool:  # pragma: no cover - interface helper
-        if not self._streams:
-            return False
-        return all(getattr(stream, "writable", lambda: True)() for stream in self._streams)
-
-    def isatty(self) -> bool:  # pragma: no cover - interface helper
-        return any(getattr(stream, "isatty", lambda: False)() for stream in self._streams)
 
 
 @dataclass(frozen=True)
@@ -2907,24 +2873,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not isinstance(date_value, str) or not date_value:
         date_value = datetime.now(timezone.utc).strftime("%Y%m%d")
         setattr(args, "date", date_value)
-    log_dir = DEFAULT_LOG_DIR
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / f"get_target_data_{date_value}.log"
     exit_code = 0
 
-    original_stream = log_cfg.stream
-    with log_path.open("a", encoding="utf-8") as log_stream:
-        tee_stream = _TeeStream(log_stream, original_stream)
-        log_cfg.stream = tee_stream
-        configure_logger(log_cfg)
-        console_stream = original_stream or sys.stdout
-        if console_stream is None:  # pragma: no cover - defensive fallback
-            console_stream = sys.stdout
-        print(
-            f"[INFO] Structured logs are mirrored to '{log_path}'.",
-            file=console_stream,
-            flush=True,
-        )
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name, log_cfg, date_value
+    ) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+        console_stream = logging_ctx.console_stream
+        log_path = logging_ctx.log_path
         try:
 
             limit_value = getattr(args, "limit", None)
@@ -2997,7 +2953,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args=argparse.Namespace(**args_dict),
                     parser=subparser,
                     base_parser=parser,
-                    log_cfg=log_cfg,
+                    log_cfg=logging_ctx.log_cfg,
                     mapping=mapping,
                     run=run,
                     logger=logger,
@@ -3006,9 +2962,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_code = 2
             logger.error("pipeline_error", error=str(exc))
             print(f"[ERROR] {exc}", file=console_stream, flush=True)
-        finally:
-            log_cfg.stream = original_stream
-            configure_logger(log_cfg)
+    configure_logger(log_cfg)
 
 
     return exit_code

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -37,9 +37,10 @@ from library import cli  # noqa: F401 - re-exported for monkeypatching in tests
 from library import io
 from library.integration import molecule_catalog
 from library.integration import pubchem_library as pl
-from library.cli import LoggerConfig
+from library.cli import LoggerConfig, configure_logger
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command
+from library.cli.logging import setup_cli_logging
 from library.config import (
     ApiCfg,
     Config,
@@ -675,14 +676,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         "limit": "testitem.limit",
         "offset": "testitem.offset",
     }
-    return run_cli_command(
-        args=args,
-        parser=parser,
-        log_cfg=log_cfg,
-        mapping=mapping,
-        run=run,
-        logger=logger,
-    )
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name, log_cfg, getattr(args, "date", None)
+    ) as logging_ctx:
+        exit_code = run_cli_command(
+            args=args,
+            parser=parser,
+            log_cfg=logging_ctx.log_cfg,
+            mapping=mapping,
+            run=run,
+            logger=logger,
+        )
+    configure_logger(log_cfg)
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/e2e/test_cli_logging_setup.py
+++ b/tests/e2e/test_cli_logging_setup.py
@@ -1,0 +1,195 @@
+"""End-to-end checks for CLI logging helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import (
+    get_activity_data,
+    get_assay_data,
+    get_document_data,
+    get_target_data,
+    get_testitem_data,
+)
+
+_SCRIPT_CASES = (
+    {
+        "module": get_activity_data,
+        "command": None,
+        "input_flag": "--input",
+        "output_flag": "--output",
+        "output_attr": "output_csv",
+        "prefix": "activity_pipeline",
+        "extra_args": (),
+    },
+    {
+        "module": get_assay_data,
+        "command": None,
+        "input_flag": "--input",
+        "output_flag": "--output",
+        "output_attr": "output_csv",
+        "prefix": "assay_pipeline",
+        "extra_args": (),
+    },
+    {
+        "module": get_document_data,
+        "command": "pubmed",
+        "input_flag": "--input",
+        "output_flag": "--output",
+        "output_attr": "output_csv",
+        "prefix": "document_pipeline",
+        "extra_args": (),
+    },
+    {
+        "module": get_target_data,
+        "command": "chembl",
+        "input_flag": "--input",
+        "output_flag": "--final-out",
+        "output_attr": "final_out",
+        "prefix": "target_pipeline",
+        "extra_args": ("--date", "20240102"),
+    },
+    {
+        "module": get_testitem_data,
+        "command": None,
+        "input_flag": "--input",
+        "output_flag": "--output",
+        "output_attr": "output_csv",
+        "prefix": "testitem_pipeline",
+        "extra_args": (),
+    },
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("case", _SCRIPT_CASES, ids=lambda c: Path(c["module"].__file__).stem)
+def test_cli_logging__creates_log_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: dict[str, Any]
+) -> None:
+    base_path = tmp_path
+    data_dir = base_path / "data"
+    log_dir = data_dir / "logs"
+    log_dir.mkdir(parents=True)
+
+    config_path = base_path / "config.yaml"
+    config_path.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n", encoding="utf-8")
+
+    input_path = base_path / "input.csv"
+    input_path.write_text("identifier\nCHEMBL1\n", encoding="utf-8")
+
+    output_path = base_path / "output.csv"
+
+    monkeypatch.chdir(base_path)
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(base_path))
+    monkeypatch.setattr(
+        "library.cli.logging._current_date_str", lambda: "20240102"
+    )
+
+    module = case["module"]
+    prefix = case["prefix"]
+    command = case["command"]
+    input_flag = case["input_flag"]
+    output_flag = case["output_flag"]
+    output_attr = case["output_attr"]
+    extra_args = list(case["extra_args"])
+
+    def _run_cli_command_stub(
+        *,
+        args: Any,
+        parser: Any,
+        log_cfg: Any,
+        mapping: Any,
+        run: Any,
+        logger: Any,
+        base_parser: Any | None = None,
+    ) -> int:
+        module.configure_logger(log_cfg)
+        logger.info(
+            "pipeline_start",
+            run_id=log_cfg.run_id,
+            command=getattr(args, "command", command or Path(module.__file__).stem),
+        )
+        logger.info(
+            "pipeline_parameters",
+            input=str(getattr(args, "input_csv", "")),
+            output=str(getattr(args, output_attr, "")),
+            limit=getattr(args, "limit", None),
+            offset=getattr(args, "offset", None),
+        )
+        exit_code = run(object(), args)
+        if exit_code == 0:
+            logger.info("pipeline_done", run_id=log_cfg.run_id)
+        else:
+            logger.info("pipeline_fail", run_id=log_cfg.run_id, exit_code=exit_code)
+        return int(exit_code)
+
+    monkeypatch.setattr(module, "run_cli_command", _run_cli_command_stub)
+
+    def _stub_run(_cfg: Any, args: Any) -> int:
+        module.logger.info(
+            f"{prefix}_start",
+            stage="ingest",
+            input=str(getattr(args, "input_csv", "")),
+        )
+        module.logger.info(
+            f"{prefix}_records",
+            processed=2,
+            discarded=1,
+            stage="ingest",
+        )
+        module.logger.info(
+            f"{prefix}_done",
+            output=str(getattr(args, output_attr, "")),
+        )
+        return 0
+
+    monkeypatch.setattr(module, "run", _stub_run)
+
+    argv: list[str] = []
+    if command:
+        argv.append(command)
+    argv.extend(["--config", str(config_path)])
+    if input_flag:
+        argv.extend([input_flag, str(input_path)])
+    if output_flag:
+        target_output = output_path if output_flag != "--final-out" else base_path / "targets.csv"
+        argv.extend([output_flag, str(target_output)])
+    argv.extend(extra_args)
+
+    exit_code = module.main(argv)
+    assert exit_code == 0
+
+    log_files = sorted(log_dir.glob("*.log"))
+    assert len(log_files) == 1
+    log_path = log_files[0]
+    expected_name = f"{Path(module.__file__).stem}_20240102.log"
+    assert log_path.name == expected_name
+
+    events = []
+    with log_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            record = json.loads(line)
+            events.append(record)
+
+    event_names = {record.get("event") for record in events}
+    expected_events = {
+        "pipeline_start",
+        "pipeline_parameters",
+        f"{prefix}_start",
+        f"{prefix}_records",
+        f"{prefix}_done",
+        "pipeline_done",
+    }
+    assert expected_events.issubset(event_names)
+
+    record_entry = next(
+        record
+        for record in events
+        if record.get("event") == f"{prefix}_records"
+    )
+    assert record_entry.get("processed") == 2
+    assert record_entry.get("discarded") == 1


### PR DESCRIPTION
## Summary
- add a shared `setup_cli_logging` helper to create CLI log files and mirror output to the console
- update the activity, assay, document, target, and testitem entrypoints to use the helper and restore logging after execution
- introduce an end-to-end test that runs each CLI in isolation and asserts log files contain key events

## Testing
- pytest tests/e2e/test_cli_logging_setup.py
- pytest tests/e2e/test_get_cli_pipelines.py -k run_skip

------
https://chatgpt.com/codex/tasks/task_e_68e10b7d367883248f11b21097715d49