### PR TITLE
Fix activity extended export naming and fill required columns

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -17,6 +17,7 @@ import warnings
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+import numpy as np
 import pandas as pd
 
 from library.common.log import logger
@@ -329,13 +330,15 @@ def _empty_series(index: pd.Index, dtype: str) -> pd.Series:
     return pd.Series(pd.NA, index=index, dtype=dtype)
 
 
-def _ensure_required_input_columns(frame: pd.DataFrame) -> pd.DataFrame:
+def _ensure_required_input_columns(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]]:
     df = frame.copy()
+    filled: set[str] = set()
     if df.empty:
         for column, dtype in _REQUIRED_COLUMN_DTYPES.items():
             if column not in df.columns:
                 df[column] = pd.Series([], dtype=dtype)
-        return df
+                filled.add(column)
+        return df, filled
 
     for column, dtype in _REQUIRED_COLUMN_DTYPES.items():
         if column in df.columns:
@@ -349,9 +352,11 @@ def _ensure_required_input_columns(frame: pd.DataFrame) -> pd.DataFrame:
                     df[column] = aligned.astype(dtype)
                 except (TypeError, ValueError):
                     df[column] = aligned.astype("string")
+                filled.add(column)
                 continue
         df[column] = _empty_series(df.index, dtype)
-    return df
+        filled.add(column)
+    return df, filled
 
 
 def _rename_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -527,6 +532,30 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
         df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce")
         filled.add("log_value")
 
+    if "log_value" in df.columns and "standard_value" in df.columns and "standard_units" in df.columns:
+        std_value = pd.to_numeric(df["standard_value"], errors="coerce")
+        units = df["standard_units"].astype("string").str.strip().str.lower()
+        factors = units.map({
+            "m": 1.0,
+            "mm": 1e-3,
+            "um": 1e-6,
+            "µm": 1e-6,
+            "nm": 1e-9,
+            "pm": 1e-12,
+        })
+        factors = pd.to_numeric(factors, errors="coerce")
+        molar = std_value * factors
+        computed = pd.Series(pd.NA, index=df.index, dtype="Float64")
+        valid = molar.notna() & (molar > 0)
+        if valid.any():
+            computed_values = -np.log10(molar[valid].astype("float64"))
+            computed.loc[valid] = pd.Series(computed_values, index=df.index[valid]).astype(
+                "Float64"
+            )
+        mask = df["log_value"].isna() & computed.notna()
+        if mask.any():
+            df.loc[mask, "log_value"] = computed.loc[mask]
+
     bool_defaults = {
         "multmol_assay",
         "approx_cited_activity",
@@ -564,7 +593,9 @@ def _transform_activity_frame(
     dictionary_root: Path,
     targets_override: Path | None,
 ) -> pd.DataFrame:
-    df = _ensure_required_input_columns(frame)
+    df, ensured = _ensure_required_input_columns(frame)
+    df, augmented = _augment_activity_frame(df)
+    filled = ensured | augmented
     missing = _REQUIRED_COLUMNS - set(df.columns)
     if missing:
         available = ", ".join(sorted(df.columns))
@@ -580,7 +611,6 @@ def _transform_activity_frame(
             columns=sorted(filled),
         )
 
-    df = working
     df = _prepare_unknown_chirality(df)
     df = _apply_multimol_logic(df)
     df = _rename_columns(df)
@@ -593,7 +623,13 @@ def _transform_activity_frame(
 
 
 def _derive_output_path(input_path: Path) -> Path:
-    return input_path.with_name(f"extended.{input_path.name}")
+    base_name = helpers.normalise_export_basename(input_path)
+    if base_name.startswith("output.activities_"):
+        base_name = base_name.replace("output.activities_", "output.activity_", 1)
+    if not base_name.startswith("output.activity_"):
+        logger.warning("activity_extended_unexpected_basename", basename=base_name)
+    final_name = base_name.replace("output.activity_", "extended.output.activity_", 1)
+    return input_path.with_name(final_name)
 
 
 def process_activity_extended(
@@ -678,7 +714,30 @@ def process_activity_extended(
     )
 
     output_path = _derive_output_path(input_path)
+    logger.info(
+        "activity_extended_dataframe_shape",
+        rows=processed.shape[0],
+        columns=processed.shape[1],
+    )
+    logger.info(
+        "activity_extended_columns",
+        columns=sorted(processed.columns.tolist()),
+    )
+    for column in ("activity_chembl_id", "saltform_id", "pA_value"):
+        non_null = int(processed[column].notna().sum()) if column in processed.columns else 0
+        logger.info(
+            "activity_extended_non_null_counts",
+            column=column,
+            non_null=non_null,
+            total=len(processed),
+        )
+    logger.info("activity_extended_saving", path=str(output_path))
     helpers.write_csv(processed, output_path, columns=_FINAL_COLUMN_ORDER)
+    logger.info(
+        "activity_extended_saved",
+        path=str(output_path),
+        rows=len(processed),
+    )
     return output_path
 
 


### PR DESCRIPTION
## Summary
- normalise activity extended output filenames to keep the expected `extended.output.activity_YYYYMMDD.csv` shape
- backfill critical activity columns, including computing `pA_value` from standard measurements when `pChEMBL` is missing
- add diagnostic logging for emitted column sets and non-null coverage

## Testing
- pytest -q *(fails: import file mismatch between tests/unit/test_tissue_pipeline.py and tests/integration/test_tissue_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e29242f350832496a9c6ac1d980a03