### PR TITLE
Add deterministic tissue pipeline tests

### DIFF
--- a/tests/e2e/test_get_tissue_data_cli.py
+++ b/tests/e2e/test_get_tissue_data_cli.py
@@ -214,6 +214,13 @@ def test_get_tissue_data_cli__end_to_end(
     assert first_run_calls[0]["url"].endswith("CHEMBLT1,CHEMBLT2&limit=2")
     assert "CHEMBLT3" in first_run_calls[-1]["url"]
 
+    fetch_event = next(
+        (payload for level, event, payload in logger.events if event == "tissue_fetch_start"),
+        None,
+    )
+    assert fetch_event is not None
+    assert fetch_event["requested"] == 3
+
     start_event = next((event for event in logger.events if event[1] == "tissue_pipeline_start"), None)
     assert start_event is not None
     assert start_event[2]["input"] == str(input_csv)
@@ -270,4 +277,7 @@ def test_get_tissue_data_cli__end_to_end(
 
     new_events = logger.events[first_event_count:]
     assert any(event == "tissue_pipeline_start" for _, event, _ in new_events)
-    assert any(event == "tissue_pipeline_summary" for _, event, data in new_events if data.get("records") == 3)
+    assert any(
+        event == "tissue_pipeline_summary" and data.get("records") == 3 and data.get("duration", 0) >= 0
+        for _, event, data in new_events
+    )

--- a/tests/integration/test_tissue_pipeline_integration.py
+++ b/tests/integration/test_tissue_pipeline_integration.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import datetime as dt
+import json
 from pathlib import Path
 
 import pandas as pd
+import pytest
+import yaml
 
+from library.io import default_output_path
+import library.io.metadata as io_metadata
 from library.pipelines.tissue import TISSUE_COLUMN_ORDER
 from library.pipelines.tissue.pipeline import (
     TissuePipelineOptions,
     run_tissue_pipeline,
 )
+from library.pipelines.common import metadata as pipeline_metadata_module
 
 
 class _DummyClient:
@@ -94,4 +101,106 @@ def test_run_tissue_pipeline__writes_normalised_output(tmp_path: Path, cfg, monk
     assert (tmp_path / "output_validation_failures.csv").exists() is False
     meta_path = Path(f"{output_csv}.meta.yaml")
     assert meta_path.exists()
+
+
+@pytest.mark.integration
+def test_run_tissue_pipeline__deterministic_output_from_fixtures(
+    tmp_path: Path,
+    cfg,
+    snapshot_resource: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pipeline output matches recorded fixtures and respects deterministic naming."""
+
+    resource_dir = snapshot_resource / "tissue_pipeline"
+    payload_path = resource_dir / "integration_payload.json"
+    expected_csv = resource_dir / "integration_expected_output.csv"
+    payload = json.loads(payload_path.read_text(encoding="utf-8"))
+
+    input_dir = tmp_path / "inputs"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    input_csv = input_dir / "tissue_ids.csv"
+    with input_csv.open("w", encoding="utf-8", newline="") as handle:
+        handle.write("tissue_chembl_id\n")
+        for identifier in payload["input_ids"]:
+            handle.write(f"{identifier}\n")
+
+    cfg.io.output_dir = tmp_path / "exports"
+    cfg.io.csv_sep = ","
+    cfg.io.csv_encoding = "utf-8"
+    cfg.tissue.timeout = 9.25
+
+    output_path = default_output_path(input_csv, cfg.io)
+
+    expected_calls: list[dict[str, object]] = []
+
+    def fake_get_tissues(ids, *, cfg, client, chunk_size: int, timeout: float | None):
+        expected_calls.append(
+            {
+                "ids": list(ids),
+                "chunk_size": chunk_size,
+                "timeout": timeout,
+            }
+        )
+        frame = pd.DataFrame(payload["records"])
+        return frame.iloc[[1, 0, 2]].reset_index(drop=True)
+
+    monkeypatch.setattr(
+        "library.pipelines.tissue.pipeline.get_tissues",
+        fake_get_tissues,
+    )
+
+    options = TissuePipelineOptions(
+        input_csv=input_csv,
+        output_csv=output_path,
+        column="tissue_chembl_id",
+        batch_size=2,
+        limit=None,
+        offset=0,
+        timeout=None,
+    )
+
+    monkeypatch.setattr(
+        pipeline_metadata_module,
+        "datetime",
+        dt.datetime,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        io_metadata,
+        "datetime",
+        dt.datetime,
+        raising=False,
+    )
+    pipeline_metadata_module.get_timestamp_utc.cache_clear()
+    pipeline_metadata_module.pipeline_metadata.cache_clear()
+
+    result = run_tissue_pipeline(cfg, options, client=_DummyClient())
+
+    assert result.exit_code == 0
+    assert result.missing_ids == ()
+    assert result.records == 3
+    assert result.output_path == output_path
+    assert result.output_path.name == output_path.name
+    assert expected_calls == [
+        {
+            "ids": payload["input_ids"],
+            "chunk_size": 2,
+            "timeout": cfg.tissue.timeout,
+        }
+    ]
+
+    output_df = pd.read_csv(result.output_path, sep=cfg.io.csv_sep, dtype="string")
+    expected_df = pd.read_csv(expected_csv, sep=cfg.io.csv_sep, dtype="string")
+
+    pd.testing.assert_frame_equal(output_df, expected_df)
+    assert list(output_df.columns) == TISSUE_COLUMN_ORDER
+    assert output_df["tissue_chembl_id"].tolist() == sorted(payload["input_ids"])
+
+    meta_path = Path(f"{result.output_path}.meta.yaml")
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["columns"] == TISSUE_COLUMN_ORDER
+    assert metadata["generated_at"] == expected_df["timestamp_utc"].iloc[0]
+    assert metadata["command"]
 

--- a/tests/resources/README.md
+++ b/tests/resources/README.md
@@ -7,3 +7,5 @@ Recorded fixtures for the tissue pipeline integration tests.
 - `tissue_ids.csv` — minimal input identifiers used to seed the pipeline run with a mixture of present and missing tissues.
 - `chembl_tissue_page1.json` — first page of a captured ChEMBL API response containing tissues with null and empty string fields.
 - `chembl_tissue_page2.json` — second page continuing the response with additional tissues and terminating the pagination chain.
+- `integration_payload.json` — representative payload used for integration tests covering deterministic CSV ordering and metadata enrichment.
+- `integration_expected_output.csv` — expected CSV produced by the integration scenario, including pipeline metadata columns.

--- a/tests/resources/tissue_pipeline/integration_expected_output.csv
+++ b/tests/resources/tissue_pipeline/integration_expected_output.csv
@@ -1,0 +1,4 @@
+tissue_chembl_id,pref_name,uberon_id,efo_id,bto_id,caloha_id,pipeline_version,timestamp_utc
+CHEMBLT001,Beta Tissue,,EFO:0000116,,CALOHA:0000001,0.1.3,2020-01-01T00:00:00+00:00
+CHEMBLT002,Alpha Tissue,UBERON:0000955,,BTO:0000955,,0.1.3,2020-01-01T00:00:00+00:00
+CHEMBLT003,,UBERON:0000178,EFO:0003077,,,0.1.3,2020-01-01T00:00:00+00:00

--- a/tests/resources/tissue_pipeline/integration_payload.json
+++ b/tests/resources/tissue_pipeline/integration_payload.json
@@ -1,0 +1,33 @@
+{
+  "input_ids": [
+    "CHEMBLT003",
+    "CHEMBLT001",
+    "CHEMBLT002"
+  ],
+  "records": [
+    {
+      "tissue_chembl_id": "CHEMBLT002",
+      "pref_name": "Alpha Tissue",
+      "uberon_id": "UBERON:0000955",
+      "efo_id": null,
+      "bto_id": "BTO:0000955",
+      "caloha_id": null
+    },
+    {
+      "tissue_chembl_id": "CHEMBLT001",
+      "pref_name": "Beta Tissue",
+      "uberon_id": null,
+      "efo_id": "EFO:0000116",
+      "bto_id": null,
+      "caloha_id": "CALOHA:0000001"
+    },
+    {
+      "tissue_chembl_id": "CHEMBLT003",
+      "pref_name": null,
+      "uberon_id": "UBERON:0000178",
+      "efo_id": "EFO:0003077",
+      "bto_id": null,
+      "caloha_id": null
+    }
+  ]
+}

--- a/tests/unit/test_tissue_chembl.py
+++ b/tests/unit/test_tissue_chembl.py
@@ -3,64 +3,59 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Any, Iterable
+from typing import Any
+from unittest.mock import create_autospec
 
 import pandas as pd
 import pytest
 
+from library.clients import ChemblClient
 from library.config import ApiCfg
 from library.pipelines.tissue.chembl import TISSUE_BASE_COLUMNS, get_tissues
 
 
-class MockChemblClient:
-    """Minimal stand-in for :class:`~library.clients.ChemblClient` used in tests."""
+def _make_payload(
+    *,
+    tissues: list[dict[str, Any]],
+    next_token: str | None = None,
+) -> dict[str, Any]:
+    """Return a mock payload with optional pagination metadata."""
 
-    def __init__(self, payloads: Iterable[dict[str, Any]]):
-        self._payloads: deque[dict[str, Any]] = deque(payloads)
-        self.calls: list[tuple[str, float | None]] = []
-
-    def request_json(
-        self,
-        url: str,
-        *,
-        cfg: ApiCfg,
-        timeout: float | None = None,
-    ) -> dict[str, Any]:
-        self.calls.append((url, timeout))
-        if not self._payloads:
-            raise AssertionError("No payload queued for request")
-        return self._payloads.popleft()
+    page_meta: dict[str, Any] = {}
+    if next_token is not None:
+        page_meta["next"] = next_token
+    return {"tissues": tissues, "page_meta": page_meta}
 
 
 @pytest.mark.unit
-def test_get_tissues__chunked_requests() -> None:
+def test_get_tissues__paginates_and_preserves_order() -> None:
+    """The client is called with chunked URLs and honours custom timeouts."""
+
     cfg = ApiCfg(chembl_base="https://example.test/custom", timeout_read=12.5)
-    client = MockChemblClient(
+    client = create_autospec(ChemblClient, instance=True)
+    client.request_json.side_effect = deque(
         [
-            {
-                "tissues": [
+            _make_payload(
+                tissues=[
                     {
                         "tissue_chembl_id": "TIS_1",
                         "pref_name": "Alpha",
                         "uberon_id": "UBERON:1",
                     }
                 ],
-                "page_meta": {
-                    "next": "https://example.test/custom/tissue.json?format=json&offset=1"
-                },
-            },
-            {
-                "tissues": [
+                next_token="/tissue.json?format=json&offset=1",
+            ),
+            _make_payload(
+                tissues=[
                     {
                         "tissue_chembl_id": "TIS_2",
                         "pref_name": "Beta",
                         "uberon_id": "UBERON:2",
                     }
-                ],
-                "page_meta": {},
-            },
-            {
-                "tissues": [
+                ]
+            ),
+            _make_payload(
+                tissues=[
                     {
                         "tissue_chembl_id": "TIS_3",
                         "pref_name": "Gamma",
@@ -71,9 +66,8 @@ def test_get_tissues__chunked_requests() -> None:
                         "pref_name": "Delta",
                         "uberon_id": "UBERON:4",
                     },
-                ],
-                "page_meta": {},
-            },
+                ]
+            ),
         ]
     )
 
@@ -82,37 +76,43 @@ def test_get_tissues__chunked_requests() -> None:
         cfg=cfg,
         client=client,
         chunk_size=2,
+        timeout=7.0,
     )
 
-    expected_urls = [
+    urls = [call.args[0] for call in client.request_json.call_args_list]
+    timeouts = [call.kwargs["timeout"] for call in client.request_json.call_args_list]
+    cfgs = [call.kwargs["cfg"] for call in client.request_json.call_args_list]
+
+    assert urls == [
         "https://example.test/custom/tissue.json?format=json"
         "&tissue_chembl_id__in=TIS_1,TIS_2&limit=2",
-        "https://example.test/custom/tissue.json?format=json&offset=1",
+        "https://example.test/tissue.json?format=json&offset=1",
         "https://example.test/custom/tissue.json?format=json"
         "&tissue_chembl_id__in=TIS_3,TIS_4&limit=2",
     ]
-    assert client.calls == [(url, 12.5) for url in expected_urls]
+    assert timeouts == [7.0, 7.0, 7.0]
+    assert all(obj is cfg for obj in cfgs)
     assert df["tissue_chembl_id"].tolist() == ["TIS_1", "TIS_2", "TIS_3", "TIS_4"]
 
 
 @pytest.mark.unit
 def test_get_tissues__normalises_missing_columns() -> None:
+    """Missing keys from the payload are filled with ``pd.NA``."""
+
     cfg = ApiCfg(chembl_base="https://example.test/base", timeout_read=5.0)
-    client = MockChemblClient(
-        [
-            {
-                "tissues": [
-                    {
-                        "tissue_chembl_id": "TIS_MISSING",
-                        "pref_name": None,
-                        "uberon_id": "",
-                        "caloha_id": None,
-                    }
-                ],
-                "page_meta": {},
-            }
-        ]
-    )
+    client = create_autospec(ChemblClient, instance=True)
+    client.request_json.side_effect = [
+        _make_payload(
+            tissues=[
+                {
+                    "tissue_chembl_id": "TIS_MISSING",
+                    "pref_name": None,
+                    "uberon_id": "",
+                    "caloha_id": None,
+                }
+            ]
+        )
+    ]
 
     df = get_tissues(
         ["TIS_MISSING"],
@@ -132,9 +132,33 @@ def test_get_tissues__normalises_missing_columns() -> None:
 
 
 @pytest.mark.unit
-def test_get_tissues__skips_invalid_ids() -> None:
+def test_get_tissues__handles_empty_or_null_payload() -> None:
+    """Empty ``tissues`` payloads yield an empty dataframe with base columns."""
+
     cfg = ApiCfg(chembl_base="https://example.test/base", timeout_read=5.0)
-    client = MockChemblClient([])
+    client = create_autospec(ChemblClient, instance=True)
+    client.request_json.side_effect = [
+        {"tissues": None, "page_meta": {}},
+    ]
+
+    df = get_tissues(
+        ["CHEMBLT1"],
+        cfg=cfg,
+        client=client,
+        chunk_size=3,
+    )
+
+    client.request_json.assert_called_once()
+    assert df.empty
+    assert df.columns.tolist() == TISSUE_BASE_COLUMNS
+
+
+@pytest.mark.unit
+def test_get_tissues__skips_invalid_identifiers() -> None:
+    """Blank identifiers are ignored without contacting the API."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/base", timeout_read=5.0)
+    client = create_autospec(ChemblClient, instance=True)
 
     df = get_tissues(
         ["", "#N/A"],
@@ -143,7 +167,7 @@ def test_get_tissues__skips_invalid_ids() -> None:
         chunk_size=3,
     )
 
-    assert client.calls == []
+    client.request_json.assert_not_called()
     assert df.empty
     assert df.columns.tolist() == TISSUE_BASE_COLUMNS
 


### PR DESCRIPTION
## Summary
- add unit coverage for tissue Chembl client pagination, normalisation, and empty payload handling using autospecced mocks
- introduce recorded tissue payload fixtures and an integration test that asserts deterministic CSV output and metadata
- tighten the tissue CLI smoke test with fetch logging assertions and duration checks while documenting new fixtures

## Testing
- pytest tests/unit/test_tissue_chembl.py -q
- pytest tests/integration/test_tissue_pipeline_integration.py -k deterministic -q

------
https://chatgpt.com/codex/tasks/task_e_68e25ffc96b483248fdd0354a64fabd6