### PR TITLE
Handle missing target config attributes gracefully

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -574,6 +574,8 @@ def apply_config_overrides(
     }
     setattr(args, "_config_metadata", metadata)
 
+    missing_cfg_paths: set[str] = set()
+
     for arg, key in override_map.items():
         if not hasattr(args, arg):
             continue
@@ -583,7 +585,20 @@ def apply_config_overrides(
         ):
             default = base_parser.get_default(arg)
         if getattr(args, arg) == default:
-            setattr(args, arg, _get_cfg_value(cfg, key))
+            if not key:
+                continue
+            try:
+                value = _get_cfg_value(cfg, key)
+            except AttributeError:
+                if key not in missing_cfg_paths:
+                    logger.warning(
+                        "config_missing_attribute",
+                        argument=arg,
+                        path=key,
+                    )
+                    missing_cfg_paths.add(key)
+                continue
+            setattr(args, arg, value)
 
     return cfg
 

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -1,0 +1,63 @@
+"""Unit tests for :mod:`library.cli.parser`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from library.cli import parser as parser_module
+from library.cli.parser import apply_config_overrides
+
+
+class _SpyLogger:
+    """Test double capturing warning calls."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:  # pragma: no cover - thin
+        self.events.append((event, kwargs))
+
+    # Compatibility methods used elsewhere in the module.  They are no-ops for
+    # the scope of these tests.
+    def info(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+        return None
+
+    def error(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+        return None
+
+    def bind(self, **kwargs: object) -> "_SpyLogger":  # pragma: no cover
+        return self
+
+
+@pytest.mark.unit
+def test_apply_config_overrides__missing_config_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gracefully ignore CLI mappings that point to absent config attributes."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config/config.yaml")
+    parser.add_argument("--column", default="target_chembl_id")
+    args = parser.parse_args([])
+
+    spy = _SpyLogger()
+    monkeypatch.setattr(parser_module, "logger", spy)
+
+    cfg = apply_config_overrides(
+        args,
+        parser,
+        Path("config/config.yaml"),
+        mapping={"column": "target.all.legacy_column"},
+    )
+
+    assert cfg.sources.chembl.pipelines.target.all.column == "target_chembl_id"
+    assert args.column == "target_chembl_id"
+    expected_event = (
+        "config_missing_attribute",
+        {
+            "argument": "column",
+            "path": "sources.chembl.pipelines.target.all.legacy_column",
+        },
+    )
+    assert expected_event in spy.events


### PR DESCRIPTION
## Summary
- handle missing configuration attributes when applying CLI overrides so that target pipelines fall back to parser defaults and emit a warning instead of crashing
- add a unit test covering the legacy configuration scenario for target pipelines

## Testing
- pytest -q tests/unit/test_cli_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68e12013b3508324bd5c63242c5bc70a