### PR TITLE
Fix missing inspect import in target data script

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -20,7 +20,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import math
-import inspect
+from inspect import signature
 from functools import partial
 from itertools import islice
 from pathlib import Path
@@ -131,7 +131,7 @@ else:  # pragma: no cover - compatibility bridge
     setattr(target_pp, "process_targets", _process_targets_impl)
 
 try:
-    _TARGET_PROCESS_SIGNATURE = inspect.signature(_process_targets_impl)
+    _TARGET_PROCESS_SIGNATURE = signature(_process_targets_impl)
 except (TypeError, ValueError):  # pragma: no cover - unexpected callable
     _TARGET_PROCESS_PARAMETERS: set[str] = set()
 else:


### PR DESCRIPTION
## Summary
- import the inspect.signature helper directly in scripts/get_target_data.py
- update signature usage to match the new import, preventing NameError on execution

## Testing
- python scripts/get_target_data.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e15ff16d2c832491812e0705dde05a