### PR TITLE
Backfill activity identifiers when columns contain nulls

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -517,7 +517,16 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
     df = frame.copy()
     filled: set[str] = set()
 
-    if "activity_chembl_id" not in df.columns and "activity_id" in df.columns:
+    if "activity_chembl_id" in df.columns:
+        activity_series = df["activity_chembl_id"].astype("string")
+        missing_mask = activity_series.isna() | activity_series.str.strip().eq("").fillna(False)
+        if missing_mask.any() and "activity_id" in df.columns:
+            df.loc[missing_mask, "activity_chembl_id"] = (
+                df.loc[missing_mask, "activity_id"].astype("string")
+            )
+            filled.add("activity_chembl_id")
+        df["activity_chembl_id"] = df["activity_chembl_id"].astype("string")
+    elif "activity_id" in df.columns:
         df["activity_chembl_id"] = df["activity_id"].astype("string")
         filled.add("activity_chembl_id")
 
@@ -544,11 +553,22 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
 
     log_value_series: pd.Series | None = None
 
+    pchembl_series: pd.Series | None = None
+
     if "log_value" in df.columns:
         log_value_series = pd.to_numeric(df["log_value"], errors="coerce").astype("Float64")
-    elif "pchembl_value" in df.columns:
-        log_value_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+    if "pchembl_value" in df.columns:
+        pchembl_series = pd.to_numeric(df["pchembl_value"], errors="coerce").astype("Float64")
+
+    if log_value_series is None and pchembl_series is not None:
+        log_value_series = pchembl_series.copy()
         filled.add("log_value")
+    elif log_value_series is not None and pchembl_series is not None:
+        mask = log_value_series.isna() & pchembl_series.notna()
+        if mask.any():
+            log_value_series = log_value_series.copy()
+            log_value_series.loc[mask] = pchembl_series.loc[mask]
+            filled.add("log_value")
 
     if log_value_series is not None:
         df["log_value"] = log_value_series
@@ -581,6 +601,7 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
         if mask.any():
             log_value_series = log_value_series.copy()
             log_value_series.loc[mask] = computed.loc[mask]
+            filled.add("log_value")
 
     if log_value_series is not None:
         df["log_value"] = log_value_series
