### PR TITLE
Fix isoform postprocessing typing for broader Python compatibility

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple, Union
 import sys
 
 import pandas as pd
@@ -35,7 +35,7 @@ def _project_source_columns(frame: pd.DataFrame) -> pd.DataFrame:
             projected[column] = frame[column].astype(object)
             continue
 
-        fallback_series: pd.Series | None = None
+        fallback_series: Optional[pd.Series] = None
         for candidate in _SOURCE_FALLBACKS.get(column, ()):  # pragma: no branch - small tuple
             if candidate in frame.columns:
                 fallback_series = frame[candidate].astype(object)
@@ -54,7 +54,7 @@ def _project_source_columns(frame: pd.DataFrame) -> pd.DataFrame:
     return projected
 
 # Ordered list of encodings attempted when reading the aggregated targets CSV.
-_DEFAULT_ENCODINGS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
+_DEFAULT_ENCODINGS: Tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
 
 # Directory searched when ``process_targets`` is invoked without an explicit
 # path. The Power Query workflow consumed the canonical exports emitted under
@@ -62,7 +62,7 @@ _DEFAULT_ENCODINGS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
 _DEFAULT_SEARCH_DIR = Path("data/output")
 
 # Accepted filename patterns for aggregated target exports.
-_INPUT_NAME_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+_INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"output\.target_\d{8}\.csv\Z"), "output.target_<YYYYMMDD>.csv"),
     (re.compile(r"output\.targets_\d{8}\.csv\Z"), "output.targets_<YYYYMMDD>.csv"),
     (
@@ -95,7 +95,7 @@ def _current_default_search_dir() -> Path:
     return _DEFAULT_SEARCH_DIR
 
 # Columns projected from the aggregated target table before isoform expansion.
-_SOURCE_COLUMNS: tuple[str, ...] = (
+_SOURCE_COLUMNS: Tuple[str, ...] = (
     "isoform_synonyms",
     "isoform_names",
     "isoform_ids",
@@ -109,7 +109,7 @@ _SOURCE_COLUMNS: tuple[str, ...] = (
 # ``uniProtkbId`` (and friends).  The fallbacks ensure that these shapes can be
 # processed without raising ``KeyError`` while keeping legacy behaviour for the
 # canonical aggregated target table.
-_SOURCE_FALLBACKS: dict[str, tuple[str, ...]] = {
+_SOURCE_FALLBACKS: Dict[str, Tuple[str, ...]] = {
     "uniprot_id_primary": (
         "uniprot_id",
         "uniprotkb_Id",
@@ -129,7 +129,7 @@ _SOURCE_FALLBACKS: dict[str, tuple[str, ...]] = {
     ),
 }
 
-_SOURCE_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
+_SOURCE_COLUMN_ALIASES: Dict[str, Tuple[str, ...]] = {
     "uniprot_id_primary": (
         "uniprot_id",
         "primary_accession",
@@ -144,7 +144,7 @@ _SOURCE_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 # Column order of the emitted CSV artefact.
-_OUTPUT_COLUMNS: tuple[str, ...] = (
+_OUTPUT_COLUMNS: Tuple[str, ...] = (
     "id",
     "uniprot_id_primary",
     "target_chembl_id",
@@ -157,18 +157,18 @@ def _normalize_column_name(column: str) -> str:
     return re.sub(r"[^a-z0-9]", "", _to_text(column).lower())
 
 
-def _resolve_source_columns(frame: pd.DataFrame) -> dict[str, str]:
+def _resolve_source_columns(frame: pd.DataFrame) -> Dict[str, str]:
     """Resolve the source column names accounting for legacy aliases."""
 
-    normalized_lookup: dict[str, list[str]] = {}
+    normalized_lookup: Dict[str, List[str]] = {}
     for column in frame.columns:
         normalized_lookup.setdefault(_normalize_column_name(column), []).append(column)
 
-    resolved: dict[str, str] = {}
-    missing: list[str] = []
+    resolved: Dict[str, str] = {}
+    missing: List[str] = []
 
     for canonical in _SOURCE_COLUMNS:
-        match: str | None = None
+        match: Optional[str] = None
         if canonical in frame.columns:
             match = canonical
         else:
@@ -224,7 +224,7 @@ def _to_text(value: Any) -> str:
     return str(value)
 
 
-def _split_pipes(value: Any) -> list[str]:
+def _split_pipes(value: Any) -> List[str]:
     """Split values by ``"|"`` trimming whitespace and dropping blanks."""
 
     text = _to_text(value)
@@ -236,13 +236,13 @@ def _split_pipes(value: Any) -> list[str]:
 
 def _make_triples(
     names: Sequence[str], ids: Sequence[str], synonyms: Sequence[str]
-) -> list[dict[str, str | None]]:
+) -> List[Dict[str, Optional[str]]]:
     """Align isoform names/ids/synonyms into indexed triplets."""
 
     n = max(len(names), len(ids), len(synonyms))
     if n == 0:
         return []
-    triples: list[dict[str, str | None]] = []
+    triples: List[Dict[str, Optional[str]]] = []
     for idx in range(n):
         triples.append(
             {
@@ -254,13 +254,13 @@ def _make_triples(
     return triples
 
 
-def _syn_expand(value: Any) -> list[str]:
+def _syn_expand(value: Any) -> List[str]:
     """Expand a synonym token according to the Power Query rules."""
 
     token = _to_text(value).lower().strip()
     if not token:
         return []
-    candidates: list[str] = []
+    candidates: List[str] = []
     for variant in (token, token.replace("pde", ""), token.replace("pld", "")):
         variant = variant.strip()
         if variant and variant not in candidates:
@@ -268,14 +268,14 @@ def _syn_expand(value: Any) -> list[str]:
     return candidates
 
 
-def _tokenize_synonym(value: Any) -> list[str]:
+def _tokenize_synonym(value: Any) -> List[str]:
     """Tokenise isoform synonyms by ``":"`` with ``SynExpand`` variants."""
 
     text = _to_text(value)
     if not text:
         return []
     parts = [segment.strip() for segment in text.split(":")]
-    tokens: list[str] = []
+    tokens: List[str] = []
     for part in parts:
         if not part:
             continue
@@ -377,10 +377,10 @@ def _transform(frame: pd.DataFrame) -> _TransformationResult:
     )
 
 
-def _read_csv(path: Path, *, encodings: Iterable[str]) -> tuple[pd.DataFrame, str]:
+def _read_csv(path: Path, *, encodings: Iterable[str]) -> Tuple[pd.DataFrame, str]:
     """Read ``path`` trying encodings sequentially until success."""
 
-    last_error: Exception | None = None
+    last_error: Optional[Exception] = None
     for encoding in encodings:
         try:
             frame = pd.read_csv(
@@ -399,7 +399,7 @@ def _read_csv(path: Path, *, encodings: Iterable[str]) -> tuple[pd.DataFrame, st
     raise UnicodeDecodeError("utf-8", b"", 0, 1, "unable to decode input")
 
 
-def _resolve_input_path(input_csv: str | Path | None) -> Path:
+def _resolve_input_path(input_csv: Optional[Union[str, Path]]) -> Path:
     """Resolve the source CSV path following the documented conventions."""
 
     if input_csv is not None:
@@ -443,7 +443,7 @@ def _resolve_input_path(input_csv: str | Path | None) -> Path:
     return max(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
-def _resolve_output_path(input_path: Path, output_csv: str | None) -> Path:
+def _resolve_output_path(input_path: Path, output_csv: Optional[str]) -> Path:
     if output_csv is not None:
         output_path = Path(output_csv)
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -457,8 +457,8 @@ def _stringify_for_csv(value: Any) -> str:
 
 
 def process_targets(
-    input_csv: str | None = None,
-    output_csv: str | None = None,
+    input_csv: Optional[str] = None,
+    output_csv: Optional[str] = None,
     verbose: bool = True,
 ) -> Path:
     """Run the isoform post-processing pipeline on canonical target exports."""


### PR DESCRIPTION
## Summary
- replace usage of PEP 585/604 syntax in the isoform post-processing helper with typing aliases compatible with older interpreters
- rely on Optional/Union/List/Dict/Tuple annotations so the module imports cleanly on Python versions that previously raised a SyntaxError

## Testing
- python -m compileall library/postprocessing/target/isoform.py

------
https://chatgpt.com/codex/tasks/task_e_68e1932fe01c83249d0f9c5227910de8