### PR TITLE
Add target post-processing orchestrator and helpers

### DIFF
--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from .document import preprocess_document_export, postprocess_export_file
-from .target import process_targets
+from .main import postprocess_target_table
 
 __all__ = [
     "preprocess_document_export",
     "postprocess_export_file",
-    "process_targets",
+    "postprocess_target_table",
 ]
 

--- a/library/postprocessing/cellularity.py
+++ b/library/postprocessing/cellularity.py
@@ -1,0 +1,69 @@
+"""Cellularity helpers mirroring the legacy Power Query logic."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from library.pipelines.target import organism_classification
+from library.schemas.targets import CELLULARITY_COLUMN_NAME
+
+TYPE_MULTICELLULAR = "Multicellular organism"
+TYPE_UNICELLULAR = "Unicellular organism"
+TYPE_VIRAL = "Viral"
+
+_VIRAL_LEGACY_LABEL = organism_classification.TYPE_VIRAL
+
+
+def _normalise_label(value: object | None) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    if text.lower() in {"viruses", "virus", "viral"}:
+        return TYPE_VIRAL
+    if text.lower() == TYPE_UNICELLULAR.lower():
+        return TYPE_UNICELLULAR
+    if text.lower() == TYPE_MULTICELLULAR.lower():
+        return TYPE_MULTICELLULAR
+    return text
+
+
+def normalise_series(series: pd.Series) -> pd.Series:
+    """Return ``series`` with canonical cellularity labels."""
+
+    return series.map(_normalise_label).astype("string")
+
+
+def ensure_cellularity(
+    frame: pd.DataFrame,
+    *,
+    genus_col: str = organism_classification.DEFAULT_GENUS_COLUMN,
+    superkingdom_col: str = organism_classification.DEFAULT_SUPERKINGDOM_COLUMN,
+    phylum_col: str = organism_classification.DEFAULT_PHYLUM_COLUMN,
+    class_col: str = organism_classification.DEFAULT_CLASS_COLUMN,
+    output_col: str = CELLULARITY_COLUMN_NAME,
+) -> pd.DataFrame:
+    """Return ``frame`` with the canonical cellularity column present."""
+
+    result = frame.copy()
+    if output_col not in result.columns:
+        result = organism_classification.add_cellularity_smart(
+            result,
+            genus_col=genus_col,
+            superkingdom_col=superkingdom_col,
+            phylum_col=phylum_col,
+            class_col=class_col,
+            output_col=output_col,
+        )
+    result[output_col] = normalise_series(result[output_col])
+    return result
+
+
+def unicellular_flag(series: pd.Series) -> pd.Series:
+    """Return the boolean unicellular flag derived from ``series`` labels."""
+
+    lowered = series.astype("string").str.strip().str.lower()
+    mask = lowered.isin({TYPE_UNICELLULAR.lower(), TYPE_VIRAL.lower(), _VIRAL_LEGACY_LABEL.lower()})
+    return mask.astype("boolean")
+

--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -1,0 +1,117 @@
+"""Common helpers for target post-processing.
+
+The original pipeline relied on a Power Query workbook where a number of text
+cleaning and XML parsing helpers were reused across multiple steps.  The
+implementation below mirrors those routines so that the Python port remains
+byte-for-byte compatible with the canonical Single Source of Truth (SSoT)
+exports.  The helpers are intentionally small and focused: they deal with text
+normalisation, best-effort XML parsing and deterministic CSV emission.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+from xml.etree import ElementTree
+
+import pandas as pd
+
+from library.common.csv_utils import write_csv_deterministic
+
+# Accepted encodings – these match the Power Query ``Binary.Decompress`` fallbacks
+# that were historically used when loading the aggregated targets table.
+ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
+
+
+def normalise_text(value: object | None) -> str:
+    """Return a trimmed textual representation of ``value``.
+
+    ``None`` values, NaNs and empty strings are mapped to ``""`` mirroring the
+    behaviour of the Power Query ``ToText`` helper.
+    """
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value.strip()
+        return text
+    try:
+        if pd.isna(value):  # type: ignore[arg-type]
+            return ""
+    except TypeError:
+        pass
+    text = str(value).strip()
+    return "" if text.lower() in {"none", "nan"} else text
+
+
+def ensure_string_columns(frame: pd.DataFrame, columns: Iterable[str]) -> pd.DataFrame:
+    """Return ``frame`` with the specified ``columns`` coerced to ``string`` dtype."""
+
+    result = frame.copy()
+    for column in columns:
+        if column in result.columns:
+            result[column] = result[column].astype("string")
+    return result
+
+
+def read_csv_with_fallbacks(
+    path: Path | str,
+    *,
+    sep: str = ",",
+    encodings: Sequence[str] = ENCODING_FALLBACKS,
+) -> pd.DataFrame:
+    """Load a CSV file trying the known Power Query encoding fallbacks."""
+
+    errors: list[Exception] = []
+    for encoding in encodings:
+        try:
+            return pd.read_csv(path, sep=sep, encoding=encoding, dtype="string")
+        except Exception as exc:  # pragma: no cover - defensive guard
+            errors.append(exc)
+    if not errors:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"Unable to read CSV at {path!s}")
+    # Re-raise the last error so the traceback points to the failing codec.
+    raise errors[-1]
+
+
+def extract_xml_texts(value: str, xpath: str) -> list[str]:
+    """Return the text nodes matching ``xpath`` from an XML fragment.
+
+    The helper is intentionally permissive: parsing failures yield an empty list
+    to mirror the defensive ``try ... otherwise { { "Value" = "" } }`` guards in
+    the original M workbook.
+    """
+
+    text = normalise_text(value)
+    if not text:
+        return []
+    try:
+        root = ElementTree.fromstring(text)
+    except ElementTree.ParseError:
+        return []
+    return [normalise_text(node.text) for node in root.findall(xpath)]
+
+
+def write_csv(frame: pd.DataFrame, path: Path, *, columns: Sequence[str]) -> Path:
+    """Serialise ``frame`` to ``path`` using deterministic ordering."""
+
+    return write_csv_deterministic(
+        frame.copy(),
+        path,
+        col_order=columns,
+        key_cols=[columns[0]] if columns else [],
+        encoding="utf-8",
+        sep=",",
+        cfg=None,
+    )
+
+
+def fill_missing(frame: pd.DataFrame, columns: Iterable[str], fill_value: str = "-") -> pd.DataFrame:
+    """Fill ``columns`` missing from ``frame`` with ``fill_value``."""
+
+    result = frame.copy()
+    for column in columns:
+        if column not in result.columns:
+            result[column] = fill_value
+    return result
+

