### PR TITLE
Fix IUPHAR postprocessing tests and refresh test reports

### DIFF
--- a/reports/test_report.json
+++ b/reports/test_report.json
@@ -1,16 +1,16 @@
 {
   "meta": {
     "repo": "SatoryKono/ChEMBL_data_acquisition",
-    "commit": "abf623bbd40e012d0f004b35fe3b8ed9defabeaa",
+    "commit": "890be8b0e9b6af22d3e797c231dac6dc60427b2d",
     "branch": "work",
-    "ts_utc": "2025-10-04T23:26:43.505857+00:00",
-    "duration_sec": 6.403,
+    "ts_utc": "2025-10-05T00:48:18.768037+00:00",
+    "duration_sec": 8.766,
     "python": "3.11.12",
     "pytest": "8.4.1"
   },
   "summary": {
-    "total": 292,
-    "passed": 292,
+    "total": 320,
+    "passed": 320,
     "failed": 0,
     "skipped": 0,
     "xfailed": 0,
@@ -22,13 +22,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_activity_data]",
       "status": "passed",
-      "duration_ms": 3.466,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:37.797843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.798322+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T23:26:37.798460+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.798599+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798729+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.798870+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798951+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 4.999,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.144897+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.145511+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-05T00:48:11.145680+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.145815+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.145918+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.146037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.146227+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:37.797843+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.798322+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-04T23:26:37.798460+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.798599+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798729+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.798870+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.798951+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.144897+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_activity_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.145511+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"command\": \"get_activity_data\"}\n{\"ts\": \"2025-10-05T00:48:11.145680+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.145815+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_start\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.145918+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_records\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.146037+00:00\", \"level\": \"INFO\", \"event\": \"activity_pipeline_done\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_0/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.146227+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -36,13 +36,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_assay_data]",
       "status": "passed",
-      "duration_ms": 3.054,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:37.803301+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.803645+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T23:26:37.803801+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.803929+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804050+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.804142+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804284+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 4.569,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.152503+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.152978+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-05T00:48:11.153155+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.153311+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.153411+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.153513+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.153596+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:37.803301+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"733bc9807a5f4d48b92a1c3f576d4d3e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.803645+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-04T23:26:37.803801+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.803929+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804050+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.804142+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.804284+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.152503+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ec52461a44724b7db11ff60d507a08b7\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_assay_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.152978+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"command\": \"get_assay_data\"}\n{\"ts\": \"2025-10-05T00:48:11.153155+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.153311+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_start\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.153411+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_records\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.153513+00:00\", \"level\": \"INFO\", \"event\": \"assay_pipeline_done\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_1/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.153596+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -50,13 +50,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_document_data]",
       "status": "passed",
-      "duration_ms": 4.268,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:37.809147+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.809538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T23:26:37.809663+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.809784+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.809918+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.810223+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.810306+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 5.852,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.159760+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.160160+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-05T00:48:11.160378+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.160517+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.160613+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.160860+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.161405+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:37.809147+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"6a7e55ecb1424eb2a058bb4d60912159\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.809538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-04T23:26:37.809663+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.809784+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.809918+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.810223+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.810306+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9b73e415d8ef4a978dbb9c5e983d0d60\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.159760+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"fb30cd0e56dd42f2b0c13fba6504e126\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_document_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.160160+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"command\": \"pubmed\"}\n{\"ts\": \"2025-10-05T00:48:11.160378+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.160517+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_start\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.160613+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_records\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.160860+00:00\", \"level\": \"INFO\", \"event\": \"document_pipeline_done\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_2/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.161405+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"a2b2b4006454478f941b0ef85705b0d5\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -64,13 +64,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_target_data]",
       "status": "passed",
-      "duration_ms": 5.728,
-      "stdout": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.817195+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T23:26:37.817350+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.817461+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817724+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.817816+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817889+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 10.246,
+      "stdout": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.173463+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-05T00:48:11.173630+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.173847+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.174157+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.174270+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.174357+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.817195+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-04T23:26:37.817350+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.817461+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817724+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.817816+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.817889+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null}\n"
+          "content": "[INFO] Structured logs are mirrored to 'data/logs/get_target_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.173463+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"command\": \"chembl\"}\n{\"ts\": \"2025-10-05T00:48:11.173630+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/targets.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.173847+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_start\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.174157+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_records\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.174270+00:00\", \"level\": \"INFO\", \"event\": \"target_pipeline_done\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_3/targets.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.174357+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -78,13 +78,13 @@
     {
       "nodeid": "tests/e2e/test_cli_logging_setup.py::test_cli_logging__creates_log_file[get_testitem_data]",
       "status": "passed",
-      "duration_ms": 2.757,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:37.821612+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.821937+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T23:26:37.822092+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.822212+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822298+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.822385+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822458+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 3.461,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.179125+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.179538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-05T00:48:11.179678+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.179801+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.179896+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.179994+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.180159+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:37.821612+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"c53580325e2b44c0a5b857b1a0cb4c48\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-04T23:26:37.821937+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-04T23:26:37.822092+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-04T23:26:37.822212+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822298+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-04T23:26:37.822385+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-04T23:26:37.822458+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.179125+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"76374c20747741a0863cd45f5b751018\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n[INFO] Structured logs are mirrored to 'data/logs/get_testitem_data_20240102.log'.\n{\"ts\": \"2025-10-05T00:48:11.179538+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"command\": \"get_testitem_data\"}\n{\"ts\": \"2025-10-05T00:48:11.179678+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_parameters\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/input.csv\", \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/output.csv\", \"limit\": null, \"offset\": 0}\n{\"ts\": \"2025-10-05T00:48:11.179801+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"input\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/input.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.179896+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_records\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"stage\": \"ingest\", \"status\": null, \"rps\": null, \"processed\": 2, \"discarded\": 1}\n{\"ts\": \"2025-10-05T00:48:11.179994+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_cli_logging__creates_log_4/output.csv\"}\n{\"ts\": \"2025-10-05T00:48:11.180159+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -92,13 +92,13 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__non_csv_output_path",
       "status": "passed",
-      "duration_ms": 69.054,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:38.133295+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.133467+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.147971+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:38.148559+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:38.165707+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.198868+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n",
+      "duration_ms": 110.185,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.619409+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.619616+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.642154+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.643326+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.674917+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.724890+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:38.133295+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.133467+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.147971+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:38.148559+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:38.165707+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.198868+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.619409+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.619616+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.642154+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.643326+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.674917+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.724890+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__non_csv0/out/activities.tsv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -106,13 +106,13 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__retry_and_idempotent",
       "status": "passed",
-      "duration_ms": 205.707,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:37.850420+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.850599+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.871945+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.872695+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.905162+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:37.924689+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T23:26:37.949435+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:37.951349+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.951511+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.967552+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.968131+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.986033+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.051651+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n",
+      "duration_ms": 292.867,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.217993+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.218255+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.250375+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.251390+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.295485+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.331262+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-05T00:48:11.362646+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:11.365628+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.365850+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.392584+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.393554+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.418762+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.504656+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:37.850420+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.850599+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.871945+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.872695+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.905162+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:37.924689+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-04T23:26:37.949435+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:37.951349+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.951511+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:37.967552+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:37.968131+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-04T23:26:37.986033+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.051651+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.217993+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.218255+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.250375+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.251390+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.295485+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.331262+00:00\", \"level\": \"WARN\", \"event\": \"git_directory_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/workspace/ChEMBL_data_acquisition/library\"}\n{\"ts\": \"2025-10-05T00:48:11.362646+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:11.365628+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.365850+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.392584+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:11.393554+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3}\n{\"ts\": \"2025-10-05T00:48:11.418762+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 3, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.504656+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__retry_a0/out/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -120,13 +120,13 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_cli__workers_and_offset",
       "status": "passed",
-      "duration_ms": 70.402,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:38.059004+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.059181+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.073808+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-04T23:26:38.074377+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:38.091953+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.125491+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n",
+      "duration_ms": 100.049,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:11.515683+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.515892+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.538324+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-05T00:48:11.539121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:11.565547+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.609716+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:38.059004+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.059181+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:38.073808+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-04T23:26:38.074377+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:38.091953+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.125491+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:11.515683+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.515892+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:11.538324+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 2}}\n{\"ts\": \"2025-10-05T00:48:11.539121+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:11.565547+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:11.609716+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_cli__workers0/out/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -134,7 +134,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_failure",
       "status": "passed",
-      "duration_ms": 0.296,
+      "duration_ms": 0.797,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -143,13 +143,13 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_retry_and_idempotent",
       "status": "passed",
-      "duration_ms": 566.861,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:38.777285+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.777922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.790093+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.829012+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n",
+      "duration_ms": 595.73,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:12.360083+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:12.361217+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:12.380256+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.426918+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:38.777285+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.777922+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.790093+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.829012+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:12.360083+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:12.361217+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:12.380256+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.426918+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_run_retry_an0/out/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -157,7 +157,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.379,
+      "duration_ms": 0.83,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -166,7 +166,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_success",
       "status": "passed",
-      "duration_ms": 7.621,
+      "duration_ms": 16.097,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -175,13 +175,13 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_activity_run_workers_offset_and_non_csv",
       "status": "passed",
-      "duration_ms": 63.644,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:38.845480+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.845994+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.859508+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.896134+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n",
+      "duration_ms": 88.066,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:12.451296+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:12.451992+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:12.470361+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.518862+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:38.845480+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:38.845994+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:38.859508+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:38.896134+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:12.451296+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:12.451992+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:12.470361+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.518862+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_get_activity_run_workers_0/out/activities.tsv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -189,7 +189,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_failure",
       "status": "passed",
-      "duration_ms": 0.376,
+      "duration_ms": 0.495,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -198,7 +198,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.387,
+      "duration_ms": 0.737,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -207,7 +207,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_success",
       "status": "passed",
-      "duration_ms": 5.377,
+      "duration_ms": 8.565,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -216,7 +216,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.477,
+      "duration_ms": 0.465,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -225,7 +225,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_all_success",
       "status": "passed",
-      "duration_ms": 6.732,
+      "duration_ms": 10.275,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -234,7 +234,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_document_run_missing_handler",
       "status": "passed",
-      "duration_ms": 0.316,
+      "duration_ms": 0.584,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -243,7 +243,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_failure",
       "status": "passed",
-      "duration_ms": 0.547,
+      "duration_ms": 0.612,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -252,7 +252,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_all_success",
       "status": "passed",
-      "duration_ms": 6.706,
+      "duration_ms": 10.943,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -261,7 +261,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_target_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.572,
+      "duration_ms": 1.676,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -270,7 +270,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_failure_logs",
       "status": "passed",
-      "duration_ms": 0.491,
+      "duration_ms": 0.449,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -279,7 +279,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_skip_existing",
       "status": "passed",
-      "duration_ms": 0.481,
+      "duration_ms": 0.593,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -288,7 +288,7 @@
     {
       "nodeid": "tests/e2e/test_get_cli_pipelines.py::test_get_testitem_run_success",
       "status": "passed",
-      "duration_ms": 11.075,
+      "duration_ms": 15.091,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -297,7 +297,7 @@
     {
       "nodeid": "tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline",
       "status": "passed",
-      "duration_ms": 177.862,
+      "duration_ms": 280.102,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -306,13 +306,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__deterministic_output",
       "status": "passed",
-      "duration_ms": 62.521,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.099703+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.099916+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.103128+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 103.734,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:12.842257+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-05T00:48:12.842592+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-05T00:48:12.847898+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.099703+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.099916+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-04T23:26:39.103128+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:12.842257+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_child_flags\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-05T00:48:12.842592+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_missing_parent_flags\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"count\": 1}\n{\"ts\": \"2025-10-05T00:48:12.847898+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -320,13 +320,13 @@
     {
       "nodeid": "tests/e2e/test_testitem_pipeline.py::test_testitem_pipeline_e2e__finalize_stage_idempotent",
       "status": "passed",
-      "duration_ms": 192.699,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.149338+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.162235+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.162431+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.191277+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.241550+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:39.244464+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.255292+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.255464+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.286051+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.336032+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
+      "duration_ms": 317.38,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:12.923100+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:12.939011+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.939221+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:12.976040+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.038849+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:13.044711+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:13.061658+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.061968+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.098982+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.232212+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.149338+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.162235+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.162431+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.191277+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.241550+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:39.244464+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.255292+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.255464+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.286051+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.336032+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:12.923100+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:12.939011+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:12.939221+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:12.976040+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.038849+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:13.044711+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:13.061658+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.061968+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.098982+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.232212+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_testitem_pipeline_e2e__fi0/finalized.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -334,7 +334,7 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__attaches_flags_and_parent",
       "status": "passed",
-      "duration_ms": 24.943,
+      "duration_ms": 36.228,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -343,13 +343,13 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__handles_unknown_flag_values",
       "status": "passed",
-      "duration_ms": 24.441,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.390756+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
+      "duration_ms": 37.738,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.313452+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.390756+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"843ce2ae9e2a4225a9afef0ca3611249\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.313452+00:00\", \"level\": \"WARN\", \"event\": \"testitem_enrichment_inconsistent_flag\", \"run_id\": \"1f8434b043144536b481c8bbb555f48c\", \"status\": null, \"rps\": null, \"column\": \"prodrug\", \"count\": 1}\n"
         }
       ],
       "error": null
@@ -357,7 +357,7 @@
     {
       "nodeid": "tests/integration/test_enrichment.py::test_enrich__missing_sources_gracefully_fills_columns",
       "status": "passed",
-      "duration_ms": 5.641,
+      "duration_ms": 9.555,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -366,13 +366,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[False]",
       "status": "passed",
-      "duration_ms": 53.947,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.584014+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.619000+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 69.914,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.514317+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"01e04a5e3fbb4ed4bd781ad8511f868b\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.557830+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"01e04a5e3fbb4ed4bd781ad8511f868b\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.584014+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.619000+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"18c08123bbd04e7282aed538f098568e\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.514317+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"01e04a5e3fbb4ed4bd781ad8511f868b\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.557830+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"01e04a5e3fbb4ed4bd781ad8511f868b\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -380,13 +380,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__skip_existing_conflict[True]",
       "status": "passed",
-      "duration_ms": 52.921,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.640089+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.674068+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 72.452,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.588006+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.633644+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.640089+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.674068+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.588006+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.633644+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -394,13 +394,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__with_fallback_csv",
       "status": "passed",
-      "duration_ms": 53.954,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.527943+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.562894+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 72.021,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.438244+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"31f449e5621a40ae855e8a3fae72f6a9\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.484577+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"31f449e5621a40ae855e8a3fae72f6a9\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.527943+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.562894+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"d50bbacf73f64ef09e293be4b5cae30c\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.438244+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"31f449e5621a40ae855e8a3fae72f6a9\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.484577+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"31f449e5621a40ae855e8a3fae72f6a9\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -408,13 +408,13 @@
     {
       "nodeid": "tests/integration/test_fallback_doi.py::test_main_pubmed__without_fallback_csv",
       "status": "passed",
-      "duration_ms": 101.582,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.424429+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.506877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 74.042,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.362899+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ea2b2d699b714839ade975a8d810c69c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.409452+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ea2b2d699b714839ade975a8d810c69c\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.424429+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:39.506877+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"5412af6285c04b9eb133a7d0a4bb9217\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.362899+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ea2b2d699b714839ade975a8d810c69c\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:13.409452+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ea2b2d699b714839ade975a8d810c69c\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -422,13 +422,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__empty_input_produces_placeholder",
       "status": "passed",
-      "duration_ms": 95.575,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:40.559239+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566407+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566647+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.593633+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.650071+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
+      "duration_ms": 115.053,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.291425+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-05T00:48:14.301662+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.301866+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.334149+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.399786+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:40.559239+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566407+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.566647+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.593633+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.650071+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.291425+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0}\n{\"ts\": \"2025-10-05T00:48:14.301662+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 0, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.301866+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.334149+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 0, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__empty_in0/empty.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.399786+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__empty_in0/empty.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -436,13 +436,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__idempotent_results",
       "status": "passed",
-      "duration_ms": 199.247,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:40.658125+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.667921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.668224+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.697645+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.756256+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.758367+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.769037+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.769291+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.797425+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.854591+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
+      "duration_ms": 243.068,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.410176+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:14.419715+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.419910+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.453086+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.522825+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.526032+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:14.539798+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.540061+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.583583+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.649867+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:40.658125+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.667921+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.668224+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.697645+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.756256+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.758367+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:40.769037+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.769291+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.797425+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.854591+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.410176+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:14.419715+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.419910+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.453086+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.522825+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.526032+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:14.539798+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.540061+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.583583+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.649867+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__idempote0/stable.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -450,7 +450,7 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__missing_required_columns_fails",
       "status": "passed",
-      "duration_ms": 1.313,
+      "duration_ms": 2.215,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -459,13 +459,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__optional_columns_missing_warns",
       "status": "passed",
-      "duration_ms": 82.53,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.811843+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.818857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.844867+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.892415+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
+      "duration_ms": 110.526,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.826837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:13.837312+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.872527+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.934197+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.811843+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.818857+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.844867+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.892415+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.826837+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:13.837312+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.872527+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__optional0/optional.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.934197+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__optional0/optional.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -473,13 +473,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal",
       "status": "passed",
-      "duration_ms": 532.954,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:40.021897+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:40.030332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.030524+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.058903+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.120390+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.179812+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.552346+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
+      "duration_ms": 172.393,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.113821+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:14.123647+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.123907+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.156578+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.217726+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.282396+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.283171+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:40.021897+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:40.030332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:40.030524+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:40.058903+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.120390+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.179812+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.552346+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.113821+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:14.123647+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.123907+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.156578+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.217726+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.282396+00:00\", \"level\": \"INFO\", \"event\": \"metadata_quality_status\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": \"failed\", \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.283171+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_1/quality_fatal.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 222, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\", \"fatal\": true}\n"
         }
       ],
       "error": null
@@ -487,13 +487,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal",
       "status": "passed",
-      "duration_ms": 85.387,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.931871+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.938392+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.938549+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.965005+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.014251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.015520+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
+      "duration_ms": 107.4,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.001332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:14.011944+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.012217+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.043543+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.104557+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.105982+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.931871+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.938392+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.938549+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.965005+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-04T23:26:40.014251+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-04T23:26:40.015520+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.001332+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:14.011944+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:14.012217+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"natural_product\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:14.043543+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv\"}\n{\"ts\": \"2025-10-05T00:48:14.104557+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv.meta.yaml\"}\n{\"ts\": \"2025-10-05T00:48:14.105982+00:00\", \"level\": \"WARN\", \"event\": \"quality_report_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"error\": \"quality failed\", \"error_type\": \"RuntimeError\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__quality_0/quality.csv\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/pipelines/testitem/cli.py\\\", line 899, in finalize_output\\n    analyze_table_quality(\\n  File \\\"/workspace/ChEMBL_data_acquisition/tests/integration/test_finalize_output.py\\\", line 187, in fake_analyze\\n    raise RuntimeError(\\\"quality failed\\\")\\nRuntimeError: quality failed\\n\"}\n"
         }
       ],
       "error": null
