### PR TITLE
Handle null activity identifiers in activity extended pipeline

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -513,23 +513,54 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
     df = frame.copy()
     filled: set[str] = set()
 
-    if "activity_chembl_id" not in df.columns and "activity_id" in df.columns:
-        df["activity_chembl_id"] = df["activity_id"].astype("string")
-        filled.add("activity_chembl_id")
+    def _prepare_string(column: str) -> pd.Series:
+        df[column] = df[column].astype("string")
+        return df[column]
+
+    def _string_missing(series: pd.Series) -> pd.Series:
+        stripped = series.str.strip()
+        empty = stripped.eq("").fillna(False)
+        return series.isna() | empty
+
+    def _fill_from(column: str, fallback_column: str) -> None:
+        if column in df.columns:
+            target = _prepare_string(column)
+            if fallback_column in df.columns:
+                fallback = df[fallback_column].astype("string")
+                mask = _string_missing(target)
+                if mask.any():
+                    fallback_mask = ~_string_missing(fallback)
+                    combined = mask & fallback_mask
+                    if combined.any():
+                        df.loc[combined, column] = fallback.loc[combined]
+                        filled.add(column)
+        elif fallback_column in df.columns:
+            df[column] = df[fallback_column].astype("string")
+            filled.add(column)
+
+    _fill_from("activity_chembl_id", "activity_id")
 
     if "compound_name" not in df.columns and "molecule_pref_name" in df.columns:
         df["compound_name"] = df["molecule_pref_name"].astype("string")
         filled.add("compound_name")
 
-    if "compound_key" not in df.columns:
-        for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
-            if candidate in df.columns:
-                df["compound_key"] = df[candidate].astype("string")
-                filled.add("compound_key")
+    for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
+        _fill_from("compound_key", candidate)
+        if "compound_key" in df.columns:
+            current = df["compound_key"].astype("string")
+            if not _string_missing(current).any():
                 break
+
+    _fill_from("salt_chembl_id", "molecule_chembl_id")
 
     if "log_value" in df.columns:
         df["log_value"] = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
+        if "pchembl_value" in df.columns:
+            fallback = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+            mask = df["log_value"].isna() & fallback.notna()
+            if mask.any():
+                df.loc[mask, "log_value"] = fallback.loc[mask]
+                filled.add("log_value")
     elif "pchembl_value" in df.columns:
         df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
         filled.add("log_value")
@@ -557,6 +588,7 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
         mask = df["log_value"].isna() & computed.notna()
         if mask.any():
             df.loc[mask, "log_value"] = computed.loc[mask]
