### PR TITLE
Add extended tests for activity data pipeline CLI

### DIFF
--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable
+from types import SimpleNamespace
+from typing import Callable, Iterable
 
 import pandas as pd
 import pytest
+import requests
 
 from library.config import Config
+from library import cli_utils
 from scripts import (
     get_activity_data,
     get_assay_data,
@@ -59,6 +63,109 @@ def _patch_logger(monkeypatch: pytest.MonkeyPatch, module: object) -> _MemoryLog
     logger = _MemoryLogger()
     monkeypatch.setattr(module, "logger", logger)
     return logger
+
+
+class _DummyChemblClient:
+    """Minimal context manager used to stub :class:`ChemblClient`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+    def __enter__(self) -> "_DummyChemblClient":  # pragma: no cover - trivial helper
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial helper
+        return False
+
+
+@pytest.fixture()
+def activity_resource_dir(snapshot_resource: Path) -> Path:
+    return snapshot_resource / "activity_pipeline"
+
+
+def _configure_activity_cfg(cfg: Config) -> None:
+    cfg.activity.limit = None
+    cfg.activity.offset = 0
+    cfg.activity.dry_run = False
+    cfg.activity.batch_size = 5
+    cfg.activity.workers = 1
+    cfg.system.doc_quality.enable = False
+    cfg.activity_enrichment.action_type.enabled = False
+    cfg.activity_enrichment.action_type.log_missing = False
+    cfg.activity_enrichment.activity_properties.enabled = False
+
+
+def _install_activity_writer(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, pd.DataFrame, str]]:
+    written: list[tuple[Path, pd.DataFrame, str]] = []
+
+    def _writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        *,
+        key_cols: Iterable[str] | None,
+        col_order: Iterable[str] | None,
+        chunksize: int,
+        sort_chunksize: int | None = None,
+        sep: str = ",",
+        encoding: str = "utf-8",
+        cfg=None,
+        **_: object,
+    ) -> Path:
+        frames = [chunk.copy() for chunk in chunks]
+        if frames:
+            result = pd.concat(frames, ignore_index=True)
+        else:
+            result = pd.DataFrame(columns=list(col_order or []))
+        if col_order:
+            order = [str(col) for col in col_order]
+            result = result.reindex(columns=order, fill_value=pd.NA)
+        destination_path = Path(destination)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        result.to_csv(destination_path, index=False, sep=sep, encoding=encoding)
+        written.append((destination_path, result, sep))
+        return destination_path
+
+    monkeypatch.setattr(get_activity_data, "write_csv_chunks_deterministic", _writer)
+    return written
+
+
+def _patch_activity_cli(monkeypatch: pytest.MonkeyPatch, cfg: Config) -> None:
+    def fake_apply_config_overrides(
+        args,
+        parser,
+        config_path,
+        mapping=None,
+        *,
+        base_parser=None,
+    ) -> Config:
+        args._config_metadata = None
+        if hasattr(args, "output_csv") and args.output_csv is not None:
+            args.output_csv = Path(args.output_csv)
+        cfg.activity.batch_size = getattr(args, "batch_size", cfg.activity.batch_size)
+        cfg.activity.limit = getattr(args, "limit", cfg.activity.limit)
+        cfg.activity.offset = getattr(args, "offset", cfg.activity.offset)
+        cfg.activity.dry_run = getattr(args, "dry_run", cfg.activity.dry_run)
+        cfg.activity.timeout = getattr(args, "timeout", cfg.activity.timeout)
+        workers = getattr(args, "workers", None)
+        if workers is not None:
+            cfg.activity.workers = workers
+        return cfg
+
+    monkeypatch.setattr(cli_utils, "apply_config_overrides", fake_apply_config_overrides)
+    monkeypatch.setattr(cli_utils, "ensure_dirs", lambda _cfg: None)
+
+    def fake_configure_logger(log_cfg):
+        return get_activity_data.logger
+
+    monkeypatch.setattr(cli_utils.cli, "configure_logger", fake_configure_logger)
+    monkeypatch.setattr(get_activity_data.cli, "configure_logger", fake_configure_logger)
+    monkeypatch.setattr(get_activity_data, "configure_logger", fake_configure_logger)
+
+    @contextmanager
+    def fake_setup_cli_logging(script_name, log_cfg, date_str=None, **_kwargs):
+        yield SimpleNamespace(log_cfg=log_cfg, console_stream=None)
+
+    monkeypatch.setattr(get_activity_data, "setup_cli_logging", fake_setup_cli_logging)
 
 @pytest.mark.e2e
 def test_get_testitem_run_success(
@@ -182,6 +289,189 @@ def test_get_testitem_run_skip_existing(
     assert call_counter["called"] == 0
     events = [event for _, event, _ in logger_stub.events]
     assert "pipeline_skip_existing" in events
+
+
+@pytest.mark.e2e
+def test_get_activity_cli__retry_and_idempotent(
+    tmp_path: Path,
+    activity_resource_dir: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_activity_cfg(cfg)
+    input_csv = tmp_path / "activities_input.csv"
+    input_csv.write_text(
+        (activity_resource_dir / "ids_happy.csv").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "out" / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    attempts = {"count": 0}
+
+    def _fake_get_activities(chunk_ids, **_kwargs):
+        attempts["count"] += 1
+        if attempts["count"] % 2 == 1:
+            raise requests.RequestException("temporary failure")
+        identifiers = [str(item) for item in chunk_ids]
+        mask = chunk_df["activity_id"].astype(str).isin(identifiers)
+        return chunk_df.loc[mask].reset_index(drop=True)
+
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
+    monkeypatch.setattr(get_activity_data, "sleep", lambda *_args, **_kwargs: None)
+
+    written = _install_activity_writer(monkeypatch)
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+    _patch_activity_cli(monkeypatch, cfg)
+
+    args = ["--input", str(input_csv), "--output", str(output_csv)]
+
+    first_exit = get_activity_data.main(args)
+    assert first_exit == 0
+    assert output_csv.exists()
+    first_content = output_csv.read_text(encoding="utf-8")
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_fetch_retry" in events
+    assert "activity_pipeline_done" in events
+    assert not any(event == "activity_pipeline_failed" for event in events)
+    assert attempts["count"] >= 2
+    assert len(written) == 1
+    assert list(written[0][1]["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
+
+    logger_stub.events.clear()
+    written.clear()
+    attempts["count"] = 0
+
+    second_exit = get_activity_data.main(args)
+    assert second_exit == 0
+    second_content = output_csv.read_text(encoding="utf-8")
+    assert second_content == first_content
+    done_events = [event for _, event, _ in logger_stub.events]
+    assert done_events.count("activity_pipeline_done") >= 1
+    assert not any(event == "activity_pipeline_failed" for event in done_events)
+
+
+@pytest.mark.e2e
+def test_get_activity_cli__workers_and_offset(
+    tmp_path: Path,
+    activity_resource_dir: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_activity_cfg(cfg)
+    input_csv = tmp_path / "activities_input.csv"
+    input_csv.write_text(
+        (activity_resource_dir / "ids_happy.csv").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "out" / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    def _fake_get_activities(chunk_ids, **_kwargs):
+        identifiers = [str(item) for item in chunk_ids]
+        mask = chunk_df["activity_id"].astype(str).isin(identifiers)
+        return chunk_df.loc[mask].reset_index(drop=True)
+
+    captured: dict[str, int] = {}
+
+    def _fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
+        captured["workers"] = fetch_config.workers
+        captured["chunk_size"] = fetch_config.chunk_size
+
+        def _fetcher():
+            for chunk_ids in fetch_config.chunker(fetch_config.ids, fetch_config.chunk_size):
+                yield fetch_chunk(list(chunk_ids))
+
+        def _writer(chunks, destination, col_order, key_cols):
+            return csv_writer.writer(
+                chunks,
+                destination,
+                col_order=col_order,
+                key_cols=key_cols,
+            )
+
+        return _fetcher, _writer
+
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
+    monkeypatch.setattr(
+        get_activity_data,
+        "prepare_chunked_pipeline",
+        _fake_prepare_chunked_pipeline,
+    )
+
+    written = _install_activity_writer(monkeypatch)
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+    _patch_activity_cli(monkeypatch, cfg)
+
+    args = [
+        "--input",
+        str(input_csv),
+        "--output",
+        str(output_csv),
+        "--workers",
+        "2",
+        "--offset",
+        "1",
+        "--batch-size",
+        "2",
+    ]
+
+    exit_code = get_activity_data.main(args)
+
+    assert exit_code == 0
+    assert captured["workers"] == 2
+    assert output_csv.exists()
+    assert len(written) == 1
+    written_df = written[0][1]
+    assert written_df["activity_id"].tolist() == ["ACT2", "ACT3"]
+    events = [event for _, event, _ in logger_stub.events]
+    assert "process_offset" in events
+    assert "activity_pipeline_done" in events
+
+
+@pytest.mark.e2e
+def test_get_activity_cli__non_csv_output_path(
+    tmp_path: Path,
+    activity_resource_dir: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_activity_cfg(cfg)
+    cfg.io.csv_sep = "\t"
+    input_csv = tmp_path / "activities_input.csv"
+    input_csv.write_text(
+        (activity_resource_dir / "ids_happy.csv").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "out" / "activities.tsv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    def _fake_get_activities(chunk_ids, **_kwargs):
+        identifiers = [str(item) for item in chunk_ids]
+        mask = chunk_df["activity_id"].astype(str).isin(identifiers)
+        return chunk_df.loc[mask].reset_index(drop=True)
+
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
+
+    written = _install_activity_writer(monkeypatch)
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+    _patch_activity_cli(monkeypatch, cfg)
+
+    exit_code = get_activity_data.main(
+        ["--input", str(input_csv), "--output", str(output_csv)]
+    )
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    content = output_csv.read_text(encoding="utf-8")
+    assert "\t" in content.splitlines()[1]
+    assert len(written) == 1
+    assert written[0][2] == "\t"
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_pipeline_done" in events
 
 
 @pytest.mark.e2e
@@ -679,3 +969,169 @@ def test_get_activity_run_failure(
     assert rc == 1
     events = [event for _, event, _ in logger_stub.events]
     assert "activity_pipeline_failed" in events
+
+
+@pytest.mark.e2e
+def test_get_activity_run_retry_and_idempotent(
+    tmp_path: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_csv = tmp_path / "activities.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    output_csv = tmp_path / "out" / "activities.csv"
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+
+    cfg.activity.dry_run = False
+    cfg.activity.limit = None
+    cfg.activity.batch_size = 3
+    cfg.activity.workers = 1
+    cfg.system.doc_quality.enable = False
+    cfg.activity_enrichment.action_type.enabled = False
+    cfg.activity_enrichment.action_type.log_missing = False
+    cfg.activity_enrichment.activity_properties.enabled = False
+
+    frame = pd.DataFrame(
+        [
+            {
+                "activity_id": "ACT1",
+                "molecule_chembl_id": "CHEMBL1",
+                "assay_chembl_id": "ASSAY1",
+                "standard_value": 5.0,
+            }
+        ]
+    )
+
+    call_counter = {"count": 0}
+
+    def _fetch_with_retry(chunk_ids: list[str], **_: object) -> pd.DataFrame:
+        call_counter["count"] += 1
+        if call_counter["count"] == 1:
+            raise requests.RequestException("temporary failure")
+        return frame.copy()
+
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fetch_with_retry)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+
+    written: list[Path] = []
+
+    def _writer_stub(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        *,
+        key_cols: Iterable[str] | None,
+        col_order: Iterable[str] | None,
+        chunksize: int,
+        sort_chunksize: int | None = None,
+        sep: str = ",",
+        encoding: str = "utf-8",
+        cfg=None,
+        **_: object,
+    ) -> Path:
+        frames = list(chunks)
+        result = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+        destination = Path(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        result.to_csv(destination, index=False, sep=sep, encoding=encoding)
+        written.append(destination)
+        return destination
+
+    monkeypatch.setattr(get_activity_data, "write_csv_chunks_deterministic", _writer_stub)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        skip_existing=False,
+        force=False,
+    )
+
+    rc = get_activity_data.run(cfg, args)
+
+    assert rc == 0
+    assert call_counter["count"] == 2
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_fetch_retry" in events
+    assert "activity_pipeline_done" in events
+    assert output_csv in written
+
+    args.skip_existing = True
+    rc_second = get_activity_data.run(cfg, args)
+
+    assert rc_second == 0
+    events_second = [event for _, event, _ in logger_stub.events]
+    assert "pipeline_skip_existing" in events_second
+
+
+@pytest.mark.e2e
+def test_get_activity_run_workers_offset_and_non_csv(
+    tmp_path: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_csv = tmp_path / "activities.csv"
+    input_csv.write_text("activity_id\nACT1\nACT2\n", encoding="utf-8")
+    output_csv = tmp_path / "out" / "activities.tsv"
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+
+    cfg.activity.dry_run = False
+    cfg.activity.limit = None
+    cfg.activity.batch_size = 2
+    cfg.activity.workers = 3
+    cfg.system.doc_quality.enable = False
+    cfg.activity_enrichment.action_type.enabled = False
+    cfg.activity_enrichment.action_type.log_missing = False
+    cfg.activity_enrichment.activity_properties.enabled = False
+    cfg.io.csv_sep = "\t"
+
+    monkeypatch.setattr(
+        get_activity_data.io,
+        "read_ids",
+        lambda *_args, **_kwargs: iter(["ACT0", "ACT1", "ACT2"]),
+    )
+
+    captured: dict[str, int] = {}
+
+    def _prepare_stub(*, fetch_config, fetch_chunk, csv_writer):
+        captured["workers"] = fetch_config.workers
+
+        def _fetcher() -> Iterable[pd.DataFrame]:
+            yield pd.DataFrame(
+                [
+                    {
+                        "activity_id": "ACT2",
+                        "molecule_chembl_id": "CHEMBL2",
+                        "assay_chembl_id": "ASSAY2",
+                        "standard_value": 7.0,
+                    }
+                ]
+            )
+
+        def _writer(chunks: Iterable[pd.DataFrame], destination: Path, col_order, key_cols):
+            frames = list(chunks)
+            result = pd.concat(frames, ignore_index=True)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            result.to_csv(destination, index=False, sep=cfg.io.csv_sep)
+            return destination
+
+        return _fetcher, _writer
+
+    monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", _prepare_stub)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        skip_existing=False,
+        force=False,
+        offset=1,
+        workers=cfg.activity.workers,
+    )
+
+    rc = get_activity_data.run(cfg, args)
+
+    assert rc == 0
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_pipeline_done" in events
+    assert any(event_name == "process_offset" for _, event_name, _ in logger_stub.events)
+    assert captured["workers"] == max(1, cfg.activity.workers)
+    assert output_csv.exists()

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -1,0 +1,275 @@
+"""Integration tests for the activity pipeline CLI helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+import pytest
+
+from scripts import get_activity_data
+
+
+class _DummyChemblClient:
+    """Minimal stand-in for :class:`ChemblClient` used in tests."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+    def __enter__(self) -> "_DummyChemblClient":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial
+        return False
+
+
+class _RecordingLogger:
+    """Capture structured events emitted during the pipeline run."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.events.append(("info", event, dict(kwargs)))
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append(("warning", event, dict(kwargs)))
+
+    def error(self, event: str, **kwargs: object) -> None:
+        self.events.append(("error", event, dict(kwargs)))
+
+
+@pytest.fixture()
+def activity_resource_dir(snapshot_resource: Path) -> Path:
+    return snapshot_resource / "activity_pipeline"
+
+
+def _copy_resource(resource_dir: Path, name: str, destination: Path) -> Path:
+    target = destination / name
+    target.write_text((resource_dir / name).read_text(encoding="utf-8"), encoding="utf-8")
+    return target
+
+
+def _install_fetch_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    frame: pd.DataFrame,
+) -> list[tuple[str, ...]]:
+    captured: list[tuple[str, ...]] = []
+
+    def _fake_get_activities(chunk_ids: Iterable[str], **_: object) -> pd.DataFrame:
+        identifiers = [str(item) for item in chunk_ids]
+        captured.append(tuple(identifiers))
+        mask = frame["activity_id"].astype(str).isin(identifiers)
+        result = frame.loc[mask].copy().reset_index(drop=True)
+        if identifiers:
+            result = result.drop_duplicates(subset=["activity_id"], keep="first")
+        return result
+
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    return captured
+
+
+def _install_writer_stub(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, pd.DataFrame]]:
+    written: list[tuple[Path, pd.DataFrame]] = []
+
+    def _writer(
+        chunks: Iterable[pd.DataFrame],
+        destination: Path,
+        *,
+        key_cols: Iterable[str] | None,
+        col_order: Iterable[str] | None,
+        chunksize: int,
+        sort_chunksize: int | None = None,
+        sep: str = ",",
+        encoding: str = "utf-8",
+        cfg=None,
+        **_: object,
+    ) -> Path:
+        collected = [chunk.copy() for chunk in chunks]
+        if collected:
+            result = pd.concat(collected, ignore_index=True)
+        else:
+            result = pd.DataFrame(columns=list(col_order or []))
+        if col_order:
+            order = [str(col) for col in col_order]
+            result = result.reindex(columns=order, fill_value=pd.NA)
+        destination_path = Path(destination)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        result.to_csv(destination_path, index=False, sep=sep, encoding=encoding)
+        written.append((destination_path, result))
+        return destination_path
+
+    monkeypatch.setattr(get_activity_data, "write_csv_chunks_deterministic", _writer)
+    return written
+
+
+def _configure_cfg(cfg) -> None:
+    cfg.activity.limit = None
+    cfg.activity.dry_run = False
+    cfg.activity.batch_size = 5
+    cfg.activity.workers = 1
+    cfg.system.doc_quality.enable = False
+    cfg.activity_enrichment.action_type.enabled = False
+    cfg.activity_enrichment.action_type.log_missing = False
+    cfg.activity_enrichment.activity_properties.enabled = False
+
+
+def _make_args(input_csv: Path, output_csv: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        input_csv=input_csv,
+        output_csv=output_csv,
+        offset=0,
+        workers=None,
+        skip_existing=False,
+        force=False,
+        dry_run=False,
+        invocation=None,
+    )
+
+
+def _collect_events(stdout: str) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:  # pragma: no cover - defensive for unrelated output
+            continue
+    return events
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    input_csv = _copy_resource(activity_resource_dir, "ids_happy.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    captured = _install_fetch_stubs(monkeypatch, chunk_df)
+    written = _install_writer_stub(monkeypatch)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    activity_events = [event for _, event, _ in logger_stub.events]
+
+    assert exit_code == 0
+    assert {path for path, _ in written} == {output_csv}
+    assert set(activity_events).issuperset(
+        {
+            "activity_pipeline_start",
+            "activity_pipeline_done",
+            "records_dropped",
+            "schema_validate_start",
+            "schema_validate_done",
+        }
+    )
+    assert captured == [("ACT1", "ACT2", "ACT3")]
+
+    written_df = written[0][1]
+    assert list(written_df["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
+    assert pd.api.types.is_float_dtype(written_df["standard_value"])  # type: ignore[arg-type]
+    assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    input_csv = _copy_resource(activity_resource_dir, "ids_missing_column.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+
+    # Ensure we never reach the fetch stage when validation of inputs fails.
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", lambda *_, **__: pd.DataFrame())
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    activity_events = [event for _, event, _ in logger_stub.events]
+
+    assert exit_code == 1
+    assert "read_fail" in activity_events
+    assert not output_csv.exists()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__malformed_values(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    input_csv = _copy_resource(activity_resource_dir, "ids_happy.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_malformed.csv")
+
+    _install_fetch_stubs(monkeypatch, chunk_df)
+    written = _install_writer_stub(monkeypatch)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    activity_events = [event for _, event, _ in logger_stub.events]
+
+    assert exit_code == 1
+    assert not written
+    assert "validation_failed" in activity_events
+    failure_path = output_csv.with_name("activities_failure_cases.csv")
+    assert failure_path.exists()
+    failure_df = pd.read_csv(failure_path)
+    assert len(failure_df) >= 2
+    assert set(failure_df["column"]) == {"standard_value"}
+    failure_cases = " ".join(str(value) for value in failure_df["failure_case"])
+    assert "not-a-number" in failure_cases
+    assert ">=" in failure_cases
+    error_events = {event for level, event, _ in logger_stub.events if level == "error"}
+    assert {"validation_failed", "activity_pipeline_failed"}.issubset(error_events)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__deduplicates_identifiers(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    input_csv = _copy_resource(activity_resource_dir, "ids_duplicates.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    captured = _install_fetch_stubs(monkeypatch, chunk_df)
+    written = _install_writer_stub(monkeypatch)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    assert len(captured) == 1
+    recorded = captured[0]
+    assert len({item.lower() for item in recorded}) == 3
+    assert len(written) == 1
+    written_df = written[0][1]
+    assert written_df["activity_id"].tolist() == ["ACT1", "ACT2", "ACT3"]
+    info_events = {event for _, event, _ in logger_stub.events}
+    assert "records_dropped" in info_events
+    assert "schema_validate_done" in info_events
+    warning_events = {event for level, event, _ in logger_stub.events if level == "warning"}
+    assert "read_ids_dropped_na_markers" not in warning_events

--- a/tests/resources/activity_pipeline/chunk_happy.csv
+++ b/tests/resources/activity_pipeline/chunk_happy.csv
@@ -1,0 +1,4 @@
+activity_id,molecule_chembl_id,assay_chembl_id,standard_value,standard_units,standard_type,relation,activity_comment
+ACT1,CHEMBL1,ASSAY1,"5.500",nM,IC50,=,
+ACT2,CHEMBL2,ASSAY2,"7.250",nM,IC50,=,
+ACT3,CHEMBL3,ASSAY3,"9.000",nM,IC50,=,

--- a/tests/resources/activity_pipeline/chunk_malformed.csv
+++ b/tests/resources/activity_pipeline/chunk_malformed.csv
@@ -1,0 +1,5 @@
+activity_id,molecule_chembl_id,assay_chembl_id,standard_value,standard_units,standard_type,relation,activity_comment
+ACT1,CHEMBL1,ASSAY1,"5.500",nM,IC50,=,valid primary record
+ACT1,CHEMBL1,ASSAY1,-3.000,nM,IC50,=,negative measurement duplicate
+ACT2,CHEMBL2,ASSAY2,not-a-number,nM,IC50,=,non numeric value
+ACT3,CHEMBL3,ASSAY3,12.100,nM,IC50,=,trailing record

--- a/tests/resources/activity_pipeline/ids_duplicates.csv
+++ b/tests/resources/activity_pipeline/ids_duplicates.csv
@@ -1,0 +1,6 @@
+activity_id
+ACT1
+act1
+ACT2
+ACT2
+ACT3

--- a/tests/resources/activity_pipeline/ids_happy.csv
+++ b/tests/resources/activity_pipeline/ids_happy.csv
@@ -1,0 +1,4 @@
+activity_id
+ACT1
+ACT2
+ACT3

--- a/tests/resources/activity_pipeline/ids_missing_column.csv
+++ b/tests/resources/activity_pipeline/ids_missing_column.csv
@@ -1,0 +1,3 @@
+wrong_header
+ACT1
+ACT2

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from typing import Iterable
 
+import pandas as pd
 import pytest
 
 from scripts import get_activity_data
@@ -26,6 +28,48 @@ def _make_args(tmp_path: Path) -> argparse.Namespace:
         dry_run=False,
         invocation=None,
     )
+
+
+class _DummyClient:
+    """Minimal context manager emulating :class:`ChemblClient`."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+    def __enter__(self) -> "_DummyClient":  # pragma: no cover - trivial helper
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial helper
+        return False
+
+
+class _RecordingLogger:
+    """Capture structured log events emitted by :mod:`get_activity_data`."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.events.append(("info", event, dict(kwargs)))
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append(("warning", event, dict(kwargs)))
+
+    def error(self, event: str, **kwargs: object) -> None:
+        self.events.append(("error", event, dict(kwargs)))
+
+
+def _extract_events(stdout: str) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:  # pragma: no cover - defensive fallback
+            continue
+    return events
 
 
 @pytest.mark.parametrize(
@@ -58,35 +102,272 @@ def test_run_chembl__invalid_limit_logs_error(cfg, tmp_path, caplog) -> None:
     assert exit_code == 1
 
 
-def test_run_chembl__dry_run_short_circuits(cfg, tmp_path, caplog) -> None:
+def test_run_chembl__dry_run_short_circuits(cfg, tmp_path, monkeypatch) -> None:
     args = _make_args(tmp_path)
     cfg.activity.dry_run = True
     cfg.activity.limit = 7
 
-    caplog.set_level("INFO")
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
     exit_code = get_activity_data.run_chembl(cfg, args)
 
     assert exit_code == 0
+    assert ("info", "dry_run", {"limit": 7}) in [
+        (level, event, context) for level, event, context in logger_stub.events
+    ]
 
 
-def test_run__skip_existing_respects_flags(cfg, tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "skip_existing, force, explicit_output, has_existing, expected_calls",
+    [
+        (True, False, False, True, 0),
+        (True, True, False, True, 1),
+        (False, False, True, True, 1),
+        (False, False, True, False, 1),
+    ],
+)
+def test_run__skip_existing_matrix(
+    skip_existing: bool,
+    force: bool,
+    explicit_output: bool,
+    has_existing: bool,
+    expected_calls: int,
+    cfg,
+    tmp_path,
+    monkeypatch,
+) -> None:
     args = _make_args(tmp_path)
-    args.output_csv = None
-    args.skip_existing = True
-    args.force = False
+    args.skip_existing = skip_existing
+    args.force = force
 
-    calls: list[str] = []
+    if explicit_output:
+        output_path = tmp_path / "explicit.csv"
+        args.output_csv = output_path
+    else:
+        args.output_csv = None
+        output_path = tmp_path / "default.csv"
 
-    def fake_default_output_path(input_path: Path, _io_cfg) -> Path:  # pragma: no cover - exercised via tests
-        assert input_path == args.input_csv
-        destination = tmp_path / "output.csv"
-        destination.write_text("existing", encoding="utf-8")
-        return destination
+        def fake_default_output_path(input_path: Path, _io_cfg) -> Path:
+            assert input_path == args.input_csv
+            return output_path
 
-    monkeypatch.setattr(get_activity_data.io, "default_output_path", fake_default_output_path)
-    monkeypatch.setattr(get_activity_data, "run_chembl", lambda *_: calls.append("run") or 0)
+        monkeypatch.setattr(get_activity_data.io, "default_output_path", fake_default_output_path)
+
+    if has_existing:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("existing", encoding="utf-8")
+
+    call_counter: list[str] = []
+    monkeypatch.setattr(
+        get_activity_data,
+        "run_chembl",
+        lambda *_args, **_kwargs: call_counter.append("run") or 0,
+    )
 
     exit_code = get_activity_data.run(cfg, args)
 
     assert exit_code == 0
-    assert calls == []
+    assert len(call_counter) == expected_calls
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_substring"),
+    [
+        (["--limit", "-1"], "--limit must be zero or a positive integer"),
+        (["--offset", "-2"], "--offset must be zero or a positive integer"),
+        (["--workers", "0"], "chunk size must be a positive integer"),
+    ],
+)
+def test_main__invalid_cli_options(argv, expected_substring, monkeypatch, tmp_path, capsys) -> None:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    full_args = ["--input", str(input_csv), *argv]
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "run",
+        lambda *args, **kwargs: pytest.fail("run should not be invoked for invalid CLI"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        get_activity_data.main(full_args)
+
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert expected_substring in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv", [["--limit"], ["--workers"], ["--timeout"]]
+)
+def test_main__missing_cli_option_values(argv, monkeypatch, tmp_path, capsys) -> None:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    args = ["--input", str(input_csv), *argv]
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "run",
+        lambda *_, **__: pytest.fail("run should not execute when CLI value missing"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        get_activity_data.main(args)
+
+    assert exc_info.value.code != 0
+    stderr = capsys.readouterr().err
+    option = argv[0]
+    assert f"argument {option}: expected one argument" in stderr
+
+
+def test_run_chembl__offset_and_workers(monkeypatch, cfg, tmp_path) -> None:
+    args = _make_args(tmp_path)
+    args.offset = 1
+    cfg.activity.dry_run = False
+    cfg.activity.limit = None
+    cfg.activity.batch_size = 3
+    cfg.activity.workers = 4
+    cfg.system.doc_quality.enable = False
+
+    monkeypatch.setattr(
+        get_activity_data.io,
+        "read_ids",
+        lambda *_args, **_kwargs: iter(["ACT0", "ACT1", "ACT2"]),
+    )
+
+    captured: dict[str, int] = {}
+
+    def fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
+        captured["workers"] = fetch_config.workers
+        captured["chunk_size"] = fetch_config.chunk_size
+
+        def _fetcher() -> Iterable[pd.DataFrame]:
+            yield pd.DataFrame(
+                [
+                    {
+                        "activity_id": "ACT2",
+                        "molecule_chembl_id": "CHEMBL2",
+                        "assay_chembl_id": "ASSAY2",
+                        "standard_value": 4.0,
+                    }
+                ]
+            )
+
+        def _writer(chunks: Iterable[pd.DataFrame], destination: Path, col_order, key_cols):
+            frames = list(chunks)
+            result = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            result.to_csv(destination, index=False)
+            return destination
+
+        return _fetcher, _writer
+
+    monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    assert captured["workers"] == max(1, cfg.activity.workers)
+    events = [event for _, event, _ in logger_stub.events]
+    assert "process_offset" in events
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        lambda: FileNotFoundError("missing input"),
+        lambda: ValueError("malformed CSV"),
+    ],
+)
+def test_run_chembl__read_ids_failures(error_factory, cfg, tmp_path, monkeypatch) -> None:
+    args = _make_args(tmp_path)
+
+    def _raise(*_args, **_kwargs):
+        raise error_factory()
+
+    monkeypatch.setattr(get_activity_data.io, "read_ids", _raise)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 1
+    events = [event for _, event, _ in logger_stub.events]
+    assert "read_fail" in events
+
+
+def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> None:
+    args = _make_args(tmp_path)
+
+    monkeypatch.setattr(
+        get_activity_data.io,
+        "read_ids",
+        lambda *_args, **_kwargs: iter(["ACT1"]),
+    )
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+
+    def fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
+        def _fetcher() -> Iterable[pd.DataFrame]:
+            yield pd.DataFrame(
+                [
+                    {
+                        "activity_id": "ACT1",
+                        "molecule_chembl_id": "CHEMBL1",
+                        "assay_chembl_id": "ASSAY1",
+                        "standard_value": 1.0,
+                    }
+                ]
+            )
+
+        def _writer(
+            chunks: Iterable[pd.DataFrame],
+            destination: Path,
+            col_order,
+            key_cols,
+        ) -> Path:
+            dest = Path(destination)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            return dest
+
+        return _fetcher, _writer
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr(
+        get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline
+    )
+
+    def fake_run_pipeline(*, fetcher, writer, **kwargs):
+        list(fetcher())
+        return 1
+
+    monkeypatch.setattr(get_activity_data, "run_pipeline", fake_run_pipeline)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 1
+    error_events = [event for level, event, _ in logger_stub.events if level == "error"]
+    assert "activity_pipeline_failed" in error_events
+
+
+def test_main__dry_run_skip_limit(monkeypatch, tmp_path, capsys) -> None:
+    input_csv = tmp_path / "activity.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "run",
+        lambda *args, **kwargs: pytest.fail("run should not execute when limit=0"),
+    )
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    exit_code = get_activity_data.main(["--input", str(input_csv), "--limit", "0"])
+
+    assert exit_code == 0
+    events = [event for _, event, _ in logger_stub.events]
+    assert "pipeline_skip_limit" in events


### PR DESCRIPTION
## Summary
- add integration coverage for the activity pipeline using deterministic fixtures, including malformed scenarios
- extend unit tests for get_activity_data CLI argument handling and degraded paths
- introduce end-to-end tests covering retries, worker overrides, and non-CSV output behaviours
- add activity pipeline CSV fixtures for happy, missing-column, and malformed cases

## Testing
- pytest tests/unit/test_get_activity_data.py
- pytest tests/integration/test_get_activity_data_pipeline.py
- pytest tests/e2e/test_get_cli_pipelines.py

------
https://chatgpt.com/codex/tasks/task_e_68e13f116814832488b94d0a7f0ebe18