### PR TITLE
Fix CLI config defaults for IUPHAR target pipeline

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -1253,13 +1253,17 @@ class TargetChemblCfg(_BaseModel):
 
 
 class TargetIupharCfg(_BaseModel):
+    column: str = "uniprot_id"
+    chunk_size: int = Field(100, ge=1)
+    timeout: float = Field(30.0, gt=0)
+    limit: int | None = Field(default=None, ge=0)
+    offset: int = Field(0, ge=0)
     target_csv: Path = (
         DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_target.csv"
     )
     family_csv: Path = (
         DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_family.csv"
     )
-    limit: int | None = Field(default=None, ge=0)
 
 
 class TargetAllCfg(_BaseModel):

--- a/tests/unit/test_get_target_data_cli.py
+++ b/tests/unit/test_get_target_data_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from library.config import Config
+from library.pipelines.target.defaults import TARGET_MODE_DEFAULTS
 from scripts import get_target_data
 
 
@@ -72,6 +73,17 @@ def test_resolve_target_parameters__all_global_fallback():
     assert cfg.target.all.chunk_size == 9
     assert cfg.target.chembl.chunk_size == 9
     assert cfg.target.chembl.limit == 4
+
+
+@pytest.mark.unit
+def test_target_iuphar_defaults__align_with_cli() -> None:
+    cfg = Config()
+    defaults = TARGET_MODE_DEFAULTS["iuphar"]
+
+    assert cfg.target.iuphar.column == defaults.column
+    assert cfg.target.iuphar.chunk_size == defaults.chunk_size
+    assert cfg.target.iuphar.timeout == pytest.approx(defaults.timeout)
+    assert cfg.target.iuphar.offset == defaults.offset
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add CLI-aligned defaults to the `TargetIupharCfg` configuration so IUPHAR commands and the combined pipeline can resolve overrides without errors
- add a regression test asserting the configuration matches the CLI defaults for the IUPHAR mode

## Testing
- pytest tests/unit/test_get_target_data_cli.py -q -rA

------
https://chatgpt.com/codex/tasks/task_e_68e11db6d2188324a9b8d6c8e7693be5