### PR TITLE
Handle Guide to Pharmacology responses with wrong content type

### DIFF
--- a/library/integration/uniprot_library.py
+++ b/library/integration/uniprot_library.py
@@ -153,6 +153,7 @@ UNIPROT_OUTPUT_COLUMNS: list[str] = [
 
 
 _GTOP_JSON_FAILURE_CACHE: set[tuple[str, str]] = set()
+_GTOP_NON_JSON_CONTENT_TYPE_CACHE: set[tuple[str, str]] = set()
 
 
 def _collect_name_fields(name_obj: dict[str, Any]) -> Iterable[str]:
@@ -890,14 +891,6 @@ def _fetch_gtop_endpoint(
             response.raise_for_status()
             raw_content_type = response.headers.get("Content-Type")
             content_type = raw_content_type if isinstance(raw_content_type, str) else ""
-            if "json" not in content_type.lower():
-                logger.warning(
-                    "gtop_non_json_response",
-                    gtop_id=gtop_id,
-                    endpoint=endpoint,
-                    content_type=raw_content_type,
-                )
-                return None
             body = response.content
             if isinstance(body, (bytes, bytearray)):
                 body_is_empty = not body.strip()
@@ -911,18 +904,32 @@ def _fetch_gtop_endpoint(
                     gtop_id=gtop_id,
                     endpoint=endpoint,
                     error="empty response body",
+                    content_type=raw_content_type,
                 )
                 _GTOP_JSON_FAILURE_CACHE.add(cache_key)
                 return None
-            return response.json()
-    except (json.JSONDecodeError, ValueError) as exc:
-        logger.warning(
-            "gtop_json_decode_failed",
-            gtop_id=gtop_id,
-            endpoint=endpoint,
-            error=str(exc),
-        )
-        _GTOP_JSON_FAILURE_CACHE.add(cache_key)
+            try:
+                payload = response.json()
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning(
+                    "gtop_json_decode_failed",
+                    gtop_id=gtop_id,
+                    endpoint=endpoint,
+                    error=str(exc),
+                    content_type=raw_content_type,
+                )
+                _GTOP_JSON_FAILURE_CACHE.add(cache_key)
+                return None
+            if "json" not in content_type.lower():
+                if cache_key not in _GTOP_NON_JSON_CONTENT_TYPE_CACHE:
+                    logger.warning(
+                        "gtop_non_json_response",
+                        gtop_id=gtop_id,
+                        endpoint=endpoint,
+                        content_type=raw_content_type,
+                    )
+                    _GTOP_NON_JSON_CONTENT_TYPE_CACHE.add(cache_key)
+            return payload
     except requests.RequestException as exc:  # pragma: no cover - network failures
         logger.warning(
             "gtop_request_failed", gtop_id=gtop_id, endpoint=endpoint, error=str(exc)

--- a/tests/unit/test_uniprot_gtop_fetch.py
+++ b/tests/unit/test_uniprot_gtop_fetch.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from types import SimpleNamespace
+
+import pytest
+
+from library.config import IupharCfg
+from library.integration import uniprot_library as uniprot
+
+
+@pytest.fixture()
+def reset_gtop_caches() -> Iterator[None]:
+    """Ensure Guide-to-Pharmacology fetch caches are cleared for each test."""
+
+    uniprot._GTOP_JSON_FAILURE_CACHE.clear()
+    uniprot._GTOP_NON_JSON_CONTENT_TYPE_CACHE.clear()
+    yield
+    uniprot._GTOP_JSON_FAILURE_CACHE.clear()
+    uniprot._GTOP_NON_JSON_CONTENT_TYPE_CACHE.clear()
+
+
+class _DummyResponse:
+    def __init__(self, payload: object, content_type: str, *, json_exc: Exception | None = None):
+        self._payload = payload
+        self._json_exc = json_exc
+        self.headers = {"Content-Type": content_type}
+
+    def raise_for_status(self) -> None:  # pragma: no cover - always OK in tests
+        return None
+
+    @property
+    def content(self) -> bytes:
+        if isinstance(self._payload, (bytes, bytearray)):
+            return bytes(self._payload)
+        return json.dumps(self._payload).encode("utf-8")
+
+    def json(self) -> object:
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._payload
+
+    def __enter__(self) -> "_DummyResponse":  # pragma: no cover - context manager boilerplate
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - context manager boilerplate
+        return False
+
+
+class _DummySession:
+    def __init__(self, response_factory: Callable[[], _DummyResponse]):
+        self._factory = response_factory
+        self.calls: int = 0
+        self.last_url: str | None = None
+        self.last_timeout: tuple[float, float] | None = None
+
+    def get(self, url: str, timeout: tuple[float, float]) -> _DummyResponse:
+        self.calls += 1
+        self.last_url = url
+        self.last_timeout = timeout
+        return self._factory()
+
+
+def _patch_dependencies(monkeypatch: pytest.MonkeyPatch, session: _DummySession) -> None:
+    monkeypatch.setattr(uniprot, "get_uniprot_session", lambda: session)
+    monkeypatch.setattr(
+        uniprot,
+        "get_limiter",
+        lambda name, rps, burst=None: SimpleNamespace(acquire=lambda: None),
+    )
+
+
+@pytest.mark.unit
+def test_fetch_gtop_endpoint__accepts_text_plain_json(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_gtop_caches: None,
+) -> None:
+    session = _DummySession(
+        lambda: _DummyResponse({"value": 1}, "text/plain; charset=utf-8")
+    )
+    _patch_dependencies(monkeypatch, session)
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, *args: object, **kwargs: object) -> None:
+        events.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(uniprot.logger, "warning", capture)
+
+    cfg = IupharCfg()
+
+    result = uniprot._fetch_gtop_endpoint("GTP1", "function", cfg=cfg)
+    assert result == {"value": 1}
+    assert events == [
+        (
+            "gtop_non_json_response",
+            {
+                "gtop_id": "GTP1",
+                "endpoint": "function",
+                "content_type": "text/plain; charset=utf-8",
+            },
+        )
+    ]
+    assert ("GTP1", "function") not in uniprot._GTOP_JSON_FAILURE_CACHE
+    assert ("GTP1", "function") in uniprot._GTOP_NON_JSON_CONTENT_TYPE_CACHE
+    assert session.calls == 1
+
+    result_again = uniprot._fetch_gtop_endpoint("GTP1", "function", cfg=cfg)
+    assert result_again == {"value": 1}
+    assert events == [
+        (
+            "gtop_non_json_response",
+            {
+                "gtop_id": "GTP1",
+                "endpoint": "function",
+                "content_type": "text/plain; charset=utf-8",
+            },
+        )
+    ]
+    assert session.calls == 2
+
+
+@pytest.mark.unit
+def test_fetch_gtop_endpoint__records_decode_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_gtop_caches: None,
+) -> None:
+    json_error = json.JSONDecodeError("invalid", "{", 0)
+    session = _DummySession(
+        lambda: _DummyResponse({"invalid": True}, "application/json", json_exc=json_error)
+    )
+    _patch_dependencies(monkeypatch, session)
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def capture(event: str, *args: object, **kwargs: object) -> None:
+        events.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(uniprot.logger, "warning", capture)
+
+    cfg = IupharCfg()
+
+    result = uniprot._fetch_gtop_endpoint("GTP2", "interactions", cfg=cfg)
+    assert result is None
+    assert events == [
+        (
+            "gtop_json_decode_failed",
+            {
+                "gtop_id": "GTP2",
+                "endpoint": "interactions",
+                "error": "invalid: line 1 column 1 (char 0)",
+                "content_type": "application/json",
+            },
+        )
+    ]
+    assert ("GTP2", "interactions") in uniprot._GTOP_JSON_FAILURE_CACHE
+    assert session.calls == 1
+
+    second = uniprot._fetch_gtop_endpoint("GTP2", "interactions", cfg=cfg)
+    assert second is None
+    assert events == [
+        (
+            "gtop_json_decode_failed",
+            {
+                "gtop_id": "GTP2",
+                "endpoint": "interactions",
+                "error": "invalid: line 1 column 1 (char 0)",
+                "content_type": "application/json",
+            },
+        )
+    ]
+    assert session.calls == 1


### PR DESCRIPTION
## Summary
- parse Guide-to-Pharmacology responses even when the endpoint returns JSON with an incorrect content type and avoid repeated warnings
- include the observed content type on JSON decode failures
- add unit tests covering the non-JSON content type scenario and the cached failure path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e17906a7e483249c944af5346d2345