### PR TITLE
Fix lineage retrieval for numeric tax IDs

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -111,15 +111,16 @@ class Cellularity:
         return "ambiguous"
 
     def get_lineage_names(self, tax_id: Any, email: str | None = None) -> list[str]:
+        missing_value: Any = False
         try:
             if bool(pd.isna(tax_id)):
                 return []
+            missing_value = pd.isna(tax_id)
         except (TypeError, ValueError):
             # ``pd.isna`` may return array-like objects for non-scalar inputs;
             # those should simply fall back to the fetcher.
-            pass
             missing_value = pd.isna(tax_id)
-        except (TypeError, ValueError):
+        except Exception:
             missing_value = False
 
         if tax_id is None:

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -267,3 +267,20 @@ def test_classify_by_fetch__trailing_spaces_remain_ambiguous() -> None:
 
     assert result == "ambiguous"
     assert classifier.get_lineage_names("9606") == lineage
+
+
+@pytest.mark.unit
+def test_get_lineage_names__numeric_tax_id_returns_lineage() -> None:
+    lineage = ["Cellular organisms", "Eukaryota", "Chordata", "Homo sapiens"]
+    calls: list[tuple[Any, str | None]] = []
+
+    def _fetcher(tax_id: Any, email: str | None) -> list[str]:
+        calls.append((tax_id, email))
+        return list(lineage)
+
+    classifier = Cellularity(fetcher=_fetcher)
+
+    result = classifier.get_lineage_names(9606)
+
+    assert result == lineage
+    assert calls == [(9606, None)]


### PR DESCRIPTION
## Summary
- ensure the cellularity lineage fetch handles missing tax IDs with a defined sentinel before fallback logic
- keep the pd.isna exception handling aligned with Power Query expectations and cover numeric tax ID lookups in tests

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py -k numeric -q

------
https://chatgpt.com/codex/tasks/task_e_68e197dd04788324baeffbf452b8f4c9