### PR TITLE
Fix activity extended augmentation logging

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -574,6 +574,8 @@ def _transform_activity_frame(
             f"{missing_list}. Available columns: {available}"
         )
 
+    working, filled = _augment_activity_frame(df)
+
     if filled:
         logger.warning(
             "activity_extended_missing_columns_filled",


### PR DESCRIPTION
## Summary
- ensure the activity extended transformation augments the frame before emitting missing column warnings

## Testing
- pytest -q *(fails: import file mismatch: tests/unit/test_tissue_pipeline.py vs tests/integration/test_tissue_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e2929bed808324b164504983376a7b