### PR TITLE
Allow isoform postprocessing for normalized target exports

### DIFF
--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import re
 
 # Ordered list of encodings attempted when reading the aggregated targets CSV.
 _DEFAULT_ENCODINGS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
@@ -22,6 +23,25 @@ _DEFAULT_ENCODINGS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
 # path. The Power Query workflow consumed the canonical exports emitted under
 # ``data/output`` so we keep the same convention here.
 _DEFAULT_SEARCH_DIR = Path("data/output")
+
+# Accepted filename patterns for aggregated target exports.
+_INPUT_NAME_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"output\.target_\d{8}\.csv\Z"), "output.target_<YYYYMMDD>.csv"),
+    (re.compile(r"output\.targets_\d{8}\.csv\Z"), "output.targets_<YYYYMMDD>.csv"),
+    (re.compile(r"targets_\d{8}(?:_normalized)?\.csv\Z"), "targets_<YYYYMMDD>[_normalized].csv"),
+)
+
+
+def _matches_expected_input_name(filename: str) -> bool:
+    """Return ``True`` when ``filename`` matches a supported input pattern."""
+
+    return any(pattern.match(filename) for pattern, _ in _INPUT_NAME_RULES)
+
+
+def _supported_patterns_text() -> str:
+    """Return a human-readable list of accepted filename templates."""
+
+    return ", ".join(description for _, description in _INPUT_NAME_RULES)
 
 # Columns projected from the aggregated target table before isoform expansion.
 _SOURCE_COLUMNS: tuple[str, ...] = (
@@ -224,14 +244,24 @@ def _resolve_input_path(input_csv: str | Path | None) -> Path:
     if input_csv is not None:
         candidate = Path(input_csv)
         if candidate.is_dir():
-            matches = list(candidate.glob("output.target_*.csv"))
+            matches = [
+                path
+                for path in candidate.glob("*.csv")
+                if _matches_expected_input_name(path.name)
+            ]
             if not matches:
                 raise FileNotFoundError(
-                    f"No output.target_*.csv files found under {candidate}"
+                    "No supported target exports found under "
+                    f"{candidate} (expected patterns: {_supported_patterns_text()})"
                 )
             return max(matches, key=lambda path: path.stat().st_mtime)
         if not candidate.exists():
             raise FileNotFoundError(candidate)
+        if not _matches_expected_input_name(candidate.name):
+            raise ValueError(
+                "Input file must match one of the supported patterns: "
+                + _supported_patterns_text()
+            )
         return candidate
 
     search_dir = _DEFAULT_SEARCH_DIR
@@ -239,10 +269,15 @@ def _resolve_input_path(input_csv: str | Path | None) -> Path:
         raise FileNotFoundError(
             "No input CSV supplied and default search directory does not exist"
         )
-    matches = list(search_dir.glob("output.target_*.csv"))
+    matches = [
+        path
+        for path in search_dir.glob("*.csv")
+        if _matches_expected_input_name(path.name)
+    ]
     if not matches:
         raise FileNotFoundError(
-            f"No output.target_*.csv files found under {search_dir}" 
+            "No supported target exports found under "
+            f"{search_dir} (expected patterns: {_supported_patterns_text()})"
         )
     return max(matches, key=lambda path: path.stat().st_mtime)
 
@@ -265,11 +300,14 @@ def process_targets(
     output_csv: str | None = None,
     verbose: bool = True,
 ) -> Path:
-    """Run the isoform post-processing pipeline on ``output.target_*.csv``."""
+    """Run the isoform post-processing pipeline on canonical target exports."""
 
     input_path = _resolve_input_path(input_csv)
-    if not input_path.name.startswith("output.target_"):
-        raise ValueError("Input file must match pattern output.target_*.csv")
+    if not _matches_expected_input_name(input_path.name):
+        raise ValueError(
+            "Input file must match one of the supported patterns: "
+            + _supported_patterns_text()
+        )
 
     output_path = _resolve_output_path(input_path, output_csv)
 

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -194,3 +194,39 @@ def test_process_targets__auto_discovers_latest_input(tmp_path: Path, snapshot_r
         target._DEFAULT_SEARCH_DIR = original_search_dir
 
     assert output_path.name == "isoform.output.target_20250101.csv"
+
+
+@pytest.mark.unit
+def test_process_targets__accepts_normalized_targets_file(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    expected = snapshot_resource / "target_isoform_minimal_expected.csv"
+    working = tmp_path / "targets_20250101_normalized.csv"
+    shutil.copy(source, working)
+
+    output_path = target.process_targets(str(working), verbose=False)
+
+    assert output_path.name == "isoform.targets_20250101_normalized.csv"
+    result = pd.read_csv(output_path, dtype=str, keep_default_na=False)
+    expected_frame = pd.read_csv(expected, dtype=str, keep_default_na=False)
+    pdt.assert_frame_equal(result, expected_frame)
+
+
+@pytest.mark.unit
+def test_process_targets__auto_discovers_latest_input_targets_prefix(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    first = tmp_path / "targets_20240101_normalized.csv"
+    shutil.copy(snapshot_resource / "target_isoform_minimal.csv", first)
+    newer = tmp_path / "targets_20250101_normalized.csv"
+    shutil.copy(snapshot_resource / "target_isoform_minimal.csv", newer)
+
+    original_search_dir = target._DEFAULT_SEARCH_DIR
+    target._DEFAULT_SEARCH_DIR = tmp_path
+    try:
+        output_path = target.process_targets(verbose=False)
+    finally:
+        target._DEFAULT_SEARCH_DIR = original_search_dir
+
+    assert output_path.name == "isoform.targets_20250101_normalized.csv"


### PR DESCRIPTION
## Summary
- extend the isoform post-processing helper to recognise the new targets_<date>[_normalized].csv naming scheme
- improve error messages while keeping compatibility with the legacy output.target_<date>.csv files
- add regression tests covering normalised inputs and directory discovery for the new filenames

## Testing
- pytest -q tests/postprocessing/test_target_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68e17857c3448324b3162ab3cc1b02e0