### PR TITLE
Skip post-processing for helper target exports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -594,6 +594,23 @@ def _postprocess_target_exports(
 ) -> None:
     """Run all target post-processing helpers for ``source`` export."""
 
+    def _normalised_export_name(path: Path) -> str:
+        name = path.name
+        for suffix in reversed(path.suffixes):
+            if suffix == ".csv":
+                break
+            name = name.removesuffix(suffix)
+        return name
+
+    export_name = _normalised_export_name(source)
+    if not target_pp._matches_expected_input_name(export_name):
+        logger.info(
+            "target_postprocess_skipped",
+            path=str(source),
+            reason="unsupported_export_name",
+        )
+        return
+
     _postprocess_organism_export(source, cfg=cfg)
     _postprocess_isoform_export(
         source,

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -361,3 +361,29 @@ def test_postprocess_target_exports__chains_helpers(
     get_target_data._postprocess_target_exports(source, cfg=cfg)
 
     assert call_order == ["organism", "isoform"]
+
+
+def test_postprocess_target_exports__skips_for_uniprot_suffix(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    logger_stub: _MemoryLogger,
+) -> None:
+    source = tmp_path / "output.targets_20250101_uniprot.csv"
+    source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    def _unexpected(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("post-processing should be skipped")
+
+    monkeypatch.setattr(get_target_data, "_postprocess_organism_export", _unexpected)
+    monkeypatch.setattr(get_target_data, "_postprocess_isoform_export", _unexpected)
+    monkeypatch.setattr(get_target_data, "_postprocess_names_export", _unexpected)
+    monkeypatch.setattr(get_target_data, "_postprocess_iuphar_export", _unexpected)
+
+    get_target_data._postprocess_target_exports(source, cfg=cfg)
+
+    assert (
+        "info",
+        "target_postprocess_skipped",
+        {"path": str(source), "reason": "unsupported_export_name"},
+    ) in logger_stub.events


### PR DESCRIPTION
## Summary
- skip organism/isoform/name/IUPHAR helpers when the export filename does not match canonical target patterns
- log a skip event for unsupported helper inputs and guard against compressed suffixes
- add unit coverage ensuring helper exports with `_uniprot` suffix do not trigger target post-processing

## Testing
- pytest tests/unit/test_get_target_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e21c6268988324a78a4314337d2d5b