### PR TITLE
docs: add windows usage example for target pipeline

### DIFF
--- a/docs/en/USAGE.md
+++ b/docs/en/USAGE.md
@@ -175,6 +175,23 @@ python scripts/get_target_data.py all \
   --chembl-chunk-size 10 --uniprot-chunk-size 200
 ```
 
+#### Windows Command Prompt example
+
+On Windows the shell prompt already shows the current directory
+(`C:\\Users\\<you>\\Documents\\GitHub\\ChEMBL_data_acquisition>`). Type only the
+command after the prompt:
+
+```cmd
+py -3 scripts\get_target_data.py all ^
+  --input data\input\target.csv ^
+  --final-out data\output\targets_20251002.csv ^
+  --limit 10
+```
+
+The `^` line continuations are optional but keep the command readable. The
+`--final-out` option supersedes the deprecated `--output` alias printed by older
+examples.
+
 ## Assay pipeline `get_assay_data`
 
 Options include:

--- a/docs/ru/USAGE.md
+++ b/docs/ru/USAGE.md
@@ -170,6 +170,22 @@ python scripts/get_target_data.py all \
   --chembl-chunk-size 10 --uniprot-chunk-size 200
 ```
 
+#### Пример для Windows (Command Prompt)
+
+В командной строке Windows приглашение уже содержит путь
+(`C:\\Users\\<вы>\\Documents\\GitHub\\ChEMBL_data_acquisition>`). После него вводите
+только саму команду:
+
+```cmd
+py -3 scripts\get_target_data.py all ^
+  --input data\input\target.csv ^
+  --final-out data\output\targets_20251002.csv ^
+  --limit 10
+```
+
+Символ `^` на конце строк необязателен, но помогает разбить длинную команду.
+Используйте параметр `--final-out` вместо устаревшего алиаса `--output`.
+
 ## Конвейер ассайев `get_assay_data`
 
 | Опция | Значение по умолчанию | Описание |


### PR DESCRIPTION
## Summary
- add a Windows Command Prompt example for running `get_target_data`
- highlight the preferred `--final-out` flag in the Windows instructions

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e15fa587208324a86877f0bb9e1ec5