### PR TITLE
Expand activity pipeline coverage and refresh reports

### DIFF
--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,16 +1,16 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "f41249415e36cb1b1616b610ca2aa40b8cf5e00a",
+    "commit": "5a4b46f1aaf0f8e1e4fd62a1e752910c251ae4da",
     "branch": "work",
-    "ts_utc": "2025-10-04T00:25:58.693932+00:00",
-    "duration_sec": 1.824,
+    "ts_utc": "2025-10-04T15:38:26.315854+00:00",
+    "duration_sec": 3.435,
     "python": "3.11.12",
     "pytest": "8.4.1"
   },
   "summary": {
-    "total": 183,
-    "passed": 183,
+    "total": 215,
+    "passed": 215,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
@@ -20,9 +20,79 @@
   },
   "tests": [
     {
+      "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_activity_data]",
+      "status": "passed",
+      "duration_ms": 3.62,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.668964+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.669409+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T15:38:23.669627+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.669791+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.669911+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.670037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.670115+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:23.668964+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.669409+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T15:38:23.669627+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.669791+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.669911+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.670037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.670115+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_assay_data]",
+      "status": "passed",
+      "duration_ms": 4.212,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.675250+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.675877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T15:38:23.676013+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.676128+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676215+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.676310+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676402+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:23.675250+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.675877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T15:38:23.676013+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.676128+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676215+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.676310+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676402+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_document_data]",
+      "status": "passed",
+      "duration_ms": 5.643,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.682428+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.682959+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T15:38:23.683210+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.683444+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.683576+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.683724+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.684148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:23.682428+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.682959+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T15:38:23.683210+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.683444+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.683576+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.683724+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.684148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_target_data]",
+      "status": "passed",
+      "duration_ms": 7.378,
+      "stdout": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.691922+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T15:38:23.692078+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.692221+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693401+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.693589+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693698+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.691922+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T15:38:23.692078+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.692221+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693401+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.693589+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693698+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_testitem_data]",
+      "status": "passed",
+      "duration_ms": 2.909,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.697539+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.698004+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T15:38:23.698146+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.698286+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698388+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.698501+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698589+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:23.697539+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.698004+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T15:38:23.698146+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.698286+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698388+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.698501+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698589+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_failure",
       "status": "passed",
-      "duration_ms": 0.216,
+      "duration_ms": 0.285,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -31,7 +101,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.284,
+      "duration_ms": 0.45,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -40,7 +110,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_success",
       "status": "passed",
-      "duration_ms": 5.705,
+      "duration_ms": 8.887,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -49,7 +119,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_failure",
       "status": "passed",
-      "duration_ms": 0.199,
+      "duration_ms": 0.34,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -58,7 +128,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.267,
+      "duration_ms": 0.378,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -67,7 +137,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_success",
       "status": "passed",
-      "duration_ms": 4.135,
+      "duration_ms": 7.14,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -76,7 +146,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.203,
+      "duration_ms": 0.323,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -85,7 +155,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_success",
       "status": "passed",
-      "duration_ms": 5.01,
+      "duration_ms": 8.495,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -94,7 +164,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_missing_handler",
       "status": "passed",
-      "duration_ms": 0.228,
+      "duration_ms": 0.314,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -103,7 +173,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.219,
+      "duration_ms": 0.451,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -112,7 +182,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_success",
       "status": "passed",
-      "duration_ms": 4.414,
+      "duration_ms": 9.388,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -121,7 +191,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.302,
+      "duration_ms": 0.533,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -130,7 +200,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_failure_logs",
       "status": "passed",
-      "duration_ms": 0.273,
+      "duration_ms": 0.495,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -139,7 +209,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.305,
+      "duration_ms": 0.475,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -148,7 +218,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_success",
       "status": "passed",
-      "duration_ms": 7.355,
+      "duration_ms": 11.799,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -157,7 +227,7 @@
     {
       "nodeid": "tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline",
       "status": "passed",
-      "duration_ms": 71.866,
+      "duration_ms": 98.867,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -166,13 +236,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
       "status": "passed",
-      "duration_ms": 49.819,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.515127+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:25:57.515234+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:25:57.518629+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 67.609,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.919967+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.920193+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.923940+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.515127+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:25:57.515234+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T00:25:57.518629+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:23.919967+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.920193+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.923940+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -180,13 +250,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__finalize_stage_idempotent",
       "status": "passed",
-      "duration_ms": 133.331,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.556191+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.572378+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.572499+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.590474+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.611653+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T00:25:57.626449+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:57.628245+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.635414+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.635531+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.653268+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.684947+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
+      "duration_ms": 211.099,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:23.976121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.003014+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.003251+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.031620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.064937+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T15:38:24.088251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.091506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.102434+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.102637+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.129150+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.178712+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.556191+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.572378+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.572499+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.590474+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.611653+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T00:25:57.626449+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:57.628245+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.635414+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.635531+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.653268+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.684947+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:23.976121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.003014+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.003251+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.031620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.064937+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T15:38:24.088251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.091506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.102434+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.102637+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.129150+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.178712+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -194,7 +264,7 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
       "status": "passed",
-      "duration_ms": 18.215,
+      "duration_ms": 23.942,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -203,13 +273,13 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
       "status": "passed",
-      "duration_ms": 16.593,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.723558+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 22.745,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.230977+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.723558+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.230977+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -217,22 +287,78 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
       "status": "passed",
-      "duration_ms": 3.935,
+      "duration_ms": 5.386,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
+      "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[False]",
       "status": "passed",
-      "duration_ms": 56.218,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.059812+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T00:25:58.064356+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.064470+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.079935+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.113077+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
+      "duration_ms": 55.402,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.383802+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.418954+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.059812+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T00:25:58.064356+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.064470+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.079935+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.113077+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.383802+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.418954+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[True]",
+      "status": "passed",
+      "duration_ms": 56.575,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.442067+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.477654+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:24.442067+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.477654+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__with_fallback_csv",
+      "status": "passed",
+      "duration_ms": 57.249,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.324062+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.361148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:24.324062+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.361148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__without_fallback_csv",
+      "status": "passed",
+      "duration_ms": 57.15,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.265843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.301774+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:24.265843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.301774+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
+      "status": "passed",
+      "duration_ms": 84.571,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.012477+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019016+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019194+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.042110+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.092480+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:25.012477+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019016+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019194+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.042110+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.092480+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -240,13 +366,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
       "status": "passed",
-      "duration_ms": 139.187,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.117966+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:58.123074+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.123187+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.139666+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.200490+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.201865+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:58.207075+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.207188+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.223532+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.255698+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
+      "duration_ms": 178.903,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.100399+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.108452+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.108634+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.136190+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.188816+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.190858+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.198493+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.198671+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.224701+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.276902+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.117966+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:58.123074+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.123187+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.139666+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.200490+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.201865+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:58.207075+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:58.207188+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:58.223532+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.255698+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.100399+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.108452+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.108634+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.136190+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.188816+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.190858+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.198493+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.198671+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.224701+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.276902+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -254,7 +380,7 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__missing_required_columns_fails",
       "status": "passed",
-      "duration_ms": 0.882,
+      "duration_ms": 1.773,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -263,13 +389,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__optional_columns_missing_warns",
       "status": "passed",
-      "duration_ms": 57.913,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.825569+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.832465+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.849548+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.882000+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
+      "duration_ms": 84.949,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.627705+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.635469+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.661880+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.710586+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.825569+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.832465+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.849548+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.882000+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.627705+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.635469+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.661880+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.710586+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -277,13 +403,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal",
       "status": "passed",
-      "duration_ms": 89.242,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.967681+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.972506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.972619+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.988533+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.021041+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.055270+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.055561+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
+      "duration_ms": 176.256,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.832281+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.839921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.840113+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.863815+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.956413+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006176+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006627+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.967681+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.972506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.972619+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.988533+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T00:25:58.021041+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.055270+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:58.055561+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.832281+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.839921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.840113+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.863815+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.956413+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006176+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006627+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
         }
       ],
       "error": null