@@ -501,13 +501,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_csv_and_metadata",
       "status": "passed",
-      "duration_ms": 125.453,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.681624+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.692463+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.692628+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.720728+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.768722+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
+      "duration_ms": 174.715,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.645103+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:13.661048+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.661284+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.700479+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.771003+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.681624+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-04T23:26:39.692463+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:39.692628+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.720728+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-04T23:26:39.768722+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.645103+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2}\n{\"ts\": \"2025-10-05T00:48:13.661048+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 2, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:13.661284+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.700479+00:00\", \"level\": \"INFO\", \"event\": \"write_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"rows\": 2, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_c0/final.csv\"}\n{\"ts\": \"2025-10-05T00:48:13.771003+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_c0/final.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -515,13 +515,13 @@
     {
       "nodeid": "tests/integration/test_finalize_output.py::test_finalize_output__writes_failure_cases",
       "status": "passed",
-      "duration_ms": 31.283,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:39.897975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907261+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907999+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.925739+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
+      "duration_ms": 52.426,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:13.944736+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:13.961823+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-05T00:48:13.963502+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.989948+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:39.897975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907261+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-04T23:26:39.907999+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-04T23:26:39.925739+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-5/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:13.944736+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:13.961823+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_error\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"schema\": \"TestitemsSchema\", \"rows\": 1, \"failures\": 1}\n{\"ts\": \"2025-10-05T00:48:13.963502+00:00\", \"level\": \"WARN\", \"event\": \"optional_columns_missing\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"columns\": [\"black_box_warning\", \"canonical_smiles\", \"first_approval\", \"max_phase\", \"molecule_type\", \"oral\", \"parent_molecule_chembl_id\", \"parenteral\", \"polymer_flag\", \"pref_name\", \"prodrug\", \"pubchem_canonical_smiles\", \"pubchem_cid\", \"pubchem_inchi\", \"pubchem_inchikey\", \"pubchem_isomeric_smiles\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"salt_chembl_id\", \"standard_inchi\", \"standard_inchi_key\", \"structure_type\", \"topical\"]}\n{\"ts\": \"2025-10-05T00:48:13.989948+00:00\", \"level\": \"ERROR\", \"event\": \"validation_failed\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"failures\": 1, \"path\": \"/tmp/pytest-of-root/pytest-1/test_finalize_output__writes_f0/failures_failure_cases.csv\"}\n"
         }
       ],
       "error": null
