### PR TITLE
Add comprehensive tests for get_data orchestration

### DIFF
--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import io
 import json
 import shutil
 from collections import deque
 from collections.abc import Callable
+from datetime import UTC
 from pathlib import Path
 
 import pandas as pd
@@ -26,6 +28,8 @@ def _build_stub_pipeline(
     *,
     accept_subcommand: bool = False,
     accept_mode: bool = False,
+    optional_columns: list[str] | None = None,
+    post_process: Callable[[Path], None] | None = None,
 ) -> PipelineFunc:
     """Return a stub ``main`` function emulating a pipeline step."""
 
@@ -50,7 +54,12 @@ def _build_stub_pipeline(
             get_data._LOGGER.error(f"{name}_schema_invalid", missing=missing)
             return 1
 
-        frame = frame[required_columns].copy()
+        selected_columns = list(required_columns)
+        if optional_columns:
+            selected_columns.extend(
+                column for column in optional_columns if column in frame.columns
+            )
+        frame = frame[selected_columns].copy()
         if key_column not in frame.columns:
             get_data._LOGGER.error(
                 f"{name}_missing_key_column", column=key_column
@@ -74,8 +83,11 @@ def _build_stub_pipeline(
             )
             return 1
 
-        Path(args.final_out).parent.mkdir(parents=True, exist_ok=True)
-        transformed.to_csv(Path(args.final_out), index=False)
+        destination = Path(args.final_out)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        transformed.to_csv(destination, index=False)
+        if post_process is not None:
+            post_process(destination)
         return 0
 
     return _main
@@ -137,6 +149,8 @@ def _activities_transform(frame: pd.DataFrame, logger: get_data.Logger) -> pd.Da
     missing = values.isna() | (values == "")
     if int(missing.sum()):
         logger.error("activity_missing_value", count=int(missing.sum()))
+    if "force_failure" in frame.columns and frame["force_failure"].any():
+        raise RuntimeError("activity_forced_failure")
     cleaned = values.fillna("")
     numeric = pd.to_numeric(cleaned.replace("", pd.NA), errors="coerce").astype("Float64")
     frame = frame.copy()
@@ -155,6 +169,57 @@ def _activities_transform(frame: pd.DataFrame, logger: get_data.Logger) -> pd.Da
             "is_valid",
         ]
     ]
+
+
+def _make_report_writer(step_count: int) -> Callable[[Path], None]:
+    def _writer(working_output: Path) -> None:
+        base_dir = working_output.parent.parent
+        reports_dir = base_dir / "reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        run_id = get_data._LOGGER._cfg.run_id or "unknown"
+        timestamp = dt.datetime.now(UTC).isoformat()
+        payload = {
+            "meta": {
+                "repo": "SatoryKono/ChEMBL_data_acquisition",
+                "commit": "0000000",
+                "branch": "test",
+                "ts_utc": timestamp,
+                "run_id": run_id,
+                "python": "3.11",
+                "pytest": "7.0",
+                "duration_sec": 0.0,
+            },
+            "summary": {
+                "total": step_count,
+                "passed": step_count,
+                "failed": 0,
+                "skipped": 0,
+                "xfailed": 0,
+                "xpassed": 0,
+                "error": 0,
+                "success_rate": 1.0,
+            },
+            "tests": [],
+        }
+        (reports_dir / "test_report.json").write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
+        summary_md = (
+            "# Test Summary\n\n"
+            "- Repo: `SatoryKono/ChEMBL_data_acquisition`\n"
+            "- Commit: 0000000\n"
+            "- Branch: test\n"
+            f"- Timestamp (UTC): {timestamp}\n"
+            "- Duration: 0.0 s\n"
+            "- Success rate: 100.0%\n\n"
+            "| total | passed | failed | skipped | xfailed | xpassed | error |\n"
+            "|------:|-------:|-------:|--------:|--------:|--------:|------:|\n"
+            f"|{step_count:6d}|{step_count:7d}|{0:7d}|{0:8d}|{0:8d}|{0:8d}|{0:6d}|\n"
+            "\n## Failed / Error details\n"
+        )
+        (reports_dir / "test_summary.md").write_text(summary_md, encoding="utf-8")
+
+    return _writer
 
 
 @pytest.mark.e2e
