### PR TITLE
Handle non-canonical target export names in isoform post-processing

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -453,20 +453,27 @@ def _resolve_input_path(input_csv: Optional[Union[str, Path]]) -> Path:
             raise FileNotFoundError(candidate)
         if not _matches_expected_input_name(candidate.name):
             if candidate.suffix.lower() != ".csv":
-                raise ValueError(
-                    "Input file must match one of the supported patterns: "
-                    + _supported_patterns_text()
+                warnings.warn(
+                    (
+                        "Input file '%s' does not use the canonical '.csv' extension "
+                        "(%s); attempting to proceed because an explicit path was "
+                        "provided."
+                    )
+                    % (candidate.name, _supported_patterns_text()),
+                    UserWarning,
+                    stacklevel=2,
                 )
-            warnings.warn(
-                (
-                    "Input file '%s' does not match the canonical target export "
-                    "naming conventions (%s); proceeding because an explicit path "
-                    "was provided."
+            else:
+                warnings.warn(
+                    (
+                        "Input file '%s' does not match the canonical target export "
+                        "naming conventions (%s); proceeding because an explicit path "
+                        "was provided."
+                    )
+                    % (candidate.name, _supported_patterns_text()),
+                    UserWarning,
+                    stacklevel=2,
                 )
-                % (candidate.name, _supported_patterns_text()),
-                UserWarning,
-                stacklevel=2,
-            )
         return candidate
 
     search_dir = _current_default_search_dir()

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -499,3 +499,19 @@ def test_isoform_process_targets__accepts_explicit_custom_name(
 
     assert output_path.name == "isoform.custom_export.csv"
     assert output_path.parent == input_path.parent
+
+
+@pytest.mark.unit
+def test_isoform_process_targets__warns_on_non_csv_extension(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "custom_export.txt"
+    input_path.write_bytes(source.read_bytes())
+
+    match = "does not use the canonical '.csv' extension"
+    with pytest.warns(UserWarning, match=match):
+        output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.custom_export.txt"
+    assert output_path.parent == input_path.parent


### PR DESCRIPTION
## Summary
- relax the isoform input name guard to emit warnings instead of raising when an explicit file path uses a non-canonical name or extension
- cover the behaviour with a unit test that exercises a non-csv suffix

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e221eb3228832482702b1b03712bb8