@@ -529,13 +529,13 @@
     {
       "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__deduplicates_identifiers",
       "status": "passed",
-      "duration_ms": 86.46,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:41.077750+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:41.142153+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n",
+      "duration_ms": 101.688,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.966784+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:15.041052+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:41.077750+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:41.142153+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.966784+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:15.041052+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_activity_pipeline__dedupl0/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -543,13 +543,13 @@
     {
       "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__happy_path",
       "status": "passed",
-      "duration_ms": 75.81,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:40.878973+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:40.933796+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n",
+      "duration_ms": 116.506,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.686758+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:14.771625+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:40.878973+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-04T23:26:40.933796+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.686758+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n{\"ts\": \"2025-10-05T00:48:14.771625+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_activity_pipeline__happy_0/activities.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -557,13 +557,13 @@
     {
       "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__malformed_values",
       "status": "passed",
-      "duration_ms": 110.646,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:40.963022+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n",
+      "duration_ms": 146.733,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:14.813735+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:40.963022+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:14.813735+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null, \"counts\": {\"inhibition\": 3}}\n"
         }
       ],
       "error": null
@@ -571,7 +571,7 @@
     {
       "nodeid": "tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__missing_column_input",
       "status": "passed",
-      "duration_ms": 0.619,
+      "duration_ms": 1.202,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -580,7 +580,7 @@
     {
       "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__retry_after_failure",
       "status": "passed",
-      "duration_ms": 8.881,
+      "duration_ms": 11.642,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -589,7 +589,7 @@
     {
       "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__schema_and_duplicates",
       "status": "passed",
-      "duration_ms": 10.402,
+      "duration_ms": 14.986,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -598,7 +598,7 @@
     {
       "nodeid": "tests/integration/test_get_data_workflow.py::test_pipeline_subset__skip_existing_and_force",
       "status": "passed",
-      "duration_ms": 9.566,
+      "duration_ms": 13.438,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -607,7 +607,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__empty_file_returns_no_values",
       "status": "passed",
-      "duration_ms": 0.47,
+      "duration_ms": 0.614,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -616,7 +616,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_encoding_recovers_values",
       "status": "passed",
-      "duration_ms": 1.315,
+      "duration_ms": 1.538,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -625,7 +625,7 @@
     {
       "nodeid": "tests/integration/test_io_readers.py::test_read_ids__fallback_separator_emits_info",
       "status": "passed",
-      "duration_ms": 0.6,
+      "duration_ms": 0.557,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -634,13 +634,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__disabled_mode_passthrough",
       "status": "passed",
-      "duration_ms": 0.932,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:41.246254+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 0.752,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:15.175872+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:41.246254+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:15.175872+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_disabled\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -652,13 +652,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__expires_stale_cache",
       "status": "passed",
-      "duration_ms": 7.339,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:41.235339+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 8.441,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:15.164538+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:41.235339+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:15.164538+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_cache_expired\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -670,7 +670,7 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__normal_flow_populates_cache",
       "status": "passed",
-      "duration_ms": 9.545,
+      "duration_ms": 12.286,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -679,13 +679,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_add_pubchem_data__skips_polymers_when_disallowed",
       "status": "passed",
-      "duration_ms": 8.421,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:41.209639+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n",
+      "duration_ms": 11.01,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:15.130808+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:41.209639+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"pubchem-test\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:15.130808+00:00\", \"level\": \"WARNING\", \"event\": \"pubchem_skip_polymers\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"pubchem-test\"}\n"
         },
         {
           "section": "Captured log call",
@@ -697,13 +697,13 @@
     {
       "nodeid": "tests/integration/test_pubchem_augmentation.py::test_augment_pubchem__initialises_session_and_reuses_cache",
       "status": "passed",
-      "duration_ms": 12.646,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:41.219053+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224554+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224877+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.230424+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 16.892,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:15.143215+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.151186+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.151575+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.158370+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:41.219053+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224554+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.224877+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:41.230424+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:15.143215+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.151186+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.151575+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_start\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:15.158370+00:00\", \"level\": \"INFO\", \"event\": \"pubchem_augment_done\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -711,7 +711,7 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__missing_required_column_raises",
       "status": "passed",
-      "duration_ms": 1.802,
+      "duration_ms": 1.852,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -720,7 +720,7 @@
     {
       "nodeid": "tests/integration/test_schema_validation.py::test_testitems_schema__valid_frame",
       "status": "passed",
-      "duration_ms": 8.556,
+      "duration_ms": 7.789,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -729,7 +729,7 @@
     {
       "nodeid": "tests/integration/test_target_postprocess_table.py::test_postprocess_target_table__is_idempotent",
       "status": "passed",
-      "duration_ms": 260.042,
+      "duration_ms": 357.156,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -738,7 +738,7 @@
     {
       "nodeid": "tests/integration/test_target_postprocess_table.py::test_postprocess_target_table__matches_golden",
       "status": "passed",
-      "duration_ms": 180.039,
+      "duration_ms": 257.85,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -747,7 +747,223 @@
     {
       "nodeid": "tests/postprocessing/test_cellularity_missing_values.py::test_add_cellularity_smart__skips_fetch_for_missing_tax_ids",
       "status": "passed",
-      "duration_ms": 1.607,
+      "duration_ms": 2.236,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_clean_brackets__removes_nested_annotations",
+      "status": "passed",
+      "duration_ms": 0.578,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_collect_synonym_tokens__deduplicates_preserving_order",
+      "status": "passed",
+      "duration_ms": 0.663,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_collect_synonym_tokens__handles_none_values",
+      "status": "passed",
+      "duration_ms": 0.507,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_collect_synonym_tokens__ignores_empty_array_tokens",
+      "status": "passed",
+      "duration_ms": 0.796,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_ensure_required_columns__raises_for_missing_columns",
+      "status": "passed",
+      "duration_ms": 0.695,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_latest_target_file__returns_newest_export",
+      "status": "passed",
+      "duration_ms": 0.564,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_parse_component_descriptions__handles_fallback_delimiters",
+      "status": "passed",
+      "duration_ms": 0.218,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_parse_component_descriptions__supports_json_payloads",
+      "status": "passed",
+      "duration_ms": 0.195,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_prepare_output__orders_columns_and_applies_renames",
+      "status": "passed",
+      "duration_ms": 2.795,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_process_iuphar_targets__fills_missing_component_description",
+      "status": "passed",
+      "duration_ms": 17.838,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_iuphar_postprocessing.py::test_process_iuphar_targets__produces_expected_csv",
+      "status": "passed",
+      "duration_ms": 15.134,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_component_rows__hydrates_salts_and_structures",
+      "status": "passed",
+      "duration_ms": 4.141,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_component_rows__missing_identifier_raises_error",
+      "status": "passed",
+      "duration_ms": 1.323,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_ensure_columns__missing_required_columns_raise",
+      "status": "passed",
+      "duration_ms": 0.669,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_is_hidrate__detects_known_annotations",
+      "status": "passed",
+      "duration_ms": 0.179,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_process_target_names_helper__stable_sorting_of_duplicates",
+      "status": "passed",
+      "duration_ms": 17.111,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_process_target_names_helper__summary_counts",
+      "status": "passed",
+      "duration_ms": 17.499,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_process_target_names_helper__verbose_logs_summary",
+      "status": "passed",
+      "duration_ms": 13.991,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_process_target_names_helper__writes_byte_identical_output",
+      "status": "passed",
+      "duration_ms": 35.259,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_reference_smiles__missing_required_columns_raises",
+      "status": "passed",
+      "duration_ms": 1.946,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_reference_smiles__missing_table_raises_error",
+      "status": "passed",
+      "duration_ms": 1.126,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_reference_smiles__override_priority_over_table",
+      "status": "passed",
+      "duration_ms": 0.97,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_remove_hidrate__removes_tokens_and_collapses_spaces",
+      "status": "passed",
+      "duration_ms": 0.362,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/postprocessing/test_names_postprocessing.py::test_sort_my_list__deduplicates_and_preserves_stable_order",
+      "status": "passed",
+      "duration_ms": 0.174,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -756,7 +972,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_add_cellularity_smart__fills_column",
       "status": "passed",
-      "duration_ms": 4.401,
+      "duration_ms": 7.702,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -765,7 +981,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_add_cellularity_smart__missing_tax_ids_skip_fetch",
       "status": "passed",
-      "duration_ms": 1.125,
+      "duration_ms": 2.166,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -774,7 +990,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_append_multifunctional_flag__detects_keywords",
       "status": "passed",
-      "duration_ms": 3.977,
+      "duration_ms": 7.261,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -783,7 +999,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_cellularity_classification__matches_examples",
       "status": "passed",
-      "duration_ms": 0.169,
+      "duration_ms": 0.254,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -792,7 +1008,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_classify_by_fetch__trailing_spaces_remain_ambiguous",
       "status": "passed",
-      "duration_ms": 0.182,
+      "duration_ms": 0.213,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -801,7 +1017,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_classify_by_fetch__trailing_whitespace_lineage_remains_ambiguous",
       "status": "passed",
-      "duration_ms": 0.146,
+      "duration_ms": 0.332,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -810,7 +1026,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_get_lineage_names__numeric_tax_id_returns_lineage",
       "status": "passed",
-      "duration_ms": 0.119,
+      "duration_ms": 0.295,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -819,7 +1035,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_final_dedup__matches_last_distinct",
       "status": "passed",
-      "duration_ms": 16.008,
+      "duration_ms": 26.642,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -828,7 +1044,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_make_triples__pads_shorter_lists",
       "status": "passed",
-      "duration_ms": 0.121,
+      "duration_ms": 0.295,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -837,7 +1053,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_make_triples_fixture__pads_missing_values",
       "status": "passed",
-      "duration_ms": 16.965,
+      "duration_ms": 29.0,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -846,7 +1062,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_name_filter__drops_empty_and_na",
       "status": "passed",
-      "duration_ms": 16.398,
+      "duration_ms": 27.212,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -855,7 +1071,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_normalisation__only_names_and_synonyms_lowercased",
       "status": "passed",
-      "duration_ms": 15.142,
+      "duration_ms": 25.237,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -864,7 +1080,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_output_columns__match_spec",
       "status": "passed",
-      "duration_ms": 16.207,
+      "duration_ms": 26.727,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -873,7 +1089,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_process_targets__writes_isoform_prefix",
       "status": "passed",
-      "duration_ms": 17.431,
+      "duration_ms": 27.732,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -882,7 +1098,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_sorted_stage__uses_mergesort",
       "status": "passed",
-      "duration_ms": 16.107,
+      "duration_ms": 26.414,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -891,7 +1107,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_split_pipes__trims_and_discards_empty",
       "status": "passed",
-      "duration_ms": 0.122,
+      "duration_ms": 0.321,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -900,7 +1116,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_stage1_dedup__matches_table_distinct",
       "status": "passed",
-      "duration_ms": 16.001,
+      "duration_ms": 26.31,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -909,7 +1125,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_stage2_dedup__matches_drop_duplicates",
       "status": "passed",
-      "duration_ms": 15.577,
+      "duration_ms": 28.435,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -918,7 +1134,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_synonym_tokens__preserve_identifier",
       "status": "passed",
-      "duration_ms": 17.02,
+      "duration_ms": 30.277,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -927,7 +1143,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_isoform_tokenise_synonym__pde3a_alpha",
       "status": "passed",
-      "duration_ms": 0.124,
+      "duration_ms": 0.249,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -936,7 +1152,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_postprocess_target_table__matches_power_query_snapshot",
       "status": "passed",
-      "duration_ms": 140.77,
+      "duration_ms": 260.35,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -945,7 +1161,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_postprocess_target_table_file__writes_expected_bytes",
       "status": "passed",
-      "duration_ms": 191.162,
+      "duration_ms": 247.898,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -954,7 +1170,7 @@
     {
       "nodeid": "tests/postprocessing/test_target_postprocessing.py::test_read_snapshot__validates_required_columns",
       "status": "passed",
-      "duration_ms": 3.788,
+      "duration_ms": 4.883,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -963,7 +1179,7 @@
     {
       "nodeid": "tests/unit/postprocessing/target/test_cellularity.py::test_classify_by_fetch__fungal_phylum_without_literal_token",
       "status": "passed",
-      "duration_ms": 0.15,
+      "duration_ms": 0.224,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -972,7 +1188,7 @@
     {
       "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_resolve_source_columns__includes_fallback_aliases_in_error",
       "status": "passed",
-      "duration_ms": 0.834,
+      "duration_ms": 1.222,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -981,7 +1197,7 @@
     {
       "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_transform__empty_input_returns_empty_frame",
       "status": "passed",
-      "duration_ms": 1.24,
+      "duration_ms": 2.244,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -990,7 +1206,7 @@
     {
       "nodeid": "tests/unit/postprocessing/target/test_isoform.py::test_transform__falls_back_to_uniprot_columns",
       "status": "passed",
-      "duration_ms": 14.457,
+      "duration_ms": 26.634,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -999,7 +1215,7 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__passes_when_success_rate_meets_threshold",
       "status": "passed",
-      "duration_ms": 1.325,
+      "duration_ms": 2.14,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1008,17 +1224,17 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_main__returns_error_when_success_rate_below_threshold",
       "status": "passed",
-      "duration_ms": 1.632,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.294961+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"scripts.run_test_suite\"}\n",
+      "duration_ms": 2.631,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:16.936392+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"scripts.run_test_suite\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.294961+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"8939954a492d41ea8abe004d958c9e7f\", \"logger\": \"scripts.run_test_suite\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:16.936392+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 94.74% is below the required threshold of 95.00%\", \"run_id\": \"fc191e37f5e44a0eacc95150ef6e84eb\", \"logger\": \"scripts.run_test_suite\"}\n"
         },
         {
           "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
+          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m scripts.run_test_suite:run_test_suite.py:210 Success rate 94.74% is below the required threshold of 95.00%"
         }
       ],
       "error": null
@@ -1026,7 +1242,7 @@
     {
       "nodeid": "tests/unit/scripts/test_run_test_suite.py::test_write_reports__includes_success_rate",
       "status": "passed",
-      "duration_ms": 0.692,
+      "duration_ms": 0.967,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1035,7 +1251,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_ensure_no_parant_column__raises",
       "status": "passed",
-      "duration_ms": 0.364,
+      "duration_ms": 0.574,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1044,7 +1260,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__accumulates_counts",
       "status": "passed",
-      "duration_ms": 0.139,
+      "duration_ms": 0.289,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1053,7 +1269,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_merge_parent_stats__keeps_higher_priority_source",
       "status": "passed",
-      "duration_ms": 0.179,
+      "duration_ms": 0.303,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1062,7 +1278,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[ chembl2 -CHEMBL1-CHEMBL2]",
       "status": "passed",
-      "duration_ms": 0.122,
+      "duration_ms": 0.251,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1071,7 +1287,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.127,
+      "duration_ms": 0.19,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1080,7 +1296,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[CHEMBL1-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.116,
+      "duration_ms": 0.178,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1089,7 +1305,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NO PARENT-CHEMBL2-None]",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 0.184,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1098,7 +1314,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[NULL-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.118,
+      "duration_ms": 0.258,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1107,7 +1323,7 @@
     {
       "nodeid": "tests/unit/test_catalog_utils.py::test_normalise_parent_identifier__cases[None-CHEMBL1-None]",
       "status": "passed",
-      "duration_ms": 0.114,
+      "duration_ms": 0.165,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1116,7 +1332,7 @@
     {
       "nodeid": "tests/unit/test_cli_get_document_data.py::test_build_parser__pubmed_defaults",
       "status": "passed",
-      "duration_ms": 1.802,
+      "duration_ms": 3.068,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1125,13 +1341,13 @@
     {
       "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__cli_overrides_config",
       "status": "passed",
-      "duration_ms": 60.869,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.340718+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.340841+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.374346+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.381953+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 87.787,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.011623+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:17.011787+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:17.060061+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-05T00:48:17.069254+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.340718+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.340841+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.374346+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.381953+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"762e575aef714de1a147ecadc016a5da\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.011623+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:17.011787+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:17.060061+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 77, \"source\": \"cli\", \"detail\": \"batch_size\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__cli_overrides_confi0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-05T00:48:17.069254+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ef224a882f9241ad82b10bd70f623490\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -1139,13 +1355,13 @@
     {
       "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__config_overrides_defaults",
       "status": "passed",
-      "duration_ms": 60.683,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.403719+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.403885+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.436343+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.444567+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n",
+      "duration_ms": 75.149,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.098379+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:17.098629+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:17.139089+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-05T00:48:17.147577+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.403719+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-04T23:26:42.403885+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-04T23:26:42.436343+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-5/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-04T23:26:42.444567+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.098379+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null}\n{\"ts\": \"2025-10-05T00:48:17.098629+00:00\", \"level\": \"WARN\", \"event\": \"cli_option_deprecated\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"option\": \"--output\", \"replacement\": \"--final-out\"}\n{\"ts\": \"2025-10-05T00:48:17.139089+00:00\", \"level\": \"INFO\", \"event\": \"config_snapshot\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"config\": {\"sources\": {\"chembl\": {\"api\": {\"chembl_base\": {\"value\": \"https://www.ebi.ac.uk/chembl/api/data\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"cache\": {\"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"molecule_catalog\": {\"cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sqlite_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/molecule_parent_catalog.sqlite\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"endpoint\": {\"value\": \"molecule\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"child_field\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"parent_field\": {\"value\": \"parent_molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hierarchy_lookup_delimiter\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"force_refresh_existing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"filters\": {\"parent_molecule_chembl_id__isnull\": {\"value\": \"false\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"page_size\": {\"value\": 500, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fallback_single_limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pipelines\": {\"activity\": {\"column\": {\"value\": \"activity_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"dry_run\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"assay\": {\"column\": {\"value\": \"assay_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 10, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"testitem\": {\"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fields\": {\"value\": [\"molecule_chembl_id\", \"parent_molecule_chembl_id\", \"pref_name\", \"max_phase\", \"molecule_type\", \"first_approval\", \"oral\", \"parenteral\", \"topical\", \"black_box_warning\", \"structure_type\", \"molecule_structures.canonical_smiles\", \"molecule_structures.standard_inchi\", \"molecule_structures.standard_inchi_key\", \"pubchem_cid\", \"pubchem_iupac_name\", \"pubchem_molecular_formula\", \"pubchem_isomeric_smiles\", \"pubchem_canonical_smiles\", \"pubchem_inchi\", \"pubchem_inchikey\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"request_limit\": {\"value\": 1000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_retry\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"shrink_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"min_size\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"parent_watchdog_idle_minutes\": {\"value\": 0.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"execution_budget_minutes\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"document\": {\"pubmed\": {\"column\": {\"value\": \"PMID\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 31, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"document_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sleep\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"workers\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"target\": {\"uniprot\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"chembl\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"iuphar\": {\"column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 100, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"all\": {\"column\": {\"value\": \"target_chembl_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chunk_size\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_column\": {\"value\": \"uniprot_id\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"chembl_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_out\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"offset\": {\"value\": 0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}}}, \"openalex\": {\"base\": {\"value\": \"https://api.openalex.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"crossref\": {\"base\": {\"value\": \"https://api.crossref.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mailto\": {\"value\": \"chembl-data@ebi.ac.uk\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"uniprot\": {\"api\": {\"base\": {\"value\": \"https://rest.uniprot.org\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.25, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"mapping\": {\"base\": {\"value\": \"https://rest.uniprot.org/idmapping\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"poll_interval\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout\": {\"value\": 300.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"iuphar\": {\"base\": {\"value\": \"https://www.guidetopharmacology.org/services\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pubchem\": {\"enable\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"base\": {\"value\": \"https://pubchem.ncbi.nlm.nih.gov/rest/pug\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"user_agent\": {\"value\": \"chembl-da/1.0 (mailto:chembl-data@ebi.ac.uk)\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 60.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_seconds\": {\"value\": 30.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": 5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"delay\": {\"value\": 0.2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_initial_seconds\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"resolve_order\": {\"value\": [\"cache\", \"smiles\", \"inchikey\", \"inchi\", \"pref_name\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl\": {\"value\": 3600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_maxsize\": {\"value\": 1024, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_ttl_hours\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cid_cache_path\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/cache/pubchem_cid_cache.json\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"batch_size\": {\"value\": 50, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_smiles\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"prefer_local_values\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"use_parent_for_salts\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allow_polymer\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"write_not_found_literal\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"pubmed\": {\"base\": {\"value\": \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"semantic_scholar\": {\"base\": {\"value\": \"https://api.semanticscholar.org/graph/v1\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_connect\": {\"value\": 5.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"timeout_read\": {\"value\": 10.0, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"retries\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rps\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"burst\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"local\": {\"resources\": {\"dictionary_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_target_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"iuphar_family_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"uniprot_data_dir\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/_uniprot\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"targets_type_csv\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_target/targets_type.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"io\": {\"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/output\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"cache_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/cache\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_sep\": {\"value\": \",\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_encoding\": {\"value\": \"utf-8-sig\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_encodings\": {\"value\": [\"utf-8\", \"cp1252\", \"windows-1251\", \"latin-1\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_fallback_separators\": {\"value\": [\"\\t\", \";\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"na_markers\": {\"value\": [\"#N/A\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"csv_chunksize\": {\"value\": 10000, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"exist_ok\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"keep_na_markers\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"init\": {\"same_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_same_document_20_05.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"all_doc\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/input/ChEMBL/ChEMBL_all_10_05_step5.xlsx\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"output_dir\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/.local/share/chembl-da/output/ChEMBL/processed\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"system\": {\"log\": {\"level\": {\"value\": \"INFO\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"rate\": {\"global_rps\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"global_burst\": {\"value\": 8, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_maxsize\": {\"value\": 128, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"limiter_cache_ttl\": {\"value\": 600, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"retry\": {\"max_attempts\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_factor\": {\"value\": 0.5, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"backoff_cap\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"status_forcelist\": {\"value\": [429, 500, 502, 503, 504], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"doc_type\": {\"weights\": {\"pubmed\": {\"value\": 4, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"openalex\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"scholar\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"thresholds\": {\"review\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"experimental\": {\"value\": 1, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"unknown\": {\"value\": 2, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"limit\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"doc_quality\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sample_rows\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"include_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"exclude_columns\": {\"value\": null, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fatal_on_error\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"activity_bounds\": {\"enable_from_relation\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"enable_from_uncertainty\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"rounding_digits\": {\"value\": 3, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"clamp_nonnegative\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_unknown_relations\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"activity_enrichment\": {\"action_type\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"action_type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"metrics\": {\"ic50\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ec50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ac50\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"ki\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"kd\": {\"value\": \"binding\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"triages\": {}, \"functionality\": {\"agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"partial agonist\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"antagonist\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"inhibitor\": {\"value\": \"inhibition\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"activator\": {\"value\": \"activation\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"mechanism\": {}, \"triage_fields\": {\"value\": [\"data_validity_description\", \"data_validity_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"functionality_fields\": {\"value\": [\"functional_activity\", \"action_type\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"mechanism_fields\": {\"value\": [\"mechanism_of_action\", \"mechanism_comment\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"activation\", \"inhibition\", \"binding\", \"pam\", \"nam\", \"triaged\", \"unknown\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"positive_label\": {\"value\": \"PAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"negative_label\": {\"value\": \"NAM\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"fallback\": {\"value\": \"unknown\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"activity_properties\": {\"enabled\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"column\": {\"value\": \"activity_properties\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"summary_column\": {\"value\": \"activity_property_summary\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"name_field\": {\"value\": \"type\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"value_field\": {\"value\": \"value\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"units_field\": {\"value\": \"units\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"separator\": {\"value\": \"; \", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"pair_separator\": {\"value\": \"=\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"drop_source_column\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_missing\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"log_distribution\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"allowlist\": {\"value\": [\"measurement\", \"assay\", \"comments\", \"effect_features\", \"triage\", \"mechanism\", \"functionality\"], \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"hash_column\": {\"value\": \"properties_hash\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}, \"testitem_molecule_enrichment\": {\"enable\": {\"value\": false, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"sources\": {\"molecule_catalog_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_catalog.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"molecule_hierarchy_path\": {\"value\": \"/workspace/ChEMBL_data_acquisition/config/dictionary/_testitem/molecule_hierarchy.csv\", \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"output\": {\"salt_as_null_when_absent\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"flags\": {\"coerce_to_bool\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"parent_fallback\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}, \"logging\": {\"warn_missing_molecule\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}, \"warn_inconsistent_flags\": {\"value\": true, \"source\": \"config\", \"detail\": \"/tmp/pytest-of-root/pytest-1/test_main__config_overrides_de0/config.yaml\"}}}}}\n{\"ts\": \"2025-10-05T00:48:17.147577+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null}\n"
         }
       ],
       "error": null
@@ -1153,7 +1369,7 @@
     {
       "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--limit--1---limit must be zero or a positive integer]",
       "status": "passed",
-      "duration_ms": 2.97,
+      "duration_ms": 4.266,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1162,7 +1378,7 @@
     {
       "nodeid": "tests/unit/test_cli_get_document_data.py::test_main__negative_values_raise[--offset--5---offset must be zero or a positive integer]",
       "status": "passed",
-      "duration_ms": 2.554,
+      "duration_ms": 3.656,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1171,7 +1387,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__appends_placeholders_in_order",
       "status": "passed",
-      "duration_ms": 2.529,
+      "duration_ms": 4.38,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1180,7 +1396,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__ignores_blank_requested_ids",
       "status": "passed",
-      "duration_ms": 1.626,
+      "duration_ms": 2.358,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1189,7 +1405,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__missing_ids_appended_at_end",
       "status": "passed",
-      "duration_ms": 1.813,
+      "duration_ms": 2.423,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1198,7 +1414,7 @@
     {
       "nodeid": "tests/unit/test_cli_integrate_missing.py::test_integrate_missing_identifiers__restores_requested_order",
       "status": "passed",
-      "duration_ms": 1.479,
+      "duration_ms": 1.939,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1207,7 +1423,7 @@
     {
       "nodeid": "tests/unit/test_cli_parser.py::test_apply_config_overrides__missing_config_attribute",
       "status": "passed",
-      "duration_ms": 35.756,
+      "duration_ms": 47.867,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1216,7 +1432,7 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__raises_for_placeholder",
       "status": "passed",
-      "duration_ms": 1.031,
+      "duration_ms": 1.362,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1225,7 +1441,7 @@
     {
       "nodeid": "tests/unit/test_cli_pubchem_cfg.py::test_prepare_pubchem_api_cfg__uses_pubchem_contact",
       "status": "passed",
-      "duration_ms": 0.161,
+      "duration_ms": 0.227,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1234,13 +1450,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__invalid_column",
       "status": "passed",
-      "duration_ms": 1.231,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.530178+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv\"}\n",
+      "duration_ms": 1.77,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.266643+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-1/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_read_input_ids__invalid_c0/input.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.530178+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-5/test_read_input_ids__invalid_c0/input.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.266643+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"error\": \"column 'molecule_chembl_id' not found in /tmp/pytest-of-root/pytest-1/test_read_input_ids__invalid_c0/input.csv; available columns: ['other_column']\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_read_input_ids__invalid_c0/input.csv\"}\n"
         }
       ],
       "error": null
@@ -1248,13 +1464,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__limit_and_offset",
       "status": "passed",
-      "duration_ms": 1.283,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.526187+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
+      "duration_ms": 1.791,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.260678+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"offset\": 3}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.526187+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.260678+00:00\", \"level\": \"INFO\", \"event\": \"process_offset\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"offset\": 3}\n"
         }
       ],
       "error": null
@@ -1262,7 +1478,7 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__load_and_validate",
       "status": "passed",
-      "duration_ms": 3.19,
+      "duration_ms": 4.186,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1271,13 +1487,13 @@
     {
       "nodeid": "tests/unit/test_cli_read_input.py::test_read_input_ids__missing_file",
       "status": "passed",
-      "duration_ms": 0.332,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.522264+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
+      "duration_ms": 0.651,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.254627+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.522264+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.254627+00:00\", \"level\": \"ERROR\", \"event\": \"read_fail\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"error\": \"[Errno 2] No such file or directory: 'does-not-exist.csv'\", \"path\": \"does-not-exist.csv\"}\n"
         }
       ],
       "error": null
@@ -1285,7 +1501,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items0-3-expected0]",
       "status": "passed",
-      "duration_ms": 0.112,
+      "duration_ms": 0.171,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1294,7 +1510,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items1-2-expected1]",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 0.306,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1303,7 +1519,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items2-2-expected2]",
       "status": "passed",
-      "duration_ms": 0.118,
+      "duration_ms": 0.457,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1312,7 +1528,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_batched__yields_expected_groups[items3-5-expected3]",
       "status": "passed",
-      "duration_ms": 0.114,
+      "duration_ms": 0.356,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1321,7 +1537,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__emits_warning",
       "status": "passed",
-      "duration_ms": 0.123,
+      "duration_ms": 0.313,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1330,7 +1546,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_log_missing_identifier_summary__skips_empty",
       "status": "passed",
-      "duration_ms": 0.116,
+      "duration_ms": 0.261,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1339,7 +1555,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_after_budget_raises",
       "status": "passed",
-      "duration_ms": 0.259,
+      "duration_ms": 0.264,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1348,7 +1564,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__enforce_within_budget",
       "status": "passed",
-      "duration_ms": 0.143,
+      "duration_ms": 0.22,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1357,7 +1573,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_execution_budget__start_logs_budget",
       "status": "passed",
-      "duration_ms": 0.14,
+      "duration_ms": 0.201,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1366,7 +1582,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__monitor_emits_timeout",
       "status": "passed",
-      "duration_ms": 0.179,
+      "duration_ms": 0.308,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1375,7 +1591,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__ping_logs_progress",
       "status": "passed",
-      "duration_ms": 0.183,
+      "duration_ms": 0.485,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1384,7 +1600,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__raise_if_timed_out",
       "status": "passed",
-      "duration_ms": 0.182,
+      "duration_ms": 0.249,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1393,7 +1609,7 @@
     {
       "nodeid": "tests/unit/test_cli_stage_controls.py::test_stage_watchdog__start_without_timeout",
       "status": "passed",
-      "duration_ms": 0.15,
+      "duration_ms": 0.346,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1402,7 +1618,7 @@
     {
       "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[config/dictionary/_testitem/molecule_hierarchy.csv]",
       "status": "passed",
-      "duration_ms": 0.746,
+      "duration_ms": 1.328,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1411,7 +1627,7 @@
     {
       "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__avoids_duplicate_config_segment[value1]",
       "status": "passed",
-      "duration_ms": 0.546,
+      "duration_ms": 0.911,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1420,7 +1636,7 @@
     {
       "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[data/output/test.csv]",
       "status": "passed",
-      "duration_ms": 0.601,
+      "duration_ms": 0.79,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1429,7 +1645,7 @@
     {
       "nodeid": "tests/unit/test_config_path_resolution.py::test_absolutise_path_value__keeps_standard_relative_paths[value1]",
       "status": "passed",
-      "duration_ms": 0.423,
+      "duration_ms": 1.141,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1438,7 +1654,7 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__drops_unexpected_columns",
       "status": "passed",
-      "duration_ms": 4.607,
+      "duration_ms": 5.705,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1447,7 +1663,7 @@
     {
       "nodeid": "tests/unit/test_csv_utils.py::test_write_csv_deterministic__orders_columns_and_rows",
       "status": "passed",
-      "duration_ms": 9.412,
+      "duration_ms": 14.864,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1456,7 +1672,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[None-expected0]",
       "status": "passed",
-      "duration_ms": 0.16,
+      "duration_ms": 0.301,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1465,7 +1681,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation1-expected1]",
       "status": "passed",
-      "duration_ms": 0.117,
+      "duration_ms": 0.177,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1474,7 +1690,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation2-expected2]",
       "status": "passed",
-      "duration_ms": 0.118,
+      "duration_ms": 0.182,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1483,7 +1699,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation3-expected3]",
       "status": "passed",
-      "duration_ms": 0.116,
+      "duration_ms": 0.379,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1492,7 +1708,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation4-expected4]",
       "status": "passed",
-      "duration_ms": 0.122,
+      "duration_ms": 0.418,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1501,7 +1717,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation5-expected5]",
       "status": "passed",
-      "duration_ms": 0.137,
+      "duration_ms": 0.407,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1510,7 +1726,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation6-expected6]",
       "status": "passed",
-      "duration_ms": 0.121,
+      "duration_ms": 0.319,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1519,7 +1735,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation7-expected7]",
       "status": "passed",
-      "duration_ms": 0.337,
+      "duration_ms": 0.96,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1528,7 +1744,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation8-expected8]",
       "status": "passed",
-      "duration_ms": 0.12,
+      "duration_ms": 0.196,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1537,7 +1753,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_args_invocation__cases[invocation9-expected9]",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.199,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1546,7 +1762,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__dry_run_skip_limit",
       "status": "passed",
-      "duration_ms": 1.582,
+      "duration_ms": 1.8,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1555,7 +1771,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv0---limit must be zero or a positive integer]",
       "status": "passed",
-      "duration_ms": 1.559,
+      "duration_ms": 2.976,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1564,7 +1780,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv1---offset must be zero or a positive integer]",
       "status": "passed",
-      "duration_ms": 1.492,
+      "duration_ms": 2.63,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1573,7 +1789,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__invalid_cli_options[argv2-chunk size must be a positive integer]",
       "status": "passed",
-      "duration_ms": 1.445,
+      "duration_ms": 2.321,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1582,7 +1798,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv0]",
       "status": "passed",
-      "duration_ms": 1.735,
+      "duration_ms": 2.464,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1591,7 +1807,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv1]",
       "status": "passed",
-      "duration_ms": 1.618,
+      "duration_ms": 2.462,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1600,7 +1816,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_main__missing_cli_option_values[argv2]",
       "status": "passed",
-      "duration_ms": 1.559,
+      "duration_ms": 2.39,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1609,7 +1825,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[False-False-True-False-1]",
       "status": "passed",
-      "duration_ms": 0.249,
+      "duration_ms": 0.344,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1618,7 +1834,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[False-False-True-True-1]",
       "status": "passed",
-      "duration_ms": 0.308,
+      "duration_ms": 0.626,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1627,13 +1843,13 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[True-False-False-True-0]",
       "status": "passed",
-      "duration_ms": 0.45,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.610559+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__skip_existing_matrix0/default.csv\"}\n",
+      "duration_ms": 0.993,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.406319+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_run__skip_existing_matrix0/default.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.610559+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__skip_existing_matrix0/default.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.406319+00:00\", \"level\": \"INFO\", \"event\": \"pipeline_skip_existing\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_run__skip_existing_matrix0/default.csv\"}\n"
         }
       ],
       "error": null
@@ -1641,7 +1857,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run__skip_existing_matrix[True-True-False-True-1]",
       "status": "passed",
-      "duration_ms": 0.398,
+      "duration_ms": 0.561,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1650,7 +1866,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__dry_run_short_circuits",
       "status": "passed",
-      "duration_ms": 0.303,
+      "duration_ms": 0.432,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1659,13 +1875,13 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__invalid_limit_logs_error",
       "status": "passed",
-      "duration_ms": 0.535,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.604260+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
+      "duration_ms": 0.827,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.396707+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.604260+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.396707+00:00\", \"level\": \"ERROR\", \"event\": \"invalid_limit\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"section\": \"activity.limit\", \"limit\": -5}\n"
         }
       ],
       "error": null
@@ -1673,13 +1889,13 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__offset_and_workers",
       "status": "passed",
-      "duration_ms": 65.155,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.657413+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:42.658282+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:42.673796+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:42.708718+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n",
+      "duration_ms": 93.887,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.480407+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:17.481650+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:17.503975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:17.553747+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.657413+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-04T23:26:42.658282+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-04T23:26:42.673796+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-04T23:26:42.708718+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.480407+00:00\", \"level\": \"INFO\", \"event\": \"activity_action_type_distribution\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"counts\": {\"unknown\": 1}}\n{\"ts\": \"2025-10-05T00:48:17.481650+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1}\n{\"ts\": \"2025-10-05T00:48:17.503975+00:00\", \"level\": \"INFO\", \"event\": \"schema_validate_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"schema\": \"ActivitiesSchema\", \"rows\": 1, \"dropped\": 0, \"failures\": 0}\n{\"ts\": \"2025-10-05T00:48:17.553747+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_run_chembl__offset_and_wo0/output.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -1687,7 +1903,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__pipeline_failure_logs_error",
       "status": "passed",
-      "duration_ms": 1.851,
+      "duration_ms": 1.952,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1696,7 +1912,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_failures[<lambda>0]",
       "status": "passed",
-      "duration_ms": 0.432,
+      "duration_ms": 0.489,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1705,7 +1921,7 @@
     {
       "nodeid": "tests/unit/test_get_activity_data.py::test_run_chembl__read_ids_failures[<lambda>1]",
       "status": "passed",
-      "duration_ms": 0.302,
+      "duration_ms": 0.394,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1714,7 +1930,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_build_parser__defaults",
       "status": "passed",
-      "duration_ms": 1.081,
+      "duration_ms": 1.455,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1723,7 +1939,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__force_overrides_skip",
       "status": "passed",
-      "duration_ms": 0.341,
+      "duration_ms": 0.343,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1732,7 +1948,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__propagates_exit_code",
       "status": "passed",
-      "duration_ms": 0.182,
+      "duration_ms": 0.262,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1741,7 +1957,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run__skip_existing_returns_zero",
       "status": "passed",
-      "duration_ms": 0.335,
+      "duration_ms": 0.371,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1750,7 +1966,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__invalid_limit_logs_error",
       "status": "passed",
-      "duration_ms": 0.234,
+      "duration_ms": 0.226,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1759,7 +1975,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__read_ids_failure",
       "status": "passed",
-      "duration_ms": 0.22,
+      "duration_ms": 0.272,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1768,7 +1984,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[0]",
       "status": "passed",
-      "duration_ms": 1.464,
+      "duration_ms": 1.479,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1777,7 +1993,7 @@
     {
       "nodeid": "tests/unit/test_get_assay_data.py::test_run_chembl__successful_execution[2]",
       "status": "passed",
-      "duration_ms": 0.751,
+      "duration_ms": 1.076,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1786,7 +2002,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_configure_logging__delegates_to_configure_logger",
       "status": "passed",
-      "duration_ms": 0.483,
+      "duration_ms": 0.628,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1795,7 +2011,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_configure_logging__invalid_level",
       "status": "passed",
-      "duration_ms": 0.162,
+      "duration_ms": 0.278,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1804,7 +2020,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_parse_args__custom_paths",
       "status": "passed",
-      "duration_ms": 0.807,
+      "duration_ms": 1.099,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1813,7 +2029,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_parse_args__defaults",
       "status": "passed",
-      "duration_ms": 1.066,
+      "duration_ms": 1.049,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1822,7 +2038,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_pipeline_step_registration__expected_shape",
       "status": "passed",
-      "duration_ms": 0.145,
+      "duration_ms": 0.221,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1831,7 +2047,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_run_pipeline__handles_step_exception",
       "status": "passed",
-      "duration_ms": 1.619,
+      "duration_ms": 2.721,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1840,7 +2056,7 @@
     {
       "nodeid": "tests/unit/test_get_data.py::test_run_pipeline__propagates_step_failure",
       "status": "passed",
-      "duration_ms": 1.965,
+      "duration_ms": 2.661,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1849,7 +2065,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coalesce_columns__prefers_first_non_empty",
       "status": "passed",
-      "duration_ms": 2.778,
+      "duration_ms": 4.584,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1858,7 +2074,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[ 7 -7-None]",
       "status": "passed",
-      "duration_ms": 0.137,
+      "duration_ms": 0.186,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1867,7 +2083,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[-None-None]",
       "status": "passed",
-      "duration_ms": 0.192,
+      "duration_ms": 0.26,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1876,7 +2092,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.0-2-None]",
       "status": "passed",
-      "duration_ms": 0.142,
+      "duration_ms": 0.266,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1885,7 +2101,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[2.5-None-invalid_stream_chunk_size_float]",
       "status": "passed",
-      "duration_ms": 0.15,
+      "duration_ms": 0.206,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1894,7 +2110,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[5-5-None]",
       "status": "passed",
-      "duration_ms": 0.197,
+      "duration_ms": 0.187,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1903,7 +2119,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[None-None-None]",
       "status": "passed",
-      "duration_ms": 0.115,
+      "duration_ms": 0.346,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1912,7 +2128,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[True-None-invalid_stream_chunk_size_bool]",
       "status": "passed",
-      "duration_ms": 0.289,
+      "duration_ms": 0.452,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1921,7 +2137,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[abc-None-invalid_stream_chunk_size_string]",
       "status": "passed",
-      "duration_ms": 0.133,
+      "duration_ms": 0.223,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1930,7 +2146,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[nan-None-None]",
       "status": "passed",
-      "duration_ms": 0.132,
+      "duration_ms": 0.302,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1939,7 +2155,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value10-None-invalid_stream_chunk_size_series]",
       "status": "passed",
-      "duration_ms": 0.146,
+      "duration_ms": 0.201,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1948,7 +2164,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value11-None-invalid_stream_chunk_size_type]",
       "status": "passed",
-      "duration_ms": 0.139,
+      "duration_ms": 0.209,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1957,7 +2173,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_coerce_chunk_size_value__cases[value9-3-None]",
       "status": "passed",
-      "duration_ms": 0.213,
+      "duration_ms": 0.331,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1966,7 +2182,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_collapse_duplicate_columns__projects_first_instance",
       "status": "passed",
-      "duration_ms": 2.527,
+      "duration_ms": 4.39,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1975,7 +2191,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_prepare_export_frame__renames_and_coalesces",
       "status": "passed",
-      "duration_ms": 13.141,
+      "duration_ms": 23.612,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1984,7 +2200,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[-5-None]",
       "status": "passed",
-      "duration_ms": 0.112,
+      "duration_ms": 0.189,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -1993,7 +2209,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[0-None]",
       "status": "passed",
-      "duration_ms": 0.128,
+      "duration_ms": 0.277,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2002,7 +2218,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[10-10]",
       "status": "passed",
-      "duration_ms": 0.11,
+      "duration_ms": 0.196,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2011,7 +2227,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_chunk_size__cases[None-None]",
       "status": "passed",
-      "duration_ms": 0.135,
+      "duration_ms": 0.265,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2020,7 +2236,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_resolve_duplicate_column__merges_frames",
       "status": "passed",
-      "duration_ms": 1.965,
+      "duration_ms": 2.931,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2029,7 +2245,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__missing_handler_logs_error",
       "status": "passed",
-      "duration_ms": 0.235,
+      "duration_ms": 0.34,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2038,7 +2254,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__propagates_timeout",
       "status": "passed",
-      "duration_ms": 0.269,
+      "duration_ms": 0.393,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2047,7 +2263,7 @@
     {
       "nodeid": "tests/unit/test_get_document_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 0.472,
+      "duration_ms": 0.798,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2056,7 +2272,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_collect_uniprot_candidate_columns__orders_columns",
       "status": "passed",
-      "duration_ms": 0.608,
+      "duration_ms": 1.053,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2065,7 +2281,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__raises",
       "status": "passed",
-      "duration_ms": 0.424,
+      "duration_ms": 0.578,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2074,7 +2290,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_ensure_merge_column_present__uses_alias",
       "status": "passed",
-      "duration_ms": 1.617,
+      "duration_ms": 2.542,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2083,7 +2299,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[ - ]",
       "status": "passed",
-      "duration_ms": 0.11,
+      "duration_ms": 0.189,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2092,7 +2308,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[None-]",
       "status": "passed",
-      "duration_ms": 0.115,
+      "duration_ms": 0.168,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2101,7 +2317,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345-P12345]",
       "status": "passed",
-      "duration_ms": 0.148,
+      "duration_ms": 0.178,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2110,7 +2326,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_first_token__cases[P12345|Q67890-P12345]",
       "status": "passed",
-      "duration_ms": 0.125,
+      "duration_ms": 0.172,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2119,7 +2335,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[all]",
       "status": "passed",
-      "duration_ms": 0.125,
+      "duration_ms": 0.422,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2128,7 +2344,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[fetch]",
       "status": "passed",
-      "duration_ms": 0.196,
+      "duration_ms": 0.236,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2137,7 +2353,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_keyboard_aliases__cases[run]",
       "status": "passed",
-      "duration_ms": 0.152,
+      "duration_ms": 0.334,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2146,13 +2362,13 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_limited_ids__respects_limit",
       "status": "passed",
-      "duration_ms": 0.26,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:42.924443+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
+      "duration_ms": 0.662,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.866144+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"limit\": 2}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:42.924443+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.866144+00:00\", \"level\": \"INFO\", \"event\": \"process_limit\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"limit\": 2}\n"
         }
       ],
       "error": null
@@ -2160,7 +2376,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values0-P12345|Q67890]",
       "status": "passed",
-      "duration_ms": 0.134,
+      "duration_ms": 0.257,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2169,7 +2385,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values1-Q67890]",
       "status": "passed",
-      "duration_ms": 0.12,
+      "duration_ms": 0.184,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2178,7 +2394,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values2-]",
       "status": "passed",
