### PR TITLE
Add configuration metadata snapshot logging and richer pipeline diagnostics

### DIFF
--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -12,6 +12,7 @@ from .parser import (
     prepare_io_paths,
     path_argument,
     positive_int,
+    ConfigMetadata,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "prepare_io_paths",
     "path_argument",
     "positive_int",
+    "ConfigMetadata",
 ]

--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -13,12 +13,12 @@ import os
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path, PureWindowsPath
-from typing import Any
+from typing import Any, cast
 
 from pydantic import ValidationError
 
 from ..common.log import logger
-from ..config import Config, ConfigError, load_config
+from ..config import Config, ConfigError, ConfigMetadata, load_config
 from ..common.logging_setup import Logger, LoggerConfig
 from ..common.logging_setup import configure_logger as _configure_logger
 from ..version import require_python_version
@@ -521,7 +521,13 @@ def apply_config_overrides(
         for arg, path in {**_DEFAULT_OVERRIDES, **(mapping or {})}.items()
     }
 
+    normalized_cli_paths: dict[str, tuple[str, ...]] = {
+        arg: tuple(value.split(".")) if value else tuple()
+        for arg, value in override_map.items()
+    }
+
     cli_overrides: dict[str, Any] = {}
+    cli_override_sources: dict[tuple[str, ...], str] = {}
     for arg, key in override_map.items():
         if not hasattr(args, arg):
             continue
