### PR TITLE
Handle missing target identifiers during target postprocessing

### DIFF
--- a/library/postprocessing/target/multifunctional.py
+++ b/library/postprocessing/target/multifunctional.py
@@ -147,6 +147,21 @@ def compute_multifunctional(source: pd.DataFrame) -> pd.DataFrame:
     else:
         trimmed = source.copy()
     result = trimmed.copy()
+
+    if "target_chembl_id" not in result.columns:
+        result.insert(
+            0,
+            "target_chembl_id",
+            pd.Series("", index=result.index, dtype="string"),
+        )
+    else:
+        result["target_chembl_id"] = result["target_chembl_id"].astype("string")
+
+    reaction_numbers = result.get(
+        "reaction_ec_numbers",
+        pd.Series(pd.NA, index=result.index, dtype="string"),
+    )
+    result["reaction_ec_numbers"] = reaction_numbers
     result["reaction_ec_numbers"] = result["reaction_ec_numbers"].map(
         _transform_reaction_ec_numbers
     )

--- a/tests/unit/test_target_multifunctional.py
+++ b/tests/unit/test_target_multifunctional.py
@@ -60,3 +60,25 @@ def test_compute_multifunctional__ignores_missing_optional_columns() -> None:
     ]
     assert result.loc[0, "reaction_ec_numbers"] == ["1", "2"]
     assert bool(result.loc[0, "multifunctional_enzyme"]) is True
+
+
+@pytest.mark.unit
+def test_compute_multifunctional__adds_missing_identifier_column() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "reaction_ec_numbers": "1.2.3.4|2.7.11.1",
+            }
+        ]
+    )
+
+    result = compute_multifunctional(source)
+
+    assert result.columns.tolist() == [
+        "target_chembl_id",
+        "reaction_ec_numbers",
+        "multifunctional_enzyme",
+    ]
+    assert result.loc[0, "target_chembl_id"] == ""
+    assert result.loc[0, "reaction_ec_numbers"] == ["1", "2"]
+    assert bool(result.loc[0, "multifunctional_enzyme"]) is True

--- a/tests/unit/test_target_postprocess_main.py
+++ b/tests/unit/test_target_postprocess_main.py
@@ -74,3 +74,32 @@ def test_postprocess_target_table__fills_missing_columns(tmp_path: Path) -> None
     assert result_frame.at[0, "cellularity"] == "multicellular"
     assert result_frame.at[0, "multifunctional_enzyme"] == "True"
 
+
+@pytest.mark.unit
+def test_postprocess_target_table__handles_missing_identifier_column(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "targets_missing_id.csv"
+    frame = pd.DataFrame(
+        {
+            "taxon_id": ["9606"],
+            "reaction_ec_numbers": ["1.2.3.4|2.7.11.1"],
+        }
+    )
+    frame.to_csv(input_path, index=False)
+
+    fetch_calls: list[tuple[object, object | None]] = []
+
+    def _fake_fetcher(tax_id: object, email: str | None) -> list[str]:
+        fetch_calls.append((tax_id, email))
+        return ["Eukaryota", "Chordata"]
+
+    output_location = postprocess_target_table(input_path, fetcher=_fake_fetcher)
+    output_path = Path(output_location)
+
+    result_frame = pd.read_csv(output_path, dtype=str, keep_default_na=False)
+
+    assert result_frame.at[0, "target_chembl_id"] == ""
+    assert result_frame.at[0, "multifunctional_enzyme"] == "True"
+    assert fetch_calls == [("9606", None)]
+


### PR DESCRIPTION
## Summary
- ensure the multifunctional helper preserves a target identifier column even when absent in the source export
- cover the missing identifier case in the target post-processing flow to guarantee deterministic outputs
- add unit coverage around compute_multifunctional for exports without target identifiers

## Testing
- pytest tests/unit/test_target_multifunctional.py tests/unit/test_target_postprocess_main.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bd55acec8324901cd1bf279da710