### PR TITLE
Fix target names export to use expected prefix

### DIFF
--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -399,7 +399,7 @@ def process_target_names(
             by=["target_chembl_id", "molecule_chembl_id", "all_names"],
             kind="mergesort",
         )
-    output_path = path.with_name(f"names.{path.name}")
+    output_path = path.with_name(f"name.{path.name}")
     write_csv_deterministic(
         result,
         output_path,
@@ -584,7 +584,7 @@ def process_target_names(input_path: str | Path, *, verbose: bool = False) -> di
     frame = helpers.ensure_string_columns(frame, frame.columns)
 
     names_df = _build_names_table(frame)
-    output_path = source_path.with_name(f"names.{source_path.name}")
+    output_path = source_path.with_name(f"name.{source_path.name}")
     helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
 
     summary: dict[str, Any] = {

--- a/tests/unit/test_postprocessing_names.py
+++ b/tests/unit/test_postprocessing_names.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from pathlib import Path
+
+from library.postprocessing import names
+
+
+def test_process_target_names__creates_name_output_file(tmp_path):
+    input_path = tmp_path / "output.target_20240101.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL_TARGET",
+                "uniprot_id_primary": "P12345",
+                "pref_name": "Alpha",
+                "synonyms": "Beta|Gamma",
+                "gtop_synonyms": "Delta",
+                "gene_symbol": "GENE1",
+                "gene_symbol_list": "GENE1|GENE2",
+                "isoform_names": "Isoform A",
+                "isoform_synonyms": "IsoSyn|IsoSyn2",
+                "secondaryAccessionNames": "Secondary",
+                "contrion": "Token1|Token2",
+                "active_component_type": "Protein",
+            }
+        ],
+        dtype="string",
+    )
+    frame.to_csv(input_path, index=False, encoding="utf-8")
+
+    result = names.process_target_names(input_path, verbose=False)
+
+    assert isinstance(result, dict)
+    output_path = Path(result["path"])
+    assert output_path.name == "name.output.target_20240101.csv"
+    assert output_path.exists()
+
+    exported = pd.read_csv(output_path, dtype=str)
+    assert not exported.empty
+    assert (exported["target_chembl_id"] == "CHEMBL_TARGET").all()
+    assert "Alpha" in exported["name"].values


### PR DESCRIPTION
## Summary
- update the target names post-processing helper to emit files with the expected `name.output` prefix
- add a regression test covering the helper to ensure the output file is created correctly

## Testing
- pytest tests/unit/test_postprocessing_names.py


------
https://chatgpt.com/codex/tasks/task_e_68e1b74fce608324a3a4515f5613f63f