### PR TITLE
Fix missing inspect import in get_target_data CLI

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -20,6 +20,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import math
+import inspect
 from functools import partial
 from itertools import islice
 from pathlib import Path


### PR DESCRIPTION
## Summary
- import the standard library `inspect` module used for target post-processing signature detection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15e96955883249853d305fab50d78