### PR TITLE
Handle missing activity fields before activity extended post-processing

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -436,13 +436,68 @@ def _select_and_cast(df: pd.DataFrame) -> pd.DataFrame:
     return result
 
 
+def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]]:
+    df = frame.copy()
+    filled: set[str] = set()
+
+    if "activity_chembl_id" not in df.columns and "activity_id" in df.columns:
+        df["activity_chembl_id"] = df["activity_id"].astype("string")
+        filled.add("activity_chembl_id")
+
+    if "compound_name" not in df.columns and "molecule_pref_name" in df.columns:
+        df["compound_name"] = df["molecule_pref_name"].astype("string")
+        filled.add("compound_name")
+
+    if "compound_key" not in df.columns:
+        for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
+            if candidate in df.columns:
+                df["compound_key"] = df[candidate].astype("string")
+                filled.add("compound_key")
+                break
+
+    if "log_value" not in df.columns and "pchembl_value" in df.columns:
+        df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce")
+        filled.add("log_value")
+
+    bool_defaults = {
+        "multmol_assay",
+        "approx_cited_activity",
+        "shuffled_cit",
+        "exact_cited_activity",
+        "higly_correlated_cit",
+        "review_doc",
+        "rounded_data_citation",
+    }
+    for column in bool_defaults:
+        if column not in df.columns:
+            df[column] = pd.Series(False, index=df.index, dtype="boolean")
+            filled.add(column)
+
+    float_defaults = {"original_activity_approx", "original_activity_exact"}
+    for column in float_defaults:
+        if column not in df.columns:
+            df[column] = pd.Series(pd.NA, index=df.index, dtype="Float64")
+            filled.add(column)
+
+    if "salt_chembl_id" not in df.columns:
+        df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
+        filled.add("salt_chembl_id")
+
+    if "nstereo" not in df.columns:
+        df["nstereo"] = pd.Series(pd.NA, index=df.index, dtype="Int64")
+        filled.add("nstereo")
+
+    return df, filled
+
+
 def _transform_activity_frame(
     frame: pd.DataFrame,
     *,
     dictionary_root: Path,
     targets_override: Path | None,
 ) -> pd.DataFrame:
-    missing = _REQUIRED_COLUMNS - set(frame.columns)
+    working, filled = _augment_activity_frame(frame)
+    missing = _REQUIRED_COLUMNS - set(working.columns)
     if missing:
         available = ", ".join(sorted(frame.columns))
         missing_list = ", ".join(sorted(missing))
@@ -451,7 +506,13 @@ def _transform_activity_frame(
             f"{missing_list}. Available columns: {available}"
         )
 
-    df = frame.copy()
+    if filled:
+        logger.warning(
+            "activity_extended_missing_columns_filled",
+            columns=sorted(filled),
+        )
+
+    df = working
     df = _prepare_unknown_chirality(df)
     df = _apply_multimol_logic(df)
     df = _rename_columns(df)

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -178,6 +178,45 @@ def test_transform_activity_frame__parses_activity_properties_flags(
         assert bool(row.is_citation) == any(flags.values())
 
 
+def test_transform_activity_frame__fills_missing_columns(activity_resources: Path) -> None:
+    dictionary_root = activity_resources / "dictionary"
+    frame = pd.DataFrame(
+        {
+            "activity_id": ["ACT-001"],
+            "assay_chembl_id": ["ASSAY-1"],
+            "molecule_chembl_id": ["MOL-1"],
+            "target_chembl_id": ["TAR-ALPHA"],
+            "document_chembl_id": ["DOC-1"],
+            "bao_endpoint": ["BAO:000001"],
+            "bao_format": ["FMT-1"],
+            "standard_type": ["IC50"],
+            "standard_value": [8.0],
+            "pchembl_value": [5.0],
+            "molecule_pref_name": ["Compound One"],
+            "parent_molecule_chembl_id": ["CMPD-1"],
+        }
+    )
+
+    transformed = _transform_activity_frame(
+        frame,
+        dictionary_root=dictionary_root,
+        targets_override=None,
+    )
+
+    assert list(transformed.columns) == list(_FINAL_COLUMN_ORDER)
+    row = transformed.iloc[0]
+    assert row.activity_chembl_id == "ACT-001"
+    assert row.compound_key == "CMPD-1"
+    assert row.compound_name == "Compound One"
+    assert pd.isna(row.saltform_id)
+    assert bool(row.multmol_assay) is False
+    assert bool(row.rounded_data_citation) is False
+    assert bool(row.is_citation) is False
+    assert pd.isna(row.original_activity_approx)
+    assert pd.isna(row.original_activity_exact)
+    assert row.pA_value == pytest.approx(5.0)
+
+
 def test_apply_multimol_logic__marks_duplicate_multimol_assay(
     activity_resources: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a preprocessing helper that backfills legacy activity columns when they are missing from the raw export before running the extended transformation
- log which columns required fallbacks and continue the extended pipeline using the augmented frame
- add regression coverage ensuring the extended transformation succeeds on a minimal API-like activity payload

## Testing
- pytest tests/postprocessing/test_activity_extended.py

------
https://chatgpt.com/codex/tasks/task_e_68e28d00b11c8324b2553a80f3b0ce89