### PR TITLE
Fix target names module docstring termination

### DIFF
--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -1,7 +1,16 @@
 """Target names post-processing mirroring the legacy Power Query workbook.
 
+The ``SSOT_CONTEXT`` constant holds the original Power Query script used as the
+single source of truth for these transformations so that future refactors can
+validate behaviour against the historical pipeline.
+"""
+
+from __future__ import annotations
+
+
+SSOT_CONTEXT = '''
 The implementation follows the Single Source of Truth (SSoT) captured in the
-Power Query (M) script that shipped with the historical Excel workbook.  The
+Power Query (M) script that shipped with the historical Excel workbook. The
 script is reproduced below so future refactors can be validated against the
 original transformation pipeline:
 
@@ -34,9 +43,7 @@ Query workbook that produced auxiliary name tables for reporting. It extracts
 textual identifiers from the merged targets export, normalises them and emits a
 long-form table where each row represents a distinct name attributed to a
 target.
-"""
-
-from __future__ import annotations
+'''
 
 from dataclasses import dataclass
 import json


### PR DESCRIPTION
## Summary
- ensure the module docstring in `library/postprocessing/names.py` closes before executing imports
- preserve the original Power Query SSoT reference in a dedicated `SSOT_CONTEXT` constant

## Testing
- python scripts/get_target_data.py --input data/input/target.csv --output data/output/targets_20251002.csv all --limit 1 | tail -n 20
- python -m py_compile library/postprocessing/names.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b8004b248324bc18d164c6e43063