### PR TITLE
Fix activity log_value augmentation for string dtype inputs

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -542,19 +542,18 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
                     filled.add("compound_key")
                     break
 
-    log_value_series: pd.Series | None = None
+    has_log_value = False
 
     if "log_value" in df.columns:
-        log_value_series = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
+        df["log_value"] = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
+        has_log_value = True
     elif "pchembl_value" in df.columns:
-        log_value_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+        df["log_value"] = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
         filled.add("log_value")
-
-    if log_value_series is not None:
-        df["log_value"] = log_value_series
+        has_log_value = True
 
     if (
-        log_value_series is not None
+        has_log_value
         and "standard_value" in df.columns
         and "standard_units" in df.columns
     ):
@@ -577,13 +576,9 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
             computed.loc[valid] = pd.Series(computed_values, index=df.index[valid]).astype(
                 "Float64"
             )
-        mask = log_value_series.isna() & computed.notna()
+        mask = df["log_value"].isna() & computed.notna()
         if mask.any():
-            log_value_series = log_value_series.copy()
-            log_value_series.loc[mask] = computed.loc[mask]
-
-    if log_value_series is not None:
-        df["log_value"] = log_value_series
+            df.loc[mask, "log_value"] = computed.loc[mask]
 
     bool_defaults = {
         "multmol_assay",

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -14,6 +14,7 @@ from library.postprocessing.activity_extended import (
     _FINAL_COLUMN_ORDER,
     _annotate_high_citation,
     _apply_multimol_logic,
+    _augment_activity_frame,
     _compute_citation_flags,
     _derive_output_path,
     _latest_activity_export,
@@ -174,6 +175,23 @@ def test_derive_output_path__prefixes_custom_exports(tmp_path: Path) -> None:
     derived = _derive_output_path(source)
 
     assert derived.name == "extended.chembl_activities_snapshot.csv"
+
+
+def test_augment_activity_frame__fills_log_value_from_standard_value_string_dtype() -> None:
+    frame = pd.DataFrame(
+        {
+            "activity_id": [1, 2],
+            "log_value": pd.Series(["", "7.0"], dtype="string"),
+            "standard_value": pd.Series(["1000", "100"], dtype="string"),
+            "standard_units": pd.Series(["nM", "nM"], dtype="string"),
+        }
+    )
+
+    augmented, _ = _augment_activity_frame(frame)
+
+    assert str(augmented["log_value"].dtype) == "Float64"
+    assert augmented.loc[0, "log_value"] == pytest.approx(6.0)
+    assert augmented.loc[1, "log_value"] == pytest.approx(7.0)
 
 
 def test_transform_activity_frame__parses_activity_properties_flags(


### PR DESCRIPTION
## Summary
- normalize the activity log_value column to a numeric dtype before enriching with computed values to avoid assignment errors
- add a regression test covering string-typed log_value data when deriving values from standard units

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k log_value -q

------
https://chatgpt.com/codex/tasks/task_e_68e29aad32808324a431791c212fbb90