-      "duration_ms": 0.115,
+      "duration_ms": 0.179,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2187,7 +2403,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_pipe_merge__cases[values3-A|B]",
       "status": "passed",
-      "duration_ms": 0.125,
+      "duration_ms": 0.294,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2196,7 +2412,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_organism_export__failure",
       "status": "passed",
-      "duration_ms": 0.379,
+      "duration_ms": 0.453,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2205,7 +2421,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_organism_export__success",
       "status": "passed",
-      "duration_ms": 0.3,
+      "duration_ms": 0.447,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2214,22 +2430,27 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_postprocess_target_exports__chains_helpers",
       "status": "passed",
-      "duration_ms": 0.244,
-      "stdout": "",
+      "duration_ms": 12.665,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:18.007225+00:00\", \"level\": \"INFO\", \"event\": \"target_names_helper_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/names.output.target_20250101.csv\", \"rows\": 0}\n{\"ts\": \"2025-10-05T00:48:18.007467+00:00\", \"level\": \"INFO\", \"event\": \"target_names_postprocess_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/names.output.target_20250101.csv\", \"source\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/output.target_20250101.csv\", \"rows_before\": 1, \"rows_after\": 0, \"contrion_unique\": 0, \"contrion_non_empty\": 0, \"contrion_total\": 0}\n{\"ts\": \"2025-10-05T00:48:18.010798+00:00\", \"level\": \"ERROR\", \"event\": \"target_iuphar_postprocess_failed\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"msg\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"status\": null, \"rps\": null, \"exc_type\": \"IUPHARPostProcessingError\", \"exc_message\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/scripts/get_target_data.py\\\", line 561, in _postprocess_iuphar_export\\n    result = iuphar_pp.process_iuphar_targets(str(source), verbose=verbose)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/postprocessing/iuphar.py\\\", line 241, in process_iuphar_targets\\n    _ensure_required_columns(df)\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/postprocessing/iuphar.py\\\", line 106, in _ensure_required_columns\\n    raise IUPHARPostProcessingError(\\nlibrary.postprocessing.iuphar.IUPHARPostProcessingError: Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/output.target_20250101.csv\", \"error\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\"}\n",
       "stderr": "",
