### PR TITLE
Fix log value augmentation for extended activity export

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -528,13 +528,22 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
                 filled.add("compound_key")
                 break
 
+    log_value_series: pd.Series | None = None
+
     if "log_value" in df.columns:
-        df["log_value"] = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
+        log_value_series = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
     elif "pchembl_value" in df.columns:
-        df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+        log_value_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
         filled.add("log_value")
 
-    if "log_value" in df.columns and "standard_value" in df.columns and "standard_units" in df.columns:
+    if log_value_series is not None:
+        df["log_value"] = log_value_series
+
+    if (
+        log_value_series is not None
+        and "standard_value" in df.columns
+        and "standard_units" in df.columns
+    ):
         std_value = pd.to_numeric(df["standard_value"], errors="coerce")
         units = df["standard_units"].astype("string").str.strip().str.lower()
         factors = units.map({
@@ -554,9 +563,13 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
             computed.loc[valid] = pd.Series(computed_values, index=df.index[valid]).astype(
                 "Float64"
             )
-        mask = df["log_value"].isna() & computed.notna()
+        mask = log_value_series.isna() & computed.notna()
         if mask.any():
-            df.loc[mask, "log_value"] = computed.loc[mask]
+            log_value_series = log_value_series.copy()
+            log_value_series.loc[mask] = computed.loc[mask]
+
+    if log_value_series is not None:
+        df["log_value"] = log_value_series
 
     bool_defaults = {
         "multmol_assay",

--- a/tests/unit/postprocessing/test_activity_extended.py
+++ b/tests/unit/postprocessing/test_activity_extended.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from library.postprocessing.activity_extended import _augment_activity_frame
+
+
+def test_augment_activity_frame__fills_missing_log_value():
+    frame = pd.DataFrame(
+        {
+            "log_value": pd.Series(["not-a-number", pd.NA], dtype="string"),
+            "standard_value": [1.0, 1.0],
+            "standard_units": ["nM", "nM"],
+        }
+    )
+
+    result, _ = _augment_activity_frame(frame)
+
+    expected = pd.Series([9.0, 9.0], dtype="Float64", name="log_value")
+
+    assert str(result["log_value"].dtype) == "Float64"
+    pd.testing.assert_series_equal(result["log_value"], expected)


### PR DESCRIPTION
## Summary
- ensure the activity extended augmentation keeps log values in a Float64 series before filling computed values
- add a regression test covering log value filling when the source column uses pandas string dtype

## Testing
- pytest -q tests/unit/postprocessing/test_activity_extended.py

------
https://chatgpt.com/codex/tasks/task_e_68e295bc06f48324bbf5d55b78e4cd73