+            filled.add("log_value")
 
     bool_defaults = {
         "multmol_assay",
@@ -577,10 +609,6 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
         if column not in df.columns:
             df[column] = pd.Series(pd.NA, index=df.index, dtype="Float64")
             filled.add(column)
-
-    if "salt_chembl_id" not in df.columns:
-        df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
-        filled.add("salt_chembl_id")
 
     if "nstereo" not in df.columns:
         df["nstereo"] = pd.Series(pd.NA, index=df.index, dtype="Int64")
@@ -630,9 +658,11 @@ def _derive_output_path(input_path: Path) -> Path:
     base_name = helpers.normalise_export_basename(input_path)
     if base_name.startswith("output.activities_"):
         base_name = base_name.replace("output.activities_", "output.activity_", 1)
-    if not base_name.startswith("output.activity_"):
+    if base_name.startswith("output.activity_"):
+        final_name = base_name.replace("output.activity_", "extended.output.activity_", 1)
+    else:
         logger.warning("activity_extended_unexpected_basename", basename=base_name)
-    final_name = base_name.replace("output.activity_", "extended.output.activity_", 1)
+        final_name = base_name if base_name.startswith("extended.") else f"extended.{base_name}"
     return input_path.with_name(final_name)
 
 
@@ -736,7 +766,10 @@ def process_activity_extended(
             total=len(processed),
         )
     logger.info("activity_extended_saving", path=str(output_path))
-    helpers.write_csv(processed, output_path, columns=_FINAL_COLUMN_ORDER)
+    to_write = processed.copy()
+    if "pA_value" in to_write.columns:
+        to_write["pA_value"] = to_write["pA_value"].astype("string")
+    helpers.write_csv(to_write, output_path, columns=_FINAL_COLUMN_ORDER)
     logger.info(
         "activity_extended_saved",
         path=str(output_path),

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -208,13 +208,81 @@ def test_transform_activity_frame__fills_missing_columns(activity_resources: Pat
     assert row.activity_chembl_id == "ACT-001"
     assert row.compound_key == "CMPD-1"
     assert row.compound_name == "Compound One"
-    assert pd.isna(row.saltform_id)
+    assert row.saltform_id == "MOL-1"
     assert bool(row.multmol_assay) is False
     assert bool(row.rounded_data_citation) is False
     assert bool(row.is_citation) is False
     assert pd.isna(row.original_activity_approx)
     assert pd.isna(row.original_activity_exact)
     assert row.pA_value == pytest.approx(5.0)
+
+
+def test_transform_activity_frame__backfills_null_identifiers_and_log_value(
+    activity_resources: Path,
+) -> None:
+    dictionary_root = activity_resources / "dictionary"
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": [pd.NA, ""],
+            "activity_id": ["ACT-1", "ACT-2"],
+            "salt_chembl_id": [pd.NA, ""],
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2"],
+            "target_chembl_id": ["TAR-1", "TAR-1"],
+            "assay_chembl_id": ["ASSAY-1", "ASSAY-1"],
+            "document_chembl_id": ["DOC-1", "DOC-1"],
+            "bao_endpoint": ["BAO:000001", "BAO:000001"],
+            "standard_type": ["IC50", "IC50"],
+            "standard_value": [1.0, 10.0],
+            "standard_units": ["nM", "uM"],
+            "log_value": [pd.NA, ""],
+            "pchembl_value": [9.0, 8.0],
+            "bao_format": ["fmt", "fmt"],
+        }
+    )
+
+    transformed = _transform_activity_frame(
+        frame,
+        dictionary_root=dictionary_root,
+        targets_override=None,
+    )
+
+    assert transformed["activity_chembl_id"].tolist() == ["ACT-1", "ACT-2"]
+    assert transformed["saltform_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert transformed["pA_value"].tolist() == pytest.approx([9.0, 8.0])
+
+
+def test_transform_activity_frame__computes_log_value_from_standard_fields(
+    activity_resources: Path,
+) -> None:
+    dictionary_root = activity_resources / "dictionary"
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": [pd.NA],
+            "activity_id": ["ACT-3"],
+            "salt_chembl_id": [pd.NA],
+            "molecule_chembl_id": ["CHEMBL3"],
+            "target_chembl_id": ["TAR-2"],
+            "assay_chembl_id": ["ASSAY-2"],
+            "document_chembl_id": ["DOC-2"],
+            "bao_endpoint": ["BAO:000002"],
+            "standard_type": ["IC50"],
+            "standard_value": [10.0],
+            "standard_units": ["nM"],
+            "log_value": [pd.NA],
+            "pchembl_value": [pd.NA],
+            "bao_format": ["fmt"],
+        }
+    )
+
+    transformed = _transform_activity_frame(
+        frame,
+        dictionary_root=dictionary_root,
+        targets_override=None,
+    )
+
+    assert transformed.loc[0, "activity_chembl_id"] == "ACT-3"
+    assert transformed.loc[0, "saltform_id"] == "CHEMBL3"
+    assert transformed.loc[0, "pA_value"] == pytest.approx(8.0)
 
 
 def test_apply_multimol_logic__marks_duplicate_multimol_assay(


### PR DESCRIPTION
## Summary
- allow `_augment_activity_frame` to backfill empty activity identifiers, salt identifiers, and log values from fallback columns while preserving computed pA values
- ensure extended exports retain the `extended.` prefix for custom filenames and persist pA values with their decimal precision
- add regression tests that exercise the new backfilling scenarios and verify pA value propagation after renaming

## Testing
- pytest tests/postprocessing/test_activity_extended.py

------
https://chatgpt.com/codex/tasks/task_e_68e295e31614832487a8a2df127861d3