### PR TITLE
Ensure IUPHAR exports are written without BOM

### DIFF
--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -290,6 +290,7 @@ def process_iuphar_targets(
         output_path,
         col_order=_OUTPUT_COLUMNS,
         key_cols=("target_chembl_id",),
+        encoding="utf-8",
     )
 
     if verbose:

--- a/tests/postprocessing/test_iuphar_postprocessing.py
+++ b/tests/postprocessing/test_iuphar_postprocessing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from codecs import BOM_UTF8
 from pathlib import Path
 
 import pandas as pd
@@ -183,6 +184,9 @@ def test_process_iuphar_targets__produces_expected_csv(tmp_path: Path, snapshot_
     expected_bytes = (snapshot_resource / "iuphar_postprocessing_expected.csv").read_bytes()
     actual_bytes = output_path.read_bytes()
     assert actual_bytes == expected_bytes
+    assert not actual_bytes.startswith(BOM_UTF8)
+    expected_header = ",".join(iuphar._OUTPUT_COLUMNS) + "\n"
+    assert actual_bytes.startswith(expected_header.encode("utf-8"))
 
 
 def test_process_iuphar_targets__normalises_tmp_suffix(tmp_path: Path) -> None:

--- a/tests/resources/iuphar_postprocessing_expected.csv
+++ b/tests/resources/iuphar_postprocessing_expected.csv
@@ -1,3 +1,3 @@
-﻿target_chembl_id,guidetopharmacology_id,iuphar_target_id,iuphar_family_id,iuphar_type,iuphar_class,iuphar_subclass,iuphar_chain,iuphar_name,iuphar_synonyms
+target_chembl_id,guidetopharmacology_id,iuphar_target_id,iuphar_family_id,iuphar_type,iuphar_class,iuphar_subclass,iuphar_chain,iuphar_name,iuphar_synonyms
 CHEMBL123,GTOP123,T-123,F-10,Receptor,ClassA,SubclassA,A,Alpha Receptor,alpha|beta|gamma|delta|alpha receptor
 CHEMBL999,GTOP999,T-999,F-99,Enzyme,ClassB,SubclassB,B,Omega,omega


### PR DESCRIPTION
## Summary
- update the IUPHAR target post-processing helper to write CSV exports using UTF-8 without adding a BOM
- extend the regression test to assert the output starts with the expected header and refresh the snapshot to match the BOM-free encoding

## Testing
- pytest tests/postprocessing/test_iuphar_postprocessing.py -k "produces_expected_csv" -q

------
https://chatgpt.com/codex/tasks/task_e_68e29194ce208324a769ce80ad87103d