### PR TITLE
Ignore placeholder UniProt tokens in target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -478,7 +478,7 @@ def _split_uniprot_tokens(value: str) -> Iterator[str]:
 
     for token in value.split("|"):
         token = token.strip()
-        if token:
+        if token and any(char.isalnum() for char in token):
             yield token
 
 

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -71,6 +71,8 @@ def test_keyboard_aliases__cases(command: str) -> None:
         ("P12345", ["P12345"]),
         ("P12345|Q67890", ["P12345", "Q67890"]),
         (" |P99999| ", ["P99999"]),
+        ("-", []),
+        ("P12345-2|-|Q99999", ["P12345-2", "Q99999"]),
     ],
 )
 def test_split_uniprot_tokens__cases(value: str, tokens: list[str]) -> None:


### PR DESCRIPTION
## Summary
- skip UniProt tokens that do not contain any alphanumeric characters so we do not query UniProt for placeholders
- extend the split token unit test to cover placeholder and isoform tokens

## Testing
- pytest tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases -q

------
https://chatgpt.com/codex/tasks/task_e_68e178f3c88c8324af3af5e3c6cb4992