### PR TITLE
Handle missing target columns in multifunctional postprocessing

### DIFF
--- a/library/postprocessing/target/multifunctional.py
+++ b/library/postprocessing/target/multifunctional.py
@@ -136,7 +136,7 @@ def _transform_reaction_ec_numbers(value: Any) -> list[str]:
 def compute_multifunctional(source: pd.DataFrame) -> pd.DataFrame:
     """Replicate the ``multifunctional`` helper from the M script."""
 
-    trimmed = source.drop(columns=list(_COLUMNS_TO_REMOVE))
+    trimmed = source.drop(columns=list(_COLUMNS_TO_REMOVE), errors="ignore")
     result = trimmed.copy()
     result["reaction_ec_numbers"] = result["reaction_ec_numbers"].map(
         _transform_reaction_ec_numbers

--- a/tests/unit/test_target_multifunctional.py
+++ b/tests/unit/test_target_multifunctional.py
@@ -38,3 +38,25 @@ def test_compute_multifunctional__derives_boolean_flag() -> None:
     assert bool(result.loc[2, "multifunctional_enzyme"]) is False
     assert result.loc[0, "reaction_ec_numbers"] == ["1", "2"]
     assert result.loc[2, "reaction_ec_numbers"] == [""]
+
+
+@pytest.mark.unit
+def test_compute_multifunctional__ignores_missing_optional_columns() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL1",
+                "reaction_ec_numbers": "1.2.3.4|2.7.11.1",
+            }
+        ]
+    )
+
+    result = compute_multifunctional(source)
+
+    assert result.columns.tolist() == [
+        "target_chembl_id",
+        "reaction_ec_numbers",
+        "multifunctional_enzyme",
+    ]
+    assert result.loc[0, "reaction_ec_numbers"] == ["1", "2"]
+    assert bool(result.loc[0, "multifunctional_enzyme"]) is True


### PR DESCRIPTION
## Summary
- allow the multifunctional postprocessing helper to tolerate missing optional target metadata columns
- add a unit test ensuring the computation works when only required columns are provided

## Testing
- pytest tests/unit/test_target_multifunctional.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a3cb3efc8324a11b5e118796e74c