### PR TITLE
Respect retry backoff caps in HTTP clients

### DIFF
--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import requests
 
+from ..common.fetch_retry import compute_backoff_delay
 from ..config import PubMedCfg, RetryCfg
 from ..common.log import logger
 from ..common.rate_limiter import sleep
@@ -161,9 +162,12 @@ def _retry_delay(
     delay = min_delay
 
     if retry_cfg is not None and retry_cfg.backoff_factor > 0:
-        backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
+        backoff = compute_backoff_delay(attempt, retry_cfg)
         jitter = random.uniform(0.0, retry_cfg.backoff_factor)
-        delay = max(delay, backoff + jitter)
+        candidate = backoff + jitter
+        if retry_cfg.backoff_cap is not None:
+            candidate = min(candidate, retry_cfg.backoff_cap)
+        delay = max(delay, candidate)
 
     timeout_cap = _max_timeout(timeout)
     if timeout_cap is not None:

--- a/library/config.py
+++ b/library/config.py
@@ -1519,16 +1519,20 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
     """
 
     session = Session()
-    retry_cfg = Retry(
-        total=max(0, retry.max_attempts - 1),
-        backoff_factor=retry.backoff_factor,
-        status_forcelist=retry.status_forcelist,
+    retry_kwargs: dict[str, Any] = {
+        "total": max(0, retry.max_attempts - 1),
+        "backoff_factor": retry.backoff_factor,
+        "status_forcelist": retry.status_forcelist,
         # ``None`` disables method filtering and retries all HTTP methods.
         # Using ``None`` directly avoids ``Collection`` union type evaluation
         # issues under Python 3.12.
-        allowed_methods=None,
-        raise_on_status=False,
-    )
+        "allowed_methods": None,
+        "raise_on_status": False,
+    }
+    if retry.backoff_cap is not None:
+        retry_kwargs["backoff_max"] = retry.backoff_cap
+
+    retry_cfg = Retry(**retry_kwargs)
     adapter = HTTPAdapter(max_retries=retry_cfg)
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/tests/unit/test_pubmed_client.py
+++ b/tests/unit/test_pubmed_client.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+from urllib3.util import retry as urllib3_retry
+
+from library.clients import pubmed
+from library.config import ApiCfg, RetryCfg, session_with_retry
+
+
+@pytest.mark.unit
+def test_retry_delay__respects_backoff_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    retry_cfg = RetryCfg(max_attempts=4, backoff_factor=2.0, backoff_cap=3.0)
+
+    monkeypatch.setattr(pubmed.random, "uniform", lambda *args, **kwargs: 0.5)
+
+    delay = pubmed._retry_delay(2, 0.25, retry_cfg, timeout=None)
+
+    assert delay == pytest.approx(3.0)
+
+
+@pytest.mark.unit
+def test_session_with_retry__uses_backoff_cap() -> None:
+    api_cfg = ApiCfg()
+    retry_cfg = RetryCfg(max_attempts=4, backoff_factor=1.0, backoff_cap=7.5)
+
+    with session_with_retry(api_cfg, retry_cfg) as session:
+        adapter = session.get_adapter("https://")
+        max_retries = adapter.max_retries
+
+    assert isinstance(max_retries, urllib3_retry.Retry)
+    assert max_retries.backoff_max == pytest.approx(7.5)


### PR DESCRIPTION
## Summary
- ensure the PubMed retry delay computation honours configured backoff caps and jitter bounds
- propagate retry backoff caps to the shared HTTP session factory so urllib3 adapters respect the same limits
- add unit tests verifying the capped delay behaviour and adapter configuration

## Testing
- pytest -q tests/unit/test_pubmed_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cd0323388324a1d2b2c3597dde84