### PR TITLE
Add get_document_data CLI tests and configure coverage reporting

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -13,6 +13,7 @@ aliases are supported; see ``_ALIAS_MAP`` for the full list.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import re

--- a/reports/tests/get_document_data_CLI_report.md
+++ b/reports/tests/get_document_data_CLI_report.md
@@ -1,0 +1,18 @@
+# Document CLI Test Report
+
+## Summary
+- ✅ `pytest tests/unit/test_cli_get_document_data.py`
+- ✅ `pytest tests/integration/test_fallback_doi.py`
+
+## CLI Flag Matrix
+
+| Scenario | Flags | Expected Outcome |
+|----------|-------|------------------|
+| PubMed defaults | `get-document-data pubmed --input <file>` | Parser applies default batch size, offsets, and disables DOI fallback. |
+| PubMed CLI override | `get-document-data pubmed --batch-size 77 --final-out <out>` | CLI flag overrides configuration and default values for batch sizing. |
+| DOI fallback CSV | `get-document-data pubmed --fallback-doi-csv fallback.csv` | PMID→DOI overrides are loaded and handed to the fetch pipeline, logging fallback metrics. |
+| Skip existing output | `get-document-data pubmed --skip-existing [--force] --final-out <out>` | Without `--force` the run short-circuits with `pipeline_skip_existing`; with `--force` it reprocesses the input. |
+
+## Notes
+- Unit tests cover parser defaults, CLI/config/default precedence, and boundary validation for `--limit`/`--offset`.
+- Integration tests stub network fetches, replay deterministic CSV fixtures, and assert structured log events for fallback DOI handling.

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -17,6 +17,9 @@ RAW_REPORT_FILE = REPORTS_DIR / "pytest_raw_report.json"
 REPORT_FILE = REPORTS_DIR / "test_report.json"
 LOG_FILE = REPORTS_DIR / "test_run.log"
 SUMMARY_FILE = REPORTS_DIR / "test_summary.md"
