### PR TITLE
Preserve whitespace in cellularity lineage classification

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -147,12 +147,12 @@ class Cellularity:
         if lineage_text:
             lineage_names = [segment.strip() for segment in lineage_text.split(";")]
         lineage_names = [name for name in lineage_names if name]
-        if sci_name and sci_name.strip() and sci_name not in lineage_names:
-            lineage_names.append(sci_name.strip())
+        if sci_name is not None and sci_name not in lineage_names:
+            lineage_names.append(sci_name)
         return lineage_names
 
     def classify_by_fetch(self, tax_id: Any, email: str | None = None) -> str:
-        names = [normalize_text(name) for name in self.get_lineage_names(tax_id, email)]
+        names = [self._lower_token(name) for name in self.get_lineage_names(tax_id, email)]
         if "viruses" in names:
             return "acellular (virus)"
         if "bacteria" in names or "archaea" in names:
@@ -180,6 +180,16 @@ class Cellularity:
             if candidate in lookup:
                 return True
         return False
+
+    @staticmethod
+    def _lower_token(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, float) and pd.isna(value):
+            return ""
+        if value is pd.NA:
+            return ""
+        return str(value).lower()
 
 
 def add_cellularity_smart(

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import importlib.util
+import sys
+import types
 from pathlib import Path
-
-import pandas as pd
-from pathlib import Path
+from typing import Any
 
 import pandas as pd
 import pandas.testing as pdt
@@ -15,6 +16,28 @@ from library.schemas.targets import CELLULARITY_COLUMN_NAME, TARGETS_COLUMN_ORDE
 
 INPUT_FILE = "target_postprocess_power_query_input.csv"
 EXPECTED_FILE = "target_postprocess_power_query_expected.csv"
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+if "library.postprocessing" not in sys.modules:
+    postprocessing_pkg = types.ModuleType("library.postprocessing")
+    postprocessing_pkg.__path__ = [str(_ROOT / "library/postprocessing")]
+    sys.modules["library.postprocessing"] = postprocessing_pkg
+
+if "library.postprocessing.target" not in sys.modules:
+    target_pkg = types.ModuleType("library.postprocessing.target")
+    target_pkg.__path__ = [str(_ROOT / "library/postprocessing/target")]
+    sys.modules["library.postprocessing.target"] = target_pkg
+
+_SPEC = importlib.util.spec_from_file_location(
+    "library.postprocessing.target.cellularity",
+    _ROOT / "library/postprocessing/target/cellularity.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_cellularity_module = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _cellularity_module
+_SPEC.loader.exec_module(_cellularity_module)
+Cellularity = _cellularity_module.Cellularity
 
 
 @pytest.mark.unit
@@ -127,3 +150,23 @@ def test_append_multifunctional_flag__detects_keywords(snapshot_resource: Path) 
     assert "multifunctional_enzyme" in result.columns
     assert result["multifunctional_enzyme"].dtype == "boolean"
     assert result["multifunctional_enzyme"].tolist() == [True, False, False]
+
+
+@pytest.mark.unit
+def test_classify_by_fetch__trailing_spaces_remain_ambiguous() -> None:
+    lineage = [
+        "Cellular organisms",
+        "Eukaryota ",
+        "Chordata ",
+        "Homo sapiens   ",
+    ]
+
+    def _fetcher(tax_id: Any, email: str | None) -> list[str]:
+        return list(lineage)
+
+    classifier = Cellularity(fetcher=_fetcher)
+
+    result = classifier.classify_by_fetch("9606")
+
+    assert result == "ambiguous"
+    assert classifier.get_lineage_names("9606") == lineage


### PR DESCRIPTION
## Summary
- retain scientific names from the taxonomy fetcher without trimming whitespace
- classify lineage data by lowercasing tokens only to mimic Power Query behaviour
- add a regression test that keeps trailing spaces when fetching cellular lineages and asserts the result stays ambiguous

## Testing
- pytest tests/postprocessing -q

------
https://chatgpt.com/codex/tasks/task_e_68e192d2dd74832488efd0bc2e82cec2