### PR TITLE
Add deterministic test for dictionary directory path

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import atexit
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from importlib import resources

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.paths import DICTIONARY_DIR
+
+
+@pytest.mark.unit
+def test_dictionary_dir__points_to_project_resource() -> None:
+    """DICTIONARY_DIR should resolve to ``config/dictionary`` within the repo."""
+
+    project_root = Path(__file__).resolve().parents[2]
+    expected = project_root / "config" / "dictionary"
+
+    assert DICTIONARY_DIR == expected
+    assert DICTIONARY_DIR.is_absolute()
+    assert DICTIONARY_DIR.relative_to(project_root) == Path("config/dictionary")


### PR DESCRIPTION
## Summary
- add a unit test that asserts `config.paths.DICTIONARY_DIR` resolves to the `config/dictionary` directory at the project root
- ensure `library.config` imports `atexit` so its module-level resource cleanup registration works during tests

## Testing
- pytest tests/unit/test_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68e111b2a2088324b148b3e965879823