### PR TITLE
Point orchestrator logs to data directory

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -900,7 +900,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     script_name = Path(__file__).with_suffix("").name
     base_cfg = LoggerConfig(level=desired_level, run_id=uuid.uuid4().hex)
-    log_directory = Path(args.base_path).expanduser().resolve() / "logs"
+    resolved_base_path = Path(args.base_path).expanduser().resolve()
+    log_directory = resolved_base_path / "data" / "logs"
     status = 1
 
     with setup_cli_logging(

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -364,7 +364,7 @@ def test_get_data_end_to_end__miniature_pipeline(
     exit_code, logs = _invoke(argv)
     assert exit_code == 0
 
-    log_dir = base_path / "logs"
+    log_dir = base_path / "data" / "logs"
     orchestrator_log = log_dir / f"get_data_{date_prefix}.log"
     assert orchestrator_log.exists()
     orchestrator_records = parse_log_file(orchestrator_log)


### PR DESCRIPTION
## Summary
- update `get_data` to resolve its log directory under `<base_path>/data/logs`
- adjust the end-to-end pipeline test to assert against the new log location

## Testing
- pytest tests/e2e/test_get_data_end_to_end.py -k "pipeline" -q

------
https://chatgpt.com/codex/tasks/task_e_68e38503c7bc8324ab61877551934a73