### PR TITLE
Gracefully skip IUPHAR post-processing when columns are missing

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 # ruff: noqa: E402
 import argparse
+import csv
 import sys
 import shutil
 from collections.abc import Iterator, Mapping, Sequence
@@ -115,6 +116,7 @@ from library.schemas.targets import TARGETS_COLUMN_ORDER
 
 from library.postprocessing import target as target_pp
 from library.postprocessing import names as names_pp
+from library.postprocessing.helpers import ENCODING_FALLBACKS
 
 try:
     from library.postprocessing import iuphar as iuphar_pp
@@ -607,6 +609,15 @@ def _postprocess_iuphar_export(
         )
         return None
 
+    missing_columns = _missing_iuphar_columns(source)
+    if missing_columns:
+        logger.warning(
+            "target_iuphar_postprocess_missing_columns",
+            path=str(source),
+            columns=sorted(missing_columns),
+        )
+        return None
+
     try:
         result = iuphar_pp.process_iuphar_targets(str(source), verbose=verbose)
     except Exception as exc:  # pragma: no cover - defensive logging
@@ -632,6 +643,58 @@ def _postprocess_iuphar_export(
         source=str(source),
     )
     return output_path
+
+
+def _missing_iuphar_columns(source: Path) -> tuple[str, ...]:
+    """Return missing required columns for the IUPHAR helper."""
+
+    if iuphar_pp is None:
+        return ()
+
+    required: Sequence[str] | None = getattr(iuphar_pp, "_REQUIRED_COLUMNS", None)
+    if not required:
+        return ()
+
+    try:
+        header = _read_csv_header_with_fallbacks(source)
+    except FileNotFoundError:
+        logger.warning("target_iuphar_postprocess_header_missing", path=str(source))
+        return tuple(required)
+    if header is None:
+        return tuple(required)
+
+    normalise = getattr(iuphar_pp, "_normalise_column_name", None)
+    if callable(normalise):
+        header = [normalise(name) for name in header]
+
+    missing = [column for column in required if column not in header]
+    return tuple(missing)
+
+
+def _read_csv_header_with_fallbacks(path: Path) -> list[str] | None:
+    """Read the header row using the known encoding fallbacks."""
+
+    errors: list[Exception] = []
+    for encoding in ENCODING_FALLBACKS:
+        try:
+            with path.open("r", encoding=encoding, newline="") as handle:
+                reader = csv.reader(handle)
+                try:
+                    return next(reader)
+                except StopIteration:
+                    return []
+        except FileNotFoundError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard
+            errors.append(exc)
+
+    if errors:
+        logger.warning(
+            "target_iuphar_postprocess_header_read_failed",
+            path=str(path),
+            error=str(errors[-1]),
+        )
+    return None
 
 
 def _postprocess_target_exports(

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -199,6 +199,41 @@ def test_run__skip_existing(
     assert ("info", "pipeline_skip_existing", {"output": str(final_out)}) in logger_stub.events
 
 
+def test_postprocess_iuphar_export__skips_when_required_columns_missing(
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "output.target_20250101.csv"
+    source.write_text(
+        "target_chembl_id,GuidetoPHARMACOLOGY\nCHEMBL1,GTOP1\n",
+        encoding="utf-8",
+    )
+
+    called = False
+
+    def _unexpected(*args: object, **kwargs: object) -> None:
+        nonlocal called
+        called = True
+        raise AssertionError("IUPHAR helper should not be invoked when columns are missing")
+
+    monkeypatch.setattr(
+        get_target_data.iuphar_pp,
+        "process_iuphar_targets",
+        _unexpected,
+    )
+
+    result = get_target_data._postprocess_iuphar_export(source)
+
+    assert result is None
+    assert not called
+
+    warning_payload = [payload for level, event, payload in logger_stub.events if event == "target_iuphar_postprocess_missing_columns"]
+    assert warning_payload, "Expected warning about missing IUPHAR columns"
+    assert warning_payload[0]["path"] == str(source)
+    assert "gtop_synonyms" in warning_payload[0]["columns"]
+
+
 def test_run_uniprot__invokes_target_postprocess(
     cfg: Config,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- add a header pre-check before invoking the IUPHAR helper so missing required columns are logged and skipped gracefully
- extend the unit tests to cover the new skip behaviour when the export lacks IUPHAR fields

## Testing
- pytest tests/unit/test_get_target_data.py::test_postprocess_iuphar_export__skips_when_required_columns_missing -q

------
https://chatgpt.com/codex/tasks/task_e_68e22429b614832489a47d22055fc472