### PR TITLE
Add assay detail fallback for 404 responses

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -392,15 +392,39 @@ def get_assays(
     def _fetch_single(identifier: str) -> list[pd.DataFrame]:
         single_url = _build_url({"assay_chembl_id": identifier, "limit": 1})
         try:
-            return _fetch_chunk(single_url)
+            frames = _fetch_chunk(single_url)
         except requests.HTTPError as exc:  # pragma: no cover - exercised via caller
             response = exc.response
             if response is not None and response.status_code == 404:
                 logger.info(
                     "assay_missing", extra={"stage": "chunk_skip", "assay_chembl_id": identifier}
                 )
-                return []
+                fallback_df = get_assay(
+                    identifier,
+                    cfg=cfg,
+                    client=client,
+                    timeout=effective_timeout,
+                )
+                if require_variant_sequence and not fallback_df.empty:
+                    sequence_series = fallback_df.get("sequence")
+                    if sequence_series is not None:
+                        fallback_df = fallback_df[sequence_series.notna()]
+                if fallback_df.empty:
+                    return []
+                return [fallback_df]
             raise
+        else:
+            if require_variant_sequence and frames:
+                filtered_frames: list[pd.DataFrame] = []
+                for frame in frames:
+                    sequence_series = frame.get("sequence")
+                    if sequence_series is None:
+                        continue
+                    filtered = frame[sequence_series.notna()]
+                    if not filtered.empty:
+                        filtered_frames.append(filtered)
+                frames = filtered_frames
+            return frames
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):
         chunk_key = ",".join(chunk)

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -51,6 +51,26 @@ def test_get_assays__splits_chunk_on_404() -> None:
 
 
 @pytest.mark.unit
+def test_get_assays__detail_fallback_on_single_404() -> None:
+    """Single-item 404 fallbacks query the detail endpoint."""
+
+    responders = [
+        "HTTP404",
+        "HTTP404",
+        {"assay": {"assay_chembl_id": "CHEMBL1"}},
+        "HTTP404",
+        {"assays": []},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_assays(["CHEMBL1", "CHEMBL2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert list(df["assay_chembl_id"]) == ["CHEMBL1"]
+    assert any("/assay/CHEMBL1" in call for call in client.calls)
+
+
+@pytest.mark.unit
 def test_get_assays__preserves_data_segment_in_pagination() -> None:
     """Relative ``page_meta.next`` links keep the ``/data`` segment."""
 


### PR DESCRIPTION
## Summary
- fall back to the single-assay endpoint when batched assay lookups return HTTP 404
- ensure variant-sequence filtering is applied when the fallback is used
- cover the new behaviour with a unit test for the assay fetcher

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py


------
https://chatgpt.com/codex/tasks/task_e_68e3d3838eb88324b045385c58d8180b