### PR TITLE
Handle latin-1 dictionary exports

### DIFF
--- a/library/postprocessing/helpers.py
+++ b/library/postprocessing/helpers.py
@@ -25,7 +25,12 @@ from library.common.csv_utils import write_csv_deterministic
 
 # Accepted encodings – these match the Power Query ``Binary.Decompress`` fallbacks
 # that were historically used when loading the aggregated targets table.
-ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252")
+# ``latin-1`` is included as the final fallback because a handful of legacy
+# dictionary exports produced by Power Query use extended control characters
+# (e.g. ``0x81``) that are not representable in ``cp1252``.  The ISO-8859-1
+# codec accepts these bytes and preserves them verbatim so the downstream
+# normalisation logic can continue operating deterministically.
+ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8", "utf-8-sig", "cp1252", "latin-1")
 CSV_SEPARATORS: tuple[str, ...] = (",", "\t", ";")
 
 

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -106,6 +106,25 @@ def test_load_document_lookup__renames_legacy_identifier(tmp_path: Path, caplog:
     assert "Renamed document identifier column" in caplog.text
 
 
+def test_load_document_lookup__latin1_encoding_fallback(tmp_path: Path) -> None:
+    dictionary_root = tmp_path
+    document_dir = dictionary_root / "_document"
+    document_dir.mkdir(parents=True)
+
+    frame = pd.DataFrame(
+        {
+            "document_chembl_id": pd.Series(["DOC-1"], dtype="string"),
+            "completed": pd.Series(["value\x81with_control"], dtype="string"),
+        }
+    )
+    frame.to_csv(document_dir / "document.csv", index=False, sep="\t", encoding="latin-1")
+
+    lookup = _load_document_lookup(dictionary_root)
+
+    assert lookup.loc[0, "document_chembl_id"] == "DOC-1"
+    assert lookup.loc[0, "completed"] == "value\x81with_control"
+
+
 def test_load_document_lookup__missing_identifier_reports_available_columns(tmp_path: Path) -> None:
     dictionary_root = tmp_path
     document_dir = dictionary_root / "_document"


### PR DESCRIPTION
## Summary
- extend the CSV encoding fallbacks with latin-1 so dictionary exports containing extended control bytes continue to load
- add a regression test covering latin-1 encoded document dictionaries

## Testing
- pytest tests/postprocessing/test_activity_extended.py::test_load_document_lookup__latin1_encoding_fallback -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e36e73608324b88e09289c012deb