### PR TITLE
Improve activity extended augmentation and logging

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -84,7 +84,11 @@ _REQUIRED_COLUMN_DTYPES: Mapping[str, str] = {
 
 _REQUIRED_COLUMN_FALLBACKS: Mapping[str, Callable[[pd.DataFrame], pd.Series | None]] = {
     "activity_chembl_id": lambda frame: frame.get("activity_id"),
-    "salt_chembl_id": lambda frame: frame.get("molecule_chembl_id"),
+    "salt_chembl_id": (
+        lambda frame: frame.get("molecule_chembl_id")
+        if "parent_molecule_chembl_id" not in frame.columns
+        else None
+    ),
     "compound_name": lambda frame: frame.get("molecule_pref_name"),
     "log_value": lambda frame: frame.get("pchembl_value"),
 }
@@ -522,6 +526,16 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
                 df["compound_key"] = df[candidate].astype("string")
                 filled.add("compound_key")
                 break
+    else:
+        missing_mask = df["compound_key"].isna()
+        if missing_mask.any():
+            for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
+                if candidate in df.columns:
+                    df.loc[missing_mask, "compound_key"] = (
+                        df.loc[missing_mask, candidate].astype("string")
+                    )
+                    filled.add("compound_key")
+                    break
 
     if "log_value" not in df.columns and "pchembl_value" in df.columns:
         df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce")
@@ -574,15 +588,15 @@ def _transform_activity_frame(
             f"{missing_list}. Available columns: {available}"
         )
 
-    working, filled = _augment_activity_frame(df)
+    df, ensured_filled = _augment_activity_frame(df)
+    original_filled = _augment_activity_frame(frame)[1]
+    filled = ensured_filled | original_filled
 
     if filled:
         logger.warning(
             "activity_extended_missing_columns_filled",
             columns=sorted(filled),
         )
-
-    df = working
     df = _prepare_unknown_chirality(df)
     df = _apply_multimol_logic(df)
     df = _rename_columns(df)

--- a/library/postprocessing/iuphar.py
+++ b/library/postprocessing/iuphar.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
 import sys
 from dataclasses import dataclass
@@ -14,10 +13,9 @@ import pandas as pd
 
 from .helpers import normalise_export_basename, normalise_text, read_csv_with_fallbacks
 from library.common.csv_utils import write_csv_deterministic
+from library.common.log import logger
 
 __all__ = ["process_iuphar_targets", "IUPHARPostProcessingError"]
-
-logger = logging.getLogger(__name__)
 
 _DEFAULT_SEARCH_DIR = Path("data/output")
 _TARGET_PATTERN = re.compile(r"output\.target_\d{8}\.csv\Z")
@@ -128,8 +126,10 @@ def _ensure_required_columns(df: pd.DataFrame) -> tuple[pd.DataFrame, tuple[str,
         "iuphar_postprocess_missing_columns", missing=list(missing), available=list(df.columns)
     )
 
-    placeholder = pd.DataFrame(columns=list(_REQUIRED_COLUMNS))
-    return placeholder, missing
+    formatted = ", ".join(missing)
+    raise IUPHARPostProcessingError(
+        f"Input CSV is missing required columns: {formatted}"
+    )
 
 
 def _ensure_optional_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/library/postprocessing/names.py
+++ b/library/postprocessing/names.py
@@ -598,7 +598,7 @@ def process_target_names(input_path: str | Path, *, verbose: bool = False) -> di
 
     names_df = _build_names_table(frame)
     base = normalise_export_basename(source_path)
-    output_path = source_path.with_name(f"name.{base}").with_suffix(".csv")
+    output_path = source_path.with_name(f"names.{base}").with_suffix(".csv")
     helpers.write_csv(names_df, output_path, columns=TARGET_NAMES_COLUMNS)
 
     summary: dict[str, Any] = {

--- a/tests/integration/test_activity_extended_integration.py
+++ b/tests/integration/test_activity_extended_integration.py
@@ -1,0 +1,125 @@
+"""Integration tests for the activity extended post-processing pipeline."""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import random
+
+import numpy as np
+import pytest
+
+from library.postprocessing.activity_extended import process_activity_extended
+
+
+def _fix_seed(seed: int = 42) -> None:
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+@pytest.mark.integration
+def test_process_activity_extended__fills_missing_optional_columns(tmp_path, caplog):
+    """Process minimal export missing optional columns and emit backfill warning."""
+
+    _fix_seed()
+
+    activity_dir = tmp_path / "input"
+    dictionary_root = tmp_path / "dictionary"
+    activity_dir.mkdir()
+
+    activity_path = activity_dir / "output.activities_20240101.csv"
+    activity_columns = [
+        "activity_id",
+        "molecule_chembl_id",
+        "target_chembl_id",
+        "assay_chembl_id",
+        "document_chembl_id",
+        "bao_endpoint",
+        "standard_type",
+        "standard_value",
+        "bao_format",
+        "parent_molecule_chembl_id",
+        "molecule_pref_name",
+        "pchembl_value",
+    ]
+    with activity_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=activity_columns)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "activity_id": "1",
+                "molecule_chembl_id": "CHEMBL1",
+                "target_chembl_id": "CHEMBLT1",
+                "assay_chembl_id": "ASSAY1",
+                "document_chembl_id": "DOC1",
+                "bao_endpoint": "endpoint",
+                "standard_type": "IC50",
+                "standard_value": "1.0",
+                "bao_format": "format",
+                "parent_molecule_chembl_id": "CHEMBL1",
+                "molecule_pref_name": "Example compound",
+                "pchembl_value": "7.0",
+            }
+        )
+
+    activity_subdir = dictionary_root / "_activity"
+    activity_subdir.mkdir(parents=True)
+    with (activity_subdir / "citation_fraction.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["N", "K_min_significant"])
+        writer.writeheader()
+        writer.writerow({"N": "1", "K_min_significant": "1"})
+
+    targets_subdir = dictionary_root / "_target"
+    targets_subdir.mkdir(parents=True)
+    with (targets_subdir / "targets_type.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "target_chembl_id",
+                "target_sort_order",
+                "multifunctional_enzyme",
+                "IUPHAR_class",
+                "IUPHAR_subclass",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
+                "gene_index",
+                "taxon_index",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "target_chembl_id": "CHEMBLT1",
+                "target_sort_order": "1",
+                "multifunctional_enzyme": "false",
+                "IUPHAR_class": "ClassA",
+                "IUPHAR_subclass": "SubclassA",
+                "genus": "Candida",
+                "superkingdom": "Eukaryota",
+                "phylum": "Ascomycota",
+                "taxon_id": "1234",
+                "gene_index": "GENE1",
+                "taxon_index": "TAX1",
+            }
+        )
+
+    with caplog.at_level(logging.WARNING):
+        output_path = process_activity_extended(
+            input_path=activity_path,
+            dictionary_dir=dictionary_root,
+        )
+
+    assert output_path.exists()
+
+    filled_warnings = [
+        record for record in caplog.records if "activity_extended_missing_columns_filled" in record.message
+    ]
+    assert filled_warnings, "Expected warning about backfilled columns not emitted"
+
+    message = filled_warnings[0].message
+    for column_name in ("activity_chembl_id", "compound_key", "log_value"):
+        assert column_name in message

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -173,7 +173,7 @@ def test_process_target_names__strips_bom_headers(tmp_path: Path) -> None:
     result_info = process_target_names(csv_path)
     output_path = Path(result_info["path"])
 
-    assert output_path.name == "name.output.target_20240101.csv"
+    assert output_path.name == "names.output.target_20240101.csv"
     assert output_path.exists()
     assert result_info["summary"]["rows_after"] == 3
 


### PR DESCRIPTION
## Summary
- refine `_transform_activity_frame` to merge augmented columns, restore `compound_key` fallbacks, and emit warnings only when backfilling
- switch the IUPHAR helper to the shared structured logger and raise an error when required columns are missing
- align target names output naming with expectations and add an integration test covering missing optional columns

## Testing
- `pytest -q` *(fails: test_postprocess_isoform_export__skips_for_custom_name expects different log event)*

------
https://chatgpt.com/codex/tasks/task_e_68e29368ae6c83249d56776d0b70d5a9