### PR TITLE
Ensure fungal lineage classification requires explicit token

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -196,7 +196,7 @@ class Cellularity:
                 return "multicellular"
             if self._has_any(names, self.unicell_phyla):
                 return "unicellular"
-            if "fungi" in names or self._has_any(names, self.fungi_phyla):
+            if "fungi" in names:
                 return "multicellular"
             if self._has_any(names, self.mostly_multicell_phyla):
                 return "multicellular"

--- a/tests/unit/postprocessing/target/test_cellularity.py
+++ b/tests/unit/postprocessing/target/test_cellularity.py
@@ -1,0 +1,14 @@
+import pytest
+
+from library.postprocessing.target.cellularity import Cellularity
+
+
+@pytest.mark.unit
+def test_classify_by_fetch__fungal_phylum_without_literal_token():
+    classifier = Cellularity(
+        fetcher=lambda tax_id, email: ("Eukaryota", "Ascomycota"),
+    )
+
+    result = classifier.classify_by_fetch(tax_id=9606)
+
+    assert result == "ambiguous"


### PR DESCRIPTION
## Summary
- require the literal "fungi" token before classifying fetched lineages as multicellular
- add a unit test verifying that a fungi phylum without the literal token remains ambiguous

## Testing
- pytest tests/unit/postprocessing/target/test_cellularity.py

------
https://chatgpt.com/codex/tasks/task_e_68e19a8e831c83249ad33c903b3ab540