@@ -605,8 +626,23 @@ def _augment_activity_frame(frame: pd.DataFrame) -> tuple[pd.DataFrame, set[str]
             df[column] = pd.Series(pd.NA, index=df.index, dtype="Float64")
             filled.add(column)
 
-    if "salt_chembl_id" not in df.columns:
-        df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
+    if "salt_chembl_id" in df.columns:
+        salt_series = df["salt_chembl_id"].astype("string")
+        missing_mask = salt_series.isna() | salt_series.str.strip().eq("").fillna(False)
+        if missing_mask.any():
+            if "molecule_chembl_id" in df.columns:
+                df.loc[missing_mask, "salt_chembl_id"] = (
+                    df.loc[missing_mask, "molecule_chembl_id"].astype("string")
+                )
+                filled.add("salt_chembl_id")
+            else:
+                df.loc[missing_mask, "salt_chembl_id"] = pd.NA
+        df["salt_chembl_id"] = df["salt_chembl_id"].astype("string")
+    else:
+        if "molecule_chembl_id" in df.columns:
+            df["salt_chembl_id"] = df["molecule_chembl_id"].astype("string")
+        else:
+            df["salt_chembl_id"] = pd.Series(pd.NA, index=df.index, dtype="string")
         filled.add("salt_chembl_id")
 
     if "nstereo" not in df.columns:

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -12,6 +12,7 @@ import pytest
 from library.postprocessing import ActivityExtendedError, process_activity_extended
 from library.postprocessing.activity_extended import (
     _FINAL_COLUMN_ORDER,
+    _augment_activity_frame,
     _annotate_high_citation,
     _apply_multimol_logic,
     _compute_citation_flags,
@@ -39,6 +40,51 @@ def activity_resources(snapshot_resource: Path) -> Path:
 def _copytree(src: Path, dst: Path) -> Path:
     shutil.copytree(src, dst)
     return dst
+
+
+def test_augment_activity_frame__backfills_existing_columns() -> None:
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": [pd.NA, "", "  "],
+            "activity_id": [101, 102, 103],
+            "salt_chembl_id": [pd.NA, "", None],
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+            "log_value": [pd.NA, "", None],
+            "pchembl_value": [7.0, 8.0, pd.NA],
+            "standard_value": [1.0, 1.0, 1.0],
+            "standard_units": ["uM", "nM", "nM"],
+        }
+    )
+
+    augmented, filled = _augment_activity_frame(frame)
+
+    assert str(augmented["activity_chembl_id"].dtype) == "string"
+    assert str(augmented["salt_chembl_id"].dtype) == "string"
+    assert {"activity_chembl_id", "salt_chembl_id", "log_value"}.issubset(filled)
+    assert augmented["activity_chembl_id"].tolist() == ["101", "102", "103"]
+    assert augmented["salt_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    assert augmented["log_value"].isna().sum() == 0
+    assert augmented["log_value"].tolist() == pytest.approx([7.0, 8.0, 9.0])
+
+
+def test_rename_columns__pA_value_after_backfill() -> None:
+    frame = pd.DataFrame(
+        {
+            "activity_chembl_id": [pd.NA],
+            "activity_id": [201],
+            "salt_chembl_id": [""],
+            "molecule_chembl_id": ["CHEMBL42"],
+            "log_value": [pd.NA],
+            "pchembl_value": [6.5],
+        }
+    )
+
+    augmented, _ = _augment_activity_frame(frame)
+    renamed = _rename_columns(augmented)
+
+    assert "pA_value" in renamed.columns
+    assert renamed["pA_value"].tolist() == pytest.approx([6.5])
+    assert renamed["saltform_id"].tolist() == ["CHEMBL42"]
 
 
 def test_load_citation_fraction__missing_file(tmp_path: Path) -> None:
@@ -242,7 +288,7 @@ def test_transform_activity_frame__fills_missing_columns(activity_resources: Pat
     assert row.activity_chembl_id == "ACT-001"
     assert row.compound_key == "CMPD-1"
     assert row.compound_name == "Compound One"
-    assert pd.isna(row.saltform_id)
+    assert row.saltform_id == "MOL-1"
     assert bool(row.multmol_assay) is False
     assert bool(row.rounded_data_citation) is False
     assert bool(row.is_citation) is False
@@ -368,6 +414,10 @@ def test_process_activity_extended__writes_expected_payload(
         dtype=str,
     ).fillna("")
 
+    for column in ("pA_value",):
+        result[column] = pd.to_numeric(result[column], errors="coerce")
+        expected[column] = pd.to_numeric(expected[column], errors="coerce")
+
     pd.testing.assert_frame_equal(result, expected, check_dtype=False)
 
 
@@ -441,5 +491,9 @@ def test_process_activity_extended__uses_explicit_input_path(
         activity_resources / "expected.extended.output.activity_20240101.csv",
         dtype=str,
     ).fillna("")
+
+    for column in ("pA_value",):
+        result[column] = pd.to_numeric(result[column], errors="coerce")
+        expected[column] = pd.to_numeric(expected[column], errors="coerce")
 
     pd.testing.assert_frame_equal(result, expected, check_dtype=False)


### PR DESCRIPTION
## Summary
- update the activity extended augmentation logic to refill existing activity IDs, salt IDs, and log values when they contain blanks or pd.NA
- reuse pChEMBL and molar conversions to backfill log values even if the log_value column is present
- add regression tests that cover the new backfilling behaviour and ensure pA_value remains populated after renaming

## Testing
- pytest tests/postprocessing/test_activity_extended.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e29a95976483248352c3094ad2c94c