### PR TITLE
Drop deprecated assay output columns

### DIFF
--- a/REPORT_assay_drop_columns.md
+++ b/REPORT_assay_drop_columns.md
@@ -1,0 +1,8 @@
+# Assay output column pruning
+
+## Summary
+- Added a final metadata hook in `scripts/get_assay_data.py` to drop the deprecated assay columns before export while preserving schema order.
+- Logged the removed columns once per pipeline run to aid auditing.
+
+## Testing
+- `pytest tests/test_assay_output_schema.py` *(fails: file or directory not found in repository)*

--- a/patch/get_assay_data_drop_columns.diff
+++ b/patch/get_assay_data_drop_columns.diff
@@ -1,0 +1,48 @@
+diff --git a/scripts/get_assay_data.py b/scripts/get_assay_data.py
+index 339d7f2..3da0352 100644
+--- a/scripts/get_assay_data.py
++++ b/scripts/get_assay_data.py
+@@ -218,11 +218,43 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
+     def _enrich_with_dictionaries(frame: pd.DataFrame) -> pd.DataFrame:
+         return enrich_assay_metadata(frame, dictionary_dir=cfg.resources.dictionary_dir)
+ 
++    drop_cols = [
++        "acts_per_assay_step5",
++        "higly_correlated_cit",
++        "month",
++        "shuffled_cit",
++        "error_assay_corr",
++        "shuffled_target_assay",
++        "substrate_name",
++        "version",
++        "ASSAY_ID",
++        "Target TYPE",
++    ]
++
++    drop_columns_logged = False
++
++    def _drop_assay_columns(frame: pd.DataFrame) -> pd.DataFrame:
++        nonlocal drop_columns_logged
++        columns_to_drop = [c for c in drop_cols if c in frame.columns]
++        if not drop_columns_logged:
++            if columns_to_drop:
++                logger.info(
++                    "Dropped columns from output.assay_*: %s",
++                    ", ".join(columns_to_drop),
++                )
++            else:
++                logger.info("Dropped columns from output.assay_*: <none>")
++            drop_columns_logged = True
++        if columns_to_drop:
++            frame = frame.drop(columns=columns_to_drop, errors="ignore")
++        return frame
++
+     metadata_hooks = [
+         _enrich_with_dictionaries,
+         ap.postprocess_assays,
+         normalize_assays,
+         add_pipeline_metadata,
++        _drop_assay_columns,
+     ]
+ 
+     validators = [partial(validate_assays, return_result=True)]

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -218,11 +218,43 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     def _enrich_with_dictionaries(frame: pd.DataFrame) -> pd.DataFrame:
         return enrich_assay_metadata(frame, dictionary_dir=cfg.resources.dictionary_dir)
 
+    drop_cols = [
+        "acts_per_assay_step5",
+        "higly_correlated_cit",
+        "month",
+        "shuffled_cit",
+        "error_assay_corr",
+        "shuffled_target_assay",
+        "substrate_name",
+        "version",
+        "ASSAY_ID",
+        "Target TYPE",
+    ]
+
+    drop_columns_logged = False
+
+    def _drop_assay_columns(frame: pd.DataFrame) -> pd.DataFrame:
+        nonlocal drop_columns_logged
+        columns_to_drop = [c for c in drop_cols if c in frame.columns]
+        if not drop_columns_logged:
+            if columns_to_drop:
+                logger.info(
+                    "Dropped columns from output.assay_*: %s",
+                    ", ".join(columns_to_drop),
+                )
+            else:
+                logger.info("Dropped columns from output.assay_*: <none>")
+            drop_columns_logged = True
+        if columns_to_drop:
+            frame = frame.drop(columns=columns_to_drop, errors="ignore")
+        return frame
+
     metadata_hooks = [
         _enrich_with_dictionaries,
         ap.postprocess_assays,
         normalize_assays,
         add_pipeline_metadata,
+        _drop_assay_columns,
     ]
 
     validators = [partial(validate_assays, return_result=True)]


### PR DESCRIPTION
## Summary
- drop the deprecated assay output columns via a final metadata hook before export
- add logging to record the removed columns and include accompanying diff/report artifacts

## Testing
- pytest tests/test_assay_output_schema.py *(fails: file or directory not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d620967483248793ef702debba75