### PR TITLE
Handle missing identifier columns in isoform post-processing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -17,6 +17,42 @@ import sys
 import pandas as pd
 import re
 
+
+def _empty_like(index: pd.Index) -> pd.Series:
+    """Return an empty object-typed series aligned with *index*."""
+
+    if len(index):
+        return pd.Series([""] * len(index), index=index, dtype=object)
+    return pd.Series(dtype=object)
+
+
+def _project_source_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return ``frame`` projected onto :data:`_SOURCE_COLUMNS` with fallbacks."""
+
+    projected = frame.reindex(columns=list(_SOURCE_COLUMNS)).copy()
+    for column in _SOURCE_COLUMNS:
+        if column in frame.columns:
+            projected[column] = frame[column].astype(object)
+            continue
+
+        fallback_series: pd.Series | None = None
+        for candidate in _SOURCE_FALLBACKS.get(column, ()):  # pragma: no branch - small tuple
+            if candidate in frame.columns:
+                fallback_series = frame[candidate].astype(object)
+                break
+            if candidate in projected.columns and candidate != column:
+                existing = projected[candidate]
+                if not existing.replace("", pd.NA).isna().all():
+                    fallback_series = existing.astype(object)
+                    break
+
+        if fallback_series is None:
+            projected[column] = _empty_like(projected.index)
+        else:
+            projected[column] = fallback_series.reindex(projected.index).astype(object)
+
+    return projected
+
 # Ordered list of encodings attempted when reading the aggregated targets CSV.
 _DEFAULT_ENCODINGS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
 
@@ -66,6 +102,32 @@ _SOURCE_COLUMNS: tuple[str, ...] = (
     "uniprot_id_primary",
     "target_chembl_id",
 )
+
+# Alternative column names consulted when projecting the input frame.  The
+# UniProt-only export, for instance, lacks ``target_chembl_id`` and
+# ``uniprot_id_primary`` because the identifiers are represented as
+# ``uniProtkbId`` (and friends).  The fallbacks ensure that these shapes can be
+# processed without raising ``KeyError`` while keeping legacy behaviour for the
+# canonical aggregated target table.
+_SOURCE_FALLBACKS: dict[str, tuple[str, ...]] = {
+    "uniprot_id_primary": (
+        "uniprot_id",
+        "uniprotkb_Id",
+        "uniprotkb_id",
+        "uniProtkbId",
+        "uniProtkbIdFallback",
+    ),
+    "target_chembl_id": (
+        "target_id",
+        "chembl_id",
+        "target",
+        "uniprot_id_primary",
+        "uniprot_id",
+        "uniprotkb_Id",
+        "uniProtkbId",
+        "uniProtkbIdFallback",
+    ),
+}
 
 # Column order of the emitted CSV artefact.
 _OUTPUT_COLUMNS: tuple[str, ...] = (
@@ -163,7 +225,16 @@ class _TransformationResult:
 def _transform(frame: pd.DataFrame) -> _TransformationResult:
     """Apply the isoform expansion stages mirroring the Power Query steps."""
 
-    projected = frame.loc[:, list(_SOURCE_COLUMNS)].copy()
+    projected = _project_source_columns(frame)
+    if projected.empty:
+        empty_result = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
+        return _TransformationResult(
+            result=empty_result.copy(),
+            combined=empty_result.copy(),
+            dedup_stage1=empty_result.copy(),
+            sorted_stage=empty_result.copy(),
+            dedup_stage2=empty_result.copy(),
+        )
 
     projected["isoform_synonyms"] = projected["isoform_synonyms"].map(
         lambda value: _to_text(value).lower()

--- a/tests/unit/postprocessing/target/test_isoform.py
+++ b/tests/unit/postprocessing/target/test_isoform.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pytest
+
+from library.postprocessing.target import isoform
+
+
+@pytest.mark.unit
+def test_transform__falls_back_to_uniprot_columns():
+    frame = pd.DataFrame(
+        {
+            "isoform_synonyms": ["Alpha|Beta"],
+            "isoform_names": ["Alpha|Beta"],
+            "isoform_ids": ["ID_A|ID_B"],
+            "uniProtkbId": ["Q11111"],
+        }
+    )
+
+    transform = isoform._transform(frame)
+
+    result = transform.result
+    assert result["uniprot_id_primary"].unique().tolist() == ["Q11111"]
+    assert result["target_chembl_id"].unique().tolist() == ["Q11111"]
+    assert result.isna().sum().sum() == 0
+
+
+@pytest.mark.unit
+def test_transform__empty_input_returns_empty_frame():
+    frame = pd.DataFrame(
+        columns=["isoform_synonyms", "isoform_names", "isoform_ids"]
+    )
+
+    transform = isoform._transform(frame)
+
+    result = transform.result
+    assert result.empty
+    assert list(result.columns) == list(isoform._OUTPUT_COLUMNS)


### PR DESCRIPTION
## Summary
- allow isoform post-processing to project missing identifier columns using fallbacks so UniProt exports no longer fail
- return empty result sets safely when the input contains no isoform rows
- add unit coverage for the new fallbacks and empty input handling

## Testing
- pytest tests/unit/postprocessing/target/test_isoform.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e18bf242908324beb0aa163a9a7ebc