### PR TITLE
Handle sparse activity identifiers during augmentation

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -506,6 +506,8 @@ def _select_and_cast(df: pd.DataFrame) -> pd.DataFrame:
     for column in bool_columns:
         if column in result.columns:
             result[column] = _safe_to_bool(result[column], column)
+    if "pA_value" in result.columns:
+        result["pA_value"] = result["pA_value"].astype("string")
     return result
 
 
@@ -513,28 +515,80 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
     df = frame.copy()
     filled: set[str] = set()
 
-    if "activity_chembl_id" not in df.columns and "activity_id" in df.columns:
-        df["activity_chembl_id"] = df["activity_id"].astype("string")
-        filled.add("activity_chembl_id")
+    def _as_string(series: pd.Series) -> pd.Series:
+        return series.astype("string")
 
-    if "compound_name" not in df.columns and "molecule_pref_name" in df.columns:
-        df["compound_name"] = df["molecule_pref_name"].astype("string")
-        filled.add("compound_name")
+    def _missing_string(series: pd.Series) -> pd.Series:
+        stripped = series.str.strip()
+        return stripped.isna() | stripped.eq("").fillna(False)
 
-    if "compound_key" not in df.columns:
+    if "activity_id" in df.columns:
+        source = _as_string(df["activity_id"])
+        if "activity_chembl_id" not in df.columns:
+            df["activity_chembl_id"] = source
+            filled.add("activity_chembl_id")
+        else:
+            target = _as_string(df["activity_chembl_id"])
+            mask = _missing_string(target)
+            if mask.any():
+                updated = target.copy()
+                updated.loc[mask] = source.loc[mask]
+                df["activity_chembl_id"] = updated
+                filled.add("activity_chembl_id")
+
+    if "molecule_pref_name" in df.columns:
+        source = _as_string(df["molecule_pref_name"])
+        if "compound_name" not in df.columns:
+            df["compound_name"] = source
+            filled.add("compound_name")
+        else:
+            target = _as_string(df["compound_name"])
+            mask = _missing_string(target)
+            if mask.any():
+                updated = target.copy()
+                updated.loc[mask] = source.loc[mask]
+                df["compound_name"] = updated
+                filled.add("compound_name")
+
+    if "compound_key" in df.columns:
+        target = _as_string(df["compound_key"])
+    else:
+        target = pd.Series(pd.NA, index=df.index, dtype="string")
+    missing_mask = _missing_string(target)
+    if missing_mask.any():
         for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
-            if candidate in df.columns:
-                df["compound_key"] = df[candidate].astype("string")
+            if candidate not in df.columns:
+                continue
+            source = _as_string(df[candidate])
+            source_missing = _missing_string(source)
+            fill_mask = missing_mask & ~source_missing
+            if fill_mask.any():
+                target = target.copy()
+                target.loc[fill_mask] = source.loc[fill_mask]
+                missing_mask = _missing_string(target)
                 filled.add("compound_key")
+            if not missing_mask.any():
                 break
+    df["compound_key"] = target
 
     log_value_series: pd.Series | None = None
 
+    pchembl_series: pd.Series | None = None
+
     if "log_value" in df.columns:
         log_value_series = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
-    elif "pchembl_value" in df.columns:
-        log_value_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
-        filled.add("log_value")
+
+    if "pchembl_value" in df.columns:
+        pchembl_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+        if log_value_series is None:
+            log_value_series = pchembl_series
+            filled.add("log_value")
+        else:
+            missing = log_value_series.isna()
+            if missing.any():
+                log_value_series = log_value_series.copy()
+                log_value_series.loc[missing] = pchembl_series.loc[missing]
+                filled.add("log_value")
 
     if log_value_series is not None:
         df["log_value"] = log_value_series
@@ -591,7 +645,22 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
             df[column] = pd.Series(pd.NA, index=df.index, dtype="Float64")
             filled.add(column)
 
