### PR TITLE
feat: add target SSoT post-processing pipeline

### DIFF
--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 from .document import preprocess_document_export, postprocess_export_file
-from .target import process_targets
+from .target import (
+    Cellularity,
+    FirstElementText,
+    NormalizeText,
+    multifunctional,
+    process_targets,
+)
 
 __all__ = [
     "preprocess_document_export",
     "postprocess_export_file",
+    "NormalizeText",
+    "FirstElementText",
+    "Cellularity",
+    "multifunctional",
     "process_targets",
 ]
 

--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -1,27 +1,49 @@
-"""Target post-processing helpers.
+"""Post-processing helpers for target exports.
 
-This module implements a lightweight transformation that mirrors the
-Power Query workbook used during the early iterations of the pipeline.
-The intent is to keep a deterministic, fully scripted variant that can
-be exercised in automated tests without relying on Excel.
+The implementation mirrors the Single Source of Truth (SSoT) workbook that is
+used by the analytics team to derive the *organism* enriched target tables.
+The goal of this module is to provide a deterministic Python port that can be
+executed in automated environments without depending on Excel.
+
+The transformation performs the following high level steps:
+
+* Locate the latest ``output.target_*.csv`` file within the provided directory
+  (or process a specific file when the exact path is supplied).
+* Load the CSV using a small catalogue of legacy encodings that were observed
+  in historical exports.
+* Normalise key textual columns using the :func:`NormalizeText` helper to
+  ensure that whitespace, sentinels and casing are processed consistently.
+* Derive additional helper columns used downstream by analytics including the
+  organism cellularity classification and the multifunctional enzyme flag.
+* Persist the transformed dataset as ``organism.output.target_*.csv`` encoded
+  in UTF-8 with Unix line terminators, matching the legacy SSoT workbook.
+
+Where possible the logic intentionally stays close to the semantics of the
+original spreadsheet.  For example, the :class:`Cellularity` helper implements
+the same lookup strategy by querying the NCBI taxonomy API (with graceful
+offline fallbacks) and the :func:`FirstElementText` helper emulates the Excel
+formulae that extract primary values from pipe separated lists.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import re
-from itertools import zip_longest
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Iterable, Mapping, Sequence
 
 import pandas as pd
+import requests
+
+from ..schemas.targets import TARGETS_COLUMN_ORDER
 
 LOGGER = logging.getLogger(__name__)
 
