### PR TITLE
Fix dtype coercion for activity extended columns

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -205,6 +205,60 @@ _EXTENDED_ACTIVITY_FALLBACKS: dict[str, Callable[[pd.DataFrame], pd.Series | Non
 }
 
 
+def _coerce_extended_series(
+    series: pd.Series,
+    dtype: str,
+    column: str,
+) -> tuple[pd.Series, pd.Series]:
+    """Return ``series`` coerced to ``dtype`` and a mask of conversion failures."""
+
+    if not isinstance(series, pd.Series):
+        series = pd.Series(series)
+
+    if dtype == "string":
+        converted = series.astype(pd.StringDtype())
+        failures = pd.Series(False, index=converted.index)
+        return converted, failures
+
+    if dtype == "Float64":
+        numeric = pd.to_numeric(series, errors="coerce")
+        converted = pd.Series(pd.array(numeric, dtype="Float64"), index=series.index)
+        failures = series.notna() & converted.isna()
+        return converted, failures
+
+    if dtype == "Int64":
+        numeric = pd.to_numeric(series, errors="coerce")
+        converted_float = pd.Series(pd.array(numeric, dtype="Float64"), index=series.index)
+        failures = series.notna() & converted_float.isna()
+        non_integral_mask = converted_float.notna() & converted_float.ne(converted_float.round())
+        if non_integral_mask.any():
+            converted_float.loc[non_integral_mask] = pd.NA
+            failures = failures | non_integral_mask
+        try:
+            converted = converted_float.astype("Int64")
+        except (TypeError, ValueError):
+            converted = pd.Series(pd.NA, index=series.index, dtype="Int64")
+            failures = series.notna()
+        return converted, failures
+
+    if dtype == "boolean":
+        try:
+            converted = series.astype("boolean")
+            failures = series.notna() & converted.isna()
+        except (TypeError, ValueError):
+            converted = pd.Series(pd.NA, index=series.index, dtype="boolean")
+            failures = series.notna()
+        return converted, failures
+
+    try:
+        converted = series.astype(dtype)
+        failures = series.notna() & converted.isna()
+    except (TypeError, ValueError):
+        converted = pd.Series(pd.NA, index=series.index, dtype=dtype)
+        failures = series.notna()
+    return converted, failures
+
+
  
 def _string_like_missing(series: pd.Series) -> pd.Series:
     """Return a boolean mask for ``series`` treating blanks as missing."""
@@ -434,30 +488,47 @@ def _ensure_extended_activity_columns(frame: pd.DataFrame) -> pd.DataFrame:
     for column, dtype in _EXTENDED_ACTIVITY_DTYPES.items():
         fallback = _EXTENDED_ACTIVITY_FALLBACKS.get(column)
         if column in result.columns:
+            coerced_existing, _ = _coerce_extended_series(result[column], dtype, column)
+            result[column] = coerced_existing
             if fallback is not None:
-                existing = result[column]
-                if dtype in {"Float64", "Int64"}:
-                    missing_mask = existing.isna()
+                if dtype in {"Float64", "Int64", "boolean"}:
+                    missing_mask = coerced_existing.isna()
                 else:
-                    missing_mask = _string_like_missing(existing)
+                    missing_mask = _string_like_missing(coerced_existing)
                 if missing_mask.any():
                     candidate = fallback(result)
                     if candidate is not None:
                         aligned = candidate.reindex(result.index)
-                        try:
-                            filled = aligned.astype(dtype)
-                        except (TypeError, ValueError):
-                            filled = aligned.astype("string")
-                        result.loc[missing_mask, column] = filled.loc[missing_mask]
+                        coerced_fallback, fallback_failures = _coerce_extended_series(
+                            aligned, dtype, column
+                        )
+                        failure_subset = fallback_failures & missing_mask
+                        if failure_subset.any():
+                            logger.debug(
+                                "activity_extended_fallback_conversion_failed",
+                                column=column,
+                                dtype=dtype,
+                                rows=int(failure_subset.sum()),
+                                context="existing",
+                            )
+                        result.loc[missing_mask, column] = coerced_fallback.loc[missing_mask]
             continue
         if fallback is not None:
             candidate = fallback(result)
             if candidate is not None:
                 aligned = candidate.reindex(result.index)
-                try:
-                    result[column] = aligned.astype(dtype)
-                except TypeError:
-                    result[column] = aligned.astype("string")
+                coerced_fallback, fallback_failures = _coerce_extended_series(
+                    aligned, dtype, column
+                )
+                if fallback_failures.any():
+                    logger.debug(
+                        "activity_extended_fallback_conversion_failed",
+                        column=column,
+                        dtype=dtype,
+                        rows=int(fallback_failures.sum()),
+                        context="missing_column",
+                    )
+                result[column] = coerced_fallback
                 continue
         if dtype == "boolean":
             filler = pd.Series(pd.NA, index=result.index, dtype="boolean")

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import warnings
 from pathlib import Path
 from typing import Iterable
 
@@ -32,6 +33,9 @@ class _RecordingLogger:
 
     def __init__(self) -> None:
         self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def debug(self, event: str, **kwargs: object) -> None:
+        self.events.append(("debug", event, dict(kwargs)))
 
     def info(self, event: str, **kwargs: object) -> None:
         self.events.append(("info", event, dict(kwargs)))
@@ -198,6 +202,76 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
     written_df = written[0][1]
     assert list(written_df["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
     assert pd.api.types.is_float_dtype(written_df["standard_value"])  # type: ignore[arg-type]
+    assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
+    assert "src_assay_id" in written_df.columns
+    src_assay_series = written_df["src_assay_id"].astype("string")
+    assert src_assay_series.tolist() == ["SRC-ASSAY1", "SRC-ASSAY2", "SRC-ASSAY3"]
+    assert src_assay_series.str.strip().ne("").all()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__extended_columns_dtype_coercion(
+    activity_resource_dir: Path, cfg, tmp_path, monkeypatch
+):
+    _configure_cfg(cfg)
+    input_csv = _copy_resource(activity_resource_dir, "ids_happy.csv", tmp_path)
+    output_csv = tmp_path / "activities.csv"
+
+    chunk_df = pd.read_csv(activity_resource_dir / "chunk_happy.csv")
+    chunk_df["activity_chembl_id"] = pd.Series([float("nan"), 502.0, float("nan")], dtype="float64")
+    chunk_df["compound_name"] = pd.Series([float("nan"), 1.0, float("nan")], dtype="float64")
+    chunk_df["molecule_pref_name"] = pd.Series(["NALTREXONE", "CLOZAPINE", pd.NA], dtype="string")
+    chunk_df["pchembl_value"] = pd.Series(["7.5", "not-a-number", "6.25"], dtype="object")
+    chunk_df["log_value"] = pd.Series([float("nan")] * len(chunk_df), dtype="float64")
+
+    testitem_frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+            "pref_name": ["NALTREXONE", "CLOZAPINE", "OXFORD"],
+        }
+    )
+
+    monkeypatch.setattr(
+        get_activity_data,
+        "_load_assay_src_lookup",
+        lambda *_: {"ASSAY1": "SRC-ASSAY1", "ASSAY2": "SRC-ASSAY2", "ASSAY3": "SRC-ASSAY3"},
+    )
+
+    _install_fetch_stubs(monkeypatch, chunk_df, testitem_frame=testitem_frame)
+    written = _install_writer_stub(monkeypatch)
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.validation.logger", logger_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        exit_code = get_activity_data.run_chembl(cfg, args)
+
+    dtype_warnings = [
+        warning
+        for warning in caught
+        if "incompatible dtype" in str(warning.message)
+        or "Setting an item of incompatible dtype" in str(warning.message)
+    ]
+
+    assert exit_code == 0
+    assert not dtype_warnings
+    assert {path for path, _ in written} == {output_csv}
+
+    debug_events = [event for level, event, _ in logger_stub.events if level == "debug"]
+    assert "activity_extended_fallback_conversion_failed" in debug_events
+
+    written_df = written[0][1]
+    assert pd.api.types.is_string_dtype(written_df["activity_chembl_id"])  # type: ignore[arg-type]
+    assert pd.api.types.is_string_dtype(written_df["compound_name"])  # type: ignore[arg-type]
+    assert pd.api.types.is_float_dtype(written_df["log_value"])  # type: ignore[arg-type]
+    assert written_df.loc[0, "activity_chembl_id"] == "ACT1"
+    assert written_df.loc[0, "compound_name"] == "NALTREXONE"
+    assert pytest.approx(written_df.loc[0, "log_value"], rel=1e-6) == 7.5
+    assert pd.isna(written_df.loc[1, "log_value"])
     assert written_df["standard_value"].tolist() == [5.5, 7.25, 9.0]
     assert "src_assay_id" in written_df.columns
     src_assay_series = written_df["src_assay_id"].astype("string")


### PR DESCRIPTION
## Summary
- coerce existing and fallback activity extended columns to their target dtypes and log failed conversions
- extend the integration suite with a dtype-focused scenario and capture debug logs from the pipeline

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e3d9635ad48324bd3e51c77b93401b