### PR TITLE
Align target post-processing helpers with PQ lineage parsing

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -176,9 +176,11 @@ class Cellularity:
         lineage_text = first_element_text(list(taxon), "Lineage")
         sci_name = first_element_text(list(taxon), "ScientificName")
         lineage_names: list[str] = []
-        if lineage_text:
-            lineage_names = [segment.strip() for segment in lineage_text.split(";")]
-        lineage_names = [name for name in lineage_names if name]
+        if lineage_text is not None:
+            trimmed_lineage = lineage_text.strip()
+            if len(trimmed_lineage) > 0:
+                segments = lineage_text.split(";")
+                lineage_names = [segment.strip() for segment in segments]
         if sci_name is not None and sci_name not in lineage_names:
             lineage_names.append(sci_name)
         return lineage_names

--- a/library/postprocessing/target/multifunctional.py
+++ b/library/postprocessing/target/multifunctional.py
@@ -113,8 +113,15 @@ def _distinct(values: Iterable[str]) -> list[str]:
 
 
 def _transform_reaction_ec_numbers(value: Any) -> list[str]:
-    if value is None or (isinstance(value, float) and pd.isna(value)):
+    if value is None or value is pd.NA:
         return []
+    try:
+        if isinstance(value, float) and pd.isna(value):
+            return []
+        if pd.isna(value):
+            return []
+    except (TypeError, ValueError):
+        pass
     text = str(value)
     parts = text.split("|")
     parts = _distinct(parts)


### PR DESCRIPTION
## Summary
- preserve the Power Query handling of lineage names by keeping trimmed-but-empty lineage fragments when parsing XML
- treat pandas-masked values in reaction_ec_numbers as empty before computing the multifunctional flag

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py::test_postprocess_target_table__matches_power_query_snapshot -q
- pytest tests/integration/test_target_postprocess_table.py::test_postprocess_target_table__matches_golden -q

------
https://chatgpt.com/codex/tasks/task_e_68e199dc12308324b9e0a4ba05cd084c