### PR TITLE
Fix isoform export naming for normalized CSV inputs

### DIFF
--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -40,6 +40,8 @@ def normalise_export_basename(path: Path) -> str:
     while name.lower().endswith(tmp_suffix):
         name = name[: -len(tmp_suffix)]
     stem, ext = os.path.splitext(name)
+    if ext.lower() in {".csv_normalized", ".csv_normalised"}:
+        ext = ".csv"
     lowered_stem = stem.lower()
     for suffix in ("_normalized", "_normalised"):
         if lowered_stem.endswith(suffix):

--- a/tests/postprocessing/test_target_postprocessing.py
+++ b/tests/postprocessing/test_target_postprocessing.py
@@ -528,6 +528,22 @@ def test_isoform_process_targets__writes_isoform_prefix(tmp_path: Path, snapshot
 
 
 @pytest.mark.unit
+def test_isoform_process_targets__strips_csv_normalized_suffix(
+    tmp_path: Path, snapshot_resource: Path
+) -> None:
+    source = snapshot_resource / "target_isoform_minimal.csv"
+    input_path = tmp_path / "output.targets_20250101.csv_normalized"
+    input_path.write_bytes(source.read_bytes())
+
+    match = "does not use the canonical '.csv' extension"
+    with pytest.warns(UserWarning, match=match):
+        output_path = isoform.process_targets(str(input_path), verbose=False)
+
+    assert output_path.name == "isoform.output.targets_20250101.csv"
+    assert output_path.parent == input_path.parent
+
+
+@pytest.mark.unit
 def test_isoform_process_targets__accepts_explicit_custom_name(
     tmp_path: Path, snapshot_resource: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- update the isoform export basename normalisation to collapse `.csv_normalized` and `.csv_normalised` extensions to `.csv`
- add a regression test ensuring isoform post-processing writes the canonical filename when the source export uses a `.csv_normalized` suffix

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py::test_isoform_process_targets__strips_csv_normalized_suffix -q

------
https://chatgpt.com/codex/tasks/task_e_68e2a2f6dfe083248b3be65ba7db7c1d