### PR TITLE
Fix isoform alias handling in isoform post-processing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -313,7 +313,25 @@ class _TransformationResult:
 def _transform(frame: pd.DataFrame) -> _TransformationResult:
     """Apply the isoform expansion stages mirroring the Power Query steps."""
 
-    projected = _project_source_columns(frame)
+    if frame.empty:
+        empty_result = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
+        return _TransformationResult(
+            result=empty_result.copy(),
+            combined=empty_result.copy(),
+            dedup_stage1=empty_result.copy(),
+            sorted_stage=empty_result.copy(),
+            dedup_stage2=empty_result.copy(),
+        )
+
+    resolved = _resolve_source_columns(frame)
+    aligned = frame.copy()
+    for canonical, source in resolved.items():
+        if source in aligned.columns:
+            aligned[canonical] = aligned[source].astype(object)
+        else:  # pragma: no cover - defensive guard for mutated inputs
+            aligned[canonical] = _empty_like(aligned.index)
+
+    projected = _project_source_columns(aligned)
     if projected.empty:
         empty_result = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
         return _TransformationResult(
@@ -323,7 +341,6 @@ def _transform(frame: pd.DataFrame) -> _TransformationResult:
             sorted_stage=empty_result.copy(),
             dedup_stage2=empty_result.copy(),
         )
-    _resolve_source_columns(frame)
     projected = projected.loc[:, list(_SOURCE_COLUMNS)].copy()
 
     projected["isoform_synonyms"] = projected["isoform_synonyms"].map(

--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,16 +1,16 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "5a4b46f1aaf0f8e1e4fd62a1e752910c251ae4da",
+    "commit": "abf623bbd40e012d0f004b35fe3b8ed9defabeaa",
     "branch": "work",
-    "ts_utc": "2025-10-04T15:38:26.315854+00:00",
-    "duration_sec": 3.435,
+    "ts_utc": "2025-10-04T23:26:43.505857+00:00",
+    "duration_sec": 6.403,
     "python": "3.11.12",
     "pytest": "8.4.1"
   },
   "summary": {
-    "total": 215,
-    "passed": 215,
+    "total": 292,
+    "passed": 292,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
@@ -22,13 +22,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_activity_data]",
       "status": "passed",
-      "duration_ms": 3.62,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.668964+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.669409+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T15:38:23.669627+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.669791+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.669911+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.670037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.670115+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 3.466,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:37.797843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.798322+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T23:26:37.798460+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.798599+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798729+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.798870+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798951+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.668964+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.669409+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T15:38:23.669627+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.669791+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.669911+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.670037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.670115+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:37.797843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.798322+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T23:26:37.798460+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.798599+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798729+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.798870+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798951+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -36,13 +36,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_assay_data]",
       "status": "passed",
-      "duration_ms": 4.212,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.675250+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.675877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T15:38:23.676013+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.676128+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676215+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.676310+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676402+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 3.054,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:37.803301+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.803645+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T23:26:37.803801+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.803929+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804050+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.804142+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804284+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.675250+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8dad4674a6cf4c3d88e1730724ea7544\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.675877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T15:38:23.676013+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.676128+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676215+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.676310+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.676402+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:37.803301+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.803645+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T23:26:37.803801+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.803929+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804050+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.804142+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804284+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -50,13 +50,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_document_data]",
       "status": "passed",
-      "duration_ms": 5.643,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.682428+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.682959+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T15:38:23.683210+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.683444+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.683576+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.683724+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.684148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 4.268,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:37.809147+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.809538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T23:26:37.809663+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.809784+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.809918+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.810223+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.810306+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.682428+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5eaa9babc6614db39d5c9639f49e4d92\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.682959+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T15:38:23.683210+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.683444+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.683576+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.683724+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.684148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8f82cd92a91c49ebaa90a1ce1e2660ac\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:37.809147+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.809538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T23:26:37.809663+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.809784+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.809918+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.810223+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.810306+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -64,13 +64,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_target_data]",
       "status": "passed",
-      "duration_ms": 7.378,
-      "stdout": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.691922+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T15:38:23.692078+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.692221+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693401+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.693589+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693698+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 5.728,
+      "stdout": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.817195+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T23:26:37.817350+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.817461+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817724+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.817816+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817889+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.691922+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T15:38:23.692078+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.692221+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693401+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.693589+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.693698+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null}\n"
+          "content": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.817195+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T23:26:37.817350+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.817461+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817724+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.817816+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817889+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -78,13 +78,55 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_testitem_data]",
       "status": "passed",
-      "duration_ms": 2.909,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.697539+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.698004+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T15:38:23.698146+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.698286+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698388+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.698501+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698589+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 2.757,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:37.821612+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.821937+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T23:26:37.822092+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.822212+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822298+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.822385+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822458+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.697539+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"42f772b8c70d484388b2fd7208a6182c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T15:38:23.698004+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T15:38:23.698146+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T15:38:23.698286+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698388+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T15:38:23.698501+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T15:38:23.698589+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:37.821612+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.821937+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T23:26:37.822092+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.822212+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822298+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.822385+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822458+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__non_csv_output_path",
+      "status": "passed",
+      "duration_ms": 69.054,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:38.133295+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.133467+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.147971+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:38.148559+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:38.165707+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.198868+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:38.133295+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.133467+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.147971+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:38.148559+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:38.165707+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.198868+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__retry_and_idempotent",
+      "status": "passed",
+      "duration_ms": 205.707,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:37.850420+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.850599+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.871945+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.872695+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.905162+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:37.924689+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T23:26:37.949435+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:37.951349+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.951511+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.967552+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.968131+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.986033+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.051651+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:37.850420+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.850599+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.871945+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.872695+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.905162+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:37.924689+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T23:26:37.949435+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:37.951349+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.951511+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.967552+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.968131+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.986033+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.051651+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__workers_and_offset",
+      "status": "passed",
+      "duration_ms": 70.402,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:38.059004+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.059181+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.073808+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-04T23:26:38.074377+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:38.091953+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.125491+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:38.059004+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.059181+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.073808+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-04T23:26:38.074377+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:38.091953+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.125491+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -92,16 +134,30 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_failure",
       "status": "passed",
-      "duration_ms": 0.285,
+      "duration_ms": 0.296,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
+      "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_retry_and_idempotent",
+      "status": "passed",
+      "duration_ms": 566.861,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:38.777285+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.777922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.790093+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.829012+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:38.777285+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.777922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.790093+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.829012+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.45,
+      "duration_ms": 0.379,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -110,16 +166,30 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_success",
       "status": "passed",
-      "duration_ms": 8.887,
+      "duration_ms": 7.621,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
+      "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_workers_offset_and_non_csv",
+      "status": "passed",
+      "duration_ms": 63.644,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:38.845480+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.845994+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.859508+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.896134+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:38.845480+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.845994+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.859508+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.896134+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_failure",
       "status": "passed",
