### PR TITLE
Ensure target post-processing runs for single-source exports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -306,6 +306,24 @@ def _postprocess_organism_export(
     return organism_path
 
 
+def _postprocess_target_exports(
+    source: Path,
+    *,
+    cfg: Config,
+    context: IsoformPostprocessContext | None = None,
+    ambiguous_classifications: int | None = None,
+) -> None:
+    """Run all target post-processing helpers for ``source`` export."""
+
+    _postprocess_organism_export(source, cfg=cfg)
+    _postprocess_isoform_export(
+        source,
+        cfg=cfg,
+        context=context,
+        ambiguous_classifications=ambiguous_classifications,
+    )
+
+
 def _resolve_parameter(
     namespace: argparse.Namespace,
     cfg_section: Any,
@@ -1566,8 +1584,9 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             encoding=cfg.io.csv_encoding,
             key_cols=["uniprot_id"],
         )
-        _postprocess_isoform_export(
-            Path(csv_path),
+        export_path = Path(csv_path)
+        _postprocess_target_exports(
+            export_path,
             cfg=cfg,
             context=IsoformPostprocessContext(args=args),
         )
@@ -1809,7 +1828,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 )
                 return 1
 
-        _postprocess_isoform_export(
+        _postprocess_target_exports(
             destination,
             cfg=cfg,
             context=IsoformPostprocessContext(
@@ -1966,7 +1985,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 final_path = final_output
             else:
                 final_path = raw_path
-            _postprocess_isoform_export(
+            _postprocess_target_exports(
                 final_path,
                 cfg=cfg,
                 context=IsoformPostprocessContext(
@@ -2030,7 +2049,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 key_cols=resolved_keys or None,
                 col_order=TARGETS_COLUMN_ORDER,
             )
-        _postprocess_isoform_export(
+        _postprocess_target_exports(
             final_path,
             cfg=cfg,
             context=IsoformPostprocessContext(
@@ -3153,8 +3172,7 @@ def validate_and_write(
         http_requests=http_requests,
     )
     if exit_code == 0:
-        _postprocess_organism_export(final_csv_path, cfg=cfg)
-        _postprocess_isoform_export(
+        _postprocess_target_exports(
             final_csv_path,
             cfg=cfg,
             context=isoform_context,

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -199,6 +199,56 @@ def test_run__skip_existing(
     assert ("info", "pipeline_skip_existing", {"output": str(final_out)}) in logger_stub.events
 
 
+def test_run_uniprot__invokes_target_postprocess(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg.system.doc_quality.enable = False
+    input_csv = tmp_path / "uniprot_ids.csv"
+    input_csv.write_text("uniprot_id\nP12345\n", encoding="utf-8")
+    output_csv = tmp_path / "output.target_20250101.csv"
+
+    monkeypatch.setattr(get_target_data.uu, "init_session", lambda *_, **__: None)
+
+    def _fake_process(**kwargs: object) -> None:
+        assert kwargs["output_csv"] == str(output_csv)
+        Path(kwargs["output_csv"]).write_text(
+            "uniprot_id\nP12345\n", encoding=cfg.io.csv_encoding
+        )
+
+    monkeypatch.setattr(get_target_data.uu, "process", _fake_process)
+
+    recorded: dict[str, object] = {}
+
+    def _fake_postprocess(
+        path: Path,
+        *,
+        cfg: Config,
+        context: get_target_data.IsoformPostprocessContext | None = None,
+        ambiguous_classifications: int | None = None,
+    ) -> None:
+        recorded["path"] = Path(path)
+        recorded["context"] = context
+        recorded["ambiguous"] = ambiguous_classifications
+
+    monkeypatch.setattr(
+        get_target_data,
+        "_postprocess_target_exports",
+        _fake_postprocess,
+    )
+
+    args = argparse.Namespace(input_csv=input_csv, output_csv=output_csv)
+
+    exit_code = get_target_data.run_uniprot(cfg, args)
+
+    assert exit_code == 0
+    assert recorded["path"] == output_csv
+    assert isinstance(recorded["context"], get_target_data.IsoformPostprocessContext)
+    assert recorded["context"].args is args
+    assert recorded["ambiguous"] is None
+
+
 def test_run__delegates_to_handler(
     cfg: Config,
     tmp_path: Path,
@@ -277,3 +327,37 @@ def test_postprocess_organism_export__failure(
         "target_organism_postprocess_failed",
         {"path": str(source), "error": "boom"},
     ) in logger_stub.events
+
+
+def test_postprocess_target_exports__chains_helpers(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "output.target_20250101.csv"
+    source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    call_order: list[str] = []
+
+    def _fake_organism(path: Path, *, cfg: Config) -> Path:
+        assert Path(path) == source
+        call_order.append("organism")
+        return source
+
+    def _fake_isoform(
+        path: Path,
+        *,
+        cfg: Config,
+        context: get_target_data.IsoformPostprocessContext | None = None,
+        ambiguous_classifications: int | None = None,
+    ) -> Path | None:
+        assert Path(path) == source
+        call_order.append("isoform")
+        return source
+
+    monkeypatch.setattr(get_target_data, "_postprocess_organism_export", _fake_organism)
+    monkeypatch.setattr(get_target_data, "_postprocess_isoform_export", _fake_isoform)
+
+    get_target_data._postprocess_target_exports(source, cfg=cfg)
+
+    assert call_order == ["organism", "isoform"]


### PR DESCRIPTION
## Summary
- add a helper that runs both organism and isoform post-processing steps for target exports
- invoke the combined helper from the uniprot, chembl and full target pipelines so organism outputs are written everywhere
- cover the new helper and the uniprot pipeline with unit tests

## Testing
- pytest tests/unit/test_get_target_data.py -k "postprocess or run_uniprot" -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a276b6c883248b5750eb5f9649c6