### PR TITLE
Fix UniProt export quality reporting paths

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1923,6 +1923,10 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 1
 
+    output_path: Path | None = None
+    export_path: Path | None = None
+    resolved_export_path: Path | None = None
+
     try:
         df = pd.read_csv(
             args.input_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
@@ -2029,26 +2033,36 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             "uniprot_processing_failed",
             error=str(exc),
             input=str(args.input_csv),
-            output=str(output),
+            output=str(output_path) if output_path is not None else None,
         )
         return 1
     doc_quality_cfg = cfg.system.doc_quality
     try:
         if doc_quality_cfg.enable:
-            quality_table_name = output.stem
+            if export_path is None:
+                raise RuntimeError("export path not available for quality analysis")
+            resolved_export_path = export_path.resolve()
+            quality_table_name = resolved_export_path.stem
             analyze_table_quality(
                 out_df,
                 table_name=quality_table_name,
-                destination_dir=output.parent,
+                destination_dir=resolved_export_path.parent,
                 sample_rows=doc_quality_cfg.sample_rows,
                 include_columns=doc_quality_cfg.include_columns,
                 exclude_columns=doc_quality_cfg.exclude_columns,
             )
     except Exception as exc:
+        quality_log_path: Path | None = None
+        if resolved_export_path is not None:
+            quality_log_path = resolved_export_path
+        elif export_path is not None:
+            quality_log_path = export_path.resolve()
+        elif output_path is not None:
+            quality_log_path = output_path.resolve()
         logger.exception(
             "quality_report_failed",
             error=str(exc),
-            path=str(output),
+            path=str(quality_log_path) if quality_log_path is not None else None,
             exc=exc,
         )
         return 1

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import pandas as pd
 from types import SimpleNamespace
@@ -275,6 +275,62 @@ def test_run_uniprot__invokes_target_postprocess(
     assert isinstance(recorded["context"], get_target_data.IsoformPostprocessContext)
     assert recorded["context"].args is args
     assert recorded["ambiguous"] is None
+
+
+def test_run_uniprot__doc_quality_reports(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg.system.doc_quality.enable = True
+    cfg.system.doc_quality.sample_rows = 5
+    input_csv = tmp_path / "uniprot_ids.csv"
+    input_csv.write_text("uniprot_id\nP12345\n", encoding="utf-8")
+    output_csv = tmp_path / "output.target_20250101.csv"
+
+    monkeypatch.setattr(get_target_data.uu, "init_session", lambda *_, **__: None)
+
+    def _fake_process(**kwargs: object) -> None:
+        Path(kwargs["output_csv"]).write_text(
+            "uniprot_id\nP12345\n", encoding=cfg.io.csv_encoding
+        )
+
+    monkeypatch.setattr(get_target_data.uu, "process", _fake_process)
+
+    monkeypatch.setattr(
+        get_target_data,
+        "_postprocess_target_exports",
+        lambda *_, **__: None,
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_analyze(
+        df: pd.DataFrame,
+        *,
+        table_name: str,
+        destination_dir: Path,
+        sample_rows: int | None,
+        include_columns: Sequence[str] | None,
+        exclude_columns: Sequence[str] | None,
+    ) -> None:
+        captured["table_name"] = table_name
+        captured["destination_dir"] = destination_dir
+        captured["sample_rows"] = sample_rows
+        captured["df"] = df.copy()
+
+    monkeypatch.setattr(get_target_data, "analyze_table_quality", _fake_analyze)
+
+    args = argparse.Namespace(input_csv=input_csv, final_out=output_csv)
+
+    exit_code = get_target_data.run_uniprot(cfg, args)
+
+    assert exit_code == 0
+    assert captured["table_name"] == output_csv.resolve().stem
+    assert captured["destination_dir"] == output_csv.resolve().parent
+    pd.testing.assert_frame_equal(
+        captured["df"], pd.DataFrame({"uniprot_id": ["P12345"]})
+    )
 
 
 def test_run__delegates_to_handler(


### PR DESCRIPTION
## Summary
- ensure the UniProt CLI uses the correct Path objects when logging errors and running quality analysis
- resolve the export destination before invoking the table quality reporter to avoid crashes and improve diagnostics
- add unit coverage for the doc-quality path to confirm analyze_table_quality integration succeeds

## Testing
- pytest tests/unit/test_get_target_data.py -k doc_quality

------
https://chatgpt.com/codex/tasks/task_e_68e3d9190404832494a005bc6008e163