### PR TITLE
Add missing target all column default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -115,6 +115,7 @@ sources:
           family_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
           limit: null
         all:
+          column: "target_chembl_id"  # Column containing ChEMBL target identifiers
           data_dir: "config/dictionary/_target/_uniprot"
           target_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
           family_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv"


### PR DESCRIPTION
## Summary
- add the missing `target.all.column` default to the shared configuration so CLI overrides resolve
- keep the combined target pipeline aligned with the schema defaults

## Testing
- pytest -q tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68e12a7a4ecc8324a29b2b99fe3090ea