-      "log": [],
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-05T00:48:18.007225+00:00\", \"level\": \"INFO\", \"event\": \"target_names_helper_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/names.output.target_20250101.csv\", \"rows\": 0}\n{\"ts\": \"2025-10-05T00:48:18.007467+00:00\", \"level\": \"INFO\", \"event\": \"target_names_postprocess_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/names.output.target_20250101.csv\", \"source\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/output.target_20250101.csv\", \"rows_before\": 1, \"rows_after\": 0, \"contrion_unique\": 0, \"contrion_non_empty\": 0, \"contrion_total\": 0}\n{\"ts\": \"2025-10-05T00:48:18.010798+00:00\", \"level\": \"ERROR\", \"event\": \"target_iuphar_postprocess_failed\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"msg\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"status\": null, \"rps\": null, \"exc_type\": \"IUPHARPostProcessingError\", \"exc_message\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"traceback\": \"Traceback (most recent call last):\\n  File \\\"/workspace/ChEMBL_data_acquisition/scripts/get_target_data.py\\\", line 561, in _postprocess_iuphar_export\\n    result = iuphar_pp.process_iuphar_targets(str(source), verbose=verbose)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/postprocessing/iuphar.py\\\", line 241, in process_iuphar_targets\\n    _ensure_required_columns(df)\\n  File \\\"/workspace/ChEMBL_data_acquisition/library/postprocessing/iuphar.py\\\", line 106, in _ensure_required_columns\\n    raise IUPHARPostProcessingError(\\nlibrary.postprocessing.iuphar.IUPHARPostProcessingError: Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\", \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_export0/output.target_20250101.csv\", \"error\": \"Input CSV is missing required columns: GuidetoPHARMACOLOGY, gtop_synonyms, iuphar_chain, iuphar_class, iuphar_family_id, iuphar_name, iuphar_subclass, iuphar_target_id, iuphar_type\"}\n"
+        }
+      ],
       "error": null
     },
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__delegates_to_handler",
       "status": "passed",
