### PR TITLE
Normalise extended activity output filenames

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -628,11 +628,18 @@ def _transform_activity_frame(
 
 def _derive_output_path(input_path: Path) -> Path:
     base_name = helpers.normalise_export_basename(input_path)
-    if base_name.startswith("output.activities_"):
-        base_name = base_name.replace("output.activities_", "output.activity_", 1)
-    if not base_name.startswith("output.activity_"):
+    candidate = base_name
+    while candidate.startswith("extended."):
+        candidate = candidate[len("extended.") :]
+
+    match = _FILENAME_RE.match(candidate)
+    if match is not None:
+        stamp = match.group(1)
+        final_name = f"extended.output.activity_{stamp}.csv"
+    else:
         logger.warning("activity_extended_unexpected_basename", basename=base_name)
-    final_name = base_name.replace("output.activity_", "extended.output.activity_", 1)
+        final_name = f"extended.{candidate}"
+
     return input_path.with_name(final_name)
 
 

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -15,6 +15,7 @@ from library.postprocessing.activity_extended import (
     _annotate_high_citation,
     _apply_multimol_logic,
     _compute_citation_flags,
+    _derive_output_path,
     _latest_activity_export,
     _load_citation_fraction,
     _load_target_metadata,
@@ -140,6 +141,22 @@ def test_latest_activity_export__handles_hidden_temporary_file(tmp_path: Path) -
     resolved = _latest_activity_export(search_dir)
 
     assert resolved == hidden_tmp
+
+
+def test_derive_output_path__normalises_plural_basename(tmp_path: Path) -> None:
+    source = tmp_path / "extended.output.activities_20240101.csv"
+
+    derived = _derive_output_path(source)
+
+    assert derived.name == "extended.output.activity_20240101.csv"
+
+
+def test_derive_output_path__prefixes_custom_exports(tmp_path: Path) -> None:
+    source = tmp_path / "chembl_activities_snapshot.csv"
+
+    derived = _derive_output_path(source)
+
+    assert derived.name == "extended.chembl_activities_snapshot.csv"
 
 
 def test_transform_activity_frame__parses_activity_properties_flags(


### PR DESCRIPTION
## Summary
- normalise derived extended activity filenames when source exports use plural activity tokens or are already extended
- ensure custom activity exports without the legacy token are prefixed consistently during post-processing
- add regression coverage for the new filename derivation cases

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k derive -q

------
https://chatgpt.com/codex/tasks/task_e_68e295df5c1483248bbec337952d62bd