### PR TITLE
Normalise post-processing export basenames

### DIFF
--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -23,6 +23,26 @@ from library.common.csv_utils import write_csv_deterministic
 ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
 
 
+def normalise_export_basename(path: Path) -> str:
+    """Return a deterministic basename for post-processed exports.
+
+    The helper mirrors the naming conventions used by the legacy Power Query
+    workbook: temporary suffixes (``.tmp``) are stripped, leading dots are
+    removed so that subsequent ``Path.with_name`` calls do not introduce
+    accidental hidden files, and the remaining stem is returned unchanged.
+    """
+
+    name = path.name
+    while name.startswith("."):
+        name = name[1:]
+    tmp_suffix = ".tmp"
+    while name.lower().endswith(tmp_suffix):
+        name = name[: -len(tmp_suffix)]
+    if not name:
+        raise ValueError(f"Unable to derive export basename from {path!s}")
+    return name
+
+
 def normalise_text(value: object | None) -> str:
     """Return a trimmed textual representation of ``value``.
 

--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -12,7 +12,7 @@ from typing import Sequence
 
 import pandas as pd
 
-from .helpers import normalise_text, read_csv_with_fallbacks
+from .helpers import normalise_export_basename, normalise_text, read_csv_with_fallbacks
 from library.common.csv_utils import write_csv_deterministic
 
 __all__ = ["process_iuphar_targets", "IUPHARPostProcessingError"]
@@ -252,7 +252,8 @@ def process_iuphar_targets(
     else:
         input_path = Path(input_csv)
     if output_csv is None:
-        output_path = input_path.with_name(f"IUPHAR.{input_path.name}")
+        base = normalise_export_basename(input_path)
+        output_path = input_path.with_name(f"IUPHAR.{base}").with_suffix(".csv")
     else:
         output_path = Path(output_csv)
 

--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -54,7 +54,12 @@ from typing import Any, Iterable, Mapping, MutableMapping, Sequence
 
 import pandas as pd
 
-from .helpers import ENCODING_FALLBACKS, normalise_text, read_csv_with_fallbacks
+from .helpers import (
+    ENCODING_FALLBACKS,
+    normalise_export_basename,
+    normalise_text,
+    read_csv_with_fallbacks,
+)
 from library.common.csv_utils import write_csv_deterministic
 
 _DEFAULT_SEARCH_DIR = Path("data/output")
@@ -406,7 +411,8 @@ def process_target_names(
             by=["target_chembl_id", "molecule_chembl_id", "all_names"],
             kind="mergesort",
         )
-    output_path = path.with_name(f"name.{path.name}")
+    base = normalise_export_basename(path)
+    output_path = path.with_name(f"name.{base}").with_suffix(".csv")
     write_csv_deterministic(
         result,
         output_path,
@@ -592,7 +598,8 @@ def process_target_names(input_path: str | Path, *, verbose: bool = False) -> di
 
     names_df = _build_names_table(frame)
     prefix = "names" if verbose else "name"
-    output_path = source_path.with_name(f"{prefix}.{source_path.name}")
+    base = normalise_export_basename(source_path)
+    output_path = source_path.with_name(f"{prefix}.{base}").with_suffix(".csv")
     helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
 
     summary: dict[str, Any] = {

--- a/library/postprocessing/target/main.py
+++ b/library/postprocessing/target/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from ...common.log import logger
+from ..helpers import normalise_export_basename
 from .cellularity import add_cellularity_smart, FetchLineageCallable
 from .multifunctional import compute_multifunctional
 
@@ -69,7 +70,8 @@ def postprocess_target_table(
         sort=False,
     )
 
-    output_path = path.with_name(f"organism.{path.name}")
+    base = normalise_export_basename(path)
+    output_path = path.with_name(f"organism.{base}").with_suffix(".csv")
     joined.to_csv(output_path, index=False, encoding="utf-8", lineterminator="\n")
     print(f"Postprocessed target table saved to: {output_path.name}")
     return str(output_path)

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -185,6 +185,32 @@ def test_process_iuphar_targets__produces_expected_csv(tmp_path: Path, snapshot_
     assert actual_bytes == expected_bytes
 
 
+def test_process_iuphar_targets__normalises_tmp_suffix(tmp_path: Path) -> None:
+    input_path = tmp_path / "output.target_20250101.csv.tmp"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL42",
+                "GuidetoPHARMACOLOGY": "GTOP42",
+                "iuphar_target_id": "T-42",
+                "iuphar_family_id": "F-42",
+                "iuphar_type": "Type",
+                "iuphar_class": "Class",
+                "iuphar_subclass": "Subclass",
+                "iuphar_chain": "A",
+                "iuphar_name": "Alpha",
+                "gtop_synonyms": "Alpha|Beta",
+            }
+        ]
+    )
+    frame.to_csv(input_path, index=False)
+
+    output_path = iuphar.process_iuphar_targets(input_path)
+
+    assert output_path.name == "IUPHAR.output.target_20250101.csv"
+    assert output_path.exists()
+
+
 def test_process_iuphar_targets__fills_missing_component_description(tmp_path: Path) -> None:
     path = tmp_path / "output.target_20240606.csv"
     frame = pd.DataFrame(

--- a/tests/unit/test_postprocessing_names.py
+++ b/tests/unit/test_postprocessing_names.py
@@ -38,3 +38,25 @@ def test_process_target_names__creates_name_output_file(tmp_path):
     assert not exported.empty
     assert (exported["target_chembl_id"] == "CHEMBL_TARGET").all()
     assert "Alpha" in exported["name"].values
+
+
+def test_process_target_names__normalises_tmp_suffix(tmp_path: Path) -> None:
+    input_path = tmp_path / "output.target_20250101.csv.tmp"
+    frame = pd.DataFrame(
+        [
+            {
+                "target_chembl_id": "CHEMBL_TARGET",
+                "uniprot_id_primary": "P54321",
+                "pref_name": "Beta",
+                "gene_symbol": "GENE2",
+            }
+        ],
+        dtype="string",
+    )
+    frame.to_csv(input_path, index=False, encoding="utf-8")
+
+    result = names.process_target_names(input_path, verbose=False)
+
+    output_path = Path(result["path"])
+    assert output_path.name == "name.output.target_20250101.csv"
+    assert output_path.exists()

--- a/tests/unit/test_target_postprocess_main.py
+++ b/tests/unit/test_target_postprocess_main.py
@@ -76,6 +76,29 @@ def test_postprocess_target_table__fills_missing_columns(tmp_path: Path) -> None
 
 
 @pytest.mark.unit
+def test_postprocess_target_table__normalises_tmp_suffix(tmp_path: Path) -> None:
+    input_path = tmp_path / "output.target_20250101.csv.tmp"
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprot_id_primary": ["P11111"],
+            "organism": ["Human"],
+            "taxon_id": ["9606"],
+            "lineage_superkingdom": ["Eukaryota"],
+            "lineage_phylum": ["Chordata"],
+            "lineage_class": ["Mammalia"],
+        }
+    )
+    frame.to_csv(input_path, index=False)
+
+    output_location = postprocess_target_table(input_path)
+    output_path = Path(output_location)
+
+    assert output_path.name == "organism.output.target_20250101.csv"
+    assert output_path.exists()
+
+
+@pytest.mark.unit
 def test_postprocess_target_table__handles_missing_identifier_column(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a reusable helper that strips temporary suffixes and leading dots from export basenames
- use the helper in the IUPHAR, target names, and organism post-processing flows to build csv paths safely
- extend post-processing tests to cover .tmp inputs and ensure csv outputs use the expected names

## Testing
- pytest tests/postprocessing/test_iuphar_postprocessing.py tests/unit/test_postprocessing_names.py tests/unit/test_target_postprocess_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e2214d04448324be073affe7056975