### PR TITLE
Support base_dir alias for activity extended post-processing

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 import sys
+import warnings
 from pathlib import Path
 from typing import Mapping, Sequence
 
@@ -456,6 +457,7 @@ def process_activity_extended(
     *,
     dictionary_dir: Path | str | None = None,
     targets_csv: Path | str | None = None,
+    base_dir: Path | str | None = None,
 ) -> Path:
     """Create the extended activity export mirroring the Power Query workflow.
 
@@ -471,11 +473,27 @@ def process_activity_extended(
         Optional explicit path to ``targets_type.csv`` overriding the dictionary
         lookup.
 
+    base_dir:
+        Deprecated alias for ``search_dir`` kept for backwards compatibility.
+
     Returns
     -------
     pathlib.Path
         Path to the generated ``extended.output.activity_<stamp>.csv`` file.
     """
+
+    if base_dir is not None:
+        if search_dir is not None:
+            raise TypeError(
+                "process_activity_extended() received both 'search_dir' and 'base_dir'. "
+                "Use 'search_dir' only."
+            )
+        warnings.warn(
+            "'base_dir' is deprecated; pass 'search_dir' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        search_dir = base_dir
 
     resolved_search_dir = Path(search_dir) if search_dir is not None else _current_default_search_dir()
     if not resolved_search_dir.exists():

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -255,6 +255,37 @@ def test_process_activity_extended__writes_expected_payload(
     pd.testing.assert_frame_equal(result, expected, check_dtype=False)
 
 
+def test_process_activity_extended__supports_base_dir_alias(
+    activity_resources: Path,
+    tmp_path: Path,
+) -> None:
+    tmp_exports = _copytree(activity_resources / "exports", tmp_path / "exports")
+    tmp_dictionary = _copytree(activity_resources / "dictionary", tmp_path / "dictionary")
+
+    with pytest.warns(DeprecationWarning, match="base_dir"):
+        output_path = process_activity_extended(
+            base_dir=tmp_exports,
+            dictionary_dir=tmp_dictionary,
+        )
+
+    assert output_path.name == "extended.output.activity_20240101.csv"
+
+
+def test_process_activity_extended__raises_when_search_and_base_dir_provided(
+    activity_resources: Path,
+    tmp_path: Path,
+) -> None:
+    tmp_exports = _copytree(activity_resources / "exports", tmp_path / "exports")
+    tmp_dictionary = _copytree(activity_resources / "dictionary", tmp_path / "dictionary")
+
+    with pytest.raises(TypeError, match="both 'search_dir' and 'base_dir'"):
+        process_activity_extended(
+            search_dir=tmp_exports,
+            base_dir=tmp_exports,
+            dictionary_dir=tmp_dictionary,
+        )
+
+
 def test_process_activity_extended__raises_for_missing_dictionary(
     activity_resources: Path,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- accept the deprecated `base_dir` keyword in `process_activity_extended` while emitting a deprecation warning
- add regression coverage ensuring the alias works and that conflicting arguments raise a clear error

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k base_dir -q

------
https://chatgpt.com/codex/tasks/task_e_68e286df48b88324a1e6952bacdda907