@@ -291,13 +417,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
       "status": "passed",
-      "duration_ms": 54.331,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.911010+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.915824+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.915933+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.931798+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.963529+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:57.964239+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
+      "duration_ms": 78.13,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.750857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.757640+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.757829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.780801+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.826359+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.827406+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.911010+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.915824+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.915933+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.931798+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.963529+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T00:25:57.964239+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.750857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.757640+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.757829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.780801+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.826359+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.827406+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
         }
       ],
       "error": null
@@ -305,13 +431,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
       "status": "passed",
-      "duration_ms": 84.96,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.736793+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.744922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.745059+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.763187+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.796154+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
+      "duration_ms": 135.953,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.486683+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.498167+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.498340+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.526462+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.579772+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.736793+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T00:25:57.744922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T00:25:57.745059+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.763187+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T00:25:57.796154+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.486683+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.498167+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.498340+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.526462+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.579772+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -319,13 +445,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
       "status": "passed",
-      "duration_ms": 23.089,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:57.886127+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.893305+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T00:25:57.894324+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.906633+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
+      "duration_ms": 32.386,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:24.716174+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.725837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T15:38:24.727178+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.744876+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:57.886127+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T00:25:57.893305+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T00:25:57.894324+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T00:25:57.906633+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-9/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:24.716174+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.725837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T15:38:24.727178+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.744876+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
         }
       ],
       "error": null
@@ -333,7 +459,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
       "status": "passed",
-      "duration_ms": 0.446,
+      "duration_ms": 0.36,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -342,7 +468,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_encoding_recovers_values",
       "status": "passed",
-      "duration_ms": 0.709,
+      "duration_ms": 1.322,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -351,7 +477,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_separator_emits_info",
       "status": "passed",
-      "duration_ms": 0.316,
+      "duration_ms": 0.635,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -360,13 +486,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
       "status": "passed",
-      "duration_ms": 0.43,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.297497+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 0.563,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.339406+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.297497+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.339406+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -378,13 +504,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
       "status": "passed",
-      "duration_ms": 4.121,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.292074+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 6.195,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.331366+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.292074+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.331366+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -396,7 +522,7 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__normal_flow_populates_cache",
       "status": "passed",
-      "duration_ms": 5.766,
+      "duration_ms": 9.556,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -405,13 +531,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__skips_polymers_when_disallowed",
       "status": "passed",
-      "duration_ms": 5.471,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.275028+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 9.336,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.306836+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.275028+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.306836+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -423,13 +549,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_augment_pubchem__initialises_session_and_reuses_cache",
       "status": "passed",
-      "duration_ms": 7.913,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.281723+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.285298+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.285498+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.288857+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 11.387,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.316594+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.321782+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.322042+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.326906+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.281723+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.285298+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.285498+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T00:25:58.288857+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.316594+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.321782+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.322042+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.326906+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -437,7 +563,7 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
       "status": "passed",
-      "duration_ms": 0.789,
+      "duration_ms": 1.393,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -446,7 +572,7 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
       "status": "passed",
-      "duration_ms": 3.727,
+      "duration_ms": 5.694,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -455,7 +581,7 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
       "status": "passed",
-      "duration_ms": 0.921,
+      "duration_ms": 1.415,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -464,17 +590,17 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
       "status": "passed",
-      "duration_ms": 1.179,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.307929+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n",
+      "duration_ms": 1.735,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.355336+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"scripts.run_test_suite\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.307929+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"scripts.run_test_suite\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.355336+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"scripts.run_test_suite\"}\n"
         },
         {
           "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
+          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
         }
       ],
       "error": null
@@ -482,7 +608,7 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
       "status": "passed",
-      "duration_ms": 0.709,
+      "duration_ms": 0.708,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -491,7 +617,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
       "status": "passed",
-      "duration_ms": 0.278,
+      "duration_ms": 0.436,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -500,7 +626,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
       "status": "passed",
-      "duration_ms": 0.107,
+      "duration_ms": 0.186,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -509,7 +635,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
       "status": "passed",
