### PR TITLE
Allow isoform postprocessing for modern target exports

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -74,6 +74,10 @@ _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
         re.compile(r"out_uniprot(?:_[A-Za-z0-9]+)*\.csv\Z"),
         "out_uniprot[_<suffixes>].csv",
     ),
+    (
+        re.compile(r"out(?:_[A-Za-z0-9]+)*\.csv\Z"),
+        "out[_<suffixes>].csv",
+    ),
 )
 
 

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -335,7 +335,7 @@ def test_postprocess_isoform_export__skips_for_custom_name(
     logger_stub: _MemoryLogger,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    source = tmp_path / "out_chembl.csv"
+    source = tmp_path / "custom_export.csv"
     source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
     def _unexpected(*_: object, **__: object) -> None:  # pragma: no cover - defensive

--- a/tests/unit/test_target_isoform.py
+++ b/tests/unit/test_target_isoform.py
@@ -74,3 +74,19 @@ def test_transform__missing_identifier_columns_raises_key_error():
     message = str(exc.value)
     assert "uniprot_id_primary" in message
     assert "target_chembl_id" in message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "out.csv",
+        "out_chembl.csv",
+        "out_normalized.csv",
+        "out_uniprot.csv",
+    ],
+)
+def test_matches_expected_input_name__supports_modern_exports(filename: str) -> None:
+    """Modern ``out*.csv`` exports are accepted for isoform processing."""
+
+    assert isoform._matches_expected_input_name(filename)


### PR DESCRIPTION
## Summary
- extend the isoform post-processing filename patterns to cover the new out*.csv exports emitted by the CLI
- update unit tests to reflect the broader support and to keep coverage around skip scenarios

## Testing
- pytest tests/unit/test_target_isoform.py tests/unit/test_get_target_data.py -k isoform -q

------
https://chatgpt.com/codex/tasks/task_e_68e222e83e188324b4d1ce40d00e6b82