### PR TITLE
Handle isoform identifier aliases in postprocessing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -67,6 +67,20 @@ _SOURCE_COLUMNS: tuple[str, ...] = (
     "target_chembl_id",
 )
 
+_SOURCE_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
+    "uniprot_id_primary": (
+        "uniprot_id",
+        "primary_accession",
+        "uniprot_accession",
+        "accession",
+    ),
+    "target_chembl_id": (
+        "chembl_id",
+        "target_id",
+        "target_chemblid",
+    ),
+}
+
 # Column order of the emitted CSV artefact.
 _OUTPUT_COLUMNS: tuple[str, ...] = (
     "id",
@@ -74,6 +88,64 @@ _OUTPUT_COLUMNS: tuple[str, ...] = (
     "target_chembl_id",
     "name",
 )
+
+def _normalize_column_name(column: str) -> str:
+    """Return a normalised representation of ``column`` for fuzzy matching."""
+
+    return re.sub(r"[^a-z0-9]", "", _to_text(column).lower())
+
+
+def _resolve_source_columns(frame: pd.DataFrame) -> dict[str, str]:
+    """Resolve the source column names accounting for legacy aliases."""
+
+    normalized_lookup: dict[str, list[str]] = {}
+    for column in frame.columns:
+        normalized_lookup.setdefault(_normalize_column_name(column), []).append(column)
+
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+
+    for canonical in _SOURCE_COLUMNS:
+        match: str | None = None
+        if canonical in frame.columns:
+            match = canonical
+        else:
+            for alias in _SOURCE_COLUMN_ALIASES.get(canonical, ()):  # pragma: no branch - small tuple
+                if alias in frame.columns:
+                    match = alias
+                    break
+
+        if match is None:
+            candidate_norms = {_normalize_column_name(canonical)}
+            candidate_norms.update(
+                _normalize_column_name(alias)
+                for alias in _SOURCE_COLUMN_ALIASES.get(canonical, ())
+            )
+            for norm in candidate_norms:
+                candidates = normalized_lookup.get(norm)
+                if candidates:
+                    match = sorted(candidates)[0]
+                    break
+
+        if match is None:
+            missing.append(canonical)
+        else:
+            resolved[canonical] = match
+
+    if missing:
+        alias_hints = ", ".join(
+            f"{name} (aliases: {', '.join((name,) + _SOURCE_COLUMN_ALIASES.get(name, ()))})"
+            for name in missing
+        )
+        available = ", ".join(frame.columns)
+        raise KeyError(
+            "Required columns missing from isoform export: "
+            + f"{missing}. "
+            + f"Available columns: {available}. "
+            + f"Accepted names: {alias_hints}"
+        )
+
+    return resolved
 
 
 def _to_text(value: Any) -> str:
@@ -163,7 +235,9 @@ class _TransformationResult:
 def _transform(frame: pd.DataFrame) -> _TransformationResult:
     """Apply the isoform expansion stages mirroring the Power Query steps."""
 
-    projected = frame.loc[:, list(_SOURCE_COLUMNS)].copy()
+    column_map = _resolve_source_columns(frame)
+    projected = frame.loc[:, [column_map[column] for column in _SOURCE_COLUMNS]].copy()
+    projected = projected.rename(columns={column_map[column]: column for column in _SOURCE_COLUMNS})
 
     projected["isoform_synonyms"] = projected["isoform_synonyms"].map(
         lambda value: _to_text(value).lower()

--- a/tests/unit/test_target_isoform.py
+++ b/tests/unit/test_target_isoform.py
@@ -1,0 +1,76 @@
+"""Unit tests for the isoform post-processing helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocessing.target import isoform
+
+
+@pytest.mark.unit
+def test_transform__supports_alias_columns():
+    """Isoform transform accepts common legacy aliases for required columns."""
+
+    frame = pd.DataFrame(
+        {
+            "isoform_synonyms": ["SynA|SynB"],
+            "isoform_names": ["Isoform 1|Isoform 2"],
+            "isoform_ids": ["P12345-1|P12345-2"],
+            "primary_accession": ["P12345"],
+            "chembl_id": ["CHEMBL123"],
+        }
+    )
+
+    result = isoform._transform(frame).result
+
+    expected = pd.DataFrame(
+        [
+            {
+                "id": "P12345-1",
+                "uniprot_id_primary": "P12345",
+                "target_chembl_id": "CHEMBL123",
+                "name": "isoform 1",
+            },
+            {
+                "id": "P12345-1",
+                "uniprot_id_primary": "P12345",
+                "target_chembl_id": "CHEMBL123",
+                "name": "syna",
+            },
+            {
+                "id": "P12345-2",
+                "uniprot_id_primary": "P12345",
+                "target_chembl_id": "CHEMBL123",
+                "name": "isoform 2",
+            },
+            {
+                "id": "P12345-2",
+                "uniprot_id_primary": "P12345",
+                "target_chembl_id": "CHEMBL123",
+                "name": "synb",
+            },
+        ]
+    )
+
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.unit
+def test_transform__missing_identifier_columns_raises_key_error():
+    """A descriptive error is raised when identifier columns are absent."""
+
+    frame = pd.DataFrame(
+        {
+            "isoform_synonyms": ["SynA"],
+            "isoform_names": ["Isoform 1"],
+            "isoform_ids": ["P12345-1"],
+        }
+    )
+
+    with pytest.raises(KeyError) as exc:
+        isoform._transform(frame)
+
+    message = str(exc.value)
+    assert "uniprot_id_primary" in message
+    assert "target_chembl_id" in message


### PR DESCRIPTION
## Summary
- allow the isoform post-processing pipeline to resolve legacy identifier column aliases when projecting inputs
- provide a clearer error message when identifier columns are missing
- add unit coverage for the alias handling and failure path

## Testing
- pytest tests/unit/test_target_isoform.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e18a9a7a808324bdb0dd848feefcc7