@@ -533,6 +539,7 @@ def apply_config_overrides(
             default = base_parser.get_default(arg)
         if value != default:
             cli_overrides[key] = value
+            cli_override_sources[tuple(key.split("."))] = arg
 
     try:
         base_path_arg = getattr(args, "base_path", None)
@@ -543,12 +550,15 @@ def apply_config_overrides(
         else:
             config_base_path = Path(base_path_arg)
 
-        cfg = load_config(
+        load_result = load_config(
             config_path,
             cli_overrides=cli_overrides,
             base_path=config_base_path,
             strict=True,
+            include_metadata=True,
+            cli_sources=cli_override_sources,
         )
+        cfg, metadata = cast(tuple[Config, ConfigMetadata], load_result)
     except ConfigError as exc:
         logger.error(
             "config_load_failed",
@@ -558,6 +568,11 @@ def apply_config_overrides(
         raise
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
+
+    metadata.cli_paths = {
+        arg: path for arg, path in normalized_cli_paths.items() if path
+    }
+    setattr(args, "_config_metadata", metadata)
 
     for arg, key in override_map.items():
         if not hasattr(args, arg):

--- a/library/cli/utils.py
+++ b/library/cli/utils.py
@@ -156,6 +156,7 @@ def run_cli_command(
             mapping=dict(mapping),
             base_parser=base_parser,
         )
+        metadata = getattr(args, "_config_metadata", None)
     except (ConfigError, FileNotFoundError, ValueError) as exc:
         use_logger.error(
             "config_error",
@@ -164,6 +165,9 @@ def run_cli_command(
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
+
+    if metadata is not None:
+        use_logger.info("config_snapshot", config=getattr(metadata, "snapshot", {}))
 
     try:
         if getattr(args, "print_config", False):

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -151,6 +151,7 @@ def run_cli_command(
             mapping=dict(mapping),
             base_parser=base_parser,
         )
+        metadata = getattr(args, "_config_metadata", None)
     except (ConfigError, FileNotFoundError, ValueError) as exc:
         use_logger.error(
             "config_error",
@@ -159,6 +160,9 @@ def run_cli_command(
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
+
+    if metadata is not None:
+        use_logger.info("config_snapshot", config=getattr(metadata, "snapshot", {}))
 
     try:
         if getattr(args, "print_config", False):

--- a/library/config.py
+++ b/library/config.py
@@ -17,12 +17,14 @@ import atexit
 import logging
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from importlib import resources
 from pathlib import Path
 from types import UnionType
 from typing import Any, Mapping, Union, get_args, get_origin
+
+from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
 import yaml
@@ -38,8 +40,6 @@ from pydantic_core import ErrorDetails
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-
-from .common.rate_limiter import configure_limiter_cache
 
 from .common.log import logger
 from .common.rate_limiter import configure_limiter_cache
@@ -193,6 +193,114 @@ def _resolve_placeholder_base_path(base_path: Path | str | None) -> Path:
 
 _RESOURCE_STACK = ExitStack()
 atexit.register(_RESOURCE_STACK.close)
+
+_UNSET = object()
+
+
+@dataclass(slots=True)
+class ConfigSource:
+    """Origin of a configuration value used in :class:`ConfigMetadata`."""
+
+    source: str
+    detail: str | None = None
+
+
+@dataclass(slots=True)
+class ConfigMetadata:
+    """Metadata describing configuration values and their provenance."""
+
+    snapshot: dict[str, Any]
+    sources: dict[tuple[str, ...], ConfigSource]
+    cli_paths: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def get(self, path: Sequence[str] | str) -> dict[str, Any]:
+        """Return a copy of the metadata entry located at ``path``."""
+
+        tuple_path = (
+            tuple(str(part) for part in path)
+            if isinstance(path, Sequence) and not isinstance(path, str)
+            else tuple(str(part) for part in str(path).split(".") if str(part))
+        )
+        current: Any = self.snapshot
+        for key in tuple_path:
+            if not isinstance(current, dict) or key not in current:
+                return {"value": None, "source": "unknown"}
+            current = current[key]
+        if isinstance(current, dict) and "value" in current and "source" in current:
+            result = {"value": current["value"], "source": current["source"]}
+            if "detail" in current and current["detail"] is not None:
+                result["detail"] = current["detail"]
+            return result
+        return {"value": current, "source": "unknown"}
+
+    def cli_entry(self, argument: str) -> dict[str, Any] | None:
+        """Return metadata for the CLI destination ``argument`` if available."""
+
+        path = self.cli_paths.get(argument)
+        if path is None:
+            return None
+        return self.get(path)
+
+    def option(
+        self,
+        *,
+        argument: str | None = None,
+        path: Sequence[str] | str | None = None,
+        value: Any = _UNSET,
+        default_source: str = "unknown",
+        default_detail: str | None = None,
+    ) -> dict[str, Any]:
+        """Return metadata for ``argument`` or ``path`` overriding ``value``."""
+
+        entry: dict[str, Any] | None = None
+        if argument is not None:
+            entry = self.cli_entry(argument)
+        if entry is None and path is not None:
+            entry = self.get(path)
+        if entry is None:
+            entry = {"value": None, "source": default_source}
+            if default_detail is not None:
+                entry["detail"] = default_detail
+        else:
+            entry = dict(entry)
+        if value is not _UNSET:
+            entry["value"] = value
+        return entry
+
+
+def _iter_leaf_items(
+    data: Any, prefix: tuple[str, ...] = ()
+) -> Iterator[tuple[tuple[str, ...], Any]]:
+    """Yield ``(path, value)`` pairs for leaf nodes in ``data``."""
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            key_str = str(key)
+            yield from _iter_leaf_items(value, (*prefix, key_str))
+        return
+    yield prefix, data
+
+
+def _build_snapshot(
+    data: Mapping[str, Any],
+    sources: Mapping[tuple[str, ...], ConfigSource],
+    prefix: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Return nested mapping annotating ``data`` with source metadata."""
+
+    snapshot: dict[str, Any] = {}
+    for key, value in data.items():
+        key_str = str(key)
+        path = (*prefix, key_str)
+        if isinstance(value, Mapping):
+            snapshot[key_str] = _build_snapshot(value, sources, path)
+            continue
+        source = sources.get(path, ConfigSource("default", None))
+        entry: dict[str, Any] = {"value": value, "source": source.source}
+        if source.detail is not None:
+            entry["detail"] = source.detail
+        snapshot[key_str] = entry
+    return snapshot
 
 
 def _dictionary_resource(*parts: str) -> Path:
@@ -967,7 +1075,7 @@ class ActivityCfg(_BoolModel):
     column: str = "activity_id"
     batch_size: int = Field(5, ge=1)
     workers: int = Field(1, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
     offset: int = Field(0, ge=0)
     dry_run: bool = False
@@ -981,7 +1089,7 @@ class ActivityCfg(_BoolModel):
 class AssayCfg(_BaseModel):
     column: str = "assay_chembl_id"
     batch_size: int = Field(10, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
 
 
@@ -999,7 +1107,7 @@ class TestitemBatchRetryCfg(_BoolModel):
 class TestitemCfg(_BaseModel):
     column: str = "molecule_chembl_id"
     batch_size: int = Field(1000, ge=1, le=1000)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
     offset: int = Field(0, ge=0)
     fields: tuple[str, ...] = Field(default=TESTITEM_FIELD_DEFAULTS)
@@ -1090,7 +1198,7 @@ class DocumentPubmedCfg(_BaseModel):
 class DocumentChemblCfg(_BaseModel):
     column: str = "document_chembl_id"
     chunk_size: int = Field(5, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
 
 
@@ -1100,7 +1208,7 @@ class DocumentAllCfg(_BaseModel):
     sleep: float = Field(5.0, ge=0)
     workers: int = Field(1, ge=1)
     batch_size: int = Field(50, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
 
 
@@ -1126,7 +1234,7 @@ class TargetChemblCfg(_BaseModel):
     column: str = "target_chembl_id"
 
     chunk_size: int = Field(5, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     limit: int | None = Field(default=None, ge=0)
 
 
@@ -1141,7 +1249,7 @@ class TargetAllCfg(_BaseModel):
     target_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_target.csv")
     family_csv: Path = Path("dictionary/_target/_IUPHAR/_IUPHAR_family.csv")
     chunk_size: int = Field(5, ge=1)
-    timeout: float = Field(30.0, ge=0)
+    timeout: float = Field(30.0, gt=0)
     uniprot_column: str = "uniprot_id"
     chembl_out: Path | None = None
     uniprot_out: Path | None = None
@@ -1585,7 +1693,9 @@ def load_config(
     *,
     base_path: Path | str | None = None,
     strict: bool = True,
-) -> Config:
+    include_metadata: bool = False,
+    cli_sources: Mapping[tuple[str, ...], str] | None = None,
+) -> Config | tuple[Config, ConfigMetadata]:
     """Load configuration from *path* applying overrides.
 
     Parameters
@@ -1593,12 +1703,22 @@ def load_config(
     base_path:
         Optional root directory used to resolve ``$CHEMBL_DA_BASE_PATH``
         placeholders.
+    include_metadata:
+        When ``True`` return a tuple containing the configuration and
+        :class:`ConfigMetadata` describing value provenance.
+    cli_sources:
+        Optional mapping of CLI override paths to argument identifiers used to
+        populate metadata detail fields.
     """
 
     try:
         data, resolved_path = load_yaml_config(path)
     except ConfigLoaderError as exc:
         raise ConfigError(str(exc)) from exc
+
+    source_map: dict[tuple[str, ...], ConfigSource] = {}
+    for path_tuple, _ in _iter_leaf_items(data):
+        source_map[path_tuple] = ConfigSource("config", str(resolved_path))
 
     local_path = resolved_path.with_name(
         f"{resolved_path.stem}.local{resolved_path.suffix}"
@@ -1609,6 +1729,8 @@ def load_config(
         except ConfigLoaderError as exc:
             raise ConfigError(str(exc)) from exc
         _merge_mapping(data, local_data)
+        for path_tuple, _ in _iter_leaf_items(local_data):
+            source_map[path_tuple] = ConfigSource("config", str(local_path))
 
     data = _coerce_integral_numbers(data)
 
@@ -1622,11 +1744,17 @@ def load_config(
         )
 
     env_overrides = _apply_env_overrides(data)
+    for path_tuple, env_key in env_overrides.items():
+        source_map[path_tuple] = ConfigSource("env", env_key)
     _upgrade_legacy_config(data)
 
     if cli_overrides:
         for key, val in cli_overrides.items():
-            _set_by_path(data, key.split("."), val)
+            parts = key.split(".")
+            _set_by_path(data, parts, val)
+            path_tuple = tuple(parts)
+            detail = cli_sources.get(path_tuple) if cli_sources else None
+            source_map[path_tuple] = ConfigSource("cli", detail)
 
     placeholder_base = _resolve_placeholder_base_path(base_path)
     data = _expand_config_placeholders(data, base_path=placeholder_base)
@@ -1673,7 +1801,15 @@ def load_config(
                 raise FileNotFoundError(p)
 
     configure_limiter_cache(cfg.rate.limiter_cache_maxsize, cfg.rate.limiter_cache_ttl)
-    return cfg
+    if not include_metadata:
+        return cfg
+
+    cfg_dict = _serialize_paths(cfg.to_dict())
+    for path_tuple, _ in _iter_leaf_items(cfg_dict):
+        source_map.setdefault(path_tuple, ConfigSource("default", None))
+    snapshot = _build_snapshot(cfg_dict, source_map)
+    metadata = ConfigMetadata(snapshot=snapshot, sources=source_map)
+    return cfg, metadata
 
 
 def ensure_dirs(cfg: Config) -> None:
@@ -1938,6 +2074,8 @@ __all__ = [
     "DocumentPubmedCfg",
     "DocumentChemblCfg",
     "DocumentAllCfg",
+    "ConfigMetadata",
+    "ConfigSource",
     "DocumentCfg",
     "TargetUniprotCfg",
     "TargetChemblCfg",

--- a/library/integration/pubmed_library.py
+++ b/library/integration/pubmed_library.py
@@ -242,6 +242,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "chunk_size": "document.pubmed.batch_size",
             },
         )
+        metadata = getattr(args, "_config_metadata", None)
     except (ConfigError, FileNotFoundError, ValueError) as exc:
         logger.error(
             "config_error",
@@ -250,6 +251,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
+
+    if metadata is not None:
+        logger.info("config_snapshot", config=getattr(metadata, "snapshot", {}))
 
     try:
         cfg = Config.model_validate(cfg.model_dump())

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -76,6 +76,7 @@ from library.pipelines.common import (
 from library.cli import (
     LoggerConfig,
     positive_int,
+    ConfigMetadata,
 )
 from library.cli import (
     build_parser as base_parser,
@@ -107,6 +108,41 @@ from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_dela
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
 PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+_OPTION_UNSET = object()
+
+
+def _option(
+    metadata: ConfigMetadata | None,
+    *,
+    argument: str | None = None,
+    path: str | None = None,
+    value: object = _OPTION_UNSET,
+    default_source: str = "unknown",
+    default_detail: str | None = None,
+) -> dict[str, object]:
+    """Return structured option metadata for pipeline logging."""
+
+    if metadata is not None:
+        if value is _OPTION_UNSET:
+            return metadata.option(
+                argument=argument,
+                path=path,
+                default_source=default_source,
+                default_detail=default_detail,
+            )
+        return metadata.option(
+            argument=argument,
+            path=path,
+            value=value,
+            default_source=default_source,
+            default_detail=default_detail,
+        )
+    actual = None if value is _OPTION_UNSET else value
+    entry: dict[str, object] = {"value": actual, "source": default_source}
+    if default_detail is not None:
+        entry["detail"] = default_detail
+    return entry
 
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
@@ -179,16 +215,57 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
     logger.info(
         "activity_pipeline_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=limit,
-        offset=offset,
-        batch_size=cfg.activity.batch_size,
-        timeout=cfg.activity.timeout,
-        dry_run=cfg.activity.dry_run,
-        workers=configured_workers,
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.activity.limit",
+            value=limit,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.activity.offset",
+            value=offset,
+        ),
+        batch_size=_option(
+            metadata_obj,
+            argument="batch_size",
+            path="sources.chembl.pipelines.activity.batch_size",
+            value=cfg.activity.batch_size,
+        ),
+        timeout=_option(
+            metadata_obj,
+            argument="timeout",
+            path="sources.chembl.pipelines.activity.timeout",
+            value=cfg.activity.timeout,
+        ),
+        dry_run=_option(
+            metadata_obj,
+            argument="dry_run",
+            path="sources.chembl.pipelines.activity.dry_run",
+            value=cfg.activity.dry_run,
+            default_source="cli",
+        ),
+        workers=_option(
+            metadata_obj,
+            argument="workers",
+            path="sources.chembl.pipelines.activity.workers",
+            value=configured_workers,
+        ),
     )
 
     if cfg.activity.dry_run:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -39,6 +39,7 @@ from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
 from library.cli import (
     LoggerConfig,
+    ConfigMetadata,
 )
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command, run_pipeline
@@ -60,6 +61,39 @@ __all__ = ["ap", "main", "run", "run_chembl"]
 
 DEFAULT_INPUT_NAME = "assay.csv"
 DEFAULT_OUTPUT_STEM = "assays"
+
+_OPTION_UNSET = object()
+
+
+def _option(
+    metadata: ConfigMetadata | None,
+    *,
+    argument: str | None = None,
+    path: str | None = None,
+    value: object = _OPTION_UNSET,
+    default_source: str = "unknown",
+    default_detail: str | None = None,
+) -> dict[str, object]:
+    if metadata is not None:
+        if value is _OPTION_UNSET:
+            return metadata.option(
+                argument=argument,
+                path=path,
+                default_source=default_source,
+                default_detail=default_detail,
+            )
+        return metadata.option(
+            argument=argument,
+            path=path,
+            value=value,
+            default_source=default_source,
+            default_detail=default_detail,
+        )
+    actual = None if value is _OPTION_UNSET else value
+    entry: dict[str, object] = {"value": actual, "source": default_source}
+    if default_detail is not None:
+        entry["detail"] = default_detail
+    return entry
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -103,14 +137,42 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
     logger.info(
         "assay_pipeline_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=limit,
-        offset=offset,
-        batch_size=cfg.assay.batch_size,
-        timeout=cfg.assay.timeout,
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.assay.limit",
+            value=limit,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.assay.offset",
+            value=offset,
+        ),
+        batch_size=_option(
+            metadata_obj,
+            argument="batch_size",
+            path="sources.chembl.pipelines.assay.batch_size",
+            value=cfg.assay.batch_size,
+        ),
+        timeout=_option(
+            metadata_obj,
+            argument="timeout",
+            path="sources.chembl.pipelines.assay.timeout",
+            value=cfg.assay.timeout,
+        ),
     )
     if offset:
         ids_iter = islice(ids_iter, offset, None)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -93,6 +93,7 @@ from library.postprocessing import document as document_export_postprocessing
 from library.clients import ChemblClient, _chunked
 from library.cli import (
     LoggerConfig,
+    ConfigMetadata,
     build_root_parser,
     path_argument,
     positive_int,
@@ -135,6 +136,39 @@ DEFAULT_INPUT_NAME = "document.csv"
 DEFAULT_OUTPUT_STEM = "documents"
 DOCUMENT_PROGRESS_INFO_INTERVAL = 100
 DOCUMENT_FRAME_CONCAT_STRIDE = 16
+
+_OPTION_UNSET = object()
+
+
+def _option(
+    metadata: ConfigMetadata | None,
+    *,
+    argument: str | None = None,
+    path: str | None = None,
+    value: object = _OPTION_UNSET,
+    default_source: str = "unknown",
+    default_detail: str | None = None,
+) -> dict[str, object]:
+    if metadata is not None:
+        if value is _OPTION_UNSET:
+            return metadata.option(
+                argument=argument,
+                path=path,
+                default_source=default_source,
+                default_detail=default_detail,
+            )
+        return metadata.option(
+            argument=argument,
+            path=path,
+            value=value,
+            default_source=default_source,
+            default_detail=default_detail,
+        )
+    actual = None if value is _OPTION_UNSET else value
+    entry: dict[str, object] = {"value": actual, "source": default_source}
+    if default_detail is not None:
+        entry["detail"] = default_detail
+    return entry
 
 
 T = TypeVar("T")
@@ -1646,16 +1680,64 @@ def run_pubmed(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+    workers = getattr(args, "workers", pubmed_defaults.workers)
+    batch_size = getattr(args, "batch_size", pubmed_defaults.batch_size)
+    sleep = getattr(args, "sleep", pubmed_defaults.sleep)
+    fallback_doi = bool(getattr(args, "fallback_doi_csv", None))
+    if workers > 1 and sleep == 0:
+        logger.warning(
+            "zero_sleep_workers",
+            workers=workers,
+            sleep=sleep,
+        )
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
     logger.info(
         "document_pubmed_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=limit,
-        offset=offset,
-        workers=getattr(args, "workers", pubmed_defaults.workers),
-        batch_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
-        sleep=getattr(args, "sleep", pubmed_defaults.sleep),
-        fallback_doi=bool(getattr(args, "fallback_doi_csv", None)),
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.document.pubmed.limit",
+            value=limit,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.document.pubmed.offset",
+            value=offset,
+            default_source="cli",
+        ),
+        workers=_option(
+            metadata_obj,
+            argument="workers",
+            path="sources.chembl.pipelines.document.pubmed.workers",
+            value=workers,
+        ),
+        batch_size=_option(
+            metadata_obj,
+            argument="batch_size",
+            path="sources.chembl.pipelines.document.pubmed.batch_size",
+            value=batch_size,
+        ),
+        sleep=_option(
+            metadata_obj,
+            argument="sleep",
+            path="sources.chembl.pipelines.document.pubmed.sleep",
+            value=sleep,
+        ),
+        fallback_doi=_option(
+            metadata_obj,
+            value=fallback_doi,
+            default_source="cli",
+        ),
     )
     try:
         pmids_iter = io.read_ids(
@@ -1780,14 +1862,45 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+    chunk_size = getattr(args, "chunk_size", chembl_defaults.chunk_size)
+    timeout = getattr(args, "timeout", chembl_defaults.timeout)
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
     logger.info(
         "document_chembl_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=limit,
-        offset=offset,
-        chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
-        timeout=getattr(args, "timeout", chembl_defaults.timeout),
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.document.chembl.limit",
+            value=limit,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.document.chembl.offset",
+            value=offset,
+            default_source="cli",
+        ),
+        chunk_size=_option(
+            metadata_obj,
+            argument="chunk_size",
+            path="sources.chembl.pipelines.document.chembl.chunk_size",
+            value=chunk_size,
+        ),
+        timeout=_option(
+            metadata_obj,
+            argument="timeout",
+            path="sources.chembl.pipelines.document.chembl.timeout",
+            value=timeout,
+        ),
     )
 
     # Configure session for ChEMBL requests
@@ -1932,17 +2045,72 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     output_path = Path(
         args.output_csv or io.default_output_path(args.input_csv, cfg.io)
     )
+    workers = getattr(args, "workers", all_defaults.workers)
+    batch_size = getattr(args, "batch_size", all_defaults.batch_size)
+    sleep = getattr(args, "sleep", all_defaults.sleep)
+    timeout = getattr(args, "timeout", all_defaults.timeout)
+    chunk_size = getattr(args, "chunk_size", all_defaults.chunk_size)
+    if workers > 1 and sleep == 0:
+        logger.warning(
+            "zero_sleep_workers",
+            workers=workers,
+            sleep=sleep,
+        )
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
     logger.info(
         "document_all_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=limit,
-        offset=offset,
-        chunk_size=getattr(args, "chunk_size", all_defaults.chunk_size),
-        workers=getattr(args, "workers", all_defaults.workers),
-        batch_size=getattr(args, "batch_size", all_defaults.batch_size),
-        sleep=getattr(args, "sleep", all_defaults.sleep),
-        timeout=getattr(args, "timeout", all_defaults.timeout),
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.document.all.limit",
+            value=limit,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.document.all.offset",
+            value=offset,
+            default_source="cli",
+        ),
+        chunk_size=_option(
+            metadata_obj,
+            argument="chunk_size",
+            path="sources.chembl.pipelines.document.all.chunk_size",
+            value=chunk_size,
+        ),
+        workers=_option(
+            metadata_obj,
+            argument="workers",
+            path="sources.chembl.pipelines.document.all.workers",
+            value=workers,
+        ),
+        batch_size=_option(
+            metadata_obj,
+            argument="batch_size",
+            path="sources.chembl.pipelines.document.all.batch_size",
+            value=batch_size,
+        ),
+        sleep=_option(
+            metadata_obj,
+            argument="sleep",
+            path="sources.chembl.pipelines.document.all.sleep",
+            value=sleep,
+        ),
+        timeout=_option(
+            metadata_obj,
+            argument="timeout",
+            path="sources.chembl.pipelines.document.all.timeout",
+            value=timeout,
+        ),
     )
 
     try:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -23,6 +23,39 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_NAME = "testitem.csv"
 DEFAULT_OUTPUT_STEM = "testitems"
 
+_OPTION_UNSET = object()
+
+
+def _option(
+    metadata: ConfigMetadata | None,
+    *,
+    argument: str | None = None,
+    path: str | None = None,
+    value: object = _OPTION_UNSET,
+    default_source: str = "unknown",
+    default_detail: str | None = None,
+) -> dict[str, object]:
+    if metadata is not None:
+        if value is _OPTION_UNSET:
+            return metadata.option(
+                argument=argument,
+                path=path,
+                default_source=default_source,
+                default_detail=default_detail,
+            )
+        return metadata.option(
+            argument=argument,
+            path=path,
+            value=value,
+            default_source=default_source,
+            default_detail=default_detail,
+        )
+    actual = None if value is _OPTION_UNSET else value
+    entry: dict[str, object] = {"value": actual, "source": default_source}
+    if default_detail is not None:
+        entry["detail"] = default_detail
+    return entry
+
 
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -37,7 +70,7 @@ from library import cli  # noqa: F401 - re-exported for monkeypatching in tests
 from library import io
 from library.integration import molecule_catalog
 from library.integration import pubchem_library as pl
-from library.cli import LoggerConfig
+from library.cli import LoggerConfig, ConfigMetadata
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command
 from library.config import (
@@ -567,14 +600,50 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     if args.skip_existing and output_path.exists() and not args.force:
         logger.info("pipeline_skip_existing", output=str(output_path))
         return 0
+    metadata_obj = getattr(args, "_config_metadata", None)
+    if not isinstance(metadata_obj, ConfigMetadata):
+        metadata_obj = None
+    output_source = "cli" if getattr(args, "output_csv", None) else "derived"
+    limit_value = getattr(cfg.testitem, "limit", None)
+    offset_value = getattr(args, "offset", getattr(cfg.testitem, "offset", None))
     logger.info(
         "testitem_pipeline_start",
-        input=str(args.input_csv),
-        output=str(output_path),
-        limit=getattr(cfg.testitem, "limit", None),
-        offset=getattr(args, "offset", getattr(cfg.testitem, "offset", None)),
-        batch_size=getattr(cfg.testitem, "batch_size", None),
-        timeout=getattr(cfg.testitem, "timeout", None),
+        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=_option(
+            metadata_obj,
+            value=str(output_path),
+            default_source=output_source,
+        ),
+        limit=_option(
+            metadata_obj,
+            argument="limit",
+            path="sources.chembl.pipelines.testitem.limit",
+            value=limit_value,
+        ),
+        offset=_option(
+            metadata_obj,
+            argument="offset",
+            path="sources.chembl.pipelines.testitem.offset",
+            value=offset_value,
+        ),
+        batch_size=_option(
+            metadata_obj,
+            argument="batch_size",
+            path="sources.chembl.pipelines.testitem.batch_size",
+            value=getattr(cfg.testitem, "batch_size", None),
+        ),
+        timeout=_option(
+            metadata_obj,
+            argument="timeout",
+            path="sources.chembl.pipelines.testitem.timeout",
+            value=getattr(cfg.testitem, "timeout", None),
+        ),
+        column=_option(
+            metadata_obj,
+            argument="column",
+            path="sources.chembl.pipelines.testitem.column",
+            value=getattr(cfg.testitem, "column", None),
+        ),
     )
     exit_code = run_chembl(cfg, args)
     if exit_code == 0:


### PR DESCRIPTION
## Summary
- track configuration value provenance in ConfigMetadata, emit a config_snapshot event after CLI overrides, and expose helpers to consume metadata
- update activity, assay, test item, and document pipelines to log structured option payloads with value/source information and warn when workers run with zero sleep
- tighten timeout validation to require positive values and reuse structured logging in supporting utilities and integration tooling

## Testing
- `pytest -k pipeline_start -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e10c0cab648324bb403be0b9f1774a