### PR TITLE
Fix isoform fallback dictionary syntax

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -126,6 +126,9 @@ _SOURCE_FALLBACKS: dict[str, tuple[str, ...]] = {
         "uniprotkb_Id",
         "uniProtkbId",
         "uniProtkbIdFallback",
+    ),
+}
+
 _SOURCE_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
     "uniprot_id_primary": (
         "uniprot_id",


### PR DESCRIPTION
## Summary
- close the `_SOURCE_FALLBACKS` mapping in `isoform.py` to restore valid syntax

## Testing
- python -m compileall library/postprocessing/target/isoform.py

------
https://chatgpt.com/codex/tasks/task_e_68e192677188832490683db45fbc3b0d