### PR TITLE
Add tissue metadata pipeline and CLI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -427,6 +427,49 @@
       "title": "AssayCfg",
       "type": "object"
     },
+    "TissueCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "default": "tissue_chembl_id",
+          "title": "Column",
+          "type": "string"
+        },
+        "batch_size": {
+          "default": 20,
+          "minimum": 1,
+          "title": "Batch Size",
+          "type": "integer"
+        },
+        "timeout": {
+          "default": 30.0,
+          "exclusiveMinimum": 0,
+          "title": "Timeout",
+          "type": "number"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        },
+        "offset": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Offset",
+          "type": "integer"
+        }
+      },
+      "title": "TissueCfg",
+      "type": "object"
+    },
     "ChemblCacheCfg": {
       "additionalProperties": false,
       "properties": {
@@ -553,6 +596,9 @@
         },
         "assay": {
           "$ref": "#/$defs/AssayCfg"
+        },
+        "tissue": {
+          "$ref": "#/$defs/TissueCfg"
         },
         "testitem": {
           "$ref": "#/$defs/TestitemCfg"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,6 +45,12 @@ sources:
         batch_size: 50
         timeout: 30.0
         limit: null
+      tissue:
+        column: "tissue_chembl_id"
+        batch_size: 20
+        timeout: 30.0
+        limit: null
+        offset: 0
       testitem:
         column: "molecule_chembl_id"
         batch_size: 1000

--- a/library/config.py
+++ b/library/config.py
@@ -1099,6 +1099,14 @@ class AssayCfg(_BaseModel):
     limit: int | None = Field(default=None, ge=0)
 
 
+class TissueCfg(_BaseModel):
+    column: str = "tissue_chembl_id"
+    batch_size: int = Field(20, ge=1)
+    timeout: float = Field(30.0, gt=0)
+    limit: int | None = Field(default=None, ge=0)
+    offset: int = Field(0, ge=0)
+
+
 class TestitemBatchRetryCfg(_BoolModel):
     enable: bool = False
     shrink_factor: float = Field(0.5, gt=0, lt=1)
@@ -1297,6 +1305,7 @@ class TargetCfg(_BaseModel):
 class ChemblPipelinesCfg(_BaseModel):
     activity: ActivityCfg = Field(default_factory=lambda: ActivityCfg())
     assay: AssayCfg = Field(default_factory=lambda: AssayCfg())
+    tissue: TissueCfg = Field(default_factory=lambda: TissueCfg())
     testitem: TestitemCfg = Field(default_factory=lambda: TestitemCfg())
     document: DocumentCfg = Field(default_factory=lambda: DocumentCfg())
     target: TargetCfg = Field(default_factory=lambda: TargetCfg())
@@ -1447,6 +1456,10 @@ class Config(_BaseModel):
     @property
     def assay(self) -> AssayCfg:
         return self.sources.chembl.pipelines.assay
+
+    @property
+    def tissue(self) -> TissueCfg:
+        return self.sources.chembl.pipelines.tissue
 
     @property
     def testitem(self) -> TestitemCfg:

--- a/library/integration/chembl_library.py
+++ b/library/integration/chembl_library.py
@@ -20,11 +20,13 @@ from ..pipelines.target.chembl_target import (
     get_targets_raw_frame,
     iter_target_batches,
 )
+from ..pipelines.tissue import get_tissues
 
 __all__ = [
     "get_assay",
     "get_assays",
     "get_activities",
+    "get_tissues",
     "get_testitem",
     "get_documents",
     "get_target",

--- a/library/pipelines/__init__.py
+++ b/library/pipelines/__init__.py
@@ -13,7 +13,15 @@ from importlib import import_module
 from typing import Any
 
 # ===== Helpers =====
-_LAZY_SUBMODULES = {"activity", "assay", "common", "document", "target", "testitem"}
+_LAZY_SUBMODULES = {
+  "activity",
+  "assay",
+  "common",
+  "document",
+  "target",
+  "testitem",
+  "tissue",
+}
 
 
 def _load_submodule(name: str) -> Any:
@@ -25,7 +33,15 @@ def _load_submodule(name: str) -> Any:
 
 
 # ===== Exports =====
-__all__ = ["activity", "assay", "common", "document", "target", "testitem"]
+__all__ = [
+  "activity",
+  "assay",
+  "common",
+  "document",
+  "target",
+  "testitem",
+  "tissue",
+]
 
 
 def __getattr__(name: str) -> Any:

--- a/library/pipelines/tissue/__init__.py
+++ b/library/pipelines/tissue/__init__.py
@@ -1,0 +1,21 @@
+"""Helpers for retrieving and processing ChEMBL tissue metadata."""
+
+from .chembl import TISSUE_BASE_COLUMNS, TISSUE_COLUMN_ORDER, get_tissues
+from .pipeline import (
+    TissuePipelineOptions,
+    TissuePipelineResult,
+    prepare_tissue_dataframe,
+    read_tissue_identifiers,
+    run_tissue_pipeline,
+)
+
+__all__ = [
+    "TISSUE_BASE_COLUMNS",
+    "TISSUE_COLUMN_ORDER",
+    "get_tissues",
+    "prepare_tissue_dataframe",
+    "read_tissue_identifiers",
+    "run_tissue_pipeline",
+    "TissuePipelineOptions",
+    "TissuePipelineResult",
+]

--- a/library/pipelines/tissue/chembl.py
+++ b/library/pipelines/tissue/chembl.py
@@ -1,0 +1,91 @@
+"""Minimal ChEMBL client helpers for tissue metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from urllib.parse import urljoin
+
+import pandas as pd
+
+from ...clients import ChemblClient, _chunked
+from ...common.log import logger
+from ...common.pandas_utils import json_normalize_pyarrow
+from ...config import ApiCfg
+
+TISSUE_BASE_COLUMNS: list[str] = [
+    "tissue_chembl_id",
+    "pref_name",
+    "uberon_id",
+    "efo_id",
+    "bto_id",
+    "caloha_id",
+]
+"""Canonical column order for tissue records retrieved from ChEMBL."""
+
+TISSUE_COLUMN_ORDER: list[str] = [
+    *TISSUE_BASE_COLUMNS,
+    "pipeline_version",
+    "timestamp_utc",
+]
+"""Final column order after pipeline metadata enrichment."""
+
+
+def _normalise_records(frame: pd.DataFrame) -> pd.DataFrame:
+    """Ensure that ``frame`` exposes the expected columns in stable order."""
+
+    work = frame.copy()
+    for column in TISSUE_BASE_COLUMNS:
+        if column not in work.columns:
+            work[column] = pd.NA
+    return work.reindex(columns=TISSUE_BASE_COLUMNS)
+
+
+def get_tissues(
+    ids: Iterable[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    chunk_size: int = 20,
+    timeout: float | None = None,
+) -> pd.DataFrame:
+    """Fetch tissue metadata for ``ids`` from the ChEMBL API."""
+
+    valid = [identifier for identifier in ids if identifier not in {"", "#N/A"}]
+    if not valid:
+        return pd.DataFrame(columns=TISSUE_BASE_COLUMNS)
+
+    records: list[pd.DataFrame] = []
+    base = f"{cfg.chembl_base.rstrip('/')}/tissue.json?format=json"
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+
+    for chunk in _chunked(valid, max(1, chunk_size)):
+        chunk_key = ",".join(chunk)
+        logger.info("chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key})
+        url = f"{base}&tissue_chembl_id__in={chunk_key}&limit={len(chunk)}"
+        chunk_frames: list[pd.DataFrame] = []
+        next_url: str | None = url
+        while next_url:
+            data = client.request_json(next_url, cfg=cfg, timeout=effective_timeout)
+            items = data.get("tissues") or data.get("tissue") or []
+            if items:
+                df_chunk = json_normalize_pyarrow(items).dropna(axis="columns", how="all")
+                if not df_chunk.empty:
+                    chunk_frames.append(_normalise_records(df_chunk))
+            page_meta = data.get("page_meta") or {}
+            next_token = page_meta.get("next")
+            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+        if chunk_frames:
+            records.append(pd.concat(chunk_frames, ignore_index=True, sort=False))
+            logger.info("chunk_done", extra={"stage": "chunk_done", "chunk_key": chunk_key})
+        else:
+            logger.info("chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key})
+
+    if not records:
+        return pd.DataFrame(columns=TISSUE_BASE_COLUMNS)
+
+    df = pd.concat(records, ignore_index=True, sort=False)
+    df = _normalise_records(df)
+    return df.reset_index(drop=True)
+
+
+__all__ = ["TISSUE_BASE_COLUMNS", "TISSUE_COLUMN_ORDER", "get_tissues"]

--- a/library/pipelines/tissue/pipeline.py
+++ b/library/pipelines/tissue/pipeline.py
@@ -1,0 +1,341 @@
+"""Orchestration helpers for the tissue data acquisition pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import islice
+from pathlib import Path
+from time import perf_counter
+from typing import Sequence
+
+import pandas as pd
+import requests
+
+from ... import io
+from ...clients import ChemblClient
+from ...common.csv_utils import write_csv_deterministic
+from ...common.log import logger
+from ...common.rate_limiter import get_global_limiter
+from ...config import Config, IoCfg
+from ...pipelines.common import add_pipeline_metadata
+from ...schemas import normalize_tissues
+from ...validation import validate_tissues
+from .chembl import TISSUE_BASE_COLUMNS, TISSUE_COLUMN_ORDER, get_tissues
+
+
+@dataclass(slots=True)
+class TissuePipelineOptions:
+    """Configuration for executing the tissue pipeline."""
+
+    input_csv: Path
+    output_csv: Path
+    column: str
+    batch_size: int
+    limit: int | None = None
+    offset: int = 0
+    timeout: float | None = None
+    mode: str = "chembl"
+
+
+@dataclass(slots=True)
+class TissuePipelineResult:
+    """Outcome of running the tissue pipeline."""
+
+    exit_code: int
+    records: int
+    duration: float
+    output_path: Path
+    failure_path: Path | None
+    failures: int
+    missing_ids: tuple[str, ...]
+    written: bool
+
+
+def read_tissue_identifiers(
+    input_csv: Path,
+    *,
+    column: str,
+    io_cfg: IoCfg,
+    limit: int | None,
+    offset: int,
+) -> list[str]:
+    """Return identifiers from ``input_csv`` honouring ``limit`` and ``offset``."""
+
+    ids_iter = io.read_ids(input_csv, column=column, cfg=io_cfg)
+    ids_iter = (identifier.strip() for identifier in ids_iter)
+    if offset:
+        ids_iter = islice(ids_iter, offset, None)
+    if limit is not None:
+        ids_iter = islice(ids_iter, limit)
+    identifiers = [identifier for identifier in ids_iter if identifier]
+    return identifiers
+
+
+def _ensure_string_columns(df: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    """Coerce the specified ``columns`` to :class:`pandas.StringDtype`."""
+
+    result = df.copy()
+    for column in columns:
+        if column not in result.columns:
+            result[column] = pd.Series(pd.NA, dtype=pd.StringDtype())
+        else:
+            result[column] = result[column].astype(pd.StringDtype())
+    return result
+
+
+def prepare_tissue_dataframe(
+    df: pd.DataFrame,
+    requested: Sequence[str],
+) -> tuple[pd.DataFrame, tuple[str, ...]]:
+    """Return normalised tissue records together with missing identifiers."""
+
+    work = df.copy()
+    for column in TISSUE_BASE_COLUMNS:
+        if column not in work.columns:
+            work[column] = pd.NA
+    work = work.reindex(columns=TISSUE_BASE_COLUMNS, fill_value=pd.NA)
+    work = _ensure_string_columns(work, TISSUE_BASE_COLUMNS)
+    work = work.replace({"": pd.NA})
+
+    present = {
+        value.strip().upper()
+        for value in work["tissue_chembl_id"].dropna()
+        if isinstance(value, str) and value.strip()
+    }
+    missing: list[str] = []
+    for identifier in requested:
+        normalised = str(identifier).strip()
+        if not normalised:
+            continue
+        if normalised.upper() not in present:
+            missing.append(identifier)
+
+    if missing:
+        placeholder = pd.DataFrame(
+            {
+                column: pd.Series(pd.NA, index=range(len(missing)), dtype=pd.StringDtype())
+                for column in TISSUE_BASE_COLUMNS
+            }
+        )
+        placeholder["tissue_chembl_id"] = pd.Series(missing, dtype=pd.StringDtype())
+        work = pd.concat([work, placeholder], ignore_index=True, sort=False)
+
+    work = work.drop_duplicates(subset=["tissue_chembl_id"], keep="first")
+    work = work.reindex(columns=TISSUE_BASE_COLUMNS, fill_value=pd.NA)
+    work = normalize_tissues(work)
+    work = _ensure_string_columns(work, TISSUE_BASE_COLUMNS)
+    return work, tuple(missing)
+
+
+def _write_failures(
+    failure_cases: pd.DataFrame,
+    *,
+    destination: Path,
+    cfg: Config,
+) -> None:
+    """Persist validation failures to ``destination`` using deterministic CSV."""
+
+    if failure_cases.empty:
+        if destination.exists():
+            destination.unlink()
+        return
+
+    failure_key_cols = [col for col in ("index", "column") if col in failure_cases.columns]
+    if not failure_key_cols and not failure_cases.empty:
+        failure_key_cols = [failure_cases.columns[0]]
+
+    write_csv_deterministic(
+        failure_cases.copy(),
+        destination,
+        col_order=list(failure_cases.columns),
+        key_cols=failure_key_cols,
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+        chunksize=cfg.io.csv_chunksize,
+        sort_chunksize=cfg.io.csv_chunksize,
+        cfg=cfg,
+    )
+
+
+def run_tissue_pipeline(
+    cfg: Config,
+    options: TissuePipelineOptions,
+    *,
+    client: ChemblClient | None = None,
+) -> TissuePipelineResult:
+    """Execute the tissue retrieval pipeline and return summary information."""
+
+    start = perf_counter()
+    failure_path = options.output_csv.with_name(
+        f"{options.output_csv.stem}_validation_failures.csv"
+    )
+    identifiers: list[str]
+    try:
+        identifiers = read_tissue_identifiers(
+            options.input_csv,
+            column=options.column,
+            io_cfg=cfg.io,
+            limit=options.limit,
+            offset=options.offset,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        logger.error("read_fail", error=str(exc), path=str(options.input_csv))
+        duration = perf_counter() - start
+        return TissuePipelineResult(
+            exit_code=1,
+            records=0,
+            duration=duration,
+            output_path=options.output_csv,
+            failure_path=None,
+            failures=0,
+            missing_ids=(),
+            written=False,
+        )
+
+    logger.info("tissue_identifiers_loaded", count=len(identifiers))
+
+    if not identifiers:
+        empty = pd.DataFrame(columns=TISSUE_BASE_COLUMNS)
+        empty = add_pipeline_metadata(empty)
+        empty = normalize_tissues(empty)
+        empty = _ensure_string_columns(empty, TISSUE_COLUMN_ORDER)
+        write_csv_deterministic(
+            empty.copy(),
+            options.output_csv,
+            col_order=TISSUE_COLUMN_ORDER,
+            key_cols=["tissue_chembl_id"],
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            chunksize=cfg.io.csv_chunksize,
+            sort_chunksize=cfg.io.csv_chunksize,
+            cfg=cfg,
+        )
+        duration = perf_counter() - start
+        return TissuePipelineResult(
+            exit_code=0,
+            records=0,
+            duration=duration,
+            output_path=options.output_csv,
+            failure_path=None,
+            failures=0,
+            missing_ids=(),
+            written=True,
+        )
+
+    rate_cfg = cfg.rate
+    global_limiter = None
+    if (rate_cfg.global_rps or 0) > 0:
+        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
+
+    session_client = client
+    close_client = False
+    if session_client is None:
+        session_client = ChemblClient(
+            cfg.api,
+            cfg.retry,
+            cfg.chembl,
+            global_limiter=global_limiter,
+        )
+        close_client = True
+
+    try:
+        logger.info("tissue_fetch_start", requested=len(identifiers))
+        effective_timeout = (
+            options.timeout if options.timeout is not None else cfg.tissue.timeout
+        )
+        raw = get_tissues(
+            identifiers,
+            cfg=cfg.api,
+            client=session_client,
+            chunk_size=max(1, options.batch_size),
+            timeout=effective_timeout,
+        )
+    except (requests.RequestException, ValueError) as exc:
+        logger.error("tissue_fetch_failed", error=str(exc))
+        duration = perf_counter() - start
+        if close_client:
+            session_client.close()
+        return TissuePipelineResult(
+            exit_code=1,
+            records=0,
+            duration=duration,
+            output_path=options.output_csv,
+            failure_path=None,
+            failures=0,
+            missing_ids=(),
+            written=False,
+        )
+    finally:
+        if close_client:
+            session_client.close()
+
+    prepared, missing_ids = prepare_tissue_dataframe(raw, identifiers)
+    if missing_ids:
+        sample = list(missing_ids[:5])
+        logger.warning(
+            "tissue_missing_identifiers",
+            total=len(missing_ids),
+            sample=sample,
+        )
+
+    enriched = add_pipeline_metadata(prepared)
+    enriched = _ensure_string_columns(enriched, TISSUE_COLUMN_ORDER)
+    enriched = normalize_tissues(enriched)
+    enriched = _ensure_string_columns(enriched, TISSUE_COLUMN_ORDER)
+    enriched = enriched.reindex(columns=TISSUE_COLUMN_ORDER, fill_value=pd.NA)
+
+    validation = validate_tissues(enriched, return_result=True)
+    failure_cases = validation.failure_cases
+    if not failure_cases.empty:
+        _write_failures(failure_cases, destination=failure_path, cfg=cfg)
+        duration = perf_counter() - start
+        return TissuePipelineResult(
+            exit_code=1,
+            records=len(validation.data),
+            duration=duration,
+            output_path=options.output_csv,
+            failure_path=failure_path,
+            failures=len(failure_cases),
+            missing_ids=missing_ids,
+            written=False,
+        )
+
+    if failure_path.exists():
+        failure_path.unlink()
+
+    output_df = validation.data.copy()
+    output_df = _ensure_string_columns(output_df, TISSUE_COLUMN_ORDER)
+    output_df = output_df.reindex(columns=TISSUE_COLUMN_ORDER, fill_value=pd.NA)
+
+    write_csv_deterministic(
+        output_df,
+        options.output_csv,
+        col_order=TISSUE_COLUMN_ORDER,
+        key_cols=["tissue_chembl_id"],
+        sep=cfg.io.csv_sep,
+        encoding=cfg.io.csv_encoding,
+        chunksize=cfg.io.csv_chunksize,
+        sort_chunksize=cfg.io.csv_chunksize,
+        cfg=cfg,
+    )
+
+    duration = perf_counter() - start
+    return TissuePipelineResult(
+        exit_code=0,
+        records=len(output_df),
+        duration=duration,
+        output_path=options.output_csv,
+        failure_path=None,
+        failures=0,
+        missing_ids=missing_ids,
+        written=True,
+    )
+
+
+__all__ = [
+    "TissuePipelineOptions",
+    "TissuePipelineResult",
+    "prepare_tissue_dataframe",
+    "read_tissue_identifiers",
+    "run_tissue_pipeline",
+]

--- a/library/schemas/__init__.py
+++ b/library/schemas/__init__.py
@@ -9,9 +9,11 @@ from .normalize import (
     normalize_activities,
     normalize_assays,
     normalize_documents,
+    normalize_tissues,
     normalize_targets,
     normalize_testitems,
 )
+from .tissues import TissuesSchema
 from .targets import TargetsSchema
 from .testitems import TestitemsSchema
 
@@ -20,12 +22,14 @@ __all__ = [
     "AssaysSchema",
     "AssayPostprocessSchema",
     "DocumentsSchema",
+    "TissuesSchema",
     "TargetsSchema",
     "TestitemsSchema",
     "CsvMetaSchema",
     "normalize_activities",
     "normalize_assays",
     "normalize_documents",
+    "normalize_tissues",
     "normalize_targets",
     "normalize_testitems",
     "configure_activity_schema",

--- a/library/schemas/normalize.py
+++ b/library/schemas/normalize.py
@@ -96,6 +96,12 @@ def normalize_documents(df: pd.DataFrame) -> pd.DataFrame:
     return _normalize_common(df)
 
 
+def normalize_tissues(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalise a tissues dataframe."""
+
+    return _normalize_common(df)
+
+
 def normalize_targets(df: pd.DataFrame) -> pd.DataFrame:
     """Normalise a targets dataframe.
 
@@ -132,6 +138,7 @@ __all__ = [
     "normalize_activities",
     "normalize_assays",
     "normalize_documents",
+    "normalize_tissues",
     "normalize_targets",
     "normalize_testitems",
 ]

--- a/library/schemas/tissues.py
+++ b/library/schemas/tissues.py
@@ -1,0 +1,25 @@
+"""Schema definition for tissue metadata exported by the pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Final, cast
+
+import pandera.pandas as pa
+
+FLEXIBLE_DTYPE: Final[Any] = cast(Any, None)
+
+TissuesSchema: pa.DataFrameSchema = pa.DataFrameSchema(
+    {
+        "tissue_chembl_id": pa.Column(str, required=True, nullable=True),
+        "pref_name": pa.Column(str, required=False, nullable=True),
+        "uberon_id": pa.Column(str, required=False, nullable=True),
+        "efo_id": pa.Column(str, required=False, nullable=True),
+        "bto_id": pa.Column(str, required=False, nullable=True),
+        "caloha_id": pa.Column(str, required=False, nullable=True),
+        "pipeline_version": pa.Column(str, required=False, nullable=True),
+        "timestamp_utc": pa.Column(str, required=False, nullable=True),
+    }
+)
+"""pandera schema enforcing the column layout for tissue exports."""
+
+__all__ = ["TissuesSchema"]

--- a/library/validation.py
+++ b/library/validation.py
@@ -16,6 +16,7 @@ __all__ = [
     "validate_columns",
     "validate_activities",
     "validate_assays",
+    "validate_tissues",
     "validate_testitems",
 ]
 
@@ -190,6 +191,21 @@ def validate_assays(
         df,
         schema=AssaysSchema,
         schema_name="AssaysSchema",
+        return_result=return_result,
+    )
+
+
+def validate_tissues(
+    df: pd.DataFrame, *, return_result: bool = False
+) -> ValidationResult | pd.DataFrame:
+    """Validate tissue dataframe using :data:`library.schemas.TissuesSchema`."""
+
+    from library.schemas import TissuesSchema
+
+    return _validate_with_schema(
+        df,
+        schema=TissuesSchema,
+        schema_name="TissuesSchema",
         return_result=return_result,
     )
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -292,6 +292,8 @@ def _is_supported_target_export(path: Path) -> bool:
 
     if stem.endswith(_UNSUPPORTED_EXPORT_SUFFIXES):
         return False
+    if stem == "out" or stem.startswith("out_"):
+        return False
     if stem.endswith(NORMALIZED_SUFFIX.lower()) and not target_pp._matches_expected_input_name(
         export_name
     ):

--- a/scripts/get_tissue_data.py
+++ b/scripts/get_tissue_data.py
@@ -1,0 +1,189 @@
+"""Command line interface for retrieving ChEMBL tissue metadata."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from library.utils.bootstrap import ensure_project_root
+except ModuleNotFoundError:  # pragma: no cover - direct execution fallback
+    def ensure_project_root() -> None:
+        project_root = Path(__file__).resolve().parents[1]
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
+
+
+if __package__ in {None, ""}:
+    ensure_project_root()
+
+from library import cli, io
+from library.cli import LoggerConfig, configure_logger
+from library.cli import build_parser as base_parser
+from library.cli.logging import setup_cli_logging
+from library.cli_utils import run_cli_command
+from library.common.log import logger
+from library.config import Config
+from library.pipelines.tissue import TissuePipelineOptions, run_tissue_pipeline
+
+DEFAULT_INPUT_NAME = "tissue.csv"
+DEFAULT_OUTPUT_STEM = "tissue"
+MODE_CHOICES: tuple[str, ...] = ("chembl",)
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Create the command-line parser for the tissue pipeline."""
+
+    parser, log_cfg = base_parser(
+        "ChEMBL tissue data utilities",
+        column="tissue_chembl_id",
+        chunk_size=20,
+        size_option="--batch-size",
+        size_dest="batch_size",
+    )
+    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.add_argument(
+        "--mode",
+        choices=MODE_CHOICES,
+        default="chembl",
+        help="Data source to query (default: chembl)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Override request timeout in seconds",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of identifiers to process (0 skips processing)",
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of identifiers to skip before processing",
+    )
+    parser.set_defaults(func=run)
+    return parser, log_cfg
+
+
+def run(cfg: Config, args: argparse.Namespace) -> int:
+    """Execute the tissue pipeline using ``cfg`` and parsed ``args``."""
+
+    mode = str(getattr(args, "mode", "chembl")).lower()
+    if mode not in MODE_CHOICES:
+        logger.error("unsupported_mode", mode=mode)
+        return 1
+
+    output_path = Path(
+        args.output_csv or io.default_output_path(args.input_csv, cfg.io)
+    )
+    args.output_csv = output_path
+
+    if (
+        getattr(args, "skip_existing", False)
+        and output_path.exists()
+        and not getattr(args, "force", False)
+    ):
+        logger.info("pipeline_skip_existing", output=str(output_path))
+        return 0
+
+    batch_size = getattr(args, "batch_size", cfg.tissue.batch_size)
+    timeout = args.timeout if args.timeout is not None else None
+
+    options = TissuePipelineOptions(
+        input_csv=Path(args.input_csv),
+        output_csv=output_path,
+        column=str(args.column),
+        batch_size=int(batch_size),
+        limit=args.limit,
+        offset=int(args.offset),
+        timeout=timeout,
+        mode=mode,
+    )
+
+    logger.info(
+        "tissue_pipeline_start",
+        input=str(args.input_csv),
+        output=str(output_path),
+        limit=args.limit,
+        offset=args.offset,
+        timeout=timeout if timeout is not None else cfg.tissue.timeout,
+        batch_size=options.batch_size,
+    )
+
+    result = run_tissue_pipeline(cfg, options)
+
+    if result.failure_path and result.failures:
+        logger.error(
+            "tissue_validation_failed",
+            failures=result.failures,
+            path=str(result.failure_path),
+        )
+    if result.missing_ids:
+        sample = list(result.missing_ids[:5])
+        logger.warning(
+            "tissue_missing_identifiers_summary",
+            total=len(result.missing_ids),
+            sample=sample,
+        )
+
+    logger.info(
+        "tissue_pipeline_summary",
+        records=result.records,
+        duration=result.duration,
+        output=str(result.output_path),
+        exit_code=result.exit_code,
+    )
+    return result.exit_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Program entry point for the tissue CLI."""
+
+    parser, log_cfg = build_parser()
+    args = parser.parse_args(argv)
+    cli.prepare_io_paths(
+        args,
+        input_default=DEFAULT_INPUT_NAME,
+        output_stem=DEFAULT_OUTPUT_STEM,
+    )
+    if args.limit == 0:
+        logger.info("pipeline_skip_limit", limit=args.limit)
+        return 0
+    if args.limit is not None and args.limit < 0:
+        parser.error("--limit must be zero or a positive integer")
+    if args.offset < 0:
+        parser.error("--offset must be zero or a positive integer")
+
+    with setup_cli_logging(
+        Path(__file__).with_suffix("").name,
+        log_cfg,
+        getattr(args, "date", None),
+    ) as logging_ctx:
+        exit_code = run_cli_command(
+            args=args,
+            parser=parser,
+            log_cfg=logging_ctx.log_cfg,
+            mapping={
+                "timeout": "tissue.timeout",
+                "column": "tissue.column",
+                "batch_size": "tissue.batch_size",
+                "limit": "tissue.limit",
+                "offset": "tissue.offset",
+            },
+            run=run,
+            logger=logger,
+        )
+    configure_logger(log_cfg)
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated `get_tissue_data.py` CLI mirroring the existing acquisition scripts
- implement tissue-specific pipeline helpers for fetching, normalising, validating and writing ChEMBL tissue metadata
- extend configuration, schema, and validation support to cover the new tissue pipeline while tightening target export detection for legacy filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e24dd8d0288324aad8e4dfd19b8730