### PR TITLE
Ensure target post-processing always emits CSV artifacts

### DIFF
--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -119,12 +119,17 @@ def _normalise_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _ensure_required_columns(df: pd.DataFrame) -> None:
-    missing = [column for column in _REQUIRED_COLUMNS if column not in df.columns]
-    if missing:
-        raise IUPHARPostProcessingError(
-            "Input CSV is missing required columns: " + ", ".join(sorted(missing))
-        )
+def _ensure_required_columns(df: pd.DataFrame) -> tuple[pd.DataFrame, tuple[str, ...]]:
+    missing = tuple(column for column in _REQUIRED_COLUMNS if column not in df.columns)
+    if not missing:
+        return df, ()
+
+    logger.warning(
+        "iuphar_postprocess_missing_columns", missing=list(missing), available=list(df.columns)
+    )
+
+    placeholder = pd.DataFrame(columns=list(_REQUIRED_COLUMNS))
+    return placeholder, missing
 
 
 def _ensure_optional_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -259,7 +264,7 @@ def process_iuphar_targets(
 
     df = read_csv_with_fallbacks(input_path)
     df = _normalise_columns(df)
-    _ensure_required_columns(df)
+    df, missing_required = _ensure_required_columns(df)
     df = _ensure_optional_columns(df)
 
     input_rows = len(df)
@@ -267,6 +272,17 @@ def process_iuphar_targets(
     df, stats = _apply_synonym_processing(df)
     df = _prepare_output(df)
     output_rows = len(df)
+
+    if missing_required:
+        df = df.iloc[0:0]
+        if verbose:
+            logger.info(
+                "iuphar_postprocess: emitted empty result due to missing columns",
+                extra={
+                    "missing_columns": list(missing_required),
+                    "input_path": str(input_path),
+                },
+            )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_csv_deterministic(

--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -333,17 +333,32 @@ class _TransformationResult:
 def _transform(frame: pd.DataFrame) -> _TransformationResult:
     """Apply the isoform expansion stages mirroring the Power Query steps."""
 
-    if frame.empty:
-        empty_result = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
+    def _empty_result() -> _TransformationResult:
+        empty = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
         return _TransformationResult(
-            result=empty_result.copy(),
-            combined=empty_result.copy(),
-            dedup_stage1=empty_result.copy(),
-            sorted_stage=empty_result.copy(),
-            dedup_stage2=empty_result.copy(),
+            result=empty.copy(),
+            combined=empty.copy(),
+            dedup_stage1=empty.copy(),
+            sorted_stage=empty.copy(),
+            dedup_stage2=empty.copy(),
         )
 
-    resolved = _resolve_source_columns(frame)
+    if frame.empty:
+        return _empty_result()
+
+    try:
+        resolved = _resolve_source_columns(frame)
+    except KeyError as exc:
+        warnings.warn(
+            (
+                "Isoform post-processing could not resolve required columns; "
+                "emitting an empty result instead. Details: %s"
+            )
+            % exc,
+            UserWarning,
+            stacklevel=2,
+        )
+        return _empty_result()
     aligned = frame.copy()
     for canonical, source in resolved.items():
         if source in aligned.columns:
@@ -353,14 +368,7 @@ def _transform(frame: pd.DataFrame) -> _TransformationResult:
 
     projected = _project_source_columns(aligned)
     if projected.empty:
-        empty_result = pd.DataFrame(columns=list(_OUTPUT_COLUMNS))
-        return _TransformationResult(
-            result=empty_result.copy(),
-            combined=empty_result.copy(),
-            dedup_stage1=empty_result.copy(),
-            sorted_stage=empty_result.copy(),
-            dedup_stage2=empty_result.copy(),
-        )
+        return _empty_result()
     projected = projected.loc[:, list(_SOURCE_COLUMNS)].copy()
 
     projected["isoform_synonyms"] = projected["isoform_synonyms"].map(

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -294,12 +294,19 @@ def _is_supported_target_export(path: Path) -> bool:
         return False
     if stem == "out" or stem.startswith("out_"):
         return False
-    if stem.endswith(NORMALIZED_SUFFIX.lower()) and not target_pp._matches_expected_input_name(
-        export_name
-    ):
+
+    if target_pp._matches_expected_input_name(export_name):
+        return True
+
+    if path.suffix.lower() != ".csv":
         return False
 
-    return target_pp._matches_expected_input_name(export_name)
+    logger.info(
+        "target_postprocess_noncanonical_name",
+        path=str(path),
+        reason="noncanonical_filename",
+    )
+    return True
 
 
 def _postprocess_isoform_export(


### PR DESCRIPTION
## Summary
- allow non-canonical target export names through the target post-processing guard while logging the condition
- teach the isoform helper to emit an empty CSV when required columns are missing instead of aborting
- make the IUPHAR helper log missing columns and write an empty artifact rather than raising

## Testing
- pytest -q *(fails: import file mismatch between integration/unit tissue pipeline tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e28c850b848324919a5d050874a9ba