### PR TITLE
Handle blank activity fallback columns

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -513,42 +513,71 @@ def _select_and_cast(df: pd.DataFrame) -> pd.DataFrame:
     return result
 
 
+def _string_missing_mask(series: pd.Series) -> pd.Series:
+    values = series.astype("string")
+    stripped = values.str.strip()
+    return values.isna() | stripped.fillna("").eq("")
+
+
 def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]]:
     df = frame.copy()
     filled: set[str] = set()
 
-    if "activity_chembl_id" not in df.columns and "activity_id" in df.columns:
-        df["activity_chembl_id"] = df["activity_id"].astype("string")
-        filled.add("activity_chembl_id")
+    if "activity_chembl_id" not in df.columns:
+        if "activity_id" in df.columns:
+            df["activity_chembl_id"] = df["activity_id"].astype("string")
+            filled.add("activity_chembl_id")
+    else:
+        mask = _string_missing_mask(df["activity_chembl_id"])
+        if mask.any() and "activity_id" in df.columns:
+            df.loc[mask, "activity_chembl_id"] = df.loc[mask, "activity_id"].astype(
+                "string"
+            )
+            filled.add("activity_chembl_id")
 
-    if "compound_name" not in df.columns and "molecule_pref_name" in df.columns:
-        df["compound_name"] = df["molecule_pref_name"].astype("string")
-        filled.add("compound_name")
+    if "compound_name" not in df.columns:
+        if "molecule_pref_name" in df.columns:
+            df["compound_name"] = df["molecule_pref_name"].astype("string")
+            filled.add("compound_name")
+    else:
+        mask = _string_missing_mask(df["compound_name"])
+        if mask.any() and "molecule_pref_name" in df.columns:
+            df.loc[mask, "compound_name"] = df.loc[mask, "molecule_pref_name"].astype(
+                "string"
+            )
+            filled.add("compound_name")
 
-    if "compound_key" not in df.columns:
+    if "compound_key" in df.columns:
+        missing_mask = _string_missing_mask(df["compound_key"])
+    else:
+        missing_mask = pd.Series(True, index=df.index, dtype="boolean")
+        df["compound_key"] = pd.Series(pd.NA, index=df.index, dtype="string")
+
+    if missing_mask.any():
         for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
             if candidate in df.columns:
-                df["compound_key"] = df[candidate].astype("string")
+                df.loc[missing_mask, "compound_key"] = (
+                    df.loc[missing_mask, candidate].astype("string")
+                )
                 filled.add("compound_key")
                 break
-    else:
-        missing_mask = df["compound_key"].isna()
-        if missing_mask.any():
-            for candidate in ("parent_molecule_chembl_id", "molecule_chembl_id"):
-                if candidate in df.columns:
-                    df.loc[missing_mask, "compound_key"] = (
-                        df.loc[missing_mask, candidate].astype("string")
-                    )
-                    filled.add("compound_key")
-                    break
 
     log_value_series: pd.Series | None = None
 
     if "log_value" in df.columns:
         log_value_series = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
-    elif "pchembl_value" in df.columns:
-        log_value_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
-        filled.add("log_value")
+    pchembl_series: pd.Series | None = None
+    if "pchembl_value" in df.columns:
+        pchembl_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+        if log_value_series is None:
+            log_value_series = pchembl_series
+            filled.add("log_value")
+        else:
+            mask = log_value_series.isna()
+            if mask.any():
+                log_value_series = log_value_series.copy()
+                log_value_series.loc[mask] = pchembl_series.loc[mask]
+                filled.add("log_value")
 
     if log_value_series is not None:
         df["log_value"] = log_value_series

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -24,6 +24,7 @@ from library.postprocessing.activity_extended import (
     _resolve_targets_path,
     _select_and_cast,
     _transform_activity_frame,
+    _augment_activity_frame,
 )
 
 pytestmark = pytest.mark.postprocessing
@@ -39,6 +40,33 @@ def activity_resources(snapshot_resource: Path) -> Path:
 def _copytree(src: Path, dst: Path) -> Path:
     shutil.copytree(src, dst)
     return dst
+
+
+def test_augment_activity_frame__fills_existing_blanks() -> None:
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": pd.Series(["", pd.NA], dtype="string"),
+            "activity_id": pd.Series(["ACT-1", "ACT-2"], dtype="string"),
+            "compound_name": pd.Series([pd.NA, ""], dtype="string"),
+            "molecule_pref_name": pd.Series(["Preferred-1", "Preferred-2"], dtype="string"),
+            "compound_key": pd.Series(["   ", pd.NA], dtype="string"),
+            "molecule_chembl_id": pd.Series(["CHEMBL1", "CHEMBL2"], dtype="string"),
+            "pchembl_value": pd.Series([5.0, 6.0], dtype="Float64"),
+            "log_value": pd.Series([pd.NA, ""], dtype="object"),
+        }
+    )
+
+    augmented, filled = _augment_activity_frame(frame)
+
+    assert augmented["activity_chembl_id"].tolist() == ["ACT-1", "ACT-2"]
+    assert augmented["compound_name"].tolist() == ["Preferred-1", "Preferred-2"]
+    assert augmented["compound_key"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    pd.testing.assert_series_equal(
+        augmented["log_value"],
+        pd.Series([5.0, 6.0], index=frame.index, dtype="Float64"),
+        check_names=False,
+    )
+    assert {"activity_chembl_id", "compound_name", "compound_key", "log_value"} <= filled
 
 
 def test_load_citation_fraction__missing_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- fill activity_chembl_id, compound_name, and compound_key fields when blank rows remain after ingest
- backfill log_value from pchembl_value before computing molar fallbacks to keep pA_value populated
- add regression coverage for _augment_activity_frame blank handling

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k augment

------
https://chatgpt.com/codex/tasks/task_e_68e29b0d88548324b7edc6ec65d38f35