### PR TITLE
Add Power Query-compatible target names post-processing

### DIFF
--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from .document import preprocess_document_export, postprocess_export_file
-from .target import postprocess_target_table, process_targets
+from .target import process_targets
 from .main import postprocess_target_table
+from .names import process_target_names
 
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "postprocess_export_file",
     "process_targets",
     "postprocess_target_table",
+    "process_target_names",
 ]
 

--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -1,0 +1,415 @@
+"""Target names post-processing mirroring the legacy Power Query workbook.
+
+The implementation follows the Single Source of Truth (SSoT) captured in the
+Power Query (M) script that shipped with the historical Excel workbook.  The
+script is reproduced below so future refactors can be validated against the
+original transformation pipeline:
+
+contrion=()=>let
+    Source = #"Target Aggregated",
+    #"Expanded target_components" = Table.ExpandListColumn(Source, "target_components"),
+    #"Expanded target_components1" = Table.ExpandRecordColumn(#"Expanded target_components", "target_components", {"molecule_chembl_id", "component_id", "component_type", "component_name", "accession", "organism", "sequence", "description", "component_synonyms", "molecule", "molecule_pref_name", "molecule_synonyms", "molecule_structures", "molecule_properties", "active_component", "active_component_type", "salt_chembl_id", "relationships", "contrion"}, {"molecule_chembl_id", "component_id", "component_type", "component_name", "accession", "organism", "sequence", "description", "component_synonyms", "molecule", "molecule_pref_name", "molecule_synonyms", "molecule_structures", "molecule_properties", "active_component", "active_component_type", "salt_chembl_id", "relationships", "contrion"}),
+    #"Expanded component_synonyms" = Table.ExpandTableColumn(#"Expanded target_components1", "component_synonyms", {"synonym"}, {"component_synonym"}),
+    #"Expanded molecule_synonyms" = Table.ExpandTableColumn(#"Expanded component_synonyms", "molecule_synonyms", {"synonyms"}, {"molecule_synonym"}),
+    #"Expanded relationships" = Table.ExpandTableColumn(#"Expanded molecule_synonyms", "relationships", {"relationship", "related_component"}, {"relationship", "related_component"}),
+    #"Added Is Hydrate" = Table.AddColumn(#"Expanded relationships", "is_hydrate", each is_hidrate([component_synonym])),
+    #"Removed Hydrate" = Table.TransformColumns(#"Added Is Hydrate", {{"component_synonym", remove_hidrate}}),
+    #"Sorted Names" = Table.Sort(#"Removed Hydrate", {{"target_chembl_id", Order.Ascending}, {"molecule_chembl_id", Order.Ascending}, {"component_synonym", Order.Ascending}}),
+    #"Grouped Rows" = Table.Group(#"Sorted Names", {"target_chembl_id", "molecule_chembl_id"}, {{"All Names", each sort_my_list([component_synonym]), type text}, {"Active Component", each Text.FirstN(Text.Combine(List.RemoveNulls([active_component]), "|"), 32766), type text}, {"Active Component Type", each Text.FirstN(Text.Combine(List.RemoveNulls([active_component_type]), "|"), 32766), type text}, {"Contrion", each sort_my_list([contrion]), type text}}),
+    #"Merged Molecule" = Table.NestedJoin(#"Grouped Rows", {"molecule_chembl_id"}, Table.Distinct(#"Expanded relationships"[["molecule_chembl_id"], ["molecule"]]), {"molecule_chembl_id"}, "molecule", JoinKind.LeftOuter),
+    #"Expanded molecule" = Table.ExpandRecordColumn(#"Merged Molecule", "molecule", {"molecule_structures", "molecule_properties", "unknown_chirality"}, {"molecule_structures", "molecule_properties", "unknown_chirality"}),
+    #"Expanded molecule_structures" = Table.ExpandRecordColumn(#"Expanded molecule", "molecule_structures", {"canonical_smiles", "standard_inchi_key", "standard_inchi", "standard_inchi_stereo"}, {"canonical_smiles", "standard_inchi_key", "standard_inchi", "standard_inchi_stereo"}),
+    #"Expanded molecule_properties" = Table.ExpandRecordColumn(#"Expanded molecule_structures", "molecule_properties", {"mw_freebase"}, {"mw_freebase"}),
+    #"Added Reference SMILES" = Table.AddColumn(#"Expanded molecule_properties", "canonical_smiles_reference", each reference_SMILES([molecule_chembl_id])),
+    #"Replaced Null SMILES" = Table.ReplaceValue(#"Added Reference SMILES", null, each [canonical_smiles_reference], Replacer.ReplaceValue, {"canonical_smiles"}),
+    #"Removed Helper" = Table.RemoveColumns(#"Replaced Null SMILES", {"canonical_smiles_reference"}),
+    #"Filled Down" = Table.FillDown(#"Removed Helper", {"mw_freebase", "standard_inchi_key", "standard_inchi", "standard_inchi_stereo", "unknown_chirality"}),
+    #"Changed Type" = Table.TransformColumnTypes(#"Filled Down", {{"mw_freebase", type number}, {"unknown_chirality", type text}}),
+    #"Sorted Rows" = Table.Sort(#"Changed Type", {{"target_chembl_id", Order.Ascending}, {"molecule_chembl_id", Order.Ascending}})
+in
+    #"Sorted Rows"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+import pandas as pd
+
+from .helpers import ENCODING_FALLBACKS, normalise_text, read_csv_with_fallbacks
+from library.common.csv_utils import write_csv_deterministic
+
+_DEFAULT_SEARCH_DIR = Path("data/output")
+_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "target_chembl_id",
+    "molecule_chembl_id",
+    "all_names",
+    "canonical_smiles",
+    "mw_freebase",
+    "unknown_chirality",
+    "salt_chembl_id",
+    "standard_inchi_key",
+    "standard_inchi_skeleton",
+    "standard_inchi_stereo",
+    "is_hydrate",
+    "is_saltform",
+    "active_component",
+    "contrion",
+    "active_component_type",
+)
+
+
+class TargetNamesError(RuntimeError):
+    """Raised when the target names post-processing cannot proceed."""
+
+
+def _current_default_search_dir() -> Path:
+    package = sys.modules.get(__name__)
+    if package is not None and hasattr(package, "_DEFAULT_SEARCH_DIR"):
+        override = getattr(package, "_DEFAULT_SEARCH_DIR")
+        if override is not None:
+            return Path(override)
+    return _DEFAULT_SEARCH_DIR
+
+
+def _matches_target_filename(name: str) -> bool:
+    return bool(re.match(r"output\.target_\d{8}\.csv\Z", name))
+
+
+def _latest_target_file(search_dir: Path) -> Path:
+    candidates = sorted(
+        (path for path in search_dir.iterdir() if path.is_file() and _matches_target_filename(path.name)),
+        key=lambda item: item.name,
+    )
+    if not candidates:
+        raise TargetNamesError(
+            f"No target exports matching 'output.target_YYYYMMDD.csv' found in {search_dir!s}"
+        )
+    return candidates[-1]
+
+
+def is_hidrate(value: object | None) -> bool:
+    """Return ``True`` when ``value`` contains a hydrate annotation."""
+
+    text = normalise_text(value)
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(token in lowered for token in ("hydrate", "hemihydrate", "sesquihydrate", "trihydrate", "dihydrate"))
+
+
+def remove_hidrate(value: object | None) -> str:
+    """Strip hydrate-related qualifiers from ``value``."""
+
+    text = normalise_text(value)
+    if not text:
+        return ""
+    cleaned = re.sub(r"\b[\w\-]*hydrate\b", "", text, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def sort_my_list(values: Iterable[object] | object | None) -> str:
+    """Return a deterministic pipe-delimited list derived from ``values``."""
+
+    tokens: list[str] = []
+    if values is None:
+        return ""
+    if isinstance(values, str):
+        values = values.split("|")
+    for item in values:
+        text = normalise_text(item)
+        if text and text not in tokens:
+            tokens.append(text)
+    decorated = [(token.lower(), idx, token) for idx, token in enumerate(tokens)]
+    decorated.sort(key=lambda item: (item[0], item[1]))
+    return "|".join(item[2] for item in decorated)
+
+
+@dataclass
+class MoleculeStructures:
+    canonical_smiles: str | None = None
+    standard_inchi_key: str | None = None
+    standard_inchi: str | None = None
+    standard_inchi_stereo: str | None = None
+
+
+@dataclass
+class MoleculeProperties:
+    mw_freebase: str | None = None
+
+
+def _coerce_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _coerce_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if value in (None, "", float("nan")):
+        return []
+    return [value]
+
+
+def _parse_components(value: Any) -> list[dict[str, Any]]:
+    text = normalise_text(value)
+    if not text:
+        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            data = json.loads(f"[{text}]")
+        except json.JSONDecodeError as exc:
+            raise TargetNamesError(f"Unable to parse target_components payload: {text!r}") from exc
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    raise TargetNamesError("Parsed target_components payload is not a list of records")
+
+
+def _extract_synonyms(component: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for key in ("component_synonyms", "molecule_synonyms", "synonyms"):
+        entries = component.get(key)
+        for entry in _coerce_list(entries):
+            if isinstance(entry, str):
+                text = normalise_text(entry)
+                if text:
+                    names.append(text)
+            elif isinstance(entry, Mapping):
+                text = normalise_text(entry.get("synonym") or entry.get("name") or entry.get("synonyms"))
+                if text:
+                    names.append(text)
+    return names
+
+
+def _extract_contrion(component: Mapping[str, Any]) -> list[str]:
+    contrion_value = component.get("contrion")
+    if isinstance(contrion_value, str):
+        return [contrion_value]
+    if isinstance(contrion_value, Iterable) and not isinstance(contrion_value, (str, bytes)):
+        result: list[str] = []
+        for item in contrion_value:
+            text = normalise_text(item)
+            if text:
+                result.append(text)
+        return result
+    return []
+
+
+def _extract_structures(component: Mapping[str, Any]) -> MoleculeStructures:
+    structures = _coerce_dict(component.get("molecule_structures") or component.get("structures"))
+    return MoleculeStructures(
+        canonical_smiles=normalise_text(structures.get("canonical_smiles")),
+        standard_inchi_key=normalise_text(structures.get("standard_inchi_key")),
+        standard_inchi=normalise_text(structures.get("standard_inchi")),
+        standard_inchi_stereo=normalise_text(structures.get("standard_inchi_stereo")),
+    )
+
+
+def _extract_properties(component: Mapping[str, Any]) -> MoleculeProperties:
+    properties = _coerce_dict(component.get("molecule_properties") or component.get("properties"))
+    value = properties.get("mw_freebase")
+    if value is None:
+        return MoleculeProperties()
+    return MoleculeProperties(mw_freebase=str(value))
+
+
+def _extract_unknown_chirality(component: Mapping[str, Any]) -> str:
+    value = component.get("unknown_chirality")
+    if isinstance(value, bool):
+        return "Y" if value else "N"
+    text = normalise_text(value)
+    if not text:
+        return ""
+    if text.lower() in {"true", "yes", "1"}:
+        return "Y"
+    if text.lower() in {"false", "no", "0"}:
+        return "N"
+    return text
+
+
+def _salt_identifier(component: Mapping[str, Any]) -> str:
+    salt = component.get("salt_chembl_id")
+    if salt:
+        return normalise_text(salt)
+    hierarchy = _coerce_dict(component.get("molecule") or {}).get("molecule_hierarchy")
+    if isinstance(hierarchy, Mapping):
+        salt_candidate = hierarchy.get("parent_molecule_chembl_id")
+        return normalise_text(salt_candidate)
+    return ""
+
+
+def _component_identifier(component: Mapping[str, Any]) -> str:
+    for key in ("molecule_chembl_id", "component_chembl_id", "molecule_id"):
+        text = normalise_text(component.get(key))
+        if text:
+            return text
+    molecule = _coerce_dict(component.get("molecule"))
+    text = normalise_text(molecule.get("molecule_chembl_id") or molecule.get("chembl_id"))
+    if text:
+        return text
+    raise TargetNamesError("Component record is missing molecule_chembl_id")
+
+
+def _component_name(component: Mapping[str, Any]) -> str:
+    text = normalise_text(
+        component.get("component_name")
+        or component.get("component_pref_name")
+        or component.get("molecule_pref_name")
+        or component.get("name")
+    )
+    return text
+
+
+def _active_component(component: Mapping[str, Any]) -> str:
+    text = normalise_text(component.get("active_component"))
+    if text:
+        return text
+    name = _component_name(component)
+    return remove_hidrate(name)
+
+
+def _active_component_type(component: Mapping[str, Any]) -> str:
+    text = normalise_text(component.get("active_component_type") or component.get("component_type"))
+    return text
+
+
+_REFERENCE_CACHE: MutableMapping[Path, pd.Series] = {}
+
+
+def reference_SMILES(
+    molecule_id: object | None,
+    *,
+    overrides: Mapping[str, str] | None = None,
+    reference_path: str | Path | None = None,
+) -> str | None:
+    text = normalise_text(molecule_id)
+    if not text:
+        return None
+    if overrides and text in overrides:
+        return normalise_text(overrides[text]) or None
+    path = Path(reference_path or Path("data/reference/Table6.csv"))
+    if not path.exists():
+        raise TargetNamesError(f"Reference SMILES table not found at {path!s}")
+    if path not in _REFERENCE_CACHE:
+        frame = read_csv_with_fallbacks(path, encodings=ENCODING_FALLBACKS)
+        required = {"molecule_chembl_id", "canonical_smiles"}
+        missing = required - set(frame.columns)
+        if missing:
+            raise TargetNamesError(
+                f"Reference table {path!s} is missing required columns: {', '.join(sorted(missing))}"
+            )
+        series = (
+            frame.set_index("molecule_chembl_id")["canonical_smiles"].astype("string").map(normalise_text)
+        )
+        _REFERENCE_CACHE[path] = series
+    series = _REFERENCE_CACHE[path]
+    value = series.get(text)
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _component_rows(frame: pd.DataFrame) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for record in frame.to_dict("records"):
+        target_id = normalise_text(record.get("target_chembl_id"))
+        components = _parse_components(record.get("target_components"))
+        for component in components:
+            molecule_id = _component_identifier(component)
+            structures = _extract_structures(component)
+            properties = _extract_properties(component)
+            canonical_smiles = structures.canonical_smiles
+            if not canonical_smiles:
+                canonical_smiles = reference_SMILES(molecule_id)
+            salt_id = _salt_identifier(component)
+            synonyms = _extract_synonyms(component)
+            component_name = _component_name(component)
+            if component_name:
+                synonyms.insert(0, component_name)
+            all_names = sort_my_list(synonyms)
+            hydrate_flag = "Y" if is_hidrate(all_names) else "N"
+            rows.append(
+                {
+                    "target_chembl_id": target_id,
+                    "molecule_chembl_id": molecule_id,
+                    "all_names": all_names,
+                    "canonical_smiles": canonical_smiles or "",
+                    "mw_freebase": properties.mw_freebase or "",
+                    "unknown_chirality": _extract_unknown_chirality(component),
+                    "salt_chembl_id": salt_id,
+                    "standard_inchi_key": structures.standard_inchi_key or "",
+                    "standard_inchi_skeleton": structures.standard_inchi or "",
+                    "standard_inchi_stereo": structures.standard_inchi_stereo or "",
+                    "is_hydrate": hydrate_flag,
+                    "is_saltform": "Y" if salt_id and salt_id != molecule_id else "N",
+                    "active_component": _active_component(component),
+                    "contrion": sort_my_list(_extract_contrion(component)),
+                    "active_component_type": _active_component_type(component),
+                }
+            )
+    return rows
+
+
+def _ensure_columns(frame: pd.DataFrame, columns: Sequence[str]) -> None:
+    missing = [column for column in columns if column not in frame.columns]
+    if missing:
+        raise TargetNamesError(
+            "Input target table is missing required columns: " + ", ".join(missing)
+        )
+
+
+def process_target_names(
+    input_path: str | Path | None = None,
+    *,
+    search_dir: str | Path | None = None,
+) -> str:
+    if input_path is None:
+        directory = Path(search_dir) if search_dir is not None else _current_default_search_dir()
+        path = _latest_target_file(directory)
+    else:
+        path = Path(input_path)
+        if not path.exists():
+            raise TargetNamesError(f"Target export not found at {path!s}")
+
+    frame = read_csv_with_fallbacks(path, encodings=ENCODING_FALLBACKS)
+    _ensure_columns(frame, ["target_chembl_id", "target_components"])
+
+    rows = _component_rows(frame)
+    result = pd.DataFrame(rows, columns=_OUTPUT_COLUMNS)
+    result = result.fillna("")
+    if not result.empty:
+        result = result.sort_values(
+            by=["target_chembl_id", "molecule_chembl_id", "all_names"],
+            kind="mergesort",
+        )
+    output_path = path.with_name(f"names.{path.name}")
+    write_csv_deterministic(
+        result,
+        output_path,
+        col_order=_OUTPUT_COLUMNS,
+        key_cols=["target_chembl_id", "molecule_chembl_id"],
+        encoding="utf-8",
+        sep=",",
+        cfg=None,
+    )
+    return str(output_path)
+
+
+__all__ = [
+    "process_target_names",
+    "is_hidrate",
+    "remove_hidrate",
+    "sort_my_list",
+    "reference_SMILES",
+]


### PR DESCRIPTION
## Summary
- add a Python port of the Power Query target names transformation, including the contrion grouping SSoT
- implement hydrate/SMILES helpers and deterministic sorting/lookup logic used by the target names export
- expose `process_target_names` from the postprocessing package for external callers

## Testing
- python -m compileall library/postprocessing/names.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b01bf64883248c1b575bf27b7e33