### PR TITLE
Add isoform target post-processing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ outputs.
 | `reports/` | Location where JSON/Markdown test reports are emitted by CI and local runs. |
 | `Makefile` | Convenience targets for formatting, linting, tests and documentation checks. |
 
+
+## Pipelines
+
+### Targets
+
+The targets pipeline produces a deterministic CSV named
+`output.target_<date>.csv` (the date reflects the UTC execution time). After
+the export completes, the repository's post-processing step
+(`library.postprocessing.target.process_targets`) derives an additional file
+`isoform.output.target_<date>.csv` located alongside the main output. The
+helper mirrors the legacy Power Query workbook by normalising
+isoform-specific names, splitting pipe-separated lists and removing duplicate
+`(id, name)` combinations. Both artefacts are written using UTF-8 without BOM
+and share the same metadata sidecars described in the output reference.
+
 A detailed breakdown of sub-packages, glossary and extended guides is available
 in [`docs/en/SUMMARY.md`](./docs/en/SUMMARY.md) and
 [`docs/ru/SUMMARY.md`](./docs/ru/SUMMARY.md).

--- a/docs/OUTPUT_TARGETS_EN.md
+++ b/docs/OUTPUT_TARGETS_EN.md
@@ -1,76 +1,99 @@
-# Target pipeline output: isoform post-processing
 
-This addendum complements the [Output specification](./en/OUTPUT.md) by detailing
-the optional `isoform.*` post-processing stage executed after the target pipeline.
-The same content is available in Russian in
-[`OUTPUT_TARGETS_RU.md`](./OUTPUT_TARGETS_RU.md).
+    # Target pipeline outputs: isoform post-processing
 
-## Post-processing `isoform.*`
+    This document extends the [output reference](./en/OUTPUT.md) and describes the
+    optional `isoform.*` stage executed after the target pipeline has produced
+    `output.target_YYYYMMDD.csv`. The Russian translation is available in
+    [`OUTPUT_TARGETS_RU.md`](./OUTPUT_TARGETS_RU.md).
 
-### Stages
-1. **Read aggregated targets** — load the pipeline CSV using the encoding fallbacks
-   described in `library.postprocessing.target.DEFAULT_ENCODINGS`.
-2. **Normalise name fields** — trim whitespace, collapse sentinels (`"None"`,
-   `"n/a"`), and lowercase synonym columns to mirror the legacy Power Query rules.
-3. **Expand isoforms** — split `isoform_ids`, `isoform_names`, and
-   `isoform_synonyms` on the pipe delimiter and align entries with `zip_longest`.
-4. **Tokenise synonyms** — split colon-separated synonym groups, drop empty
-   variants, preserve order, and generate per-token records via `_syn_expand`.
-5. **Deduplicate & sort** — drop duplicate
-   (`target_chembl_id`, `isoform_id`, `term`, `token`) combinations and sort with
-   a stable mergesort before emission.
-6. **Emit artefact** — write `isoform.output.<original>.csv` encoded as UTF-8 with
-   Unix newlines alongside the source file (or into the chosen output folder).
+    ## `isoform.*` post-processing
 
-### Invariants
-- Output columns are exactly: `target_chembl_id`, `isoform_id`, `isoform_name`,
-  `term`, `token`.
-- `token` values are lowercase ASCII without punctuation; `term` keeps the
-  normalised original text.
-- Rows are globally sorted by (`target_chembl_id`, `isoform_id`, `term`, `token`).
-- Duplicate tokens per isoform are removed while retaining the first occurrence.
-- Empty isoform identifiers are permitted only when at least one synonym/token is
-  present.
-- The writer always uses `\n` line endings to guarantee cross-platform diffs.
+    ### Steps
+    1. **Load the aggregated CSV.** The file is read by trying `utf-8`,
+       `utf-8-sig`, then `cp1252`. Only the columns `isoform_synonyms`,
+       `isoform_names`, `isoform_ids`, `uniprot_id_primary` and
+       `target_chembl_id` are retained.
+    2. **Normalise text.** `isoform_synonyms` and `isoform_names` are converted to
+       lowercase, split by `|`, trimmed and stripped of empty entries. The
+        `isoform_ids` column is split by `|` without changing the letter case.
+    3. **Align records.** Name, identifier and synonym lists are aligned by index
+       with `null` padding when one of the lists is shorter.
+    4. **Tokenise synonyms.** Every synonym is split on `":"`; empty segments are
+       discarded. For each token the variants `[token, token without "pde",
+       token without "pld"]` are generated and deduplicated while keeping the
+       original order.
+    5. **Build tables.** Two tables are produced: `names` from
+       `isoform_names` and `synonyms` from the expanded tokens (renaming the
+       `tokens` column to `name`). The tables are concatenated.
+    6. **Deduplicate.** Three passes are executed in sequence:
+       `distinct(id, name, target_chembl_id, uniprot_id_primary)`, stable sorting
+       by `(uniprot_id_primary, id)` with `mergesort`, followed by
+       `distinct(id, target_chembl_id, name)` and a final `distinct(id, name)`.
+    7. **Export.** The resulting frame is written as
+       `isoform.output.<basename>.csv` next to the input file (or the provided
+       path) using UTF-8 without BOM.
 
-### Example (input → output)
+    ### Invariants
+    - Output columns are exactly `id`, `uniprot_id_primary`,
+      `target_chembl_id`, `name` in that order.
+    - `name` values are lowercase; `id` preserves the original `isoform_ids`
+      casing and may be empty when no identifier was available.
+    - Placeholders `"", "n/a", "none"` are filtered before combining the
+      tables.
+    - The deduplication sequence guarantees deterministic results for identical
+      inputs.
 
-Input snapshot:
-```
-target_chembl_id,isoform_ids,isoform_names,isoform_synonyms
-CHEMBL1824,ENSP00000350283,Nav1.7,"Nav1.7:SCN9A isoform 3"
-CHEMBL1824,ENSP00000350284,"Nav1.7 isoform 2","Nav1.7 splice variant:SCN9A-2"
-CHEMBL6130,,"",""
-CHEMBL240,ENSP00000456012,ALK2,"Activin receptor-like kinase 2:ACVR1"
-CHEMBL259,ENSP00000263253,FGFR4,"FGFR-4 isoform:Fibroblast growth factor receptor-4"
-```
+    ### Example (input → output)
 
-Generated artefact (first 10 lines):
-```
-target_chembl_id,isoform_id,isoform_name,term,token
-CHEMBL1824,ENSP00000350283,Nav1.7,Nav1.7,7
-CHEMBL1824,ENSP00000350283,Nav1.7,Nav1.7,nav1
-CHEMBL1824,ENSP00000350283,Nav1.7,nav1.7,7
-CHEMBL1824,ENSP00000350283,Nav1.7,nav1.7,nav1
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,3
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,isoform
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,scn9a
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,2
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,7
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,isoform
-```
+    Input excerpt `output.target_20250228.csv`:
 
