### PR TITLE
Handle normalised CSV extensions in isoform exports

### DIFF
--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -40,8 +40,14 @@ def normalise_export_basename(path: Path) -> str:
     while name.lower().endswith(tmp_suffix):
         name = name[: -len(tmp_suffix)]
     stem, ext = os.path.splitext(name)
-    if ext.lower() in {".csv_normalized", ".csv_normalised"}:
-        ext = ".csv"
+    ext_lower = ext.lower()
+    for suffix in ("_normalized", "_normalised"):
+        if ext_lower.endswith(suffix):
+            ext = ext[: -len(suffix)] or ""
+            if ext == ".":
+                ext = ""
+            ext_lower = ext.lower()
+            break
     lowered_stem = stem.lower()
     for suffix in ("_normalized", "_normalised"):
         if lowered_stem.endswith(suffix):

--- a/tests/integration/test_target_isoform_postprocess.py
+++ b/tests/integration/test_target_isoform_postprocess.py
@@ -35,3 +35,14 @@ def test_process_targets__normalises_temp_export_basename(tmp_path: Path) -> Non
     expected = tmp_path / "isoform.output.targets_20251005.csv"
     assert output_path == expected
     assert output_path.exists()
+
+
+def test_process_targets__normalises_normalized_extension(tmp_path: Path) -> None:
+    input_path = tmp_path / "output.targets_20251005.csv_normalized"
+    _write_isoform_input(input_path)
+
+    output_path = process_targets(input_csv=str(input_path), verbose=False)
+
+    expected = tmp_path / "isoform.output.targets_20251005.csv"
+    assert output_path == expected
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- extend export basename normalisation to strip *_normalized markers from CSV extensions
- cover isoform target processing with a regression test for .csv_normalized inputs

## Testing
- pytest tests/postprocessing/test_target_postprocessing.py tests/integration/test_target_isoform_postprocess.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a6a4ca208324a65fa4efd13ffcd1