### PR TITLE
Allow isoform postprocessing custom filenames

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 import sys
+import warnings
 
 import pandas as pd
 import re
@@ -451,9 +452,20 @@ def _resolve_input_path(input_csv: Optional[Union[str, Path]]) -> Path:
         if not candidate.exists():
             raise FileNotFoundError(candidate)
         if not _matches_expected_input_name(candidate.name):
-            raise ValueError(
-                "Input file must match one of the supported patterns: "
-                + _supported_patterns_text()
+            if candidate.suffix.lower() != ".csv":
+                raise ValueError(
+                    "Input file must match one of the supported patterns: "
+                    + _supported_patterns_text()
+                )
+            warnings.warn(
+                (
+                    "Input file '%s' does not match the canonical target export "
+                    "naming conventions (%s); proceeding because an explicit path "
+                    "was provided."
+                )
+                % (candidate.name, _supported_patterns_text()),
+                UserWarning,
+                stacklevel=2,
             )
         return candidate
 
@@ -496,11 +508,6 @@ def process_targets(
     """Run the isoform post-processing pipeline on canonical target exports."""
 
     input_path = _resolve_input_path(input_csv)
-    if not _matches_expected_input_name(input_path.name):
-        raise ValueError(
-            "Input file must match one of the supported patterns: "
-            + _supported_patterns_text()
-        )
 
     output_path = _resolve_output_path(input_path, output_csv)
 

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -483,3 +483,19 @@ def test_isoform_process_targets__writes_isoform_prefix(tmp_path: Path, snapshot
 
     assert output_path.name == "isoform.output.target_20250101.csv"
     assert output_path.parent == input_path.parent
+
+
+@pytest.mark.unit
+def test_isoform_process_targets__accepts_explicit_custom_name(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "custom_export.csv"
+    input_path.write_bytes(source.read_bytes())
+
+    match = "does not match the canonical target export naming conventions"
+    with pytest.warns(UserWarning, match=match):
+        output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.custom_export.csv"
+    assert output_path.parent == input_path.parent


### PR DESCRIPTION
## Summary
- allow the isoform post-processing helper to accept explicitly provided CSV files that do not follow the canonical naming pattern while emitting a warning
- add a regression test ensuring custom filenames are accepted and produce the expected isoform-prefixed output

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py -k custom_name -q

------
https://chatgpt.com/codex/tasks/task_e_68e2206b3cdc83249a97b5b887357740