-      "duration_ms": 2.553,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:43.010250+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010400+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010496+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010588+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010786+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010872+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010957+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011043+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011153+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011241+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011325+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011410+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011495+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011581+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011667+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011948+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012046+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012134+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012281+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n",
+      "duration_ms": 3.663,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.981958+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982107+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982233+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982363+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982538+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982741+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982921+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983093+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983456+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983567+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983711+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983819+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983924+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984025+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984127+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984466+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984593+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984837+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:43.010250+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010400+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010496+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010588+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010786+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010872+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.010957+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011043+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011153+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011241+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011325+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011410+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011495+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011581+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011667+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.011948+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012046+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012134+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-04T23:26:43.012281+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.981958+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982107+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982233+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982363+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982538+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982741+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.column\", \"param\": \"column\", \"value\": \"target_chembl_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.982921+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.chunk_size\", \"param\": \"chunk_size\", \"value\": 5, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983093+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983299+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983456+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.chembl.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983567+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983711+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983819+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.983924+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984025+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.uniprot.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984127+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.column\", \"param\": \"column\", \"value\": \"uniprot_id\", \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984466+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.chunk_size\", \"param\": \"chunk_size\", \"value\": 100, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984593+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.timeout\", \"param\": \"timeout\", \"value\": 30.0, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984695+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.limit\", \"param\": \"limit\", \"value\": null, \"source\": \"default\"}\n{\"ts\": \"2025-10-05T00:48:17.984837+00:00\", \"level\": \"INFO\", \"event\": \"cli_parameter\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"command\": \"all\", \"scope\": \"all.iuphar.offset\", \"param\": \"offset\", \"value\": 0, \"source\": \"default\"}\n"
         }
       ],
       "error": null