-      "duration_ms": 0.34,
+      "duration_ms": 0.376,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -128,7 +198,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.378,
+      "duration_ms": 0.387,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -137,7 +207,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_success",
       "status": "passed",
-      "duration_ms": 7.14,
+      "duration_ms": 5.377,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -146,7 +216,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.323,
+      "duration_ms": 0.477,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -155,7 +225,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_success",
       "status": "passed",
-      "duration_ms": 8.495,
+      "duration_ms": 6.732,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -164,7 +234,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_missing_handler",
       "status": "passed",
-      "duration_ms": 0.314,
+      "duration_ms": 0.316,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -173,7 +243,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.451,
+      "duration_ms": 0.547,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -182,7 +252,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_success",
       "status": "passed",
-      "duration_ms": 9.388,
+      "duration_ms": 6.706,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -191,7 +261,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.533,
+      "duration_ms": 0.572,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -200,7 +270,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_failure_logs",
       "status": "passed",
-      "duration_ms": 0.495,
+      "duration_ms": 0.491,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -209,7 +279,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.475,
+      "duration_ms": 0.481,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -218,7 +288,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_success",
       "status": "passed",
-      "duration_ms": 11.799,
+      "duration_ms": 11.075,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -227,7 +297,7 @@
     {
       "nodeid": "tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline",
       "status": "passed",
-      "duration_ms": 98.867,
+      "duration_ms": 177.862,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -236,13 +306,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
       "status": "passed",
-      "duration_ms": 67.609,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.919967+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.920193+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.923940+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 62.521,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.099703+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.099916+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.103128+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.919967+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.920193+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T15:38:23.923940+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.099703+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.099916+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.103128+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -250,13 +320,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__finalize_stage_idempotent",
       "status": "passed",
-      "duration_ms": 211.099,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:23.976121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.003014+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.003251+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.031620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.064937+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T15:38:24.088251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.091506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.102434+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.102637+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.129150+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.178712+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
+      "duration_ms": 192.699,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.149338+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.162235+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.162431+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.191277+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.241550+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:39.244464+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.255292+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.255464+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.286051+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.336032+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:23.976121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.003014+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.003251+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.031620+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.064937+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T15:38:24.088251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.091506+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.102434+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.102637+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.129150+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.178712+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.149338+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.162235+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.162431+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.191277+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.241550+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:39.244464+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.255292+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.255464+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.286051+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.336032+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -264,7 +334,7 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
       "status": "passed",
-      "duration_ms": 23.942,
+      "duration_ms": 24.943,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -273,13 +343,13 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
       "status": "passed",
-      "duration_ms": 22.745,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.230977+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 24.441,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.390756+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.230977+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"a5bad570652d4f8c91147311d5393374\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.390756+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -287,7 +357,7 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
       "status": "passed",
-      "duration_ms": 5.386,
+      "duration_ms": 5.641,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -296,13 +366,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[False]",
       "status": "passed",
-      "duration_ms": 55.402,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.383802+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.418954+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 53.947,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.584014+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.619000+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.383802+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.418954+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c52af63f99c74871bbc4583a9436dba6\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.584014+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.619000+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -310,13 +380,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[True]",
       "status": "passed",
-      "duration_ms": 56.575,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.442067+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.477654+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 52.921,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.640089+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.674068+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.442067+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.477654+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.640089+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.674068+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -324,13 +394,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__with_fallback_csv",
       "status": "passed",
-      "duration_ms": 57.249,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.324062+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.361148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 53.954,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.527943+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.562894+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.324062+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.361148+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"96e8136ef73249ab9c2020ba47be5b2c\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.527943+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.562894+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -338,13 +408,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__without_fallback_csv",
       "status": "passed",
-      "duration_ms": 57.15,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.265843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.301774+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 101.582,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.424429+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.506877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.265843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:24.301774+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"36168e233b7c49c185c97bd78f6d3839\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.424429+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.506877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -352,13 +422,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
       "status": "passed",
-      "duration_ms": 84.571,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.012477+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019016+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019194+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.042110+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.092480+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
+      "duration_ms": 95.575,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:40.559239+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566407+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566647+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.593633+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.650071+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.012477+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019016+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.019194+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.042110+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.092480+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:40.559239+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566407+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566647+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.593633+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.650071+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -366,13 +436,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
       "status": "passed",
-      "duration_ms": 178.903,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.100399+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.108452+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.108634+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.136190+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.188816+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.190858+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.198493+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.198671+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.224701+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.276902+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
+      "duration_ms": 199.247,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:40.658125+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.667921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.668224+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.697645+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.756256+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.758367+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.769037+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.769291+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.797425+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.854591+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.100399+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.108452+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.108634+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.136190+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.188816+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.190858+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:25.198493+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:25.198671+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:25.224701+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T15:38:25.276902+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:40.658125+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.667921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.668224+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.697645+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.756256+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.758367+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.769037+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.769291+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.797425+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.854591+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -380,7 +450,7 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__missing_required_columns_fails",
       "status": "passed",
-      "duration_ms": 1.773,
+      "duration_ms": 1.313,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -389,13 +459,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__optional_columns_missing_warns",
       "status": "passed",
-      "duration_ms": 84.949,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.627705+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.635469+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.661880+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.710586+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
+      "duration_ms": 82.53,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.811843+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.818857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.844867+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.892415+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.627705+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.635469+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.661880+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.710586+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.811843+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.818857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.844867+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.892415+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -403,13 +473,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal",
       "status": "passed",
-      "duration_ms": 176.256,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.832281+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.839921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.840113+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.863815+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.956413+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006176+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006627+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
+      "duration_ms": 532.954,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:40.021897+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:40.030332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.030524+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.058903+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.120390+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.179812+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.552346+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.832281+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.839921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.840113+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.863815+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.956413+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006176+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:25.006627+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:40.021897+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:40.030332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.030524+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.058903+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.120390+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.179812+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.552346+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
         }
       ],
       "error": null
@@ -417,13 +487,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
       "status": "passed",
-      "duration_ms": 78.13,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.750857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.757640+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.757829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.780801+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.826359+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.827406+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
+      "duration_ms": 85.387,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.931871+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.938392+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.938549+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.965005+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.014251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.015520+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.750857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.757640+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.757829+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.780801+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.826359+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T15:38:24.827406+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.931871+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.938392+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.938549+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.965005+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.014251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.015520+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
         }
       ],
       "error": null
@@ -431,13 +501,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
       "status": "passed",
-      "duration_ms": 135.953,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.486683+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.498167+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.498340+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.526462+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.579772+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
+      "duration_ms": 125.453,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.681624+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.692463+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.692628+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.720728+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.768722+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.486683+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T15:38:24.498167+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T15:38:24.498340+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.526462+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T15:38:24.579772+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.681624+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.692463+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.692628+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.720728+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.768722+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -445,21 +515,99 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
       "status": "passed",
