### PR TITLE
Handle missing config attributes when applying CLI overrides

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -469,6 +469,11 @@ def _get_cfg_value(cfg: Config, path: str) -> Any:
 
     current: Any = cfg
     for part in path.split("."):
+        if not hasattr(current, part):
+            raise AttributeError(
+                f"{type(current).__name__!r} object has no attribute {part!r} "
+                f"while resolving configuration path '{path}'"
+            )
         current = getattr(current, part)
     return current
 
@@ -583,7 +588,16 @@ def apply_config_overrides(
         ):
             default = base_parser.get_default(arg)
         if getattr(args, arg) == default:
-            setattr(args, arg, _get_cfg_value(cfg, key))
+            try:
+                value = _get_cfg_value(cfg, key)
+            except AttributeError:
+                logger.warning(
+                    "config_attribute_missing",
+                    argument=arg,
+                    path=key,
+                )
+                continue
+            setattr(args, arg, value)
 
     return cfg
 

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+from io import StringIO
+from pathlib import Path
+
+from library.cli.parser import apply_config_overrides
+from library.common.log import logger
+
+
+def test_apply_config_overrides__missing_config_path(monkeypatch, tmp_path):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--iuphar-column",
+        dest="iuphar_column",
+        default="uniprot_id",
+    )
+
+    args = parser.parse_args([])
+    setattr(args, "base_path", tmp_path)
+
+    root = Path(__file__).resolve().parents[2]
+    config_path = root / "config" / "config.yaml"
+
+    buffer = StringIO()
+    monkeypatch.setattr(logger._cfg, "stream", buffer, raising=False)
+
+    apply_config_overrides(
+        args,
+        parser,
+        config_path,
+        mapping={"iuphar_column": "target.iuphar.missing_column"},
+    )
+
+    log_output = buffer.getvalue()
+
+    assert '"event": "config_attribute_missing"' in log_output
+    assert args.iuphar_column == "uniprot_id"


### PR DESCRIPTION
## Summary
- avoid AttributeError when configuration sections are missing expected attributes by skipping the override and logging a warning
- add a unit test for apply_config_overrides covering missing configuration paths

## Testing
- pytest -q tests/unit/test_cli_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68e1200b0eb0832484991bd6c88979a2