### PR TITLE
Ensure activity bounds inputs are fetched and monitored

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -115,6 +115,15 @@ ACTIVITY_COLUMNS = [
     "action_type",
 ]
 
+
+_ACTIVITY_EXTRA_FIELDS: tuple[str, ...] = (
+    "standard_text_value",
+)
+
+ACTIVITY_QUERY_FIELDS: tuple[str, ...] = tuple(
+    dict.fromkeys(list(ACTIVITY_COLUMNS) + list(_ACTIVITY_EXTRA_FIELDS))
+)
+
 TESTITEM_PUBCHEM_COLUMNS: tuple[str, ...] = (
     "pubchem_cid",
     "pubchem_iupac_name",
@@ -425,7 +434,11 @@ def get_activities(
         return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = f"{cfg.chembl_base.rstrip('/')}/activity.json?format=json"
+    base_params: list[tuple[str, str]] = [("format", "json")]
+    if ACTIVITY_QUERY_FIELDS:
+        base_params.append(("fields", ",".join(ACTIVITY_QUERY_FIELDS)))
+    base_query = urlencode(base_params)
+    base = f"{cfg.chembl_base.rstrip('/')}/activity.json?{base_query}"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         chunk_key = ",".join(chunk)

--- a/library/processing/activity/bounds.py
+++ b/library/processing/activity/bounds.py
@@ -14,6 +14,8 @@ from ...common.pandas_utils import merge_series_prefer_left
 
 __all__ = ["compute_activity_bounds"]
 
+_COVERAGE_WARN_THRESHOLD = 0.95
+
 _UNCERTAINTY_PATTERN = re.compile(
     r"^\s*(?P<value>-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*(?:±|\+/-|\+-)\s*(?P<delta>\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*$"
 )
@@ -211,6 +213,53 @@ def _clamp_nonnegative(
     return lower, upper
 
 
+def _log_bounds_coverage(
+    std_lower: pd.Series,
+    std_upper: pd.Series,
+    lower: pd.Series,
+    upper: pd.Series,
+) -> None:
+    total = len(lower)
+    if total == 0:
+        return
+
+    def _coverage(series: pd.Series) -> tuple[int, float]:
+        count = int(series.notna().sum())
+        ratio = count / total if total else 0.0
+        return count, ratio
+
+    std_lower_count, std_lower_ratio = _coverage(std_lower)
+    std_upper_count, std_upper_ratio = _coverage(std_upper)
+    lower_count, lower_ratio = _coverage(lower)
+    upper_count, upper_ratio = _coverage(upper)
+
+    logger.info(
+        "activity_bounds_coverage",
+        rows=total,
+        standard_lower_count=std_lower_count,
+        standard_lower_pct=round(std_lower_ratio * 100, 2),
+        standard_upper_count=std_upper_count,
+        standard_upper_pct=round(std_upper_ratio * 100, 2),
+        lower_count=lower_count,
+        lower_pct=round(lower_ratio * 100, 2),
+        upper_count=upper_count,
+        upper_pct=round(upper_ratio * 100, 2),
+    )
+
+    for column, input_ratio, output_ratio in (
+        ("lower_value", std_lower_ratio, lower_ratio),
+        ("upper_value", std_upper_ratio, upper_ratio),
+    ):
+        if input_ratio >= _COVERAGE_WARN_THRESHOLD and output_ratio < _COVERAGE_WARN_THRESHOLD:
+            logger.warning(
+                "activity_bounds_low_output_coverage",
+                column=column,
+                rows=total,
+                input_pct=round(input_ratio * 100, 2),
+                output_pct=round(output_ratio * 100, 2),
+            )
+
+
 def _normalize_relations(df: pd.DataFrame) -> pd.Series:
     return _relation_series(df).map(_normalize_relation)
 
@@ -334,4 +383,5 @@ def compute_activity_bounds(
         result["activity_id"].dtype
     ):
         result["activity_id"] = result["activity_id"].astype("object")
+    _log_bounds_coverage(std_lower, std_upper, result["lower_value"], result["upper_value"])
     return result

--- a/tests/integration/test_activity_bounds.py
+++ b/tests/integration/test_activity_bounds.py
@@ -1,0 +1,47 @@
+import pandas as pd
+
+from library.config import ActivityBoundsCfg
+from library.processing.activity.bounds import compute_activity_bounds
+
+
+def test_compute_activity_bounds__preserves_standard_ranges() -> None:
+    rows: list[dict[str, object]] = []
+    for idx in range(20):
+        rows.append(
+            {
+                "activity_id": f"ACT{idx}",
+                "standard_lower_value": float(idx),
+                "standard_upper_value": float(idx) + 1.0,
+                "standard_value": float(idx) + 0.5,
+                "standard_type": "IC50",
+                "standard_units": "nM",
+            }
+        )
+
+    rows[0]["standard_lower_value"] = None
+    rows[0]["standard_upper_value"] = None
+
+    frame = pd.DataFrame(rows)
+    cfg = ActivityBoundsCfg()
+
+    result = compute_activity_bounds(frame, cfg)
+
+    lower_ratio = result["lower_value"].notna().mean()
+    upper_ratio = result["upper_value"].notna().mean()
+
+    assert lower_ratio >= 0.95
+    assert upper_ratio >= 0.95
+
+    populated = result.dropna(subset=["standard_lower_value", "standard_upper_value"])
+    pd.testing.assert_series_equal(
+        populated["lower_value"].reset_index(drop=True),
+        pd.to_numeric(populated["standard_lower_value"], errors="coerce").reset_index(drop=True),
+        check_names=False,
+        check_dtype=False,
+    )
+    pd.testing.assert_series_equal(
+        populated["upper_value"].reset_index(drop=True),
+        pd.to_numeric(populated["standard_upper_value"], errors="coerce").reset_index(drop=True),
+        check_names=False,
+        check_dtype=False,
+    )

--- a/tests/unit/test_chembl_activity_fetch.py
+++ b/tests/unit/test_chembl_activity_fetch.py
@@ -1,0 +1,38 @@
+from urllib.parse import parse_qs, urlparse
+
+from library.config import ApiCfg
+from library.pipelines.assay.chembl_assay import (
+    ACTIVITY_QUERY_FIELDS,
+    get_activities,
+)
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float) -> dict[str, object]:
+        self.urls.append(url)
+        return {"activities": [{"activity_id": "ACT1"}], "page_meta": {}}
+
+
+def test_get_activities__requests_required_fields(monkeypatch) -> None:
+    cfg = ApiCfg()
+    client = _RecordingClient()
+
+    frame = get_activities(["ACT1"], cfg=cfg, client=client, chunk_size=1)
+
+    assert not frame.empty
+    assert "standard_lower_value" in ACTIVITY_QUERY_FIELDS
+    assert "standard_upper_value" in ACTIVITY_QUERY_FIELDS
+
+    requested_url = client.urls[0]
+    query = parse_qs(urlparse(requested_url).query)
+    assert "fields" in query
+    requested_fields = query["fields"][0].split(",")
+
+    assert "standard_lower_value" in requested_fields
+    assert "standard_upper_value" in requested_fields
+    assert {"activity_id", "standard_lower_value", "standard_upper_value"}.issubset(
+        set(frame.columns)
+    )


### PR DESCRIPTION
## Summary
- request the ChEMBL activity API fields needed for bound calculations
- add coverage diagnostics to compute_activity_bounds to detect missing lower/upper values
- cover the behaviour with a unit test for field requests and an integration test for bound preservation

## Testing
- pytest tests/unit/test_chembl_activity_fetch.py tests/integration/test_activity_bounds.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c5a30a1483248286b7f0f503505a