-      "duration_ms": 32.386,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:24.716174+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.725837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T15:38:24.727178+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.744876+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
+      "duration_ms": 31.283,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:39.897975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907261+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907999+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.925739+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:24.716174+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T15:38:24.725837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T15:38:24.727178+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T15:38:24.744876+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-4/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:39.897975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907261+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907999+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.925739+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
         }
       ],
       "error": null
     },
     {
+      "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__deduplicates_identifiers",
+      "status": "passed",
+      "duration_ms": 86.46,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:41.077750+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:41.142153+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:41.077750+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:41.142153+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__happy_path",
+      "status": "passed",
+      "duration_ms": 75.81,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:40.878973+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:40.933796+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:40.878973+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:40.933796+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__malformed_values",
+      "status": "passed",
+      "duration_ms": 110.646,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:40.963022+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:40.963022+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__missing_column_input",
+      "status": "passed",
+      "duration_ms": 0.619,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__retry_after_failure",
+      "status": "passed",
+      "duration_ms": 8.881,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__schema_and_duplicates",
+      "status": "passed",
+      "duration_ms": 10.402,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__skip_existing_and_force",
+      "status": "passed",
+      "duration_ms": 9.566,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
       "status": "passed",
-      "duration_ms": 0.36,
+      "duration_ms": 0.47,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -468,7 +616,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_encoding_recovers_values",
       "status": "passed",
-      "duration_ms": 1.322,
+      "duration_ms": 1.315,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -477,7 +625,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_separator_emits_info",
       "status": "passed",
-      "duration_ms": 0.635,
+      "duration_ms": 0.6,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -486,13 +634,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
       "status": "passed",
-      "duration_ms": 0.563,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.339406+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 0.932,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:41.246254+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.339406+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:41.246254+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -504,13 +652,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
       "status": "passed",
-      "duration_ms": 6.195,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.331366+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 7.339,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:41.235339+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.331366+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:41.235339+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -522,7 +670,7 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__normal_flow_populates_cache",
       "status": "passed",
-      "duration_ms": 9.556,
+      "duration_ms": 9.545,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -531,13 +679,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__skips_polymers_when_disallowed",
       "status": "passed",
-      "duration_ms": 9.336,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.306836+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 8.421,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:41.209639+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.306836+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:41.209639+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -549,13 +697,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_augment_pubchem__initialises_session_and_reuses_cache",
       "status": "passed",
-      "duration_ms": 11.387,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.316594+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.321782+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.322042+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.326906+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 12.646,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:41.219053+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224554+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224877+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.230424+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.316594+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.321782+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.322042+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.326906+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:41.219053+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224554+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224877+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.230424+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -563,7 +711,7 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
       "status": "passed",
-      "duration_ms": 1.393,
+      "duration_ms": 1.802,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -572,95 +720,113 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
       "status": "passed",
-      "duration_ms": 5.694,
+      "duration_ms": 8.556,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
+      "nodeid": "tests/integration/test_target_postprocess_table.py::test_postprocess_target_table__is_idempotent",
       "status": "passed",
-      "duration_ms": 1.415,
+      "duration_ms": 260.042,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
+      "nodeid": "tests/integration/test_target_postprocess_table.py::test_postprocess_target_table__matches_golden",
       "status": "passed",
-      "duration_ms": 1.735,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.355336+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"scripts.run_test_suite\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.355336+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"c42fcb16184e4c609ba65f685044e985\", \"logger\": \"scripts.run_test_suite\"}\n"
-        },
-        {
-          "section": "Captured log call",
-          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
-      "status": "passed",
-      "duration_ms": 0.708,
+      "duration_ms": 180.039,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
+      "nodeid": "tests/postprocessing/test_cellularity_missing_values.py::test_add_cellularity_smart__skips_fetch_for_missing_tax_ids",
       "status": "passed",
-      "duration_ms": 0.436,
+      "duration_ms": 1.607,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_add_cellularity_smart__fills_column",
       "status": "passed",
-      "duration_ms": 0.186,
+      "duration_ms": 4.401,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_add_cellularity_smart__missing_tax_ids_skip_fetch",
       "status": "passed",
-      "duration_ms": 0.132,
+      "duration_ms": 1.125,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_append_multifunctional_flag__detects_keywords",
       "status": "passed",
-      "duration_ms": 0.124,
+      "duration_ms": 3.977,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_cellularity_classification__matches_examples",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 0.169,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_classify_by_fetch__trailing_spaces_remain_ambiguous",
+      "status": "passed",
+      "duration_ms": 0.182,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_classify_by_fetch__trailing_whitespace_lineage_remains_ambiguous",
+      "status": "passed",
+      "duration_ms": 0.146,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_get_lineage_names__numeric_tax_id_returns_lineage",
+      "status": "passed",
+      "duration_ms": 0.119,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_final_dedup__matches_last_distinct",
+      "status": "passed",
+      "duration_ms": 16.008,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_make_triples__pads_shorter_lists",
       "status": "passed",
       "duration_ms": 0.121,
       "stdout": "",
@@ -669,230 +835,133 @@
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_make_triples_fixture__pads_missing_values",
       "status": "passed",
-      "duration_ms": 0.128,
+      "duration_ms": 16.965,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_name_filter__drops_empty_and_na",
       "status": "passed",
-      "duration_ms": 0.147,
+      "duration_ms": 16.398,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_normalisation__only_names_and_synonyms_lowercased",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 15.142,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_get_document_data.py::test_build_parser__pubmed_defaults",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_output_columns__match_spec",
       "status": "passed",
-      "duration_ms": 2.002,
+      "duration_ms": 16.207,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__cli_overrides_config",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_process_targets__writes_isoform_prefix",
       "status": "passed",
-      "duration_ms": 65.771,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.402065+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.402198+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.439149+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.446995+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.402065+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.402198+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.439149+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.446995+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"dca888702a444acbacb5728d783434c1\", \"status\": null, \"rps\": null}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__config_overrides_defaults",
-      "status": "passed",
-      "duration_ms": 73.478,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.468768+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.468884+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.512265+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.522094+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.468768+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T15:38:25.468884+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T15:38:25.512265+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-4/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T15:38:25.522094+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--limit--1---limit must be zero or a positive integer]",
-      "status": "passed",
-      "duration_ms": 3.456,
+      "duration_ms": 17.431,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--offset--5---offset must be zero or a positive integer]",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_sorted_stage__uses_mergesort",
       "status": "passed",
-      "duration_ms": 2.811,
+      "duration_ms": 16.107,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_split_pipes__trims_and_discards_empty",
       "status": "passed",
-      "duration_ms": 3.049,
+      "duration_ms": 0.122,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_stage1_dedup__matches_table_distinct",
       "status": "passed",
-      "duration_ms": 1.789,
+      "duration_ms": 16.001,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_stage2_dedup__matches_drop_duplicates",
       "status": "passed",
