### PR TITLE
Fix activity extended post-processing invocation

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -549,9 +549,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     if exit_code == 0:
         extended_output_path = process_activity_extended(
-            output_path,
-            base_dir=output_path.parent,
-            verbose=bool(getattr(args, "verbose", False)),
+            search_dir=output_path.parent,
+            dictionary_dir=cfg.resources.dictionary_dir,
+            targets_csv=cfg.resources.targets_type_csv,
         )
 
     if limit is not None:


### PR DESCRIPTION
## Summary
- update the activity pipeline to call `process_activity_extended` with the new keyword arguments introduced by the post-processing refactor

## Testing
- pytest tests/postprocessing/test_activity_extended.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e285a06aac8324b7eb789377783dcd