### PR TITLE
Fix document pipeline mode invocation

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -120,6 +120,7 @@ class PipelineStep:
     name: str
     main: Callable[[Sequence[str] | None], int]
     subcommand: str | None
+    extra_args: tuple[str, ...] = ()
     output_flag: str = "--final-out"
     supports_dry_run: bool = False
 
@@ -143,6 +144,8 @@ class PipelineStep:
             args.append("--skip-existing")
         if cfg.dry_run and self.supports_dry_run:
             args.append("--dry-run")
+        if self.extra_args:
+            args = [*self.extra_args, *args]
         if self.subcommand is not None:
             return [self.subcommand, *args]
         return args
@@ -159,7 +162,12 @@ class PipelineStep:
 
 
 _PIPELINE_STEPS: tuple[PipelineStep, ...] = (
-    PipelineStep("document", get_document_data.main, "all"),
+    PipelineStep(
+        "document",
+        get_document_data.main,
+        None,
+        extra_args=("--mode", "all"),
+    ),
     PipelineStep(
         "target",
         get_target_data.main,

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -25,6 +25,7 @@ def _build_stub_pipeline(
     transform: Callable[[pd.DataFrame, get_data.Logger], pd.DataFrame],
     *,
     accept_subcommand: bool = False,
+    accept_mode: bool = False,
 ) -> PipelineFunc:
     """Return a stub ``main`` function emulating a pipeline step."""
 
@@ -32,6 +33,8 @@ def _build_stub_pipeline(
         parser = argparse.ArgumentParser(prog=f"get_data_{name}_stub")
         if accept_subcommand:
             parser.add_argument("subcommand", nargs="?", default=None)
+        if accept_mode:
+            parser.add_argument("--mode", required=True)
         parser.add_argument("--config", required=True)
         parser.add_argument("--input", required=True)
         parser.add_argument("--final-out", required=True)
@@ -198,9 +201,10 @@ def test_get_data_end_to_end__miniature_pipeline(
                 "document_chembl_id",
                 ["document_chembl_id", "title", "pubmed_id"],
                 _documents_transform,
-                accept_subcommand=True,
+                accept_mode=True,
             ),
-            "all",
+            None,
+            extra_args=("--mode", "all"),
         ),
         get_data.PipelineStep(
             "target",


### PR DESCRIPTION
## Summary
- ensure the get_data orchestrator explicitly passes `--mode all` to the document pipeline
- allow pipeline steps to define static CLI arguments and adapt the e2e stub to parse the mode flag

## Testing
- pytest tests/e2e/test_get_data_end_to_end.py

------
https://chatgpt.com/codex/tasks/task_e_68e116b5e400832497487675600465a7