-      "duration_ms": 0.109,
+      "duration_ms": 0.132,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -518,7 +644,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -527,7 +653,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.097,
+      "duration_ms": 0.123,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -536,7 +662,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.098,
+      "duration_ms": 0.121,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -545,7 +671,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
       "status": "passed",
-      "duration_ms": 0.11,
+      "duration_ms": 0.128,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -554,7 +680,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.088,
+      "duration_ms": 0.147,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -563,7 +689,62 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.082,
+      "duration_ms": 0.123,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_build_parser__pubmed_defaults",
+      "status": "passed",
+      "duration_ms": 2.002,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__cli_overrides_config",
+      "status": "passed",
+      "duration_ms": 65.771,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.402065+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.402198+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.439149+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.446995+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:25.402065+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.402198+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.439149+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.446995+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__config_overrides_defaults",
+      "status": "passed",
+      "duration_ms": 73.478,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.468768+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.468884+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.512265+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.522094+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:25.468768+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.468884+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.512265+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.522094+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--limit--1---limit must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 3.456,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--offset--5---offset must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 2.811,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -572,7 +753,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
       "status": "passed",
-      "duration_ms": 1.737,
+      "duration_ms": 3.049,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -581,7 +762,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
       "status": "passed",
-      "duration_ms": 1.24,
+      "duration_ms": 1.789,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -590,7 +771,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
       "status": "passed",
-      "duration_ms": 1.209,
+      "duration_ms": 1.852,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -599,7 +780,16 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
       "status": "passed",
-      "duration_ms": 1.099,
+      "duration_ms": 1.739,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_parser.py::test_apply_config_overrides__missing_config_attribute",
+      "status": "passed",
+      "duration_ms": 38.741,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -608,7 +798,7 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
       "status": "passed",
-      "duration_ms": 0.895,
+      "duration_ms": 1.061,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -617,7 +807,7 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
       "status": "passed",
-      "duration_ms": 0.105,
+      "duration_ms": 0.176,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -626,13 +816,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
       "status": "passed",
-      "duration_ms": 0.801,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.347135+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-9/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_read_input_ids__invalid_c0/input.csv\"}\n",
+      "duration_ms": 1.373,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.616422+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.347135+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-9/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-9/test_read_input_ids__invalid_c0/input.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.616422+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv\"}\n"
         }
       ],
       "error": null
@@ -640,13 +830,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
       "status": "passed",
-      "duration_ms": 0.857,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.344408+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
+      "duration_ms": 1.815,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.612163+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.344408+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.612163+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
         }
       ],
       "error": null
@@ -654,7 +844,7 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
       "status": "passed",
-      "duration_ms": 1.919,
+      "duration_ms": 3.647,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -663,13 +853,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
       "status": "passed",
-      "duration_ms": 0.223,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.341666+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
+      "duration_ms": 0.416,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.606665+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.341666+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.606665+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
         }
       ],
       "error": null
@@ -677,7 +867,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 0.113,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -686,7 +876,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
       "status": "passed",
-      "duration_ms": 0.081,
+      "duration_ms": 0.131,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -695,7 +885,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
       "status": "passed",
-      "duration_ms": 0.08,
+      "duration_ms": 0.115,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -704,7 +894,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
       "status": "passed",
-      "duration_ms": 0.081,
+      "duration_ms": 0.15,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -713,7 +903,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
       "status": "passed",
-      "duration_ms": 0.088,
+      "duration_ms": 0.13,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -722,7 +912,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
       "status": "passed",
-      "duration_ms": 0.083,
+      "duration_ms": 0.158,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -731,7 +921,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
       "status": "passed",
-      "duration_ms": 0.15,
+      "duration_ms": 0.272,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -740,7 +930,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
       "status": "passed",
-      "duration_ms": 0.097,
+      "duration_ms": 0.145,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -749,7 +939,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
       "status": "passed",
-      "duration_ms": 0.095,
+      "duration_ms": 0.141,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -758,7 +948,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.221,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -767,7 +957,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
       "status": "passed",
-      "duration_ms": 0.141,
+      "duration_ms": 0.199,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -776,7 +966,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
       "status": "passed",
-      "duration_ms": 0.132,
+      "duration_ms": 0.273,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -785,7 +975,43 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.251,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[config/dictionary/_testitem/molecule_hierarchy.csv]",
+      "status": "passed",
+      "duration_ms": 0.633,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[value1]",
+      "status": "passed",
+      "duration_ms": 0.542,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[data/output/test.csv]",
+      "status": "passed",
+      "duration_ms": 0.404,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[value1]",
+      "status": "passed",
+      "duration_ms": 0.691,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -794,7 +1020,7 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
       "status": "passed",
-      "duration_ms": 2.317,
+      "duration_ms": 3.968,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -803,7 +1029,7 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
       "status": "passed",
-      "duration_ms": 5.461,
+      "duration_ms": 12.262,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -812,7 +1038,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[None-expected0]",
       "status": "passed",
-      "duration_ms": 0.088,
+      "duration_ms": 0.154,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -821,7 +1047,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation1-expected1]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.164,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -830,7 +1056,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation2-expected2]",
       "status": "passed",
-      "duration_ms": 0.083,
+      "duration_ms": 0.142,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -839,7 +1065,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation3-expected3]",
       "status": "passed",
-      "duration_ms": 0.091,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -848,7 +1074,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation4-expected4]",
       "status": "passed",
-      "duration_ms": 0.084,
+      "duration_ms": 0.125,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -857,7 +1083,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation5-expected5]",
       "status": "passed",
-      "duration_ms": 0.087,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -866,7 +1092,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation6-expected6]",
       "status": "passed",
-      "duration_ms": 0.084,
+      "duration_ms": 0.117,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -875,7 +1101,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation7-expected7]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.385,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -884,7 +1110,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation8-expected8]",
       "status": "passed",
-      "duration_ms": 0.112,
+      "duration_ms": 0.131,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -893,7 +1119,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation9-expected9]",
       "status": "passed",
-      "duration_ms": 0.084,
+      "duration_ms": 0.15,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -902,13 +1128,13 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_respects_flags",
       "status": "passed",
