### PR TITLE
Normalise activity extended output path derivation

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -645,13 +645,14 @@ def _derive_output_path(input_path: Path) -> Path:
     while candidate.startswith("extended."):
         candidate = candidate[len("extended.") :]
 
-    match = _FILENAME_RE.match(candidate)
-    if match is not None:
-        stamp = match.group(1)
+    normalised = _normalised_activity_basename(Path(candidate))
+    if normalised is not None:
+        stamp, _ = normalised
         final_name = f"extended.output.activity_{stamp}.csv"
     else:
         logger.warning("activity_extended_unexpected_basename", basename=base_name)
-        final_name = f"extended.{candidate}"
+        normalised_candidate = helpers.normalise_export_basename(Path(candidate))
+        final_name = f"extended.{normalised_candidate}"
 
     return input_path.with_name(final_name)
 

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -144,11 +144,28 @@ def test_latest_activity_export__handles_hidden_temporary_file(tmp_path: Path) -
 
 
 def test_derive_output_path__normalises_plural_basename(tmp_path: Path) -> None:
-    source = tmp_path / "extended.output.activities_20240101.csv"
+    source = tmp_path / ".output.activities_20240101.csv.tmp"
 
     derived = _derive_output_path(source)
 
-    assert derived.name == "extended.output.activity_20240101.csv"
+    assert derived == source.with_name("extended.output.activity_20240101.csv")
+
+
+@pytest.mark.parametrize(
+    "source_name",
+    [
+        "extended.output.activity_20240101.csv",
+        "extended.extended.output.activity_20240101.csv.tmp",
+    ],
+)
+def test_derive_output_path__deduplicates_extended_prefix(
+    tmp_path: Path, source_name: str
+) -> None:
+    source = tmp_path / source_name
+
+    derived = _derive_output_path(source)
+
+    assert derived == source.with_name("extended.output.activity_20240101.csv")
 
 
 def test_derive_output_path__prefixes_custom_exports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- normalise the derived activity extended output filename using the existing basename helper
- ensure temporary suffixes and duplicate extended prefixes are stripped before composing the destination name
- extend derive-output-path tests to cover hidden temporary exports and previously generated extended files

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k "derive_output_path"


------
https://chatgpt.com/codex/tasks/task_e_68e2986b0b988324a82e0019d550428a