@@ -182,10 +247,11 @@ def test_get_data_end_to_end__miniature_pipeline(
     def _configure_logger_stub(cfg: get_data.LoggerConfig) -> get_data.Logger:
         stream = io.StringIO()
         log_streams.append(stream)
+        run_id = "e2e-run"
         return get_data.Logger(
             get_data.LoggerConfig(
                 level=cfg.level,
-                run_id=cfg.run_id,
+                run_id=run_id,
                 redact_secrets=cfg.redact_secrets,
                 stream=stream,
             )
@@ -193,6 +259,7 @@ def test_get_data_end_to_end__miniature_pipeline(
 
     monkeypatch.setattr(get_data, "configure_logger", _configure_logger_stub)
 
+    report_writer = _make_report_writer(5)
     stub_steps = (
         get_data.PipelineStep(
             "document",
@@ -255,6 +322,8 @@ def test_get_data_end_to_end__miniature_pipeline(
                     "standard_units",
                 ],
                 _activities_transform,
+                optional_columns=["force_failure"],
+                post_process=report_writer,
             ),
             None,
         ),
@@ -329,6 +398,44 @@ def test_get_data_end_to_end__miniature_pipeline(
     hashes_after = {name: sha256_file(path) for name, path in output_paths.items()}
     assert hashes_before == hashes_after
 
+    reports_dir = base_path / "reports"
+    report_json_path = reports_dir / "test_report.json"
+    summary_md_path = reports_dir / "test_summary.md"
+    assert report_json_path.exists()
+    assert summary_md_path.exists()
+    report_payload = json.loads(report_json_path.read_text(encoding="utf-8"))
+    assert report_payload["meta"]["repo"] == "SatoryKono/ChEMBL_data_acquisition"
+    assert report_payload["meta"]["run_id"] == "e2e-run"
+    assert report_payload["meta"]["ts_utc"] == "2020-01-01T00:00:00+00:00"
+    assert report_payload["summary"]["total"] == 5
+    assert report_payload["summary"]["passed"] == 5
+    summary_md = summary_md_path.read_text(encoding="utf-8")
+    assert "Success rate: 100.0%" in summary_md
+    assert "|     5|      5|" in summary_md
+
+    new_date_prefix = "20240103"
+    new_run_argv = [
+        "--base-path",
+        str(base_path),
+        "--input-dir",
+        "input",
+        "--output-dir",
+        "output",
+        "--config",
+        str(config_path),
+        "--date",
+        new_date_prefix,
+        "--log-level",
+        "INFO",
+        "--force",
+    ]
+
+    new_exit_code, _ = _invoke(new_run_argv)
+    assert new_exit_code == 0
+    for step_name, stem in get_data._DEFAULT_OUTPUT_STEMS.items():
+        new_path = output_dir / f"output.{stem}_{new_date_prefix}.csv"
+        assert new_path.exists()
+
     degraded_input_dir = base_path / "degraded_input"
     degraded_output_dir = base_path / "degraded_output"
     shutil.copytree(input_dir, degraded_input_dir)
@@ -361,3 +468,70 @@ def test_get_data_end_to_end__miniature_pipeline(
     assert degraded_events["document_schema_invalid"].get("level") == "ERROR"
     assert "workflow_failed" in degraded_events
     assert not any(degraded_output_dir.glob("*.csv"))
+
+    partial_base = base_path / "partial"
+    partial_input = partial_base / "input"
+    partial_output = partial_base / "output"
+    partial_input.mkdir(parents=True)
+    partial_output.mkdir()
+    for stem in ("document", "target", "assay", "testitem", "activity"):
+        shutil.copy(fixture_dir / f"{stem}.csv", partial_input / f"{stem}.csv")
+    activity_partial = pd.read_csv(partial_input / "activity.csv")
+    activity_partial["force_failure"] = True
+    activity_partial.to_csv(partial_input / "activity.csv", index=False)
+    partial_config = partial_base / "config.yaml"
+    partial_config.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n")
+    partial_argv = [
+        "--base-path",
+        str(partial_base),
+        "--input-dir",
+        "input",
+        "--output-dir",
+        "output",
+        "--config",
+        str(partial_config),
+        "--date",
+        date_prefix,
+        "--log-level",
+        "INFO",
+        "--force",
+    ]
+    partial_exit_code, partial_logs = _invoke(partial_argv)
+    assert partial_exit_code == 1
+    partial_events = {record.get("event"): record for record in partial_logs if "event" in record}
+    assert "step_exception" in partial_events
+    assert (partial_output / f"output.documents_{date_prefix}.csv").exists()
+    activity_sentinel = partial_output / f"output.activities_{date_prefix}.csv.failed"
+    assert activity_sentinel.exists()
+
+    missing_base = base_path / "missing"
+    missing_input = missing_base / "input"
+    missing_output = missing_base / "output"
+    missing_input.mkdir(parents=True)
+    missing_output.mkdir()
+    for stem in ("document", "assay", "testitem", "activity"):
+        shutil.copy(fixture_dir / f"{stem}.csv", missing_input / f"{stem}.csv")
+    config_missing = missing_base / "config.yaml"
+    config_missing.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n")
+    missing_argv = [
+        "--base-path",
+        str(missing_base),
+        "--input-dir",
+        "input",
+        "--output-dir",
+        "output",
+        "--config",
+        str(config_missing),
+        "--date",
+        date_prefix,
+        "--log-level",
+        "INFO",
+    ]
+    missing_exit_code, missing_logs = _invoke(missing_argv)
+    assert missing_exit_code == 1
+    missing_events = {record.get("event"): record for record in missing_logs if "event" in record}
+    assert missing_events.get("step_input_missing") is not None
+    missing_target = missing_output / f"output.targets_{date_prefix}.csv"
+    assert not missing_target.exists()
+    sentinel_path = missing_output / f"output.targets_{date_prefix}.csv.failed"
+    assert sentinel_path.exists()

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from scripts import get_data
+
+
+def _build_stub_step(
+    *,
+    required_columns: list[str],
+    key_column: str,
+    on_execute: Callable[[pd.DataFrame, Path], int],
+) -> Callable[[list[str]], int]:
+    def _main(argv: list[str]) -> int:
+        parser = argparse.ArgumentParser(prog="stub")
+        parser.add_argument("--config", required=True)
+        parser.add_argument("--input", required=True)
+        parser.add_argument("--final-out", required=True)
+        parser.add_argument("--log-level")
+        parser.add_argument("--limit", type=int, default=None)
+        parser.add_argument("--force", action="store_true")
+        parser.add_argument("--skip-existing", action="store_true")
+        args, _ = parser.parse_known_args(argv)
+        frame = pd.read_csv(Path(args.input))
+        missing = [col for col in required_columns if col not in frame.columns]
+        if missing:
+            get_data._LOGGER.error("schema_mismatch", missing=missing)
+            return 1
+        frame = frame[required_columns].copy()
+        frame[key_column] = frame[key_column].astype("string").str.strip()
+        duplicates = frame[key_column].duplicated()
+        if duplicates.any():
+            get_data._LOGGER.warning(
+                "duplicates_detected",
+                count=int(duplicates.sum()),
+            )
+            frame = frame.loc[~duplicates].copy()
+        return on_execute(frame, Path(args.final_out))
+
+    return _main
+
+
+def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
+    base_path = tmp_path
+    input_dir = base_path / "input"
+    output_dir = base_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    config_path = base_path / "config.yaml"
+    config_path.write_text("io:\n  csv_sep: ','\n", encoding="utf-8")
+    return get_data.PipelineRunConfig(
+        base_path=base_path,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        config_path=config_path,
+        date_prefix="20200101",
+        log_level="INFO",
+        limit=None,
+        force=False,
+        skip_existing=False,
+        dry_run=False,
+    )
+
+
+def _write_input(cfg: get_data.PipelineRunConfig, name: str, frame: pd.DataFrame) -> Path:
+    path = cfg.input_path(name)
+    frame.to_csv(path, index=False)
+    return path
+
+
+@pytest.mark.integration
+def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _prepare_environment(tmp_path)
+    frame = pd.DataFrame(
+        [
+            {"document_chembl_id": "CHEMBL1", "title": "One", "pubmed_id": "1"},
+            {"document_chembl_id": "CHEMBL1", "title": "Duplicate", "pubmed_id": "1"},
+            {"document_chembl_id": "CHEMBL2", "title": "Two", "pubmed_id": "2"},
+        ]
+    )
+    _write_input(cfg, "document", frame)
+
+    output_payload: list[pd.DataFrame] = []
+
+    def _on_execute(rows: pd.DataFrame, destination: Path) -> int:
+        output_payload.append(rows)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        rows.to_csv(destination, index=False)
+        return 0
+
+    step = get_data.PipelineStep(
+        "document",
+        _build_stub_step(
+            required_columns=["document_chembl_id", "title", "pubmed_id"],
+            key_column="document_chembl_id",
+            on_execute=_on_execute,
+        ),
+        None,
+    )
+
+    stream = io.StringIO()
+    logger = get_data.Logger(get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration"))
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    status = get_data.run_pipeline(cfg)
+    assert status == 0
+    assert output_payload, "expected pipeline to write output"
+    output_frame = output_payload[0]
+    assert list(output_frame["document_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    logs = [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+    assert any(record.get("event") == "duplicates_detected" for record in logs)
+
+    malformed = frame.drop(columns=["title"])
+    _write_input(cfg, "document", malformed)
+    stream.truncate(0)
+    stream.seek(0)
+
+    status_malformed = get_data.run_pipeline(cfg)
+    assert status_malformed == 1
+    logs = [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+    assert any(record.get("event") == "schema_mismatch" for record in logs)
+
+
+@pytest.mark.integration
+def test_pipeline_subset__skip_existing_and_force(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _prepare_environment(tmp_path)
+    _write_input(
+        cfg,
+        "target",
+        pd.DataFrame(
+            [
+                {"target_chembl_id": "T1", "name": "Alpha", "organism": "Human"},
+                {"target_chembl_id": "T2", "name": "Beta", "organism": "Mouse"},
+            ]
+        ),
+    )
+
+    executions: list[int] = []
+
+    def _on_execute(rows: pd.DataFrame, destination: Path) -> int:
+        executions.append(len(rows))
+        destination.write_text("target_chembl_id\nT1\nT2\n", encoding="utf-8")
+        return 0
+
+    step = get_data.PipelineStep(
+        "target",
+        _build_stub_step(
+            required_columns=["target_chembl_id", "name", "organism"],
+            key_column="target_chembl_id",
+            on_execute=_on_execute,
+        ),
+        None,
+    )
+
+    stream = io.StringIO()
+    logger = get_data.Logger(get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration"))
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    status_first = get_data.run_pipeline(cfg)
+    assert status_first == 0
+    assert executions == [2]
+
+    cfg_skip = replace(cfg, skip_existing=True)
+    status_skip = get_data.run_pipeline(cfg_skip)
+    assert status_skip == 0
+    assert executions == [2]
+    logs = [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+    assert any(record.get("event") == "step_skipped_existing" for record in logs)
+
+    cfg_force = replace(cfg, skip_existing=True, force=True)
+    status_force = get_data.run_pipeline(cfg_force)
+    assert status_force == 0
+    assert executions == [2, 2]
+
+
+@pytest.mark.integration
+def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _prepare_environment(tmp_path)
+    _write_input(
+        cfg,
+        "assay",
+        pd.DataFrame(
+            [
+                {
+                    "assay_chembl_id": "A1",
+                    "target_chembl_id": "T1",
+                    "document_chembl_id": "D1",
+                    "description": "First",
+                }
+            ]
+        ),
+    )
+
+    attempts = {"count": 0}
+
+    def _on_execute(rows: pd.DataFrame, destination: Path) -> int:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = destination.with_suffix(".tmp")
+            tmp_path.write_text("partial\n", encoding="utf-8")
+            return 1
+        destination.write_text("assay_chembl_id\nA1\n", encoding="utf-8")
+        return 0
+
+    step = get_data.PipelineStep(
+        "assay",
+        _build_stub_step(
+            required_columns=[
+                "assay_chembl_id",
+                "target_chembl_id",
+                "document_chembl_id",
+                "description",
+            ],
+            key_column="assay_chembl_id",
+            on_execute=_on_execute,
+        ),
+        None,
+    )
+
+    stream = io.StringIO()
+    logger = get_data.Logger(get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration"))
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    first_status = get_data.run_pipeline(cfg)
+    assert first_status == 1
+    working = get_data._temporary_output_path(step.expected_output(cfg))
+    assert not working.exists()
+    sentinel = get_data._failure_sentinel_path(step.expected_output(cfg))
+    assert sentinel.exists()
+
+    sentinel.unlink()
+    second_status = get_data.run_pipeline(cfg)
+    assert second_status == 0
+    final_output = step.expected_output(cfg)
+    assert final_output.exists()
+    assert attempts["count"] == 2

--- a/tests/unit/test_get_data.py
+++ b/tests/unit/test_get_data.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from scripts import get_data
+
+
+def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
+    base_path = tmp_path
+    input_dir = base_path / "input"
+    output_dir = base_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    for name, filename in get_data._DEFAULT_INPUT_FILES.items():
+        target = input_dir / filename
+        target.write_text("id\nplaceholder\n", encoding="utf-8")
+    config_path = base_path / "config.yaml"
+    config_path.write_text("io:\n  csv_sep: ','\n", encoding="utf-8")
+    return get_data.PipelineRunConfig(
+        base_path=base_path,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        config_path=config_path,
+        date_prefix="20200101",
+        log_level="INFO",
+        limit=None,
+        force=False,
+        skip_existing=False,
+        dry_run=False,
+    )
+
+
+@pytest.mark.unit
+def test_parse_args__defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CHEMBL_DA_BASE_PATH", raising=False)
+    args = get_data._parse_args([])
+    assert args.base_path == Path("data")
+    assert args.input_dir == Path("input")
+    assert args.output_dir == Path("output")
+    assert args.config == get_data.DEFAULT_CONFIG_PATH
+    expected_prefix = get_data.datetime.now(get_data.UTC).strftime("%Y%m%d")
+    assert args.date_prefix == expected_prefix
+    assert args.log_level == "INFO"
+    assert args.limit is None
+    assert args.force is False
+    assert args.skip_existing is False
+    assert args.dry_run is False
+
+
+@pytest.mark.unit
+def test_parse_args__custom_paths(tmp_path: Path) -> None:
+    base = tmp_path / "workspace"
+    args = get_data._parse_args(
+        [
+            "--base-path",
+            str(base),
+            "--input-dir",
+            "inputs",
+            "--output-dir",
+            "outputs",
+            "--config",
+            str(tmp_path / "custom.yaml"),
+            "--date",
+            "20240203",
+            "--log-level",
+            "debug",
+            "--limit",
+            "50",
+            "--force",
+            "--skip-existing",
+            "--dry-run",
+        ]
+    )
+    assert args.base_path == base
+    assert args.input_dir == Path("inputs")
+    assert args.output_dir == Path("outputs")
+    assert args.config == tmp_path / "custom.yaml"
+    assert args.date_prefix == "20240203"
+    assert args.log_level == "debug"
+    assert args.limit == 50
+    assert args.force is True
+    assert args.skip_existing is True
+    assert args.dry_run is True
+
+
+@pytest.mark.unit
+def test_pipeline_step_registration__expected_shape() -> None:
+    steps = get_data._PIPELINE_STEPS
+    names = [step.name for step in steps]
+    assert names == ["document", "target", "assay", "testitem", "activity"]
+    assert steps[0].extra_args == ("--mode", "all")
+    assert steps[1].subcommand == "all"
+    assert steps[-1].supports_dry_run is True
+    for step in steps:
+        assert callable(step.main)
+
+
+@pytest.mark.unit
+def test_configure_logging__delegates_to_configure_logger(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[get_data.LoggerConfig] = []
+
+    def _fake_configure_logger(cfg: get_data.LoggerConfig) -> get_data.Logger:
+        captured.append(cfg)
+        stream = io.StringIO()
+        return get_data.Logger(
+            get_data.LoggerConfig(
+                level=cfg.level,
+                run_id=cfg.run_id,
+                redact_secrets=cfg.redact_secrets,
+                stream=stream,
+            )
+        )
+
+    monkeypatch.setattr(get_data, "configure_logger", _fake_configure_logger)
+    logger = get_data._configure_logging("warn", run_id="fixed")
+    assert captured, "expected configure_logger to be invoked"
+    cfg = captured[0]
+    assert cfg.level == "WARN"
+    assert cfg.run_id == "fixed"
+    logger.warning("test_event")
+    record = json.loads(logger._cfg.stream.getvalue().strip())
+    assert record["event"] == "test_event"
+    assert record["run_id"] == "fixed"
+
+
+@pytest.mark.unit
+def test_configure_logging__invalid_level() -> None:
+    with pytest.raises(ValueError):
+        get_data._configure_logging("invalid")
+
+
+@pytest.mark.unit
+def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_config(tmp_path)
+    failure_calls: list[Sequence[str]] = []
+
+    def _success(argv: Sequence[str]) -> int:
+        final_out = Path(argv[argv.index("--final-out") + 1])
+        final_out.parent.mkdir(parents=True, exist_ok=True)
+        final_out.write_text("id\n1\n", encoding="utf-8")
+        return 0
+
+    def _failure(argv: Sequence[str]) -> int:
+        failure_calls.append(tuple(argv))
+        return 2
+
+    steps = (
+        get_data.PipelineStep("document", _success, None),
+        get_data.PipelineStep("target", _failure, None),
+        get_data.PipelineStep("assay", _success, None),
+    )
+
+    stream = io.StringIO()
+    logger = get_data.Logger(get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit"))
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", steps, raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    status = get_data.run_pipeline(cfg)
+    assert status == 2
+    assert failure_calls, "expected failing step to execute"
+    events = [json.loads(line)["event"] for line in stream.getvalue().splitlines() if line.strip()]
+    assert "step_failed" in events
+    assert "step_done" not in events[-1]
+
+
+@pytest.mark.unit
+def test_run_pipeline__handles_step_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _make_config(tmp_path)
+
+    def _raising(argv: Sequence[str]) -> int:  # pragma: no cover - executed via pipeline
+        raise RuntimeError("malformed output")
+
+    steps = (get_data.PipelineStep("document", _raising, None),)
+    stream = io.StringIO()
+    logger = get_data.Logger(get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit"))
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", steps, raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    status = get_data.run_pipeline(cfg)
+    assert status == 1
+    records = [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+    assert any(record.get("event") == "step_exception" for record in records)


### PR DESCRIPTION
## Summary
- add unit coverage for get_data CLI parsing, pipeline registry, logging configuration, and error handling
- add integration workflow tests to exercise schema checks, skip-existing/force flags, and retry behaviour
- expand the get_data end-to-end scenario with report verification plus additional degradation and failure cases

## Testing
- pytest tests/unit/test_get_data.py tests/integration/test_get_data_workflow.py tests/e2e/test_get_data_end_to_end.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e13f152bb0832493051620188c0ecf