--- a/library/postprocessing/main.py
+++ b/library/postprocessing/main.py
@@ -1,0 +1,87 @@
+"""Entry points for the target post-processing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from library.pipelines.target.postprocessing import (
+    finalise_targets,
+    postprocess_targets,
+)
+from library.schemas.targets import CELLULARITY_COLUMN_NAME, TARGETS_COLUMN_ORDER
+
+from . import cellularity, helpers, multifunctional
+
+ORGANISM_COLUMNS: list[str] = [
+    "target_chembl_id",
+    "target_type",
+    "unicellular_organism",
+    "multifunctional_enzyme",
+    "IUPHAR_class",
+    "IUPHAR_subclass",
+    "target_sort_order",
+    "gene_index",
+    "taxon_index",
+]
+
+
+def _build_organism_lookup(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return the helper organism lookup mirroring the legacy PQ workbook."""
+
+    lookup = pd.DataFrame(index=frame.index.copy())
+    lookup["target_chembl_id"] = frame["target_chembl_id"].astype("string")
+    lookup["target_type"] = cellularity.normalise_series(frame[CELLULARITY_COLUMN_NAME])
+    lookup["unicellular_organism"] = cellularity.unicellular_flag(lookup["target_type"])
+
+    if "multifunctional_enzyme" in frame.columns:
+        mf_series = multifunctional.normalise_multifunctional(frame["multifunctional_enzyme"])
+    else:
+        mf_series = pd.Series(pd.NA, index=frame.index, dtype="boolean")
+    lookup["multifunctional_enzyme"] = mf_series.fillna(False).astype("boolean")
+
+    for column in ("IUPHAR_class", "IUPHAR_subclass", "target_sort_order", "gene_index", "taxon_index"):
+        if column in frame.columns:
+            lookup[column] = frame[column].map(helpers.normalise_text).replace("", "-").astype("string")
+        else:
+            lookup[column] = "-"
+
+    lookup = lookup.reindex(columns=ORGANISM_COLUMNS)
+    lookup = helpers.ensure_string_columns(lookup, ["target_chembl_id", "target_type", "IUPHAR_class", "IUPHAR_subclass", "target_sort_order", "gene_index", "taxon_index"])
+    lookup = lookup.sort_values(by="target_chembl_id", kind="mergesort").reset_index(drop=True)
+    return lookup
+
+
+def _write_outputs(frame: pd.DataFrame, target_path: Path) -> str:
+    output_path = target_path.with_name(f"postprocessed.{target_path.name}")
+    helpers.write_csv(frame, output_path, columns=TARGETS_COLUMN_ORDER)
+
+    organism_frame = _build_organism_lookup(frame)
+    organism_path = target_path.with_name(f"organism.{target_path.name}")
+    helpers.write_csv(organism_frame, organism_path, columns=ORGANISM_COLUMNS)
+
+    print(f"Postprocessed target table saved to: {output_path}")
+    return str(output_path)
+
+
+def postprocess_target_table(input_path: str) -> str:
+    """Post-process the merged target table and emit organism helpers."""
+
+    source_path = Path(input_path)
+    frame = helpers.read_csv_with_fallbacks(source_path)
+    frame = helpers.ensure_string_columns(frame, frame.columns)
+
+    processed = postprocess_targets(frame)
+    processed = finalise_targets(processed)
+    processed = cellularity.ensure_cellularity(processed)
+
+    if CELLULARITY_COLUMN_NAME in processed.columns:
+        processed[CELLULARITY_COLUMN_NAME] = cellularity.normalise_series(
+            processed[CELLULARITY_COLUMN_NAME]
+        )
+
+    processed = helpers.fill_missing(processed, TARGETS_COLUMN_ORDER)
+
+    return _write_outputs(processed, source_path)
+