-      "duration_ms": 1.852,
+      "duration_ms": 15.577,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_synonym_tokens__preserve_identifier",
       "status": "passed",
-      "duration_ms": 1.739,
+      "duration_ms": 17.02,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_parser.py::test_apply_config_overrides__missing_config_attribute",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_tokenise_synonym__pde3a_alpha",
       "status": "passed",
-      "duration_ms": 38.741,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_postprocess_target_table__matches_power_query_snapshot",
       "status": "passed",
-      "duration_ms": 1.061,
+      "duration_ms": 140.77,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_postprocess_target_table_file__writes_expected_bytes",
       "status": "passed",
-      "duration_ms": 0.176,
+      "duration_ms": 191.162,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
+      "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_read_snapshot__validates_required_columns",
       "status": "passed",
-      "duration_ms": 1.373,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.616422+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.616422+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-4/test_read_input_ids__invalid_c0/input.csv\"}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
-      "status": "passed",
-      "duration_ms": 1.815,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.612163+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.612163+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
-      "status": "passed",
-      "duration_ms": 3.647,
+      "duration_ms": 3.788,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
-      "status": "passed",
-      "duration_ms": 0.416,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.606665+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.606665+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
-      "status": "passed",
-      "duration_ms": 0.113,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
-      "status": "passed",
-      "duration_ms": 0.131,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
-      "status": "passed",
-      "duration_ms": 0.115,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
+      "nodeid": "tests/unit/postprocessing/target/test_cellularity.py::test_classify_by_fetch__fungal_phylum_without_literal_token",
       "status": "passed",
       "duration_ms": 0.15,
       "stdout": "",
@@ -901,472 +970,79 @@
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
+      "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_resolve_source_columns__includes_fallback_aliases_in_error",
       "status": "passed",
-      "duration_ms": 0.13,
+      "duration_ms": 0.834,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
+      "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_transform__empty_input_returns_empty_frame",
       "status": "passed",
-      "duration_ms": 0.158,
+      "duration_ms": 1.24,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
+      "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_transform__falls_back_to_uniprot_columns",
       "status": "passed",
-      "duration_ms": 0.272,
+      "duration_ms": 14.457,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
       "status": "passed",
-      "duration_ms": 0.145,
+      "duration_ms": 1.325,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
       "status": "passed",
-      "duration_ms": 0.141,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
-      "status": "passed",
-      "duration_ms": 0.221,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
-      "status": "passed",
-      "duration_ms": 0.199,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
-      "status": "passed",
-      "duration_ms": 0.273,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
-      "status": "passed",
-      "duration_ms": 0.251,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[config/dictionary/_testitem/molecule_hierarchy.csv]",
-      "status": "passed",
-      "duration_ms": 0.633,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[value1]",
-      "status": "passed",
-      "duration_ms": 0.542,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[data/output/test.csv]",
-      "status": "passed",
-      "duration_ms": 0.404,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[value1]",
-      "status": "passed",
-      "duration_ms": 0.691,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
-      "status": "passed",
-      "duration_ms": 3.968,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
-      "status": "passed",
-      "duration_ms": 12.262,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[None-expected0]",
-      "status": "passed",
-      "duration_ms": 0.154,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation1-expected1]",
-      "status": "passed",
-      "duration_ms": 0.164,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation2-expected2]",
-      "status": "passed",
-      "duration_ms": 0.142,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation3-expected3]",
-      "status": "passed",
-      "duration_ms": 0.124,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation4-expected4]",
-      "status": "passed",
-      "duration_ms": 0.125,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation5-expected5]",
-      "status": "passed",
-      "duration_ms": 0.124,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation6-expected6]",
-      "status": "passed",
-      "duration_ms": 0.117,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation7-expected7]",
-      "status": "passed",
-      "duration_ms": 0.385,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation8-expected8]",
-      "status": "passed",
-      "duration_ms": 0.131,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation9-expected9]",
-      "status": "passed",
-      "duration_ms": 0.15,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_respects_flags",
-      "status": "passed",
-      "duration_ms": 0.527,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.704309+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__skip_existing_respec0/output.csv\"}\n",
+      "duration_ms": 1.632,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.294961+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"scripts.run_test_suite\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.704309+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__skip_existing_respec0/output.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:42.294961+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"scripts.run_test_suite\"}\n"
+        },
+        {
+          "section": "Captured log call",
+          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
         }
       ],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__dry_run_short_circuits",
+      "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
       "status": "passed",
-      "duration_ms": 0.74,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.700444+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": 7, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 5, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"dry_run\": {\"value\": true, \"source\": \"cli\"}, \"workers\": {\"value\": 1, \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:25.700726+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 7}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.700444+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run_chembl__dry_run_short0/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": 7, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 5, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"dry_run\": {\"value\": true, \"source\": \"cli\"}, \"workers\": {\"value\": 1, \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:25.700726+00:00\", \"level\": \"INFO\", \"event\": \"dry_run\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 7}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__invalid_limit_logs_error",
-      "status": "passed",
-      "duration_ms": 0.476,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.697025+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
-      "stderr": "",
-      "log": [
-        {
-          "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.697025+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
-        }
-      ],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__metadata_hooks_fill_required_columns",
-      "status": "passed",
-      "duration_ms": 5.966,
+      "duration_ms": 0.692,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__offset_limit_and_success_logging",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
       "status": "passed",
-      "duration_ms": 6.719,
+      "duration_ms": 0.364,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__pipeline_failure_emits_error",
-      "status": "passed",
-      "duration_ms": 6.303,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_value_error_logs",
-      "status": "passed",
-      "duration_ms": 0.36,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__worker_count_floors_to_one",
-      "status": "passed",
-      "duration_ms": 6.183,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_build_parser__defaults",
-      "status": "passed",
-      "duration_ms": 1.149,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run__force_overrides_skip",
-      "status": "passed",
-      "duration_ms": 0.244,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run__propagates_exit_code",
-      "status": "passed",
-      "duration_ms": 0.145,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run__skip_existing_returns_zero",
-      "status": "passed",
-      "duration_ms": 0.25,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__invalid_limit_logs_error",
-      "status": "passed",
-      "duration_ms": 0.192,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__read_ids_failure",
-      "status": "passed",
-      "duration_ms": 0.181,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[0]",
-      "status": "passed",
-      "duration_ms": 1.177,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[2]",
-      "status": "passed",
-      "duration_ms": 1.751,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coalesce_columns__prefers_first_non_empty",
-      "status": "passed",
-      "duration_ms": 3.624,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[ 7 -7-None]",
-      "status": "passed",
-      "duration_ms": 0.127,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[-None-None]",
-      "status": "passed",
-      "duration_ms": 0.12,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.0-2-None]",
-      "status": "passed",
-      "duration_ms": 0.143,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.5-None-invalid_stream_chunk_size_float]",
-      "status": "passed",
-      "duration_ms": 0.147,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[5-5-None]",
-      "status": "passed",
-      "duration_ms": 0.151,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[None-None-None]",
-      "status": "passed",
-      "duration_ms": 0.124,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[True-None-invalid_stream_chunk_size_bool]",
-      "status": "passed",
-      "duration_ms": 0.124,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[abc-None-invalid_stream_chunk_size_string]",
-      "status": "passed",
-      "duration_ms": 0.145,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[nan-None-None]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
       "status": "passed",
       "duration_ms": 0.139,
       "stdout": "",
