### PR TITLE
Handle whitespace when classifying cellularity lineages

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -147,12 +147,12 @@ class Cellularity:
         if lineage_text:
             lineage_names = [segment.strip() for segment in lineage_text.split(";")]
         lineage_names = [name for name in lineage_names if name]
-        if sci_name and sci_name.strip() and sci_name not in lineage_names:
-            lineage_names.append(sci_name.strip())
+        if sci_name is not None and sci_name not in lineage_names:
+            lineage_names.append(sci_name)
         return lineage_names
 
     def classify_by_fetch(self, tax_id: Any, email: str | None = None) -> str:
-        names = [normalize_text(name) for name in self.get_lineage_names(tax_id, email)]
+        names = [self._lower_token(name) for name in self.get_lineage_names(tax_id, email)]
         if "viruses" in names:
             return "acellular (virus)"
         if "bacteria" in names or "archaea" in names:
@@ -180,6 +180,16 @@ class Cellularity:
             if candidate in lookup:
                 return True
         return False
+
+    @staticmethod
+    def _lower_token(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, float) and pd.isna(value):
+            return ""
+        if value is pd.NA:
+            return ""
+        return str(value).lower()
 
 
 def add_cellularity_smart(

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
-from pathlib import Path
-
-import pandas as pd
 import pandas.testing as pdt
 import pytest
 
 from library.config import Config
 from library.pipelines.target import cellularity, helpers, multifunctional
+from library.postprocessing.target.cellularity import Cellularity
 from library.schemas.targets import CELLULARITY_COLUMN_NAME, TARGETS_COLUMN_ORDER
 
 INPUT_FILE = "target_postprocess_power_query_input.csv"
@@ -127,3 +125,28 @@ def test_append_multifunctional_flag__detects_keywords(snapshot_resource: Path) 
     assert "multifunctional_enzyme" in result.columns
     assert result["multifunctional_enzyme"].dtype == "boolean"
     assert result["multifunctional_enzyme"].tolist() == [True, False, False]
+
+
+@pytest.mark.unit
+def test_classify_by_fetch__trailing_whitespace_lineage_remains_ambiguous() -> None:
+    lineage = [
+        "Viruses ",
+        "Duplodnaviria ",
+        "Herpesvirales ",
+        "Herpesviridae ",
+        "Varicellovirus ",
+        "Human alphaherpesvirus 3 ",
+    ]
+
+    def _mock_fetcher(tax_id: object, email: str | None) -> list[str]:
+        assert tax_id == "10335"
+        return list(lineage)
+
+    classifier = Cellularity(fetcher=_mock_fetcher)
+
+    names = classifier.get_lineage_names("10335")
+    assert names[-1].endswith(" ")
+
+    result = classifier.classify_by_fetch("10335")
+
+    assert result == "ambiguous"


### PR DESCRIPTION
## Summary
- preserve the scientific name from the taxonomy fetch without trimming whitespace
- mirror Power Query token handling by only lowercasing lineage names during fetch classification
- cover trailing-whitespace lineages with a regression test to ensure the result stays ambiguous

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68e1935503448324a2d9b65e5d820ac0