### PR TITLE
Handle temporary target exports in orchestrator

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -258,14 +258,34 @@ def _bool_from_cli(value: object) -> bool | None:
     return bool(value)
 
 
+_TEMPORARY_EXPORT_SUFFIXES: tuple[str, ...] = (".tmp",)
+_NORMALISED_MARKERS: tuple[str, ...] = (NORMALIZED_SUFFIX, "_normalised")
+
+
 def _normalise_target_export_name(path: Path) -> str:
     """Return a normalised filename for target exports."""
 
     name = path.name
-    for suffix in reversed(path.suffixes):
-        if suffix == ".csv":
+    lowered_name = name.lower()
+
+    for suffix in _TEMPORARY_EXPORT_SUFFIXES:
+        suffix_lower = suffix.lower()
+        while lowered_name.endswith(suffix_lower):
+            name = name[: -len(suffix)]
+            lowered_name = name.lower()
+
+    for marker in _NORMALISED_MARKERS:
+        marker_lower = marker.lower()
+        csv_marker = f".csv{marker_lower}"
+        if lowered_name.endswith(csv_marker):
+            name = name[: -len(marker)]
+            lowered_name = name.lower()
             break
-        name = name.removesuffix(suffix)
+        if lowered_name.endswith(marker_lower):
+            name = name[: -len(marker)]
+            lowered_name = name.lower()
+            break
+
     return name
 
 
@@ -299,7 +319,15 @@ def _is_supported_target_export(path: Path) -> bool:
         return True
 
     if path.suffix.lower() != ".csv":
