### PR TITLE
Align run_test_suite reports with reporting spec

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -6,8 +6,11 @@ import argparse
 import json
 import logging
 import os
-from dataclasses import dataclass, asdict
-from datetime import datetime
+import platform
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -15,20 +18,45 @@ import pytest
 
 
 SUCCESS_RATE_THRESHOLD = 0.95
+REPO_FALLBACK = "SatoryKono/ChEMBL_data_acquisition"
 
 
 logger = logging.getLogger(__name__)
+
+
+_STATUS_PRIORITY: dict[str, int] = {
+    "passed": 0,
+    "xpassed": 1,
+    "skipped": 2,
+    "xfailed": 3,
+    "failed": 4,
+    "error": 5,
+    "pending": -1,
+}
 
 
 @dataclass
 class TestResult:
     """Serializable representation of a single pytest outcome."""
 
-    name: str
-    status: str
-    duration: float
-    message: str
-    log_path: str | None
+    nodeid: str
+    status: str = "pending"
+    duration_ms: float = 0.0
+    stdout: str = ""
+    stderr: str = ""
+    log: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodeid": self.nodeid,
+            "status": self.status if self.status != "pending" else "error",
+            "duration_ms": round(self.duration_ms, 3),
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "log": self.log,
+            "error": self.error,
+        }
 
 
 class JsonReportPlugin:
@@ -37,34 +65,90 @@ class JsonReportPlugin:
     def __init__(self, log_path: Path) -> None:
         self._log_path = log_path
         self._results: dict[str, TestResult] = {}
+        self._started_at: float | None = None
+        self._finished_at: float | None = None
+
+    def pytest_sessionstart(self, session: pytest.Session) -> None:  # type: ignore[override]
+        self._started_at = time.perf_counter()
+
+    def pytest_sessionfinish(self, session: pytest.Session) -> None:  # type: ignore[override]
+        self._finished_at = time.perf_counter()
 
     def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:  # type: ignore[override]
+        if report.when not in {"setup", "call", "teardown"}:
+            return
+
         entry = self._results.get(report.nodeid)
         if entry is None:
-            entry = TestResult(
-                name=report.nodeid,
-                status="passed",
-                duration=0.0,
-                message="",
-                log_path=str(self._log_path) if self._log_path else None,
-            )
+            entry = TestResult(nodeid=report.nodeid)
             self._results[report.nodeid] = entry
 
-        entry.duration += report.duration
+        entry.duration_ms += max(report.duration * 1000.0, 0.0)
+        entry.stdout += getattr(report, "capstdout", "") or ""
+        entry.stderr += getattr(report, "capstderr", "") or ""
 
-        if report.outcome == "failed":
-            entry.status = "failed"
-            entry.message = _format_longrepr(report.longrepr)
-        elif report.outcome == "skipped":
-            entry.status = "skipped"
-            entry.message = _format_longrepr(report.longrepr)
+        caplog = getattr(report, "caplog", None)
+        if caplog:
+            entry.log.append(caplog)
+
+        for section_name, content in getattr(report, "sections", []):
+            if "Captured log" in section_name:
+                entry.log.append(content)
+
+        status, message = _status_from_report(report)
+        if status is None:
+            return
+
+        if _STATUS_PRIORITY.get(status, 0) >= _STATUS_PRIORITY.get(entry.status, -1):
+            entry.status = status
+            entry.error = message
 
     @property
     def results(self) -> list[TestResult]:
-        return list(self._results.values())
+        ordered = sorted(self._results.values(), key=lambda item: item.nodeid)
+        return ordered
+
+    @property
+    def duration_seconds(self) -> float:
+        if self._started_at is None:
+            return 0.0
+        end = self._finished_at if self._finished_at is not None else time.perf_counter()
+        return max(end - self._started_at, 0.0)
+
+
+def _status_from_report(report: pytest.TestReport) -> tuple[str | None, str | None]:
+    message: str | None = None
+    status: str | None = None
+
+    if report.when == "setup" and report.outcome == "failed":
+        status = "error"
+        message = _format_longrepr(report.longrepr)
+    elif report.when == "teardown" and report.outcome == "failed":
+        status = "error"
+        message = _format_longrepr(report.longrepr)
+    elif report.outcome == "skipped":
+        status = "xfailed" if getattr(report, "wasxfail", None) else "skipped"
+        message = _format_longrepr(report.longrepr)
+    elif report.when == "call":
+        if report.outcome == "failed":
+            if getattr(report, "wasxfail", None):
+                status = "xfailed"
+                message = str(report.wasxfail)
+            else:
+                status = "failed"
+                message = _format_longrepr(report.longrepr)
+        elif report.outcome == "passed":
+            if getattr(report, "wasxfail", None):
+                status = "xpassed"
+                message = str(report.wasxfail)
+            else:
+                status = "passed"
+    return status, message
 
 
 def _format_longrepr(longrepr: Any) -> str:
