### PR TITLE
Fix log_value augmentation dtype handling

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -528,8 +528,10 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
                 filled.add("compound_key")
                 break
 
-    if "log_value" not in df.columns and "pchembl_value" in df.columns:
-        df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce")
+    if "log_value" in df.columns:
+        df["log_value"] = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
+    elif "pchembl_value" in df.columns:
+        df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
         filled.add("log_value")
 
     if "log_value" in df.columns and "standard_value" in df.columns and "standard_units" in df.columns:


### PR DESCRIPTION
## Summary
- coerce existing `log_value` columns to nullable Float64 before augmentation logic runs
- create new `log_value` columns from `pchembl_value` using the same nullable Float64 dtype to allow numeric enrichment

## Testing
- pytest -q *(fails: import file mismatch between unit and integration tissue pipeline tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e294782bd883248d7dbd94e640986d