### PR TITLE
Fix isoform post-processing for custom target exports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -262,10 +262,14 @@ def _normalise_target_export_name(path: Path) -> str:
     """Return a normalised filename for target exports."""
 
     name = path.name
+    if "/" in name or "\\" in name:
+        name = name.replace("\\", "/").split("/")[-1]
+
     for suffix in reversed(path.suffixes):
-        if suffix == ".csv":
+        if suffix.lower() == ".csv":
             break
-        name = name.removesuffix(suffix)
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
     return name
 
 
@@ -273,7 +277,11 @@ def _is_supported_target_export(path: Path) -> bool:
     """Return ``True`` if *path* represents a canonical target export."""
 
     export_name = _normalise_target_export_name(path)
-    return target_pp._matches_expected_input_name(export_name)
+    if target_pp._matches_expected_input_name(export_name):
+        return True
+
+    lowered = export_name.lower()
+    return lowered.startswith(("output.target_", "output.targets_", "targets_"))
 
 
 def _postprocess_isoform_export(
@@ -297,7 +305,7 @@ def _postprocess_isoform_export(
         isoform_path = Path(target_pp.process_targets(str(source), verbose=True))
     except ValueError as exc:
         message = str(exc)
-        if "supported patterns" in message:
+        if "supported patterns" in message.lower():
             logger.info(
                 "target_isoform_postprocess_skipped",
                 path=str(source),

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Iterable
 
 import pandas as pd
@@ -351,6 +351,47 @@ def test_postprocess_isoform_export__skips_for_custom_name(
         "target_isoform_postprocess_skipped",
         {"path": str(source), "reason": "unsupported_export_name"},
     ) in logger_stub.events
+
+
+def test_postprocess_isoform_export__handles_value_error(
+    cfg: Config,
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "output.target_20250101.csv"
+    source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    class _RejectingIsoform:
+        def __call__(self, *_: object, **__: object) -> str:
+            raise ValueError("Input file must match one of the supported patterns: foo.csv")
+
+    monkeypatch.setattr(get_target_data.target_pp, "process_targets", _RejectingIsoform())
+
+    result = get_target_data._postprocess_isoform_export(source, cfg=cfg)
+
+    assert result is None
+    assert (
+        "info",
+        "target_isoform_postprocess_skipped",
+        {
+            "path": str(source),
+            "reason": "unsupported_export_name",
+            "error": "Input file must match one of the supported patterns: foo.csv",
+        },
+    ) in logger_stub.events
+
+
+def test_is_supported_target_export__rejects_custom_names() -> None:
+    path = PureWindowsPath("C:/tmp/out_chembl.csv")
+
+    assert get_target_data._is_supported_target_export(path) is False
+
+
+def test_is_supported_target_export__accepts_gzipped_export() -> None:
+    path = Path("output.target_20250101.csv.gz")
+
+    assert get_target_data._is_supported_target_export(path) is True
 
 
 def test_postprocess_target_exports__chains_helpers(


### PR DESCRIPTION
## Summary
- normalise target export filenames before deciding whether to run downstream isoform helpers
- guard isoform post-processing against ValueError noise and recognise canonical prefixes when matching exports
- extend unit coverage for custom file names and isoform error handling

## Testing
- pytest tests/unit/test_get_target_data.py -k "isoform or is_supported_target_export" -q

------
https://chatgpt.com/codex/tasks/task_e_68e2224395fc8324bb312a04342bae00