### PR TITLE
Fix configure_logger alias in testitem CLI

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -128,9 +128,9 @@ _pubchem_resolution_key = pipeline_pubchem._pubchem_resolution_key
 _load_pubchem_cid_cache = pipeline_pubchem._load_pubchem_cid_cache
 resolve_pubchem_cid = pipeline_pubchem.resolve_pubchem_cid
 
- 
+configure_logger = cli.configure_logger
 
- 
+
 def _resolve_catalog_load_source(
     before: tuple[bool, float | None], after: tuple[bool, float | None]
 ) -> str:


### PR DESCRIPTION
## Summary
- expose the CLI configure_logger alias in get_testitem_data to avoid NameError when invoked after logging teardown

## Testing
- python scripts/get_testitem_data.py --limit 0 --input data/input/full/testitem.csv --output data/output/out.csv

------
https://chatgpt.com/codex/tasks/task_e_68e11a72e8208324ada9f6f7e1479e5b