@@ -1375,79 +1051,857 @@
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value10-None-invalid_stream_chunk_size_series]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
       "status": "passed",
-      "duration_ms": 0.235,
+      "duration_ms": 0.179,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value11-None-invalid_stream_chunk_size_type]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
       "status": "passed",
-      "duration_ms": 0.213,
+      "duration_ms": 0.122,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value9-3-None]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.236,
+      "duration_ms": 0.127,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_collapse_duplicate_columns__projects_first_instance",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 3.256,
+      "duration_ms": 0.116,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_prepare_export_frame__renames_and_coalesces",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
       "status": "passed",
-      "duration_ms": 17.843,
+      "duration_ms": 0.123,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[-5-None]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.144,
+      "duration_ms": 0.118,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[0-None]",
+      "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.153,
+      "duration_ms": 0.114,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[10-10]",
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_build_parser__pubmed_defaults",
       "status": "passed",
-      "duration_ms": 0.148,
+      "duration_ms": 1.802,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
-      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[None-None]",
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__cli_overrides_config",
+      "status": "passed",
+      "duration_ms": 60.869,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.340718+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.340841+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.374346+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.381953+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.340718+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.340841+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.374346+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.381953+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__config_overrides_defaults",
+      "status": "passed",
+      "duration_ms": 60.683,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.403719+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.403885+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.436343+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.444567+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.403719+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.403885+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.436343+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.444567+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--limit--1---limit must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 2.97,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--offset--5---offset must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 2.554,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
+      "status": "passed",
+      "duration_ms": 2.529,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
+      "status": "passed",
+      "duration_ms": 1.626,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
+      "status": "passed",
+      "duration_ms": 1.813,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
+      "status": "passed",
+      "duration_ms": 1.479,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_parser.py::test_apply_config_overrides__missing_config_attribute",
+      "status": "passed",
+      "duration_ms": 35.756,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
+      "status": "passed",
+      "duration_ms": 1.031,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
+      "status": "passed",
+      "duration_ms": 0.161,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
+      "status": "passed",
+      "duration_ms": 1.231,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.530178+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.530178+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
+      "status": "passed",
+      "duration_ms": 1.283,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.526187+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.526187+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
+      "status": "passed",
+      "duration_ms": 3.19,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
+      "status": "passed",
+      "duration_ms": 0.332,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.522264+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.522264+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
+      "status": "passed",
+      "duration_ms": 0.112,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
+      "status": "passed",
+      "duration_ms": 0.123,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
+      "status": "passed",
+      "duration_ms": 0.118,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
+      "status": "passed",
+      "duration_ms": 0.114,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
+      "status": "passed",
+      "duration_ms": 0.123,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
+      "status": "passed",
+      "duration_ms": 0.116,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
+      "status": "passed",
+      "duration_ms": 0.259,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
+      "status": "passed",
+      "duration_ms": 0.143,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
+      "status": "passed",
+      "duration_ms": 0.14,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
+      "status": "passed",
+      "duration_ms": 0.179,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
+      "status": "passed",
+      "duration_ms": 0.183,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
+      "status": "passed",
+      "duration_ms": 0.182,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
+      "status": "passed",
+      "duration_ms": 0.15,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[config/dictionary/_testitem/molecule_hierarchy.csv]",
+      "status": "passed",
+      "duration_ms": 0.746,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[value1]",
+      "status": "passed",
+      "duration_ms": 0.546,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[data/output/test.csv]",
+      "status": "passed",
+      "duration_ms": 0.601,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[value1]",
+      "status": "passed",
+      "duration_ms": 0.423,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
+      "status": "passed",
+      "duration_ms": 4.607,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
+      "status": "passed",
+      "duration_ms": 9.412,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[None-expected0]",
+      "status": "passed",
+      "duration_ms": 0.16,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation1-expected1]",
+      "status": "passed",
+      "duration_ms": 0.117,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation2-expected2]",
+      "status": "passed",
+      "duration_ms": 0.118,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation3-expected3]",
+      "status": "passed",
+      "duration_ms": 0.116,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation4-expected4]",
+      "status": "passed",
+      "duration_ms": 0.122,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation5-expected5]",
+      "status": "passed",
+      "duration_ms": 0.137,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation6-expected6]",
+      "status": "passed",
+      "duration_ms": 0.121,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation7-expected7]",
+      "status": "passed",
+      "duration_ms": 0.337,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation8-expected8]",
+      "status": "passed",
+      "duration_ms": 0.12,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation9-expected9]",
+      "status": "passed",
+      "duration_ms": 0.126,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__dry_run_skip_limit",
+      "status": "passed",
+      "duration_ms": 1.582,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv0---limit must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 1.559,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv1---offset must be zero or a positive integer]",
+      "status": "passed",
+      "duration_ms": 1.492,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv2-chunk size must be a positive integer]",
+      "status": "passed",
+      "duration_ms": 1.445,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv0]",
+      "status": "passed",
+      "duration_ms": 1.735,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv1]",
+      "status": "passed",
+      "duration_ms": 1.618,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv2]",
+      "status": "passed",
+      "duration_ms": 1.559,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[False-False-True-False-1]",
+      "status": "passed",
+      "duration_ms": 0.249,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[False-False-True-True-1]",
+      "status": "passed",
+      "duration_ms": 0.308,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[True-False-False-True-0]",
+      "status": "passed",
+      "duration_ms": 0.45,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.610559+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__skip_existing_matrix0/default.csv\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.610559+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__skip_existing_matrix0/default.csv\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[True-True-False-True-1]",
+      "status": "passed",
+      "duration_ms": 0.398,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__dry_run_short_circuits",
+      "status": "passed",
+      "duration_ms": 0.303,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__invalid_limit_logs_error",
+      "status": "passed",
+      "duration_ms": 0.535,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.604260+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.604260+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__offset_and_workers",
+      "status": "passed",
+      "duration_ms": 65.155,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.657413+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:42.658282+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:42.673796+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:42.708718+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:42.657413+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:42.658282+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:42.673796+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:42.708718+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__pipeline_failure_logs_error",
+      "status": "passed",
+      "duration_ms": 1.851,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_failures[<lambda>0]",
+      "status": "passed",
+      "duration_ms": 0.432,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_failures[<lambda>1]",
+      "status": "passed",
+      "duration_ms": 0.302,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_build_parser__defaults",
+      "status": "passed",
+      "duration_ms": 1.081,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run__force_overrides_skip",
+      "status": "passed",
+      "duration_ms": 0.341,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run__propagates_exit_code",
+      "status": "passed",
+      "duration_ms": 0.182,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run__skip_existing_returns_zero",
+      "status": "passed",
+      "duration_ms": 0.335,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__invalid_limit_logs_error",
+      "status": "passed",
+      "duration_ms": 0.234,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__read_ids_failure",
+      "status": "passed",
+      "duration_ms": 0.22,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[0]",
+      "status": "passed",
+      "duration_ms": 1.464,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[2]",
+      "status": "passed",
+      "duration_ms": 0.751,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_configure_logging__delegates_to_configure_logger",
+      "status": "passed",
+      "duration_ms": 0.483,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_configure_logging__invalid_level",
+      "status": "passed",
+      "duration_ms": 0.162,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_parse_args__custom_paths",
+      "status": "passed",
+      "duration_ms": 0.807,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_parse_args__defaults",
+      "status": "passed",
+      "duration_ms": 1.066,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_pipeline_step_registration__expected_shape",
+      "status": "passed",
+      "duration_ms": 0.145,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_run_pipeline__handles_step_exception",
+      "status": "passed",
+      "duration_ms": 1.619,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_data.py::test_run_pipeline__propagates_step_failure",
+      "status": "passed",
+      "duration_ms": 1.965,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coalesce_columns__prefers_first_non_empty",
+      "status": "passed",
+      "duration_ms": 2.778,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[ 7 -7-None]",
+      "status": "passed",
+      "duration_ms": 0.137,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[-None-None]",
+      "status": "passed",
+      "duration_ms": 0.192,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.0-2-None]",
+      "status": "passed",
+      "duration_ms": 0.142,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.5-None-invalid_stream_chunk_size_float]",
+      "status": "passed",
+      "duration_ms": 0.15,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[5-5-None]",
+      "status": "passed",
+      "duration_ms": 0.197,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[None-None-None]",
       "status": "passed",
       "duration_ms": 0.115,
       "stdout": "",