+COVERAGE_DIR = REPORTS_DIR / "coverage"
+COVERAGE_XML = COVERAGE_DIR / "coverage.xml"
+COVERAGE_HTML = COVERAGE_DIR / "html"
 REPO_SLUG = "SatoryKono/ChEMBL_data_acquisition"
 
 PYTEST_COMMAND: tuple[str, ...] = (
@@ -27,6 +30,11 @@ PYTEST_COMMAND: tuple[str, ...] = (
     "--json-report-file",
     str(RAW_REPORT_FILE),
     "--durations=0",
+    "--cov=library",
+    "--cov=scripts",
+    "--cov-report=term",
+    f"--cov-report=xml:{COVERAGE_XML}",
+    f"--cov-report=html:{COVERAGE_HTML}",
     "-vv",
 )
 
@@ -35,6 +43,7 @@ def ensure_reports_directory() -> None:
     """Ensure the reports directory exists."""
 
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def run_pytest() -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import random
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable, Sequence
 
 import sys
 
@@ -116,6 +116,40 @@ def sample_input_csv(tmp_path: Path) -> Path:
 @pytest.fixture()
 def snapshot_resource() -> Path:
     return Path(__file__).parent / "resources"
+
+
+@pytest.fixture()
+def make_fallback_doi_csv(tmp_path: Path) -> Callable[..., Path]:
+    """Return a factory producing deterministic fallback DOI CSV files."""
+
+    def _factory(
+        rows: Iterable[tuple[str, str]],
+        *,
+        columns: Sequence[str] = ("PMID", "DOI"),
+        filename: str = "fallback_doi.csv",
+    ) -> Path:
+        path = tmp_path / filename
+        with path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(list(columns))
+            for pmid, doi in rows:
+                writer.writerow([pmid, doi])
+        return path
+
+    return _factory
+
+
+@pytest.fixture()
+def fallback_doi_csv(
+    make_fallback_doi_csv: Callable[..., Path]
+) -> Path:
+    """Provide a default fallback DOI CSV used across tests."""
+
+    default_rows = (
+        ("123456", "10.1000/default-one"),
+        ("789012", "10.1000/default-two"),
+    )
+    return make_fallback_doi_csv(default_rows)
 
 
 @pytest.fixture()

--- a/tests/integration/test_fallback_doi.py
+++ b/tests/integration/test_fallback_doi.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+import yaml
+
+from library.config import Config, _serialize_paths
+from scripts import get_document_data
+
+
+class _MemoryLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def info(self, event: str, **payload: object) -> None:
+        self.events.append(("info", event, dict(payload)))
+
+    def warning(self, event: str, **payload: object) -> None:
+        self.events.append(("warning", event, dict(payload)))
+
+    def error(self, event: str, **payload: object) -> None:
+        self.events.append(("error", event, dict(payload)))
+
+    def exception(self, event: str, **payload: object) -> None:
+        self.events.append(("exception", event, dict(payload)))
+
+    def debug(self, event: str, **payload: object) -> None:  # pragma: no cover - optional
+        self.events.append(("debug", event, dict(payload)))
+
+
+@pytest.fixture()
+def document_cli_logger(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> _MemoryLogger:
+    logger = _MemoryLogger()
+
+    def _configure_logger(cfg: object) -> _MemoryLogger:
+        return logger
+
+    @contextmanager
+    def _setup_cli_logging(
+        _script: str, log_cfg: object, _date: str | None = None
+    ):
+        yield SimpleNamespace(log_cfg=log_cfg, log_path=tmp_path / "cli.log")
+
+    monkeypatch.setattr(get_document_data, "logger", logger)
+    monkeypatch.setattr(get_document_data, "configure_logger", _configure_logger)
+    monkeypatch.setattr(get_document_data, "setup_cli_logging", _setup_cli_logging)
+    return logger
+
+
+def _base_config(tmp_path: Path) -> dict[str, object]:
+    cfg = Config()
+    output_dir = tmp_path / "output"
+    cache_dir = tmp_path / "cache"
+    output_dir.mkdir()
+    cache_dir.mkdir()
+    cfg.io.output_dir = output_dir
+    cfg.io.cache_dir = cache_dir
+    cfg.io.exist_ok = True
+    cfg.system.doc_quality.enable = False
+    return _serialize_paths(cfg.to_dict())
+
+
+def _write_config(tmp_path: Path, data: dict[str, object]) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(data, sort_keys=False),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _create_input(tmp_path: Path) -> Path:
+    path = tmp_path / "pmids.csv"
+    path.write_text("PMID\n111\n222\n", encoding="utf-8")
+    return path
+
+
+@pytest.mark.integration
+def test_main_pubmed__without_fallback_csv(
+    tmp_path: Path,
+    document_cli_logger: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _base_config(tmp_path)
+    config_path = _write_config(tmp_path, config)
+    input_csv = _create_input(tmp_path)
+    output_path = tmp_path / "output" / "pubmed.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fallback_maps: list[object] = []
+
+    def _fake_fetch(pmids, cfg, **kwargs):  # type: ignore[override]
+        fallback_maps.append(kwargs.get("fallback_doi_map"))
+        frame = pd.DataFrame({"document_chembl_id": ["DOC1"], "PubMed.PMID": ["111"]})
+        return iter([frame])
+
+    emitted_frames: list[pd.DataFrame] = []
+
+    def _fake_finalise(frames, output, cfg, **kwargs):  # type: ignore[override]
+        emitted_frames.extend(list(frames))
+        return 0
+
+    monkeypatch.setattr(get_document_data, "fetch_pubmed_records", _fake_fetch)
+    monkeypatch.setattr(get_document_data, "_finalise_export", _fake_finalise)
+    monkeypatch.setattr(get_document_data, "normalize_documents", lambda frame: frame)
+
+    exit_code = get_document_data.main(
+        [
+            "pubmed",
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_path.parent),
+            "--final-out",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert fallback_maps == [None]
+    assert emitted_frames and isinstance(emitted_frames[0], pd.DataFrame)
+    start_event = next(
+        payload
+        for level, event, payload in document_cli_logger.events
+        if level == "info" and event == "document_pubmed_start"
+    )
+    assert start_event["fallback_doi"]["value"] is False
+    assert any(
+        event == "document_pubmed_done" for _level, event, _payload in document_cli_logger.events
+    )
+
+
+@pytest.mark.integration
+def test_main_pubmed__with_fallback_csv(
+    tmp_path: Path,
+    document_cli_logger: _MemoryLogger,
+    make_fallback_doi_csv,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _base_config(tmp_path)
+    config_path = _write_config(tmp_path, config)
+    input_csv = _create_input(tmp_path)
+    output_path = tmp_path / "output" / "pubmed.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fallback_csv = make_fallback_doi_csv([("111", "10.1000/fallback")])
+
+    fallback_maps: list[object] = []
+
+    def _fake_fetch(pmids, cfg, **kwargs):  # type: ignore[override]
+        fallback_maps.append(kwargs.get("fallback_doi_map"))
+        frame = pd.DataFrame({"document_chembl_id": ["DOC1"], "PubMed.PMID": ["111"]})
+        return iter([frame])
+
+    monkeypatch.setattr(get_document_data, "fetch_pubmed_records", _fake_fetch)
+    monkeypatch.setattr(
+        get_document_data,
+        "_finalise_export",
+        lambda frames, *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(get_document_data, "normalize_documents", lambda frame: frame)
+
+    exit_code = get_document_data.main(
+        [
+            "pubmed",
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_path.parent),
+            "--final-out",
+            str(output_path),
+            "--fallback-doi-csv",
+            str(fallback_csv),
+        ]
+    )
+
+    assert exit_code == 0
+    assert fallback_maps == [{"111": "10.1000/fallback"}]
+    start_event = next(
+        payload
+        for level, event, payload in document_cli_logger.events
+        if level == "info" and event == "document_pubmed_start"
+    )
+    assert start_event["fallback_doi"]["value"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("force", [False, True])
+def test_main_pubmed__skip_existing_conflict(
+    tmp_path: Path,
+    document_cli_logger: _MemoryLogger,
+    force: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _base_config(tmp_path)
+    config_path = _write_config(tmp_path, config)
+    input_csv = _create_input(tmp_path)
+    output_path = tmp_path / "output" / "pubmed.csv"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("existing", encoding="utf-8")
+
+    called = False
+
+    def _fake_fetch(pmids, cfg, **kwargs):  # type: ignore[override]
+        nonlocal called
+        called = True
+        frame = pd.DataFrame({"document_chembl_id": ["DOC1"], "PubMed.PMID": ["111"]})
+        return iter([frame])
+
+    monkeypatch.setattr(get_document_data, "fetch_pubmed_records", _fake_fetch)
+    monkeypatch.setattr(
+        get_document_data,
+        "_finalise_export",
+        lambda frames, *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(get_document_data, "normalize_documents", lambda frame: frame)
+
+    args = [
+        "pubmed",
+        "--config",
+        str(config_path),
+        "--input",
+        str(input_csv),
+        "--output-dir",
+        str(output_path.parent),
+        "--final-out",
+        str(output_path),
+        "--skip-existing",
+    ]
+    if force:
+        args.append("--force")
+
+    exit_code = get_document_data.main(args)
+
+    assert exit_code == 0
+    if force:
+        assert called is True
+    else:
+        assert called is False
+        assert any(
+            event == "pipeline_skip_existing"
+            for _level, event, _payload in document_cli_logger.events
+        )

--- a/tests/unit/test_cli_get_document_data.py
+++ b/tests/unit/test_cli_get_document_data.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable
+
+import pytest
+import yaml
+
+from library.config import Config, _serialize_paths
+from scripts import get_document_data
+
+
+class _RunRecorder:
+    def __init__(self) -> None:
+        self.called = False
+        self.config = None
+        self.args: argparse.Namespace | None = None
+
+    def __call__(self, cfg, args: argparse.Namespace) -> int:  # type: ignore[override]
+        self.called = True
+        self.config = cfg
+        self.args = args
+        return 0
+
+
+def _prepare_config(tmp_path: Path, mutator: Callable[[Config], None]) -> Path:
+    cfg = Config()
+    output_dir = tmp_path / "output"
+    cache_dir = tmp_path / "cache"
+    output_dir.mkdir()
+    cache_dir.mkdir()
+    cfg.io.output_dir = output_dir
+    cfg.io.cache_dir = cache_dir
+    cfg.io.exist_ok = True
+    cfg.system.doc_quality.enable = False
+    mutator(cfg)
+    data = _serialize_paths(cfg.to_dict())
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(data, sort_keys=False),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+@contextmanager
+def _stub_logging(tmp_path: Path) -> Callable[[object], object]:
+    logger_stub = get_document_data.logger
+
+    def _configure_logger(cfg: object) -> object:
+        return logger_stub
+
+    @contextmanager
+    def _setup_cli_logging(_name: str, log_cfg: object, _date: str | None = None):
+        yield SimpleNamespace(log_cfg=log_cfg, log_path=tmp_path / "cli.log")
+
+    original_configure = get_document_data.configure_logger
+    original_setup = get_document_data.setup_cli_logging
+    get_document_data.configure_logger = _configure_logger  # type: ignore[assignment]
+    get_document_data.setup_cli_logging = _setup_cli_logging  # type: ignore[assignment]
+    try:
+        yield lambda _: logger_stub
+    finally:
+        get_document_data.configure_logger = original_configure  # type: ignore[assignment]
+        get_document_data.setup_cli_logging = original_setup  # type: ignore[assignment]
+
+
+@pytest.mark.unit
+def test_build_parser__pubmed_defaults() -> None:
+    parser, _log_cfg = get_document_data.build_parser()
+    args = parser.parse_args(["pubmed"])
+
+    assert args.command == "pubmed"
+    assert args.batch_size == 100
+    assert args.limit is None
+    assert args.fallback_doi_csv is None
+    assert args.offset == 0
+
+
+@pytest.mark.unit
+def test_main__cli_overrides_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _mutator(cfg: Config) -> None:
+        cfg.document.pubmed.batch_size = 33
+
+    config_path = _prepare_config(tmp_path, _mutator)
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n12345\n", encoding="utf-8")
+    recorder = _RunRecorder()
+    monkeypatch.setattr(get_document_data, "run", recorder)
+
+    with _stub_logging(tmp_path):
+        exit_code = get_document_data.main(
+            [
+                "pubmed",
+                "--config",
+                str(config_path),
+                "--input",
+                str(input_csv),
+                "--final-out",
+                str(tmp_path / "pubmed.csv"),
+                "--batch-size",
+                "77",
+            ]
+        )
+
+    assert exit_code == 0
+    assert recorder.called is True
+    assert recorder.config.document.pubmed.batch_size == 77
+    assert recorder.args is not None
+    assert recorder.args.batch_size == 77
+
+
+@pytest.mark.unit
+def test_main__config_overrides_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _mutator(cfg: Config) -> None:
+        cfg.document.pubmed.batch_size = 31
+
+    config_path = _prepare_config(tmp_path, _mutator)
+    input_csv = tmp_path / "pmids.csv"
+    input_csv.write_text("PMID\n67890\n", encoding="utf-8")
+    recorder = _RunRecorder()
+    monkeypatch.setattr(get_document_data, "run", recorder)
+
+    with _stub_logging(tmp_path):
+        exit_code = get_document_data.main(
+            [
+                "pubmed",
+                "--config",
+                str(config_path),
+                "--input",
+                str(input_csv),
+                "--final-out",
+                str(tmp_path / "pubmed.csv"),
+            ]
+        )
+
+    assert exit_code == 0
+    assert recorder.called is True
+    assert recorder.config.document.pubmed.batch_size == 31
+    assert recorder.args is not None
+    assert recorder.args.batch_size == 31
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "option, value, message",
+    [
+        ("--limit", "-1", "--limit must be zero or a positive integer"),
+        ("--offset", "-5", "--offset must be zero or a positive integer"),
+    ],
+)
+def test_main__negative_values_raise(
+    option: str,
+    value: str,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    called = False
+
+    def _fail(*_args: object, **_kwargs: object) -> int:
+        nonlocal called
+        called = True
+        return 0
+
+    monkeypatch.setattr(get_document_data, "run_cli_command", _fail)
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_document_data.main(["pubmed", option, value])
+
+    assert excinfo.value.code == 2
+    assert called is False
+    captured = capsys.readouterr()
+    assert message in captured.err


### PR DESCRIPTION
## Summary
- add unit tests for get_document_data CLI argument parsing, precedence, and validation
- add integration tests covering DOI fallback scenarios with deterministic CSV mocks and logging assertions
- provide fixtures for fallback CSVs, fix missing `atexit` import, and enable coverage XML/HTML outputs alongside a CLI test report

## Testing
- pytest tests/unit/test_cli_get_document_data.py
- pytest tests/integration/test_fallback_doi.py

------
https://chatgpt.com/codex/tasks/task_e_68e1113954c083248eb32eb7f27077bc