### PR TITLE
Add organism-level target post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ python scripts/get_data.py \
 ```
 
 Each pipeline writes a deterministic CSV, a `<name>.meta.yaml` metadata sidecar
-and table-quality reports under the same directory. Refer to the
+and table-quality reports under the same directory. The target pipeline also
+generates an organism-level supplement (`organism.output.target_*.csv`) with
+cellularity and multifunctional enzyme flags derived from the post-processing
+step described in `docs/OUTPUT_TARGETS_EN.md`. Refer to the
 [output reference](./docs/en/OUTPUT.md) for the complete specification.
 
 ## Documentation

--- a/docs/OUTPUT_TARGETS_EN.md
+++ b/docs/OUTPUT_TARGETS_EN.md
@@ -1,0 +1,71 @@
+# Target post-processing — `organism.output.target_*.csv`
+
+The target pipeline now emits an additional organism-focused CSV derived from
+the ChEMBL/UniProt export (`output.target_*.csv`). The Power Query (M) logic
+previously used for taxonomy dashboards has been ported to Python without
+changing the resulting rows or columns.
+
+## Transformation steps
+
+1. **Input detection** — the post-processor consumes the freshly written
+   `output.target_*.csv` file (or the most recent file matching the pattern
+   when invoked standalone).
+2. **Cellularity classification** — superkingdom/phylum fields are normalised
+   to lower case. Each row is labelled using the taxonomy rules:
+   - `ClassifyByLineage` covers deterministic cases for viruses, bacteria,
+     archaea and curated eukaryotic phyla.
+   - Ambiguous or empty lineage entries trigger `ClassifyByFetch`, which reads
+     NCBI Taxonomy XML (`Lineage`, `ScientificName`) and applies the same
+     rulebook.
+3. **Multifunctional enzyme flag** — `reaction_ec_numbers` is split on `|`,
+   deduplicated, and truncated to the first EC segment. Targets with more than
+   one distinct EC prefix are marked as multifunctional.
+4. **Join and projection** — cellularity and multifunctional flags are merged
+   back into the identifier subset, producing the final column order:
+   `target_chembl_id`, `uniprot_id_primary`, `organism`, `taxon_id`,
+   `lineage_superkingdom`, `lineage_phylum`, `lineage_class`, `cellularity`,
+   `multifunctional_enzyme`.
+5. **Output** — results are saved next to the input file with the prefix
+   `organism.` while preserving UTF-8 encoding and deterministic ordering.
+
+## Example
+
+Input (`output.target_20250301.csv`):
+
+```csv
+target_chembl_id,uniprot_id_primary,organism,taxon_id,lineage_superkingdom,lineage_phylum,lineage_class,reaction_ec_numbers
+CHEMBL1,P12345,Species A,10239,Viruses,,,"1.1.1.1|2.7.11.1"
+CHEMBL2,Q54321,Species B,9606,Eukaryota,Chordata,Chordata,"1.1.1.1|3.2.1.4"
+CHEMBL3,R99999,Species C,111,Archaea,,,""
+CHEMBL4,S88888,Species D,222,,,"","1.1.1.1|2.7.11.1|1.2.3.4"
+CHEMBL5,T77777,Species E,333,Bacteria,,,"2.7.11.1"
+```
+
+Output (`organism.output.target_20250301.csv`):
+
+```csv
+target_chembl_id,uniprot_id_primary,organism,taxon_id,lineage_superkingdom,lineage_phylum,lineage_class,cellularity,multifunctional_enzyme
+CHEMBL1,P12345,Species A,10239,viruses,,,"acellular (virus)",True
+CHEMBL2,Q54321,Species B,9606,eukaryota,chordata,chordata,multicellular,True
+CHEMBL3,R99999,Species C,111,archaea,,,"unicellular",False
+CHEMBL4,S88888,Species D,222,,,ambiguous,True
+CHEMBL5,T77777,Species E,333,bacteria,,,"unicellular",False
+```
+
+The organism CSV preserves the row order of the input file. Lists produced
+from `reaction_ec_numbers` remain internal to the computation and are not
+exposed in the final export.
+
+## Operational notes
+
+- **Offline mode** — pass `offline=True` to
+  `library.postprocessing.target.process_targets` to disable HTTP calls. Rows
+  that would otherwise rely on NCBI fall back to `cellularity = "ambiguous"`.
+- **HTTP errors** — network failures or invalid XML payloads mirror the M
+  implementation and result in an ambiguous classification without raising.
+- **Logging** — the processor reports the input/output paths, number of rows,
+  HTTP requests made to NCBI and the count of ambiguous classifications when
+  `verbose=True`.
+
+Refer to the Russian counterpart (`docs/OUTPUT_TARGETS_RU.md`) for the same
+information in Russian.

--- a/docs/OUTPUT_TARGETS_RU.md
+++ b/docs/OUTPUT_TARGETS_RU.md
@@ -1,0 +1,69 @@
+# Постобработка таргетов — `organism.output.target_*.csv`
+
+Пайплайн таргетов формирует дополнительный CSV с фокусом на организмы на базе
+экспорта ChEMBL/UniProt (`output.target_*.csv`). Логика Power Query (M),
+использовавшаяся в отчётах по таксономии, перенесена на Python без изменений
+результата по строкам и столбцам.
+
+## Этапы преобразования
+
+1. **Определение входа** — используется только что созданный файл
+   `output.target_*.csv` (или самый свежий файл по шаблону при отдельном
+   запуске).
+2. **Классификация клеточности** — поля superkingdom/phylum приводятся к нижнему
+   регистру. Для каждой строки вычисляется метка:
+   - `ClassifyByLineage` закрывает детерминированные случаи для вирусов,
+     бактерий, архей и подобранных филумов эукариот.
+   - При неопределённом или пустом lineage вызывается `ClassifyByFetch`,
+     выполняющий запрос к NCBI Taxonomy (`Lineage`, `ScientificName`) и
+     применяющий те же правила.
+3. **Флаг мультифункциональности** — колонка `reaction_ec_numbers` режется по
+   символу `|`, очищается от дублей и усечённых сегментов EC; наличие более одной
+   уникальной первой части кода даёт `multifunctional_enzyme = True`.
+4. **Объединение и проекция** — рассчитанные признаки присоединяются обратно к
+   подмножеству идентификаторов. Итоговый порядок колонок:
+   `target_chembl_id`, `uniprot_id_primary`, `organism`, `taxon_id`,
+   `lineage_superkingdom`, `lineage_phylum`, `lineage_class`, `cellularity`,
+   `multifunctional_enzyme`.
+5. **Вывод** — файл сохраняется рядом с исходным под именем с префиксом
+   `organism.` в кодировке UTF-8 с фиксированным порядком строк.
+
+## Пример
+
+Вход (`output.target_20250301.csv`):
+
+```csv
+target_chembl_id,uniprot_id_primary,organism,taxon_id,lineage_superkingdom,lineage_phylum,lineage_class,reaction_ec_numbers
+CHEMBL1,P12345,Species A,10239,Viruses,,,"1.1.1.1|2.7.11.1"
+CHEMBL2,Q54321,Species B,9606,Eukaryota,Chordata,Chordata,"1.1.1.1|3.2.1.4"
+CHEMBL3,R99999,Species C,111,Archaea,,,""
+CHEMBL4,S88888,Species D,222,,,"","1.1.1.1|2.7.11.1|1.2.3.4"
+CHEMBL5,T77777,Species E,333,Bacteria,,,"2.7.11.1"
+```
+
+Выход (`organism.output.target_20250301.csv`):
+
+```csv
+target_chembl_id,uniprot_id_primary,organism,taxon_id,lineage_superkingdom,lineage_phylum,lineage_class,cellularity,multifunctional_enzyme
+CHEMBL1,P12345,Species A,10239,viruses,,,"acellular (virus)",True
+CHEMBL2,Q54321,Species B,9606,eukaryota,chordata,chordata,multicellular,True
+CHEMBL3,R99999,Species C,111,archaea,,,"unicellular",False
+CHEMBL4,S88888,Species D,222,,,ambiguous,True
+CHEMBL5,T77777,Species E,333,bacteria,,,"unicellular",False
+```
+
+Постобработанный CSV сохраняет порядок строк входного набора. Списки, полученные
+из `reaction_ec_numbers`, используются только во внутренних расчётах и не
+попадают в итоговый файл.
+
+## Эксплуатационные замечания
+
+- **Офлайн-режим** — параметр `offline=True` у
+  `library.postprocessing.target.process_targets` отключает HTTP-запросы; такие
+  строки получают `cellularity = "ambiguous"`.
+- **Ошибки HTTP** — сетевые сбои или невалидный XML повторяют поведение M-кода:
+  классификация становится неопределённой, исключения не выбрасываются.
+- **Логирование** — при `verbose=True` выводятся пути входа/выхода, число строк,
+  количество HTTP-запросов к NCBI и количество строк с результатом `ambiguous`.
+
+Аналогичный материал на английском — в `docs/OUTPUT_TARGETS_EN.md`.

--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from .document import preprocess_document_export, postprocess_export_file
+from .target import process_targets
 
 __all__ = [
     "preprocess_document_export",
     "postprocess_export_file",
+    "process_targets",
 ]
 

--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -1,0 +1,525 @@
+"""Post-processing helpers for target exports.
+
+This module ports the Power Query post-processing logic used in
+``target_all`` reports to Python. The implementation mirrors the
+behaviour of the original M queries to ensure byte-for-byte identical
+results for downstream analytics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import math
+from pathlib import Path
+from typing import Iterable
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+import xml.etree.ElementTree as ET
+
+import pandas as pd
+
+from ..common.log import logger
+
+ENCODINGS_TO_TRY: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
+NCBI_EUTILS_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+NCBI_TOOL_NAME = "cellularity-checker"
+DEFAULT_EMAIL = "noreply@example.com"
+USER_AGENT = "Python-Postproc/1.0"
+
+
+def normalize_text(value: str | None | object) -> str:
+    """Return a strictly normalised textual value.
+
+    Power Query's ``NormalizeText`` helper converts ``null`` to an empty
+    string, trims whitespace, and lowercases the result. The Python
+    implementation mirrors that behaviour exactly.
+    """
+
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    text = str(value)
+    return text.strip().lower()
+
+
+def first_element_text(nodes: Iterable[ET.Element] | None, element_name: str) -> str | None:
+    """Return the text value of the first element matching ``element_name``.
+
+    The Power Query pipeline inspects a flattened XML table. In Python we
+    work directly with ``Element`` objects, iterating through the provided
+    nodes while preserving the semantics of returning ``null``/``None``
+    when the node or its textual payload is absent.
+    """
+
+    if nodes is None:
+        return None
+    for node in nodes:
+        if node.tag != element_name:
+            continue
+        text = node.text
+        if text is None:
+            return None
+        return text
+    return None
+
+
+def _distinct(sequence: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in sequence:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _http_get(url: str, params: dict[str, str], *, timeout: float) -> bytes | None:
+    query = urlencode(params)
+    request = Request(f"{url}?{query}", headers={"User-Agent": USER_AGENT})
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec: B310 - controlled URL
+            return response.read()
+    except URLError:
+        return None
+
+
+@dataclass(frozen=True)
+class _CellularityRules:
+    unicell_phyla: tuple[str, ...] = (
+        "ciliophora",
+        "apicomplexa",
+        "euglenozoa",
+        "dinoflagellata",
+        "alveolata",
+        "euglenozoa",
+        "bacillariophyta",
+        "parabasalia",
+        "metamonada",
+        "choanoflagellata",
+        "chlorophyta",
+    )
+    multicell_animal_phyla: tuple[str, ...] = (
+        "chordata",
+        "arthropoda",
+        "mollusca",
+        "nematoda",
+        "annelida",
+        "ecdysozoa",
+        "echinodermata",
+        "cnidaria",
+        "platyhelminthes",
+        "porifera",
+        "spiralia",
+        "ctenophora",
+        "tardigrada",
+        "onychophora",
+        "bryozoa",
+        "brachiopoda",
+        "echinodermata",
+        "hemichordata",
+        "rotifera",
+        "nemertea",
+        "sipuncula",
+        "priapulida",
+        "dikarya",
+        "loricifera",
+        "gastrotricha",
+        "kinorhyncha",
+    )
+    multicell_plant_phyla: tuple[str, ...] = (
+        "streptophyta",
+        "tracheophyta",
+        "bryophyta",
+        "marchantiophyta",
+    )
+    mostly_multicell_phyla: tuple[str, ...] = ("rhodophyta",)
+    fungi_phyla: tuple[str, ...] = (
+        "ascomycota",
+        "basidiomycota",
+        "mucoromycota",
+        "microsporidia",
+        "chytridiomycota",
+    )
+
+
+class CellularityClassifier:
+    """Encapsulate the classification rules for cellularity labels."""
+
+    def __init__(
+        self,
+        *,
+        email: str | None = None,
+        timeout: float = 15.0,
+        offline: bool = False,
+    ) -> None:
+        self.email = email or DEFAULT_EMAIL
+        self.timeout = timeout
+        self.offline = offline
+        self.rules = _CellularityRules()
+        self.http_requests = 0
+        self._fetch_cache: dict[str, list[str]] = {}
+
+    def classify_by_lineage(self, superkingdom: str | None, phylum_or_class: str | None) -> str:
+        sk = normalize_text(superkingdom)
+        ph = normalize_text(phylum_or_class)
+        if sk == "viruses":
+            return "acellular (virus)"
+        if sk in {"bacteria", "archaea"}:
+            return "unicellular"
+        if sk == "eukaryota":
+            if ph in self.rules.multicell_animal_phyla or ph in self.rules.multicell_plant_phyla:
+                return "multicellular"
+            if ph in self.rules.unicell_phyla:
+                return "unicellular"
+            if ph in self.rules.fungi_phyla:
+                return "multicellular"
+            if ph in self.rules.mostly_multicell_phyla:
+                return "multicellular"
+            return "ambiguous"
+        if sk:
+            return "ambiguous"
+        return "ambiguous"
+
+    def _fetch_lineage_names(self, tax_id: str) -> list[str]:
+        if tax_id in self._fetch_cache:
+            return self._fetch_cache[tax_id]
+
+        if self.offline:
+            self._fetch_cache[tax_id] = []
+            return []
+
+        params = {
+            "db": "taxonomy",
+            "id": tax_id,
+            "retmode": "xml",
+            "tool": NCBI_TOOL_NAME,
+            "email": self.email,
+        }
+        self.http_requests += 1
+        payload = _http_get(NCBI_EUTILS_URL, params, timeout=self.timeout)
+        if payload is None:
+            self._fetch_cache[tax_id] = []
+            return []
+
+        try:
+            tree = ET.fromstring(payload)
+        except ET.ParseError:
+            self._fetch_cache[tax_id] = []
+            return []
+
+        taxon_nodes = tree.findall(".//Taxon")
+        if not taxon_nodes:
+            self._fetch_cache[tax_id] = []
+            return []
+        taxon = taxon_nodes[0]
+        children = list(taxon)
+        lineage_text = first_element_text(children, "Lineage")
+        sci_name = first_element_text(children, "ScientificName")
+        names: list[str] = []
+        if lineage_text is not None:
+            stripped = lineage_text.strip()
+            if stripped:
+                names = [segment.strip() for segment in stripped.split(";") if segment.strip()]
+        if sci_name and sci_name not in names:
+            names.append(sci_name)
+
+        self._fetch_cache[tax_id] = names
+        return names
+
+    def classify_by_fetch(self, tax_id: object) -> str:
+        if tax_id is None:
+            return "ambiguous"
+        if isinstance(tax_id, float) and math.isnan(tax_id):
+            return "ambiguous"
+
+        tax_id_str = str(tax_id)
+        if not tax_id_str.strip():
+            return "ambiguous"
+
+        names = [name.lower() for name in self._fetch_lineage_names(tax_id_str)]
+        if not names:
+            return "ambiguous"
+
+        if "viruses" in names:
+            return "acellular (virus)"
+        if "bacteria" in names or "archaea" in names:
+            return "unicellular"
+        if "eukaryota" in names:
+            if any(name in self.rules.multicell_animal_phyla for name in names) or any(
+                name in self.rules.multicell_plant_phyla for name in names
+            ) or "metazoa" in names:
+                return "multicellular"
+            if any(name in self.rules.unicell_phyla for name in names):
+                return "unicellular"
+            if "fungi" in names:
+                return "multicellular"
+            if any(name in self.rules.mostly_multicell_phyla for name in names):
+                return "multicellular"
+            return "ambiguous"
+        return "ambiguous"
+
+    def add_cellularity_smart(
+        self,
+        frame: pd.DataFrame,
+        tax_id_column: str,
+        superkingdom_column: str,
+        phylum_or_class_column: str,
+    ) -> pd.Series:
+        def _classify(row: pd.Series) -> str:
+            sk_value = row.get(superkingdom_column)
+            by_lineage = self.classify_by_lineage(sk_value, row.get(phylum_or_class_column))
+            sk_text = "" if sk_value is None else str(sk_value)
+            if by_lineage != "ambiguous" and sk_text.strip():
+                return by_lineage
+            return self.classify_by_fetch(row.get(tax_id_column))
+
+        return frame.apply(_classify, axis=1)
+
+
+def _transform_reaction_ec_numbers(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, float) and math.isnan(value):
+        return []
+    text = str(value)
+    parts = text.split("|")
+    distinct_parts = _distinct(parts)
+    first_segments = [segment.split(".")[0] if segment else "" for segment in distinct_parts]
+    return _distinct(first_segments)
+
+
+MULTIFUNCTIONAL_DROP_COLUMNS: tuple[str, ...] = (
+    "isoform_ids",
+    "isoform_names",
+    "isoform_synonyms",
+    "organism",
+    "taxon_id",
+    "lineage_superkingdom",
+    "lineage_phylum",
+    "lineage_class",
+    "xref_chembl",
+    "gtop_synonyms",
+    "gtop_natural_ligands_n",
+    "gtop_interactions_n",
+    "gtop_function_text_short",
+    "uniProtkbId",
+    "hgnc_name",
+    "secondaryAccessionNames",
+    "transmembrane",
+    "intramembrane",
+    "hgnc_id",
+    "features_signal_peptide",
+    "tax_id",
+    "species_group_flag",
+    "family",
+    "xref_uniprot",
+    "xref_ensembl",
+    "pfam",
+    "interpro",
+    "xref_pdb",
+    "xref_alphafold",
+    "SUPFAM",
+    "PROSITE",
+    "InterPro",
+    "Pfam",
+    "PRINTS",
+    "TCDB",
+    "target_type",
+    "protein_classifications",
+    "protein_name_alt",
+    "recommendedName",
+    "pref_name",
+    "target_components",
+    "cross_references",
+    "gene_symbol_list",
+    "protein_synonym_list",
+    "ptm_glycosylation",
+    "ptm_lipidation",
+    "ptm_disulfide_bond",
+    "ptm_modified_residue",
+    "glycosylation",
+    "lipidation",
+    "disulfide_bond",
+    "modified_residue",
+    "phosphorylation",
+    "acetylation",
+    "ubiquitination",
+    "signal_peptide",
+    "propeptide",
+    "gene_symbol",
+    "protein_name_canonical",
+    "sequence_length",
+    "features_transmembrane",
+    "features_topology",
+    "xref_iuphar",
+    "gtop_target_id",
+    "uniprot_last_update",
+    "uniprot_version",
+    "pipeline_version",
+    "timestamp_utc",
+    "secondaryAccessions",
+    "geneName",
+    "molecular_function",
+    "cellular_component",
+    "subcellular_location",
+    "topology",
+    "GuidetoPHARMACOLOGY",
+    "protein_class_pred_L1",
+    "protein_class_pred_L2",
+    "protein_class_pred_L3",
+    "protein_class_pred_rule_id",
+    "protein_class_pred_evidence",
+    "protein_class_pred_confidence",
+    "iuphar_target_id",
+    "iuphar_family_id",
+    "iuphar_type",
+    "iuphar_class",
+    "iuphar_subclass",
+    "iuphar_chain",
+    "iuphar_name",
+    "iuphar_full_id_path",
+    "iuphar_full_name_path",
+)
+
+
+def _prepare_multifunctional_frame(source: pd.DataFrame) -> pd.DataFrame:
+    frame = source.drop(columns=[col for col in MULTIFUNCTIONAL_DROP_COLUMNS if col in source.columns])
+    if "reaction_ec_numbers" in frame.columns:
+        frame = frame.copy()
+        frame["reaction_ec_numbers"] = frame["reaction_ec_numbers"].map(_transform_reaction_ec_numbers)
+    else:
+        frame = frame.copy()
+        frame["reaction_ec_numbers"] = [[] for _ in range(len(frame))]
+    frame["multifunctional_enzyme"] = frame["reaction_ec_numbers"].map(lambda values: len(values) > 1)
+    return frame[["target_chembl_id", "multifunctional_enzyme"]]
+
+
+TARGET_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "target_chembl_id",
+    "uniprot_id_primary",
+    "organism",
+    "taxon_id",
+    "lineage_superkingdom",
+    "lineage_phylum",
+    "lineage_class",
+    "cellularity",
+    "multifunctional_enzyme",
+)
+
+
+def _find_latest_output_csv(prefix: str = "output.target_", search_roots: Iterable[Path] | None = None) -> Path | None:
+    if search_roots is None:
+        cwd = Path.cwd()
+        search_roots = (
+            cwd,
+            cwd / "data",
+            cwd / "reports",
+        )
+
+    latest_path: Path | None = None
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for path in root.rglob(f"{prefix}*.csv"):
+            if latest_path is None or path.stat().st_mtime > latest_path.stat().st_mtime:
+                latest_path = path
+    return latest_path
+
+
+def _read_csv_with_fallback(path: Path) -> pd.DataFrame:
+    last_error: Exception | None = None
+    for encoding in ENCODINGS_TO_TRY:
+        try:
+            return pd.read_csv(path, encoding=encoding)
+        except UnicodeDecodeError as exc:  # pragma: no cover - depends on input encoding
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    return pd.read_csv(path)
+
+
+def process_targets(
+    input_csv: str | None = None,
+    output_csv: str | None = None,
+    output_prefix: str = "organism",
+    ncbi_email: str | None = None,
+    http_timeout_s: float = 15.0,
+    offline: bool = False,
+    verbose: bool = True,
+) -> Path:
+    """Post-process the target export according to the Power Query logic."""
+
+    log = logger if verbose else logging.getLogger("null")
+    if not verbose:
+        logging.getLogger("null").addHandler(logging.NullHandler())
+
+    input_path = Path(input_csv) if input_csv is not None else _find_latest_output_csv()
+    if input_path is None:
+        raise FileNotFoundError("No input CSV provided and no output.target_*.csv found")
+
+    if verbose:
+        log.info("Reading target CSV", extra={"path": str(input_path)})
+    source = _read_csv_with_fallback(input_path)
+
+    classifier = CellularityClassifier(email=ncbi_email, timeout=http_timeout_s, offline=offline)
+
+    source_base = source[[
+        "target_chembl_id",
+        "uniprot_id_primary",
+        "organism",
+        "taxon_id",
+        "lineage_superkingdom",
+        "lineage_phylum",
+        "lineage_class",
+    ]].copy()
+
+    for column in ("lineage_superkingdom", "lineage_phylum", "lineage_class"):
+        source_base[column] = source_base[column].map(
+            lambda value: value.lower() if isinstance(value, str) else value
+        )
+
+    source_base["cellularity"] = classifier.add_cellularity_smart(
+        source_base,
+        "taxon_id",
+        "lineage_superkingdom",
+        "lineage_class",
+    )
+
+    multifunctional_frame = _prepare_multifunctional_frame(source)
+    merged = source_base.merge(multifunctional_frame, on="target_chembl_id", how="left")
+    merged = merged.reindex(columns=TARGET_OUTPUT_COLUMNS)
+
+    if output_csv is None:
+        output_csv = f"{output_prefix}.{input_path.name}"
+        output_path = input_path.with_name(output_csv)
+    else:
+        output_path = Path(output_csv)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    merged.to_csv(output_path, index=False, encoding="utf-8")
+
+    ambiguous_count = int((merged["cellularity"] == "ambiguous").sum())
+    if verbose:
+        log.info(
+            "Wrote organism-level target classification",
+            extra={
+                "rows": len(merged),
+                "path": str(output_path),
+                "http_requests": classifier.http_requests,
+                "ambiguous": ambiguous_count,
+            },
+        )
+
+    return output_path
+
+
+__all__ = [
+    "process_targets",
+    "normalize_text",
+    "first_element_text",
+    "CellularityClassifier",
+]
+

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -110,6 +110,11 @@ from library.validation import ValidationResult
 from library.schemas import TargetsSchema, normalize_targets
 from library.schemas.targets import TARGETS_COLUMN_ORDER
 
+try:
+    from library.postprocessing import target as target_pp
+except ImportError:  # pragma: no cover - compatibility with legacy module name
+    import library.postprocessing.targe as target_pp  # type: ignore[no-redef]
+
 
 @contextmanager
 def _override_cli_meta_writer() -> Iterator[None]:
@@ -1965,6 +1970,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         "chembl_placeholder_replacements",
         total=placeholder_replacements,
     )
+
+    if exit_code == 0:
+        target_pp.process_targets(str(final_output), verbose=True)
 
     return exit_code
 

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.postprocessing import target as target_pp
+
+
+def _make_classifier(**kwargs: object) -> target_pp.CellularityClassifier:
+    return target_pp.CellularityClassifier(**kwargs)
+
+
+def test_normalize_text__handles_none_and_trimming() -> None:
+    assert target_pp.normalize_text(None) == ""
+    assert target_pp.normalize_text("  AbC  ") == "abc"
+    assert target_pp.normalize_text("β") == "β"
+
+
+def test_first_element_text__returns_text_when_present() -> None:
+    xml = textwrap.dedent(
+        """
+        <Taxon>
+          <Lineage>cellular organisms</Lineage>
+          <ScientificName>Example species</ScientificName>
+        </Taxon>
+        """
+    ).strip()
+    node = target_pp.ET.fromstring(xml)
+    result = target_pp.first_element_text(list(node), "ScientificName")
+    assert result == "Example species"
+
+
+def test_first_element_text__returns_none_when_missing() -> None:
+    xml = "<Taxon><Lineage>cellular organisms</Lineage></Taxon>"
+    node = target_pp.ET.fromstring(xml)
+    assert target_pp.first_element_text(list(node), "ScientificName") is None
+
+
+@pytest.mark.parametrize(
+    "superkingdom, phylum, expected",
+    [
+        ("Viruses", "", "acellular (virus)"),
+        ("Bacteria", None, "unicellular"),
+        ("Archaea", "", "unicellular"),
+        ("Eukaryota", "Chordata", "multicellular"),
+        ("Eukaryota", "ciliophora", "unicellular"),
+        ("Eukaryota", "rhodophyta", "multicellular"),
+        ("Eukaryota", "unknown", "ambiguous"),
+    ],
+)
+def test_classify_by_lineage__scenarios(superkingdom: str, phylum: str | None, expected: str) -> None:
+    classifier = _make_classifier()
+    assert classifier.classify_by_lineage(superkingdom, phylum) == expected
+
+
+def test_get_lineage_names__parses_lineage_and_scientific_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    xml = textwrap.dedent(
+        """
+        <TaxaSet>
+          <Taxon>
+            <Lineage>cellular organisms; Eukaryota; Metazoa; Chordata</Lineage>
+            <ScientificName>Homo sapiens</ScientificName>
+          </Taxon>
+        </TaxaSet>
+        """
+    ).strip()
+
+    def fake_http(url: str, params: dict[str, str], *, timeout: float) -> bytes:
+        return xml.encode("utf-8")
+
+    monkeypatch.setattr(target_pp, "_http_get", fake_http)
+    classifier = _make_classifier()
+    names = classifier._fetch_lineage_names("9606")
+    assert names == [
+        "cellular organisms",
+        "Eukaryota",
+        "Metazoa",
+        "Chordata",
+        "Homo sapiens",
+    ]
+
+
+def test_get_lineage_names__returns_empty_on_invalid_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_http(url: str, params: dict[str, str], *, timeout: float) -> bytes | None:
+        return None
+
+    monkeypatch.setattr(target_pp, "_http_get", fake_http)
+    classifier = _make_classifier()
+    assert classifier._fetch_lineage_names("0") == []
+
+
+def test_classify_by_fetch__uses_lineage_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    classifier = _make_classifier()
+
+    def fake_fetch(self: target_pp.CellularityClassifier, tax_id: str) -> list[str]:
+        return ["Eukaryota", "Metazoa", "Chordata"]
+
+    monkeypatch.setattr(target_pp.CellularityClassifier, "_fetch_lineage_names", fake_fetch)
+    assert classifier.classify_by_fetch("9606") == "multicellular"
+
+
+def test_add_cellularity_smart__lineage_without_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    classifier = _make_classifier()
+
+    def forbid_fetch(_: object) -> str:
+        raise AssertionError("fetch should not be called")
+
+    monkeypatch.setattr(classifier, "classify_by_fetch", forbid_fetch)
+
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "taxon_id": [111],
+            "lineage_superkingdom": ["bacteria"],
+            "lineage_class": ["gammaproteobacteria"],
+        }
+    )
+    result = classifier.add_cellularity_smart(
+        frame,
+        "taxon_id",
+        "lineage_superkingdom",
+        "lineage_class",
+    )
+    assert result.tolist() == ["unicellular"]
+
+
+def test_add_cellularity_smart__fallback_fetch_when_ambiguous(monkeypatch: pytest.MonkeyPatch) -> None:
+    classifier = _make_classifier()
+    calls: list[str] = []
+
+    def fake_fetch(tax_id: object) -> str:
+        calls.append(str(tax_id))
+        return "multicellular"
+
+    monkeypatch.setattr(classifier, "classify_by_fetch", fake_fetch)
+
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL2"],
+            "taxon_id": [9606],
+            "lineage_superkingdom": [None],
+            "lineage_class": [None],
+        }
+    )
+    result = classifier.add_cellularity_smart(
+        frame,
+        "taxon_id",
+        "lineage_superkingdom",
+        "lineage_class",
+    )
+    assert result.tolist() == ["multicellular"]
+    assert calls == ["9606"]
+
+
+def test_multifunctional__reaction_ec_numbers_processing() -> None:
+    values = target_pp._transform_reaction_ec_numbers("1.1.1.1|2.7.11.1|1.1.1.2|2.7.11.1")
+    assert values == ["1", "2"]
+
+
+def test_multifunctional__drops_columns_and_sets_flag() -> None:
+    df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL3"],
+            "reaction_ec_numbers": ["1.1.1.1|2.7.11.1"],
+            "isoform_ids": ["should be dropped"],
+        }
+    )
+    result = target_pp._prepare_multifunctional_frame(df)
+    assert list(result.columns) == ["target_chembl_id", "multifunctional_enzyme"]
+    assert bool(result.loc[0, "multifunctional_enzyme"])
+
+
+def test_process_targets__produces_expected_columns_and_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "uniprot_id_primary": ["P12345", "Q54321"],
+            "organism": ["Species A", "Species B"],
+            "taxon_id": [111, 222],
+            "lineage_superkingdom": ["viruses", None],
+            "lineage_phylum": ["", ""],
+            "lineage_class": ["", ""],
+            "reaction_ec_numbers": ["1.1.1.1|2.7.11.1", "1.1.1.1"],
+        }
+    )
+    input_path = tmp_path / "output.target_20251004.csv"
+    data.to_csv(input_path, index=False)
+
+    def forbid_http(url: str, params: dict[str, str], *, timeout: float) -> bytes:
+        raise AssertionError("HTTP should not be called in offline mode")
+
+    monkeypatch.setattr(target_pp, "_http_get", forbid_http)
+
+    output_path = target_pp.process_targets(
+        input_csv=str(input_path),
+        output_prefix="organism",
+        offline=True,
+        verbose=False,
+    )
+
+    assert output_path.name == "organism.output.target_20251004.csv"
+    result = pd.read_csv(output_path)
+    assert list(result.columns) == list(target_pp.TARGET_OUTPUT_COLUMNS)
+    assert result.loc[0, "cellularity"] == "acellular (virus)"
+    assert result.loc[1, "cellularity"] == "ambiguous"
+    assert bool(result.loc[0, "multifunctional_enzyme"])
+    assert not bool(result.loc[1, "multifunctional_enzyme"])
+
+
+def test_process_targets__offline_ambiguous_without_http(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL10"],
+            "uniprot_id_primary": ["P00010"],
+            "organism": ["Organism"],
+            "taxon_id": [333],
+            "lineage_superkingdom": [None],
+            "lineage_phylum": [None],
+            "lineage_class": [None],
+            "reaction_ec_numbers": ["1.1.1.1|3.2.1.4"],
+        }
+    )
+    input_path = tmp_path / "output.target_20250101.csv"
+    frame.to_csv(input_path, index=False)
+
+    def forbid_http(url: str, params: dict[str, str], *, timeout: float) -> bytes:
+        raise AssertionError("HTTP should not be executed in offline mode")
+
+    monkeypatch.setattr(target_pp, "_http_get", forbid_http)
+
+    output_path = target_pp.process_targets(
+        input_csv=str(input_path),
+        output_prefix="organism",
+        offline=True,
+        verbose=False,
+    )
+    df = pd.read_csv(output_path)
+    assert df.loc[0, "cellularity"] == "ambiguous"
+
+
+def test_process_targets__fetch_classification(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    xml = textwrap.dedent(
+        """
+        <TaxaSet>
+          <Taxon>
+            <Lineage>cellular organisms; Eukaryota; Metazoa; Chordata</Lineage>
+            <ScientificName>Example organism</ScientificName>
+          </Taxon>
+        </TaxaSet>
+        """
+    ).strip()
+
+    def fake_http(url: str, params: dict[str, str], *, timeout: float) -> bytes:
+        return xml.encode("utf-8")
+
+    monkeypatch.setattr(target_pp, "_http_get", fake_http)
+
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL20"],
+            "uniprot_id_primary": ["P00020"],
+            "organism": ["Organism"],
+            "taxon_id": [9606],
+            "lineage_superkingdom": ["Eukaryota"],
+            "lineage_phylum": ["Chordata"],
+            "lineage_class": ["Mammalia"],
+            "reaction_ec_numbers": ["1.1.1.1|2.7.11.1"],
+        }
+    )
+    input_path = tmp_path / "output.target_20250102.csv"
+    frame.to_csv(input_path, index=False)
+
+    output_path = target_pp.process_targets(
+        input_csv=str(input_path),
+        output_prefix="organism",
+        offline=False,
+        verbose=False,
+    )
+
+    df = pd.read_csv(output_path)
+    assert df.loc[0, "cellularity"] == "multicellular"
+


### PR DESCRIPTION
## Summary
- port the Power Query cellularity and multifunctional rules into `library.postprocessing.target`
- invoke the organism-level post-processing after writing `output.target_*.csv` and document the new artifact
- add deterministic pytest coverage for the classification helpers and file IO

## Testing
- pytest --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68e14d364e788324b55e83537b76acd9