### PR TITLE
Centralize dictionary paths and update defaults

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1441,31 +1441,31 @@
       "additionalProperties": false,
       "properties": {
         "dictionary_dir": {
-          "default": "../dictionary",
+          "default": "dictionary",
           "format": "path",
           "title": "Dictionary Dir",
           "type": "string"
         },
         "iuphar_target_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Iuphar Target Csv",
           "type": "string"
         },
         "iuphar_family_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Iuphar Family Csv",
           "type": "string"
         },
         "uniprot_data_dir": {
-          "default": "../dictionary/_target/_uniprot",
+          "default": "dictionary/_target/_uniprot",
           "format": "path",
           "title": "Uniprot Data Dir",
           "type": "string"
         },
         "targets_type_csv": {
-          "default": "../dictionary/_target/targets_type.csv",
+          "default": "dictionary/_target/targets_type.csv",
           "format": "path",
           "title": "Targets Type Csv",
           "type": "string"
@@ -1622,19 +1622,19 @@
       "additionalProperties": false,
       "properties": {
         "data_dir": {
-          "default": "../dictionary/_target/_uniprot",
+          "default": "dictionary/_target/_uniprot",
           "format": "path",
           "title": "Data Dir",
           "type": "string"
         },
         "target_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Target Csv",
           "type": "string"
         },
         "family_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Family Csv",
           "type": "string"
@@ -1773,13 +1773,13 @@
       "additionalProperties": false,
       "properties": {
         "target_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_target.csv",
           "format": "path",
           "title": "Target Csv",
           "type": "string"
         },
         "family_csv": {
-          "default": "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
+          "default": "dictionary/_target/_IUPHAR/_IUPHAR_family.csv",
           "format": "path",
           "title": "Family Csv",
           "type": "string"
@@ -1810,7 +1810,7 @@
           "type": "string"
         },
         "data_dir": {
-          "default": "../dictionary/_target/_uniprot",
+          "default": "dictionary/_target/_uniprot",
           "format": "path",
           "title": "Data Dir",
           "type": "string"
@@ -1964,7 +1964,7 @@
       "additionalProperties": false,
       "properties": {
         "molecule_catalog_path": {
-          "default": "../dictionary/molecule_catalog.csv",
+          "default": "dictionary/_testitem/molecule_catalog.csv",
           "format": "path",
           "title": "Molecule Catalog Path",
           "type": "string"

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,10 +1,6 @@
 """Configuration package exposing shared file-system paths."""
-
 from __future__ import annotations
 
-from pathlib import Path
+from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR
 
-CONFIG_DIR = Path(__file__).resolve().parent
-DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
-
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH"]
+__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR"]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -103,7 +103,7 @@ sources:
       target:
         uniprot:
           column: "uniprot_id"
-          data_dir: "../dictionary/_target/_uniprot"
+          data_dir: "dictionary/_target/_uniprot"
           limit: null
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers
@@ -111,13 +111,13 @@ sources:
           timeout: 30.0
           limit: null
         iuphar:
-          target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
-          family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
+          target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
+          family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           limit: null
         all:
-          data_dir: "../dictionary/_target/_uniprot"
-          target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
-          family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
+          data_dir: "dictionary/_target/_uniprot"
+          target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
+          family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           chunk_size: 5
           timeout: 30.0
           uniprot_column: mapping_uniprot_id  # Column containing primary UniProt accession used for merges
@@ -206,11 +206,11 @@ sources:
 
 local:
   resources:
-    dictionary_dir: "../dictionary"  # Directory with supplementary lookup tables
-    iuphar_target_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
-    iuphar_family_csv: "../dictionary/_target/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
-    uniprot_data_dir: "../dictionary/_target/_uniprot"  # Directory containing cached UniProt JSON files
-    targets_type_csv: "../dictionary/_target/targets_type.csv"  # Target type mapping table
+    dictionary_dir: "dictionary"  # Directory with supplementary lookup tables
+    iuphar_target_csv: "dictionary/_target/_IUPHAR/_IUPHAR_target.csv"  # IUPHAR target mapping file
+    iuphar_family_csv: "dictionary/_target/_IUPHAR/_IUPHAR_family.csv"  # IUPHAR family mapping file
+    uniprot_data_dir: "dictionary/_target/_uniprot"  # Directory containing cached UniProt JSON files
+    targets_type_csv: "dictionary/_target/targets_type.csv"  # Target type mapping table
   io:
     output_dir: "$CHEMBL_DA_BASE_PATH/output"  # Directory for generated datasets
     cache_dir: "~/.cache/chembl-da"  # Directory for cached HTTP responses (env: CHEMBL_DA_CACHE_DIR)
@@ -294,7 +294,7 @@ activity_enrichment:
 testitem_molecule_enrichment:
   enable: true
   sources:
-    molecule_catalog_path: "../dictionary/_testitem/molecule_catalog.csv"
+    molecule_catalog_path: "dictionary/_testitem/molecule_catalog.csv"
     molecule_hierarchy_path: "dictionary/_testitem/molecule_hierarchy.csv"
   output:
     salt_as_null_when_absent: true

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -24,7 +24,7 @@ local:
     cache_dir: "./data/cache"
   resources:
     dictionary_dir: "./dictionary"
-    uniprot_data_dir: "./uniprot"
+    uniprot_data_dir: "./dictionary/_target/_uniprot"
 
 system:
   log:

--- a/config/paths.py
+++ b/config/paths.py
@@ -1,0 +1,10 @@
+"""Shared filesystem paths for configuration resources."""
+from __future__ import annotations
+
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
+DICTIONARY_DIR = CONFIG_DIR / "dictionary"
+
+__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR"]

--- a/library/config.py
+++ b/library/config.py
@@ -13,13 +13,10 @@ aliases are supported; see ``_ALIAS_MAP`` for the full list.
 
 from __future__ import annotations
 
-import atexit
 import logging
 import os
 import re
 from collections.abc import Sequence
-from contextlib import ExitStack
-from importlib import resources
 from pathlib import Path
 from types import UnionType
 from typing import Any, Mapping, Union, get_args, get_origin
@@ -39,7 +36,7 @@ from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .common.rate_limiter import configure_limiter_cache
+from config import DICTIONARY_DIR
 
 from .common.log import logger
 from .common.rate_limiter import configure_limiter_cache
@@ -191,17 +188,10 @@ def _resolve_placeholder_base_path(base_path: Path | str | None) -> Path:
     return _default_base_path()
 
 
-_RESOURCE_STACK = ExitStack()
-atexit.register(_RESOURCE_STACK.close)
-
-
 def _dictionary_resource(*parts: str) -> Path:
     """Return a filesystem path for a bundled dictionary resource."""
 
-    traversable = resources.files("dictionary")
-    for part in parts:
-        traversable = traversable.joinpath(part)
-    return Path(_RESOURCE_STACK.enter_context(resources.as_file(traversable)))
+    return DICTIONARY_DIR.joinpath(*parts)
 
 
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
@@ -378,8 +368,8 @@ class MoleculeCatalogCfg(_BaseModel):
     endpoint: str = "molecule"
     child_field: str = "molecule_chembl_id"
     parent_field: str = "parent_molecule_chembl_id"
-    hierarchy_lookup_path: Path | None = Path(
-        "config/dictionary/_testitem/molecule_hierarchy.csv"
+    hierarchy_lookup_path: Path | None = (
+        DICTIONARY_DIR / "_testitem" / "molecule_hierarchy.csv"
     )
     hierarchy_lookup_encoding: str = "utf-8-sig"
     hierarchy_lookup_delimiter: str = ","
@@ -1023,9 +1013,11 @@ class TestitemCfg(_BaseModel):
 
 
 class TestitemMoleculeEnrichmentSourcesCfg(_BaseModel):
-    molecule_catalog_path: Path = Path("dictionary/molecule_catalog.csv")
-    molecule_hierarchy_path: Path = Path(
-        "config/dictionary/_testitem/molecule_hierarchy.csv"
+    molecule_catalog_path: Path = (
+        DICTIONARY_DIR / "_testitem" / "molecule_catalog.csv"
+    )
+    molecule_hierarchy_path: Path = (
+        DICTIONARY_DIR / "_testitem" / "molecule_hierarchy.csv"
     )
 
 
@@ -1112,7 +1104,7 @@ class DocumentCfg(_BaseModel):
 
 class TargetUniprotCfg(_BaseModel):
     column: str = "uniprot_id"
-    data_dir: Path = Path("dictionary/_target/_uniprot")
+    data_dir: Path = DICTIONARY_DIR / "_target" / "_uniprot"
     limit: int | None = Field(default=None, ge=0)
 
 
@@ -1131,15 +1123,23 @@ class TargetChemblCfg(_BaseModel):
 
 
 class TargetIupharCfg(_BaseModel):
-    target_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_target.csv")
-    family_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_family.csv")
+    target_csv: Path = (
+        DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_target.csv"
+    )
+    family_csv: Path = (
+        DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_family.csv"
+    )
     limit: int | None = Field(default=None, ge=0)
 
 
 class TargetAllCfg(_BaseModel):
-    data_dir: Path = Path("dictionary/_target/_uniprot")
-    target_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_target.csv")
-    family_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_family.csv")
+    data_dir: Path = DICTIONARY_DIR / "_target" / "_uniprot"
+    target_csv: Path = (
+        DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_target.csv"
+    )
+    family_csv: Path = (
+        DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_family.csv"
+    )
     chunk_size: int = Field(5, ge=1)
     timeout: float = Field(30.0, ge=0)
     uniprot_column: str = "uniprot_id"

--- a/library/integration/input_initialisation_library.py
+++ b/library/integration/input_initialisation_library.py
@@ -504,10 +504,15 @@ def process_activity_table(
             if legacy_path.exists():
                 targets_path = legacy_path
             else:
+                expected_locations = [
+                    Path(dictionary_dir) / "targets_type.csv",
+                    Path(dictionary_dir) / "_target" / "targets_type.csv",
+                ]
                 msg = (
                     "targets_type.csv not found in the provided dictionary directory. "
-                    "Expected at either 'dictionary/targets_type.csv' or "
-                    "'dictionary/_target/targets_type.csv'."
+                    "Expected at either "
+                    + " or ".join(f"'{path}'" for path in expected_locations)
+                    + "."
                 )
                 raise FileNotFoundError(msg)
 


### PR DESCRIPTION
## Summary
- add a `config.paths` helper that exposes `DICTIONARY_DIR` alongside existing configuration paths
- switch library components to resolve dictionary files via `DICTIONARY_DIR` instead of hard-coded `dictionary/…` literals
- update configuration defaults and schema entries to point at `config/dictionary` resources

## Testing
- CHEMBL_DA_BASE_PATH=$(pwd)/tests/data pytest tests/e2e/test_get_cli_pipelines.py

------
https://chatgpt.com/codex/tasks/task_e_68e10cd727448324b24eda58ffc8d06c