### PR TITLE
Fix salt identifier fallback for activity exports

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -202,7 +202,6 @@ _EXTENDED_ACTIVITY_FALLBACKS: dict[str, Callable[[pd.DataFrame], pd.Series | Non
     "activity_chembl_id": lambda df: df.get("activity_id"),
     "compound_name": lambda df: df.get("molecule_pref_name"),
     "log_value": lambda df: df.get("pchembl_value"),
-    "salt_chembl_id": lambda df: df.get("molecule_chembl_id"),
 }
 
 

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -382,4 +382,18 @@ def test_ensure_extended_activity_columns__adds_defaults() -> None:
     assert enriched["activity_chembl_id"].tolist() == ["A1"]
     assert enriched.loc[0, "log_value"] == pytest.approx(5.3)
     assert enriched["compound_name"].isna().all()
-    assert "salt_chembl_id" in enriched.columns
+    assert enriched["salt_chembl_id"].isna().all()
+
+
+def test_ensure_extended_activity_columns__preserves_salt_ids() -> None:
+    frame = pd.DataFrame(
+        {
+            "activity_id": ["A1", "A2"],
+            "salt_chembl_id": ["CHEMBL_SALT1", pd.NA],
+            "molecule_chembl_id": ["CHEMBL123", "CHEMBL456"],
+        }
+    )
+
+    enriched = get_activity_data._ensure_extended_activity_columns(frame)
+
+    assert enriched["salt_chembl_id"].tolist() == ["CHEMBL_SALT1", pd.NA]


### PR DESCRIPTION
## Summary
- remove the salt_chembl_id fallback that duplicated molecule identifiers in extended activity frames
- default-missing salt columns to nullable strings and keep provided salt identifiers untouched
- extend unit coverage to assert the default behaviour and the preservation of salt IDs

## Testing
- pytest tests/unit/test_get_activity_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c58291f48324b0b9b575ad6874d3