-### Determinism
-- Stable mergesort ordering, explicit newline handling, and deterministic token
-  extraction guarantee repeatable CSVs for identical inputs.
-- The function avoids locale-dependent transformations; all string operations are
-  ASCII and Unicode normalisation free.
-- Randomness, timestamps, and external services are not involved.
+    ```csv
+    target_chembl_id,uniprot_id_primary,isoform_ids,isoform_names,isoform_synonyms
+    CHEMBL3587,P12345,"ENSP0001|ENSP0002","Alpha|Beta","PDE3A:Alpha|Alpha variant|Beta"
+    CHEMBL1250,P67890,"ENSP0003","Gamma","Gamma isoform 1|PLD1A"
+    CHEMBL3135,Q11111,"","",""
+    CHEMBL2205,Q22222,"ENSP0004","None","None"
+    ```
 
-### Version requirements
-- `chembl-data-acquisition` **0.1.3** or newer (provides
-  `library.postprocessing.target.process_targets`).
-- Python **3.11** runtime (matching the project constraint).
-- `pandas` **2.3.3** to ensure availability of the dataframe operations used.
-- When invoked from the CLI helper, ensure the main output schema follows
-  [`docs/en/OUTPUT.md`](./en/OUTPUT.md) so that column expectations match.
+    Resulting `isoform.output.target_20250228.csv`:
+
+    ```csv
+    id,uniprot_id_primary,target_chembl_id,name
+    ,P12345,CHEMBL3587,beta
+    ENSP0001,P12345,CHEMBL3587,alpha
+    ENSP0001,P12345,CHEMBL3587,pde3a
+    ENSP0001,P12345,CHEMBL3587,3a
+    ENSP0002,P12345,CHEMBL3587,beta
+    ENSP0002,P12345,CHEMBL3587,alpha variant
+    ,P67890,CHEMBL1250,pld1a
+    ,P67890,CHEMBL1250,1a
+    ENSP0003,P67890,CHEMBL1250,gamma
+    ENSP0003,P67890,CHEMBL1250,gamma isoform 1
+    ```
+
+    ### Determinism
+    - Sorting uses the stable `mergesort` algorithm, ensuring identical ordering
+      on repeated runs.
+    - The transformation is pure: no randomness, timestamps or locale-dependent
+      operations are involved.
+    - Output encoding is UTF-8 without BOM and uses Unix (`
+`) line endings.
+
+    ### Compatibility
+    - `library.postprocessing.target.process_targets` is available starting from
+      `chembl-data-acquisition` 0.1.3.
+    - Python 3.11+ and `pandas` 2.3.x are required.
+    - The input CSV must follow the targets schema described in
+      [`docs/en/OUTPUT.md`](./en/OUTPUT.md).
+
+    ### Usage example
+
+    ```bash
+    python - <<'PY'
+    from library.postprocessing import target
+    target.process_targets("data/output/output.target_20250228.csv")
+    PY
+    ```
+
+    The command produces `data/output/isoform.output.target_20250228.csv` with
+    isoform names aligned to the Power Query logic.

--- a/docs/OUTPUT_TARGETS_RU.md
+++ b/docs/OUTPUT_TARGETS_RU.md
@@ -1,78 +1,98 @@
-# Выходные данные пайплайна целей: постобработка isoform
 
-Это дополнение уточняет [руководство по выходам](./ru/OUTPUT.md) и описывает
-необязательный этап постобработки `isoform.*`, выполняемый после пайплайна
-целей. Эквиваличная английская версия доступна в
-[`OUTPUT_TARGETS_EN.md`](./OUTPUT_TARGETS_EN.md).
+    # Выходные данные пайплайна целей: постобработка isoform
 
-## Постобработка `isoform.*`
+    Дополнение к [описанию выходов](./ru/OUTPUT.md), описывающее этап
+    `isoform.*`, выполняемый поверх CSV `output.target_YYYYMMDD.csv`. Эквиваличный
+    материал на английском приведён в
+    [`OUTPUT_TARGETS_EN.md`](./OUTPUT_TARGETS_EN.md).
 
-### Этапы
-1. **Чтение агрегированного CSV** — загрузка файла пайплайна с использованием
-   набора кодировок из `library.postprocessing.target.DEFAULT_ENCODINGS`.
-2. **Нормализация полей имён** — обрезка пробелов, удаление служебных значений
-   (`"None"`, `"n/a"`), приведение столбцов с синонимами к нижнему регистру по
-   правилам наследованного Power Query.
-3. **Развёртка изоформ** — разбиение `isoform_ids`, `isoform_names` и
-   `isoform_synonyms` по символу `|` и выравнивание записей через `zip_longest`.
-4. **Токенизация синонимов** — деление групп, разделённых двоеточием, фильтрация
-   пустых значений, сохранение порядка и генерация записей `_syn_expand` для
-   каждого токена.
-5. **Удаление дублей и сортировка** — удаление повторов по ключу
-   (`target_chembl_id`, `isoform_id`, `term`, `token`) и стабильная сортировка
-   перед сохранением.
-6. **Выгрузка артефакта** — запись `isoform.output.<original>.csv` в UTF-8 с
-   переводами строк `\n` рядом с исходным файлом (или в указанную папку).
+    ## Постобработка `isoform.*`
 
-### Инварианты
-- В выходе присутствуют строго столбцы: `target_chembl_id`, `isoform_id`,
-  `isoform_name`, `term`, `token`.
-- Значения `token` — строчные ASCII без пунктуации; `term` сохраняет
-  нормализованный исходный текст.
-- Строки отсортированы по (`target_chembl_id`, `isoform_id`, `term`, `token`).
-- Повторяющиеся токены внутри изоформ удаляются с сохранением первого вхождения.
-- Пустой `isoform_id` допустим только при наличии хотя бы одного синонима/токена.
-- Файл всегда записывается с окончаниями строк `\n`, что исключает платформенные
-  расхождения.
+    ### Этапы
+    1. **Загрузка входного CSV.** Файл читается с перебором кодировок
+       `utf-8`, `utf-8-sig`, `cp1252`. Из таблицы выбираются только столбцы
+       `isoform_synonyms`, `isoform_names`, `isoform_ids`, `uniprot_id_primary`,
+       `target_chembl_id`.
+    2. **Нормализация строк.** `isoform_synonyms` и `isoform_names`
+       переводятся в нижний регистр и разбиваются по символу `|` с обрезкой
+       пробелов и удалением пустых элементов. `isoform_ids` разбиваются по `|`
+       без изменения регистра.
+    3. **Выравнивание записей.** Списки имён, идентификаторов и синонимов
+       выравниваются по индексу, недостающие элементы заполняются `null`.
+    4. **Токенизация синонимов.** Каждый синоним разбивается по `":"`, пустые
+       части удаляются. Для каждого токена строятся варианты
+       `[token, token без "pde", token без "pld"]` с устранением дубликатов.
+    5. **Формирование таблиц.** Создаются две таблицы: `names` — из
+       нормализованных `isoform_names`, и `synonyms` — из токенов. После
+       переименования столбца `tokens` в `name` обе таблицы объединяются.
+    6. **Удаление дублей.** Последовательно выполняются три шага:
+       `distinct(id, name, target_chembl_id, uniprot_id_primary)`, стабильная
+       сортировка по `(uniprot_id_primary, id)` и `distinct(id, target_chembl_id, name)`,
+       затем финальный `distinct(id, name)`.
+    7. **Экспорт.** Результат записывается в файл
+       `isoform.output.<basename>.csv` рядом с исходным CSV (или по указанному
+       пути) в кодировке UTF-8 без BOM.
 
