### PR TITLE
Add bilingual documentation entry points for canonical guides

### DIFF
--- a/docs/CONFIG_EN.md
+++ b/docs/CONFIG_EN.md
@@ -1,0 +1,1 @@
+en/CONFIG.md

--- a/docs/CONFIG_RU.md
+++ b/docs/CONFIG_RU.md
@@ -1,0 +1,1 @@
+ru/CONFIG.md

--- a/docs/DEVELOPER_EN.md
+++ b/docs/DEVELOPER_EN.md
@@ -1,0 +1,1 @@
+en/DEVELOPER.md

--- a/docs/DEVELOPER_RU.md
+++ b/docs/DEVELOPER_RU.md
@@ -1,0 +1,1 @@
+ru/DEVELOPER.md

--- a/docs/OUTPUT_EN.md
+++ b/docs/OUTPUT_EN.md
@@ -1,0 +1,1 @@
+en/OUTPUT.md

--- a/docs/OUTPUT_RU.md
+++ b/docs/OUTPUT_RU.md
@@ -1,0 +1,1 @@
+ru/OUTPUT.md

--- a/docs/QUICKSTART_EN.md
+++ b/docs/QUICKSTART_EN.md
@@ -1,0 +1,1 @@
+en/QUICKSTART.md

--- a/docs/QUICKSTART_RU.md
+++ b/docs/QUICKSTART_RU.md
@@ -1,0 +1,1 @@
+ru/QUICKSTART.md

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,0 +1,1 @@
+en/README.md

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -1,0 +1,1 @@
+ru/README.md

--- a/docs/USAGE_EN.md
+++ b/docs/USAGE_EN.md
@@ -1,0 +1,1 @@
+en/USAGE.md

--- a/docs/USAGE_RU.md
+++ b/docs/USAGE_RU.md
@@ -1,0 +1,1 @@
+ru/USAGE.md


### PR DESCRIPTION
## Summary
- add bilingual entry-point files in docs/ so CONFIG, OUTPUT, USAGE, QUICKSTART, README, and developer guides are available via *_EN.md and *_RU.md names
- link the new entry points to the canonical English and Russian sources to keep both languages automatically synchronised

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3896f91f0832491d1e6a8e612fe03