-        return False
+        if not export_name.lower().endswith(".csv"):
+            return False
+        logger.info(
+            "target_postprocess_noncanonical_name",
+            path=str(path),
+            reason="noncanonical_filename",
+            canonical=export_name,
+        )
+        return True
 
     logger.info(
         "target_postprocess_noncanonical_name",

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -9,7 +9,8 @@ from typing import Callable
 import pandas as pd
 import pytest
 
-from scripts import get_data
+from library.config import Config
+from scripts import get_data, get_target_data
 from tests.helpers.logs import parse_log_lines
 
 
@@ -252,3 +253,100 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
     final_output = step.expected_output(cfg)
     assert final_output.exists()
     assert attempts["count"] == 2
+
+
+@pytest.mark.integration
+def test_pipeline_subset__target_postprocess_sidecars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _prepare_environment(tmp_path)
+    _write_input(
+        cfg,
+        "target",
+        pd.DataFrame(
+            [
+                {
+                    "target_chembl_id": "CHEMBL1",
+                    "target_name": "Alpha",
+                    "organism": "Homo sapiens",
+                }
+            ],
+            dtype="string",
+        ),
+    )
+
+    call_order: list[str] = []
+
+    def _sidecar_path(source: Path, prefix: str) -> Path:
+        canonical = get_target_data._normalise_target_export_name(source).lstrip(".")
+        destination = source.with_name(f"{prefix}{canonical}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+        return destination
+
+    def _fake_organism(source: Path, *, cfg: Config) -> Path:
+        call_order.append("organism")
+        return _sidecar_path(source, "organism.")
+
+    def _fake_isoform(
+        source: Path,
+        *,
+        cfg: Config,
+        context: get_target_data.IsoformPostprocessContext | None = None,
+        ambiguous_classifications: int | None = None,
+    ) -> Path:
+        call_order.append("isoform")
+        return _sidecar_path(source, "isoform.")
+
+    def _fake_names(source: Path, *, cfg: Config) -> Path:
+        call_order.append("names")
+        return _sidecar_path(source, "name.")
+
+    def _fake_iuphar(source: Path, *, verbose: bool = True) -> Path:
+        call_order.append("iuphar")
+        return _sidecar_path(source, "IUPHAR.")
+
+    def _stub_run_all(cfg_obj: Config, args: argparse.Namespace) -> int:
+        working_output = Path(args.final_out)
+        working_output.parent.mkdir(parents=True, exist_ok=True)
+        working_output.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+        normalized = get_target_data._normalized_output_path(working_output)
+        normalized.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
+        get_target_data._postprocess_target_exports(normalized, cfg=cfg_obj)
+        return 0
+
+    stream = io.StringIO()
+    logger = get_data.configure_logger(
+        get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
+    )
+
+    step = get_data.PipelineStep("target", get_target_data.main, "all")
+
+    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+    monkeypatch.setattr(get_target_data, "run_all", _stub_run_all)
+    monkeypatch.setattr(
+        get_target_data,
+        "_postprocess_organism_export",
+        _fake_organism,
+    )
+    monkeypatch.setattr(get_target_data, "_postprocess_isoform_export", _fake_isoform)
+    monkeypatch.setattr(get_target_data, "_postprocess_names_export", _fake_names)
+    monkeypatch.setattr(get_target_data, "_postprocess_iuphar_export", _fake_iuphar)
+
+    status = get_data.run_pipeline(cfg)
+
+    assert status == 0
+    assert call_order == ["organism", "isoform", "names", "iuphar"]
+
+    final_output = step.expected_output(cfg)
+    assert final_output.exists()
+    sidecars = {
+        "organism": final_output.with_name(f"organism.{final_output.name}"),
+        "isoform": final_output.with_name(f"isoform.{final_output.name}"),
+        "names": final_output.with_name(f"name.{final_output.name}"),
+        "iuphar": final_output.with_name(f"IUPHAR.{final_output.name}"),
+    }
+    for path in sidecars.values():
+        assert path.exists()
+

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -75,6 +75,8 @@ def test_keyboard_aliases__cases(command: str) -> None:
     [
         ("output.target_20251005.csv", True),
         ("targets_20251005_normalized.csv", True),
+        ("output.targets_20251005.csv.tmp", True),
+        (".output.targets_20251005.csv_normalized.tmp", True),
         ("out.csv", False),
         ("out_chembl.csv", False),
         ("out_uniprot.csv", False),
@@ -405,12 +407,24 @@ def test_postprocess_target_exports__chains_helpers(
         call_order.append("isoform")
         return source
 
+    def _fake_names(path: Path, *, cfg: Config) -> Path:
+        assert Path(path) == source
+        call_order.append("names")
+        return source
+
+    def _fake_iuphar(path: Path, *, verbose: bool = True) -> Path:
+        assert Path(path) == source
+        call_order.append("iuphar")
+        return source
+
     monkeypatch.setattr(get_target_data, "_postprocess_organism_export", _fake_organism)
     monkeypatch.setattr(get_target_data, "_postprocess_isoform_export", _fake_isoform)
+    monkeypatch.setattr(get_target_data, "_postprocess_names_export", _fake_names)
+    monkeypatch.setattr(get_target_data, "_postprocess_iuphar_export", _fake_iuphar)
 
     get_target_data._postprocess_target_exports(source, cfg=cfg)
 
-    assert call_order == ["organism", "isoform"]
+    assert call_order == ["organism", "isoform", "names", "iuphar"]
 
 
 def test_postprocess_target_exports__skips_for_uniprot_suffix(


### PR DESCRIPTION
## Summary
- normalise target export names by stripping temporary extensions while keeping the canonical `.csv`
- allow `_is_supported_target_export` to accept temporary filenames and cover the helper chain in unit tests
- add an integration test that simulates the orchestrator and asserts the isoform, organism, names, and IUPHAR sidecars are produced

## Testing
- pytest tests/unit/test_get_target_data.py::test_is_supported_target_export__cases
- pytest tests/unit/test_get_target_data.py::test_postprocess_target_exports__chains_helpers
- pytest tests/integration/test_get_data_workflow.py::test_pipeline_subset__target_postprocess_sidecars

------
https://chatgpt.com/codex/tasks/task_e_68e29824547c8324894f97bf98df2649