### PR TITLE
Handle missing optional component_description in IUPHAR postprocessing

### DIFF
--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -55,8 +55,9 @@ _REQUIRED_COLUMNS: tuple[str, ...] = (
     "iuphar_chain",
     "iuphar_name",
     "gtop_synonyms",
-    "component_description",
 )
+
+_OPTIONAL_TEXT_COLUMNS: tuple[str, ...] = ("component_description",)
 
 _OUTPUT_COLUMNS: tuple[str, ...] = (
     "target_chembl_id",
@@ -103,6 +104,21 @@ def _ensure_required_columns(df: pd.DataFrame) -> None:
         raise IUPHARPostProcessingError(
             "Input CSV is missing required columns: " + ", ".join(sorted(missing))
         )
+
+
+def _ensure_optional_columns(df: pd.DataFrame) -> pd.DataFrame:
+    if all(column in df.columns for column in _OPTIONAL_TEXT_COLUMNS):
+        return df
+
+    df = df.copy()
+    for column in _OPTIONAL_TEXT_COLUMNS:
+        if column not in df.columns:
+            df[column] = ""
+            logger.warning(
+                "iuphar_optional_column_missing column=%s",
+                column,
+            )
+    return df
 
 
 def _clean_brackets(value: str) -> str:
@@ -226,6 +242,7 @@ def process_iuphar_targets(
 
     df = read_csv_with_fallbacks(input_path)
     _ensure_required_columns(df)
+    df = _ensure_optional_columns(df)
 
     input_rows = len(df)
     df, dropped_columns = _drop_helper_columns(df)

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -130,7 +130,7 @@ def test_process_iuphar_targets__missing_required_columns(tmp_path: Path) -> Non
                 "iuphar_subclass": "Sub",
                 "iuphar_chain": "Chain",
                 "iuphar_name": "Name",
-                # Missing gtop_synonyms and component_description
+                # Missing gtop_synonyms
             }
         ]
     )
@@ -141,4 +141,29 @@ def test_process_iuphar_targets__missing_required_columns(tmp_path: Path) -> Non
 
     message = str(excinfo.value)
     assert "gtop_synonyms" in message
-    assert "component_description" in message
+
+
+def test_process_iuphar_targets__fills_missing_component_description(tmp_path: Path) -> None:
+    path = tmp_path / "output.target_20240606.csv"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL5",
+                "GuidetoPHARMACOLOGY": "GTOP5",
+                "iuphar_target_id": "T5",
+                "iuphar_family_id": "F5",
+                "iuphar_type": "Receptor",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Subclass",
+                "iuphar_chain": "Chain",
+                "iuphar_name": "Name",
+                "gtop_synonyms": "alpha|beta",
+            }
+        ]
+    )
+    frame.to_csv(path, index=False)
+
+    output = iuphar.process_iuphar_targets(path)
+
+    result = pd.read_csv(output)
+    assert result.loc[0, "iuphar_synonyms"] == "alpha|beta|name"


### PR DESCRIPTION
## Summary
- treat `component_description` as optional for the IUPHAR post-processing helper and create an empty column when missing
- log a warning when the column is absent and continue to build the synonyms export
- extend tests to cover CSV inputs without the optional column

## Testing
- pytest tests/postprocessing/test_iuphar_postprocessing.py

------
https://chatgpt.com/codex/tasks/task_e_68e1be2712a483248898c23e7efb0365