@@ -2237,7 +2458,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run__skip_existing",
       "status": "passed",
-      "duration_ms": 0.479,
+      "duration_ms": 0.987,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2246,13 +2467,13 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_run_uniprot__invokes_target_postprocess",
       "status": "passed",
-      "duration_ms": 75.207,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:43.005143+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n",
+      "duration_ms": 100.003,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:17.975880+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:43.005143+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-5/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:17.975880+00:00\", \"level\": \"INFO\", \"event\": \"metadata_written\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_run_uniprot__invokes_targ0/output.target_20250101.csv.meta.yaml\"}\n"
         }
       ],
       "error": null
@@ -2260,7 +2481,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[ |P99999| -tokens2]",
       "status": "passed",
-      "duration_ms": 0.121,
+      "duration_ms": 0.294,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2269,7 +2490,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[--tokens3]",
       "status": "passed",
-      "duration_ms": 0.149,
+      "duration_ms": 0.285,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2278,7 +2499,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-2|-|Q99999-tokens4]",
       "status": "passed",
-      "duration_ms": 0.194,
+      "duration_ms": 0.278,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2287,7 +2508,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345-tokens0]",
       "status": "passed",
-      "duration_ms": 0.164,
+      "duration_ms": 0.189,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2296,7 +2517,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_split_uniprot_tokens__cases[P12345|Q67890-tokens1]",
       "status": "passed",
-      "duration_ms": 0.134,
+      "duration_ms": 0.254,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2305,7 +2526,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[123]",
       "status": "passed",
-      "duration_ms": 0.119,
+      "duration_ms": 0.183,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2314,7 +2535,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Hello]",
       "status": "passed",
-      "duration_ms": 0.141,
+      "duration_ms": 0.193,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2323,7 +2544,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[Test-Value]",
       "status": "passed",
-      "duration_ms": 0.136,
+      "duration_ms": 0.232,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2332,7 +2553,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__composite_strings[aA]",
       "status": "passed",
-      "duration_ms": 0.116,
+      "duration_ms": 0.2,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2341,7 +2562,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[e-\\u0443]",
       "status": "passed",
-      "duration_ms": 0.126,
+      "duration_ms": 0.229,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2350,7 +2571,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[i-\\u0448]",
       "status": "passed",
-      "duration_ms": 0.12,
+      "duration_ms": 0.181,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2359,7 +2580,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[o-\\u0449]",
       "status": "passed",
-      "duration_ms": 0.125,
+      "duration_ms": 0.197,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2368,7 +2589,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[p-\\u0437]",
       "status": "passed",
-      "duration_ms": 0.12,
+      "duration_ms": 0.175,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2377,7 +2598,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[q-\\u0439]",
       "status": "passed",
-      "duration_ms": 0.13,
+      "duration_ms": 0.273,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2386,7 +2607,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[r-\\u043a]",
       "status": "passed",
-      "duration_ms": 0.122,
+      "duration_ms": 0.31,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2395,7 +2616,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[t-\\u0435]",
       "status": "passed",
-      "duration_ms": 0.118,
+      "duration_ms": 0.178,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2404,7 +2625,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[u-\\u0433]",
       "status": "passed",
-      "duration_ms": 0.124,
+      "duration_ms": 0.168,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2413,7 +2634,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[w-\\u0446]",
       "status": "passed",
-      "duration_ms": 0.129,
+      "duration_ms": 0.26,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2422,7 +2643,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data.py::test_translate_keyboard_layout__single_characters[y-\\u043d]",
       "status": "passed",
-      "duration_ms": 0.117,
+      "duration_ms": 0.204,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2431,7 +2652,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_apply_config_overrides__missing_config_attribute",
       "status": "passed",
-      "duration_ms": 4.518,
+      "duration_ms": 6.483,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2440,7 +2661,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_parser_validation__rejects_zero_chunk_size",
       "status": "passed",
-      "duration_ms": 3.547,
+      "duration_ms": 5.75,
       "stdout": "",
       "stderr": "usage: run_tests.py chembl [-h] [--log-level LOG_LEVEL] [--input INPUT_CSV] [--final-out FINAL_OUT] [--output OUTPUT_CSV]\n                           [--sep SEP] [--encoding ENCODING] [--base-path BASE_PATH] [--input-dir INPUT_DIR]\n                           [--output-dir OUTPUT_DIR] [--date DATE] [--force] [--skip-existing] [--config CONFIG]\n                           [--print-config] [--raw-out RAW_OUT] [--raw-format {csv,parquet}] [--id-cols ID_COLS [ID_COLS ...]]\n                           [--no-reindex-raw] [--normalize-at-export | --no-normalize-at-export] [--column COLUMN]\n                           [--limit LIMIT] [--offset OFFSET] [--chunk-size CHUNK_SIZE] [--timeout TIMEOUT]\nrun_tests.py chembl: error: argument --chunk-size: chunk size must be a positive integer\n",
       "log": [
@@ -2454,7 +2675,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__all_global_fallback",
       "status": "passed",
-      "duration_ms": 4.466,
+      "duration_ms": 6.52,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2463,7 +2684,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__chembl_cli_overrides",
       "status": "passed",
-      "duration_ms": 4.597,
+      "duration_ms": 7.02,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2472,7 +2693,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_resolve_target_parameters__config_precedence",
       "status": "passed",
-      "duration_ms": 4.298,
+      "duration_ms": 6.187,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2481,7 +2702,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_run_logs_parameter_sources__default_sources",
       "status": "passed",
-      "duration_ms": 4.395,
+      "duration_ms": 7.224,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2490,7 +2711,7 @@
     {
       "nodeid": "tests/unit/test_get_target_data_cli.py::test_target_iuphar_defaults__align_with_cli",
       "status": "passed",
-      "duration_ms": 1.108,
+      "duration_ms": 1.445,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2499,7 +2720,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_add_pubchem_data__delegates_to_pipeline",
       "status": "passed",
-      "duration_ms": 1.221,
+      "duration_ms": 1.6,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2508,7 +2729,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__delegates_and_logs",
       "status": "passed",
-      "duration_ms": 0.175,
+      "duration_ms": 0.349,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2517,7 +2738,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__invalid_data_raises",
       "status": "passed",
-      "duration_ms": 0.414,
+      "duration_ms": 0.576,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2526,7 +2747,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_load_molecule_hierarchy_lookup__missing_file_returns_empty",
       "status": "passed",
-      "duration_ms": 0.165,
+      "duration_ms": 0.294,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2535,7 +2756,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values0-expected0]",
       "status": "passed",
-      "duration_ms": 1.406,
+      "duration_ms": 1.792,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2544,7 +2765,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values1-expected1]",
       "status": "passed",
-      "duration_ms": 1.058,
+      "duration_ms": 1.46,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2553,7 +2774,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values2-expected2]",
       "status": "passed",
-      "duration_ms": 0.866,
+      "duration_ms": 1.2,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2562,7 +2783,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values3-expected3]",
       "status": "passed",
-      "duration_ms": 0.955,
+      "duration_ms": 1.171,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2571,7 +2792,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values4-expected4]",
       "status": "passed",
-      "duration_ms": 0.796,
+      "duration_ms": 1.257,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2580,7 +2801,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_normalise_chembl_ids__cases[values5-expected5]",
       "status": "passed",
-      "duration_ms": 1.12,
+      "duration_ms": 1.459,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2589,13 +2810,13 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__force_overrides_skip",
       "status": "passed",
-      "duration_ms": 0.655,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:43.102636+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T23:26:43.102881+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\"}\n",
+      "duration_ms": 1.168,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:18.125973+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-05T00:48:18.126260+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/output.csv\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:43.102636+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-04T23:26:43.102881+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-5/test_run__force_overrides_skip1/output.csv\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:18.125973+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_start\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"input\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/input.csv\", \"source\": \"cli\"}, \"output\": {\"value\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/output.csv\", \"source\": \"cli\"}, \"limit\": {\"value\": null, \"source\": \"unknown\"}, \"offset\": {\"value\": 0, \"source\": \"unknown\"}, \"batch_size\": {\"value\": 1000, \"source\": \"unknown\"}, \"timeout\": {\"value\": 30.0, \"source\": \"unknown\"}, \"column\": {\"value\": \"molecule_chembl_id\", \"source\": \"unknown\"}}\n{\"ts\": \"2025-10-05T00:48:18.126260+00:00\", \"level\": \"INFO\", \"event\": \"testitem_pipeline_done\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"output\": \"/tmp/pytest-of-root/pytest-1/test_run__force_overrides_skip1/output.csv\"}\n"
         }
       ],
       "error": null
@@ -2603,7 +2824,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__non_zero_exit_logs_error",
       "status": "passed",
-      "duration_ms": 0.271,
+      "duration_ms": 0.38,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2612,7 +2833,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__skip_existing_without_force",
       "status": "passed",
-      "duration_ms": 0.331,
+      "duration_ms": 0.604,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2621,7 +2842,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run__success_logs_completion",
       "status": "passed",
-      "duration_ms": 0.284,
+      "duration_ms": 0.443,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2630,7 +2851,7 @@
     {
       "nodeid": "tests/unit/test_get_testitem_data.py::test_run_chembl__passes_options",
       "status": "passed",
-      "duration_ms": 0.31,
+      "duration_ms": 0.379,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2639,7 +2860,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__does_not_mutate_original",
       "status": "passed",
-      "duration_ms": 0.754,
+      "duration_ms": 1.139,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2648,7 +2869,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__identifier_columns_trimmed",
       "status": "passed",
-      "duration_ms": 1.542,
+      "duration_ms": 2.173,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2657,7 +2878,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__micro_sign_replaced",
       "status": "passed",
-      "duration_ms": 0.652,
+      "duration_ms": 1.145,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2666,7 +2887,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__preserves_boolean_dtype",
       "status": "passed",
-      "duration_ms": 0.784,
+      "duration_ms": 1.092,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2675,7 +2896,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<-<=]",
       "status": "passed",
