### PR TITLE
Run target isoform post-processing on final CSV outputs

### DIFF
--- a/library/pipelines/target/postprocessing.py
+++ b/library/pipelines/target/postprocessing.py
@@ -17,6 +17,7 @@ from . import organism_classification
 from ...config import Config, IoCfg
 from ...common.csv_utils import write_csv_deterministic
 from ...common.log import logger
+from ...postprocessing import target as target_pp
 
 # Columns removed in the final export
 REMOVE_COLUMNS: list[str] = []
@@ -720,7 +721,7 @@ def finalise_file(
         phylum_col=phylum_col,
         class_col=class_col,
     )
-    write_csv_deterministic(
+    final_path = write_csv_deterministic(
         processed,
         output_path,
         col_order=list(processed.columns),
@@ -729,3 +730,5 @@ def finalise_file(
         encoding=encoding,
         cfg=cfg,
     )
+    if final_path.suffix.lower() == ".csv":
+        target_pp.process_targets(str(final_path), verbose=True)

--- a/library/utils/cli_tools/pipeline_targets_main.py
+++ b/library/utils/cli_tools/pipeline_targets_main.py
@@ -43,6 +43,7 @@ from library.pipelines.common import pipeline_metadata
 from library.pipelines.target.pipeline import run_pipeline
 from library.schemas import TargetsSchema
 from library.schemas.targets import TARGETS_COLUMN_ORDER
+from library.postprocessing import target as target_pp
 
 
 class PipelineConfig(BaseModel):
@@ -432,7 +433,7 @@ def _validate_and_write(
     path.parent.mkdir(parents=True, exist_ok=True)
     key_cols = resolved_key_cols
     col_order: Sequence[str] | None = TARGETS_COLUMN_ORDER if normalize else None
-    write_csv(
+    final_path = write_csv(
         _validated_stream(),
         path,
         cfg=cfg,
@@ -441,7 +442,9 @@ def _validate_and_write(
         key_cols=key_cols,
         col_order=col_order,
     )
-    return path
+    if final_path.suffix.lower() == ".csv":
+        target_pp.process_targets(str(final_path), verbose=True)
+    return final_path
 
 
 def _resolve_optional_output(

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -103,6 +103,7 @@ from library.config import (
 from library.common.csv_utils import write_csv_deterministic
 from library.common.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
+from library.postprocessing import target as target_pp
 from library.pipelines.common import add_pipeline_metadata
 from library import SidecarErrors
 from library.table_quality import analyze_table_quality
@@ -121,6 +122,15 @@ def _override_cli_meta_writer() -> Iterator[None]:
         yield
     finally:
         cli_utils_module.write_meta_yaml = original_cli_write_meta
+
+
+def _run_target_postprocessing(path: Path | str) -> None:
+    """Execute the target isoform post-processing on ``path`` when applicable."""
+
+    final_path = Path(path)
+    if final_path.suffix.lower() != ".csv":
+        return
+    target_pp.process_targets(str(final_path), verbose=True)
 
 
 def _run_pipeline_with_meta(**kwargs: object) -> int:
@@ -1838,10 +1848,12 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 col_order=column_order,
                 chunksize=cfg.io.csv_chunksize,
             )
+            final_path = raw_path
             if final_output != raw_output:
                 shutil.copy2(raw_path, final_output)
-                return final_output
-            return raw_path
+                final_path = final_output
+            _run_target_postprocessing(final_path)
+            return final_path
 
         frames: list[pd.DataFrame] = []
         for chunk in chunks:
@@ -1897,6 +1909,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 key_cols=resolved_keys or None,
                 col_order=TARGETS_COLUMN_ORDER,
             )
+        _run_target_postprocessing(final_path)
         return final_path
 
     failure_path = normalized_output.with_name(
@@ -2986,7 +2999,7 @@ def validate_and_write(
     before_dedup = len(final_df)
     final_df = final_df.drop_duplicates()
     logger.info("deduplicated_rows", dropped=before_dedup - len(final_df))
-    io.write_csv(
+    final_path = io.write_csv(
         final_df,
         normalized_output,
         cfg=cfg,
@@ -2995,6 +3008,7 @@ def validate_and_write(
         col_order=TARGETS_COLUMN_ORDER,
         key_cols=key_columns or None,
     )
+    _run_target_postprocessing(final_path)
     if final_df.empty:
         logger.info(
             "quality_report_skipped",


### PR DESCRIPTION
## Summary
- invoke the target isoform post-processing helper immediately after writing final target CSV exports
- guard against non-CSV outputs while ensuring CLI and pipeline utilities trigger the new post-processing step

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1511d808883249b51381d52bfa4ff