### PR TITLE
Adjust CLI log directory to data/logs

### DIFF
--- a/library/cli/logging.py
+++ b/library/cli/logging.py
@@ -12,7 +12,7 @@ from typing import IO, Iterator
 
 from ..common.logging_setup import LoggerConfig
 
-_DEFAULT_LOG_DIR = Path("logs")
+_DEFAULT_LOG_DIR = Path("data") / "logs"
 
 
 def _current_date_str() -> str:

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -900,7 +900,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     script_name = Path(__file__).with_suffix("").name
     base_cfg = LoggerConfig(level=desired_level, run_id=uuid.uuid4().hex)
-    log_directory = Path(args.base_path).expanduser().resolve() / "logs"
+    log_directory = Path(args.base_path).expanduser().resolve() / "data" / "logs"
     status = 1
 
     with setup_cli_logging(

--- a/tests/e2e/test_cli_logging_setup.py
+++ b/tests/e2e/test_cli_logging_setup.py
@@ -71,7 +71,7 @@ def test_cli_logging__creates_log_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: dict[str, Any]
 ) -> None:
     base_path = tmp_path
-    log_dir = base_path / "logs"
+    log_dir = base_path / "data" / "logs"
     log_dir.mkdir(parents=True)
 
     config_path = base_path / "config.yaml"

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -364,7 +364,7 @@ def test_get_data_end_to_end__miniature_pipeline(
     exit_code, logs = _invoke(argv)
     assert exit_code == 0
 
-    log_dir = base_path / "logs"
+    log_dir = base_path / "data" / "logs"
     orchestrator_log = log_dir / f"get_data_{date_prefix}.log"
     assert orchestrator_log.exists()
     orchestrator_records = parse_log_file(orchestrator_log)


### PR DESCRIPTION
## Summary
- route CLI log output to the `data/logs` directory by default
- update the get_data orchestrator and e2e tests to work with the relocated logs

## Testing
- pytest tests/e2e -q

------
https://chatgpt.com/codex/tasks/task_e_68e3850561e48324be20ef251307d6dd