### PR TITLE
Handle CLI target export aliases and skip IUPHAR when columns missing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -69,6 +69,10 @@ _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
         re.compile(r"targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"),
         "targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
     ),
+    (
+        re.compile(r"out_[A-Za-z0-9]+(?:_[A-Za-z0-9]+)*\.csv\Z"),
+        "out_<alias>.csv",
+    ),
 )
 
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 import shutil
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import math
@@ -557,8 +557,29 @@ def _postprocess_iuphar_export(
         logger.error("target_iuphar_postprocess_unavailable", **payload)
         return None
 
+    required_columns: Collection[str] = tuple(
+        getattr(iuphar_pp, "_REQUIRED_COLUMNS", ())
+    )
+    missing_columns = _missing_csv_columns(source, required_columns) if required_columns else []
+    if missing_columns:
+        logger.info(
+            "target_iuphar_postprocess_skipped",
+            path=str(source),
+            reason="missing_required_columns",
+            missing=sorted(missing_columns),
+        )
+        return None
+
     try:
         result = iuphar_pp.process_iuphar_targets(str(source), verbose=verbose)
+    except getattr(iuphar_pp, "IUPHARPostProcessingError", RuntimeError) as exc:
+        logger.info(
+            "target_iuphar_postprocess_skipped",
+            path=str(source),
+            reason="input_validation_error",
+            error=str(exc),
+        )
+        return None
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.exception(
             "target_iuphar_postprocess_failed",
@@ -582,6 +603,26 @@ def _postprocess_iuphar_export(
         source=str(source),
     )
     return output_path
+
+
+def _missing_csv_columns(path: Path, required: Collection[str]) -> list[str]:
+    """Return the subset of *required* columns missing from ``path``."""
+
+    if not required:
+        return []
+
+    try:
+        header = pd.read_csv(
+            path,
+            nrows=0,
+            dtype=str,
+            keep_default_na=False,
+        )
+    except Exception:
+        return list(required)
+
+    existing = set(header.columns)
+    return [column for column in required if column not in existing]
 
 
 def _postprocess_target_exports(

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -483,3 +483,15 @@ def test_isoform_process_targets__writes_isoform_prefix(tmp_path: Path, snapshot
 
     assert output_path.name == "isoform.output.target_20250101.csv"
     assert output_path.parent == input_path.parent
+
+
+@pytest.mark.unit
+def test_isoform_process_targets__accepts_cli_out_alias(tmp_path: Path, snapshot_resource: Path) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "out_uniprot.csv"
+    input_path.write_bytes(source.read_bytes())
+
+    output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.out_uniprot.csv"
+    assert output_path.parent == input_path.parent

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from typing import Iterable
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -386,4 +387,38 @@ def test_postprocess_target_exports__skips_for_uniprot_suffix(
         "info",
         "target_postprocess_skipped",
         {"path": str(source), "reason": "unsupported_export_name"},
+    ) in logger_stub.events
+
+
+def test_postprocess_iuphar_export__skips_when_columns_missing(
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "out_uniprot.csv"
+    source.write_text("target_chembl_id,name\nCHEMBL1,Alpha\n", encoding="utf-8")
+
+    def _not_called(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("IUPHAR post-processing should be skipped")
+
+    stub = SimpleNamespace(
+        process_iuphar_targets=_not_called,
+        _REQUIRED_COLUMNS=("target_chembl_id", "GuidetoPHARMACOLOGY"),
+        IUPHARPostProcessingError=RuntimeError,
+    )
+
+    monkeypatch.setattr(get_target_data, "iuphar_pp", stub, raising=False)
+    monkeypatch.setattr(get_target_data, "_IUPHAR_IMPORT_ERROR", None, raising=False)
+
+    result = get_target_data._postprocess_iuphar_export(source, verbose=False)
+
+    assert result is None
+    assert (
+        "info",
+        "target_iuphar_postprocess_skipped",
+        {
+            "path": str(source),
+            "reason": "missing_required_columns",
+            "missing": ["GuidetoPHARMACOLOGY"],
+        },
     ) in logger_stub.events


### PR DESCRIPTION
## Summary
- allow the isoform post-processing helper to accept CLI `out_<alias>.csv` exports
- skip the IUPHAR enrichment step when required columns are missing and treat validation errors as expected skips
- add regression tests covering the new alias support and skip behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e21ffb31cc8324b771a322b9c2c7eb