-### Пример (вход → выход)
+    ### Инварианты
+    - Столбцы результата: ровно `id`, `uniprot_id_primary`, `target_chembl_id`,
+      `name` в указанном порядке.
+    - `name` всегда в нижнем регистре; `id` сохраняет регистр входного
+      `isoform_ids` (заполняется `null`, если идентификатор отсутствовал).
+    - Дубликаты удаляются строго в порядке, задающем стабильный и
+      воспроизводимый вывод.
+    - Поля `"", "n/a", "none"` отфильтровываются перед объединением таблиц.
 
-Фрагмент входного файла:
-```
-target_chembl_id,isoform_ids,isoform_names,isoform_synonyms
-CHEMBL1824,ENSP00000350283,Nav1.7,"Nav1.7:SCN9A isoform 3"
-CHEMBL1824,ENSP00000350284,"Nav1.7 isoform 2","Nav1.7 splice variant:SCN9A-2"
-CHEMBL6130,,"",""
-CHEMBL240,ENSP00000456012,ALK2,"Activin receptor-like kinase 2:ACVR1"
-CHEMBL259,ENSP00000263253,FGFR4,"FGFR-4 isoform:Fibroblast growth factor receptor-4"
-```
+    ### Пример (вход → выход)
 
-Полученный артефакт (первые 10 строк):
-```
-target_chembl_id,isoform_id,isoform_name,term,token
-CHEMBL1824,ENSP00000350283,Nav1.7,Nav1.7,7
-CHEMBL1824,ENSP00000350283,Nav1.7,Nav1.7,nav1
-CHEMBL1824,ENSP00000350283,Nav1.7,nav1.7,7
-CHEMBL1824,ENSP00000350283,Nav1.7,nav1.7,nav1
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,3
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,isoform
-CHEMBL1824,ENSP00000350283,Nav1.7,scn9a isoform 3,scn9a
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,2
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,7
-CHEMBL1824,ENSP00000350284,Nav1.7 isoform 2,Nav1.7 isoform 2,isoform
-```
+    Входной фрагмент `output.target_20250228.csv`:
 
-### Детерминированность
-- Стабильная сортировка, явное управление переводами строк и детерминированная
-  токенизация гарантируют идентичный CSV при повторных запусках.
-- Операции со строками независимы от локали; не выполняется нормализация Unicode.
-- В процессе отсутствуют случайность, временные метки и обращения к внешним
-  сервисам.
+    ```csv
+    target_chembl_id,uniprot_id_primary,isoform_ids,isoform_names,isoform_synonyms
+    CHEMBL3587,P12345,"ENSP0001|ENSP0002","Alpha|Beta","PDE3A:Alpha|Alpha variant|Beta"
+    CHEMBL1250,P67890,"ENSP0003","Gamma","Gamma isoform 1|PLD1A"
+    CHEMBL3135,Q11111,"","",""
+    CHEMBL2205,Q22222,"ENSP0004","None","None"
+    ```
 
-### Требования к версиям
-- `chembl-data-acquisition` **0.1.3** или новее (функция
-  `library.postprocessing.target.process_targets`).
-- Python **3.11** (соответствует ограничению проекта).
-- `pandas` **2.3.3** — для используемых операций DataFrame.
-- При вызове из CLI необходимо, чтобы основной CSV соответствовал схеме из
-  [`docs/ru/OUTPUT.md`](./ru/OUTPUT.md), иначе ожидаемые столбцы не совпадут.
+    Результат `isoform.output.target_20250228.csv`:
+
+    ```csv
+    id,uniprot_id_primary,target_chembl_id,name
+    ,P12345,CHEMBL3587,beta
+    ENSP0001,P12345,CHEMBL3587,alpha
+    ENSP0001,P12345,CHEMBL3587,pde3a
+    ENSP0001,P12345,CHEMBL3587,3a
+    ENSP0002,P12345,CHEMBL3587,beta
+    ENSP0002,P12345,CHEMBL3587,alpha variant
+    ,P67890,CHEMBL1250,pld1a
+    ,P67890,CHEMBL1250,1a
+    ENSP0003,P67890,CHEMBL1250,gamma
+    ENSP0003,P67890,CHEMBL1250,gamma isoform 1
+    ```
+
+    ### Детерминизм
+    - Сортировка выполняется стабильным `mergesort`, что обеспечивает одинаковый
+      порядок строк при повторных запусках.
+    - Операции не зависят от локали, даты или случайных чисел; результат
+      воспроизводим при неизменном входе.
+    - Кодировка вывода — UTF-8 без BOM, перевод строки `
+`.
+
+    ### Совместимость
+    - Функция `library.postprocessing.target.process_targets` доступна начиная с
+      версии `chembl-data-acquisition` 0.1.3.
+    - Требуемая версия Python — 3.11+, библиотека `pandas` — 2.3.x.
+    - Ожидается, что входной файл соответствует схеме таргетов, описанной в
+      [`docs/ru/OUTPUT.md`](./ru/OUTPUT.md).
+
+    ### Пример запуска
+
+    ```bash
+    python - <<'PY'
+    from library.postprocessing import target
+    target.process_targets("data/output/output.target_20250228.csv")
+    PY
+    ```
+
+    В результате появится файл `data/output/isoform.output.target_20250228.csv`
+    с постобработанными именами изоформ.

--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -1,234 +1,288 @@
-"""Target post-processing helpers.
-
-This module implements a lightweight transformation that mirrors the
-Power Query workbook used during the early iterations of the pipeline.
-The intent is to keep a deterministic, fully scripted variant that can
-be exercised in automated tests without relying on Excel.
-"""
+"""Power Query-equivalent target isoform post-processing."""
 
 from __future__ import annotations
 
-import logging
-import re
-from itertools import zip_longest
 from pathlib import Path
 from typing import Iterable, Sequence
 
 import pandas as pd
 
