### PR TITLE
Downgrade git missing directory warning

### DIFF
--- a/library/common/git.py
+++ b/library/common/git.py
@@ -219,7 +219,7 @@ def _git_sha() -> str:
 
     git_dir = _resolve_git_dir(repo_root)
     if git_dir is None:
-        logger.warning("git_directory_missing", path=str(repo_root))
+        logger.info("git_directory_missing", path=str(repo_root))
         return "UNKNOWN"
 
     git_executable = shutil.which("git")

--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -219,7 +219,7 @@ def _git_sha() -> str:
 
     git_dir = _resolve_git_dir(repo_root)
     if git_dir is None:
-        logger.warning("git_directory_missing", path=str(repo_root))
+        logger.info("git_directory_missing", path=str(repo_root))
         return "UNKNOWN"
 
     git_executable = shutil.which("git")

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", ["library.git_utils", "library.common.git"])
+def test_git_sha__missing_git_directory_logged_as_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    module_name: str,
+) -> None:
+    """Missing ``.git`` directories should not emit warning-level logs."""
+
+    module = importlib.import_module(module_name)
+
+    cache_clear = getattr(module._git_sha, "cache_clear", None)
+    if cache_clear is None:  # pragma: no cover - defensive guard
+        pytest.skip("_git_sha missing cache_clear helper")
+    cache_clear()
+
+    monkeypatch.setattr(module, "_repo_root", lambda: tmp_path)
+
+    caplog.set_level(logging.DEBUG, logger="chembl")
+
+    sha = module._git_sha()
+
+    assert sha == "UNKNOWN"
+
+    directory_logs = [
+        (record.levelno, record.message)
+        for record in caplog.records
+        if "git_directory_missing" in record.message
+    ]
+
+    assert directory_logs, "expected git_directory_missing log entry"
+    assert all(level < logging.WARNING for level, _ in directory_logs)


### PR DESCRIPTION
## Summary
- downgrade the git_directory_missing log message to INFO when the repository lacks a .git directory
- add a regression test ensuring both git helper modules emit informational logs for missing metadata

## Testing
- pytest tests/unit/test_git_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e223ba81d88324a35d7710bff6cb97