@@ -1456,9 +1910,117 @@
       "error": null
     },
     {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[True-None-invalid_stream_chunk_size_bool]",
+      "status": "passed",
+      "duration_ms": 0.289,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[abc-None-invalid_stream_chunk_size_string]",
+      "status": "passed",
+      "duration_ms": 0.133,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[nan-None-None]",
+      "status": "passed",
+      "duration_ms": 0.132,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value10-None-invalid_stream_chunk_size_series]",
+      "status": "passed",
+      "duration_ms": 0.146,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value11-None-invalid_stream_chunk_size_type]",
+      "status": "passed",
+      "duration_ms": 0.139,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value9-3-None]",
+      "status": "passed",
+      "duration_ms": 0.213,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_collapse_duplicate_columns__projects_first_instance",
+      "status": "passed",
+      "duration_ms": 2.527,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_prepare_export_frame__renames_and_coalesces",
+      "status": "passed",
+      "duration_ms": 13.141,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[-5-None]",
+      "status": "passed",
+      "duration_ms": 0.112,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[0-None]",
+      "status": "passed",
+      "duration_ms": 0.128,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[10-10]",
+      "status": "passed",
+      "duration_ms": 0.11,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[None-None]",
+      "status": "passed",
+      "duration_ms": 0.135,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_duplicate_column__merges_frames",
       "status": "passed",
-      "duration_ms": 2.503,
+      "duration_ms": 1.965,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1467,7 +2029,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__missing_handler_logs_error",
       "status": "passed",
-      "duration_ms": 0.352,
+      "duration_ms": 0.235,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1476,7 +2038,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__propagates_timeout",
       "status": "passed",
-      "duration_ms": 0.286,
+      "duration_ms": 0.269,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1485,7 +2047,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 0.443,
+      "duration_ms": 0.472,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1494,7 +2056,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_collect_uniprot_candidate_columns__orders_columns",
       "status": "passed",
-      "duration_ms": 0.724,
+      "duration_ms": 0.608,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1503,7 +2065,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__raises",
       "status": "passed",
-      "duration_ms": 0.605,
+      "duration_ms": 0.424,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1512,7 +2074,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__uses_alias",
       "status": "passed",
-      "duration_ms": 2.033,
+      "duration_ms": 1.617,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1521,7 +2083,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[ - ]",
       "status": "passed",
-      "duration_ms": 0.155,
+      "duration_ms": 0.11,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1539,7 +2101,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345-P12345]",
       "status": "passed",
-      "duration_ms": 0.132,
+      "duration_ms": 0.148,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1548,7 +2110,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345|Q67890-P12345]",
       "status": "passed",
-      "duration_ms": 0.181,
+      "duration_ms": 0.125,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1557,7 +2119,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[all]",
       "status": "passed",
-      "duration_ms": 0.131,
+      "duration_ms": 0.125,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1566,7 +2128,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[fetch]",
       "status": "passed",
-      "duration_ms": 0.141,
+      "duration_ms": 0.196,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1575,7 +2137,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[run]",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.152,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1584,13 +2146,13 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_limited_ids__respects_limit",
       "status": "passed",
-      "duration_ms": 0.299,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.931704+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
+      "duration_ms": 0.26,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:42.924443+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.931704+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:42.924443+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
         }
       ],
       "error": null
@@ -1598,7 +2160,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values0-P12345|Q67890]",
       "status": "passed",
-      "duration_ms": 0.139,
+      "duration_ms": 0.134,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1607,7 +2169,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values1-Q67890]",
       "status": "passed",
-      "duration_ms": 0.193,
+      "duration_ms": 0.12,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1616,7 +2178,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values2-]",
       "status": "passed",
-      "duration_ms": 0.181,
+      "duration_ms": 0.115,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1625,7 +2187,34 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values3-A|B]",
       "status": "passed",
-      "duration_ms": 0.228,
+      "duration_ms": 0.125,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_organism_export__failure",
+      "status": "passed",
+      "duration_ms": 0.379,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_organism_export__success",
+      "status": "passed",
+      "duration_ms": 0.3,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_target_exports__chains_helpers",
+      "status": "passed",
+      "duration_ms": 0.244,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1634,13 +2223,13 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__delegates_to_handler",
       "status": "passed",
-      "duration_ms": 2.875,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:25.942160+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942394+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942519+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942641+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942757+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942934+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943047+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943138+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943251+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943369+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943460+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943550+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943637+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943823+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943970+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944227+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944337+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944428+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944515+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n",
+      "duration_ms": 2.553,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:43.010250+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010400+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010496+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010588+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010786+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010872+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010957+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011043+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011153+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011241+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011325+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011410+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011495+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011581+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011667+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011948+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012046+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012134+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012281+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:25.942160+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942394+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942519+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942641+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942757+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.942934+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943047+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943138+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943251+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943369+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943460+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943550+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943637+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943823+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.943970+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944227+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944337+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944428+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T15:38:25.944515+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:43.010250+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010400+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010496+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010588+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010786+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010872+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010957+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011043+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011153+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011241+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011325+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011410+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011495+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011581+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011667+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011948+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012046+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012134+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012281+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n"
         }
       ],
       "error": null
