### PR TITLE
Handle missing columns when extending activity exports

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -15,7 +15,7 @@ import re
 import sys
 import warnings
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence
 
 import pandas as pd
 
@@ -55,6 +55,39 @@ _REQUIRED_COLUMNS: frozenset[str] = frozenset(
         "nstereo",
     }
 )
+
+_REQUIRED_COLUMN_DTYPES: Mapping[str, str] = {
+    "activity_chembl_id": "string",
+    "salt_chembl_id": "string",
+    "molecule_chembl_id": "string",
+    "target_chembl_id": "string",
+    "assay_chembl_id": "string",
+    "document_chembl_id": "string",
+    "bao_endpoint": "string",
+    "standard_type": "string",
+    "standard_value": "Float64",
+    "log_value": "Float64",
+    "bao_format": "string",
+    "compound_key": "string",
+    "compound_name": "string",
+    "multmol_assay": "boolean",
+    "approx_cited_activity": "boolean",
+    "shuffled_cit": "boolean",
+    "exact_cited_activity": "boolean",
+    "higly_correlated_cit": "boolean",
+    "review_doc": "boolean",
+    "rounded_data_citation": "boolean",
+    "original_activity_approx": "string",
+    "original_activity_exact": "string",
+    "nstereo": "Int64",
+}
+
+_REQUIRED_COLUMN_FALLBACKS: Mapping[str, Callable[[pd.DataFrame], pd.Series | None]] = {
+    "activity_chembl_id": lambda frame: frame.get("activity_id"),
+    "salt_chembl_id": lambda frame: frame.get("molecule_chembl_id"),
+    "compound_name": lambda frame: frame.get("molecule_pref_name"),
+    "log_value": lambda frame: frame.get("pchembl_value"),
+}
 
 _GROUP_KEY_COLUMNS: tuple[str, ...] = (
     "salt_chembl_id",
@@ -286,6 +319,41 @@ def _apply_multimol_logic(df: pd.DataFrame) -> pd.DataFrame:
     return merged
 
 
+def _empty_series(index: pd.Index, dtype: str) -> pd.Series:
+    if dtype == "boolean":
+        return pd.Series(pd.NA, index=index, dtype="boolean")
+    if dtype == "Float64":
+        return pd.Series(pd.NA, index=index, dtype="Float64")
+    if dtype == "Int64":
+        return pd.Series(pd.NA, index=index, dtype="Int64")
+    return pd.Series(pd.NA, index=index, dtype=dtype)
+
+
+def _ensure_required_input_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    df = frame.copy()
+    if df.empty:
+        for column, dtype in _REQUIRED_COLUMN_DTYPES.items():
+            if column not in df.columns:
+                df[column] = pd.Series([], dtype=dtype)
+        return df
+
+    for column, dtype in _REQUIRED_COLUMN_DTYPES.items():
+        if column in df.columns:
+            continue
+        fallback = _REQUIRED_COLUMN_FALLBACKS.get(column)
+        if fallback is not None:
+            candidate = fallback(df)
+            if candidate is not None:
+                aligned = candidate.reindex(df.index)
+                try:
+                    df[column] = aligned.astype(dtype)
+                except (TypeError, ValueError):
+                    df[column] = aligned.astype("string")
+                continue
+        df[column] = _empty_series(df.index, dtype)
+    return df
+
+
 def _rename_columns(df: pd.DataFrame) -> pd.DataFrame:
     renamed = df.rename(
         columns={
@@ -442,16 +510,16 @@ def _transform_activity_frame(
     dictionary_root: Path,
     targets_override: Path | None,
 ) -> pd.DataFrame:
-    missing = _REQUIRED_COLUMNS - set(frame.columns)
+    df = _ensure_required_input_columns(frame)
+    missing = _REQUIRED_COLUMNS - set(df.columns)
     if missing:
-        available = ", ".join(sorted(frame.columns))
+        available = ", ".join(sorted(df.columns))
         missing_list = ", ".join(sorted(missing))
         raise ActivityExtendedError(
             "Activity export missing required columns: "
             f"{missing_list}. Available columns: {available}"
         )
 
-    df = frame.copy()
     df = _prepare_unknown_chirality(df)
     df = _apply_multimol_logic(df)
     df = _rename_columns(df)

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -245,6 +245,36 @@ def test_select_and_cast__missing_columns_error() -> None:
         _select_and_cast(frame)
 
 
+def test_transform_activity_frame__fills_missing_required_columns(
+    activity_resources: Path,
+) -> None:
+    dictionary_root = activity_resources / "dictionary"
+    frame = pd.DataFrame(
+        {
+            "activity_id": ["ACT-1"],
+            "assay_chembl_id": ["ASSAY-1"],
+            "document_chembl_id": ["DOC-1"],
+            "molecule_chembl_id": ["CHEMBL1"],
+            "target_chembl_id": ["TAR-ALPHA"],
+            "standard_type": ["IC50"],
+            "standard_value": [12.3],
+            "bao_format": ["Single protein"],
+            "pchembl_value": [6.5],
+        }
+    )
+
+    transformed = _transform_activity_frame(
+        frame,
+        dictionary_root=dictionary_root,
+        targets_override=None,
+    )
+
+    assert list(transformed.columns) == list(_FINAL_COLUMN_ORDER)
+    assert transformed.loc[0, "saltform_id"] == "CHEMBL1"
+    assert transformed.loc[0, "pA_value"] == pytest.approx(6.5)
+    assert transformed.loc[0, "compound_name"] is pd.NA
+
+
 def test_process_activity_extended__writes_expected_payload(
     activity_resources: Path,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- fill in required activity export columns during extended post-processing to accept leaner inputs
- cover the fallback behaviour with a regression test for missing enrichment fields

## Testing
- pytest tests/postprocessing/test_activity_extended.py

------
https://chatgpt.com/codex/tasks/task_e_68e28fbdf48083249cd02d11f058614b