### PR TITLE
Allow isoform post-processing for UniProt exports

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -70,6 +70,10 @@ _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
         re.compile(r"targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"),
         "targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
     ),
+    (
+        re.compile(r"out_uniprot(?:_[A-Za-z0-9]+)*\.csv\Z"),
+        "out_uniprot[_<suffixes>].csv",
+    ),
 )
 
 

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import types
+import warnings
 from pathlib import Path
 
 
@@ -498,4 +499,21 @@ def test_isoform_process_targets__accepts_explicit_custom_name(
         output_path = isoform.process_targets(str(input_path), verbose=False)
 
     assert output_path.name == "isoform.custom_export.csv"
+    assert output_path.parent == input_path.parent
+
+
+@pytest.mark.unit
+def test_isoform_process_targets__supports_uniprot_export_name(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "out_uniprot.csv"
+    input_path.write_bytes(source.read_bytes())
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("error")
+        output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert recorded == []
+    assert output_path.name == "isoform.out_uniprot.csv"
     assert output_path.parent == input_path.parent


### PR DESCRIPTION
## Summary
- allow isoform post-processing to recognize UniProt export filenames (out_uniprot*.csv)
- add a regression test confirming UniProt exports are processed without warnings

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py -k uniprot -q

------
https://chatgpt.com/codex/tasks/task_e_68e2219190e88324b24823b7eef3fd49