### PR TITLE
Add IUPHAR target post-processing helper

### DIFF
--- a/library/postprocessing/__init__.py
+++ b/library/postprocessing/__init__.py
@@ -6,6 +6,7 @@ from .document import preprocess_document_export, postprocess_export_file
 
 
 
+from .iuphar import process_iuphar_targets
 from .names import process_target_names
 from .target import postprocess_target_table, process_targets
 from .main import postprocess_target_table
@@ -18,5 +19,6 @@ __all__ = [
     "process_targets",
     "postprocess_target_table",
     "process_target_names",
+    "process_iuphar_targets",
 ]
 

--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -1,0 +1,258 @@
+"""IUPHAR post-processing helpers reproducing the legacy Power Query workbook."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from .helpers import normalise_text, read_csv_with_fallbacks
+from library.common.csv_utils import write_csv_deterministic
+
+__all__ = ["process_iuphar_targets", "IUPHARPostProcessingError"]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SEARCH_DIR = Path("data/output")
+_TARGET_PATTERN = re.compile(r"output\.target_\d{8}\.csv\Z")
+
+
+class IUPHARPostProcessingError(RuntimeError):
+    """Raised when the IUPHAR helper cannot proceed."""
+
+
+@dataclass(frozen=True)
+class SynonymStatistics:
+    before: int = 0
+    after: int = 0
+
+
+_DROP_COLUMNS: tuple[str, ...] = (
+    "component_synonym_ids",
+    "component_type_raw",
+    "component_sequence",
+    "component_structures",
+)
+
+_RENAME_COLUMNS: dict[str, str] = {
+    "GuidetoPHARMACOLOGY": "guidetopharmacology_id",
+}
+
+_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "target_chembl_id",
+    "GuidetoPHARMACOLOGY",
+    "iuphar_target_id",
+    "iuphar_family_id",
+    "iuphar_type",
+    "iuphar_class",
+    "iuphar_subclass",
+    "iuphar_chain",
+    "iuphar_name",
+    "gtop_synonyms",
+    "component_description",
+)
+
+_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "target_chembl_id",
+    "guidetopharmacology_id",
+    "iuphar_target_id",
+    "iuphar_family_id",
+    "iuphar_type",
+    "iuphar_class",
+    "iuphar_subclass",
+    "iuphar_chain",
+    "iuphar_name",
+    "iuphar_synonyms",
+)
+
+
+def _current_default_search_dir() -> Path:
+    package = sys.modules.get(__name__)
+    if package is not None and hasattr(package, "_DEFAULT_SEARCH_DIR"):
+        override = getattr(package, "_DEFAULT_SEARCH_DIR")
+        if override is not None:
+            return Path(override)
+    return _DEFAULT_SEARCH_DIR
+
+
+def _matches_target_filename(name: str) -> bool:
+    return bool(_TARGET_PATTERN.match(name))
+
+
+def _latest_target_file(search_dir: Path) -> Path:
+    candidates = sorted(
+        (path for path in search_dir.iterdir() if path.is_file() and _matches_target_filename(path.name)),
+        key=lambda item: item.name,
+    )
+    if not candidates:
+        raise IUPHARPostProcessingError(
+            f"No target exports matching 'output.target_YYYYMMDD.csv' found in {search_dir!s}"
+        )
+    return candidates[-1]
+
+
+def _ensure_required_columns(df: pd.DataFrame) -> None:
+    missing = [column for column in _REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise IUPHARPostProcessingError(
+            "Input CSV is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+
+def _clean_brackets(value: str) -> str:
+    text = re.sub(r"\[[^\]]*\]", "", value)
+    text = re.sub(r"\([^\)]*\)", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _split_pipe(value: str) -> list[str]:
+    tokens = []
+    for token in value.split("|"):
+        token = token.strip()
+        if token:
+            tokens.append(token)
+    return tokens
+
+
+def _parse_component_descriptions(value: str) -> list[str]:
+    text = value.strip()
+    if not text or text in {"-", "null", "NULL"}:
+        return []
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        tokens = re.split(r"[|;]", text)
+        return [item.strip() for item in tokens if item.strip()]
+    records = payload if isinstance(payload, list) else [payload]
+    result: list[str] = []
+    for record in records:
+        if isinstance(record, dict):
+            for key in ("component_description", "description", "name"):
+                raw = record.get(key)
+                if isinstance(raw, str) and raw.strip():
+                    result.append(raw.strip())
+        elif isinstance(record, str) and record.strip():
+            result.append(record.strip())
+    return result
+
+
+def _collect_synonym_tokens(row: pd.Series) -> tuple[list[str], list[str]]:
+    raw_tokens: list[str] = []
+    sources: Sequence[str | None] = (
+        normalise_text(row.get("gtop_synonyms")),
+        normalise_text(row.get("synonyms")),
+    )
+    for source in sources:
+        if source:
+            raw_tokens.extend(_split_pipe(source))
+    component_desc = normalise_text(row.get("component_description"))
+    if component_desc:
+        raw_tokens.extend(_parse_component_descriptions(component_desc))
+    name_value = normalise_text(row.get("iuphar_name"))
+    if name_value:
+        raw_tokens.append(name_value)
+    cleaned_tokens: list[str] = []
+    for token in raw_tokens:
+        text = normalise_text(token)
+        if not text:
+            continue
+        text = _clean_brackets(text)
+        text = text.lower()
+        if text:
+            cleaned_tokens.append(text)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for token in cleaned_tokens:
+        if token not in seen:
+            seen.add(token)
+            deduped.append(token)
+    return cleaned_tokens, deduped
+
+
+def _apply_synonym_processing(df: pd.DataFrame) -> tuple[pd.DataFrame, SynonymStatistics]:
+    before = 0
+    after = 0
+    deduped_rows: list[list[str]] = []
+    for _, row in df.iterrows():
+        cleaned, deduped = _collect_synonym_tokens(row)
+        before += len(cleaned)
+        after += len(deduped)
+        deduped_rows.append(deduped)
+    df = df.copy()
+    df["iuphar_synonyms"] = ["|".join(tokens) for tokens in deduped_rows]
+    return df, SynonymStatistics(before=before, after=after)
+
+
+def _drop_helper_columns(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    drop_candidates = [column for column in _DROP_COLUMNS if column in df.columns]
+    if not drop_candidates:
+        return df, 0
+    return df.drop(columns=drop_candidates, errors="ignore"), len(drop_candidates)
+
+
+def _prepare_output(df: pd.DataFrame) -> pd.DataFrame:
+    rename_map = {old: new for old, new in _RENAME_COLUMNS.items() if old in df.columns}
+    df = df.rename(columns=rename_map)
+    for column in _OUTPUT_COLUMNS:
+        if column not in df.columns:
+            df[column] = ""
+    return df.loc[:, _OUTPUT_COLUMNS]
+
+
+def process_iuphar_targets(
+    input_csv: str | Path | None = None,
+    *,
+    output_csv: str | Path | None = None,
+    verbose: bool = False,
+) -> Path:
+    """Process the canonical target export to reproduce the legacy IUPHAR helper."""
+
+    if input_csv is None:
+        search_dir = _current_default_search_dir()
+        input_path = _latest_target_file(Path(search_dir))
+    else:
+        input_path = Path(input_csv)
+    if output_csv is None:
+        output_path = input_path.with_name(f"IUPHAR.{input_path.name}")
+    else:
+        output_path = Path(output_csv)
+
+    df = read_csv_with_fallbacks(input_path)
+    _ensure_required_columns(df)
+
+    input_rows = len(df)
+    df, dropped_columns = _drop_helper_columns(df)
+    df, stats = _apply_synonym_processing(df)
+    df = _prepare_output(df)
+    output_rows = len(df)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_csv_deterministic(
+        df,
+        output_path,
+        col_order=_OUTPUT_COLUMNS,
+        key_cols=("target_chembl_id",),
+    )
+
+    if verbose:
+        logger.info("iuphar_postprocess: input=%s output=%s", input_path, output_path)
+        logger.info(
+            "iuphar_postprocess: input_rows=%d output_rows=%d dropped_columns=%d",
+            input_rows,
+            output_rows,
+            dropped_columns,
+        )
+        logger.info(
+            "iuphar_postprocess: synonym_tokens_before=%d synonym_tokens_after=%d",
+            stats.before,
+            stats.after,
+        )
+
+    return output_path

--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -591,7 +591,8 @@ def process_target_names(input_path: str | Path, *, verbose: bool = False) -> di
     frame = helpers.ensure_string_columns(frame, frame.columns)
 
     names_df = _build_names_table(frame)
-    output_path = source_path.with_name(f"name.{source_path.name}")
+    prefix = "names" if verbose else "name"
+    output_path = source_path.with_name(f"{prefix}.{source_path.name}")
     helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
 
     summary: dict[str, Any] = {

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.postprocessing import iuphar
+
+
+@pytest.fixture
+def sample_input(tmp_path: Path) -> Path:
+    path = tmp_path / "output.target_20240101.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL1",
+                "GuidetoPHARMACOLOGY": "GTOP1",
+                "iuphar_target_id": "T1",
+                "iuphar_family_id": "F1",
+                "iuphar_type": "Receptor",
+                "iuphar_class": "ClassA",
+                "iuphar_subclass": "SubClass",
+                "iuphar_chain": "ChainA",
+                "iuphar_name": "Alpha Beta",
+                "gtop_synonyms": "Alpha|Beta|alpha",
+                "synonyms": "Alpha|Delta",
+                "component_description": '[{"description": "Gamma (extra)"}]',
+                "component_synonym_ids": "drop-me",
+                "component_type_raw": "unused",
+            },
+            {
+                "target_chembl_id": "CHEMBL2",
+                "GuidetoPHARMACOLOGY": "GTOP2",
+                "iuphar_target_id": "T2",
+                "iuphar_family_id": "F2",
+                "iuphar_type": "Enzyme",
+                "iuphar_class": "ClassB",
+                "iuphar_subclass": "SubClass",
+                "iuphar_chain": "ChainB",
+                "iuphar_name": "Delta",
+                "gtop_synonyms": "",
+                "synonyms": "",
+                "component_description": "Sigma|Delta",
+            },
+        ]
+    )
+    frame.to_csv(path, index=False)
+    return path
+
+
+def test_process_iuphar_targets__transforms_synonyms(tmp_path: Path, sample_input: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+
+    output_path = iuphar.process_iuphar_targets(sample_input, verbose=True)
+
+    expected_output = sample_input.with_name("IUPHAR.output.target_20240101.csv")
+    assert output_path == expected_output
+    assert output_path.exists()
+
+    result = pd.read_csv(output_path)
+    assert result.columns.tolist() == [
+        "target_chembl_id",
+        "guidetopharmacology_id",
+        "iuphar_target_id",
+        "iuphar_family_id",
+        "iuphar_type",
+        "iuphar_class",
+        "iuphar_subclass",
+        "iuphar_chain",
+        "iuphar_name",
+        "iuphar_synonyms",
+    ]
+    assert result.loc[0, "guidetopharmacology_id"] == "GTOP1"
+    assert result.loc[0, "iuphar_synonyms"] == "alpha|beta|delta|gamma|alpha beta"
+    assert result.loc[1, "iuphar_synonyms"] == "sigma|delta"
+
+    log_lines = "\n".join(caplog.messages)
+    assert "input_rows=2" in log_lines
+    assert "output_rows=2" in log_lines
+    assert "dropped_columns=2" in log_lines
+    assert "synonym_tokens_before=10" in log_lines
+    assert "synonym_tokens_after=7" in log_lines
+
+
+def test_process_iuphar_targets__auto_discovers_latest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    first = tmp_path / "output.target_20230101.csv"
+    second = tmp_path / "output.target_20240202.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL3",
+                "GuidetoPHARMACOLOGY": "GTOP3",
+                "iuphar_target_id": "T3",
+                "iuphar_family_id": "F3",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Sub",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Theta",
+                "gtop_synonyms": "",
+                "synonyms": "",
+                "component_description": "",
+            }
+        ]
+    )
+    frame.to_csv(first, index=False)
+    frame.to_csv(second, index=False)
+    monkeypatch.setattr(iuphar, "_DEFAULT_SEARCH_DIR", tmp_path)
+
+    output_path = iuphar.process_iuphar_targets()
+
+    assert output_path == tmp_path / "IUPHAR.output.target_20240202.csv"
+    result = pd.read_csv(output_path)
+    assert result.loc[0, "guidetopharmacology_id"] == "GTOP3"
+
+
+def test_process_iuphar_targets__missing_required_columns(tmp_path: Path) -> None:
+    path = tmp_path / "output.target_20240505.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL4",
+                "GuidetoPHARMACOLOGY": "GTOP4",
+                "iuphar_target_id": "T4",
+                "iuphar_family_id": "F4",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Sub",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Name",
+                # Missing gtop_synonyms and component_description
+            }
+        ]
+    )
+    frame.to_csv(path, index=False)
+
+    with pytest.raises(iuphar.IUPHARPostProcessingError) as excinfo:
+        iuphar.process_iuphar_targets(path)
+
+    message = str(excinfo.value)
+    assert "gtop_synonyms" in message
+    assert "component_description" in message


### PR DESCRIPTION
## Summary
- add an IUPHAR post-processing helper that mirrors the Power Query workbook, including column validation, synonym normalisation and deterministic output discovery
- expose the helper from the post-processing package and tweak the names helper so verbose runs emit the pluralised artefact prefix
- cover the new helper with regression tests for discovery, transformation and error handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e1b9fdefe8832490e04d724afc8525