--- a/library/postprocessing/multifunctional.py
+++ b/library/postprocessing/multifunctional.py
@@ -1,0 +1,16 @@
+"""Utilities for normalising multifunctional enzyme annotations."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def normalise_multifunctional(series: pd.Series | None) -> pd.Series:
+    """Return a nullable boolean series describing multifunctional enzymes."""
+
+    if series is None:
+        return pd.Series(pd.NA, index=pd.Index([], dtype="int64"), dtype="boolean")
+    text = series.astype("string").str.strip().str.lower()
+    mapped = text.map({"true": True, "false": False})
+    return mapped.astype("boolean")
+

--- a/library/postprocessing/target.py
+++ b/library/postprocessing/target.py
@@ -257,7 +257,7 @@ def _resolve_input_path(input_csv: str | Path | None) -> Path:
                     "No supported target exports found under "
                     f"{candidate} (expected patterns: {_supported_patterns_text()})"
                 )
-            return max(matches, key=lambda path: path.stat().st_mtime)
+            return max(matches, key=lambda path: (path.stat().st_mtime, path.name))
         if not candidate.exists():
             raise FileNotFoundError(candidate)
         if not _matches_expected_input_name(candidate.name):
@@ -282,7 +282,7 @@ def _resolve_input_path(input_csv: str | Path | None) -> Path:
             "No supported target exports found under "
             f"{search_dir} (expected patterns: {_supported_patterns_text()})"
         )
-    return max(matches, key=lambda path: path.stat().st_mtime)
+    return max(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
 def _resolve_output_path(input_path: Path, output_csv: str | None) -> Path:


### PR DESCRIPTION
## Summary
- add helper modules that port the Power Query text normalisation, XML access, cellularity and multifunctional handling used by the target pipeline
- implement `postprocess_target_table` to orchestrate the SSoT post-processing flow and emit the companion `organism.*` lookup
- update the post-processing package exports and stabilise isoform input discovery when multiple dated files are present

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py


------
https://chatgpt.com/codex/tasks/task_e_68e18588b1488324ab34781a10fcb832