### PR TITLE
Ensure activities include src_assay_id from assay dictionary

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -425,6 +425,7 @@ def get_activities(
         return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 
     records: list[pd.DataFrame] = []
+    observed_columns: set[str] = set()
     base = f"{cfg.chembl_base.rstrip('/')}/activity.json?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
@@ -441,6 +442,7 @@ def get_activities(
             if items:
                 df_chunk = json_normalize_pyarrow(items)
                 if not df_chunk.empty:
+                    observed_columns.update(str(column) for column in df_chunk.columns)
                     chunk_frames.append(df_chunk)
             page_meta = data.get("page_meta") or {}
             next_token = page_meta.get("next")
@@ -467,6 +469,20 @@ def get_activities(
         for column in extra_columns:
             if column not in columns:
                 columns.append(column)
+    if observed_columns:
+        expected_core = set(ACTIVITY_COLUMNS)
+        missing_core = sorted(expected_core - observed_columns)
+        unexpected = sorted(observed_columns - expected_core)
+        if missing_core:
+            logger.debug(
+                "activity_columns_missing",
+                extra={"columns": missing_core},
+            )
+        if unexpected:
+            logger.debug(
+                "activity_columns_unexpected",
+                extra={"columns": unexpected},
+            )
     return df.reindex(columns=columns)
 
 

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -154,6 +154,92 @@ def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
     return tuple(str(arg) for arg in invocation)
 
 
+def _prepare_assay_src_lookup(dictionary_dir: Path) -> pd.Series:
+    """Return a lookup Series mapping assay IDs to source assay identifiers."""
+
+    path = Path(dictionary_dir) / "_assay" / "assay.csv"
+    try:
+        frame = pd.read_csv(path, dtype="string")
+    except FileNotFoundError:
+        logger.warning("assay_dictionary_missing", path=str(path))
+        return pd.Series(dtype="string")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "assay_dictionary_load_failed",
+            path=str(path),
+            error=str(exc),
+        )
+        return pd.Series(dtype="string")
+
+    required = ["assay_chembl_id", "src_assay_id"]
+    missing = [column for column in required if column not in frame.columns]
+    if missing:
+        logger.warning(
+            "assay_dictionary_missing_columns",
+            path=str(path),
+            columns=missing,
+        )
+        return pd.Series(dtype="string")
+
+    subset = frame[required].dropna(subset=["assay_chembl_id"])
+    if subset.empty:
+        return pd.Series(dtype="string")
+    cleaned = subset.copy()
+    cleaned["assay_chembl_id"] = cleaned["assay_chembl_id"].astype("string")
+    cleaned["src_assay_id"] = cleaned["src_assay_id"].astype("string")
+    deduped = cleaned.drop_duplicates(subset=["assay_chembl_id"], keep="first")
+    series = deduped.set_index("assay_chembl_id")["src_assay_id"]
+    if series.empty:
+        return pd.Series(dtype="string")
+    return series.astype("string")
+
+
+def _ensure_src_assay_id(
+    frame: pd.DataFrame, lookup: pd.Series | Mapping[str, object]
+) -> pd.DataFrame:
+    """Populate ``src_assay_id`` using the provided assay dictionary lookup."""
+
+    if isinstance(lookup, Mapping) and not isinstance(lookup, pd.Series):
+        lookup = pd.Series(dict(lookup), dtype="string")
+
+    result = frame.copy()
+    if result.empty:
+        if "src_assay_id" not in result.columns:
+            result["src_assay_id"] = pd.Series([], dtype="string")
+        return result
+
+    if not isinstance(lookup, pd.Series) or lookup.empty:
+        if "src_assay_id" not in result.columns:
+            result["src_assay_id"] = pd.Series(pd.NA, index=result.index, dtype="string")
+        else:
+            result["src_assay_id"] = result["src_assay_id"].astype("string")
+        return result
+
+    if "assay_chembl_id" not in result.columns:
+        if "src_assay_id" not in result.columns:
+            result["src_assay_id"] = pd.Series(pd.NA, index=result.index, dtype="string")
+        else:
+            result["src_assay_id"] = result["src_assay_id"].astype("string")
+        logger.debug("activity_src_assay_missing_assay_id_column")
+        return result
+
+    assay_series = result["assay_chembl_id"].astype("string")
+    mapped = assay_series.map(lookup).astype("string")
+    if "src_assay_id" in result.columns:
+        existing = result["src_assay_id"].astype("string").replace("", pd.NA)
+        combined = existing.fillna(mapped).astype("string")
+    else:
+        combined = mapped
+    result["src_assay_id"] = combined
+    missing_count = int(combined.isna().sum())
+    if missing_count:
+        logger.debug(
+            "activity_src_assay_unmapped",
+            count=missing_count,
+        )
+    return result
+
+
 file_sha256 = _cli_file_sha256
 write_meta_yaml = _cli_write_meta_yaml
 configure_logger = cli.configure_logger
@@ -429,6 +515,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             fillers[column] = pd.Series(pd.NA, index=frame.index, dtype=fill_dtype)
         return frame.assign(**fillers)
 
+    assay_src_lookup = _prepare_assay_src_lookup(cfg.resources.dictionary_dir)
+
+    def _ensure_src_assay(frame: pd.DataFrame) -> pd.DataFrame:
+        return _ensure_src_assay_id(frame, assay_src_lookup)
+
     available_columns: set[str] = set()
 
     def _record_columns(frame: pd.DataFrame) -> pd.DataFrame:
@@ -437,6 +528,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     metadata_hooks = [
         _ensure_required_activity_columns,
+        _ensure_src_assay,
         _ensure_extended_activity_columns,
         normalize_activities,
         add_pipeline_metadata,

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -72,6 +72,24 @@ def _install_fetch_stubs(
     return captured
 
 
+def _install_assay_lookup_stub(monkeypatch: pytest.MonkeyPatch) -> pd.Series:
+    lookup = pd.Series(
+        {
+            "ASSAY1": "SRC_ASSAY_1",
+            "ASSAY2": "SRC_ASSAY_2",
+            "ASSAY3": "SRC_ASSAY_3",
+        },
+        dtype="string",
+    )
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "_prepare_assay_src_lookup",
+        lambda *_: lookup,
+    )
+    return lookup
+
+
 def _install_writer_stub(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, pd.DataFrame]]:
     written: list[tuple[Path, pd.DataFrame]] = []
 
@@ -136,6 +154,7 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     output_csv = tmp_path / "activities.csv"
     chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
 
+    _install_assay_lookup_stub(monkeypatch)
     captured = _install_fetch_stubs(monkeypatch, chunk_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()
@@ -165,6 +184,12 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     assert list(written_df["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
     assert pd.api.types.is_float_dtype(written_df["standard_value"])  # type: ignore[arg-type]
     assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
+    assert "src_assay_id" in written_df.columns
+    assert written_df["src_assay_id"].tolist() == [
+        "SRC_ASSAY_1",
+        "SRC_ASSAY_2",
+        "SRC_ASSAY_3",
+    ]
 
 
 @pytest.mark.integration
@@ -177,6 +202,7 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
     # Ensure we never reach the fetch stage when validation of inputs fails.
     monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
     monkeypatch.setattr(get_activity_data.cl, "get_activities", lambda *_, **__: pd.DataFrame())
+    _install_assay_lookup_stub(monkeypatch)
     logger_stub = _RecordingLogger()
     monkeypatch.setattr(get_activity_data, "logger", logger_stub)
     monkeypatch.setattr("library.validation.logger", logger_stub)
@@ -235,6 +261,7 @@ def test_activity_pipeline__deduplicates_identifiers(activity_resource_dir: Path
     output_csv = tmp_path / "activities.csv"
     chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
 
+    _install_assay_lookup_stub(monkeypatch)
     captured = _install_fetch_stubs(monkeypatch, chunk_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -383,3 +383,25 @@ def test_ensure_extended_activity_columns__adds_defaults() -> None:
     assert enriched.loc[0, "log_value"] == pytest.approx(5.3)
     assert enriched["compound_name"].isna().all()
     assert "salt_chembl_id" in enriched.columns
+
+
+def test_ensure_src_assay_id__fills_from_lookup() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_chembl_id": ["ASSAY1", "ASSAY2"],
+            "src_assay_id": [pd.NA, "legacy"],
+        }
+    )
+    lookup = pd.Series({"ASSAY1": "SRC1", "ASSAY2": "SRC2"}, dtype="string")
+
+    enriched = get_activity_data._ensure_src_assay_id(frame, lookup)
+
+    assert enriched["src_assay_id"].tolist() == ["SRC1", "legacy"]
+
+
+def test_ensure_src_assay_id__handles_missing_lookup() -> None:
+    frame = pd.DataFrame({"assay_chembl_id": ["ASSAY1"]})
+
+    enriched = get_activity_data._ensure_src_assay_id(frame, pd.Series(dtype="string"))
+
+    assert enriched["src_assay_id"].isna().all()


### PR DESCRIPTION
## Summary
- track activity API columns and log missing or unexpected fields
- load the assay dictionary to backfill missing `src_assay_id` values before writing activities
- extend unit and integration tests to cover the new enrichment behaviour

## Testing
- pytest tests/unit/test_get_activity_data.py tests/integration/test_get_activity_data_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c58cef048324b2c55c23c94493e9