### PR TITLE
Handle assay chunk 404s with per-ID fallback

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -352,17 +352,19 @@ def get_assays(
         return pd.DataFrame(columns=ASSAY_COLUMNS)
 
     records: list[pd.DataFrame] = []
-    base = f"{cfg.chembl_base.rstrip('/')}/assay.json?format=json"
+    base_root = cfg.chembl_base.rstrip("/")
+    base_url = f"{base_root}/assay.json"
+    base_query: dict[str, str] = {"format": "json"}
     if require_variant_sequence:
-        base += "&variant_sequence__isnull=false"
-    effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    for chunk in _chunked(valid, chunk_size):
-        chunk_key = ",".join(chunk)
-        logger.info(
-            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
-        )
-        url = f"{base}&assay_chembl_id__in={chunk_key}&limit={len(chunk)}"
-        chunk_frames: list[pd.DataFrame] = []
+        base_query["variant_sequence__isnull"] = "false"
+    join_base = f"{base_root}/"
+
+    def _build_url(extra: dict[str, object]) -> str:
+        params = base_query | {k: str(v) for k, v in extra.items()}
+        return f"{base_url}?{urlencode(params)}"
+
+    def _fetch_chunk(url: str) -> list[pd.DataFrame]:
+        frames: list[pd.DataFrame] = []
         next_url: str | None = url
         while next_url:
             data = client.request_json(next_url, cfg=cfg, timeout=effective_timeout)
@@ -372,10 +374,50 @@ def get_assays(
                     axis="columns", how="all"
                 )
                 if not df_chunk.empty:
-                    chunk_frames.append(_apply_assay_column_aliases(df_chunk))
+                    frames.append(_apply_assay_column_aliases(df_chunk))
             page_meta = data.get("page_meta") or {}
             next_token = page_meta.get("next")
-            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+            next_url = urljoin(join_base, next_token) if next_token else None
+        return frames
+
+    def _fetch_single(identifier: str) -> list[pd.DataFrame]:
+        single_url = _build_url({"assay_chembl_id": identifier, "limit": 1})
+        try:
+            return _fetch_chunk(single_url)
+        except requests.HTTPError as exc:  # pragma: no cover - exercised via caller
+            response = exc.response
+            if response is not None and response.status_code == 404:
+                logger.info(
+                    "assay_missing", extra={"stage": "chunk_skip", "assay_chembl_id": identifier}
+                )
+                return []
+            raise
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+    for chunk in _chunked(valid, chunk_size):
+        chunk_key = ",".join(chunk)
+        logger.info(
+            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
+        )
+        url = _build_url({"assay_chembl_id__in": ",".join(chunk), "limit": len(chunk)})
+        try:
+            chunk_frames = _fetch_chunk(url)
+        except requests.HTTPError as exc:
+            response = exc.response
+            if response is not None and response.status_code == 404:
+                logger.warning(
+                    "chunk_split_retry",
+                    extra={
+                        "stage": "chunk_retry",
+                        "chunk_key": chunk_key,
+                        "chunk_size": len(chunk),
+                        "status": 404,
+                    },
+                )
+                chunk_frames = []
+                for identifier in chunk:
+                    chunk_frames.extend(_fetch_single(identifier))
+            else:
+                raise
         if chunk_frames:
             records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -1,0 +1,73 @@
+"""Unit tests for :mod:`library.pipelines.assay.chembl_assay`."""
+
+from __future__ import annotations
+
+from typing import Any
+import pytest
+from requests import HTTPError, Response
+
+from library.config import ApiCfg
+from library.pipelines.assay.chembl_assay import get_assays
+
+
+class _StubClient:
+    """Simple stub mimicking the :class:`ChemblClient` interface."""
+
+    def __init__(self, responders: list[dict[str, Any] | str]) -> None:
+        self._responders = responders
+        self.calls: list[str] = []
+
+    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None) -> dict[str, Any]:
+        self.calls.append(url)
+        next_response = self._responders.pop(0)
+        if isinstance(next_response, str) and next_response == "HTTP404":
+            response = Response()
+            response.status_code = 404
+            response.url = url
+            raise HTTPError(response=response)
+        if isinstance(next_response, dict):
+            return next_response
+        raise AssertionError(f"Unexpected responder type: {type(next_response)!r}")
+
+
+@pytest.mark.unit
+def test_get_assays__splits_chunk_on_404() -> None:
+    """Chunk-level 404 errors fall back to per-ID requests."""
+
+    responders = [
+        "HTTP404",
+        {"assays": [{"assay_chembl_id": "CHEMBL1"}], "page_meta": {}},
+        {"assays": [], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_assays(["CHEMBL1", "CHEMBL2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert list(df["assay_chembl_id"]) == ["CHEMBL1"]
+    assert any("assay_chembl_id__in" in call for call in client.calls)
+    assert any("assay_chembl_id=CHEMBL1" in call for call in client.calls)
+    assert any("assay_chembl_id=CHEMBL2" in call for call in client.calls)
+
+
+@pytest.mark.unit
+def test_get_assays__preserves_data_segment_in_pagination() -> None:
+    """Relative ``page_meta.next`` links keep the ``/data`` segment."""
+
+    responders = [
+        {
+            "assays": [{"assay_chembl_id": "CHEMBL1"}],
+            "page_meta": {"next": "assay.json?offset=1&limit=1"},
+        },
+        {"assays": [{"assay_chembl_id": "CHEMBL2"}], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_assays(["CHEMBL1"], cfg=cfg, client=client, chunk_size=1)
+
+    assert sorted(df["assay_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    assert any(
+        call.startswith("https://www.ebi.ac.uk/chembl/api/data/assay.json?offset=1")
+        for call in client.calls[1:]
+    )


### PR DESCRIPTION
## Summary
- encode assay request URLs and ensure pagination keeps the /data segment
- split assay chunks into single-record lookups when the ChEMBL API returns HTTP 404
- cover the new fallback and pagination handling with dedicated unit tests

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c5c7a804832497286b0a243e4ede