-      "duration_ms": 0.315,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.391590+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__skip_existing_respec0/output.csv\"}\n",
+      "duration_ms": 0.527,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.704309+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__skip_existing_respec0/output.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.391590+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__skip_existing_respec0/output.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.704309+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__skip_existing_respec0/output.csv\"}\n"
         }
       ],
       "error": null
@@ -916,13 +1142,13 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__dry_run_short_circuits",
       "status": "passed",
-      "duration_ms": 0.384,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.389276+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-9/test_run_chembl__dry_run_short0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-9/test_run_chembl__dry_run_short0/output.csv\", \"limit\": 7, \"offset\": 0, \"batch_size\": 5, \"timeout\": 30.0, \"dry_run\": true, \"workers\": 1}\n{\"ts\": \"2025-10-04T00:25:58.389382+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 7}\n",
+      "duration_ms": 0.74,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.700444+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": 7, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 5, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"dry_run\": {\"value\": true, \"source\": \"cli\"}, \"workers\": {\"value\": 1, \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:25.700726+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 7}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.389276+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-9/test_run_chembl__dry_run_short0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-9/test_run_chembl__dry_run_short0/output.csv\", \"limit\": 7, \"offset\": 0, \"batch_size\": 5, \"timeout\": 30.0, \"dry_run\": true, \"workers\": 1}\n{\"ts\": \"2025-10-04T00:25:58.389382+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 7}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.700444+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": 7, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 5, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"dry_run\": {\"value\": true, \"source\": \"cli\"}, \"workers\": {\"value\": 1, \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:25.700726+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 7}\n"
         }
       ],
       "error": null
@@ -930,21 +1156,66 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__invalid_limit_logs_error",
       "status": "passed",
-      "duration_ms": 0.301,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.386990+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
+      "duration_ms": 0.476,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.697025+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.386990+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.697025+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
         }
       ],
       "error": null
     },
     {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__metadata_hooks_fill_required_columns",
+      "status": "passed",
+      "duration_ms": 5.966,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__offset_limit_and_success_logging",
+      "status": "passed",
+      "duration_ms": 6.719,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__pipeline_failure_emits_error",
+      "status": "passed",
+      "duration_ms": 6.303,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_value_error_logs",
+      "status": "passed",
+      "duration_ms": 0.36,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__worker_count_floors_to_one",
+      "status": "passed",
+      "duration_ms": 6.183,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
       "nodeid": "tests/unit/test_get_assay_data.py::test_build_parser__defaults",
       "status": "passed",
-      "duration_ms": 0.694,
+      "duration_ms": 1.149,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -953,7 +1224,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__force_overrides_skip",
       "status": "passed",
-      "duration_ms": 0.168,
+      "duration_ms": 0.244,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -962,7 +1233,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__propagates_exit_code",
       "status": "passed",
-      "duration_ms": 0.096,
+      "duration_ms": 0.145,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -971,7 +1242,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__skip_existing_returns_zero",
       "status": "passed",
-      "duration_ms": 0.162,
+      "duration_ms": 0.25,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -980,7 +1251,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__invalid_limit_logs_error",
       "status": "passed",
-      "duration_ms": 0.102,
+      "duration_ms": 0.192,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -989,7 +1260,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__read_ids_failure",
       "status": "passed",
-      "duration_ms": 0.1,
+      "duration_ms": 0.181,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -998,7 +1269,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[0]",
       "status": "passed",
-      "duration_ms": 0.8,
+      "duration_ms": 1.177,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1007,7 +1278,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[2]",
       "status": "passed",
-      "duration_ms": 0.549,
+      "duration_ms": 1.751,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1016,7 +1287,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coalesce_columns__prefers_first_non_empty",
       "status": "passed",
-      "duration_ms": 1.987,
+      "duration_ms": 3.624,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1025,7 +1296,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[ 7 -7-None]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.127,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1034,7 +1305,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[-None-None]",
       "status": "passed",
-      "duration_ms": 0.091,
+      "duration_ms": 0.12,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1043,7 +1314,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.0-2-None]",
       "status": "passed",
-      "duration_ms": 0.11,
+      "duration_ms": 0.143,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1052,7 +1323,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.5-None-invalid_stream_chunk_size_float]",
       "status": "passed",
-      "duration_ms": 0.111,
+      "duration_ms": 0.147,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1061,7 +1332,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[5-5-None]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.151,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1070,7 +1341,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[None-None-None]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1079,7 +1350,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[True-None-invalid_stream_chunk_size_bool]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1088,7 +1359,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[abc-None-invalid_stream_chunk_size_string]",
       "status": "passed",
-      "duration_ms": 0.096,
+      "duration_ms": 0.145,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1097,7 +1368,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[nan-None-None]",
       "status": "passed",
-      "duration_ms": 0.094,
+      "duration_ms": 0.139,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1106,7 +1377,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value10-None-invalid_stream_chunk_size_series]",
       "status": "passed",
-      "duration_ms": 0.12,
+      "duration_ms": 0.235,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1115,7 +1386,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value11-None-invalid_stream_chunk_size_type]",
       "status": "passed",
-      "duration_ms": 0.107,
+      "duration_ms": 0.213,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1124,7 +1395,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value9-3-None]",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.236,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1133,7 +1404,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_collapse_duplicate_columns__projects_first_instance",
       "status": "passed",
-      "duration_ms": 1.934,
+      "duration_ms": 3.256,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1142,7 +1413,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_prepare_export_frame__renames_and_coalesces",
       "status": "passed",
-      "duration_ms": 10.046,
+      "duration_ms": 17.843,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1151,7 +1422,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[-5-None]",
       "status": "passed",
-      "duration_ms": 0.084,
+      "duration_ms": 0.144,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1160,7 +1431,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[0-None]",
       "status": "passed",
-      "duration_ms": 0.087,
+      "duration_ms": 0.153,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1169,7 +1440,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[10-10]",
       "status": "passed",
-      "duration_ms": 0.078,
+      "duration_ms": 0.148,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1178,7 +1449,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[None-None]",
       "status": "passed",
