### PR TITLE
Update CLI logging default directory to repository data logs

### DIFF
--- a/library/cli/logging.py
+++ b/library/cli/logging.py
@@ -12,7 +12,7 @@ from typing import IO, Iterator
 
 from ..common.logging_setup import LoggerConfig
 
-_DEFAULT_LOG_DIR = Path("logs")
+_DEFAULT_LOG_DIR = Path(__file__).resolve().parents[2] / "data" / "logs"
 
 
 def _current_date_str() -> str:


### PR DESCRIPTION
## Summary
- update the default CLI logging directory to the repository's data/logs folder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38501b00083248957e732906e6ce7