-    if "salt_chembl_id" not in df.columns:
+    if "salt_chembl_id" in df.columns:
+        target = _as_string(df["salt_chembl_id"])
+        mask = _missing_string(target)
+        if mask.any() and "molecule_chembl_id" in df.columns:
+            source = _as_string(df["molecule_chembl_id"])
+            source_missing = _missing_string(source)
+            fill_mask = mask & ~source_missing
+            if fill_mask.any():
+                target = target.copy()
+                target.loc[fill_mask] = source.loc[fill_mask]
+                filled.add("salt_chembl_id")
+        df["salt_chembl_id"] = target
+    elif "molecule_chembl_id" in df.columns:
+        df["salt_chembl_id"] = _as_string(df["molecule_chembl_id"])
+        filled.add("salt_chembl_id")
+    else:
         df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
         filled.add("salt_chembl_id")
 

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -225,13 +225,13 @@ def test_transform_activity_frame__fills_missing_columns(activity_resources: Pat
     assert row.activity_chembl_id == "ACT-001"
     assert row.compound_key == "CMPD-1"
     assert row.compound_name == "Compound One"
-    assert pd.isna(row.saltform_id)
+    assert row.saltform_id == "MOL-1"
     assert bool(row.multmol_assay) is False
     assert bool(row.rounded_data_citation) is False
     assert bool(row.is_citation) is False
     assert pd.isna(row.original_activity_approx)
     assert pd.isna(row.original_activity_exact)
-    assert row.pA_value == pytest.approx(5.0)
+    assert row.pA_value == "5.0"
 
 
 def test_apply_multimol_logic__marks_duplicate_multimol_assay(
@@ -327,8 +327,54 @@ def test_transform_activity_frame__fills_missing_required_columns(
 
     assert list(transformed.columns) == list(_FINAL_COLUMN_ORDER)
     assert transformed.loc[0, "saltform_id"] == "CHEMBL1"
-    assert transformed.loc[0, "pA_value"] == pytest.approx(6.5)
+    assert transformed.loc[0, "pA_value"] == "6.5"
     assert transformed.loc[0, "compound_name"] is pd.NA
+
+
+def test_transform_activity_frame__backfills_present_columns(
+    activity_resources: Path,
+) -> None:
+    dictionary_root = activity_resources / "dictionary"
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": [pd.NA],
+            "activity_id": ["ACT-002"],
+            "assay_chembl_id": ["ASSAY-2"],
+            "molecule_chembl_id": ["CHEMBL2"],
+            "salt_chembl_id": [pd.NA],
+            "parent_molecule_chembl_id": ["CMPD-2"],
+            "target_chembl_id": ["TAR-BETA"],
+            "document_chembl_id": ["DOC-2"],
+            "bao_endpoint": ["BAO:000002"],
+            "bao_format": ["Single protein"],
+            "standard_type": ["IC50"],
+            "standard_value": [1.0],
+            "standard_units": ["uM"],
+            "pchembl_value": [6.5],
+            "compound_key": [""],
+            "compound_name": [""],
+            "molecule_pref_name": ["Compound Two"],
+            "log_value": [pd.NA],
+        }
+    )
+    frame["activity_chembl_id"] = frame["activity_chembl_id"].astype("string")
+    frame["compound_key"] = frame["compound_key"].astype("string")
+    frame["compound_name"] = frame["compound_name"].astype("string")
+    frame["salt_chembl_id"] = frame["salt_chembl_id"].astype("string")
+    frame["log_value"] = frame["log_value"].astype("Float64")
+
+    transformed = _transform_activity_frame(
+        frame,
+        dictionary_root=dictionary_root,
+        targets_override=None,
+    )
+
+    row = transformed.iloc[0]
+    assert row.activity_chembl_id == "ACT-002"
+    assert row.compound_key == "CMPD-2"
+    assert row.compound_name == "Compound Two"
+    assert row.saltform_id == "CHEMBL2"
+    assert row.pA_value == "6.5"
 
 
 def test_process_activity_extended__writes_expected_payload(


### PR DESCRIPTION
## Summary
- allow `_augment_activity_frame` to backfill existing identifier and measurement columns from their fallback sources when values are blank
- ensure `pA_value` is derived from `pchembl_value` before molar fallback and keep the exported column textual
- add regression tests covering `<NA>` and empty-string values in the activity export input

## Testing
- pytest tests/postprocessing/test_activity_extended.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2984fdee88324897c92c389180808