-      "duration_ms": 0.079,
+      "duration_ms": 0.115,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1187,7 +1458,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_duplicate_column__merges_frames",
       "status": "passed",
-      "duration_ms": 1.392,
+      "duration_ms": 2.503,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1196,7 +1467,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__missing_handler_logs_error",
       "status": "passed",
-      "duration_ms": 0.198,
+      "duration_ms": 0.352,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1205,7 +1476,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__propagates_timeout",
       "status": "passed",
-      "duration_ms": 0.181,
+      "duration_ms": 0.286,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1214,7 +1485,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 0.209,
+      "duration_ms": 0.443,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1223,7 +1494,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_collect_uniprot_candidate_columns__orders_columns",
       "status": "passed",
-      "duration_ms": 0.342,
+      "duration_ms": 0.724,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1232,7 +1503,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__raises",
       "status": "passed",
-      "duration_ms": 0.309,
+      "duration_ms": 0.605,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1241,7 +1512,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__uses_alias",
       "status": "passed",
-      "duration_ms": 1.048,
+      "duration_ms": 2.033,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1250,7 +1521,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[ - ]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.155,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1259,7 +1530,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[None-]",
       "status": "passed",
-      "duration_ms": 0.083,
+      "duration_ms": 0.115,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1268,7 +1539,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345-P12345]",
       "status": "passed",
-      "duration_ms": 0.083,
+      "duration_ms": 0.132,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1277,7 +1548,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345|Q67890-P12345]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.181,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1286,7 +1557,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[all]",
       "status": "passed",
-      "duration_ms": 0.087,
+      "duration_ms": 0.131,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1295,7 +1566,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[fetch]",
       "status": "passed",
-      "duration_ms": 0.122,
+      "duration_ms": 0.141,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1304,7 +1575,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[run]",
       "status": "passed",
-      "duration_ms": 0.113,
+      "duration_ms": 0.126,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1313,13 +1584,13 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_limited_ids__respects_limit",
       "status": "passed",
-      "duration_ms": 0.181,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.501840+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
+      "duration_ms": 0.299,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.931704+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.501840+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:25.931704+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
         }
       ],
       "error": null
@@ -1327,7 +1598,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values0-P12345|Q67890]",
       "status": "passed",
-      "duration_ms": 0.095,
+      "duration_ms": 0.139,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1336,7 +1607,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values1-Q67890]",
       "status": "passed",
-      "duration_ms": 0.09,
+      "duration_ms": 0.193,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1345,7 +1616,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values2-]",
       "status": "passed",
-      "duration_ms": 0.086,
+      "duration_ms": 0.181,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1354,7 +1625,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values3-A|B]",
       "status": "passed",
-      "duration_ms": 0.098,
+      "duration_ms": 0.228,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1363,16 +1634,21 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__delegates_to_handler",
       "status": "passed",
-      "duration_ms": 0.177,
-      "stdout": "",
+      "duration_ms": 2.875,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:25.942160+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942394+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942519+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942641+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942757+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942934+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943047+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943138+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943251+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943369+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943460+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943550+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943637+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943823+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943970+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944227+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944337+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944428+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944515+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T15:38:25.942160+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942394+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942519+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942641+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942757+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942934+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943047+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943138+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943251+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943369+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943460+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943550+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943637+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943823+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943970+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944227+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944337+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944428+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944515+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 0.27,
+      "duration_ms": 1.776,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1381,7 +1657,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[ |P99999| -tokens2]",
       "status": "passed",
-      "duration_ms": 0.113,
+      "duration_ms": 0.16,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1390,7 +1666,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-tokens0]",
       "status": "passed",
-      "duration_ms": 0.082,
+      "duration_ms": 0.123,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1399,7 +1675,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345|Q67890-tokens1]",
       "status": "passed",
-      "duration_ms": 0.083,
+      "duration_ms": 0.142,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1408,7 +1684,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[123]",
       "status": "passed",
-      "duration_ms": 0.105,
+      "duration_ms": 0.127,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1417,7 +1693,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Hello]",
       "status": "passed",
-      "duration_ms": 0.091,
+      "duration_ms": 0.167,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1426,7 +1702,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Test-Value]",
       "status": "passed",
-      "duration_ms": 0.105,
+      "duration_ms": 0.14,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1435,7 +1711,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[aA]",
       "status": "passed",
-      "duration_ms": 0.138,
+      "duration_ms": 0.122,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1444,7 +1720,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[e-\\u0443]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.14,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1453,7 +1729,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[i-\\u0448]",
       "status": "passed",
-      "duration_ms": 0.103,
+      "duration_ms": 0.166,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1462,7 +1738,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[o-\\u0449]",
       "status": "passed",
-      "duration_ms": 0.098,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1471,7 +1747,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[p-\\u0437]",
       "status": "passed",
-      "duration_ms": 0.104,
+      "duration_ms": 0.121,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1480,7 +1756,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[q-\\u0439]",
       "status": "passed",
-      "duration_ms": 0.112,
+      "duration_ms": 0.171,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1489,7 +1765,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[r-\\u043a]",
       "status": "passed",
-      "duration_ms": 0.09,
+      "duration_ms": 0.128,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1498,7 +1774,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[t-\\u0435]",
       "status": "passed",
-      "duration_ms": 0.082,
+      "duration_ms": 0.284,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1507,7 +1783,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[u-\\u0433]",
       "status": "passed",
-      "duration_ms": 0.085,
+      "duration_ms": 0.148,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1516,7 +1792,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[w-\\u0446]",
       "status": "passed",
-      "duration_ms": 0.113,
+      "duration_ms": 0.147,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1525,7 +1801,75 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[y-\\u043d]",
       "status": "passed",
