### PR TITLE
Fix config path resolution for dictionary lookups

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -101,16 +101,21 @@ def _absolutise_path_value(value: Any, base_dir: Path) -> Any:
 
     if value is None:
         return value
-    if isinstance(value, str):
-        path = Path(value)
-        if path.is_absolute():
-            return value
-        return str((base_dir / path).resolve())
-    if isinstance(value, os.PathLike):
-        path = Path(value)
+    base_dir = base_dir.resolve()
+
+    def _resolve(path: Path) -> Path:
         if path.is_absolute():
             return path
+        if base_dir.name and path.parts and path.parts[0] == base_dir.name:
+            return (base_dir.parent / path).resolve()
         return (base_dir / path).resolve()
+
+    if isinstance(value, str):
+        resolved = _resolve(Path(value))
+        return str(resolved)
+    if isinstance(value, os.PathLike):
+        resolved = _resolve(Path(value))
+        return resolved
     return value
 
 

--- a/tests/unit/test_config_path_resolution.py
+++ b/tests/unit/test_config_path_resolution.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.config import _absolutise_path_value
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "config/dictionary/_testitem/molecule_hierarchy.csv",
+        Path("config/dictionary/_testitem/molecule_hierarchy.csv"),
+    ],
+)
+def test_absolutise_path_value__avoids_duplicate_config_segment(tmp_path, value):
+    project_root = tmp_path / "project"
+    base_dir = project_root / "config"
+    base_dir.mkdir(parents=True)
+
+    resolved = _absolutise_path_value(value, base_dir)
+
+    expected = (project_root / "config" / "dictionary" / "_testitem" / "molecule_hierarchy.csv").resolve()
+    if isinstance(resolved, Path):
+        assert resolved == expected
+    else:
+        assert resolved == str(expected)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "data/output/test.csv",
+        Path("data/output/test.csv"),
+    ],
+)
+def test_absolutise_path_value__keeps_standard_relative_paths(tmp_path, value):
+    project_root = tmp_path / "workspace"
+    base_dir = project_root / "config"
+    base_dir.mkdir(parents=True)
+
+    resolved = _absolutise_path_value(value, base_dir)
+
+    expected = (base_dir / value).resolve()
+    if isinstance(resolved, Path):
+        assert resolved == expected
+    else:
+        assert resolved == str(expected)


### PR DESCRIPTION
## Summary
- prevent relative dictionary paths from duplicating the configuration directory when loading settings
- cover the path resolution behaviour with unit tests for duplicate and standard relative paths

## Testing
- pytest tests/unit/test_config_path_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68e115a9084c8324aca829ac604604d3