### PR TITLE
Ensure target post-processing mirrors Power Query output

### DIFF
--- a/library/postprocessing/target/cellularity.py
+++ b/library/postprocessing/target/cellularity.py
@@ -13,6 +13,8 @@ import pandas as pd
 
 from .helpers import first_element_text, normalize_text
 
+ADD_CELLULARITY_SMART_FIELD_NAME = "AddCellularitySmart "
+
 FetchLineageCallable = Callable[[Any, str | None], Sequence[str]]
 
 
@@ -31,6 +33,7 @@ class Cellularity:
         "euglenozoa",
         "dinoflagellata",
         "alveolata",
+        "euglenozoa",
         "bacillariophyta",
         "parabasalia",
         "metamonada",
@@ -54,6 +57,7 @@ class Cellularity:
         "onychophora",
         "bryozoa",
         "brachiopoda",
+        "echinodermata",
         "hemichordata",
         "rotifera",
         "nemertea",
@@ -79,7 +83,9 @@ class Cellularity:
         "chytridiomycota",
     )
 
-    add_cellularity_smart_field: str = field(init=False, default="AddCellularitySmart ")
+    add_cellularity_smart_field: str = field(
+        init=False, default=ADD_CELLULARITY_SMART_FIELD_NAME
+    )
 
     def __post_init__(self) -> None:
         if self.fetcher is None:
@@ -255,4 +261,8 @@ def add_cellularity_smart(
     return result
 
 
-__all__ = ["Cellularity", "add_cellularity_smart"]
+__all__ = [
+    "Cellularity",
+    "add_cellularity_smart",
+    "ADD_CELLULARITY_SMART_FIELD_NAME",
+]

--- a/tests/unit/test_target_postprocess_main.py
+++ b/tests/unit/test_target_postprocess_main.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from library.postprocessing.target.main import postprocess_target_table
+
+
+@pytest.mark.unit
+def test_postprocess_target_table__produces_power_query_equivalent_csv(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    input_path = snapshot_resource / "target_postprocess_input.csv"
+    expected_path = snapshot_resource / "target_postprocess_expected.csv"
+
+    working_input = tmp_path / input_path.name
+    working_input.write_bytes(input_path.read_bytes())
+
+    output_location = postprocess_target_table(working_input)
+    output_path = Path(output_location)
+
+    assert output_path == tmp_path / f"organism.{input_path.name}"
+    assert output_path.read_bytes() == expected_path.read_bytes()
+
+    result_frame = pd.read_csv(output_path, dtype=str, keep_default_na=False)
+    expected_frame = pd.read_csv(expected_path, dtype=str, keep_default_na=False)
+    pdt.assert_frame_equal(result_frame, expected_frame)
+
+    bool_frame = pd.read_csv(
+        output_path,
+        dtype={"multifunctional_enzyme": "boolean"},
+        keep_default_na=False,
+    )
+    assert str(bool_frame["multifunctional_enzyme"].dtype) == "boolean"
+


### PR DESCRIPTION
## Summary
- expose the Power Query field name for AddCellularitySmart and preserve the source phyla listings verbatim
- add a regression test that runs postprocess_target_table against the snapshot CSV and asserts byte-for-byte parity plus boolean typing

## Testing
- pytest tests/unit/test_target_postprocess_main.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e19dfdaa80832494b798227cc663b4