### PR TITLE
Handle cyclic IUPHAR family chains

### DIFF
--- a/library/integration/iuphar_library.py
+++ b/library/integration/iuphar_library.py
@@ -64,7 +64,17 @@ class IUPHARData:
         """
         chain: list[str] = []
         current = start_id
+        visited: set[str] = set()
         while current:
+            if current in visited:
+                logger.warning(
+                    "family_chain_cycle",
+                    start_id=start_id,
+                    cycle_member=current,
+                    chain=chain,
+                )
+                break
+            visited.add(current)
             chain.append(current)
             parent_series = self.family_df.loc[
                 self.family_df["family_id"] == current, "parent_family_id"

--- a/tests/unit/test_iuphar_library.py
+++ b/tests/unit/test_iuphar_library.py
@@ -1,0 +1,55 @@
+import pandas as pd
+import pytest
+
+from library.integration.iuphar_library import IUPHARData
+
+
+@pytest.mark.unit
+def test_map_uniprot_file__self_referential_family(tmp_path, caplog):
+    target_df = pd.DataFrame(
+        [
+            {
+                "target_id": "T1",
+                "uniprot_id": "P12345",
+                "target_name": "Cycle target",
+                "family_id": "F1",
+                "type": "Enzyme.Transferase",
+                "synonyms": "",
+                "gene_name": "",
+                "hgnc_name": "",
+                "hgnc_id": "",
+            }
+        ]
+    )
+    family_df = pd.DataFrame(
+        [
+            {
+                "family_id": "F1",
+                "parent_family_id": "F1",
+                "family_name": "Family One",
+                "type": "Enzyme.Transferase",
+            }
+        ]
+    )
+
+    data = IUPHARData(target_df=target_df, family_df=family_df)
+
+    input_path = tmp_path / "input.csv"
+    output_path = tmp_path / "output.csv"
+    pd.DataFrame(
+        [
+            {
+                "uniprot_id": "P12345",
+                "GuidetoPHARMACOLOGY": "T1",
+            }
+        ]
+    ).to_csv(input_path, index=False)
+
+    caplog.set_level("WARNING")
+
+    result = data.map_uniprot_file(input_path, output_path)
+
+    assert result.loc[0, "IUPHAR_chain"].split(">") == ["F1"]
+    assert result.loc[0, "full_id_path"] == "T1#F1"
+    assert result.loc[0, "full_name_path"] == "Cycle target#Family One"
+    assert any("family_chain_cycle" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- prevent infinite loops in `IUPHARData.family_chain` by tracking visited families and logging a warning when a cycle is detected
- ensure the shortened chain propagates through mapping outputs so cyclic hierarchies do not block processing
- add a regression test covering a self-referential family when running `map_uniprot_file`

## Testing
- pytest tests/unit/test_iuphar_library.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e27f74393c8324a21c27ac47b70d25