### PR TITLE
Handle missing tax IDs in postprocessing cellularity fetch

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -110,8 +110,13 @@ class Cellularity:
         return "ambiguous"
 
     def get_lineage_names(self, tax_id: Any, email: str | None = None) -> list[str]:
-        if tax_id is None or (isinstance(tax_id, float) and pd.isna(tax_id)):
-            return []
+        try:
+            if bool(pd.isna(tax_id)):
+                return []
+        except (TypeError, ValueError):
+            # ``pd.isna`` may return array-like objects for non-scalar inputs;
+            # those should simply fall back to the fetcher.
+            pass
         values = list(self.fetcher(tax_id, email))  # type: ignore[arg-type]
         return values
 

--- a/tests/postprocessing/test_cellularity_missing_values.py
+++ b/tests/postprocessing/test_cellularity_missing_values.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from library.postprocessing.target.cellularity import add_cellularity_smart
+
+
+@pytest.mark.unit
+def test_add_cellularity_smart__skips_fetch_for_missing_tax_ids() -> None:
+    def _fetch_stub(tax_id: object, email: str | None) -> list[str]:
+        raise AssertionError("fetcher should not be invoked for missing tax IDs")
+
+    frame = pd.DataFrame(
+        {
+            "tax_id": pd.Series([pd.NA, np.nan], dtype="object"),
+            "superkingdom": pd.Series([None, None], dtype="object"),
+            "phylum": pd.Series([None, None], dtype="object"),
+        }
+    )
+
+    result = add_cellularity_smart(
+        frame,
+        tax_id_column="tax_id",
+        superkingdom_column="superkingdom",
+        phylum_column="phylum",
+        fetcher=_fetch_stub,
+    )
+
+    assert result["cellularity"].tolist() == ["ambiguous", "ambiguous"]


### PR DESCRIPTION
## Summary
- guard `Cellularity.get_lineage_names` against missing tax IDs using `pd.isna` for all inputs before invoking the fetcher
- add a unit test covering `pd.NA` and `numpy.nan` tax IDs to ensure the fetcher is not called and the fallback classification is returned

## Testing
- pytest tests/postprocessing/test_cellularity_missing_values.py

------
https://chatgpt.com/codex/tasks/task_e_68e1935697c0832488a564d77659d077