### PR TITLE
Normalize isoform export naming

### DIFF
--- a/docs/POSTPROCESSING_RUNBOOK.md
+++ b/docs/POSTPROCESSING_RUNBOOK.md
@@ -1,0 +1,37 @@
+# Target post-processing runbook
+
+This document captures the conventions that orchestrators and downstream
+consumers rely on when running the target post-processing suite.  The goal is to
+keep exports stable and predictable so regression tests can reason about file
+names and locations without bespoke special-casing.
+
+## Export naming conventions
+
+All target post-processors must derive their export basename via
+`library.postprocessing.helpers.normalise_export_basename`.  The helper mirrors
+the legacy Power Query workbook and ensures that leading dots, temporary
+suffixes (for example `.tmp`) and trailing `_normalized` / `_normalised`
+indicators are stripped before composing the final file name.  The canonical
+`isoform` pipeline, for instance, emits artefacts using the pattern
+`isoform.<normalised-input-name>` which preserves the original `.csv` suffix.
+
+When adding a new post-processing step, call the helper before writing any
+output file so the result aligns with the orchestrator expectations.  This keeps
+retries idempotent: multiple runs on the same staged input will always emit to
+the same path, and orchestrators can clean up `.tmp` intermediates without
+additional logic.
+
+## Orchestrator interaction
+
+Workflow engines trigger the post-processing entry points (such as
+`process_targets`) once an upstream export has landed in the staging directory.
+The helper ensures that orchestrators can pass the path directly—even if it
+still carries temporary suffixes added by the ingestion stage—and receive a
+deterministically named output in the same directory.  Downstream tasks watch
+for these stable `isoform.*.csv` artefacts before proceeding with publishing or
+further enrichment.
+
+When introducing new target post-processing modules, document the emitted file
+pattern and confirm that `normalise_export_basename` is used.  This prevents
+divergence between bespoke scripts and the shared automation, keeping the CI
+environment and production scheduler aligned.

--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 import sys
@@ -18,6 +17,8 @@ import warnings
 
 import pandas as pd
 import re
+
+from ..helpers import normalise_export_basename
 
 
 def _empty_like(index: pd.Index) -> pd.Series:
@@ -527,16 +528,8 @@ def _resolve_output_path(input_path: Path, output_csv: Optional[str]) -> Path:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         return output_path
 
-    def _canonical_export_name(name: str) -> str:
-        stem, ext = os.path.splitext(name)
-        lowered = stem.lower()
-        normalized_suffix = "_normalized"
-        if lowered.endswith(normalized_suffix):
-            stem = stem[: -len(normalized_suffix)]
-        return f"{stem}{ext or ''}"
-
-    canonical_name = _canonical_export_name(input_path.name)
-    return input_path.with_name(f"isoform.{canonical_name}")
+    base_name = normalise_export_basename(input_path)
+    return input_path.with_name(f"isoform.{base_name}")
 
 
 def _stringify_for_csv(value: Any) -> str:

--- a/tests/integration/test_target_isoform_postprocess.py
+++ b/tests/integration/test_target_isoform_postprocess.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from library.postprocessing.target.isoform import process_targets
+
+
+def _write_isoform_input(path: Path) -> None:
+    columns = (
+        "isoform_synonyms",
+        "isoform_names",
+        "isoform_ids",
+        "uniprot_id_primary",
+        "target_chembl_id",
+    )
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(columns)
+        writer.writerow([
+            "synonym-a|synonym-b",
+            "Isoform Alpha",
+            "ID-001",
+            "P12345",
+            "CHEMBL123",
+        ])
+
+
+def test_process_targets__normalises_temp_export_basename(tmp_path: Path) -> None:
+    input_path = tmp_path / ".output.targets_20251005.csv.tmp"
+    _write_isoform_input(input_path)
+
+    output_path = process_targets(input_csv=str(input_path), verbose=False)
+
+    expected = tmp_path / "isoform.output.targets_20251005.csv"
+    assert output_path == expected
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- ensure the isoform post-processor derives output paths via the shared export basename normaliser
- add an integration regression test covering temp/hidden aggregated target exports
- document target post-processing naming conventions and orchestrator expectations

## Testing
- pytest tests/integration/test_target_isoform_postprocess.py

------
https://chatgpt.com/codex/tasks/task_e_68e29ac0039c8324bff5abfb26818971