### PR TITLE
Skip isoform post-processing for non-canonical target exports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -269,10 +269,34 @@ def _normalise_target_export_name(path: Path) -> str:
     return name
 
 
+def _export_stem(name: str) -> str:
+    """Return the lowercase stem for ``name`` stripping the CSV extension."""
+
+    lowered = name.lower()
+    return lowered[:-4] if lowered.endswith(".csv") else lowered
+
+
+_UNSUPPORTED_EXPORT_SUFFIXES: tuple[str, ...] = (
+    RAW_SUFFIX.lower(),
+    "_chembl",
+    "_uniprot",
+    "_iuphar",
+)
+
+
 def _is_supported_target_export(path: Path) -> bool:
     """Return ``True`` if *path* represents a canonical target export."""
 
     export_name = _normalise_target_export_name(path)
+    stem = _export_stem(export_name)
+
+    if stem.endswith(_UNSUPPORTED_EXPORT_SUFFIXES):
+        return False
+    if stem.endswith(NORMALIZED_SUFFIX.lower()) and not target_pp._matches_expected_input_name(
+        export_name
+    ):
+        return False
+
     return target_pp._matches_expected_input_name(export_name)
 
 

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -69,6 +69,30 @@ def test_keyboard_aliases__cases(command: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("output.target_20251005.csv", True),
+        ("targets_20251005_normalized.csv", True),
+        ("out.csv", False),
+        ("out_chembl.csv", False),
+        ("out_uniprot.csv", False),
+        ("out_iuphar.csv", False),
+        ("out_raw.csv", False),
+        ("out_normalized.csv", False),
+    ],
+)
+def test_is_supported_target_export__cases(
+    filename: str, expected: bool, tmp_path: Path
+) -> None:
+    path = tmp_path / filename
+    path.write_text("", encoding="utf-8")
+
+    result = get_target_data._is_supported_target_export(path)
+
+    assert result is expected
+
+
+@pytest.mark.parametrize(
     "value, tokens",
     [
         ("P12345", ["P12345"]),


### PR DESCRIPTION
## Summary
- avoid invoking isoform post-processing on intermediate ChEMBL/UniProt/IUPHAR exports whose filenames fall outside the canonical patterns
- add unit coverage ensuring the helper recognises supported and unsupported export names

## Testing
- pytest tests/unit/test_get_target_data.py::test_is_supported_target_export__cases

------
https://chatgpt.com/codex/tasks/task_e_68e222bdea60832492e0a1a43ae4eb8b