### PR TITLE
Align target post-processing with canonical export path

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -3419,7 +3419,6 @@ def validate_and_write(
     logger.info("validate_write_start", output=str(output))
 
     key_columns = list(id_cols) if id_cols else ["target_chembl_id"]
-    normalized_output = _normalized_output_path(output)
     input_rows = len(df)
 
     if raw_out is not None:
@@ -3559,7 +3558,7 @@ def validate_and_write(
     logger.info("deduplicated_rows", dropped=before_dedup - len(final_df))
     final_csv_path = io.write_csv(
         final_df,
-        normalized_output,
+        output,
         cfg=cfg,
         sep=cfg.io.csv_sep,
         encoding=cfg.io.csv_encoding,
@@ -3598,7 +3597,7 @@ def validate_and_write(
         logger.info(
             "quality_report_skipped",
             reason="empty_dataframe",
-            table=str(normalized_output.with_suffix("")),
+            table=str(output.with_suffix("")),
         )
     else:
         doc_quality_cfg = cfg.system.doc_quality
@@ -3606,8 +3605,8 @@ def validate_and_write(
             if doc_quality_cfg.enable:
                 analyze_table_quality(
                     final_df,
-                    table_name=str(normalized_output.with_suffix("")),
-                    destination_dir=normalized_output.parent,
+                    table_name=str(output.with_suffix("")),
+                    destination_dir=output.parent,
                     sample_rows=doc_quality_cfg.sample_rows,
                     include_columns=doc_quality_cfg.include_columns,
                     exclude_columns=doc_quality_cfg.exclude_columns,
@@ -3616,7 +3615,7 @@ def validate_and_write(
             logger.exception(
                 "quality_report_failed",
                 error=str(exc),
-                path=str(normalized_output),
+                path=str(output),
                 exc=exc,
             )
             return 1

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -310,9 +310,7 @@ def test_pipeline_subset__target_postprocess_sidecars(
         working_output = Path(args.final_out)
         working_output.parent.mkdir(parents=True, exist_ok=True)
         working_output.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
-        normalized = get_target_data._normalized_output_path(working_output)
-        normalized.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
-        get_target_data._postprocess_target_exports(normalized, cfg=cfg_obj)
+        get_target_data._postprocess_target_exports(working_output, cfg=cfg_obj)
         return 0
 
     stream = io.StringIO()

--- a/tests/integration/test_target_isoform_postprocess.py
+++ b/tests/integration/test_target_isoform_postprocess.py
@@ -35,3 +35,14 @@ def test_process_targets__normalises_temp_export_basename(tmp_path: Path) -> Non
     expected = tmp_path / "isoform.output.targets_20251005.csv"
     assert output_path == expected
     assert output_path.exists()
+
+
+def test_process_targets__uses_canonical_output_name(tmp_path: Path) -> None:
+    input_path = tmp_path / "targets.csv"
+    _write_isoform_input(input_path)
+
+    output_path = process_targets(input_csv=str(input_path), verbose=False)
+
+    expected = tmp_path / "isoform.targets.csv"
+    assert output_path == expected
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- write the validated target export directly to the canonical output path and reuse it for auxiliary reports
- ensure the target post-processing integration uses the canonical file name and extend isoform post-process tests for naming

## Testing
- pytest -q tests/postprocessing/test_target_postprocessing.py::test_isoform_process_targets__writes_isoform_prefix
- pytest -q tests/integration/test_target_isoform_postprocess.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a41dfd2083249fb5efb392018327