### PR TITLE
Handle missing unicellular flag in target metadata

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -227,6 +227,15 @@ _TARGET_COLUMNS: Sequence[str] = (
     "unicellular_organism",
 )
 
+_UNICELLULAR_NORMALISATIONS: Mapping[str, bool] = {
+    "unicellular": True,
+    "unicellular organism": True,
+    "multicellular": False,
+    "multicellular organism": False,
+}
+
+_NA_TYPE = type(pd.NA)
+
 
 class ActivityExtendedError(RuntimeError):
     """Raised when the activity extended post-processing cannot proceed."""
@@ -323,6 +332,32 @@ def _load_target_metadata(path: Path) -> pd.DataFrame:
         na_values=_NA_MARKERS,
     )
     frame = frame.rename(columns={"target_sort_order": "sortorder.target"})
+
+    if "unicellular_organism" not in frame.columns and "organism_type" in frame.columns:
+        frame = frame.copy()
+
+        unmapped_values: set[str] = set()
+
+        def _normalise_organism(value: object) -> bool | _NA_TYPE:
+            if pd.isna(value):
+                return pd.NA
+            text = str(value).strip()
+            if not text:
+                return pd.NA
+            resolved = _UNICELLULAR_NORMALISATIONS.get(text.casefold())
+            if resolved is None:
+                unmapped_values.add(text)
+                return pd.NA
+            return resolved
+
+        inferred = frame["organism_type"].map(_normalise_organism).astype("boolean")
+        if unmapped_values:
+            logger.warning(
+                "targets_type.csv contains organism_type values without boolean mapping: %s",
+                sorted(unmapped_values),
+            )
+        frame["unicellular_organism"] = inferred
+
     missing = [column for column in _TARGET_COLUMNS if column not in frame.columns]
     if missing:
         raise ActivityExtendedError(

--- a/tests/postprocessing/test_activity_extended.py
+++ b/tests/postprocessing/test_activity_extended.py
@@ -25,6 +25,7 @@ from library.postprocessing.activity_extended import (
     _select_and_cast,
     _transform_activity_frame,
     _augment_activity_frame,
+    _TARGET_COLUMNS,
 )
 
 pytestmark = pytest.mark.postprocessing
@@ -296,6 +297,27 @@ def test_load_target_metadata__cp1252_roundtrip(tmp_path: Path) -> None:
     assert frame["unicellular_organism"].dtype == "boolean"
     assert frame["taxon_id"].dtype == "Int64"
     assert frame["multifunctional_enzyme"].dtype == "boolean"
+
+
+def test_load_target_metadata__derives_unicellular_flag(tmp_path: Path) -> None:
+    target_path = tmp_path / "targets_type.csv"
+    target_path.write_text(
+        (
+            "target_chembl_id,target_sort_order,multifunctional_enzyme,IUPHAR_class,"
+            "IUPHAR_subclass,genus,superkingdom,phylum,taxon_id,gene_index,taxon_index,"
+            "organism_type\n"
+            "CHEMBL1,001,FALSE,ClassA,SubclassA,Homo,Eukaryota,Chordata,9606,G1,T1,Multicellular organism\n"
+            "CHEMBL2,002,TRUE,ClassB,SubclassB,Escherichia,Bacteria,Proteobacteria,83333,G2,T2,Unicellular organism\n"
+        ),
+        encoding="utf-8",
+    )
+
+    frame = _load_target_metadata(target_path)
+
+    assert list(frame.columns) == list(_TARGET_COLUMNS)
+    assert frame.loc[0, "unicellular_organism"].item() is False
+    assert frame.loc[1, "unicellular_organism"].item() is True
+    assert frame["unicellular_organism"].dtype == "boolean"
 
 
 def test_resolve_targets_path__uses_override(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- derive the `unicellular_organism` flag when dictionaries only expose the legacy `organism_type` column
- warn when target dictionaries contain organism types without a known boolean mapping
- extend the activity post-processing tests with coverage for the fallback behaviour

## Testing
- pytest tests/postprocessing/test_activity_extended.py -k "unicellular" -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e7893a6883248b89085cf861ab80