### PR TITLE
Adjust CLI logging test for new log directory

### DIFF
--- a/tests/e2e/test_cli_logging_setup.py
+++ b/tests/e2e/test_cli_logging_setup.py
@@ -71,8 +71,9 @@ def test_cli_logging__creates_log_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: dict[str, Any]
 ) -> None:
     base_path = tmp_path
-    log_dir = base_path / "logs"
+    log_dir = base_path / "data" / "logs"
     log_dir.mkdir(parents=True)
+    monkeypatch.setattr("library.cli.logging._DEFAULT_LOG_DIR", log_dir)
 
     config_path = base_path / "config.yaml"
     config_path.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- update the CLI logging end-to-end test to look for logs under `base_path/data/logs`
- patch the default CLI log directory during the test so helper parsers continue to work with the new location

## Testing
- pytest tests/e2e -q

------
https://chatgpt.com/codex/tasks/task_e_68e39154b7988324995fcc6b7d08b6fc