-# Power Query relied on a UTF-8 CSV exported from Excel, but there are a few
-# legacy snapshots encoded in various Windows code pages.  The function below
-# mimics the behaviour by attempting a handful of common encodings before
-# giving up.
+
+# ===== Constants ============================================================
+
 DEFAULT_ENCODINGS: Sequence[str] = (
     "utf-8-sig",
     "utf-8",
@@ -30,73 +52,223 @@ DEFAULT_ENCODINGS: Sequence[str] = (
     "latin-1",
 )
 
-# Tokens are extracted with a simple alphanumeric matcher.  Hyphens and other
-# separators are treated as token boundaries which mirrors the SynExpand step
-# present in the original Power Query file.
-TOKEN_PATTERN = re.compile(r"[A-Za-z0-9']+")
+INPUT_PATTERN = "output.target_*.csv"
+OUTPUT_PREFIX = "organism.output."
+NCBI_TAXON_URL = "https://api.ncbi.nlm.nih.gov/datasets/v2/taxonomy/taxon/{tax_id}"
+NCBI_HEADERS = {"User-Agent": "Python-Postproc/1.0"}
+NCBI_TIMEOUT = 10
+
+_NORMALISE_WS_RE = re.compile(r"\s+")
+_SPLIT_VALUE_RE = re.compile(r"[|;,/]+")
 
 
-def _normalise_series(series: pd.Series, *, lowercase: bool) -> pd.Series:
-    """Return a cleaned copy of ``series``.
+# ===== Helper utilities =====================================================
 
-    Empty values and sentinel strings such as ``"None"`` or ``"n/a"`` are
-    converted to the empty string.  When ``lowercase`` is true, the
-    normalised values are converted to lower case to replicate the synonym
-    handling that Power Query performed.
+def NormalizeText(value: object) -> str:
+    """Return a cleaned textual representation of ``value``.
+
+    Historically the target workbook stored a mixture of Excel ``NULL``
+    sentinels, ``N/A`` values and values padded with whitespace.  The helper
+    performs a conservative normalisation by collapsing whitespace, stripping
+    the result and mapping a small set of sentinel strings to the empty string.
+    All other values are preserved verbatim to avoid altering the analytical
+    semantics of the table.
     """
 
-    if series.empty:
-        return series.copy()
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):  # pragma: no cover - defensive
+        return ""
+    if value is pd.NA or value is pd.NaT:  # pragma: no cover - defensive
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    text = _NORMALISE_WS_RE.sub(" ", text)
+    lowered = text.lower()
+    if lowered in {"na", "n/a", "none", "null", "nan", "-"}:
+        return ""
+    return text
 
-    cleaned = (
-        series.fillna("")
-        .astype(str)
-        .str.strip()
-        .str.replace(r"\s+", " ", regex=True)
+
+def FirstElementText(value: object) -> str:
+    """Extract the first textual entry from a delimited string.
+
+    ``value`` is expected to use the pipe separator (``|``) although historical
+    exports also contained commas, semi-colons and forward slashes depending on
+    the upstream loader.  The helper mirrors the Excel ``TEXTSPLIT`` based logic
+    by considering each of these separators.
+    """
+
+    text = NormalizeText(value)
+    if not text:
+        return ""
+    if "|" not in text and ";" not in text and "," not in text and "/" not in text:
+        return text
+    parts = [part for part in _SPLIT_VALUE_RE.split(text) if part]
+    if not parts:
+        return ""
+    return NormalizeText(parts[0])
+
+
+@dataclass(frozen=True)
+class Cellularity:
+    """Representation of the organism cellularity classification.
+
+    Parameters
+    ----------
+    value:
+        Human readable classification label such as ``"unicellular"``.
+    method:
+        Indicates whether the value was inferred locally or via the NCBI API.
+    lineage:
+        Tuple of lineage tokens used during inference.  This is primarily
+        exposed for logging and testing purposes to guarantee determinism.
+    """
+
+    value: str
+    method: str
+    lineage: tuple[str, ...]
+
+    @classmethod
+    def from_row(
+        cls,
+        row: Mapping[str, object],
+        *,
+        offline: bool = False,
+        session: requests.Session | None = None,
+    ) -> "Cellularity":
+        """Infer a :class:`Cellularity` instance from a row.
+
+        The logic mirrors the Excel implementation which first relies on local
+        lineage columns and only queries NCBI when a ``taxon_id`` is available
+        and the caller allows network access.  Any network errors are treated as
+        soft failures and the function falls back to the locally inferred value.
+        """
+
+        lineage_superkingdom = NormalizeText(row.get("lineage_superkingdom"))
+        lineage_phylum = NormalizeText(row.get("lineage_phylum"))
+        lineage_class = NormalizeText(row.get("lineage_class"))
+        local_lineage = tuple(
+            value
+            for value in (lineage_superkingdom, lineage_phylum, lineage_class)
+            if value
+        )
+        local_value = _classify_lineage(local_lineage)
+
+        if offline:
+            return cls(local_value, "local", local_lineage)
+
+        taxon_id = NormalizeText(row.get("taxon_id") or row.get("tax_id"))
+        if not taxon_id:
+            return cls(local_value, "local", local_lineage)
+
+        try:
+            lineage = _fetch_taxonomy_lineage(taxon_id, session=session)
+        except requests.RequestException as exc:  # pragma: no cover - defensive
+            LOGGER.warning(
+                "Unable to resolve taxonomy %s via NCBI (%s). Falling back to local classification.",
+                taxon_id,
+                exc,
+            )
+            return cls(local_value, "local", local_lineage)
+
+        if not lineage:
+            return cls(local_value, "local", local_lineage)
+
+        remote_value = _classify_lineage(lineage)
+        return cls(remote_value, "ncbi", tuple(lineage))
+
+
+def multifunctional(row: Mapping[str, object]) -> bool:
+    """Return ``True`` if the row represents a multifunctional enzyme.
+
+    The SSoT workbook considers several columns when deriving the flag.  The
+    Python port mirrors this behaviour by scanning a selection of classification
+    columns for the literal ``"multifunctional enzyme"`` token.
+    """
+
+    CANDIDATE_COLUMNS = (
+        "target_type",
+        "protein_classifications",
+        "protein_class_pred_L1",
+        "protein_class_pred_L2",
+        "protein_class_pred_L3",
     )
-    cleaned = cleaned.replace(
-        to_replace=r"^(?i)(?:na|n/a|none|n\\.?a\\.?|n\s*/\s*a)$",
-        value="",
-        regex=True,
-    )
-    if lowercase:
-        cleaned = cleaned.str.lower()
-    return cleaned
+    for column in CANDIDATE_COLUMNS:
+        value = NormalizeText(row.get(column))
+        if value and "multifunctional enzyme" in value.lower():
+            return True
+    return False
 
 
-def _split_pipe(value: str) -> list[str]:
-    if not value:
-        return []
-    return [part.strip() for part in value.split("|") if part.strip()]
+# ===== Internal helpers =====================================================
+
+def _classify_lineage(lineage: Iterable[str]) -> str:
+    values = [value.lower() for value in lineage]
+    if not values:
+        return "unknown"
+
+    superkingdom = values[0]
+    if superkingdom in {"bacteria", "archaea"}:
+        return "prokaryote"
+    if superkingdom == "virus" or "viruses" in values:
+        return "viral"
+    if superkingdom == "eukaryota":
+        if any(token in values for token in {"metazoa", "chordata", "mammalia"}):
+            return "multicellular"
+        if any(token in values for token in {"fungi", "ascomycota", "basidiomycota"}):
+            return "fungal"
+        return "unicellular"
+    return "unknown"
 
 
-def _split_synonyms(value: str) -> list[str]:
-    if not value:
-        return []
-    parts = [segment.strip() for segment in value.split(":") if segment.strip()]
-    unique: list[str] = []
-    for part in parts:
-        lower = part.lower()
-        if lower in {"n/a", "none", "na"}:
-            continue
-        if part not in unique:
-            unique.append(part)
-    return unique
+def _fetch_taxonomy_lineage(
+    taxon_id: str,
+    *,
+    session: requests.Session | None = None,
+) -> tuple[str, ...] | tuple[()]:
+    url = NCBI_TAXON_URL.format(taxon_id=taxon_id)
+    sess = session or requests.Session()
+    response = sess.get(url, headers=NCBI_HEADERS, timeout=NCBI_TIMEOUT)
+    response.raise_for_status()
+
+    payload = response.json()
+    try:
+        nodes = payload["taxonomy_nodes"]
+    except (KeyError, TypeError) as exc:  # pragma: no cover - defensive
+        LOGGER.warning("Unexpected taxonomy payload for %s: %s", taxon_id, exc)
+        return tuple()
+
+    if not nodes:
+        return tuple()
+
+    taxonomy = nodes[0].get("taxonomy", {})
+    lineage = taxonomy.get("lineage", [])
+    lineage_names: list[str] = []
+    for entry in lineage:
+        name = entry.get("taxon_name") or entry.get("name")
+        if name:
+            lineage_names.append(NormalizeText(name))
+
+    if taxonomy.get("organism_name"):
+        lineage_names.append(NormalizeText(taxonomy["organism_name"]))
+
+    return tuple(value for value in lineage_names if value)
 
 
-def _syn_expand(term: str) -> list[str]:
-    if not term:
-        return []
-    tokens = TOKEN_PATTERN.findall(term.lower())
-    # Preserve order whilst removing duplicates.
-    return list(dict.fromkeys(tokens))
-
-
-def _read_csv(path: Path, *, encodings: Iterable[str], sep: str) -> pd.DataFrame:
+def _read_csv(
+    path: Path,
+    *,
+    encodings: Sequence[str],
+    sep: str,
+) -> pd.DataFrame:
     last_error: Exception | None = None
     for encoding in encodings:
         try:
-            LOGGER.info("Reading target isoform table from %s (encoding=%s)", path, encoding)
+            LOGGER.info(
+                "Reading target export %s with encoding %s", path, encoding
+            )
             return pd.read_csv(path, dtype=str, encoding=encoding, sep=sep)
         except UnicodeDecodeError as exc:  # pragma: no cover - defensive
             last_error = exc
@@ -106,129 +278,132 @@ def _read_csv(path: Path, *, encodings: Iterable[str], sep: str) -> pd.DataFrame
     raise UnicodeDecodeError("utf-8", b"", 0, 1, "unable to decode input")
 
 
+def _stabilise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    known_order = [col for col in TARGETS_COLUMN_ORDER if col in df.columns]
+    remaining = [col for col in df.columns if col not in known_order]
+    ordered_columns = known_order + sorted(remaining)
+    return df.loc[:, ordered_columns]
+
+
+# ===== Public API ===========================================================
+
 def process_targets(
     source: Path | str,
     *,
-    output_dir: Path | str | None = None,
+    offline: bool = False,
+    session: requests.Session | None = None,
     sep: str = ",",
     encodings: Sequence[str] | None = None,
 ) -> Path:
-    """Process the aggregated target CSV produced by :mod:`scripts.get_target_data`.
-
-    The transformation mirrors the legacy Power Query workbook.  It reads the
-    CSV, normalises name and synonym columns, expands pipe-separated fields
-    into per-isoform entries, performs a synonym tokenisation step and writes
-    the result to an ``isoform.output.<original>`` file located alongside the
-    source file (or in ``output_dir`` when provided).
+    """Process aggregated target data and persist the SSoT compliant export.
 
     Parameters
     ----------
     source:
-        Path to the CSV file that should be processed.
-    output_dir:
-        Optional destination directory.  When omitted the output is written to
-        the same directory as ``source``.
+        Either a directory containing the ``output.target_*.csv`` snapshot or
+        the full path to the file that should be processed.
+    offline:
+        When ``True`` the function skips all network lookups and relies solely
+        on the lineage information present in the CSV.
+    session:
+        Optional :class:`requests.Session` instance used for network requests.
+        When omitted a new session is created for each invocation.
     sep:
-        Field separator used in the CSV.  Defaults to a comma.
+        Column separator used by the CSV file.  Defaults to a comma.
     encodings:
-        Ordered list of encodings that will be attempted while reading the
-        source file.  The first successful attempt stops the search.
+        Optional sequence of encodings attempted while reading the CSV.  When
+        ``None`` the :data:`DEFAULT_ENCODINGS` catalogue is used.
 
     Returns
     -------
     pathlib.Path
-        Path to the generated output file.
+        Path to the generated ``organism.output.target_*.csv`` file.
     """
 
-    input_path = Path(source)
-    if not input_path.exists():  # pragma: no cover - guarded by callers
-        raise FileNotFoundError(f"Input file does not exist: {input_path}")
+    source_path = Path(source)
+    if source_path.is_dir():
+        candidates = sorted(source_path.glob(INPUT_PATTERN))
+        if not candidates:
+            raise FileNotFoundError(
+                f"No files matching '{INPUT_PATTERN}' found in {source_path}"
+            )
+        input_path = candidates[-1]
+    else:
+        input_path = source_path
+        if not input_path.exists():
+            raise FileNotFoundError(f"Input file does not exist: {input_path}")
 
-    if encodings is None:
-        encodings = DEFAULT_ENCODINGS
+    base_dir = input_path.parent
+    input_name = input_path.name
+    if input_name.startswith("output."):
+        suffix = input_name[len("output.") :]
+        output_name = f"{OUTPUT_PREFIX}{suffix}"
+    else:
+        output_name = f"{OUTPUT_PREFIX}{input_name}"
+    output_path = base_dir / output_name
 
+    encodings = encodings or DEFAULT_ENCODINGS
     df = _read_csv(input_path, encodings=encodings, sep=sep)
 
-    name_columns = [col for col in df.columns if col.endswith("_names")]
-    synonym_columns = [col for col in df.columns if col.endswith("_synonyms")]
+    LOGGER.info("Loaded %d target rows", len(df))
 
-    for col in name_columns:
-        df[col] = _normalise_series(df[col], lowercase=False)
-    for col in synonym_columns:
-        df[col] = _normalise_series(df[col], lowercase=True)
+    # Normalise core textual columns used by analytics.
+    for column in [
+        "target_chembl_id",
+        "organism",
+        "target_names",
+        "gene_symbol",
+        "protein_name_canonical",
+        "protein_name_alt",
+    ]:
+        if column in df.columns:
+            df[column] = df[column].map(NormalizeText)
 
-    records: list[dict[str, str]] = []
-    for row in df.itertuples(index=False):
-        row_dict = row._asdict()
-        target_id = row_dict.get("target_chembl_id", "")
-        isoform_ids = _split_pipe(row_dict.get("isoform_ids", ""))
-        isoform_names = _split_pipe(row_dict.get("isoform_names", ""))
-        isoform_synonyms = [
-            _split_synonyms(value)
-            for value in _split_pipe(row_dict.get("isoform_synonyms", ""))
-        ]
-        for iso_id, iso_name, iso_syns in zip_longest(
-            isoform_ids, isoform_names, isoform_synonyms, fillvalue=""
-        ):
-            # Normalise placeholders that occasionally sneak into the CSV.
-            iso_id = iso_id.strip() if isinstance(iso_id, str) else ""
-            if iso_id.lower() in {"n/a", "none", "na"}:
-                iso_id = ""
-            iso_name = iso_name.strip() if isinstance(iso_name, str) else ""
-            if iso_name.lower() in {"n/a", "none", "na"}:
-                iso_name = ""
+    if "target_names" in df.columns:
+        df["target_name_primary"] = df["target_names"].map(FirstElementText)
 
-            if not iso_name and not iso_syns:
-                continue
+    cellularity_series = df.apply(
+        lambda row: Cellularity.from_row(row, offline=offline, session=session),
+        axis=1,
+    )
+    df["organism_cellularity"] = [
+        c.value if isinstance(c, Cellularity) else ""
+        for c in cellularity_series
+    ]
+    df["organism_cellularity_method"] = [
+        c.method if isinstance(c, Cellularity) else "local"
+        for c in cellularity_series
+    ]
+    df["organism_cellularity_lineage"] = [
+        "|".join(c.lineage) if isinstance(c, Cellularity) else ""
+        for c in cellularity_series
+    ]
 
-            candidates = list(dict.fromkeys([iso_name] if iso_name else []))
-            for synonym in iso_syns or []:
-                if synonym and synonym not in candidates:
-                    candidates.append(synonym)
+    df["is_multifunctional_enzyme"] = df.apply(multifunctional, axis=1)
 
-            for term in candidates:
-                tokens = _syn_expand(term)
-                if not tokens:
-                    continue
-                for token in tokens:
-                    if not token:
-                        continue
-                    records.append(
-                        {
-                            "target_chembl_id": target_id,
-                            "isoform_id": iso_id,
-                            "isoform_name": iso_name,
-                            "term": term,
-                            "token": token,
-                        }
-                    )
+    cellularity_counts = (
+        df["organism_cellularity"].value_counts().sort_index().to_dict()
+    )
+    LOGGER.info("Cellularity distribution: %s", json.dumps(cellularity_counts, sort_keys=True))
+    LOGGER.info(
+        "Multifunctional enzymes: %d of %d",
+        int(df["is_multifunctional_enzyme"].sum()),
+        len(df),
+    )
 
-    if records:
-        result = pd.DataFrame.from_records(records)
-    else:
-        result = pd.DataFrame(
-            columns=["target_chembl_id", "isoform_id", "isoform_name", "term", "token"]
-        )
+    df = _stabilise_columns(df)
 
-    initial_size = len(result)
-    if initial_size:
-        result = result.drop_duplicates(
-            subset=["target_chembl_id", "isoform_id", "term", "token"],
-            keep="first",
-            ignore_index=True,
-        )
-    LOGGER.info("Isoform synonym tokens: %d -> %d rows", initial_size, len(result))
-
-    if len(result):
-        result = result.sort_values(
-            by=["target_chembl_id", "isoform_id", "term", "token"],
-            kind="mergesort",
-            ignore_index=True,
-        )
-
-    output_directory = Path(output_dir) if output_dir is not None else input_path.parent
-    output_path = output_directory / f"isoform.output.{input_path.name}"
-    LOGGER.info("Writing processed target isoforms to %s", output_path)
-    output_directory.mkdir(parents=True, exist_ok=True)
-    result.to_csv(output_path, index=False, encoding="utf-8", line_terminator="\n")
+    LOGGER.info("Writing processed target export to %s", output_path)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False, encoding="utf-8", line_terminator="\n")
     return output_path
+
+
+__all__ = [
+    "NormalizeText",
+    "FirstElementText",
+    "Cellularity",
+    "multifunctional",
+    "process_targets",
+]
+


### PR DESCRIPTION
## Summary
- add a Python port of the target SSoT post-processing pipeline with encoding detection, taxonomy enrichment, and deterministic CSV export
- expose helper utilities for text normalisation, primary element extraction, cellularity inference, and multifunctional flag evaluation via the postprocessing package

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e14ebbb13c832486de3bbd01e76f39