-      "duration_ms": 0.099,
+      "duration_ms": 0.214,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_apply_config_overrides__missing_config_attribute",
+      "status": "passed",
+      "duration_ms": 5.078,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_parser_validation__rejects_zero_chunk_size",
+      "status": "passed",
+      "duration_ms": 4.333,
+      "stdout": "",
+      "stderr": "usage: run_tests.py chembl [-h] [--log-level LOG_LEVEL] [--input INPUT_CSV] [--final-out FINAL_OUT] [--output OUTPUT_CSV]\n                           [--sep SEP] [--encoding ENCODING] [--base-path BASE_PATH] [--input-dir INPUT_DIR]\n                           [--output-dir OUTPUT_DIR] [--date DATE] [--force] [--skip-existing] [--config CONFIG]\n                           [--print-config] [--raw-out RAW_OUT] [--raw-format {csv,parquet}] [--id-cols ID_COLS [ID_COLS ...]]\n                           [--no-reindex-raw] [--normalize-at-export | --no-normalize-at-export] [--column COLUMN]\n                           [--limit LIMIT] [--offset OFFSET] [--chunk-size CHUNK_SIZE] [--timeout TIMEOUT]\nrun_tests.py chembl: error: argument --chunk-size: chunk size must be a positive integer\n",
+      "log": [
+        {
+          "section": "Captured stderr call",
+          "content": "usage: run_tests.py chembl [-h] [--log-level LOG_LEVEL] [--input INPUT_CSV] [--final-out FINAL_OUT] [--output OUTPUT_CSV]\n                           [--sep SEP] [--encoding ENCODING] [--base-path BASE_PATH] [--input-dir INPUT_DIR]\n                           [--output-dir OUTPUT_DIR] [--date DATE] [--force] [--skip-existing] [--config CONFIG]\n                           [--print-config] [--raw-out RAW_OUT] [--raw-format {csv,parquet}] [--id-cols ID_COLS [ID_COLS ...]]\n                           [--no-reindex-raw] [--normalize-at-export | --no-normalize-at-export] [--column COLUMN]\n                           [--limit LIMIT] [--offset OFFSET] [--chunk-size CHUNK_SIZE] [--timeout TIMEOUT]\nrun_tests.py chembl: error: argument --chunk-size: chunk size must be a positive integer\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__all_global_fallback",
+      "status": "passed",
+      "duration_ms": 5.299,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__chembl_cli_overrides",
+      "status": "passed",
+      "duration_ms": 5.12,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__config_precedence",
+      "status": "passed",
+      "duration_ms": 4.989,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_run_logs_parameter_sources__default_sources",
+      "status": "passed",
+      "duration_ms": 6.6,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data_cli.py::test_target_iuphar_defaults__align_with_cli",
+      "status": "passed",
+      "duration_ms": 1.448,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1534,7 +1878,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_add_pubchem_data__delegates_to_pipeline",
       "status": "passed",
-      "duration_ms": 0.751,
+      "duration_ms": 1.489,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1543,7 +1887,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__delegates_and_logs",
       "status": "passed",
-      "duration_ms": 0.138,
+      "duration_ms": 0.188,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1552,7 +1896,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__invalid_data_raises",
       "status": "passed",
-      "duration_ms": 0.265,
+      "duration_ms": 0.459,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1561,7 +1905,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__missing_file_returns_empty",
       "status": "passed",
-      "duration_ms": 0.108,
+      "duration_ms": 0.187,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1570,7 +1914,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values0-expected0]",
       "status": "passed",
-      "duration_ms": 0.676,
+      "duration_ms": 1.583,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1579,7 +1923,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values1-expected1]",
       "status": "passed",
-      "duration_ms": 0.632,
+      "duration_ms": 1.187,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1588,7 +1932,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values2-expected2]",
       "status": "passed",
-      "duration_ms": 0.588,
+      "duration_ms": 0.919,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1597,7 +1941,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values3-expected3]",
       "status": "passed",
-      "duration_ms": 0.622,
+      "duration_ms": 1.105,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1606,7 +1950,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values4-expected4]",
       "status": "passed",
-      "duration_ms": 0.706,
+      "duration_ms": 0.994,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1615,7 +1959,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values5-expected5]",
       "status": "passed",
-      "duration_ms": 0.593,
+      "duration_ms": 2.155,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1624,13 +1968,13 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__force_overrides_skip",
       "status": "passed",
-      "duration_ms": 0.428,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.532259+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/output.csv\", \"limit\": null, \"offset\": 0, \"batch_size\": 1000, \"timeout\": 30.0}\n{\"ts\": \"2025-10-04T00:25:58.532370+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/output.csv\"}\n",
+      "duration_ms": 0.712,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:26.035351+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:26.035617+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.532259+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/output.csv\", \"limit\": null, \"offset\": 0, \"batch_size\": 1000, \"timeout\": 30.0}\n{\"ts\": \"2025-10-04T00:25:58.532370+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-9/test_run__force_overrides_skip1/output.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:26.035351+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:26.035617+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\"}\n"
         }
       ],
       "error": null
@@ -1638,7 +1982,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__non_zero_exit_logs_error",
       "status": "passed",
-      "duration_ms": 0.178,
+      "duration_ms": 0.347,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1647,7 +1991,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__skip_existing_without_force",
       "status": "passed",
-      "duration_ms": 0.226,
+      "duration_ms": 0.416,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1656,7 +2000,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__success_logs_completion",
       "status": "passed",
-      "duration_ms": 0.177,
+      "duration_ms": 0.311,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1665,7 +2009,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run_chembl__passes_options",
       "status": "passed",
-      "duration_ms": 0.185,
+      "duration_ms": 0.291,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1674,7 +2018,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
       "status": "passed",
-      "duration_ms": 0.575,
+      "duration_ms": 0.804,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1683,7 +2027,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__identifier_columns_trimmed",
       "status": "passed",
-      "duration_ms": 1.085,
+      "duration_ms": 1.613,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1692,7 +2036,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__micro_sign_replaced",
       "status": "passed",
-      "duration_ms": 0.458,
+      "duration_ms": 0.725,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1701,7 +2045,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__preserves_boolean_dtype",
       "status": "passed",
-      "duration_ms": 0.514,
+      "duration_ms": 0.876,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1710,7 +2054,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
       "status": "passed",
