### PR TITLE
Ensure deterministic activity deduplication

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -102,6 +102,24 @@ _GROUP_KEY_COLUMNS: tuple[str, ...] = (
     "standard_type",
 )
 
+_DEDUPE_SORT_ORDER: tuple[str, ...] = (
+    "completed",
+    "activity_id",
+    "activity_chembl_id",
+    "assay_chembl_id",
+    "document_chembl_id",
+    "standard_type",
+    "standard_value",
+)
+
+_DEDUPE_SUBSET_KEYS: tuple[str, ...] = (
+    "activity_id",
+    "assay_chembl_id",
+    "document_chembl_id",
+    "standard_type",
+    "standard_value",
+)
+
 _FINAL_COLUMN_ORDER: tuple[str, ...] = (
     "activity_chembl_id",
     "saltform_id",
@@ -301,12 +319,14 @@ def _apply_multimol_logic(df: pd.DataFrame) -> pd.DataFrame:
         raise ActivityExtendedError(
             "activity table missing columns for multimol grouping: " + ", ".join(sorted(missing))
         )
+    df = helpers.sort_power_query(df, _GROUP_KEY_COLUMNS)
     counts = (
         df.groupby(list(_GROUP_KEY_COLUMNS), dropna=False)
         .size()
         .rename("Count")
         .reset_index()
     )
+    counts = helpers.sort_power_query(counts, _GROUP_KEY_COLUMNS)
     merged = df.merge(counts, on=list(_GROUP_KEY_COLUMNS), how="left")
     mask = (
         merged["unknown_chirality"].fillna(True).eq(False)
@@ -419,7 +439,7 @@ def _compute_citation_flags(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _annotate_high_citation(df: pd.DataFrame, dictionary_root: Path) -> pd.DataFrame:
-    converted = df.copy()
+    converted = helpers.sort_power_query(df, ("document_chembl_id", "activity_chembl_id"))
     counts = (
         converted.groupby("document_chembl_id")["is_citation"]
         .agg(n_citation="sum", n_non_citation=lambda s: (~s).sum())
@@ -429,6 +449,7 @@ def _annotate_high_citation(df: pd.DataFrame, dictionary_root: Path) -> pd.DataF
     counts = counts[(counts["n_citation"] > 0) & (counts["n_non_citation"] > 0)]
 
     citation_fraction = _load_citation_fraction(dictionary_root)
+    counts = helpers.sort_power_query(counts, ("document_chembl_id",))
     counts = counts.merge(
         citation_fraction[["N", "K_min_significant"]],
         on="N",
@@ -457,6 +478,8 @@ def _merge_target_metadata(
 ) -> pd.DataFrame:
     targets_path = _resolve_targets_path(dictionary_root, targets_override)
     targets = _load_target_metadata(targets_path)
+    df = helpers.sort_power_query(df, ("target_chembl_id", "assay_chembl_id"))
+    targets = helpers.sort_power_query(targets, ("target_chembl_id",))
     merged = df.merge(targets, on="target_chembl_id", how="left")
     merged = merged.loc[:, ~merged.columns.duplicated()]
 
@@ -511,6 +534,49 @@ def _select_and_cast(df: pd.DataFrame) -> pd.DataFrame:
         if column in result.columns:
             result[column] = _safe_to_bool(result[column], column)
     return result
+
+
+def dedupe_final(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` sorted and deduplicated using Power Query key rules."""
+
+    if df.empty:
+        logger.info("activity_extended_deduplicated", removed=0, remaining=0)
+        return df.copy()
+
+    sort_candidates: list[str] = []
+    for column in _DEDUPE_SORT_ORDER:
+        if column == "activity_id":
+            options = ("activity_id", "activity_chembl_id")
+        else:
+            options = (column,)
+        for option in options:
+            if option in df.columns and option not in sort_candidates:
+                sort_candidates.append(option)
+                break
+
+    sorted_df = helpers.sort_power_query(df, sort_candidates) if sort_candidates else df.copy()
+
+    subset: list[str] = []
+    missing: list[str] = []
+    for column in _DEDUPE_SUBSET_KEYS:
+        options = ("activity_id", "activity_chembl_id") if column == "activity_id" else (column,)
+        selected = next((candidate for candidate in options if candidate in sorted_df.columns), None)
+        if selected is None:
+            missing.append(column)
+        else:
+            if selected not in subset:
+                subset.append(selected)
+
+    if missing:
+        raise ActivityExtendedError(
+            "activity table missing columns required for deduplication: "
+            + ", ".join(sorted(missing))
+        )
+
+    deduped = sorted_df.drop_duplicates(subset=subset, keep="first").reset_index(drop=True)
+    removed = int(len(sorted_df) - len(deduped))
+    logger.info("activity_extended_deduplicated", removed=removed, remaining=len(deduped))
+    return deduped
 
 
 def _string_missing_mask(series: pd.Series) -> pd.Series:
@@ -820,6 +886,7 @@ def process_activity_extended(
             non_null=non_null,
             total=len(processed),
         )
+    processed = dedupe_final(processed)
     logger.info("activity_extended_saving", path=str(output_path))
     helpers.write_csv(processed, output_path, columns=_FINAL_COLUMN_ORDER)
     logger.info(

--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -145,6 +145,23 @@ def write_csv(frame: pd.DataFrame, path: Path, *, columns: Sequence[str]) -> Pat
     )
 
 
+def sort_power_query(frame: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    """Return ``frame`` sorted by ``columns`` using Power Query compatible rules."""
+
+    if frame.empty:
+        return frame.copy()
+
+    seen: list[str] = []
+    for column in columns:
+        if column in frame.columns and column not in seen:
+            seen.append(column)
+
+    if not seen:
+        return frame.copy()
+
+    return frame.sort_values(by=seen, kind="mergesort", na_position="last").reset_index(drop=True)
+
+
 def fill_missing(frame: pd.DataFrame, columns: Iterable[str], fill_value: str = "-") -> pd.DataFrame:
     """Fill ``columns`` missing from ``frame`` with ``fill_value``."""
 

--- a/tests/integration/test_activity_extended_integration.py
+++ b/tests/integration/test_activity_extended_integration.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import logging
 import os
 import random
+from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from library.postprocessing.activity_extended import process_activity_extended
@@ -17,6 +20,51 @@ def _fix_seed(seed: int = 42) -> None:
     os.environ["PYTHONHASHSEED"] = str(seed)
     random.seed(seed)
     np.random.seed(seed)
+
+
+def _prepare_dictionary(dictionary_root: Path) -> None:
+    activity_subdir = dictionary_root / "_activity"
+    activity_subdir.mkdir(parents=True, exist_ok=True)
+    with (activity_subdir / "citation_fraction.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["N", "K_min_significant"])
+        writer.writeheader()
+        writer.writerow({"N": "1", "K_min_significant": "1"})
+
+    targets_subdir = dictionary_root / "_target"
+    targets_subdir.mkdir(parents=True, exist_ok=True)
+    with (targets_subdir / "targets_type.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "target_chembl_id",
+                "target_sort_order",
+                "multifunctional_enzyme",
+                "IUPHAR_class",
+                "IUPHAR_subclass",
+                "genus",
+                "superkingdom",
+                "phylum",
+                "taxon_id",
+                "gene_index",
+                "taxon_index",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "target_chembl_id": "CHEMBLT1",
+                "target_sort_order": "1",
+                "multifunctional_enzyme": "false",
+                "IUPHAR_class": "ClassA",
+                "IUPHAR_subclass": "SubclassA",
+                "genus": "Candida",
+                "superkingdom": "Eukaryota",
+                "phylum": "Ascomycota",
+                "taxon_id": "1234",
+                "gene_index": "GENE1",
+                "taxon_index": "TAX1",
+            }
+        )
 
 
 @pytest.mark.integration
@@ -64,48 +112,7 @@ def test_process_activity_extended__fills_missing_optional_columns(tmp_path, cap
             }
         )
 
-    activity_subdir = dictionary_root / "_activity"
-    activity_subdir.mkdir(parents=True)
-    with (activity_subdir / "citation_fraction.csv").open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=["N", "K_min_significant"])
-        writer.writeheader()
-        writer.writerow({"N": "1", "K_min_significant": "1"})
-
-    targets_subdir = dictionary_root / "_target"
-    targets_subdir.mkdir(parents=True)
-    with (targets_subdir / "targets_type.csv").open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(
-            handle,
-            fieldnames=[
-                "target_chembl_id",
-                "target_sort_order",
-                "multifunctional_enzyme",
-                "IUPHAR_class",
-                "IUPHAR_subclass",
-                "genus",
-                "superkingdom",
-                "phylum",
-                "taxon_id",
-                "gene_index",
-                "taxon_index",
-            ],
-        )
-        writer.writeheader()
-        writer.writerow(
-            {
-                "target_chembl_id": "CHEMBLT1",
-                "target_sort_order": "1",
-                "multifunctional_enzyme": "false",
-                "IUPHAR_class": "ClassA",
-                "IUPHAR_subclass": "SubclassA",
-                "genus": "Candida",
-                "superkingdom": "Eukaryota",
-                "phylum": "Ascomycota",
-                "taxon_id": "1234",
-                "gene_index": "GENE1",
-                "taxon_index": "TAX1",
-            }
-        )
+    _prepare_dictionary(dictionary_root)
 
     with caplog.at_level(logging.WARNING):
         output_path = process_activity_extended(
@@ -123,3 +130,120 @@ def test_process_activity_extended__fills_missing_optional_columns(tmp_path, cap
     message = filled_warnings[0].message
     for column_name in ("activity_chembl_id", "compound_key", "log_value"):
         assert column_name in message
+
+
+@pytest.mark.integration
+def test_process_activity_extended__deduplicates_and_deterministic(tmp_path, caplog):
+    """Remove duplicate activities and produce deterministic output."""
+
+    _fix_seed()
+
+    activity_dir = tmp_path / "input"
+    dictionary_root = tmp_path / "dictionary"
+    activity_dir.mkdir()
+
+    _prepare_dictionary(dictionary_root)
+
+    activity_path = activity_dir / "output.activities_20240102.csv"
+    activity_columns = [
+        "activity_id",
+        "molecule_chembl_id",
+        "target_chembl_id",
+        "assay_chembl_id",
+        "document_chembl_id",
+        "bao_endpoint",
+        "standard_type",
+        "standard_value",
+        "bao_format",
+        "parent_molecule_chembl_id",
+        "molecule_pref_name",
+        "pchembl_value",
+    ]
+    records = [
+        {
+            "activity_id": "101",
+            "molecule_chembl_id": "CHEMBL1",
+            "target_chembl_id": "CHEMBLT1",
+            "assay_chembl_id": "ASSAY1",
+            "document_chembl_id": "DOC1",
+            "bao_endpoint": "endpoint",
+            "standard_type": "IC50",
+            "standard_value": "5.0",
+            "bao_format": "format",
+            "parent_molecule_chembl_id": "CHEMBL1",
+            "molecule_pref_name": "Compound One",
+            "pchembl_value": "7.0",
+        },
+        {
+            "activity_id": "101",
+            "molecule_chembl_id": "CHEMBL1",
+            "target_chembl_id": "CHEMBLT1",
+            "assay_chembl_id": "ASSAY1",
+            "document_chembl_id": "DOC1",
+            "bao_endpoint": "endpoint",
+            "standard_type": "IC50",
+            "standard_value": "5.0",
+            "bao_format": "format",
+            "parent_molecule_chembl_id": "CHEMBL1",
+            "molecule_pref_name": "Compound Duplicate",
+            "pchembl_value": "7.1",
+        },
+        {
+            "activity_id": "102",
+            "molecule_chembl_id": "CHEMBL2",
+            "target_chembl_id": "CHEMBLT1",
+            "assay_chembl_id": "ASSAY2",
+            "document_chembl_id": "DOC2",
+            "bao_endpoint": "endpoint",
+            "standard_type": "EC50",
+            "standard_value": "1.5",
+            "bao_format": "format",
+            "parent_molecule_chembl_id": "CHEMBL2",
+            "molecule_pref_name": "Compound Two",
+            "pchembl_value": "6.0",
+        },
+    ]
+    with activity_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=activity_columns)
+        writer.writeheader()
+        writer.writerows(records)
+
+    with caplog.at_level(logging.INFO):
+        output_path = process_activity_extended(
+            input_path=activity_path,
+            dictionary_dir=dictionary_root,
+        )
+
+    assert output_path.exists()
+
+    output_df = pd.read_csv(output_path)
+    subset = [
+        "activity_chembl_id",
+        "assay_chembl_id",
+        "document_chembl_id",
+        "standard_type",
+        "standard_value",
+    ]
+    assert set(subset).issubset(output_df.columns)
+    assert len(output_df) == 2
+    assert not output_df.duplicated(subset=subset).any()
+
+    expected_sorted = output_df.sort_values(by=subset, kind="mergesort").reset_index(drop=True)
+    pd.testing.assert_frame_equal(output_df.reset_index(drop=True), expected_sorted)
+
+    dedupe_records = [
+        record for record in caplog.records if "activity_extended_deduplicated" in record.message
+    ]
+    assert dedupe_records, "Expected deduplication log not emitted"
+    assert "removed=1" in dedupe_records[0].message
+
+    first_hash = hashlib.sha256(output_path.read_bytes()).hexdigest()
+
+    caplog.clear()
+    second_output = process_activity_extended(
+        input_path=activity_path,
+        dictionary_dir=dictionary_root,
+    )
+    assert second_output == output_path
+    second_hash = hashlib.sha256(output_path.read_bytes()).hexdigest()
+    assert second_hash == first_hash


### PR DESCRIPTION
## Summary
- add a Power Query-compatible sort helper and integrate it into the activity extended pipeline
- introduce `dedupe_final` to drop duplicate activity rows and log removals before emitting the CSV
- extend the activity extended integration suite to cover duplicate handling and deterministic outputs

## Testing
- pytest tests/integration/test_activity_extended_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e2beb5d4148324b5d0f828c05914d4