### PR TITLE
Add post-processing hook for target exports

### DIFF
--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -1,0 +1,33 @@
+"""Lightweight hooks for final target export post-processing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..common.log import logger
+
+
+def process_targets(path: str | Path, *, verbose: bool = False) -> Path:
+    """Emit a post-processing hook event for the final target export.
+
+    Parameters
+    ----------
+    path:
+        Location of the produced target table.
+    verbose:
+        When ``True`` the hook logs at ``INFO`` level, otherwise ``DEBUG``.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved path to the processed file.
+    """
+
+    resolved = Path(path)
+    log_fn = logger.info if verbose else logger.debug
+    log_fn("target_postprocess", path=str(resolved))
+    return resolved
+
+
+__all__ = ["process_targets"]
+

--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -38,6 +38,7 @@ from library.config import Config, ConfigError, ensure_dirs, print_config
 from library.io.paths import default_output_path
 from library.io.readers import read_ids
 from library.io.writers import write_csv
+from library.postprocessing import target as target_pp
 from library.common.log import logger
 from library.pipelines.common import pipeline_metadata
 from library.pipelines.target.pipeline import run_pipeline
@@ -551,8 +552,9 @@ def run(cfg: Config, options: PipelineConfig) -> int:
     if skip_final_write:
         for _ in stream:
             pass
+        processed_path = final_path
     else:
-        _validate_and_write(
+        processed_path = _validate_and_write(
             stream,
             final_path,
             cfg=cfg,
@@ -561,6 +563,7 @@ def run(cfg: Config, options: PipelineConfig) -> int:
             id_cols=id_cols,
             normalize=normalize,
         )
+    target_pp.process_targets(str(processed_path), verbose=True)
     logger.info("write_done", extra={"path": str(final_path)})
     return 0
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -77,6 +77,7 @@ from pandera.errors import SchemaErrors
 import library.cli_utils as cli_utils_module
 from library import cli
 from library import io
+from library.postprocessing import target as target_pp
 from library.integration import chembl_library as cl
 from library.integration import iuphar_library as ii
 from library.integration import uniprot_library as uu
@@ -1695,6 +1696,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 return 1
 
+        final_export_path = destination if destination.exists() else raw_destination
+        target_pp.process_targets(str(final_export_path), verbose=True)
         if limit is not None:
             logger.info("process_limit", limit=processed_ids)
         logger.info(
@@ -1840,8 +1843,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
             if final_output != raw_output:
                 shutil.copy2(raw_path, final_output)
-                return final_output
-            return raw_path
+                final_path = final_output
+            else:
+                final_path = raw_path
+            target_pp.process_targets(str(final_path), verbose=True)
+            return final_path
 
         frames: list[pd.DataFrame] = []
         for chunk in chunks:
@@ -1897,6 +1903,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 key_cols=resolved_keys or None,
                 col_order=TARGETS_COLUMN_ORDER,
             )
+        target_pp.process_targets(str(final_path), verbose=True)
         return final_path
 
     failure_path = normalized_output.with_name(
@@ -2986,7 +2993,7 @@ def validate_and_write(
     before_dedup = len(final_df)
     final_df = final_df.drop_duplicates()
     logger.info("deduplicated_rows", dropped=before_dedup - len(final_df))
-    io.write_csv(
+    final_export_path = io.write_csv(
         final_df,
         normalized_output,
         cfg=cfg,
@@ -2995,6 +3002,7 @@ def validate_and_write(
         col_order=TARGETS_COLUMN_ORDER,
         key_cols=key_columns or None,
     )
+    target_pp.process_targets(str(final_export_path), verbose=True)
     if final_df.empty:
         logger.info(
             "quality_report_skipped",


### PR DESCRIPTION
## Summary
- add a lightweight `library.postprocessing.target` module exposing `process_targets`
- invoke the post-processing hook from target CLI pipelines after writing the final export in every code path

## Testing
- pytest -q tests/unit/test_get_target_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e14ceced20832483d5ca4246cb500c