@@ -1648,104 +2237,28 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 1.776,
+      "duration_ms": 0.479,
       "stdout": "",
       "stderr": "",
       "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_run_uniprot__invokes_target_postprocess",
+      "status": "passed",
+      "duration_ms": 75.207,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:43.005143+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-04T23:26:43.005143+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[ |P99999| -tokens2]",
-      "status": "passed",
-      "duration_ms": 0.16,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-tokens0]",
-      "status": "passed",
-      "duration_ms": 0.123,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345|Q67890-tokens1]",
-      "status": "passed",
-      "duration_ms": 0.142,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[123]",
-      "status": "passed",
-      "duration_ms": 0.127,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Hello]",
-      "status": "passed",
-      "duration_ms": 0.167,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Test-Value]",
-      "status": "passed",
-      "duration_ms": 0.14,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[aA]",
-      "status": "passed",
-      "duration_ms": 0.122,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[e-\\u0443]",
-      "status": "passed",
-      "duration_ms": 0.14,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[i-\\u0448]",
-      "status": "passed",
-      "duration_ms": 0.166,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[o-\\u0449]",
-      "status": "passed",
-      "duration_ms": 0.124,
-      "stdout": "",
-      "stderr": "",
-      "log": [],
-      "error": null
-    },
-    {
-      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[p-\\u0437]",
       "status": "passed",
       "duration_ms": 0.121,
       "stdout": "",
@@ -1754,9 +2267,117 @@
       "error": null
     },
     {
+      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[--tokens3]",
+      "status": "passed",
+      "duration_ms": 0.149,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-2|-|Q99999-tokens4]",
+      "status": "passed",
+      "duration_ms": 0.194,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-tokens0]",
+      "status": "passed",
+      "duration_ms": 0.164,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345|Q67890-tokens1]",
+      "status": "passed",
+      "duration_ms": 0.134,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[123]",
+      "status": "passed",
+      "duration_ms": 0.119,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Hello]",
+      "status": "passed",
+      "duration_ms": 0.141,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Test-Value]",
+      "status": "passed",
+      "duration_ms": 0.136,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[aA]",
+      "status": "passed",
+      "duration_ms": 0.116,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[e-\\u0443]",
+      "status": "passed",
+      "duration_ms": 0.126,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[i-\\u0448]",
+      "status": "passed",
+      "duration_ms": 0.12,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[o-\\u0449]",
+      "status": "passed",
+      "duration_ms": 0.125,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[p-\\u0437]",
+      "status": "passed",
+      "duration_ms": 0.12,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[q-\\u0439]",
       "status": "passed",
-      "duration_ms": 0.171,
+      "duration_ms": 0.13,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1765,7 +2386,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[r-\\u043a]",
       "status": "passed",
-      "duration_ms": 0.128,
+      "duration_ms": 0.122,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1774,7 +2395,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[t-\\u0435]",
       "status": "passed",
-      "duration_ms": 0.284,
+      "duration_ms": 0.118,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1783,7 +2404,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[u-\\u0433]",
       "status": "passed",
-      "duration_ms": 0.148,
+      "duration_ms": 0.124,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1792,7 +2413,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[w-\\u0446]",
       "status": "passed",
-      "duration_ms": 0.147,
+      "duration_ms": 0.129,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1801,7 +2422,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[y-\\u043d]",
       "status": "passed",
-      "duration_ms": 0.214,
+      "duration_ms": 0.117,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1810,7 +2431,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_apply_config_overrides__missing_config_attribute",
       "status": "passed",
-      "duration_ms": 5.078,
+      "duration_ms": 4.518,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1819,7 +2440,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_parser_validation__rejects_zero_chunk_size",
       "status": "passed",
-      "duration_ms": 4.333,
+      "duration_ms": 3.547,
       "stdout": "",
       "stderr": "usage: run_tests.py chembl [-h] [--log-level LOG_LEVEL] [--input INPUT_CSV] [--final-out FINAL_OUT] [--output OUTPUT_CSV]\n                           [--sep SEP] [--encoding ENCODING] [--base-path BASE_PATH] [--input-dir INPUT_DIR]\n                           [--output-dir OUTPUT_DIR] [--date DATE] [--force] [--skip-existing] [--config CONFIG]\n                           [--print-config] [--raw-out RAW_OUT] [--raw-format {csv,parquet}] [--id-cols ID_COLS [ID_COLS ...]]\n                           [--no-reindex-raw] [--normalize-at-export | --no-normalize-at-export] [--column COLUMN]\n                           [--limit LIMIT] [--offset OFFSET] [--chunk-size CHUNK_SIZE] [--timeout TIMEOUT]\nrun_tests.py chembl: error: argument --chunk-size: chunk size must be a positive integer\n",
       "log": [
@@ -1833,7 +2454,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__all_global_fallback",
       "status": "passed",
-      "duration_ms": 5.299,
+      "duration_ms": 4.466,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1842,7 +2463,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__chembl_cli_overrides",
       "status": "passed",
-      "duration_ms": 5.12,
+      "duration_ms": 4.597,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1851,7 +2472,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__config_precedence",
       "status": "passed",
-      "duration_ms": 4.989,
+      "duration_ms": 4.298,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1860,7 +2481,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_run_logs_parameter_sources__default_sources",
       "status": "passed",
-      "duration_ms": 6.6,
+      "duration_ms": 4.395,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1869,7 +2490,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_target_iuphar_defaults__align_with_cli",
       "status": "passed",
-      "duration_ms": 1.448,
+      "duration_ms": 1.108,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1878,7 +2499,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_add_pubchem_data__delegates_to_pipeline",
       "status": "passed",
-      "duration_ms": 1.489,
+      "duration_ms": 1.221,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1887,7 +2508,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__delegates_and_logs",
       "status": "passed",
-      "duration_ms": 0.188,
+      "duration_ms": 0.175,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1896,7 +2517,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__invalid_data_raises",
       "status": "passed",
-      "duration_ms": 0.459,
+      "duration_ms": 0.414,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1905,7 +2526,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__missing_file_returns_empty",
       "status": "passed",
-      "duration_ms": 0.187,
+      "duration_ms": 0.165,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1914,7 +2535,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values0-expected0]",
       "status": "passed",
-      "duration_ms": 1.583,
+      "duration_ms": 1.406,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1923,7 +2544,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values1-expected1]",
       "status": "passed",
-      "duration_ms": 1.187,
+      "duration_ms": 1.058,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1932,7 +2553,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values2-expected2]",
       "status": "passed",
