### PR TITLE
Handle missing organism lineage columns during target postprocessing

### DIFF
--- a/library/postprocessing/target/main.py
+++ b/library/postprocessing/target/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from ...common.log import logger
 from .cellularity import add_cellularity_smart, FetchLineageCallable
 from .multifunctional import compute_multifunctional
 
@@ -27,17 +28,29 @@ def postprocess_target_table(
     path = Path(input_path)
     source = pd.read_csv(path, dtype=str, keep_default_na=False)
 
-    source_base = source[
-        [
-            "target_chembl_id",
-            "uniprot_id_primary",
-            "organism",
-            "taxon_id",
-            "lineage_superkingdom",
-            "lineage_phylum",
-            "lineage_class",
-        ]
-    ].copy()
+    base_columns = [
+        "target_chembl_id",
+        "uniprot_id_primary",
+        "organism",
+        "taxon_id",
+        "lineage_superkingdom",
+        "lineage_phylum",
+        "lineage_class",
+    ]
+    missing_columns = [
+        column for column in base_columns if column not in source.columns
+    ]
+    if missing_columns:
+        source = source.copy()
+        for column in missing_columns:
+            source[column] = ""
+        logger.warning(
+            "target_postprocess_missing_columns",
+            path=str(path),
+            columns=missing_columns,
+        )
+
+    source_base = source[base_columns].copy()
 
     for column in ("lineage_superkingdom", "lineage_phylum", "lineage_class"):
         source_base[column] = _lowercase_column(source_base[column])

--- a/tests/unit/test_target_postprocess_main.py
+++ b/tests/unit/test_target_postprocess_main.py
@@ -36,3 +36,41 @@ def test_postprocess_target_table__produces_power_query_equivalent_csv(
     )
     assert str(bool_frame["multifunctional_enzyme"].dtype) == "boolean"
 
+
+@pytest.mark.unit
+def test_postprocess_target_table__fills_missing_columns(tmp_path: Path) -> None:
+    input_path = tmp_path / "targets_minimal.csv"
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "taxon_id": ["9606"],
+            "reaction_ec_numbers": ["1.1.1.1|2.2.2.2"],
+        }
+    )
+    frame.to_csv(input_path, index=False)
+
+    fetch_calls: list[tuple[object, object | None]] = []
+
+    def _fake_fetcher(tax_id: object, email: str | None) -> list[str]:
+        fetch_calls.append((tax_id, email))
+        return ["Eukaryota", "Chordata"]
+
+    output_location = postprocess_target_table(input_path, fetcher=_fake_fetcher)
+    output_path = Path(output_location)
+
+    result_frame = pd.read_csv(output_path, dtype=str, keep_default_na=False)
+
+    for column in [
+        "uniprot_id_primary",
+        "organism",
+        "lineage_superkingdom",
+        "lineage_phylum",
+        "lineage_class",
+    ]:
+        assert column in result_frame.columns
+        assert result_frame.at[0, column] == ""
+
+    assert fetch_calls == [("9606", None)]
+    assert result_frame.at[0, "cellularity"] == "multicellular"
+    assert result_frame.at[0, "multifunctional_enzyme"] == "True"
+


### PR DESCRIPTION
## Summary
- ensure the organism post-processing helper backfills missing lineage columns instead of raising
- log the missing column event and keep downstream processing intact
- cover the regression with a unit test that exercises a minimal target export

## Testing
- pytest tests/unit/test_target_postprocess_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e1af7d81ec8324be4b3ded492acc55