### PR TITLE
Add toggle for activity extended export

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ python scripts/get_data.py \
 | Test item | `python scripts/get_testitem_data.py --input data/input/testitem.csv --final-out output/testitems.csv --request-limit 500 --hierarchy-path config/dictionary/_testitem/molecule_hierarchy.csv` | Provides parent-molecule enrichment controls and request throttling (`--request-limit`, `--batch-size`, `--dry-run`). |
 | Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --output output/cellline.csv --batch-size 20 --limit 100` | Retrieves ChEMBL cell line records, normalises nullable identifiers and enforces deterministic ordering. |
-| Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --action-type-enabled --bounds-enabled --quality-threshold warn` | Toggles enrichment hooks (`--action-type-enabled`, `--bounds-enabled`), derived bounds and QA thresholds. |
+| Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --action-type-enabled --bounds-enabled --quality-threshold warn` | Toggles enrichment hooks (`--action-type-enabled`, `--bounds-enabled`), derived bounds and QA thresholds. Set `sources.chembl.pipelines.activity.generate_extended=false` in the config to skip the extended artefact and keep the legacy CSV only. |
 
 Each pipeline writes a deterministic CSV, a `<name>.meta.yaml` metadata sidecar
 and table-quality reports under the same directory. The target pipeline also

--- a/config.schema.json
+++ b/config.schema.json
@@ -43,6 +43,11 @@
           "default": false,
           "title": "Dry Run",
           "type": "boolean"
+        },
+        "generate_extended": {
+          "default": true,
+          "title": "Generate Extended",
+          "type": "boolean"
         }
       },
       "title": "ActivityCfg",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,6 +40,7 @@ sources:
         timeout: 30.0
         limit: null
         dry_run: false
+        generate_extended: true
       assay:
         column: "assay_chembl_id"
         batch_size: 50

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -11,6 +11,9 @@ sources:
     cache:
       cache_ttl: 900
       cache_maxsize: 256
+    pipelines:
+      activity:
+        generate_extended: false
   pubchem:
     enable: false
   openalex:

--- a/docs/POSTPROCESSING_RUNBOOK.md
+++ b/docs/POSTPROCESSING_RUNBOOK.md
@@ -35,3 +35,13 @@ When introducing new target post-processing modules, document the emitted file
 pattern and confirm that `normalise_export_basename` is used.  This prevents
 divergence between bespoke scripts and the shared automation, keeping the CI
 environment and production scheduler aligned.
+
+## Activity extended export toggle
+
+The activity pipeline invokes `process_activity_extended` once the primary
+`activities.csv` export has been written.  To keep backwards-compatible runs for
+legacy consumers, set `sources.chembl.pipelines.activity.generate_extended`
+to `false` in the configuration.  The script skips the post-processing stage and
+logs an `activity_pipeline_legacy_output` event while still emitting the
+original CSV.  Orchestrators should monitor this log message to distinguish
+between extended artefacts and legacy-only runs.

--- a/library/config.py
+++ b/library/config.py
@@ -1085,8 +1085,9 @@ class ActivityCfg(_BoolModel):
     limit: int | None = Field(default=None, ge=0)
     offset: int = Field(0, ge=0)
     dry_run: bool = False
+    generate_extended: bool = True
 
-    @field_validator("dry_run", mode="before")
+    @field_validator("dry_run", "generate_extended", mode="before")
     @classmethod
     def _bools(cls, v: Any) -> bool:
         return cls._parse_bool(v)

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -612,12 +612,18 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             chunk_failures.save(fetch_failure_path, cfg=cfg)
 
     if exit_code == 0:
-        extended_output_path = process_activity_extended(
-            input_path=output_path,
-            search_dir=output_path.parent,
-            dictionary_dir=cfg.resources.dictionary_dir,
-            targets_csv=cfg.resources.targets_type_csv,
-        )
+        if getattr(cfg.activity, "generate_extended", True):
+            extended_output_path = process_activity_extended(
+                input_path=output_path,
+                search_dir=output_path.parent,
+                dictionary_dir=cfg.resources.dictionary_dir,
+                targets_csv=cfg.resources.targets_type_csv,
+            )
+        else:
+            logger.info(
+                "activity_pipeline_legacy_output",
+                output=str(output_path),
+            )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -109,6 +109,7 @@ def _install_writer_stub(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, pd
 def _configure_cfg(cfg) -> None:
     cfg.activity.limit = None
     cfg.activity.dry_run = False
+    cfg.activity.generate_extended = True
     cfg.activity.batch_size = 5
     cfg.activity.workers = 1
     cfg.system.doc_quality.enable = False
@@ -142,6 +143,45 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     monkeypatch.setattr(get_activity_data, "logger", logger_stub)
     monkeypatch.setattr("library.validation.logger", logger_stub)
 
+    extended_calls: list[dict[str, Path | None]] = []
+
+    def _capture_process_activity_extended(
+        search_dir=None,
+        *,
+        input_path=None,
+        dictionary_dir=None,
+        targets_csv=None,
+        base_dir=None,
+    ) -> Path:
+        search_dir_path = Path(search_dir) if search_dir is not None else None
+        input_path_path = Path(input_path) if input_path is not None else None
+        dictionary_dir_path = (
+            Path(dictionary_dir) if dictionary_dir is not None else None
+        )
+        targets_csv_path = Path(targets_csv) if targets_csv is not None else None
+        extended_calls.append(
+            {
+                "search_dir": search_dir_path,
+                "input_path": input_path_path,
+                "dictionary_dir": dictionary_dir_path,
+                "targets_csv": targets_csv_path,
+            }
+        )
+        assert base_dir is None
+        base_output_dir = search_dir_path or (
+            input_path_path.parent if input_path_path is not None else tmp_path
+        )
+        output = base_output_dir / "extended.output.activities.csv"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text("extended", encoding="utf-8")
+        return output
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "process_activity_extended",
+        _capture_process_activity_extended,
+    )
+
     args = _make_args(input_csv, output_csv)
 
     exit_code = get_activity_data.run_chembl(cfg, args)
@@ -165,6 +205,69 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     assert list(written_df["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
     assert pd.api.types.is_float_dtype(written_df["standard_value"])  # type: ignore[arg-type]
     assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
+
+    assert len(extended_calls) == 1
+    extended_call = extended_calls[0]
+    assert extended_call["input_path"] == output_csv
+    assert extended_call["search_dir"] == output_csv.parent
+    assert extended_call["dictionary_dir"] == cfg.resources.dictionary_dir
+    assert extended_call["targets_csv"] == cfg.resources.targets_type_csv
+
+    done_payload = next(
+        payload for level, event, payload in logger_stub.events if event == "activity_pipeline_done"
+    )
+    assert "extended_output" in done_payload
+    assert not any(
+        event == "activity_pipeline_legacy_output" for _, event, _ in logger_stub.events
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__legacy_mode_skips_extended(
+    activity_resource_dir: Path,
+    cfg,
+    tmp_path,
+    monkeypatch,
+):
+    _configure_cfg(cfg)
+    cfg.activity.generate_extended = False
+
+    input_csv = _copy_resource(activity_resource_dir, "ids_happy.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+
+    captured = _install_fetch_stubs(monkeypatch, chunk_df)
+    written = _install_writer_stub(monkeypatch)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    def _fail_process_activity_extended(*args, **kwargs):  # pragma: no cover - failure guard
+        raise AssertionError("process_activity_extended should not be invoked when disabled")
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "process_activity_extended",
+        _fail_process_activity_extended,
+    )
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    assert {path for path, _ in written} == {output_csv}
+    assert captured == [("ACT1", "ACT2", "ACT3")]
+
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_pipeline_done" in events
+    assert "activity_pipeline_legacy_output" in events
+
+    done_payload = next(
+        payload for level, event, payload in logger_stub.events if event == "activity_pipeline_done"
+    )
+    assert "extended_output" not in done_payload
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add an `activity.generate_extended` configuration flag surfaced through default and example configs
- guard the post-processing step in `get_activity_data` behind the new flag and emit an explicit legacy-output log entry
- document the option in the README and post-processing runbook and extend integration coverage for both extended and legacy modes

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__happy_path tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__legacy_mode_skips_extended -q


------
https://chatgpt.com/codex/tasks/task_e_68e2a911c7e883249bfa3aa8bf0719fb