-      "duration_ms": 0.919,
+      "duration_ms": 0.866,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1941,7 +2562,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values3-expected3]",
       "status": "passed",
-      "duration_ms": 1.105,
+      "duration_ms": 0.955,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1950,7 +2571,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values4-expected4]",
       "status": "passed",
-      "duration_ms": 0.994,
+      "duration_ms": 0.796,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1959,7 +2580,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values5-expected5]",
       "status": "passed",
-      "duration_ms": 2.155,
+      "duration_ms": 1.12,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1968,13 +2589,13 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__force_overrides_skip",
       "status": "passed",
-      "duration_ms": 0.712,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:26.035351+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:26.035617+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\"}\n",
+      "duration_ms": 0.655,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:43.102636+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T23:26:43.102881+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:26.035351+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T15:38:26.035617+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-4/test_run__force_overrides_skip1/output.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:43.102636+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T23:26:43.102881+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\"}\n"
         }
       ],
       "error": null
@@ -1982,7 +2603,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__non_zero_exit_logs_error",
       "status": "passed",
-      "duration_ms": 0.347,
+      "duration_ms": 0.271,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1991,7 +2612,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__skip_existing_without_force",
       "status": "passed",
-      "duration_ms": 0.416,
+      "duration_ms": 0.331,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2000,7 +2621,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__success_logs_completion",
       "status": "passed",
-      "duration_ms": 0.311,
+      "duration_ms": 0.284,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2009,7 +2630,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run_chembl__passes_options",
       "status": "passed",
-      "duration_ms": 0.291,
+      "duration_ms": 0.31,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2018,7 +2639,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
       "status": "passed",
-      "duration_ms": 0.804,
+      "duration_ms": 0.754,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2027,7 +2648,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__identifier_columns_trimmed",
       "status": "passed",
-      "duration_ms": 1.613,
+      "duration_ms": 1.542,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2036,7 +2657,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__micro_sign_replaced",
       "status": "passed",
-      "duration_ms": 0.725,
+      "duration_ms": 0.652,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2045,7 +2666,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__preserves_boolean_dtype",
       "status": "passed",
-      "duration_ms": 0.876,
+      "duration_ms": 0.784,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2054,7 +2675,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
       "status": "passed",
-      "duration_ms": 0.888,
+      "duration_ms": 0.814,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2063,7 +2684,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
       "status": "passed",
-      "duration_ms": 0.839,
+      "duration_ms": 0.767,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2072,7 +2693,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
       "status": "passed",
-      "duration_ms": 1.046,
+      "duration_ms": 1.118,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2081,7 +2702,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
       "status": "passed",
-      "duration_ms": 0.79,
+      "duration_ms": 0.69,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2090,7 +2711,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__retains_missing_values",
       "status": "passed",
-      "duration_ms": 1.132,
+      "duration_ms": 1.022,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2099,7 +2720,7 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
       "status": "passed",
-      "duration_ms": 2.341,
+      "duration_ms": 1.536,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2108,7 +2729,7 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
       "status": "passed",
-      "duration_ms": 1.618,
+      "duration_ms": 1.475,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2117,7 +2738,129 @@
     {
       "nodeid": "tests/unit/test_paths.py::test_dictionary_dir__points_to_project_resource",
       "status": "passed",
-      "duration_ms": 0.231,
+      "duration_ms": 0.238,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_cellularity.py::test_add_cellularity_smart__falls_back_to_fetch",
+      "status": "passed",
+      "duration_ms": 1.223,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_cellularity.py::test_add_cellularity_smart__prefers_lineage_over_fetch",
+      "status": "passed",
+      "duration_ms": 1.338,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_cellularity.py::test_classify_by_lineage__resolves_known_phyla",
+      "status": "passed",
+      "duration_ms": 0.144,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_helpers.py::test_first_element_text__returns_first_match",
+      "status": "passed",
+      "duration_ms": 0.309,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_helpers.py::test_normalize_text__trims_and_lowercases",
+      "status": "passed",
+      "duration_ms": 0.121,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_isoform.py::test_transform__missing_identifier_columns_raises_key_error",
+      "status": "passed",
+      "duration_ms": 0.561,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_isoform.py::test_transform__supports_alias_columns",
+      "status": "passed",
+      "duration_ms": 18.631,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_multifunctional.py::test_compute_multifunctional__derives_boolean_flag",
+      "status": "passed",
+      "duration_ms": 3.593,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_multifunctional.py::test_compute_multifunctional__ignores_missing_optional_columns",
+      "status": "passed",
+      "duration_ms": 1.556,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_postprocess_main.py::test_postprocess_target_table__produces_power_query_equivalent_csv",
+      "status": "passed",
+      "duration_ms": 26.046,
+      "stdout": "Postprocessed target table saved to: organism.target_postprocess_input.csv\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "Postprocessed target table saved to: organism.target_postprocess_input.csv\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__accepts_text_plain_json",
+      "status": "passed",
+      "duration_ms": 0.379,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__handles_empty_body",
+      "status": "passed",
+      "duration_ms": 0.287,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__records_decode_failure",
+      "status": "passed",
+      "duration_ms": 0.288,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2126,7 +2869,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 0.917,
+      "duration_ms": 0.929,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2135,7 +2878,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 0.842,
+      "duration_ms": 0.641,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2144,17 +2887,17 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_main__downgrades_exit_code_when_threshold_not_met",
       "status": "passed",
-      "duration_ms": 1.234,
-      "stdout": "{\"ts\": \"2025-10-04T15:38:26.092492+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"logger\": \"tools.run_tests\"}\n",
+      "duration_ms": 1.836,
+      "stdout": "{\"ts\": \"2025-10-04T23:26:43.245163+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"logger\": \"tests.run_tests\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T15:38:26.092492+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"79f78be43a1e448190214a8b5a2be07c\", \"logger\": \"tools.run_tests\"}\n"
+          "content": "{\"ts\": \"2025-10-04T23:26:43.245163+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"logger\": \"tests.run_tests\"}\n"
         },
         {
           "section": "Captured log call",
-          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m tools.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
+          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m tests.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
         }
       ],
       "error": null

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: 5a4b46f1aaf0f8e1e4fd62a1e752910c251ae4da
+- Commit: abf623bbd40e012d0f004b35fe3b8ed9defabeaa
 - Branch: work
-- Timestamp (UTC): 2025-10-04T15:38:26.315854+00:00
-- Duration: 3.435 s
+- Timestamp (UTC): 2025-10-04T23:26:43.505857+00:00
+- Duration: 6.403 s
 - Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|   215 |   215 |     0 |      0 |      0 |      0 |     0 |
+|   292 |   292 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
 - none


### PR DESCRIPTION
## Summary
- ensure isoform post-processing copies resolved alias columns before projecting so required identifiers are populated
- regenerate the JSON and Markdown pytest reports after the successful run

## Testing
- python tests/run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ac80bc348324873e05dc5ada1c59