### PR TITLE
Handle missing component_description in IUPHAR post-processing

### DIFF
--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -55,6 +55,9 @@ _REQUIRED_COLUMNS: tuple[str, ...] = (
     "iuphar_chain",
     "iuphar_name",
     "gtop_synonyms",
+)
+
+_OPTIONAL_COLUMNS: tuple[str, ...] = (
     "component_description",
 )
 
@@ -103,6 +106,16 @@ def _ensure_required_columns(df: pd.DataFrame) -> None:
         raise IUPHARPostProcessingError(
             "Input CSV is missing required columns: " + ", ".join(sorted(missing))
         )
+
+
+def _ensure_optional_columns(df: pd.DataFrame) -> pd.DataFrame:
+    missing = [column for column in _OPTIONAL_COLUMNS if column not in df.columns]
+    if not missing:
+        return df
+    df = df.copy()
+    for column in missing:
+        df[column] = ""
+    return df
 
 
 def _clean_brackets(value: str) -> str:
@@ -226,6 +239,7 @@ def process_iuphar_targets(
 
     df = read_csv_with_fallbacks(input_path)
     _ensure_required_columns(df)
+    df = _ensure_optional_columns(df)
 
     input_rows = len(df)
     df, dropped_columns = _drop_helper_columns(df)

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -130,7 +130,7 @@ def test_process_iuphar_targets__missing_required_columns(tmp_path: Path) -> Non
                 "iuphar_subclass": "Sub",
                 "iuphar_chain": "Chain",
                 "iuphar_name": "Name",
-                # Missing gtop_synonyms and component_description
+                # Missing gtop_synonyms
             }
         ]
     )
@@ -141,4 +141,33 @@ def test_process_iuphar_targets__missing_required_columns(tmp_path: Path) -> Non
 
     message = str(excinfo.value)
     assert "gtop_synonyms" in message
-    assert "component_description" in message
+    assert "component_description" not in message
+
+
+def test_process_iuphar_targets__fills_missing_component_description(tmp_path: Path) -> None:
+    path = tmp_path / "output.target_20240606.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL5",
+                "GuidetoPHARMACOLOGY": "GTOP5",
+                "iuphar_target_id": "T5",
+                "iuphar_family_id": "F5",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Sub",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Name",
+                "gtop_synonyms": "Alpha|Beta",
+                "synonyms": "Gamma",
+                # component_description intentionally omitted
+            }
+        ]
+    )
+    frame.to_csv(path, index=False)
+
+    output_path = iuphar.process_iuphar_targets(path)
+
+    assert output_path.exists()
+    result = pd.read_csv(output_path)
+    assert result.loc[0, "iuphar_synonyms"] == "alpha|beta|gamma|name"


### PR DESCRIPTION
## Summary
- treat the IUPHAR component_description field as optional and backfill a blank column when missing
- expand the IUPHAR post-processing tests to cover missing component_description inputs and update the required-column assertion

## Testing
- pytest tests/postprocessing/test_iuphar_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bd75d0a4832482c3ea97d183a55e