### PR TITLE
Populate activity src_assay_id from assay dictionary

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -223,6 +223,101 @@ def _string_blank_mask(series: pd.Series) -> pd.Series:
     return values.isna() | stripped.fillna("").eq("")
 
 
+def _load_assay_src_lookup(dictionary_dir: Path | str | None) -> dict[str, str]:
+    """Return mapping of assay identifiers to ``src_assay_id`` values."""
+
+    if dictionary_dir is None:
+        return {}
+
+    candidate = Path(dictionary_dir) / "_assay" / "assay.csv"
+    try:
+        frame = pd.read_csv(
+            candidate,
+            usecols=["assay_chembl_id", "src_assay_id"],
+            dtype="string",
+        )
+    except FileNotFoundError:
+        logger.warning("assay_lookup_missing", path=str(candidate))
+        return {}
+    except pd.errors.EmptyDataError:
+        logger.warning("assay_lookup_empty", path=str(candidate))
+        return {}
+    except ValueError as exc:
+        logger.warning(
+            "assay_lookup_invalid_columns",
+            path=str(candidate),
+            error=str(exc),
+        )
+        return {}
+    except OSError as exc:
+        logger.warning("assay_lookup_read_failed", path=str(candidate), error=str(exc))
+        return {}
+
+    if frame.empty:
+        return {}
+
+    cleaned = frame.dropna(subset=["assay_chembl_id", "src_assay_id"])
+    if cleaned.empty:
+        return {}
+
+    cleaned = cleaned.assign(
+        assay_chembl_id=cleaned["assay_chembl_id"].str.strip(),
+        src_assay_id=cleaned["src_assay_id"].str.strip(),
+    )
+
+    cleaned = cleaned[cleaned["assay_chembl_id"].ne("") & cleaned["src_assay_id"].ne("")]
+    if cleaned.empty:
+        return {}
+
+    return {
+        str(assay_id): str(src_id)
+        for assay_id, src_id in cleaned[["assay_chembl_id", "src_assay_id"]]
+        .itertuples(index=False, name=None)
+    }
+
+
+def _ensure_src_assay_id(
+    frame: pd.DataFrame, *, lookup: Mapping[str, str]
+) -> pd.DataFrame:
+    """Populate ``src_assay_id`` using ``lookup`` when missing."""
+
+    if "src_assay_id" not in frame.columns and "assay_chembl_id" not in frame.columns:
+        return frame
+
+    result = frame.copy()
+
+    if "src_assay_id" in result.columns:
+        try:
+            result["src_assay_id"] = result["src_assay_id"].astype("string")
+        except TypeError:
+            result["src_assay_id"] = result["src_assay_id"].astype("string")
+    else:
+        result["src_assay_id"] = pd.Series(pd.NA, index=result.index, dtype="string")
+
+    if not lookup or result.empty or "assay_chembl_id" not in result.columns:
+        return result
+
+    assay_ids = result["assay_chembl_id"].astype("string")
+    missing_mask = _string_like_missing(result["src_assay_id"])
+    if not missing_mask.any():
+        return result
+
+    normalized_ids = assay_ids.where(~assay_ids.isna(), None).astype(object)
+
+    def _resolve(value: object) -> str | None:
+        if value is None:
+            return None
+        return lookup.get(str(value))
+
+    mapped = normalized_ids.map(_resolve)
+    available = missing_mask & mapped.notna()
+    if not available.any():
+        return result
+
+    result.loc[available, "src_assay_id"] = mapped[available].astype("string")
+    return result
+
+
 def _ensure_molecule_pref_name(
     frame: pd.DataFrame,
     *,
@@ -554,6 +649,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         return frame.assign(**fillers)
 
     available_columns: set[str] = set()
+    assay_src_lookup = _load_assay_src_lookup(cfg.resources.dictionary_dir)
 
     def _record_columns(frame: pd.DataFrame) -> pd.DataFrame:
         available_columns.update(frame.columns)
@@ -561,6 +657,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     metadata_hooks = [
         _ensure_required_activity_columns,
+        partial(_ensure_src_assay_id, lookup=assay_src_lookup),
         _ensure_extended_activity_columns,
         normalize_activities,
         add_pipeline_metadata,

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -159,6 +159,16 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     output_csv = tmp_path / "activities.csv"
     chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
 
+    monkeypatch.setattr(
+        get_activity_data,
+        "_load_assay_src_lookup",
+        lambda *_: {
+            "ASSAY1": "SRC-ASSAY1",
+            "ASSAY2": "SRC-ASSAY2",
+            "ASSAY3": "SRC-ASSAY3",
+        },
+    )
+
     captured = _install_fetch_stubs(monkeypatch, chunk_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()
@@ -189,6 +199,10 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     assert list(written_df["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
     assert pd.api.types.is_float_dtype(written_df["standard_value"])  # type: ignore[arg-type]
     assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
+    assert "src_assay_id" in written_df.columns
+    src_assay_series = written_df["src_assay_id"].astype("string")
+    assert src_assay_series.tolist() == ["SRC-ASSAY1", "SRC-ASSAY2", "SRC-ASSAY3"]
+    assert src_assay_series.str.strip().ne("").all()
 
 
 @pytest.mark.integration
@@ -201,6 +215,7 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
     # Ensure we never reach the fetch stage when validation of inputs fails.
     monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
     monkeypatch.setattr(get_activity_data.cl, "get_activities", lambda *_, **__: pd.DataFrame())
+    monkeypatch.setattr(get_activity_data, "_load_assay_src_lookup", lambda *_: {})
     logger_stub = _RecordingLogger()
     monkeypatch.setattr(get_activity_data, "logger", logger_stub)
     monkeypatch.setattr("library.validation.logger", logger_stub)
@@ -224,6 +239,7 @@ def test_activity_pipeline__malformed_values(activity_resource_dir: Path, cfg, t
     output_csv = tmp_path / "activities.csv"
     chunk_df = pd.read_csv(activity_resource_dir / "chunk_malformed.csv")
 
+    monkeypatch.setattr(get_activity_data, "_load_assay_src_lookup", lambda *_: {})
     _install_fetch_stubs(monkeypatch, chunk_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()
@@ -259,6 +275,7 @@ def test_activity_pipeline__deduplicates_identifiers(activity_resource_dir: Path
     output_csv = tmp_path / "activities.csv"
     chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
 
+    monkeypatch.setattr(get_activity_data, "_load_assay_src_lookup", lambda *_: {})
     captured = _install_fetch_stubs(monkeypatch, chunk_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()
@@ -320,6 +337,7 @@ def test_activity_pipeline__fills_compound_name_from_pref_name(cfg, tmp_path, mo
         )
     testitem_df = pd.DataFrame.from_records(pref_name_records)
 
+    monkeypatch.setattr(get_activity_data, "_load_assay_src_lookup", lambda *_: {})
     capture = _install_fetch_stubs(monkeypatch, chunk_df, testitem_frame=testitem_df)
     written = _install_writer_stub(monkeypatch)
     logger_stub = _RecordingLogger()

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -397,3 +397,33 @@ def test_ensure_extended_activity_columns__preserves_salt_ids() -> None:
     enriched = get_activity_data._ensure_extended_activity_columns(frame)
 
     assert enriched["salt_chembl_id"].tolist() == ["CHEMBL_SALT1", pd.NA]
+
+
+def test_ensure_src_assay_id__fills_from_lookup() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_chembl_id": ["ASSAY1", "ASSAY2", "ASSAY3"],
+            "src_assay_id": ["", pd.NA, "custom"],
+        }
+    )
+
+    enriched = get_activity_data._ensure_src_assay_id(
+        frame,
+        lookup={
+            "ASSAY1": "SRC-1",
+            "ASSAY2": "SRC-2",
+        },
+    )
+
+    assert enriched["src_assay_id"].tolist() == ["SRC-1", "SRC-2", "custom"]
+    assert pd.api.types.is_string_dtype(enriched["src_assay_id"])  # type: ignore[arg-type]
+
+
+def test_ensure_src_assay_id__adds_column_when_missing() -> None:
+    frame = pd.DataFrame({"assay_chembl_id": ["ASSAY1"]})
+
+    enriched = get_activity_data._ensure_src_assay_id(frame, lookup={})
+
+    assert "src_assay_id" in enriched.columns
+    assert enriched["src_assay_id"].isna().all()
+    assert pd.api.types.is_string_dtype(enriched["src_assay_id"])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- load the assay `src_assay_id` mapping from the bundled dictionary and apply it during activity fetch metadata hooks
- ensure the activity pipeline emits non-empty `src_assay_id` values when the lookup is available
- cover the new enrichment path with unit tests and extend the integration suite to guard against regressions

## Testing
- pytest tests/unit/test_get_activity_data.py tests/integration/test_get_activity_data_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e3cd0327648324b553d879e10ed681