+    if longrepr is None:
+        return ""
     if isinstance(longrepr, tuple) and len(longrepr) == 3:
         return str(longrepr[2])
     if hasattr(longrepr, "longreprtext"):
@@ -74,92 +158,135 @@ def _format_longrepr(longrepr: Any) -> str:
 
 def summarize_results(results: Sequence[TestResult]) -> dict[str, Any]:
     total = len(results)
-    passed = sum(1 for item in results if item.status == "passed")
-    failed = sum(1 for item in results if item.status == "failed")
-    skipped = sum(1 for item in results if item.status == "skipped")
-    duration = sum(item.duration for item in results)
-    success_rate = 1.0 if total == 0 else passed / total
+    counts = {
+        "passed": 0,
+        "failed": 0,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0,
+        "error": 0,
+    }
+    for item in results:
+        status = item.status if item.status != "pending" else "error"
+        if status in counts:
+            counts[status] += 1
+    success_rate = 1.0 if total == 0 else counts["passed"] / total
 
     return {
         "total": total,
-        "passed": passed,
-        "failed": failed,
-        "skipped": skipped,
-        "duration": duration,
+        **counts,
         "success_rate": success_rate,
     }
 
 
-def _write_json(report_path: Path, results: Sequence[TestResult], exit_code: int, summary: dict[str, Any]) -> None:
-    payload = {
-        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        "exit_code": exit_code,
-        "summary": summary,
-        "tests": [asdict(result) for result in results],
+def _git_output(args: Sequence[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+    return completed.stdout.strip()
+
+
+def _normalise_repo_name(remote: str) -> str | None:
+    remote = remote.strip()
+    if not remote:
+        return None
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+    if remote.startswith("git@"):
+        parts = remote.split(":", 1)
+        if len(parts) == 2:
+            return parts[1]
+    if remote.startswith("https://") or remote.startswith("http://"):
+        parts = remote.split("//", 1)[-1].split("/", 1)
+        if len(parts) == 2:
+            return parts[1]
+    if "/" in remote:
+        return remote
+    return None
+
+
+def _gather_meta(duration_sec: float) -> dict[str, Any]:
+    remote = _git_output(["config", "--get", "remote.origin.url"])
+    repo_name = _normalise_repo_name(remote) or REPO_FALLBACK
+    commit = _git_output(["rev-parse", "HEAD"]) or "unknown"
+    branch = _git_output(["rev-parse", "--abbrev-ref", "HEAD"]) or "unknown"
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    return {
+        "repo": repo_name,
+        "commit": commit,
+        "branch": branch,
+        "ts_utc": timestamp,
+        "duration_sec": round(duration_sec, 3),
+        "python": platform.python_version(),
+        "pytest": pytest.__version__,
     }
+
+
+def _build_report(results: Sequence[TestResult], *, duration_sec: float) -> dict[str, Any]:
+    summary = summarize_results(results)
+    meta = _gather_meta(duration_sec)
+    return {
+        "meta": meta,
+        "summary": summary,
+        "tests": [result.to_dict() for result in results],
+    }
+
+
+def _write_json(report_path: Path, payload: dict[str, Any]) -> None:
     report_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
-def _write_summary(
-    summary_path: Path,
-    results: Sequence[TestResult],
-    exit_code: int,
-    summary: dict[str, Any],
-) -> None:
-    total = summary["total"]
-    passed = summary["passed"]
-    failed = summary["failed"]
-    skipped = summary["skipped"]
-    duration = summary["duration"]
+def _write_summary(summary_path: Path, payload: dict[str, Any]) -> None:
+    meta = payload["meta"]
+    summary = payload["summary"]
+
     success_rate = summary["success_rate"] * 100
+    duration = meta.get("duration_sec", 0.0)
 
     lines = [
-        "# Test suite summary",
+        "# Test Summary",
         "",
-        f"* Generated at: {datetime.utcnow().isoformat(timespec='seconds')}Z",
-        f"* Exit code: {exit_code}",
-        f"* Tests collected: {total}",
-        f"* Passed: {passed}",
-        f"* Failed: {failed}",
-        f"* Skipped: {skipped}",
-        f"* Cumulative duration: {duration:.2f}s",
-        f"* Success rate: {success_rate:.2f}%",
+        f"- Repo: `{meta['repo']}`",
+        f"- Commit: {meta['commit']}",
+        f"- Branch: {meta['branch']}",
+        f"- Timestamp (UTC): {meta['ts_utc']}",
+        f"- Duration: {duration:.3f} s",
+        f"- Success rate: {success_rate:.2f}%",
         "",
-        "## Failing tests" if failed else "## Failing tests",
+        "| total | passed | failed | skipped | xfailed | xpassed | error |",
+        "|------:|-------:|-------:|--------:|--------:|--------:|------:|",
+        "| {total:5d} | {passed:5d} | {failed:5d} | {skipped:6d} | {xfailed:6d} | {xpassed:6d} | {error:5d} |".format(
+            total=summary["total"],
+            passed=summary["passed"],
+            failed=summary["failed"],
+            skipped=summary["skipped"],
+            xfailed=summary["xfailed"],
+            xpassed=summary["xpassed"],
+            error=summary["error"],
+        ),
+        "",
+        "## Failed / Error details",
     ]
 
-    if failed:
-        for item in results:
-            if item.status != "failed":
-                continue
-            lines.extend(
-                [
-                    f"- `{item.name}` ({item.duration:.2f}s)",
-                    f"  - Log: `{item.log_path}`" if item.log_path else "  - Log: not captured",
-                    "  - Message:",
-                    "    ```",
-                    *[f"    {line}" for line in item.message.splitlines() or ["<no message>"]],
-                    "    ```",
-                ]
-            )
+    failing = [
+        (test["nodeid"], test.get("error") or test.get("stderr") or "")
+        for test in payload["tests"]
+        if test["status"] in {"failed", "error"}
+    ]
+    if failing:
+        for nodeid, message in failing:
+            short = message.splitlines()[0] if message else "(no message)"
+            lines.append(f"- `{nodeid}`: `{short}`")
     else:
-        lines.append("- None")
-
-    skipped_section_header = "## Skipped tests"
-    lines.append("")
-    lines.append(skipped_section_header)
-    if skipped:
-        for item in results:
-            if item.status != "skipped":
-                continue
-            lines.extend(
-                [
-                    f"- `{item.name}` ({item.duration:.2f}s)",
-                    f"  - Reason: {item.message or 'not provided'}",
-                ]
-            )
-    else:
-        lines.append("- None")
+        lines.append("- none")
 
     summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -204,7 +331,8 @@ def main(argv: list[str] | None = None) -> int:
     exit_code = int(pytest_exit_code)
 
     results = plugin.results
-    summary = summarize_results(results)
+    payload = _build_report(results, duration_sec=plugin.duration_seconds)
+    summary = payload["summary"]
 
     if summary["success_rate"] < SUCCESS_RATE_THRESHOLD:
         logger.error(
@@ -217,8 +345,8 @@ def main(argv: list[str] | None = None) -> int:
 
     json_path = report_dir / "test_report.json"
     summary_path = report_dir / "test_summary.md"
-    _write_json(json_path, results, exit_code, summary)
-    _write_summary(summary_path, results, exit_code, summary)
+    _write_json(json_path, payload)
+    _write_summary(summary_path, payload)
 
     return int(exit_code)
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -5,45 +5,73 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
 from scripts import run_test_suite
 
 
-def _make_result(name: str, status: str, *, duration: float = 0.1, message: str = "") -> run_test_suite.TestResult:
+def _make_result(
+    name: str,
+    status: str,
+    *,
+    duration_ms: float = 100.0,
+    stdout: str = "",
+    stderr: str = "",
+    error: str | None = None,
+    log: list[str] | None = None,
+) -> run_test_suite.TestResult:
     return run_test_suite.TestResult(
-        name=name,
+        nodeid=name,
         status=status,
-        duration=duration,
-        message=message,
-        log_path=None,
+        duration_ms=duration_ms,
+        stdout=stdout,
+        stderr=stderr,
+        log=list(log or []),
+        error=error,
     )
 
 
-@pytest.mark.unit
-def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
-    plugin = run_test_suite.JsonReportPlugin(tmp_path / "suite.log")
-    plugin._results = {
-        "tests::passed": _make_result("tests::passed", "passed"),
-        "tests::failed": _make_result("tests::failed", "failed", message="boom"),
-    }
+def _patch_meta(monkeypatch: pytest.MonkeyPatch, duration_factory: Callable[[float], dict[str, object]]) -> None:
+    monkeypatch.setattr(run_test_suite, "_gather_meta", duration_factory)
 
-    results = plugin.results
-    summary = run_test_suite.summarize_results(results)
+
+@pytest.mark.unit
+def test_write_reports__includes_success_rate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_meta(
+        monkeypatch,
+        lambda duration: {
+            "repo": "demo/repo",
+            "commit": "deadbeef",
+            "branch": "main",
+            "ts_utc": "2020-01-01T00:00:00Z",
+            "duration_sec": round(duration, 3),
+            "python": "3.11.0",
+            "pytest": "8.0.0",
+        },
+    )
+
+    results = [
+        _make_result("tests::passed", "passed"),
+        _make_result("tests::failed", "failed", error="boom"),
+    ]
+
+    payload = run_test_suite._build_report(results, duration_sec=12.345)
 
     json_path = tmp_path / "test_report.json"
-    run_test_suite._write_json(json_path, results, exit_code=0, summary=summary)
-    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    run_test_suite._write_json(json_path, payload)
+    saved = json.loads(json_path.read_text(encoding="utf-8"))
 
-    assert "success_rate" in payload["summary"]
-    assert pytest.approx(payload["summary"]["success_rate"]) == 0.5
+    assert saved["summary"]["success_rate"] == pytest.approx(0.5)
+    assert saved["meta"]["repo"] == "demo/repo"
 
     md_path = tmp_path / "test_summary.md"
-    run_test_suite._write_summary(md_path, results, exit_code=0, summary=summary)
+    run_test_suite._write_summary(md_path, payload)
     summary_text = md_path.read_text(encoding="utf-8")
 
-    assert "* Success rate: 50.00%" in summary_text
+    assert "- Success rate: 50.00%" in summary_text
+    assert "- `tests::failed`: `boom`" in summary_text
 
     empty_summary = run_test_suite.summarize_results([])
     assert empty_summary["success_rate"] == pytest.approx(1.0)
@@ -53,27 +81,29 @@ def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
 def test_main__returns_error_when_success_rate_below_threshold(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    _patch_meta(
+        monkeypatch,
+        lambda duration: {
+            "repo": "demo/repo",
+            "commit": "deadbeef",
+            "branch": "main",
+            "ts_utc": "2020-01-01T00:00:00Z",
+            "duration_sec": round(duration, 3),
+            "python": "3.11.0",
+            "pytest": "8.0.0",
+        },
+    )
+
     def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
-        log_path = str(plugin._log_path)
+        plugin._started_at = 0.0
+        plugin._finished_at = 1.0
         plugin._results = {
             **{
-                f"tests::pass_{index}": run_test_suite.TestResult(
-                    name=f"tests::pass_{index}",
-                    status="passed",
-                    duration=0.1,
-                    message="",
-                    log_path=log_path,
-                )
+                f"tests::pass_{index}": _make_result(f"tests::pass_{index}", "passed")
                 for index in range(18)
             },
-            "tests::fail": run_test_suite.TestResult(
-                name="tests::fail",
-                status="failed",
-                duration=0.1,
-                message="boom",
-                log_path=log_path,
-            ),
+            "tests::fail": _make_result("tests::fail", "failed", error="boom"),
         }
         return 0
 
@@ -94,27 +124,29 @@ def test_main__returns_error_when_success_rate_below_threshold(
 def test_main__passes_when_success_rate_meets_threshold(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    _patch_meta(
+        monkeypatch,
+        lambda duration: {
+            "repo": "demo/repo",
+            "commit": "deadbeef",
+            "branch": "main",
+            "ts_utc": "2020-01-01T00:00:00Z",
+            "duration_sec": round(duration, 3),
+            "python": "3.11.0",
+            "pytest": "8.0.0",
+        },
+    )
+
     def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
-        log_path = str(plugin._log_path)
+        plugin._started_at = 0.0
+        plugin._finished_at = 1.0
         plugin._results = {
             **{
-                f"tests::pass_{index}": run_test_suite.TestResult(
-                    name=f"tests::pass_{index}",
-                    status="passed",
-                    duration=0.1,
-                    message="",
-                    log_path=log_path,
-                )
+                f"tests::pass_{index}": _make_result(f"tests::pass_{index}", "passed")
                 for index in range(19)
             },
-            "tests::skip": run_test_suite.TestResult(
-                name="tests::skip",
-                status="skipped",
-                duration=0.1,
-                message="not run",
-                log_path=log_path,
-            ),
+            "tests::skip": _make_result("tests::skip", "skipped", error="not run"),
         }
         return 0
 


### PR DESCRIPTION
## Summary
- update `scripts/run_test_suite.py` to capture richer pytest metadata, normalize repository info, and emit JSON/Markdown reports that match the documented reporting format
- refresh `tests/unit/scripts/test_run_test_suite.py` to exercise the new report builder and success-rate enforcement logic

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e9651e408324963a395266ed448b