### PR TITLE
Fix invalid target pipeline config keys

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -104,17 +104,12 @@ sources:
         uniprot:
           column: "uniprot_id"
           data_dir: "config/dictionary/_target/_uniprot"
-          chunk_size: 100
-          timeout: 30.0
           limit: null
-          offset: 0
-          data_dir: "../config/dictionary/_target/_uniprot"
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers
           chunk_size: 5
           timeout: 30.0
           limit: null
-          offset: 0
         iuphar:
           target_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
           family_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv"


### PR DESCRIPTION
## Summary
- remove unsupported offset and chunk settings from the target pipeline defaults
- ensure the configuration matches the validated schema for the target pipelines

## Testing
- python scripts/get_data.py --limit 0 --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e115fb67748324ad6abaaef245ce5d