### PR TITLE
Add assay enrichment quality checks to miniature pipeline tests

### DIFF
--- a/tests/data/assay_dictionary.csv
+++ b/tests/data/assay_dictionary.csv
@@ -1,0 +1,3 @@
+assay_chembl_id,assay_strain,assay_group,year,accession
+CHEMBLA1,Homo sapiens,Binding panel,2019,ACC1234
+CHEMBLA2,Mus musculus,Functional subset,2020,ACC5678

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -23,6 +23,8 @@ from scripts import (
     get_testitem_data,
 )
 
+from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
+
 
 @pytest.fixture()
 def sample_csv(tmp_path: Path) -> Callable[[str], Path]:
@@ -838,18 +840,44 @@ def test_get_assay_run_success(
     input_csv = sample_csv("assay")
     output_csv = tmp_path / "out" / "assays.csv"
     logger_stub = _patch_logger(monkeypatch, get_assay_data)
+    data_dir = Path(__file__).resolve().parents[1] / "data"
+    dictionary_path = data_dir / "assay_dictionary.csv"
 
     def _stub_run_chembl(config: Config, args: argparse.Namespace) -> int:
         frame = pd.read_csv(args.input_csv)
-        frame["description"] = frame["description"].astype("string").str.strip()
-        frame["description_length"] = frame["description"].str.len().astype("Int64")
-        frame = frame.drop_duplicates(subset=["assay_chembl_id"])
-        frame = frame.sort_values("assay_chembl_id").reset_index(drop=True)
+        dictionary = pd.read_csv(dictionary_path)
+        dictionary["assay_chembl_id"] = dictionary["assay_chembl_id"].astype("string")
+        enriched = frame.merge(dictionary, on="assay_chembl_id", how="left")
+        enriched["description"] = enriched["description"].astype("string").str.strip()
+        enriched["description_length"] = (
+            enriched["description"].str.len().astype("Int64")
+        )
+        enriched["year"] = pd.to_numeric(enriched["year"], errors="coerce").astype("Int64")
+        enriched = enriched.drop_duplicates(subset=["assay_chembl_id"])
+        enriched = enriched.sort_values("assay_chembl_id").reset_index(drop=True)
+        quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+        completeness = 1.0 - enriched[quality_columns].isna().mean()
+        if float(completeness.min()) < ASSAY_ENRICHMENT_MIN_RATIO:
+            raise AssertionError(
+                "assay enrichment below threshold "
+                f"(threshold={ASSAY_ENRICHMENT_MIN_RATIO}, completeness={completeness.to_dict()})"
+            )
         output_path = Path(args.final_out)
         _ensure_parent(output_path)
-        frame.to_csv(output_path, index=False)
+        columns = [
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+            "description_length",
+            "assay_strain",
+            "assay_group",
+            "year",
+            "accession",
+        ]
+        enriched.to_csv(output_path, index=False, columns=columns)
         get_assay_data.logger.info(
-            "assay_pipeline_done", output=str(args.final_out), processed=len(frame)
+            "assay_pipeline_done", output=str(args.final_out), processed=len(enriched)
         )
         return 0
 
@@ -872,8 +900,15 @@ def test_get_assay_run_success(
         "document_chembl_id",
         "description",
         "description_length",
+        "assay_strain",
+        "assay_group",
+        "year",
+        "accession",
     ]
     assert (result["description_length"] == result["description"].str.len()).all()
+    quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+    completeness = 1.0 - result[quality_columns].isna().mean()
+    assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness
     events = [event for _, event, _ in logger_stub.events]
     assert "assay_pipeline_done" in events
 

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -8,6 +8,7 @@ import shutil
 from collections import deque
 from collections.abc import Callable
 from datetime import UTC
+from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
@@ -15,6 +16,7 @@ import pytest
 
 from library.common.csv_utils import sha256_file
 from scripts import get_data
+from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 from tests.helpers.logs import parse_log_file, parse_log_lines
 
 
@@ -120,13 +122,28 @@ def _assays_transform(frame: pd.DataFrame, logger: get_data.Logger) -> pd.DataFr
     frame = frame.copy()
     frame["description"] = frame["description"].astype("string").str.strip()
     frame["description_length"] = frame["description"].str.len().astype("Int64")
-    return frame[
+    lookup = _load_assay_dictionary()
+    enriched = frame.merge(lookup, on="assay_chembl_id", how="left")
+    quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+    completeness = 1.0 - enriched[quality_columns].isna().mean()
+    min_ratio = float(completeness.min()) if len(completeness) else 1.0
+    if min_ratio < ASSAY_ENRICHMENT_MIN_RATIO:
+        raise AssertionError(
+            "assay enrichment below threshold "
+            f"(threshold={ASSAY_ENRICHMENT_MIN_RATIO}, completeness={completeness.to_dict()})"
+        )
+    enriched["year"] = enriched["year"].astype("Int64")
+    return enriched[
         [
             "assay_chembl_id",
             "target_chembl_id",
             "document_chembl_id",
             "description",
             "description_length",
+            "assay_strain",
+            "assay_group",
+            "year",
+            "accession",
         ]
     ]
 
@@ -396,6 +413,10 @@ def test_get_data_end_to_end__miniature_pipeline(
         expected = pd.read_csv(expected_dir / f"{stem}.csv")
         pd.testing.assert_frame_equal(actual, expected)
         assert not actual[key_columns[step_name]].duplicated().any()
+        if step_name == "assay":
+            quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+            completeness = 1.0 - actual[quality_columns].isna().mean()
+            assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness
 
     hashes_before = {name: sha256_file(path) for name, path in output_paths.items()}
 
@@ -561,3 +582,17 @@ def test_get_data_end_to_end__miniature_pipeline(
     assert not missing_target.exists()
     sentinel_path = missing_output / f"output.targets_{date_prefix}.csv.failed"
     assert sentinel_path.exists()
+_ASSAY_DICTIONARY_PATH = Path(__file__).resolve().parents[1] / "data" / "assay_dictionary.csv"
+
+
+@lru_cache(maxsize=1)
+def _load_assay_dictionary() -> pd.DataFrame:
+    lookup = pd.read_csv(_ASSAY_DICTIONARY_PATH)
+    lookup = lookup.copy()
+    lookup["assay_chembl_id"] = lookup["assay_chembl_id"].astype("string").str.strip()
+    lookup["assay_strain"] = lookup["assay_strain"].astype("string")
+    lookup["assay_group"] = lookup["assay_group"].astype("string")
+    lookup["accession"] = lookup["accession"].astype("string")
+    lookup["year"] = pd.to_numeric(lookup["year"], errors="coerce").astype("Int64")
+    return lookup
+

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,4 @@
+"""Shared helper utilities and constants for the test suite."""
+
+ASSAY_ENRICHMENT_MIN_RATIO = 0.8
+"""Minimum acceptable non-null ratio for enriched assay attributes."""

--- a/tests/integration/test_assay_cli_quality.py
+++ b/tests/integration/test_assay_cli_quality.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.config import Config
+from scripts import get_assay_data
+from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@pytest.mark.integration
+def test_get_assay_cli__enrichment_quality(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = Path(__file__).resolve().parents[1] / "data"
+    input_csv = tmp_path / "assay.csv"
+    input_csv.write_text((data_dir / "assay.csv").read_text(encoding="utf-8"), encoding="utf-8")
+    output_csv = tmp_path / "out" / "assays.csv"
+    dictionary_path = data_dir / "assay_dictionary.csv"
+
+    def _stub_run_chembl(config: Config, args: argparse.Namespace) -> int:
+        frame = pd.read_csv(args.input_csv)
+        dictionary = pd.read_csv(dictionary_path)
+        dictionary["assay_chembl_id"] = dictionary["assay_chembl_id"].astype("string")
+        enriched = frame.merge(dictionary, on="assay_chembl_id", how="left")
+        enriched["description"] = enriched["description"].astype("string").str.strip()
+        enriched["description_length"] = enriched["description"].str.len().astype("Int64")
+        enriched["year"] = pd.to_numeric(enriched["year"], errors="coerce").astype("Int64")
+        quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+        completeness = 1.0 - enriched[quality_columns].isna().mean()
+        if float(completeness.min()) < ASSAY_ENRICHMENT_MIN_RATIO:
+            raise AssertionError(
+                "assay enrichment below threshold "
+                f"(threshold={ASSAY_ENRICHMENT_MIN_RATIO}, completeness={completeness.to_dict()})"
+            )
+        _ensure_parent(args.final_out)
+        columns = [
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+            "description_length",
+            "assay_strain",
+            "assay_group",
+            "year",
+            "accession",
+        ]
+        enriched.to_csv(args.final_out, index=False, columns=columns)
+        return 0
+
+    monkeypatch.setattr(get_assay_data, "run_chembl", _stub_run_chembl)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        skip_existing=False,
+        force=False,
+    )
+
+    exit_code = get_assay_data.run(cfg, args)
+
+    assert exit_code == 0
+    result = pd.read_csv(output_csv)
+    expected_columns = [
+        "assay_chembl_id",
+        "target_chembl_id",
+        "document_chembl_id",
+        "description",
+        "description_length",
+        "assay_strain",
+        "assay_group",
+        "year",
+        "accession",
+    ]
+    assert list(result.columns) == expected_columns
+    assert (result["description_length"] == result["description"].str.len()).all()
+    quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+    completeness = 1.0 - result[quality_columns].isna().mean()
+    assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness.to_dict()

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -11,6 +11,7 @@ import pytest
 
 from library.config import Config
 from scripts import get_data, get_target_data
+from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 from tests.helpers.logs import parse_log_lines
 
 
@@ -197,16 +198,17 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
         pd.DataFrame(
             [
                 {
-                    "assay_chembl_id": "A1",
-                    "target_chembl_id": "T1",
-                    "document_chembl_id": "D1",
-                    "description": "First",
+                    "assay_chembl_id": "CHEMBLA1",
+                    "target_chembl_id": "CHEMBLT1",
+                    "document_chembl_id": "CHEMBL123",
+                    "description": "Binding assay",
                 }
             ]
         ),
     )
 
     attempts = {"count": 0}
+    dictionary_path = Path(__file__).resolve().parents[1] / "data" / "assay_dictionary.csv"
 
     def _on_execute(rows: pd.DataFrame, destination: Path) -> int:
         attempts["count"] += 1
@@ -215,7 +217,27 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
             tmp_path = destination.with_suffix(".tmp")
             tmp_path.write_text("partial\n", encoding="utf-8")
             return 1
-        destination.write_text("assay_chembl_id\nA1\n", encoding="utf-8")
+        dictionary = pd.read_csv(dictionary_path)
+        dictionary["assay_chembl_id"] = dictionary["assay_chembl_id"].astype("string")
+        enriched = rows.merge(dictionary, on="assay_chembl_id", how="left")
+        enriched["description"] = enriched["description"].astype("string").str.strip()
+        enriched["description_length"] = enriched["description"].str.len().astype("Int64")
+        enriched["year"] = pd.to_numeric(enriched["year"], errors="coerce").astype("Int64")
+        quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+        completeness = 1.0 - enriched[quality_columns].isna().mean()
+        assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness.to_dict()
+        columns = [
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+            "description_length",
+            "assay_strain",
+            "assay_group",
+            "year",
+            "accession",
+        ]
+        enriched.to_csv(destination, index=False, columns=columns)
         return 0
 
     step = get_data.PipelineStep(
@@ -253,6 +275,22 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
     final_output = step.expected_output(cfg)
     assert final_output.exists()
     assert attempts["count"] == 2
+    result = pd.read_csv(final_output)
+    expected_columns = [
+        "assay_chembl_id",
+        "target_chembl_id",
+        "document_chembl_id",
+        "description",
+        "description_length",
+        "assay_strain",
+        "assay_group",
+        "year",
+        "accession",
+    ]
+    assert list(result.columns) == expected_columns
+    quality_columns = ["assay_strain", "assay_group", "year", "accession"]
+    completeness = 1.0 - result[quality_columns].isna().mean()
+    assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness.to_dict()
 
 
 @pytest.mark.integration

--- a/tests/resources/expected_get_data/assays.csv
+++ b/tests/resources/expected_get_data/assays.csv
@@ -1,3 +1,3 @@
-assay_chembl_id,target_chembl_id,document_chembl_id,description,description_length
-CHEMBLA1,CHEMBLT1,CHEMBL123,Binding assay,13
-CHEMBLA2,CHEMBLT2,CHEMBL456,Functional assay,16
+assay_chembl_id,target_chembl_id,document_chembl_id,description,description_length,assay_strain,assay_group,year,accession
+CHEMBLA1,CHEMBLT1,CHEMBL123,Binding assay,13,Homo sapiens,Binding panel,2019,ACC1234
+CHEMBLA2,CHEMBLT2,CHEMBL456,Functional assay,16,Mus musculus,Functional subset,2020,ACC5678


### PR DESCRIPTION
## Summary
- extend the miniature assay dictionary and expected snapshot with strain, group, year, and accession values
- enforce the enrichment completeness threshold in the get-data E2E flow, CLI stub, and workflow retry scenario
- add an integration smoke test for the assay CLI to guard the enrichment null-ratio budget

## Testing
- pytest tests/e2e/test_get_data_end_to_end.py::test_get_data_end_to_end__miniature_pipeline -q
- pytest tests/e2e/test_get_cli_pipelines.py::test_get_assay_run_success -q
- pytest tests/integration/test_assay_cli_quality.py -q
- pytest tests/integration/test_get_data_workflow.py::test_pipeline_subset__retry_after_failure -q

------
https://chatgpt.com/codex/tasks/task_e_68e3cc5dfcd88324ade2a26e73984ebb