### PR TITLE
Handle custom target export filenames in post-processing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -69,6 +69,10 @@ _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
         re.compile(r"targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"),
         "targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
     ),
+    (
+        re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*_normalized\.csv\Z"),
+        "<custom_stem>_normalized.csv",
+    ),
 )
 
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -187,6 +187,12 @@ RAW_SUFFIX = "_raw"
 NORMALIZED_SUFFIX = "_normalized"
 COMMAND_CHOICES: tuple[str, ...] = ("uniprot", "chembl", "iuphar", "all")
 
+_PARTIAL_TARGET_EXPORT_SUFFIXES: tuple[str, ...] = (
+    "_chembl.csv",
+    "_uniprot.csv",
+    "_iuphar.csv",
+)
+
 
 class StoreWithSource(argparse.Action):
     """Store CLI values while tracking their origin."""
@@ -584,6 +590,14 @@ def _postprocess_iuphar_export(
     return output_path
 
 
+def _is_partial_target_export(path: Path | str) -> bool:
+    """Return ``True`` when ``path`` refers to a partial source export."""
+
+    name = path.name if isinstance(path, Path) else str(path)
+    lowered = name.lower()
+    return any(lowered.endswith(suffix) for suffix in _PARTIAL_TARGET_EXPORT_SUFFIXES)
+
+
 def _postprocess_target_exports(
     source: Path,
     *,
@@ -601,6 +615,14 @@ def _postprocess_target_exports(
                 break
             name = name.removesuffix(suffix)
         return name
+
+    if _is_partial_target_export(source):
+        logger.info(
+            "target_postprocess_skipped",
+            path=str(source),
+            reason="partial_export",
+        )
+        return
 
     export_name = _normalised_export_name(source)
     if not target_pp._matches_expected_input_name(export_name):

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -152,6 +152,20 @@ def test_first_token__cases(value: str | None, expected: str) -> None:
     assert get_target_data._first_token(value) == expected
 
 
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("data/output/out_chembl.csv", True),
+        ("data/output/out_uniprot.csv", True),
+        ("data/output/out_iuphar.csv", True),
+        ("data/output/out_normalized.csv", False),
+        ("data/output/output.target_20250101.csv", False),
+    ],
+)
+def test_is_partial_target_export__cases(filename: str, expected: bool) -> None:
+    assert get_target_data._is_partial_target_export(Path(filename)) is expected
+
+
 def test_limited_ids__respects_limit() -> None:
     source = iter(["A", "B", "C"])
 
@@ -385,5 +399,5 @@ def test_postprocess_target_exports__skips_for_uniprot_suffix(
     assert (
         "info",
         "target_postprocess_skipped",
-        {"path": str(source), "reason": "unsupported_export_name"},
+        {"path": str(source), "reason": "partial_export"},
     ) in logger_stub.events

--- a/tests/unit/test_target_isoform.py
+++ b/tests/unit/test_target_isoform.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -74,3 +76,25 @@ def test_transform__missing_identifier_columns_raises_key_error():
     message = str(exc.value)
     assert "uniprot_id_primary" in message
     assert "target_chembl_id" in message
+
+
+@pytest.mark.unit
+def test_matches_expected_input_name__accepts_custom_normalized() -> None:
+    """Custom stems ending with ``_normalized`` are accepted."""
+
+    assert isoform._matches_expected_input_name("custom_output_normalized.csv")
+    assert not isoform._matches_expected_input_name("custom_output_chembl.csv")
+
+
+@pytest.mark.unit
+def test_process_targets__custom_normalized_name(tmp_path: Path, snapshot_resource: Path) -> None:
+    """``process_targets`` handles user-specified ``*_normalized.csv`` exports."""
+
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "user_defined_normalized.csv"
+    input_path.write_bytes(source.read_bytes())
+
+    output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.user_defined_normalized.csv"
+    assert output_path.parent == input_path.parent


### PR DESCRIPTION
## Summary
- allow the isoform post-processing helper to accept user-defined *_normalized.csv exports
- skip target post-processing for partial ChEMBL/UniProt/IUPHAR exports and expose a helper for detection
- cover the new behaviour with unit tests for the CLI helpers and isoform module

## Testing
- pytest tests/unit/test_target_isoform.py tests/unit/test_get_target_data.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e220d49a6c83249ebf2ddf6519c7e4