### PR TITLE
Handle missing optional columns in multifunctional postprocessing

### DIFF
--- a/library/postprocessing/target/multifunctional.py
+++ b/library/postprocessing/target/multifunctional.py
@@ -136,7 +136,16 @@ def _transform_reaction_ec_numbers(value: Any) -> list[str]:
 def compute_multifunctional(source: pd.DataFrame) -> pd.DataFrame:
     """Replicate the ``multifunctional`` helper from the M script."""
 
-    trimmed = source.drop(columns=list(_COLUMNS_TO_REMOVE), errors="ignore")
+    # Some datasets omit metadata fields such as ``target_type``.  We therefore
+    # trim only the columns that actually exist instead of relying on
+    # ``errors="ignore"`` which has proved brittle across pandas versions.
+    removable_columns = [
+        column for column in _COLUMNS_TO_REMOVE if column in source.columns
+    ]
+    if removable_columns:
+        trimmed = source.drop(columns=removable_columns)
+    else:
+        trimmed = source.copy()
     result = trimmed.copy()
     result["reaction_ec_numbers"] = result["reaction_ec_numbers"].map(
         _transform_reaction_ec_numbers


### PR DESCRIPTION
## Summary
- guard the multifunctional post-processing against optional metadata columns that may be absent

## Testing
- pytest tests/unit/test_target_multifunctional.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a4f48dc08324bc8469c2caff4286