### PR TITLE
Add target names post-processing step

### DIFF
--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .document import preprocess_document_export, postprocess_export_file
+from .names import process_target_names
 from .target import postprocess_target_table, process_targets
 from .main import postprocess_target_table
 
@@ -12,5 +13,6 @@ __all__ = [
     "postprocess_export_file",
     "process_targets",
     "postprocess_target_table",
+    "process_target_names",
 ]
 

--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -1,0 +1,194 @@
+"""Helpers for generating target name exports.
+
+The helper mirrors the legacy Power Query workbook that produced auxiliary
+name tables for reporting.  It extracts textual identifiers from the merged
+targets export, normalises them and emits a long-form table where each row
+represents a distinct name attributed to a target.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from . import helpers
+from ..common.log import logger
+
+# Columns in the targets table used to derive names.  Each entry maps the column
+# name to a descriptive label stored alongside the extracted token so consumers
+# can identify the provenance of a particular name.
+NAME_COLUMN_SOURCES: tuple[tuple[str, str], ...] = (
+    ("pref_name", "chembl_preferred"),
+    ("protein_name_canonical", "uniprot_canonical"),
+    ("protein_name_alt", "uniprot_alternative"),
+    ("synonyms", "chembl_synonym"),
+    ("protein_synonym_list", "uniprot_synonym"),
+    ("gtop_synonyms", "gtop_synonym"),
+    ("gene_symbol", "gene_symbol"),
+    ("gene_symbol_list", "gene_symbol"),
+    ("isoform_names", "isoform_name"),
+    ("isoform_synonyms", "isoform_synonym"),
+    ("recommendedName", "uniprot_recommended"),
+    ("secondaryAccessionNames", "uniprot_secondary"),
+)
+
+# Columns that should be split on the pipe delimiter.  Other columns are treated
+# as single textual values even if a pipe character is present.
+PIPE_SPLIT_COLUMNS: frozenset[str] = frozenset(
+    {
+        "synonyms",
+        "protein_synonym_list",
+        "gtop_synonyms",
+        "gene_symbol_list",
+        "isoform_names",
+        "isoform_synonyms",
+        "secondaryAccessionNames",
+    }
+)
+
+# Canonical column order for the emitted names table.
+TARGET_NAMES_COLUMNS: tuple[str, ...] = (
+    "target_chembl_id",
+    "uniprot_id_primary",
+    "name",
+    "name_type",
+    "source_column",
+)
+
+# Sentinel values considered as missing tokens when splitting pipe-delimited
+# strings.  The list mirrors guards in the legacy workbook.
+EMPTY_TOKEN_MARKERS: frozenset[str] = frozenset({"", "-", "n/a", "none"})
+
+
+def _iter_name_tokens(value: object, *, split: bool) -> Iterable[str]:
+    """Yield normalised name tokens extracted from ``value``."""
+
+    text = helpers.normalise_text(value)
+    if not text:
+        return []
+
+    if not split:
+        return [text]
+
+    tokens: list[str] = []
+    for raw in text.split("|"):
+        token = helpers.normalise_text(raw)
+        if not token:
+            continue
+        lower = token.lower()
+        if lower in EMPTY_TOKEN_MARKERS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def _build_names_table(frame: pd.DataFrame) -> pd.DataFrame:
+    """Project ``frame`` onto the long-form target names table."""
+
+    records: list[dict[str, Any]] = []
+    column_set = set(frame.columns)
+
+    for idx, row in frame.iterrows():
+        target_id = helpers.normalise_text(row.get("target_chembl_id"))
+        if not target_id:
+            continue
+        uniprot_id = helpers.normalise_text(row.get("uniprot_id_primary"))
+        for column, label in NAME_COLUMN_SOURCES:
+            if column not in column_set:
+                continue
+            split = column in PIPE_SPLIT_COLUMNS
+            for token in _iter_name_tokens(row.get(column), split=split):
+                records.append(
+                    {
+                        "target_chembl_id": target_id,
+                        "uniprot_id_primary": uniprot_id,
+                        "name": token,
+                        "name_type": label,
+                        "source_column": column,
+                    }
+                )
+
+    names_df = pd.DataFrame.from_records(records, columns=TARGET_NAMES_COLUMNS)
+    if names_df.empty:
+        return pd.DataFrame(columns=TARGET_NAMES_COLUMNS, dtype="string")
+
+    names_df = helpers.ensure_string_columns(names_df, TARGET_NAMES_COLUMNS)
+    names_df = names_df.drop_duplicates().sort_values(
+        by=["target_chembl_id", "name", "name_type"], kind="mergesort"
+    )
+    names_df = names_df.reset_index(drop=True)
+    return names_df
+
+
+def _summarise_contrion(series: pd.Series | None) -> dict[str, int]:
+    """Return counts for the ``contrion`` column if present."""
+
+    if series is None:
+        return {"contrion_unique": 0, "contrion_non_empty": 0, "contrion_total": 0}
+
+    tokens: set[str] = set()
+    non_empty = 0
+    total = 0
+    for value in series.dropna().astype(str):
+        text = helpers.normalise_text(value)
+        if not text or text in EMPTY_TOKEN_MARKERS:
+            continue
+        parts = [helpers.normalise_text(part) for part in text.split("|")]
+        parts = [part for part in parts if part and part not in EMPTY_TOKEN_MARKERS]
+        if not parts:
+            continue
+        non_empty += 1
+        total += len(parts)
+        tokens.update(parts)
+    return {
+        "contrion_unique": len(tokens),
+        "contrion_non_empty": non_empty,
+        "contrion_total": total,
+    }
+
+
+def _summarise_active_component_type(series: pd.Series | None) -> dict[str, int]:
+    """Return counts per ``active_component_type`` value."""
+
+    if series is None:
+        return {}
+
+    normalised = (
+        series.fillna("<NA>")
+        .astype(str)
+        .map(lambda value: helpers.normalise_text(value) or "<EMPTY>")
+    )
+    counts = normalised.value_counts(dropna=False)
+    return {str(key): int(value) for key, value in counts.items()}
+
+
+def process_target_names(input_path: str | Path, *, verbose: bool = False) -> dict[str, Any]:
+    """Process ``input_path`` and emit the target names table."""
+
+    source_path = Path(input_path)
+    frame = helpers.read_csv_with_fallbacks(source_path)
+    frame = helpers.ensure_string_columns(frame, frame.columns)
+
+    names_df = _build_names_table(frame)
+    output_path = source_path.with_name(f"names.{source_path.name}")
+    helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
+
+    summary: dict[str, Any] = {
+        "rows_before": int(len(frame)),
+        "rows_after": int(len(names_df)),
+    }
+    contrion_summary = _summarise_contrion(frame.get("contrion"))
+    summary.update(contrion_summary)
+    active_summary = _summarise_active_component_type(frame.get("active_component_type"))
+    if active_summary:
+        summary["active_component_type"] = active_summary
+    if verbose:
+        logger.info(
+            "target_names_helper_done",
+            path=str(output_path),
+            rows=len(names_df),
+        )
+    return {"path": str(output_path), "summary": summary}

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 import shutil
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import math
@@ -114,6 +114,7 @@ from library.schemas.targets import TARGETS_COLUMN_ORDER
 
 
 from library.postprocessing import target as target_pp
+from library.postprocessing import names as names_pp
 
 try:
     from library.postprocessing.target import process_targets as _process_targets_impl
@@ -306,6 +307,208 @@ def _postprocess_organism_export(
     return organism_path
 
 
+def _normalise_names_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    """Return *summary* converted to built-in container types for logging."""
+
+    normalised: dict[str, Any] = {}
+    for key, value in summary.items():
+        if isinstance(value, Mapping):
+            normalised[key] = _normalise_names_summary(value)
+        elif isinstance(value, pd.Series):
+            normalised[key] = value.to_dict()
+        elif isinstance(value, pd.DataFrame):
+            normalised[key] = value.to_dict(orient="list")
+        elif isinstance(value, set):
+            normalised[key] = sorted(value)
+        elif isinstance(value, tuple):
+            normalised[key] = list(value)
+        else:
+            normalised[key] = value
+    return normalised
+
+
+def _coerce_target_names_result(
+    result: object,
+) -> tuple[Path | None, dict[str, Any] | None]:
+    """Interpret *result* from ``process_target_names``."""
+
+    path_candidate: object | None = None
+    summary: dict[str, Any] | None = None
+
+    if isinstance(result, tuple):
+        if result:
+            path_candidate = result[0]
+            extra = result[1] if len(result) > 1 else None
+            if isinstance(extra, Mapping):
+                summary = _normalise_names_summary(extra)
+    elif isinstance(result, Mapping):
+        path_candidate = (
+            result.get("path")
+            or result.get("output")
+            or result.get("csv_path")
+            or result.get("names_path")
+        )
+        extra = result.get("summary") or result.get("stats")
+        if isinstance(extra, Mapping):
+            summary = _normalise_names_summary(extra)
+    elif hasattr(result, "path"):
+        path_candidate = getattr(result, "path")
+        extra = getattr(result, "summary", None)
+        if isinstance(extra, Mapping):
+            summary = _normalise_names_summary(extra)
+    else:
+        path_candidate = result
+
+    if path_candidate is None:
+        return None, summary
+
+    try:
+        path = Path(str(path_candidate))
+    except Exception:  # pragma: no cover - defensive
+        return None, summary
+
+    return path, summary
+
+
+def _csv_read_kwargs(cfg: Config) -> dict[str, Any]:
+    """Return keyword arguments for :func:`pandas.read_csv` respecting *cfg*."""
+
+    io_cfg = getattr(cfg, "io", None)
+    sep = getattr(io_cfg, "csv_sep", ",") if io_cfg is not None else ","
+    encoding = getattr(io_cfg, "csv_encoding", "utf-8") if io_cfg is not None else "utf-8"
+    return {"sep": sep, "encoding": encoding, "dtype": str}
+
+
+def _summarise_contrion_series(series: pd.Series | None) -> dict[str, Any] | None:
+    """Return summary statistics for the ``contrion`` column."""
+
+    if series is None:
+        return None
+
+    unique_tokens: set[str] = set()
+    non_empty_rows = 0
+    total_tokens = 0
+
+    for value in series.dropna().astype(str):
+        text = value.strip()
+        if not text or text in {"-", "--"}:
+            continue
+        parts = [part.strip() for part in text.split("|") if part.strip()]
+        if not parts:
+            continue
+        non_empty_rows += 1
+        total_tokens += len(parts)
+        unique_tokens.update(parts)
+
+    return {
+        "contrion_unique": len(unique_tokens),
+        "contrion_non_empty": non_empty_rows,
+        "contrion_total": total_tokens,
+    }
+
+
+def _summarise_active_component_types(series: pd.Series | None) -> dict[str, int] | None:
+    """Return counts per ``active_component_type`` value."""
+
+    if series is None:
+        return None
+
+    normalised = (
+        series.fillna("<NA>")
+        .astype(str)
+        .map(lambda value: value.strip() or "<EMPTY>")
+    )
+    counts = normalised.value_counts(dropna=False)
+    return {str(key): int(value) for key, value in counts.items()}
+
+
+def _compute_target_names_summary(
+    source: Path,
+    output: Path,
+    *,
+    cfg: Config,
+) -> dict[str, Any]:
+    """Compute fallback summary metrics for the target names export."""
+
+    summary: dict[str, Any] = {}
+    read_kwargs = _csv_read_kwargs(cfg)
+
+    try:
+        before_df = pd.read_csv(source, **read_kwargs)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "target_names_summary_failed",
+            stage="source",
+            path=str(source),
+            error=str(exc),
+        )
+    else:
+        summary["rows_before"] = int(len(before_df))
+
+    try:
+        after_df = pd.read_csv(output, **read_kwargs)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "target_names_summary_failed",
+            stage="output",
+            path=str(output),
+            error=str(exc),
+        )
+    else:
+        summary["rows_after"] = int(len(after_df))
+        contrion_summary = _summarise_contrion_series(after_df.get("contrion"))
+        if contrion_summary:
+            summary.update(contrion_summary)
+        active_summary = _summarise_active_component_types(
+            after_df.get("active_component_type")
+        )
+        if active_summary is not None:
+            summary["active_component_type"] = active_summary
+
+    return summary
+
+
+def _postprocess_names_export(
+    source: Path,
+    *,
+    cfg: Config,
+) -> Path | None:
+    """Invoke the target names post-processing helper."""
+
+    try:
+        result = names_pp.process_target_names(str(source), verbose=True)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception(
+            "target_names_postprocess_failed",
+            path=str(source),
+            error=str(exc),
+        )
+        return None
+
+    output_path, summary = _coerce_target_names_result(result)
+    if output_path is None:
+        logger.error(
+            "target_names_postprocess_invalid_result",
+            path=str(source),
+            result_type=type(result).__name__,
+        )
+        return None
+
+    payload: dict[str, Any] = {
+        "path": str(output_path),
+        "source": str(source),
+    }
+
+    if summary is None:
+        summary = _compute_target_names_summary(source, output_path, cfg=cfg)
+
+    if summary:
+        payload.update(summary)
+
+    logger.info("target_names_postprocess_done", **payload)
+    return output_path
+
+
 def _postprocess_target_exports(
     source: Path,
     *,
@@ -322,6 +525,7 @@ def _postprocess_target_exports(
         context=context,
         ambiguous_classifications=ambiguous_classifications,
     )
+    _postprocess_names_export(source, cfg=cfg)
 
 
 def _resolve_parameter(


### PR DESCRIPTION
## Summary
- hook the target post-processing pipeline into the new names helper and report detailed summary metrics
- implement the target names post-processing module that builds the long-form names export and returns summary statistics
- expose the helper through the postprocessing package for downstream consumers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1b01e95dc83249a32331b1441a28b