### PR TITLE
Handle whitespace and BOM in IUPHAR post-processing headers

### DIFF
--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -100,6 +100,25 @@ def _latest_target_file(search_dir: Path) -> Path:
     return candidates[-1]
 
 
+def _normalise_column_name(name: str) -> str:
+    """Return ``name`` stripped of whitespace and UTF-8 BOM markers."""
+
+    if isinstance(name, str):
+        # ``str.strip`` alone does not remove the BOM prefix, therefore we
+        # explicitly lstrip it before trimming whitespace.  The helper keeps the
+        # original casing because downstream code relies on exact header names.
+        return name.lstrip("\ufeff").strip()
+    return name
+
+
+def _normalise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with consistently normalised column headers."""
+
+    if not df.columns.empty:
+        df = df.rename(columns=_normalise_column_name)
+    return df
+
+
 def _ensure_required_columns(df: pd.DataFrame) -> None:
     missing = [column for column in _REQUIRED_COLUMNS if column not in df.columns]
     if missing:
@@ -238,6 +257,7 @@ def process_iuphar_targets(
         output_path = Path(output_csv)
 
     df = read_csv_with_fallbacks(input_path)
+    df = _normalise_columns(df)
     _ensure_required_columns(df)
     df = _ensure_optional_columns(df)
 

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -171,3 +171,60 @@ def test_process_iuphar_targets__fills_missing_component_description(tmp_path: P
     assert output_path.exists()
     result = pd.read_csv(output_path)
     assert result.loc[0, "iuphar_synonyms"] == "alpha|beta|gamma|name"
+
+
+def test_process_iuphar_targets__handles_header_whitespace(tmp_path: Path) -> None:
+    path = tmp_path / "output.target_20240707.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL6",
+                "GuidetoPHARMACOLOGY": "GTOP6",
+                "iuphar_target_id": "T6",
+                "iuphar_family_id": "F6",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Sub",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Omega",
+                "gtop_synonyms": "Omega|Omega (alt)",
+                "component_description": "Omega component",
+            }
+        ]
+    )
+    frame = frame.rename(columns={col: f"  {col}  " for col in frame.columns})
+    frame.to_csv(path, index=False)
+
+    output_path = iuphar.process_iuphar_targets(path)
+
+    assert output_path.exists()
+    result = pd.read_csv(output_path)
+    assert result.loc[0, "iuphar_synonyms"] == "omega|omega component"
+
+
+def test_process_iuphar_targets__handles_bom_prefixed_header(tmp_path: Path) -> None:
+    path = tmp_path / "output.target_20240808.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL7",
+                "GuidetoPHARMACOLOGY": "GTOP7",
+                "iuphar_target_id": "T7",
+                "iuphar_family_id": "F7",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Sub",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Lambda",
+                "gtop_synonyms": "Lambda",
+                "component_description": "Lambda",
+            }
+        ]
+    )
+    frame.to_csv(path, index=False, encoding="utf-8-sig")
+
+    output_path = iuphar.process_iuphar_targets(path)
+
+    assert output_path.exists()
+    result = pd.read_csv(output_path)
+    assert result.loc[0, "guidetopharmacology_id"] == "GTOP7"


### PR DESCRIPTION
## Summary
- normalise IUPHAR input headers to strip whitespace and UTF-8 BOM markers before validation
- extend regression coverage to ensure whitespace- and BOM-prefixed headers are processed successfully

## Testing
- pytest tests/postprocessing/test_iuphar_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bee306f08324bec4d566c1ff7693