-LOGGER = logging.getLogger(__name__)
-
-# Power Query relied on a UTF-8 CSV exported from Excel, but there are a few
-# legacy snapshots encoded in various Windows code pages.  The function below
-# mimics the behaviour by attempting a handful of common encodings before
-# giving up.
-DEFAULT_ENCODINGS: Sequence[str] = (
-    "utf-8-sig",
-    "utf-8",
-    "cp1251",
-    "cp1252",
-    "latin-1",
-)
-
-# Tokens are extracted with a simple alphanumeric matcher.  Hyphens and other
-# separators are treated as token boundaries which mirrors the SynExpand step
-# present in the original Power Query file.
-TOKEN_PATTERN = re.compile(r"[A-Za-z0-9']+")
+DEFAULT_ENCODINGS: Sequence[str] = ("utf-8", "utf-8-sig", "cp1252")
+SOURCE_COLUMNS: list[str] = [
+    "isoform_synonyms",
+    "isoform_names",
+    "isoform_ids",
+    "uniprot_id_primary",
+    "target_chembl_id",
+]
+OUTPUT_COLUMNS: list[str] = ["id", "uniprot_id_primary", "target_chembl_id", "name"]
+DEFAULT_INPUT_DIR = Path("data/output")
 
 
-def _normalise_series(series: pd.Series, *, lowercase: bool) -> pd.Series:
-    """Return a cleaned copy of ``series``.
+def _to_text(value: object) -> str:
+    """Mirror the Power Query ``ToText`` helper by normalising nulls."""
 
-    Empty values and sentinel strings such as ``"None"`` or ``"n/a"`` are
-    converted to the empty string.  When ``lowercase`` is true, the
-    normalised values are converted to lower case to replicate the synonym
-    handling that Power Query performed.
-    """
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    if pd.isna(value):  # type: ignore[arg-type]
+        return ""
+    return str(value)
 
-    if series.empty:
-        return series.copy()
 