-      "duration_ms": 0.814,
+      "duration_ms": 1.146,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2684,7 +2905,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[<=-<=]",
       "status": "passed",
-      "duration_ms": 0.767,
+      "duration_ms": 1.152,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2693,7 +2914,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[>->=]",
       "status": "passed",
-      "duration_ms": 1.118,
+      "duration_ms": 1.746,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2702,7 +2923,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__relation_mapping[invalid-invalid]",
       "status": "passed",
-      "duration_ms": 0.69,
+      "duration_ms": 1.104,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2711,7 +2932,7 @@
     {
       "nodeid": "tests/unit/test_normalize_rules.py::test_normalize_testitems__retains_missing_values",
       "status": "passed",
-      "duration_ms": 1.022,
+      "duration_ms": 2.031,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2720,7 +2941,7 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__preserves_non_string_values",
       "status": "passed",
-      "duration_ms": 1.536,
+      "duration_ms": 2.269,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2729,7 +2950,7 @@
     {
       "nodeid": "tests/unit/test_normalize_testitems.py::test_normalize_testitems__standardises_relations_and_units",
       "status": "passed",
-      "duration_ms": 1.475,
+      "duration_ms": 2.409,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2738,7 +2959,16 @@
     {
       "nodeid": "tests/unit/test_paths.py::test_dictionary_dir__points_to_project_resource",
       "status": "passed",
-      "duration_ms": 0.238,
+      "duration_ms": 0.374,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_postprocessing_names.py::test_process_target_names__creates_name_output_file",
+      "status": "passed",
+      "duration_ms": 23.537,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2747,7 +2977,7 @@
     {
       "nodeid": "tests/unit/test_target_cellularity.py::test_add_cellularity_smart__falls_back_to_fetch",
       "status": "passed",
-      "duration_ms": 1.223,
+      "duration_ms": 1.571,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2756,7 +2986,7 @@
     {
       "nodeid": "tests/unit/test_target_cellularity.py::test_add_cellularity_smart__prefers_lineage_over_fetch",
       "status": "passed",
-      "duration_ms": 1.338,
+      "duration_ms": 1.688,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2765,7 +2995,7 @@
     {
       "nodeid": "tests/unit/test_target_cellularity.py::test_classify_by_lineage__resolves_known_phyla",
       "status": "passed",
-      "duration_ms": 0.144,
+      "duration_ms": 0.286,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2774,7 +3004,7 @@
     {
       "nodeid": "tests/unit/test_target_helpers.py::test_first_element_text__returns_first_match",
       "status": "passed",
-      "duration_ms": 0.309,
+      "duration_ms": 0.419,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2783,7 +3013,7 @@
     {
       "nodeid": "tests/unit/test_target_helpers.py::test_normalize_text__trims_and_lowercases",
       "status": "passed",
-      "duration_ms": 0.121,
+      "duration_ms": 0.325,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2792,7 +3022,7 @@
     {
       "nodeid": "tests/unit/test_target_isoform.py::test_transform__missing_identifier_columns_raises_key_error",
       "status": "passed",
-      "duration_ms": 0.561,
+      "duration_ms": 0.746,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2801,7 +3031,16 @@
     {
       "nodeid": "tests/unit/test_target_isoform.py::test_transform__supports_alias_columns",
       "status": "passed",
-      "duration_ms": 18.631,
+      "duration_ms": 31.699,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_multifunctional.py::test_compute_multifunctional__adds_missing_identifier_column",
+      "status": "passed",
+      "duration_ms": 2.38,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2810,7 +3049,7 @@
     {
       "nodeid": "tests/unit/test_target_multifunctional.py::test_compute_multifunctional__derives_boolean_flag",
       "status": "passed",
-      "duration_ms": 3.593,
+      "duration_ms": 5.576,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2819,16 +3058,44 @@
     {
       "nodeid": "tests/unit/test_target_multifunctional.py::test_compute_multifunctional__ignores_missing_optional_columns",
       "status": "passed",
-      "duration_ms": 1.556,
+      "duration_ms": 2.558,
       "stdout": "",
       "stderr": "",
       "log": [],
       "error": null
     },
     {
+      "nodeid": "tests/unit/test_target_postprocess_main.py::test_postprocess_target_table__fills_missing_columns",
+      "status": "passed",
+      "duration_ms": 17.467,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:18.341239+00:00\", \"level\": \"WARN\", \"event\": \"target_postprocess_missing_columns\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_table_5/targets_minimal.csv\", \"columns\": [\"uniprot_id_primary\", \"organism\", \"lineage_superkingdom\", \"lineage_phylum\", \"lineage_class\"]}\nPostprocessed target table saved to: organism.targets_minimal.csv\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-05T00:48:18.341239+00:00\", \"level\": \"WARN\", \"event\": \"target_postprocess_missing_columns\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_table_5/targets_minimal.csv\", \"columns\": [\"uniprot_id_primary\", \"organism\", \"lineage_superkingdom\", \"lineage_phylum\", \"lineage_class\"]}\nPostprocessed target table saved to: organism.targets_minimal.csv\n"
+        }
+      ],
+      "error": null
+    },
+    {
+      "nodeid": "tests/unit/test_target_postprocess_main.py::test_postprocess_target_table__handles_missing_identifier_column",
+      "status": "passed",
+      "duration_ms": 18.689,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:18.361817+00:00\", \"level\": \"WARN\", \"event\": \"target_postprocess_missing_columns\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_table_6/targets_missing_id.csv\", \"columns\": [\"target_chembl_id\", \"uniprot_id_primary\", \"organism\", \"lineage_superkingdom\", \"lineage_phylum\", \"lineage_class\"]}\nPostprocessed target table saved to: organism.targets_missing_id.csv\n",
+      "stderr": "",
+      "log": [
+        {
+          "section": "Captured stdout call",
+          "content": "{\"ts\": \"2025-10-05T00:48:18.361817+00:00\", \"level\": \"WARN\", \"event\": \"target_postprocess_missing_columns\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"status\": null, \"rps\": null, \"path\": \"/tmp/pytest-of-root/pytest-1/test_postprocess_target_table_6/targets_missing_id.csv\", \"columns\": [\"target_chembl_id\", \"uniprot_id_primary\", \"organism\", \"lineage_superkingdom\", \"lineage_phylum\", \"lineage_class\"]}\nPostprocessed target table saved to: organism.targets_missing_id.csv\n"
+        }
+      ],
+      "error": null
+    },
+    {
       "nodeid": "tests/unit/test_target_postprocess_main.py::test_postprocess_target_table__produces_power_query_equivalent_csv",
       "status": "passed",
-      "duration_ms": 26.046,
+      "duration_ms": 35.319,
       "stdout": "Postprocessed target table saved to: organism.target_postprocess_input.csv\n",
       "stderr": "",
       "log": [
@@ -2842,7 +3109,7 @@
     {
       "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__accepts_text_plain_json",
       "status": "passed",
-      "duration_ms": 0.379,
+      "duration_ms": 0.513,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2851,7 +3118,7 @@
     {
       "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__handles_empty_body",
       "status": "passed",
-      "duration_ms": 0.287,
+      "duration_ms": 0.246,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2860,7 +3127,7 @@
     {
       "nodeid": "tests/unit/test_uniprot_gtop_fetch.py::test_fetch_gtop_endpoint__records_decode_failure",
       "status": "passed",
-      "duration_ms": 0.288,
+      "duration_ms": 0.388,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2869,7 +3136,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__stores_fractional_success_rate",
       "status": "passed",
-      "duration_ms": 0.929,
+      "duration_ms": 1.101,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2878,7 +3145,7 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_build_json__uses_full_success_for_empty_suite",
       "status": "passed",
-      "duration_ms": 0.641,
+      "duration_ms": 0.816,
       "stdout": "",
       "stderr": "",
       "log": [],
@@ -2887,17 +3154,17 @@
     {
       "nodeid": "tests/unit/tools/test_run_tests.py::test_main__downgrades_exit_code_when_threshold_not_met",
       "status": "passed",
-      "duration_ms": 1.836,
-      "stdout": "{\"ts\": \"2025-10-04T23:26:43.245163+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"logger\": \"tests.run_tests\"}\n",
+      "duration_ms": 2.38,
+      "stdout": "{\"ts\": \"2025-10-05T00:48:18.403159+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"logger\": \"tests.run_tests\"}\n",
       "stderr": "",
       "log": [
         {
           "section": "Captured stdout call",
-          "content": "{\"ts\": \"2025-10-04T23:26:43.245163+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"ce58056d59ee42ef963a1f4ccf296693\", \"logger\": \"tests.run_tests\"}\n"
+          "content": "{\"ts\": \"2025-10-05T00:48:18.403159+00:00\", \"level\": \"ERROR\", \"event\": \"Success rate 50.00% is below the required threshold of 95.00%\", \"run_id\": \"9061d782288d449fa5c6db29c8594a4b\", \"logger\": \"tests.run_tests\"}\n"
         },
         {
           "section": "Captured log call",
-          "content": "\u001b[1m\u001b[31mERROR   \u001b[0m tests.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
+          "content": "\u001b[31m\u001b[1mERROR   \u001b[0m tests.run_tests:run_tests.py:273 Success rate 50.00% is below the required threshold of 95.00%"
         }
       ],
       "error": null

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -1,15 +1,15 @@
 # Test Summary
 
 - Repo: `SatoryKono/ChEMBL_data_acquisition`
-- Commit: abf623bbd40e012d0f004b35fe3b8ed9defabeaa
+- Commit: 890be8b0e9b6af22d3e797c231dac6dc60427b2d
 - Branch: work
-- Timestamp (UTC): 2025-10-04T23:26:43.505857+00:00
-- Duration: 6.403 s
+- Timestamp (UTC): 2025-10-05T00:48:18.768037+00:00
+- Duration: 8.766 s
 - Success rate: 100.00%
 
 | total | passed | failed | skipped | xfailed | xpassed | error |
 |------:|-------:|-------:|--------:|--------:|--------:|------:|
-|   292 |   292 |     0 |      0 |      0 |      0 |     0 |
+|   320 |   320 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
 - none

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -23,7 +23,7 @@ def test_ensure_required_columns__raises_for_missing_columns() -> None:
 
     message = str(excinfo.value)
     assert "gtop_synonyms" in message
-    assert "component_description" in message
+    assert "component_description" not in message
 
 
 def test_clean_brackets__removes_nested_annotations() -> None:
@@ -172,17 +172,6 @@ def test_process_iuphar_targets__produces_expected_csv(tmp_path: Path, snapshot_
                 "component_sequence": None,
                 "component_structures": None,
             },
-                "target_chembl_id": "CHEMBL4",
-                "GuidetoPHARMACOLOGY": "GTOP4",
-                "iuphar_target_id": "T4",
-                "iuphar_family_id": "F4",
-                "iuphar_type": "Type",
-                "iuphar_class": "Class",
-                "iuphar_subclass": "Sub",
-                "iuphar_chain": "Chain",
-                "iuphar_name": "Name",
-                # Missing gtop_synonyms
-            }
         ]
     )
     frame.to_csv(input_path, index=False)
@@ -193,9 +182,6 @@ def test_process_iuphar_targets__produces_expected_csv(tmp_path: Path, snapshot_
     expected_bytes = (snapshot_resource / "iuphar_postprocessing_expected.csv").read_bytes()
     actual_bytes = output_path.read_bytes()
     assert actual_bytes == expected_bytes
-    message = str(excinfo.value)
-    assert "gtop_synonyms" in message
-    assert "component_description" not in message
 
 
 def test_process_iuphar_targets__fills_missing_component_description(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- repair the IUPHAR post-processing test fixture and expectations so the suite imports correctly
- regenerate the JSON and Markdown test run reports after a clean execution of the full pytest suite

## Testing
- python tests/run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bfdc3e048324addd94e2f51c790e