### PR TITLE
Add organism helper postprocessing to target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -281,6 +281,31 @@ def _postprocess_isoform_export(
     return isoform_path
 
 
+def _postprocess_organism_export(
+    source: Path,
+    *,
+    cfg: Config,
+) -> Path | None:
+    """Invoke the organism lookup post-processing step for target exports."""
+
+    try:
+        organism_path = Path(target_pp.postprocess_target_table(str(source)))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "target_organism_postprocess_failed",
+            path=str(source),
+            error=str(exc),
+        )
+        return None
+
+    logger.info(
+        "target_organism_postprocess_done",
+        path=str(organism_path),
+        source=str(source),
+    )
+    return organism_path
+
+
 def _resolve_parameter(
     namespace: argparse.Namespace,
     cfg_section: Any,
@@ -3128,6 +3153,7 @@ def validate_and_write(
         http_requests=http_requests,
     )
     if exit_code == 0:
+        _postprocess_organism_export(final_csv_path, cfg=cfg)
         _postprocess_isoform_export(
             final_csv_path,
             cfg=cfg,

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -28,6 +28,9 @@ class _MemoryLogger:
     def error(self, event: str, **payload: object) -> None:
         self.events.append(("error", event, dict(payload)))
 
+    def exception(self, event: str, **payload: object) -> None:
+        self.events.append(("exception", event, dict(payload)))
+
 
 @pytest.fixture()
 def logger_stub(monkeypatch: pytest.MonkeyPatch) -> _MemoryLogger:
@@ -222,3 +225,55 @@ def test_run__delegates_to_handler(
     exit_code = get_target_data.run(cfg, args)
 
     assert exit_code == 4
+
+
+def test_postprocess_organism_export__success(
+    cfg: Config,
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "output.target_20250101.csv"
+    source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    output_path = tmp_path / "organism.output.target_20250101.csv"
+
+    def _fake_postprocess(path: str) -> str:
+        assert path == str(source)
+        output_path.write_text("target_chembl_id,target_type\nCHEMBL1,Multicellular\n", encoding="utf-8")
+        return str(output_path)
+
+    monkeypatch.setattr(get_target_data.target_pp, "postprocess_target_table", _fake_postprocess)
+
+    result = get_target_data._postprocess_organism_export(source, cfg=cfg)
+
+    assert result == output_path
+    assert (
+        "info",
+        "target_organism_postprocess_done",
+        {"path": str(output_path), "source": str(source)},
+    ) in logger_stub.events
+
+
+def test_postprocess_organism_export__failure(
+    cfg: Config,
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "output.target_20250101.csv"
+    source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    def _failing_postprocess(path: str) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(get_target_data.target_pp, "postprocess_target_table", _failing_postprocess)
+
+    result = get_target_data._postprocess_organism_export(source, cfg=cfg)
+
+    assert result is None
+    assert (
+        "exception",
+        "target_organism_postprocess_failed",
+        {"path": str(source), "error": "boom"},
+    ) in logger_stub.events


### PR DESCRIPTION
## Summary
- invoke the organism lookup post-processing when the target export finishes successfully
- cover the new helper with unit tests and extend the logger stub to capture exception events

## Testing
- pytest tests/unit/test_get_target_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e19d8ef71c8324b6a9d09b8aecea0a