-    cleaned = (
-        series.fillna("")
-        .astype(str)
-        .str.strip()
-        .str.replace(r"\s+", " ", regex=True)
+def _split_pipes(value: object) -> list[str]:
+    """Split ``value`` by ``"|"`` removing blanks."""
+
+    text = _to_text(value)
+    if not text:
+        return []
+    parts = [part.strip() for part in text.split("|")]
+    return [part for part in parts if part]
+
+
+def _make_triples(
+    names: Iterable[str] | None,
+    ids: Iterable[str] | None,
+    syns: Iterable[str] | None,
+) -> list[dict[str, str | None]]:
+    """Align names, ids and synonyms by index padding with ``None``."""
+
+    name_list = list(names or [])
+    id_list = list(ids or [])
+    syn_list = list(syns or [])
+    n = max(len(name_list), len(id_list), len(syn_list))
+    if n == 0:
+        return []
+    triples: list[dict[str, str | None]] = []
+    for idx in range(n):
+        triples.append(
+            {
+                "name": name_list[idx] if idx < len(name_list) else None,
+                "id": id_list[idx] if idx < len(id_list) else None,
+                "synonym": syn_list[idx] if idx < len(syn_list) else None,
+            }
+        )
+    return triples
+
+
+def _syn_expand(value: object) -> list[str]:
+    """Return variants of ``value`` by stripping ``pde`` and ``pld`` substrings."""
+
+    text = _to_text(value).strip().lower()
+    if not text:
+        return []
+    candidates = [text, text.replace("pde", ""), text.replace("pld", "")]
+    result: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            result.append(candidate)
+    return result
+
+
+def _tokenize_synonym(value: object) -> list[str]:
+    """Split synonyms on ``":"`` and expand tokens using :func:`_syn_expand`."""
+
+    text = _to_text(value)
+    if not text:
+        return []
+    parts = [segment.strip() for segment in text.split(":")]
+    non_empty = [part for part in parts if part]
+    variants: list[str] = []
+    for part in non_empty:
+        for token in _syn_expand(part):
+            if token not in variants:
+                variants.append(token)
+    return variants
+
+
+def _dedupe_stage1(df: pd.DataFrame) -> pd.DataFrame:
+    return df.drop_duplicates(
+        subset=["id", "name", "target_chembl_id", "uniprot_id_primary"], keep="first"
     )
-    cleaned = cleaned.replace(
-        to_replace=r"(?i)^(?:na|n/a|none|n\\.?a\\.?|n\s*/\s*a)$",
-        value="",
-        regex=True,
+
+
+def _stable_sort(df: pd.DataFrame) -> pd.DataFrame:
+    return df.sort_values(
+        by=["uniprot_id_primary", "id"], kind="mergesort", na_position="first"
     )
-    if lowercase:
-        cleaned = cleaned.str.lower()
-    return cleaned
 
 
-def _split_pipe(value: str) -> list[str]:
-    if not value or not isinstance(value, str):
-        return []
-    return [part.strip() for part in value.split("|") if part.strip()]
+def _dedupe_stage2(df: pd.DataFrame) -> pd.DataFrame:
+    return df.drop_duplicates(subset=["id", "target_chembl_id", "name"], keep="first")
 
 
-def _split_synonyms(value: str) -> list[str]:
-    if not value or not isinstance(value, str):
-        return []
-    parts = [segment.strip() for segment in value.split(":") if segment.strip()]
-    unique: list[str] = []
-    for part in parts:
-        lower = part.lower()
-        if lower in {"n/a", "none", "na"}:
-            continue
-        if part not in unique:
-            unique.append(part)
-    return unique
+def _dedupe_stage3(df: pd.DataFrame) -> pd.DataFrame:
+    return df.drop_duplicates(subset=["id", "name"], keep="first")
 
 
-def _syn_expand(term: str) -> list[str]:
-    if not term:
-        return []
-    tokens = TOKEN_PATTERN.findall(term.lower())
-    # Preserve order whilst removing duplicates.
-    return list(dict.fromkeys(tokens))
+def _transform_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, int]]:
+    missing = [column for column in SOURCE_COLUMNS if column not in frame.columns]
+    if missing:
+        raise ValueError(
+            "Input CSV is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+    projected = frame[SOURCE_COLUMNS].copy()
+    projected["isoform_synonyms"] = projected["isoform_synonyms"].map(
+        lambda x: _to_text(x).lower()
+    )
+    projected["isoform_names"] = projected["isoform_names"].map(
+        lambda x: _to_text(x).lower()
+    )
+    projected["isoform_synonyms"] = projected["isoform_synonyms"].map(_split_pipes)
+    projected["isoform_names"] = projected["isoform_names"].map(_split_pipes)
+    projected["isoform_ids"] = projected["isoform_ids"].map(_split_pipes)
+
+    projected["triples"] = projected.apply(
+        lambda row: _make_triples(
+            row["isoform_names"], row["isoform_ids"], row["isoform_synonyms"]
+        ),
+        axis=1,
+    )
+
+    rows = projected.explode("triples", ignore_index=True)
+    rows = rows[rows["triples"].notna()].reset_index(drop=True)
+    if rows.empty:
+        expanded = pd.DataFrame(
+            columns=[
+                "uniprot_id_primary",
+                "target_chembl_id",
+                "name",
+                "id",
+                "synonym",
+            ]
+        )
+    else:
+        triple_df = pd.DataFrame(rows["triples"].tolist(), columns=["name", "id", "synonym"])
+        expanded = pd.concat(
+            [
+                rows[
+                    ["uniprot_id_primary", "target_chembl_id"]
+                ].reset_index(drop=True),
+                triple_df,
+            ],
+            axis=1,
+        )
+
+    expanded["tokens"] = expanded["synonym"].map(_tokenize_synonym)
+
+    names_raw = expanded[["id", "uniprot_id_primary", "target_chembl_id", "name"]].copy()
+    names_raw["name"] = names_raw["name"].map(lambda x: _to_text(x).strip())
+    names_clean = names_raw[~names_raw["name"].isin(["", "n/a", "none"])].copy()
+
+    syns_raw = expanded[["id", "uniprot_id_primary", "target_chembl_id", "tokens"]].copy()
+    syns_exploded = syns_raw.explode("tokens", ignore_index=True)
+    if syns_exploded.empty:
+        syns_clean = pd.DataFrame(
+            columns=["id", "uniprot_id_primary", "target_chembl_id", "name"]
+        )
+    else:
+        syns_exploded["tokens"] = syns_exploded["tokens"].map(
+            lambda x: _to_text(x).strip()
+        )
+        syns_clean = syns_exploded[
+            ~syns_exploded["tokens"].isin(["", "n/a", "none"])
+        ].copy()
+        syns_clean = syns_clean.rename(columns={"tokens": "name"})
+
+    combined = pd.concat([names_clean, syns_clean], ignore_index=True)
+    dedup_stage1 = _dedupe_stage1(combined)
+    sorted_df = _stable_sort(dedup_stage1)
+    dedup_stage2 = _dedupe_stage2(sorted_df)
+    result = _dedupe_stage3(dedup_stage2).reset_index(drop=True)
+
+    if result.empty:
+        final_df = pd.DataFrame(columns=OUTPUT_COLUMNS)
+    else:
+        final_df = result[OUTPUT_COLUMNS]
+
+    stats = {
+        "combined": len(combined),
+        "stage1": len(dedup_stage1),
+        "stage2": len(dedup_stage2),
+        "stage3": len(final_df),
+    }
+    return final_df, stats
 
 
-def _read_csv(path: Path, *, encodings: Iterable[str], sep: str) -> pd.DataFrame:
+def _read_csv_with_fallback(
+    path: Path, *, encodings: Sequence[str]
+) -> tuple[pd.DataFrame, str]:
     last_error: Exception | None = None
     for encoding in encodings:
         try:
-            LOGGER.info("Reading target isoform table from %s (encoding=%s)", path, encoding)
-            return pd.read_csv(path, dtype=str, encoding=encoding, sep=sep)
-        except UnicodeDecodeError as exc:  # pragma: no cover - defensive
+            frame = pd.read_csv(path, dtype=object, encoding=encoding)
+        except UnicodeDecodeError as exc:
             last_error = exc
             continue
+        else:
+            return frame, encoding
     if last_error is not None:
         raise last_error
     raise UnicodeDecodeError("utf-8", b"", 0, 1, "unable to decode input")
 
 
+def _latest_output_file(directory: Path) -> Path:
+    candidates = [
+        path
+        for path in directory.glob("output.target_*.csv")
+        if path.is_file()
+    ]
+    if not candidates:
+        raise FileNotFoundError(
+            f"No files matching 'output.target_*.csv' found in {directory}"
+        )
+    return max(candidates, key=lambda item: item.stat().st_mtime)
+
+
 def process_targets(
-    source: Path | str,
-    *,
-    output_dir: Path | str | None = None,
-    sep: str = ",",
-    encodings: Sequence[str] | None = None,
+    input_csv: str | None = None,
+    output_csv: str | None = None,
+    verbose: bool = True,
 ) -> Path:
-    """Process the aggregated target CSV produced by :mod:`scripts.get_target_data`.
+    """Process target isoform information using the Power Query pipeline."""
 
-    The transformation mirrors the legacy Power Query workbook.  It reads the
-    CSV, normalises name and synonym columns, expands pipe-separated fields
-    into per-isoform entries, performs a synonym tokenisation step and writes
-    the result to an ``isoform.output.<original>`` file located alongside the
-    source file (or in ``output_dir`` when provided).
-
-    Parameters
-    ----------
-    source:
-        Path to the CSV file that should be processed.
-    output_dir:
-        Optional destination directory.  When omitted the output is written to
-        the same directory as ``source``.
-    sep:
-        Field separator used in the CSV.  Defaults to a comma.
-    encodings:
-        Ordered list of encodings that will be attempted while reading the
-        source file.  The first successful attempt stops the search.
-
-    Returns
-    -------
-    pathlib.Path
-        Path to the generated output file.
-    """
-
-    input_path = Path(source)
-    if not input_path.exists():  # pragma: no cover - guarded by callers
+    if input_csv is None:
+        search_dir = DEFAULT_INPUT_DIR
+        input_path = _latest_output_file(search_dir)
+    else:
+        input_path = Path(input_csv)
+    if not input_path.exists():
         raise FileNotFoundError(f"Input file does not exist: {input_path}")
 
-    if encodings is None:
-        encodings = DEFAULT_ENCODINGS
-
-    df = _read_csv(input_path, encodings=encodings, sep=sep)
-
-    name_columns = [col for col in df.columns if col.endswith("_names")]
-    synonym_columns = [col for col in df.columns if col.endswith("_synonyms")]
-
-    for col in name_columns:
-        df[col] = _normalise_series(df[col], lowercase=False)
-    for col in synonym_columns:
-        df[col] = _normalise_series(df[col], lowercase=True)
-
-    records: list[dict[str, str]] = []
-    for row in df.itertuples(index=False):
-        row_dict = row._asdict()
-        target_id = row_dict.get("target_chembl_id", "")
-        isoform_ids = _split_pipe(row_dict.get("isoform_ids", ""))
-        isoform_names = _split_pipe(row_dict.get("isoform_names", ""))
-        isoform_synonyms = [
-            _split_synonyms(value)
-            for value in _split_pipe(row_dict.get("isoform_synonyms", ""))
-        ]
-        for iso_id, iso_name, iso_syns in zip_longest(
-            isoform_ids, isoform_names, isoform_synonyms, fillvalue=""
-        ):
-            # Normalise placeholders that occasionally sneak into the CSV.
-            iso_id = iso_id.strip() if isinstance(iso_id, str) else ""
-            if iso_id.lower() in {"n/a", "none", "na"}:
-                iso_id = ""
-            iso_name = iso_name.strip() if isinstance(iso_name, str) else ""
-            if iso_name.lower() in {"n/a", "none", "na"}:
-                iso_name = ""
-
-            if not iso_name and not iso_syns:
-                continue
-
-            candidates = list(dict.fromkeys([iso_name] if iso_name else []))
-            for synonym in iso_syns or []:
-                if synonym and synonym not in candidates:
-                    candidates.append(synonym)
-
-            for term in candidates:
-                tokens = _syn_expand(term)
-                if not tokens:
-                    continue
-                for token in tokens:
-                    if not token:
-                        continue
-                    records.append(
-                        {
-                            "target_chembl_id": target_id,
-                            "isoform_id": iso_id,
-                            "isoform_name": iso_name,
-                            "term": term,
-                            "token": token,
-                        }
-                    )
-
-    if records:
-        result = pd.DataFrame.from_records(records)
+    if output_csv is None:
+        output_path = input_path.with_name(f"isoform.{input_path.name}")
     else:
-        result = pd.DataFrame(
-            columns=["target_chembl_id", "isoform_id", "isoform_name", "term", "token"]
+        output_path = Path(output_csv)
+
+    frame, encoding = _read_csv_with_fallback(input_path, encodings=DEFAULT_ENCODINGS)
+    if verbose:
+        print(
+            f"[target.postprocessing] reading '{input_path}' with encoding {encoding}; rows={len(frame)}"
         )
 
-    initial_size = len(result)
-    if initial_size:
-        result = result.drop_duplicates(
-            subset=["target_chembl_id", "isoform_id", "term", "token"],
-            keep="first",
-            ignore_index=True,
+    transformed, stats = _transform_frame(frame)
+    if verbose:
+        print(
+            f"[target.postprocessing] union rows={stats['combined']}"
         )
-    LOGGER.info("Isoform synonym tokens: %d -> %d rows", initial_size, len(result))
-
-    if len(result):
-        result = result.sort_values(
-            by=["target_chembl_id", "isoform_id", "term", "token"],
-            kind="mergesort",
-            ignore_index=True,
+        print(
+            f"[target.postprocessing] dedup stage1 {stats['combined']} -> {stats['stage1']}"
+        )
+        print(
+            f"[target.postprocessing] dedup stage2 {stats['stage1']} -> {stats['stage2']}"
+        )
+        print(
+            f"[target.postprocessing] dedup stage3 {stats['stage2']} -> {stats['stage3']}"
         )
 
-    output_directory = Path(output_dir) if output_dir is not None else input_path.parent
-    output_path = output_directory / f"isoform.output.{input_path.name}"
-    LOGGER.info("Writing processed target isoforms to %s", output_path)
-    output_directory.mkdir(parents=True, exist_ok=True)
-    result.to_csv(output_path, index=False, encoding="utf-8", lineterminator="\n")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    transformed.to_csv(output_path, index=False, encoding="utf-8")
+
+    if verbose:
+        unique_ids = transformed["id"].nunique(dropna=True) if not transformed.empty else 0
+        print(
+            f"[target.postprocessing] wrote '{output_path}' with {stats['stage3']} rows; unique ids={unique_ids}"
+        )
     return output_path

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -82,6 +82,7 @@ from library.integration import iuphar_library as ii
 from library.integration import uniprot_library as uu
 from library.pipelines.target import protein_classification as pc
 from library.pipelines.target import postprocessing as tp
+from library.postprocessing import target as target_pp
 from library.pipelines.target.defaults import ModeDefaults, TARGET_MODE_DEFAULTS
 from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
@@ -3106,6 +3107,16 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
             raw_format=raw_format,
             reindex_raw=reindex_raw,
         )
+        if exit_code == 0:
+            try:
+                target_pp.process_targets(str(final_output), verbose=True)
+            except Exception as exc:
+                logger.error(
+                    "isoform_postprocessing_failed",
+                    error=str(exc),
+                    input=str(final_output),
+                )
+                return 1
         return exit_code
     except (FileNotFoundError, ValueError, OSError, RuntimeError) as exc:
         logger.error(

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -1,6 +1,7 @@
+
 from __future__ import annotations
 
-import io
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -10,337 +11,236 @@ from library.postprocessing import target
 
 
 @pytest.mark.unit
-def test_normalise_series__strips_and_normalises():
-    series = pd.Series(["  Alpha  ", "n/a", None, " NA "])
-
-    result = target._normalise_series(series, lowercase=False)
-
-    assert result.tolist() == ["Alpha", "", "", ""]
+def test_split_pipes__handles_empty_and_whitespace():
+    assert target._split_pipes("") == []
+    assert target._split_pipes("a|b") == ["a", "b"]
+    assert target._split_pipes(" a | | b ") == ["a", "b"]
 
 
 @pytest.mark.unit
-def test_normalise_series__applies_lowercase():
-    series = pd.Series(["Beta", " Mixed Case ", "NONE"])
-
-    result = target._normalise_series(series, lowercase=True)
-
-    assert result.tolist() == ["beta", "mixed case", ""]
-
-
-@pytest.mark.unit
-def test_normalise_series__empty_series_returns_copy():
-    series = pd.Series(dtype=str)
-
-    result = target._normalise_series(series, lowercase=True)
-
-    assert result.empty
-    assert result.dtype == series.dtype
+def test_make_triples__pads_shorter_lists():
+    triples = target._make_triples(["alpha", "beta"], ["ID1"], ["syn1", "syn2", "syn3"])
+    assert triples == [
+        {"name": "alpha", "id": "ID1", "synonym": "syn1"},
+        {"name": "beta", "id": None, "synonym": "syn2"},
+        {"name": None, "id": None, "synonym": "syn3"},
+    ]
 
 
 @pytest.mark.unit
-def test_split_pipe__filters_whitespace_and_blanks():
-    assert target._split_pipe(" value | |second|") == ["value", "second"]
-    assert target._split_pipe("") == []
-    assert target._split_pipe(None) == []  # type: ignore[arg-type]
+def test_syn_expand__produces_variants():
+    assert target._syn_expand("PDE3A") == ["pde3a", "3a"]
+    assert target._syn_expand("PLD2A") == ["pld2a", "2a"]
 
 
 @pytest.mark.unit
-def test_split_synonyms__deduplicates_and_skips_placeholders():
-    value = "Alpha : beta : NA : Beta : none"
-
-    assert target._split_synonyms(value) == ["Alpha", "beta", "Beta"]
-    assert target._split_synonyms(None) == []  # type: ignore[arg-type]
+def test_tokenize_synonym__pde3a_alpha():
+    assert target._tokenize_synonym("PDE3A:alpha") == ["pde3a", "3a", "alpha"]
 
 
-@pytest.mark.unit
-def test_syn_expand__tokenises_and_deduplicates():
-    term = "Alpha-beta gamma Alpha"
-
-    assert target._syn_expand(term) == ["alpha", "beta", "gamma"]
-
-
-@pytest.mark.unit
-def test_read_csv__tries_multiple_encodings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    attempted: list[str] = []
-
-    def fake_read_csv(path: Path, *, dtype, encoding: str, sep: str):  # type: ignore[override]
-        attempted.append(encoding)
-        if encoding != "utf-8":
-            raise UnicodeDecodeError("utf-8", b"", 0, 1, "boom")
-        return pd.DataFrame({"column": ["value"]})
-
-    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
-
-    csv_path = tmp_path / "input.csv"
-    csv_path.write_text("column\nvalue\n", encoding="utf-8")
-
-    frame = target._read_csv(csv_path, encodings=("utf-8-sig", "utf-8"), sep=",")
-
-    assert attempted == ["utf-8-sig", "utf-8"]
-    assert frame.to_dict(orient="list") == {"column": ["value"]}
-
-
-@pytest.mark.unit
-def test_read_csv__raises_last_unicode_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    def failing_read_csv(path: Path, *, dtype, encoding: str, sep: str):  # type: ignore[override]
-        raise UnicodeDecodeError(encoding, b"", 0, 1, "boom")
-
-    monkeypatch.setattr(pd, "read_csv", failing_read_csv)
-
-    csv_path = tmp_path / "input.csv"
-    csv_path.write_text("column\nvalue\n", encoding="utf-8")
-
-    with pytest.raises(UnicodeDecodeError):
-        target._read_csv(csv_path, encodings=("utf-8",), sep=",")
-
-
-@pytest.mark.unit
-def test_process_targets__produces_expected_csv_structure(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
-    frame = pd.DataFrame(
+def _build_sample_frame() -> pd.DataFrame:
+    return pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T1",
-                "isoform_ids": "ENSP0001",
-                "isoform_names": "Alpha",
-                "isoform_synonyms": "Alpha:Alpha Variant",
+                "isoform_synonyms": "PDE3A:Alpha|Beta Variant",
+                "isoform_names": "Alpha|Beta",
+                "isoform_ids": "EnSp1|ENSP2",
+                "uniprot_id_primary": "U1",
+                "target_chembl_id": "CHEMBL1",
             }
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
-
-    output_path = target.process_targets(input_path)
-    result = pd.read_csv(output_path)
-
-    assert list(result.columns) == [
-        "target_chembl_id",
-        "isoform_id",
-        "isoform_name",
-        "term",
-        "token",
-    ]
-    assert result.to_dict(orient="records") == [
-        {
-            "target_chembl_id": "CHEMBL_T1",
-            "isoform_id": "ENSP0001",
-            "isoform_name": "Alpha",
-            "term": "Alpha",
-            "token": "alpha",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T1",
-            "isoform_id": "ENSP0001",
-            "isoform_name": "Alpha",
-            "term": "alpha",
-            "token": "alpha",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T1",
-            "isoform_id": "ENSP0001",
-            "isoform_name": "Alpha",
-            "term": "alpha variant",
-            "token": "alpha",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T1",
-            "isoform_id": "ENSP0001",
-            "isoform_name": "Alpha",
-            "term": "alpha variant",
-            "token": "variant",
-        },
-    ]
 
 
 @pytest.mark.unit
-def test_process_targets__filters_rows_without_terms(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
+def test_transform_frame__normalises_names_preserves_ids():
+    frame = _build_sample_frame()
+    result, _ = target._transform_frame(frame)
+
+    assert all(name == name.lower() for name in result["name"])
+    assert "EnSp1" in result["id"].tolist()
+
+
+@pytest.mark.unit
+def test_transform_frame__filters_placeholder_names():
     frame = pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T2",
-                "isoform_ids": "",
-                "isoform_names": "",
-                "isoform_synonyms": "",
+                "isoform_synonyms": "SynA|None|n/a",
+                "isoform_names": "Alpha|n/a|none|",
+                "isoform_ids": "ID1|ID2|ID3",
+                "uniprot_id_primary": "U1",
+                "target_chembl_id": "CHEMBL1",
             }
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
+    result, _ = target._transform_frame(frame)
 
-    output_path = target.process_targets(input_path)
-    result = pd.read_csv(output_path)
-
-    assert result.empty
-    assert list(result.columns) == [
-        "target_chembl_id",
-        "isoform_id",
-        "isoform_name",
-        "term",
-        "token",
-    ]
+    assert "n/a" not in result["name"].values
+    assert "none" not in result["name"].values
+    assert "" not in result["name"].values
 
 
 @pytest.mark.unit
-def test_process_targets__drops_duplicate_rows(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
-    frame = pd.DataFrame(
+def test_dedup_stage1__matches_table_distinct():
+    combined = pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T3",
-                "isoform_ids": "ENSP0003",
-                "isoform_names": "Gamma",
-                "isoform_synonyms": "Gamma",
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
             },
             {
-                "target_chembl_id": "CHEMBL_T3",
-                "isoform_ids": "ENSP0003",
-                "isoform_names": "Gamma",
-                "isoform_synonyms": "Gamma",
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
+            },
+            {
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U2",
             },
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
+    expected = combined.drop_duplicates(
+        subset=["id", "name", "target_chembl_id", "uniprot_id_primary"], keep="first"
+    )
+    assert target._dedupe_stage1(combined).equals(expected)
 
-    output_path = target.process_targets(input_path)
-    result = pd.read_csv(output_path)
 
-    assert result.to_dict(orient="records") == [
-        {
-            "target_chembl_id": "CHEMBL_T3",
-            "isoform_id": "ENSP0003",
-            "isoform_name": "Gamma",
-            "term": "Gamma",
-            "token": "gamma",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T3",
-            "isoform_id": "ENSP0003",
-            "isoform_name": "Gamma",
-            "term": "gamma",
-            "token": "gamma",
-        },
+@pytest.mark.unit
+def test_stable_sort__preserves_relative_order():
+    df = pd.DataFrame(
+        [
+            {"uniprot_id_primary": "U2", "id": "B", "marker": 1},
+            {"uniprot_id_primary": "U1", "id": "B", "marker": 2},
+            {"uniprot_id_primary": "U1", "id": "A", "marker": 3},
+            {"uniprot_id_primary": "U1", "id": "A", "marker": 4},
+        ]
+    )
+    sorted_df = target._stable_sort(df)
+    assert sorted_df[["uniprot_id_primary", "id", "marker"]].to_dict("records") == [
+        {"uniprot_id_primary": "U1", "id": "A", "marker": 3},
+        {"uniprot_id_primary": "U1", "id": "A", "marker": 4},
+        {"uniprot_id_primary": "U1", "id": "B", "marker": 2},
+        {"uniprot_id_primary": "U2", "id": "B", "marker": 1},
     ]
 
 
 @pytest.mark.unit
-def test_process_targets__sorts_output_rows(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
-    frame = pd.DataFrame(
+def test_dedup_stage2__respects_sorted_order():
+    df = pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T4",
-                "isoform_ids": "ENSP0005|ENSP0004",
-                "isoform_names": "Beta|Alpha",
-                "isoform_synonyms": "Beta Alt:Beta|Alpha Alt:Alpha",
-            }
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
+            },
+            {
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U2",
+            },
+            {
+                "id": "ID1",
+                "name": "beta",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
+            },
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
-
-    output_path = target.process_targets(input_path)
-    result = pd.read_csv(output_path)
-
-    assert result["isoform_name"].tolist() == [
-        "Alpha",
-        "Alpha",
-        "Alpha",
-        "Alpha",
-        "Beta",
-        "Beta",
-        "Beta",
-        "Beta",
-    ]
+    deduped = target._dedupe_stage2(df)
+    assert deduped.iloc[0]["uniprot_id_primary"] == "U1"
+    assert len(deduped) == 2
 
 
 @pytest.mark.unit
-def test_process_targets__writes_to_custom_output_dir(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
-    frame = pd.DataFrame(
+def test_dedup_stage3__drops_duplicates_by_id_name():
+    df = pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T5",
-                "isoform_ids": "ENSP0006",
-                "isoform_names": "Delta",
-                "isoform_synonyms": "Delta",
-            }
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
+            },
+            {
+                "id": "ID1",
+                "name": "alpha",
+                "target_chembl_id": "CHEMBL2",
+                "uniprot_id_primary": "U2",
+            },
+            {
+                "id": "ID2",
+                "name": "beta",
+                "target_chembl_id": "CHEMBL1",
+                "uniprot_id_primary": "U1",
+            },
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
-
-    destination = tmp_path / "out"
-    output_path = target.process_targets(input_path, output_dir=destination)
-
-    assert output_path.parent == destination
-    assert output_path.exists()
+    deduped = target._dedupe_stage3(df)
+    assert len(deduped) == 2
+    assert deduped.iloc[0]["target_chembl_id"] == "CHEMBL1"
 
 
 @pytest.mark.unit
-def test_process_targets__supports_custom_separator(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
-    buffer = io.StringIO()
-    frame = pd.DataFrame(
-        [
-            {
-                "target_chembl_id": "CHEMBL_T6",
-                "isoform_ids": "ENSP0007",
-                "isoform_names": "Epsilon",
-                "isoform_synonyms": "Epsilon",
-            }
-        ]
-    )
-    frame.to_csv(buffer, index=False, sep=";")
-    input_path.write_text(buffer.getvalue(), encoding="utf-8")
-
-    output_path = target.process_targets(input_path, sep=";")
-    result = pd.read_csv(output_path)
-
-    assert result["isoform_name"].tolist() == ["Epsilon", "Epsilon"]
+def test_transform_frame__column_order_exact():
+    frame = _build_sample_frame()
+    result, _ = target._transform_frame(frame)
+    assert list(result.columns) == target.OUTPUT_COLUMNS
 
 
 @pytest.mark.unit
-def test_process_targets__handles_isoform_mismatch_lists(tmp_path: Path):
-    input_path = tmp_path / "targets.csv"
+def test_process_targets__writes_with_isoform_prefix(tmp_path: Path):
+    input_path = tmp_path / "output.target_20250101.csv"
+    frame = _build_sample_frame()
+    frame.to_csv(input_path, index=False, encoding="utf-8")
+
+    output_path = target.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.output.target_20250101.csv"
+    assert output_path.parent == tmp_path
+    written = pd.read_csv(output_path)
+    assert list(written.columns) == target.OUTPUT_COLUMNS
+
+
+@pytest.mark.unit
+def test_process_targets__auto_discovers_latest_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    first = tmp_path / "output.target_20240101.csv"
+    second = tmp_path / "output.target_20240201.csv"
+    frame = _build_sample_frame()
+    frame.to_csv(first, index=False, encoding="utf-8")
+    frame.to_csv(second, index=False, encoding="utf-8")
+    os.utime(first, (first.stat().st_atime, first.stat().st_mtime - 100))
+
+    monkeypatch.setattr(target, "DEFAULT_INPUT_DIR", tmp_path)
+    output_path = target.process_targets(output_csv=tmp_path / "result.csv", verbose=False)
+
+    assert output_path == tmp_path / "result.csv"
+    written = pd.read_csv(output_path)
+    assert not written.empty
+
+
+@pytest.mark.unit
+def test_transform_frame__handles_mismatched_lengths():
     frame = pd.DataFrame(
         [
             {
-                "target_chembl_id": "CHEMBL_T7",
-                "isoform_ids": "ENSP0008|ENSP0009",
-                "isoform_names": "Zeta|",
-                "isoform_synonyms": "Zeta Alt:Zeta|",
+                "isoform_synonyms": "SynA|SynB|SynC",
+                "isoform_names": "Alpha|Beta",
+                "isoform_ids": "ID1",
+                "uniprot_id_primary": "U1",
+                "target_chembl_id": "CHEMBL1",
             }
         ]
     )
-    frame.to_csv(input_path, index=False, encoding="utf-8")
+    result, _ = target._transform_frame(frame)
 
-    output_path = target.process_targets(input_path)
-    result = pd.read_csv(output_path)
-
-    assert result.to_dict(orient="records") == [
-        {
-            "target_chembl_id": "CHEMBL_T7",
-            "isoform_id": "ENSP0008",
-            "isoform_name": "Zeta",
-            "term": "Zeta",
-            "token": "zeta",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T7",
-            "isoform_id": "ENSP0008",
-            "isoform_name": "Zeta",
-            "term": "zeta",
-            "token": "zeta",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T7",
-            "isoform_id": "ENSP0008",
-            "isoform_name": "Zeta",
-            "term": "zeta alt",
-            "token": "alt",
-        },
-        {
-            "target_chembl_id": "CHEMBL_T7",
-            "isoform_id": "ENSP0008",
-            "isoform_name": "Zeta",
-            "term": "zeta alt",
-            "token": "zeta",
-        },
-    ]
+    beta_rows = result[result["name"] == "beta"]
+    assert not beta_rows.empty
+    assert beta_rows["id"].isna().all()


### PR DESCRIPTION
## Summary
- reimplement the isoform target transformation in Python so the Power Query steps run as part of the codebase
- invoke the isoform post-processing from the targets CLI and document the new artefact in both languages
- add a dedicated unit test suite that exercises splitting, tokenisation, deduplication and file discovery logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1510f0fbc83249b57618b39b2e2d5