### PR TITLE
Fix configure_logger import for assay CLI

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -40,6 +40,7 @@ from library.common.rate_limiter import get_global_limiter
 from library.cli import (
     LoggerConfig,
     ConfigMetadata,
+    configure_logger,
 )
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command, run_pipeline


### PR DESCRIPTION
## Summary
- import configure_logger from library.cli so the assay CLI can restore logging configuration

## Testing
- python scripts/get_assay_data.py --input data/input/full/assay.csv --output data/output/out.csv --limit 0

------
https://chatgpt.com/codex/tasks/task_e_68e11b051c18832485110c1d9991fea7