### PR TITLE
Log pipeline exceptions in activity workflow

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -858,16 +858,23 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 logger=logger,
                 stats_callback=_capture_stats,
             )
+        except Exception:
+            logger.exception("Activity pipeline execution failed")
+            raise
         finally:
             chunk_failures.save(fetch_failure_path, cfg=cfg)
 
     if exit_code == 0:
-        extended_output_path = process_activity_extended(
-            input_path=output_path,
-            search_dir=output_path.parent,
-            dictionary_dir=cfg.resources.dictionary_dir,
-            targets_csv=cfg.resources.targets_type_csv,
-        )
+        try:
+            extended_output_path = process_activity_extended(
+                input_path=output_path,
+                search_dir=output_path.parent,
+                dictionary_dir=cfg.resources.dictionary_dir,
+                targets_csv=cfg.resources.targets_type_csv,
+            )
+        except Exception:
+            logger.exception("Activity extended post-processing failed")
+            raise
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)


### PR DESCRIPTION
## Summary
- log activity pipeline exceptions to include tracebacks before bubbling up
- add exception logging around extended activity post-processing

## Testing
- pytest tests/unit/test_get_activity_data.py::test_run_chembl__pipeline_failure_logs_error -q

------
https://chatgpt.com/codex/tasks/task_e_68e3da1248f483248ba4207a0217d88e