### PR TITLE
Handle missing columns when postprocessing target tables

### DIFF
--- a/library/postprocessing/target/main.py
+++ b/library/postprocessing/target/main.py
@@ -41,16 +41,13 @@ def postprocess_target_table(
         column for column in base_columns if column not in source.columns
     ]
     if missing_columns:
-        source = source.copy()
-        for column in missing_columns:
-            source[column] = ""
         logger.warning(
             "target_postprocess_missing_columns",
             path=str(path),
             columns=missing_columns,
         )
 
-    source_base = source[base_columns].copy()
+    source_base = source.reindex(columns=base_columns, fill_value="").copy()
 
     for column in ("lineage_superkingdom", "lineage_phylum", "lineage_class"):
         source_base[column] = _lowercase_column(source_base[column])


### PR DESCRIPTION
## Summary
- prevent KeyErrors in the organism post-processing by reindexing missing base columns
- keep warning logging for incomplete inputs while allowing downstream processing to continue

## Testing
- pytest tests/unit/test_target_postprocess_main.py -k postprocess_target_table --maxfail=1 -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b12d1d9483249e3c3a286b46686a