### PR TITLE
Support explicit activity export input path in post-processing

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -470,6 +470,7 @@ def _derive_output_path(input_path: Path) -> Path:
 def process_activity_extended(
     search_dir: Path | str | None = None,
     *,
+    input_path: Path | str | None = None,
     dictionary_dir: Path | str | None = None,
     targets_csv: Path | str | None = None,
     base_dir: Path | str | None = None,
@@ -480,7 +481,13 @@ def process_activity_extended(
     ----------
     search_dir:
         Directory containing ``output.activity_<stamp>.csv`` exports.  When
-        omitted, ``data/output`` is scanned.
+        omitted, ``data/output`` is scanned unless ``input_path`` is provided.
+    input_path:
+        Explicit path to an activity export. When supplied the search directory
+        scan is skipped and ``input_path`` is used directly. This is useful when
+        the caller already knows the exact export path (for example when the
+        file was just produced by the pipeline) or when the export follows a
+        non-standard naming convention.
     dictionary_dir:
         Root directory with bundled dictionary CSVs.  Defaults to
         ``config/dictionary``.
@@ -510,11 +517,28 @@ def process_activity_extended(
         )
         search_dir = base_dir
 
-    resolved_search_dir = Path(search_dir) if search_dir is not None else _current_default_search_dir()
+    explicit_input: Path | None = Path(input_path) if input_path is not None else None
+    if explicit_input is not None:
+        if explicit_input.is_dir():
+            raise ActivityExtendedError(
+                f"input_path must point to a file, received directory: {explicit_input!s}"
+            )
+        if not explicit_input.exists():
+            raise ActivityExtendedError(f"Activity export not found: {explicit_input!s}")
+
+    resolved_search_dir = (
+        Path(search_dir)
+        if search_dir is not None
+        else (explicit_input.parent if explicit_input is not None else _current_default_search_dir())
+    )
     if not resolved_search_dir.exists():
         raise ActivityExtendedError(f"Search directory does not exist: {resolved_search_dir!s}")
+    if not resolved_search_dir.is_dir():
+        raise ActivityExtendedError(
+            f"Search directory is not a directory: {resolved_search_dir!s}"
+        )
 
-    input_path = _latest_activity_export(resolved_search_dir)
+    input_path = explicit_input or _latest_activity_export(resolved_search_dir)
     dictionary_root = _resolve_dictionary_root(Path(dictionary_dir) if dictionary_dir is not None else None)
 
     frame = helpers.read_csv_with_fallbacks(input_path)

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -549,6 +549,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     if exit_code == 0:
         extended_output_path = process_activity_extended(
+            input_path=output_path,
             search_dir=output_path.parent,
             dictionary_dir=cfg.resources.dictionary_dir,
             targets_csv=cfg.resources.targets_type_csv,

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -312,3 +312,31 @@ def test_process_activity_extended__raises_for_missing_dictionary(
             search_dir=tmp_exports,
             dictionary_dir=missing_dictionary,
         )
+
+
+def test_process_activity_extended__uses_explicit_input_path(
+    activity_resources: Path,
+    tmp_path: Path,
+) -> None:
+    tmp_exports = _copytree(activity_resources / "exports", tmp_path / "exports")
+    tmp_dictionary = _copytree(activity_resources / "dictionary", tmp_path / "dictionary")
+
+    original = tmp_exports / "output.activity_20240101.csv"
+    explicit = tmp_exports / "chembl_activities_snapshot.csv"
+    original.rename(explicit)
+
+    output_path = process_activity_extended(
+        search_dir=tmp_exports,
+        input_path=explicit,
+        dictionary_dir=tmp_dictionary,
+    )
+
+    assert output_path.name == "extended.chembl_activities_snapshot.csv"
+
+    result = pd.read_csv(output_path, dtype=str).fillna("")
+    expected = pd.read_csv(
+        activity_resources / "expected.extended.output.activity_20240101.csv",
+        dtype=str,
+    ).fillna("")
+
+    pd.testing.assert_frame_equal(result, expected, check_dtype=False)


### PR DESCRIPTION
## Summary
- allow `process_activity_extended` to accept an explicit `input_path` and validate the resolved search directory
- update the activity pipeline to pass the freshly written export path into the post-processing step
- add a regression test covering explicit input path handling

## Testing
- pytest tests/postprocessing/test_activity_extended.py

------
https://chatgpt.com/codex/tasks/task_e_68e28b3a1b28832489a306f87b6717ba