### PR TITLE
Handle pref name lookup failures and flexible document handlers

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -361,15 +361,24 @@ def _ensure_molecule_pref_name(
         for column in ("molecule_chembl_id", "pref_name"):
             if column not in fields:
                 fields.append(column)
-        lookup = cl.get_testitem(
-            pending,
-            cfg=cfg.api,
-            client=client,
-            chunk_size=cfg.testitem.batch_size,
-            timeout=cfg.testitem.timeout,
-            fields=fields,
-            page_limit=cfg.testitem.request_limit,
-        )
+        try:
+            lookup = cl.get_testitem(
+                pending,
+                cfg=cfg.api,
+                client=client,
+                chunk_size=cfg.testitem.batch_size,
+                timeout=cfg.testitem.timeout,
+                fields=fields,
+                page_limit=cfg.testitem.request_limit,
+            )
+        except (requests.RequestException, ValueError, AttributeError) as exc:
+            logger.warning(
+                "testitem_pref_name_lookup_failed",
+                error=str(exc),
+                error_type=exc.__class__.__name__,
+                pending_ids=list(pending),
+            )
+            lookup = pd.DataFrame(columns=["molecule_chembl_id", "pref_name"])
         if not lookup.empty and {"molecule_chembl_id", "pref_name"}.issubset(lookup.columns):
             mapped = (
                 lookup[["molecule_chembl_id", "pref_name"]]

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -25,6 +25,7 @@ The input file must contain a ``PMID`` column.
 from __future__ import annotations
 
 import argparse
+import inspect
 import os
 import sys
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -1586,7 +1587,30 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     current_handler = getattr(sys.modules[__name__], handler.__name__, handler)
     service = DocumentPipeline(cfg)
-    result = current_handler(cfg, args, pipeline=service)
+
+    supports_pipeline = True
+    try:
+        signature = inspect.signature(current_handler)
+    except (TypeError, ValueError):  # pragma: no cover - builtins or C extensions
+        signature = None
+
+    if signature is not None:
+        supports_pipeline = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            or parameter.name == "pipeline"
+            for parameter in signature.parameters.values()
+            if parameter.kind
+            in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.VAR_KEYWORD,
+            }
+        )
+
+    if supports_pipeline:
+        result = current_handler(cfg, args, pipeline=service)
+    else:
+        result = current_handler(cfg, args)
     return int(result)
 
 


### PR DESCRIPTION
## Summary
- handle failures when enriching molecule preferred names so the activity CLI retries can succeed without a Chembl client
- detect document pipeline handlers that do not accept the `pipeline` keyword and call them without it to preserve tests and custom wrappers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3d7fbd8948324830b67622491d07e