### PR TITLE
Handle empty assay postprocessing inputs

### DIFF
--- a/library/pipelines/assay/postprocessing.py
+++ b/library/pipelines/assay/postprocessing.py
@@ -39,12 +39,24 @@ def postprocess_assays(df: pd.DataFrame) -> pd.DataFrame:
         Copy of the input with the additional ``assay_with_same_target`` column.
 
     """
-    AssayPostprocessSchema.validate(df)
-    group_cols = ["document_chembl_id", "target_chembl_id"]
-    groups = df.groupby(group_cols)
-    logger.debug("Calculated counts for %d document/target groups", groups.ngroups)
+    df = df.copy()
+    required_columns = ["document_chembl_id", "target_chembl_id"]
+    for column in required_columns:
+        if column not in df.columns:
+            df[column] = pd.Series(dtype="string")
+
+    df = AssayPostprocessSchema.validate(df)
     result = df.copy()
-    result["assay_with_same_target"] = groups["document_chembl_id"].transform("size")
+
+    if result.empty:
+        result["assay_with_same_target"] = pd.Series(dtype="Int64")
+        return result
+
+    group_cols = ["document_chembl_id", "target_chembl_id"]
+    groups = result.groupby(group_cols)
+    logger.debug("Calculated counts for %d document/target groups", groups.ngroups)
+    counts = groups["document_chembl_id"].transform("size").astype("Int64")
+    result["assay_with_same_target"] = counts
     return result
 
 

--- a/tests/unit/pipelines/assay/test_postprocess_assays.py
+++ b/tests/unit/pipelines/assay/test_postprocess_assays.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.pipelines.assay.postprocessing import postprocess_assays
+
+
+@pytest.mark.unit
+def test_postprocess_assays__empty_without_columns() -> None:
+    """Ensure post-processing handles a completely column-less frame."""
+
+    df = pd.DataFrame()
+
+    result = postprocess_assays(df)
+
+    assert result.empty
+    assert set(result.columns) == {
+        "document_chembl_id",
+        "target_chembl_id",
+        "assay_with_same_target",
+    }
+    assert str(result["assay_with_same_target"].dtype) == "Int64"
+
+
+@pytest.mark.unit
+def test_postprocess_assays__empty_with_required_columns() -> None:
+    """Ensure post-processing preserves required columns on empty input."""
+
+    df = pd.DataFrame(columns=["document_chembl_id", "target_chembl_id"])
+
+    result = postprocess_assays(df)
+
+    assert result.empty
+    assert list(result.columns) == [
+        "document_chembl_id",
+        "target_chembl_id",
+        "assay_with_same_target",
+    ]
+    assert str(result["assay_with_same_target"].dtype) == "Int64"


### PR DESCRIPTION
## Summary
- ensure `postprocess_assays` backfills required columns prior to schema validation and preserves nullable counts on empty frames
- add regression tests covering empty assay inputs with and without predefined columns

## Testing
- pytest tests/unit/pipelines/assay/test_postprocess_assays.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c125f9d883248ce54ce37d84421e