### PR TITLE
Handle unicellular target metadata aliases

### DIFF
--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -99,6 +99,23 @@ _ACTIVITY_INPUT_SCHEMA: Mapping[str, str] = {
     if dtype in {"string", "boolean", "Int64", "Float64"}
 }
 
+def _normalise_column_key(name: str) -> str:
+    """Return a canonical key used to match column aliases."""
+
+    return re.sub(r"[^0-9a-z]+", "_", str(name).strip().lower()).strip("_")
+
+
+def _lookup_column_name(frame: pd.DataFrame, *candidates: str) -> str | None:
+    """Return the actual column name matching one of ``candidates``."""
+
+    normalised = {_normalise_column_key(column): column for column in frame.columns}
+    for candidate in candidates:
+        key = _normalise_column_key(candidate)
+        if key in normalised:
+            return normalised[key]
+    return None
+
+
 _TARGET_METADATA_READ_SCHEMA: Mapping[str, str] = {
     "target_chembl_id": "Text",
     "target_sort_order": "Text",
@@ -322,12 +339,11 @@ def _load_target_metadata(path: Path) -> pd.DataFrame:
         dtype_map=_TARGET_METADATA_READ_SCHEMA,
         na_values=_NA_MARKERS,
     )
+    alias = _lookup_column_name(frame, "unicellular_organism", "unicellular organism")
+    if alias is not None and alias != "unicellular_organism":
+        frame = frame.rename(columns={alias: "unicellular_organism"})
     if "unicellular_organism" not in frame.columns:
-        source_column: str | None = None
-        for candidate in ("type", "organism_type"):
-            if candidate in frame.columns:
-                source_column = candidate
-                break
+        source_column = _lookup_column_name(frame, "type", "organism_type", "organism type")
         if source_column is not None:
             source = frame[source_column].astype("string")
             normalised = source.str.strip().str.lower()

--- a/tests/unit/postprocessing/test_activity_extended_targets.py
+++ b/tests/unit/postprocessing/test_activity_extended_targets.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from library.postprocessing.activity_extended import _load_target_metadata
+
+
+def _write_target_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    columns = [
+        "target_chembl_id",
+        "target_sort_order",
+        "multifunctional_enzyme",
+        "IUPHAR_class",
+        "IUPHAR_subclass",
+        "genus",
+        "superkingdom",
+        "phylum",
+        "taxon_id",
+        "gene_index",
+        "taxon_index",
+    ]
+    if rows and "Organism Type" in rows[0]:
+        columns.append("Organism Type")
+    elif rows and "Unicellular organism" in rows[0]:
+        columns.append("Unicellular organism")
+    else:
+        columns.append("unicellular_organism")
+
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: row.get(column, "") for column in columns})
+
+
+def _base_row(**overrides: object) -> dict[str, object]:
+    base = {
+        "target_chembl_id": "CHEMBL1",
+        "target_sort_order": "001",
+        "multifunctional_enzyme": "FALSE",
+        "IUPHAR_class": "Class",
+        "IUPHAR_subclass": "Subclass",
+        "genus": "Genus",
+        "superkingdom": "Bacteria",
+        "phylum": "Firmicutes",
+        "taxon_id": 9606,
+        "gene_index": "GENE",
+        "taxon_index": "9606",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_load_target_metadata__derives_unicellular_from_type_alias(tmp_path: Path) -> None:
+    csv_path = tmp_path / "targets.csv"
+    _write_target_csv(
+        csv_path,
+        [
+            _base_row(**{"Organism Type": "Unicellular organism"}),
+            _base_row(target_chembl_id="CHEMBL2", **{"Organism Type": "Multicellular organism"}),
+        ],
+    )
+
+    frame = _load_target_metadata(csv_path)
+
+    assert list(frame.columns) == [
+        "target_chembl_id",
+        "sortorder.target",
+        "multifunctional_enzyme",
+        "IUPHAR_class",
+        "IUPHAR_subclass",
+        "genus",
+        "superkingdom",
+        "phylum",
+        "taxon_id",
+        "gene_index",
+        "taxon_index",
+        "unicellular_organism",
+    ]
+    assert frame["unicellular_organism"].tolist() == [True, False]
+
+
+def test_load_target_metadata__normalises_unicellular_column_name(tmp_path: Path) -> None:
+    csv_path = tmp_path / "targets.csv"
+    _write_target_csv(
+        csv_path,
+        [
+            _base_row(**{"Unicellular organism": True}),
+            _base_row(target_chembl_id="CHEMBL2", **{"Unicellular organism": False}),
+        ],
+    )
+
+    frame = _load_target_metadata(csv_path)
+
+    assert "unicellular_organism" in frame.columns
+    assert str(frame["unicellular_organism"].dtype) in {"boolean", "bool"}
+    assert frame["unicellular_organism"].tolist() == [True, False]


### PR DESCRIPTION
## Summary
- normalise target metadata column lookups to accept legacy aliases and case variations for the unicellular flag
- add unit tests covering target metadata loading when the CSV uses alias column names

## Testing
- pytest tests/unit/postprocessing/test_activity_extended_targets.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e8bec6e8832496a75e2b9b72eef3