### PR TITLE
Fix column alignment for missing optional numeric fields in the test item pipeline

### DIFF
--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -742,10 +742,65 @@ def finalize_output(
     rows_written = 0
     exit_code = 0
     columns_seen: set[str] = set()
+    columns_to_fill: set[str] = set()
+    expected_columns: set[str] = set()
+    column_dtypes: dict[str, pd.api.extensions.ExtensionDtype | str | type | None] = {}
     failure_cases = SidecarErrors()
     failure_count = 0
 
     chunk_iter = iter(chunks)
+
+    schema_dtype_lookup: dict[str, str] = {
+        name: str(col.dtype) for name, col in schema_model.columns.items()
+    }
+
+    def _column_dtype(column: str) -> pd.api.extensions.ExtensionDtype | str | type:
+        dtype_name = schema_dtype_lookup.get(column, "string")
+        if dtype_name in {"str", "string"}:
+            return pd.StringDtype()
+        if dtype_name == "boolean":
+            return pd.BooleanDtype()
+        if dtype_name == "object":
+            return object
+        return pd.StringDtype()
+
+    def _normalise_dtype(
+        dtype: pd.api.extensions.ExtensionDtype | str | type | None,
+    ) -> pd.api.extensions.ExtensionDtype | str | type:
+        if dtype is None:
+            return pd.StringDtype()
+        try:
+            pandas_dtype = pd.api.types.pandas_dtype(dtype)
+        except TypeError:
+            return dtype
+        if isinstance(pandas_dtype, pd.BooleanDtype):
+            return pd.BooleanDtype()
+        if isinstance(pandas_dtype, pd.StringDtype):
+            return pd.StringDtype()
+        if pd.api.types.is_integer_dtype(pandas_dtype):
+            return pd.Int64Dtype()
+        if pd.api.types.is_float_dtype(pandas_dtype):
+            return pd.Float64Dtype()
+        return pandas_dtype
+
+    def _ensure_column_alignment(frame: pd.DataFrame) -> None:
+        missing = (expected_columns | columns_to_fill | columns_seen) - set(frame.columns)
+        if not missing:
+            return
+        for column in sorted(missing):
+            dtype = column_dtypes.get(column)
+            if dtype is None:
+                dtype = _column_dtype(column)
+            dtype = _normalise_dtype(dtype)
+            column_dtypes[column] = dtype
+            if isinstance(dtype, pd.api.extensions.ExtensionDtype):
+                empty_values = pd.array([pd.NA] * len(frame.index), dtype=dtype)
+                frame[column] = pd.Series(empty_values, index=frame.index)
+            else:
+                placeholder = pd.Series([pd.NA] * len(frame.index), index=frame.index, dtype="object")
+                if dtype is not object:
+                    placeholder = placeholder.astype(dtype, copy=False)
+                frame[column] = placeholder
 
     def _process_chunk(raw: pd.DataFrame) -> pd.DataFrame:
         nonlocal rows_total, rows_written, exit_code, columns_seen, failure_count
@@ -755,7 +810,12 @@ def finalize_output(
         if "pubchem_cid" in current.columns:
             current["pubchem_cid"] = current["pubchem_cid"].astype(object)
         current = _add_pipeline_metadata(current)
+        _ensure_column_alignment(current)
+        for column in current.columns:
+            column_dtypes.setdefault(column, _normalise_dtype(current.dtypes[column]))
         columns_seen.update(current.columns)
+        expected_columns.update(columns_seen)
+        _ensure_column_alignment(current)
 
         chunk_missing_required = required_cols - set(current.columns)
         if chunk_missing_required:
@@ -806,9 +866,12 @@ def finalize_output(
     def _validated_chunks() -> Iterator[pd.DataFrame]:
         for chunk in prepared_chunks:
             if not chunk.empty or columns_seen:
+                _ensure_column_alignment(chunk)
                 yield chunk
         for raw_chunk in chunk_iter:
-            yield _process_chunk(raw_chunk)
+            processed = _process_chunk(raw_chunk)
+            _ensure_column_alignment(processed)
+            yield processed
 
     missing_required = required_cols - columns_seen
     if missing_required:
@@ -824,6 +887,13 @@ def finalize_output(
             "optional_columns_missing",
             columns=sorted(missing_optional),
         )
+        columns_to_fill.update(missing_optional)
+        expected_columns.update(columns_to_fill)
+        for column in missing_optional:
+            column_dtypes.setdefault(column, _column_dtype(column))
+        for chunk in prepared_chunks:
+            _ensure_column_alignment(chunk)
+        columns_seen.update(columns_to_fill)
 
     if failure_count:
         failure_path = Path(output).with_name(f"{Path(output).stem}_failure_cases.csv")

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -921,7 +921,7 @@ def finalize_output(
         return pandas_dtype
 
     def _ensure_column_alignment(frame: pd.DataFrame) -> None:
-        missing = (expected_columns | columns_to_fill) - set(frame.columns)
+        missing = (expected_columns | columns_to_fill | columns_seen) - set(frame.columns)
         if not missing:
             return
         for column in sorted(missing):
@@ -930,7 +930,14 @@ def finalize_output(
                 dtype = _column_dtype(column)
             dtype = _normalise_dtype(dtype)
             column_dtypes[column] = dtype
-            frame[column] = pd.Series(pd.NA, index=frame.index, dtype=dtype)
+            if isinstance(dtype, pd.api.extensions.ExtensionDtype):
+                empty_values = pd.array([pd.NA] * len(frame.index), dtype=dtype)
+                frame[column] = pd.Series(empty_values, index=frame.index)
+            else:
+                placeholder = pd.Series([pd.NA] * len(frame.index), index=frame.index, dtype="object")
+                if dtype is not object:
+                    placeholder = placeholder.astype(dtype, copy=False)
+                frame[column] = placeholder
 
     def _process_chunk(raw: pd.DataFrame) -> pd.DataFrame:
         nonlocal rows_total, rows_written, exit_code, columns_seen, failure_count
@@ -945,6 +952,7 @@ def finalize_output(
             column_dtypes.setdefault(column, _normalise_dtype(current.dtypes[column]))
         columns_seen.update(current.columns)
         expected_columns.update(columns_seen)
+        _ensure_column_alignment(current)
 
         chunk_missing_required = required_cols - set(current.columns)
         if chunk_missing_required:
@@ -995,9 +1003,12 @@ def finalize_output(
     def _validated_chunks() -> Iterator[pd.DataFrame]:
         for chunk in prepared_chunks:
             if not chunk.empty or columns_seen:
+                _ensure_column_alignment(chunk)
                 yield chunk
         for raw_chunk in chunk_iter:
-            yield _process_chunk(raw_chunk)
+            processed = _process_chunk(raw_chunk)
+            _ensure_column_alignment(processed)
+            yield processed
 
     missing_required = required_cols - columns_seen
     if missing_required:
@@ -1009,7 +1020,10 @@ def finalize_output(
 
     missing_optional = optional_cols - columns_seen
     if missing_optional:
-        added_optional = sorted(missing_optional)
+        logger.warning(
+            "optional_columns_missing",
+            columns=sorted(missing_optional),
+        )
         columns_to_fill.update(missing_optional)
         expected_columns.update(columns_to_fill)
         for column in missing_optional:
@@ -1022,11 +1036,6 @@ def finalize_output(
             logger.warning(
                 "optional_columns_missing",
                 columns=sorted(remaining_missing_optional),
-            )
-        else:
-            logger.debug(
-                "optional_columns_filled",
-                columns=added_optional,
             )
 
     if failure_count:

--- a/tests/integration/test_finalize_output.py
+++ b/tests/integration/test_finalize_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -137,6 +138,42 @@ def test_finalize_output__optional_columns_missing_warns(
 
     assert exit_code == 0
     assert any(event == "optional_columns_missing" for event, _ in warnings)
+
+
+@pytest.mark.integration
+def test_finalize_output__aligns_nullable_numeric_columns(
+    tmp_path: Path, sample_input_csv: Path, cfg
+) -> None:
+    cfg.system.doc_quality.enable = False
+
+    first_chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series(["CHEMBL1"], dtype="string"),
+            "first_approval": pd.Series([1999.0], dtype="Float64"),
+        }
+    )
+    second_chunk = pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series(["CHEMBL2"], dtype="string"),
+        }
+    )
+    output_path = tmp_path / "numeric_alignment.csv"
+    stats_supplier = _StatsSupplier(_base_stats())
+
+    exit_code = cli.finalize_output(
+        [first_chunk, second_chunk],
+        cfg=cfg,
+        output=output_path,
+        parent_stats_supplier=stats_supplier,
+        input_csv=sample_input_csv,
+    )
+
+    assert exit_code == 0
+
+    final = pd.read_csv(output_path)
+    assert "first_approval" in final.columns
+    assert final["first_approval"].iloc[0] == pytest.approx(1999.0)
+    assert math.isnan(final["first_approval"].iloc[1])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- ensure the test item finalize_output logic reuses recorded dtypes when backfilling missing columns so nullable numeric fields receive pd.NA instead of raising
- fill any outstanding optional columns for both the runtime and legacy pipeline implementations while preserving the existing warnings
- add an integration test covering repeated runs with a missing numeric optional column to guarantee the regression is covered

## Testing
- pytest tests/integration/test_finalize_output.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e388a83a388324811dfca42d2abb27