### PR TITLE
Fix target names postprocess output prefix

### DIFF
--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -597,9 +597,8 @@ def process_target_names(input_path: str | Path, *, verbose: bool = False) -> di
     frame = helpers.ensure_string_columns(frame, frame.columns)
 
     names_df = _build_names_table(frame)
-    prefix = "names" if verbose else "name"
     base = normalise_export_basename(source_path)
-    output_path = source_path.with_name(f"{prefix}.{base}").with_suffix(".csv")
+    output_path = source_path.with_name(f"name.{base}").with_suffix(".csv")
     helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
 
     summary: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- ensure the target names post-processing step always emits files with the expected `name.` prefix
- prevent verbose mode from renaming the auxiliary export and hiding it from the main output directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e282dd55f48324ab65c41d113ec0cc