### PR TITLE
Handle legacy document identifiers in activity post-processing

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -340,17 +340,47 @@ def _load_document_lookup(dictionary_root: Path) -> pd.DataFrame:
         )
 
     frame: pd.DataFrame | None = None
+    missing_errors: list[str] = []
     for sep in (",", "\t"):
         try:
             candidate_frame = helpers.read_csv_with_fallbacks(candidate, sep=sep)
-        except Exception:
+        except Exception as exc:
+            missing_errors.append(f"sep='{sep}': {exc!s}")
             continue
+
+        resolved_columns: dict[str, str] = {}
+        for column in candidate_frame.columns:
+            normalised = column.strip().lower()
+            if normalised == "document_chembl_id":
+                resolved_columns[column] = "document_chembl_id"
+            elif normalised in {"chembl.document_chembl_id", "chembl.document chembl id"}:
+                resolved_columns[column] = "document_chembl_id"
+
+        if resolved_columns:
+            candidate_frame = candidate_frame.rename(columns=resolved_columns)
+            alias_source = [src for src, dst in resolved_columns.items() if dst == "document_chembl_id" and src != dst]
+            if alias_source:
+                logger.warning(
+                    "Renamed document identifier column(s) %s to 'document_chembl_id'. "
+                    "Update the dictionary export to align with the expected schema.",
+                    alias_source,
+                )
+
         if "document_chembl_id" in candidate_frame.columns:
             frame = candidate_frame
             break
+
+        missing_errors.append(
+            "sep='{}': available columns -> {}".format(
+                sep, ", ".join(candidate_frame.columns) or "<none>"
+            )
+        )
+
     if frame is None:
+        detail = "; ".join(missing_errors)
         raise ActivityExtendedError(
             "document.csv missing required 'document_chembl_id' column; unable to join document metadata"
+            + (f". {detail}" if detail else "")
         )
 
     columns = ["document_chembl_id", "completed", "review"]

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -16,6 +16,7 @@ from library.postprocessing.activity_extended import (
     _apply_multimol_logic,
     _derive_output_path,
     _latest_activity_export,
+    _load_document_lookup,
     _load_citation_fraction,
     _load_target_metadata,
     _prepare_unknown_chirality,
@@ -81,6 +82,45 @@ def activity_resources(snapshot_resource: Path) -> Path:
 def _copytree(src: Path, dst: Path) -> Path:
     shutil.copytree(src, dst)
     return dst
+
+
+def test_load_document_lookup__renames_legacy_identifier(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    dictionary_root = tmp_path
+    document_dir = dictionary_root / "_document"
+    document_dir.mkdir(parents=True)
+
+    frame = pd.DataFrame(
+        {
+            "ChEMBL.document_chembl_id": pd.Series(["DOC-1", "DOC-2"], dtype="string"),
+            "completed": pd.Series(["yes", "no"], dtype="string"),
+        }
+    )
+    frame.to_csv(document_dir / "document.csv", index=False, sep="\t", encoding="cp1252")
+
+    with caplog.at_level("WARNING"):
+        lookup = _load_document_lookup(dictionary_root)
+
+    assert lookup.columns.tolist() == ["document_chembl_id", "completed", "review"]
+    assert lookup["document_chembl_id"].tolist() == ["DOC-1", "DOC-2"]
+    assert lookup["review"].isna().all()
+    assert "Renamed document identifier column" in caplog.text
+
+
+def test_load_document_lookup__missing_identifier_reports_available_columns(tmp_path: Path) -> None:
+    dictionary_root = tmp_path
+    document_dir = dictionary_root / "_document"
+    document_dir.mkdir(parents=True)
+
+    pd.DataFrame({"identifier": ["DOC-1"]}).to_csv(
+        document_dir / "document.csv", index=False, sep=",", encoding="utf-8"
+    )
+
+    with pytest.raises(ActivityExtendedError) as excinfo:
+        _load_document_lookup(dictionary_root)
+
+    message = str(excinfo.value)
+    assert "identifier" in message
+    assert "available columns" in message
 
 
 def test_augment_activity_frame__fills_existing_blanks() -> None:


### PR DESCRIPTION
## Summary
- normalise legacy document identifier columns when loading the document dictionary and include column listings in error messages
- add regression coverage for alias renaming and missing identifier diagnostics in the activity post-processing tests

## Testing
- pytest tests/postprocessing/test_activity_extended.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2dc633cf08324a13b5f494ab07642