-      "duration_ms": 0.638,
+      "duration_ms": 0.888,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1719,7 +2063,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
       "status": "passed",
-      "duration_ms": 0.52,
+      "duration_ms": 0.839,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1728,7 +2072,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
       "status": "passed",
-      "duration_ms": 0.574,
+      "duration_ms": 1.046,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1737,7 +2081,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
       "status": "passed",
-      "duration_ms": 0.527,
+      "duration_ms": 0.79,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1746,7 +2090,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__retains_missing_values",
       "status": "passed",
-      "duration_ms": 0.654,
+      "duration_ms": 1.132,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1755,7 +2099,7 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
       "status": "passed",
-      "duration_ms": 1.044,
+      "duration_ms": 2.341,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1764,7 +2108,16 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
       "status": "passed",
-      "duration_ms": 1.226,
+      "duration_ms": 1.618,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_paths.py::test_dictionary_dir__points_to_project_resource",
+      "status": "passed",
+      "duration_ms": 0.231,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1773,7 +2126,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 0.456,
+      "duration_ms": 0.917,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1782,7 +2135,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 0.336,
+      "duration_ms": 0.842,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1791,17 +2144,17 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_main__downgrades_exit_code_when_threshold_not_met",
       "status": "passed",
-      "duration_ms": 0.964,
-      "stdout": "{\"ts\": \"2025-10-04T00:25:58.565682+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n",
+      "duration_ms": 1.234,
+      "stdout": "{\"ts\": \"2025-10-04T15:38:26.092492+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"logger\": \"tools.run_tests\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T00:25:58.565682+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"\", \"logger\": \"tools.run_tests\"}\n"
+          "content": "{\"ts\": \"2025-10-04T15:38:26.092492+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"logger\": \"tools.run_tests\"}\n"
         },
         {
           "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m tools.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
+          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m tools.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
         }
       ],
       "error": null

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: f41249415e36cb1b1616b610ca2aa40b8cf5e00a
+- Commit: 5a4b46f1aaf0f8e1e4fd62a1e752910c251ae4da
 - Branch: work
-- Timestamp (UTC): 2025-10-04T00:25:58.693932+00:00
-- Duration: 1.824 s
+- Timestamp (UTC): 2025-10-04T15:38:26.315854+00:00
+- Duration: 3.435 s
 - Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|   183 |   183 |     0 |      0 |      0 |      0 |     0 |
+|   215 |   215 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
 - none

