### PR TITLE
Fix target post-processing for normalized exports

### DIFF
--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -10,6 +10,7 @@ normalisation, best-effort XML parsing and deterministic CSV emission.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Iterable, Sequence
 from xml.etree import ElementTree
@@ -38,6 +39,13 @@ def normalise_export_basename(path: Path) -> str:
     tmp_suffix = ".tmp"
     while name.lower().endswith(tmp_suffix):
         name = name[: -len(tmp_suffix)]
+    stem, ext = os.path.splitext(name)
+    lowered_stem = stem.lower()
+    for suffix in ("_normalized", "_normalised"):
+        if lowered_stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    name = f"{stem}{ext or ''}"
     if not name:
         raise ValueError(f"Unable to derive export basename from {path!s}")
     return name

--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 import sys
@@ -64,8 +65,18 @@ _DEFAULT_SEARCH_DIR = Path("data/output")
 
 # Accepted filename patterns for aggregated target exports.
 _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"output\.target_\d{8}\.csv\Z"), "output.target_<YYYYMMDD>.csv"),
-    (re.compile(r"output\.targets_\d{8}\.csv\Z"), "output.targets_<YYYYMMDD>.csv"),
+    (
+        re.compile(
+            r"output\.target_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"
+        ),
+        "output.target_<YYYYMMDD>[<_suffixes>][_normalized].csv",
+    ),
+    (
+        re.compile(
+            r"output\.targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"
+        ),
+        "output.targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
+    ),
     (
         re.compile(r"targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"),
         "targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
@@ -507,7 +518,17 @@ def _resolve_output_path(input_path: Path, output_csv: Optional[str]) -> Path:
         output_path = Path(output_csv)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         return output_path
-    return input_path.with_name(f"isoform.{input_path.name}")
+
+    def _canonical_export_name(name: str) -> str:
+        stem, ext = os.path.splitext(name)
+        lowered = stem.lower()
+        normalized_suffix = "_normalized"
+        if lowered.endswith(normalized_suffix):
+            stem = stem[: -len(normalized_suffix)]
+        return f"{stem}{ext or ''}"
+
+    canonical_name = _canonical_export_name(input_path.name)
+    return input_path.with_name(f"isoform.{canonical_name}")
 
 
 def _stringify_for_csv(value: Any) -> str:


### PR DESCRIPTION
## Summary
- allow target post-processing to recognise normalised target export filenames that include the `_normalized` suffix
- normalise derived output basenames so auxiliary CSVs drop legacy suffixes when emitted

## Testing
- pytest -q *(fails: import file mismatch between tests/unit/test_tissue_pipeline.py and tests/integration/test_tissue_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e2854e82f48324996f3579302f532e