### PR TITLE
Update setuptools config for relocated dictionary resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,8 @@ include = [
   "library",
   "library.*",
   "config",
-  "dictionary",
+  "config.dictionary",
+  "config.dictionary.*",
   "scripts",
   "scripts.*",
 ]
@@ -88,7 +89,7 @@ include = [
   "config.yaml",
   "dictionary/_testitem/molecule_hierarchy.csv",
 ]
-"dictionary" = ["**/*"]
+"config.dictionary" = ["**/*"]
 "library" = ["py.typed"]
 "library.qa" = ["document_schema_crosswalk.yaml"]
 


### PR DESCRIPTION
## Summary
- update setuptools package discovery to include the `config.dictionary` namespace instead of the removed `dictionary` package
- collect dictionary data files from `config/dictionary/**` so the wheel and sdist ship the relocated resources

## Testing
- python -m build
- unzip -l dist/chembl_data_acquisition-0.1.3-py3-none-any.whl | awk '{print $4}' | grep '^dictionary/'
- tar -tf dist/chembl_data_acquisition-0.1.3.tar.gz | grep '^dictionary/'


------
https://chatgpt.com/codex/tasks/task_e_68e111ed2e848324922b0c9d85cfdb01