--- a/tests/unit/test_cli_parser.py
+++ b/tests/unit/test_cli_parser.py
@@ -53,11 +53,13 @@ def test_apply_config_overrides__missing_config_attribute(monkeypatch: pytest.Mo
 
     assert cfg.sources.chembl.pipelines.target.all.column == "target_chembl_id"
     assert args.column == "target_chembl_id"
-    expected_event = (
-        "config_missing_attribute",
-        {
-            "argument": "column",
-            "path": "sources.chembl.pipelines.target.all.legacy_column",
-        },
-    )
-    assert expected_event in spy.events
+    event_name = "config_attribute_missing"
+    matching = [
+        payload
+        for name, payload in (spy.events)
+        if name == event_name
+        and payload.get("argument") == "column"
+        and payload.get("path")
+        == "sources.chembl.pipelines.target.all.legacy_column"
+    ]
+    assert matching, f"expected {event_name!r} log entry not found in {spy.events!r}"

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 from typing import Iterable
 
+import pandas as pd
 import pytest
 
 from scripts import get_activity_data
@@ -90,3 +91,259 @@ def test_run__skip_existing_respects_flags(cfg, tmp_path, monkeypatch) -> None:
 
     assert exit_code == 0
     assert calls == []
+
+
+class _MemoryLogger:
+    """Capture structured log events emitted by the activity pipeline."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def info(self, event: str, **payload: object) -> None:
+        self.events.append(("info", event, dict(payload)))
+
+    def warning(self, event: str, **payload: object) -> None:
+        self.events.append(("warning", event, dict(payload)))
+
+    def error(self, event: str, **payload: object) -> None:
+        self.events.append(("error", event, dict(payload)))
+
+    def debug(self, event: str, **payload: object) -> None:  # pragma: no cover - rarely used
+        self.events.append(("debug", event, dict(payload)))
+
+    def bind(self, **_: object) -> "_MemoryLogger":  # pragma: no cover - logging compat
+        return self
+
+
+@pytest.fixture()
+def logger_stub(monkeypatch: pytest.MonkeyPatch) -> _MemoryLogger:
+    logger = _MemoryLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger)
+    return logger
+
+
+class _DummyClient:
+    def __enter__(self) -> "_DummyClient":  # pragma: no cover - simple context helper
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no special cleanup
+        return None
+
+
+class _DummyTracker:
+    def __init__(self) -> None:
+        self.stats: dict[str, object] = {"failures": 0}
+        self.saved_path: Path | None = None
+
+    def add_failure(self, *_: object, **__: object) -> None:
+        return None
+
+    def save(self, path: Path, *, cfg: object) -> None:
+        self.saved_path = path
+
+
+def _setup_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg,
+    args: argparse.Namespace,
+    *,
+    exit_code: int = 0,
+    stats: dict[str, int] | None = None,
+) -> tuple[dict[str, object], _DummyTracker]:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        get_activity_data.io,
+        "read_ids",
+        lambda path, *, column, cfg: iter(["CHEMBL1", "CHEMBL2", "CHEMBL3"]),
+    )
+    monkeypatch.setattr(get_activity_data, "ChemblClient", lambda *a, **k: _DummyClient())
+    tracker = _DummyTracker()
+    monkeypatch.setattr(get_activity_data, "ChunkFailureTracker", lambda: tracker)
+    monkeypatch.setattr(get_activity_data, "configure_activity_schema", lambda *_: None)
+    monkeypatch.setattr(
+        get_activity_data,
+        "compute_activity_bounds",
+        lambda frame, *_: frame.assign(bounds_applied=True),
+    )
+    monkeypatch.setattr(
+        get_activity_data,
+        "apply_activity_annotations",
+        lambda frame, **__: frame.assign(annotations_applied=True),
+    )
+    monkeypatch.setattr(
+        get_activity_data,
+        "write_csv_chunks_deterministic",
+        lambda chunks, destination, **__: destination,
+    )
+
+    def fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
+        ids = list(fetch_config.ids)
+        captured["fetch_workers"] = fetch_config.workers
+        captured["fetch_chunk_size"] = fetch_config.chunk_size
+        captured["consumed_ids"] = tuple(ids)
+
+        frames = [pd.DataFrame({"activity_id": ids})]
+
+        def fetcher() -> Iterable[pd.DataFrame]:
+            yield from frames
+
+        def writer(
+            chunks: Iterable[pd.DataFrame],
+            destination: Path,
+            col_order: Iterable[str],
+            key_cols: Iterable[str],
+        ) -> Path:
+            captured["writer_destination"] = destination
+            captured["writer_columns"] = tuple(col_order)
+            captured["writer_key_cols"] = tuple(key_cols)
+            captured["written_rows"] = sum(len(chunk) for chunk in chunks)
+            return destination
+
+        return fetcher, writer
+
+    monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
+    monkeypatch.setattr(
+        get_activity_data.cl,
+        "get_activities",
+        lambda chunk_ids, **__: pd.DataFrame({"activity_id": list(chunk_ids)}),
+    )
+
+    def fake_run_pipeline(**kwargs: object) -> int:
+        fetcher = kwargs["fetcher"]
+        metadata_hooks = list(kwargs["metadata_hooks"])
+        writer = kwargs["writer"]
+        output_path = kwargs["output_path"]
+        key_columns = kwargs["key_columns"]
+        schema = kwargs["schema"]
+        stats_callback = kwargs["stats_callback"]
+
+        frames_after_hooks: list[pd.DataFrame] = []
+        for frame in fetcher():
+            for hook in metadata_hooks:
+                frame = hook(frame)
+            frames_after_hooks.append(frame)
+        captured["frames_after_hooks"] = frames_after_hooks
+
+        final_stats = stats or {
+            "rows_total": sum(len(frame) for frame in frames_after_hooks),
+            "rows_kept": sum(len(frame) for frame in frames_after_hooks),
+            "rows_dropped": 0,
+        }
+        stats_callback(final_stats)
+
+        writer(
+            frames_after_hooks,
+            output_path,
+            list(getattr(schema, "columns").keys()),
+            key_columns,
+        )
+        return exit_code
+
+    monkeypatch.setattr(get_activity_data, "run_pipeline", fake_run_pipeline)
+
+    return captured, tracker
+
+
+def test_run_chembl__read_ids_value_error_logs(cfg, tmp_path, monkeypatch, logger_stub) -> None:
+    args = _make_args(tmp_path)
+
+    def fake_read_ids(path: Path, *, column: str, cfg) -> Iterable[str]:
+        raise ValueError("bad csv")
+
+    monkeypatch.setattr(get_activity_data.io, "read_ids", fake_read_ids)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 1
+    assert (
+        "error",
+        "read_fail",
+        {"error": "bad csv", "path": str(args.input_csv)},
+    ) in logger_stub.events
+
+
+def test_run_chembl__offset_limit_and_success_logging(
+    cfg, tmp_path, monkeypatch, logger_stub
+) -> None:
+    args = _make_args(tmp_path)
+    args.offset = 1
+    args.workers = 2
+    cfg.activity.limit = 2
+
+    captured, tracker = _setup_pipeline(monkeypatch, cfg, args)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    assert captured["consumed_ids"] == ("CHEMBL2", "CHEMBL3")
+    assert tracker.saved_path == args.output_csv.with_name(
+        f"{args.output_csv.stem}_fetch_failures.csv"
+    )
+    assert captured["written_rows"] == 2
+    assert captured["fetch_workers"] == max(1, cfg.activity.workers)
+
+    events = logger_stub.events
+    assert ("info", "process_offset", {"offset": 1}) in events
+    assert ("info", "process_limit", {"limit": 2}) in events
+    assert any(event == "records_dropped" for _, event, _ in events)
+    assert any(event == "activity_pipeline_done" for _, event, _ in events)
+
+
+def test_run_chembl__pipeline_failure_emits_error(
+    cfg, tmp_path, monkeypatch, logger_stub
+) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.limit = None
+
+    captured, tracker = _setup_pipeline(
+        monkeypatch,
+        cfg,
+        args,
+        exit_code=5,
+        stats={"rows_total": 3, "rows_kept": 2, "rows_dropped": 1},
+    )
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 5
+    assert tracker.saved_path == args.output_csv.with_name(
+        f"{args.output_csv.stem}_fetch_failures.csv"
+    )
+
+    events = logger_stub.events
+    failure_events = [payload for level, name, payload in events if name == "activity_pipeline_failed"]
+    assert failure_events
+    assert failure_events[0]["exit_code"] == 5
+    assert failure_events[0]["processed"] == len(captured["consumed_ids"])
+
+
+def test_run_chembl__worker_count_floors_to_one(cfg, tmp_path, monkeypatch, logger_stub) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.limit = 1
+    cfg.activity.workers = 0
+
+    captured, _tracker = _setup_pipeline(monkeypatch, cfg, args)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    assert captured["fetch_workers"] == 1
+
+
+def test_run_chembl__metadata_hooks_fill_required_columns(
+    cfg, tmp_path, monkeypatch, logger_stub
+) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.limit = 1
+
+    captured, _ = _setup_pipeline(monkeypatch, cfg, args)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    frames = captured.get("frames_after_hooks", [])
+    assert frames
+    frame = frames[0]
+    for column in get_activity_data._ACTIVITY_REQUIRED_COLUMNS:
+        assert column in frame.columns


### PR DESCRIPTION
## Summary
- align the CLI parser unit test with the current event naming
- add extensive get_activity_data unit coverage for logging, failure, and metadata hooks
- regenerate the pytest JSON and Markdown reports after the successful test run

## Testing
- python tools/run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e13dd69af0832494d34999c4c858e8