### PR TITLE
Refine activity pipeline logging messages

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -76,7 +76,6 @@ from library.pipelines.common import (
 from library.cli import (
     LoggerConfig,
     positive_int,
-    ConfigMetadata,
 )
 from library.cli import (
     build_parser as base_parser,
@@ -110,42 +109,6 @@ from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_dela
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
 PROGRAM_NAME = Path(__file__).with_suffix("").name
-
-_OPTION_UNSET = object()
-
-
-def _option(
-    metadata: ConfigMetadata | None,
-    *,
-    argument: str | None = None,
-    path: str | None = None,
-    value: object = _OPTION_UNSET,
-    default_source: str = "unknown",
-    default_detail: str | None = None,
-) -> dict[str, object]:
-    """Return structured option metadata for pipeline logging."""
-
-    if metadata is not None:
-        if value is _OPTION_UNSET:
-            return metadata.option(
-                argument=argument,
-                path=path,
-                default_source=default_source,
-                default_detail=default_detail,
-            )
-        return metadata.option(
-            argument=argument,
-            path=path,
-            value=value,
-            default_source=default_source,
-            default_detail=default_detail,
-        )
-    actual = None if value is _OPTION_UNSET else value
-    entry: dict[str, object] = {"value": actual, "source": default_source}
-    if default_detail is not None:
-        entry["detail"] = default_detail
-    return entry
-
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
     invocation = getattr(args, "invocation", None)
@@ -238,20 +201,24 @@ def _load_assay_src_lookup(dictionary_dir: Path | str | None) -> dict[str, str]:
             dtype="string",
         )
     except FileNotFoundError:
-        logger.warning("assay_lookup_missing", path=str(candidate))
+        logger.warning(
+            f"Assay lookup file '{candidate}' was not found; skipping src_assay_id enrichment."
+        )
         return {}
     except pd.errors.EmptyDataError:
-        logger.warning("assay_lookup_empty", path=str(candidate))
+        logger.warning(
+            f"Assay lookup file '{candidate}' is empty; skipping src_assay_id enrichment."
+        )
         return {}
     except ValueError as exc:
         logger.warning(
-            "assay_lookup_invalid_columns",
-            path=str(candidate),
-            error=str(exc),
+            f"Assay lookup file '{candidate}' cannot be parsed due to invalid columns: {exc}."
         )
         return {}
     except OSError as exc:
-        logger.warning("assay_lookup_read_failed", path=str(candidate), error=str(exc))
+        logger.warning(
+            f"Encountered an error while reading assay lookup file '{candidate}': {exc}."
+        )
         return {}
 
     if frame.empty:
@@ -373,10 +340,8 @@ def _ensure_molecule_pref_name(
             )
         except (requests.RequestException, ValueError, AttributeError) as exc:
             logger.warning(
-                "testitem_pref_name_lookup_failed",
-                error=str(exc),
-                error_type=exc.__class__.__name__,
-                pending_ids=list(pending),
+                f"Failed to fetch molecule preferred names for identifiers {list(pending)} "
+                f"({exc.__class__.__name__}: {exc})."
             )
             lookup = pd.DataFrame(columns=["molecule_chembl_id", "pref_name"])
         if not lookup.empty and {"molecule_chembl_id", "pref_name"}.issubset(lookup.columns):
@@ -497,7 +462,9 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     """
     limit = cfg.activity.limit
     if limit is not None and limit < 0:
-        logger.error("invalid_limit", section="activity.limit", limit=limit)
+        logger.error(
+            f"Invalid configuration for 'activity.limit': value {limit} cannot be negative."
+        )
         return 1
 
     offset = getattr(args, "offset", 0)
@@ -525,76 +492,39 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             args.final_out = output_path
         setattr(args, "output_csv", output_path)
 
-    metadata_obj = getattr(args, "_config_metadata", None)
-    if not isinstance(metadata_obj, ConfigMetadata):
-        metadata_obj = None
-
-    output_source = "cli" if getattr(args, "final_out", None) else "derived"
     logger.info(
-        "activity_pipeline_start",
-        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
-        output=_option(
-            metadata_obj,
-            value=str(output_path),
-            default_source=output_source,
-        ),
-        limit=_option(
-            metadata_obj,
-            argument="limit",
-            path="sources.chembl.pipelines.activity.limit",
-            value=limit,
-        ),
-        offset=_option(
-            metadata_obj,
-            argument="offset",
-            path="sources.chembl.pipelines.activity.offset",
-            value=offset,
-        ),
-        batch_size=_option(
-            metadata_obj,
-            argument="batch_size",
-            path="sources.chembl.pipelines.activity.batch_size",
-            value=cfg.activity.batch_size,
-        ),
-        timeout=_option(
-            metadata_obj,
-            argument="timeout",
-            path="sources.chembl.pipelines.activity.timeout",
-            value=cfg.activity.timeout,
-        ),
-        dry_run=_option(
-            metadata_obj,
-            argument="dry_run",
-            path="sources.chembl.pipelines.activity.dry_run",
-            value=cfg.activity.dry_run,
-            default_source="cli",
-        ),
-        workers=_option(
-            metadata_obj,
-            argument="workers",
-            path="sources.chembl.pipelines.activity.workers",
-            value=configured_workers,
-        ),
+        f"Starting activity data pipeline for input '{args.input_csv}' with output '{output_path}'."
+    )
+    configured_limit = "unbounded" if limit is None else str(limit)
+    logger.info(
+        f"Loaded activity configuration: limit={configured_limit}, offset={offset}, "
+        f"batch_size={cfg.activity.batch_size}, timeout={cfg.activity.timeout}, "
+        f"dry_run={cfg.activity.dry_run}, workers={configured_workers}."
     )
 
     if cfg.activity.dry_run:
         expected = limit if limit is not None else 0
-        logger.info("dry_run", limit=expected)
+        logger.info(
+            f"Dry-run mode enabled; skipping API calls after validating up to {expected} identifiers."
+        )
         return 0
 
+    logger.info(
+        f"Reading activity identifiers from '{args.input_csv}' using column '{cfg.activity.column}'."
+    )
     try:
         ids_iter = io.read_ids(args.input_csv, column=cfg.activity.column, cfg=cfg.io)
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
-            "read_fail",
-            error=str(exc),
-            path=str(args.input_csv),
+            f"Failed to read activity identifiers from '{args.input_csv}': {exc}."
         )
         return 1
 
     if offset:
         ids_iter = islice(ids_iter, offset, None)
-        logger.info("process_offset", offset=offset)
+        logger.info(
+            f"Skipping the first {offset} identifiers before processing as requested."
+        )
 
     processed_ids = 0
     extended_output_path: Path | None = None
@@ -645,6 +575,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         ]
         if not missing:
             return frame
+        missing_text = ", ".join(sorted(missing))
+        logger.warning(
+            f"Input activity data is missing required columns: {missing_text}. "
+            "Creating empty placeholders to continue processing."
+        )
         fillers: dict[str, pd.Series] = {}
         for column in missing:
             dtype_info = _ACTIVITY_REQUIRED_DTYPES.get(column)
@@ -717,7 +652,10 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     encoding=cfg.io.csv_encoding,
                 )
             except Exception:  # pragma: no cover - defensive for patched writers
-                logger.debug("io_write_csv_stub_failed")
+                logger.debug(
+                    "Fallback CSV writer hook failed while finalizing deterministic output; "
+                    "continuing with generated file."
+                )
         return path_obj
 
 
@@ -742,8 +680,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     if (rate_cfg.global_rps or 0) > 0:
         global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
 
-    last_error_extra: dict[str, object] | None = None
-    last_error_context: dict[str, object] = {}
+    last_error_message: str | None = None
 
     pref_name_cache: dict[str, str | None] = {}
 
@@ -758,7 +695,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         chunk_failures = ChunkFailureTracker()
 
         def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
-            nonlocal last_error_extra, last_error_context
+            nonlocal last_error_message
             attempts = max(1, retry_cfg.max_attempts)
             for attempt in range(1, attempts + 1):
                 try:
@@ -772,41 +709,33 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     )
                 except (requests.RequestException, ValueError) as exc:
                     error_message = str(exc)
-                    context = {
-                        "chunk_ids": list(chunk_ids),
-                        "chunk_size": len(chunk_ids),
-                        "attempt": attempt,
-                        "max_attempts": attempts,
-                        "batch_size": cfg.activity.batch_size,
-                        "timeout": cfg.activity.timeout,
-                    }
-                    log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
-                    last_error_extra = {
-                        "msg": error_message,
-                        "chunk_ids": context["chunk_ids"],
-                    }
-                    last_error_context = dict(log_context)
+                    chunk_list = list(chunk_ids)
+                    context_text = (
+                        f"attempt {attempt} of {attempts} "
+                        f"(chunk size {len(chunk_ids)}, batch size {cfg.activity.batch_size}, "
+                        f"timeout {cfg.activity.timeout})"
+                    )
+                    last_error_message = (
+                        f"Failed to fetch activities for chunk {chunk_list} during {context_text}: "
+                        f"{error_message}"
+                    )
                     if attempt >= attempts:
                         logger.error(
-                            "activity_fetch_failed",
-                            extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
-                            error=error_message,
-                            **log_context,
+                            f"{last_error_message}. Exhausted retry budget; aborting chunk fetch."
                         )
                         chunk_failures.add_failure(chunk_ids, error_message)
                         raise PipelineError("chunk_fetch_failed")
                     delay = compute_backoff_delay(attempt, retry_cfg)
-                    logger.warning(
-                        "activity_fetch_retry",
-                        extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
-                        delay=delay,
-                        **log_context,
-                    )
+                    if delay > 0:
+                        logger.warning(
+                            f"{last_error_message}. Retrying after {delay:.2f} seconds."
+                        )
+                    else:
+                        logger.warning(f"{last_error_message}. Retrying immediately.")
                     if delay > 0:
                         sleep(delay)
                 else:
-                    last_error_extra = None
-                    last_error_context = {}
+                    last_error_message = None
                     return _ensure_molecule_pref_name(
                         result, cfg=cfg, client=client, cache=pref_name_cache
                     )
@@ -868,37 +797,47 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             dictionary_dir=cfg.resources.dictionary_dir,
             targets_csv=cfg.resources.targets_type_csv,
         )
+        if extended_output_path is not None:
+            logger.info(
+                f"Merged activity output with reference dictionaries to create '{extended_output_path}'."
+            )
+        else:
+            logger.info(
+                "Merged activity output with reference dictionaries without producing an extended dataset."
+            )
 
     if limit is not None:
-        logger.info("process_limit", limit=processed_ids)
+        logger.info(
+            f"Processed {processed_ids} identifiers in accordance with the configured limit of {limit}."
+        )
 
     if pipeline_stats is not None:
+        rows_total = int(pipeline_stats.get("rows_total", processed_ids))
+        rows_kept = int(pipeline_stats.get("rows_kept", 0))
+        rows_dropped = int(pipeline_stats.get("rows_dropped", 0))
         logger.info(
-            "records_dropped",
-            rows_total=int(pipeline_stats.get("rows_total", processed_ids)),
-            rows_kept=int(pipeline_stats.get("rows_kept", 0)),
-            rows_dropped=int(pipeline_stats.get("rows_dropped", 0)),
+            f"Filtered activity records: kept {rows_kept} of {rows_total} and dropped {rows_dropped}."
         )
 
     if exit_code == 0:
-        log_payload = {
-            "output": str(output_path),
-            "processed": processed_ids,
-            "dry_run": False,
-        }
         if extended_output_path is not None:
-            log_payload["extended_output"] = str(extended_output_path)
-        logger.info("activity_pipeline_done", **log_payload)
+            logger.info(
+                f"Successfully exported {processed_ids} activity records to '{output_path}' "
+                f"and generated extended output at '{extended_output_path}'."
+            )
+        else:
+            logger.info(
+                f"Successfully exported {processed_ids} activity records to '{output_path}'."
+            )
     else:
-        extra_payload = last_error_extra
-        context_payload = dict(last_error_context) if last_error_context else {}
+        detail = (
+            f" Last recorded chunk failure: {last_error_message}."
+            if last_error_message
+            else ""
+        )
         logger.error(
-            "activity_pipeline_failed",
-            extra=extra_payload,
-            output=str(output_path),
-            processed=processed_ids,
-            exit_code=exit_code,
-            **context_payload,
+            f"Activity pipeline failed after processing {processed_ids} identifiers. "
+            f"Intended output path was '{output_path}'. Exit code {exit_code}.{detail}"
         )
 
     return exit_code
@@ -925,7 +864,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             args.final_out = output_path
         setattr(args, "output_csv", output_path)
     if args.skip_existing and output_path.exists() and not args.force:
-        logger.info("pipeline_skip_existing", output=str(output_path))
+        logger.info(
+            f"Skipping pipeline execution because output '{output_path}' already exists and --force was not provided."
+        )
         return 0
     return run_chembl(cfg, args)
 
@@ -1012,7 +953,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         output_stem=DEFAULT_OUTPUT_STEM,
     )
     if args.limit == 0:
-        logger.info("pipeline_skip_limit", limit=args.limit)
+        logger.info(
+            "Pipeline exit requested: --limit was set to 0 so no identifiers will be processed."
+        )
         return 0
     if args.limit is not None and args.limit < 0:
         # Reject negative limits early to provide clear CLI feedback.

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -60,6 +60,11 @@ class _MemoryLogger:
     def error(self, event: str, **kwargs: object) -> None:
         self.events.append(("error", event, dict(kwargs)))
 
+    def messages(self, level: str | None = None) -> list[str]:
+        if level is None:
+            return [event for _, event, _ in self.events]
+        return [event for lvl, event, _ in self.events if lvl == level]
+
 
 def _patch_logger(monkeypatch: pytest.MonkeyPatch, module: object) -> _MemoryLogger:
     logger = _MemoryLogger()
@@ -296,8 +301,8 @@ def test_get_testitem_run_skip_existing(
 
     assert rc == 0
     assert call_counter["called"] == 0
-    events = [event for _, event, _ in logger_stub.events]
-    assert "pipeline_skip_existing" in events
+    events = logger_stub.messages()
+    assert any("Skipping pipeline execution" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -340,10 +345,10 @@ def test_get_activity_cli__retry_and_idempotent(
     assert first_exit == 0
     assert output_csv.exists()
     first_content = output_csv.read_text(encoding="utf-8")
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_fetch_retry" in events
-    assert "activity_pipeline_done" in events
-    assert not any(event == "activity_pipeline_failed" for event in events)
+    events = logger_stub.messages()
+    assert any("Retrying" in event for event in events)
+    assert any(event.startswith("Successfully exported") for event in events)
+    assert not any("Activity pipeline failed" in event for event in events)
     assert attempts["count"] >= 2
     assert len(written) == 1
     assert list(written[0][1]["activity_id"]) == ["ACT1", "ACT2", "ACT3"]
@@ -356,9 +361,9 @@ def test_get_activity_cli__retry_and_idempotent(
     assert second_exit == 0
     second_content = output_csv.read_text(encoding="utf-8")
     assert second_content == first_content
-    done_events = [event for _, event, _ in logger_stub.events]
-    assert done_events.count("activity_pipeline_done") >= 1
-    assert not any(event == "activity_pipeline_failed" for event in done_events)
+    done_events = logger_stub.messages()
+    assert sum(1 for event in done_events if event.startswith("Successfully exported")) >= 1
+    assert not any("Activity pipeline failed" in event for event in done_events)
 
 
 @pytest.mark.e2e
@@ -435,9 +440,9 @@ def test_get_activity_cli__workers_and_offset(
     assert len(written) == 1
     written_df = written[0][1]
     assert written_df["activity_id"].tolist() == ["ACT2", "ACT3"]
-    events = [event for _, event, _ in logger_stub.events]
-    assert "process_offset" in events
-    assert "activity_pipeline_done" in events
+    events = logger_stub.messages()
+    assert any("Skipping the first" in event for event in events)
+    assert any(event.startswith("Successfully exported") for event in events)
 
 
 @pytest.mark.e2e
@@ -516,9 +521,9 @@ def test_get_activity_cli__chembl_identifier_backfill_ratio(
         == id_series[id_present].iloc[:5].tolist()
     )
 
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_pipeline_done" in events
-    assert "activity_pipeline_failed" not in events
+    events = logger_stub.messages()
+    assert any(event.startswith("Successfully exported") for event in events)
+    assert not any("Activity pipeline failed" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -560,8 +565,8 @@ def test_get_activity_cli__non_csv_output_path(
     assert "\t" in content.splitlines()[1]
     assert len(written) == 1
     assert written[0][2] == "\t"
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_pipeline_done" in events
+    events = logger_stub.messages()
+    assert any(event.startswith("Successfully exported") for event in events)
 
 
 @pytest.mark.e2e
@@ -784,8 +789,8 @@ def test_get_target_run_skip_existing(
     rc = get_target_data.run(cfg, args)
 
     assert rc == 0
-    events = [event for _, event, _ in logger_stub.events]
-    assert "pipeline_skip_existing" in events
+    events = logger_stub.messages()
+    assert any("Skipping pipeline execution" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -997,7 +1002,7 @@ def test_get_activity_run_success(
         missing = numeric.isna()
         if int(missing.sum()):
             get_activity_data.logger.error(
-                "activity_missing_value", count=int(missing.sum())
+                f"Encountered {int(missing.sum())} activity rows with missing numeric values."
             )
         frame["standard_value_numeric"] = numeric.astype("Float64")
         frame["is_valid"] = (~missing).astype("boolean")
@@ -1007,7 +1012,7 @@ def test_get_activity_run_success(
         _ensure_parent(output_path)
         frame.to_csv(output_path, index=False)
         get_activity_data.logger.info(
-            "activity_pipeline_done", output=str(args.final_out), rows=len(frame)
+            f"Successfully exported {len(frame)} activity records to '{args.final_out}'."
         )
         return 0
 
@@ -1027,9 +1032,9 @@ def test_get_activity_run_success(
     assert "standard_value_numeric" in result.columns
     assert "is_valid" in result.columns
     assert not result[result["activity_id"] == "A3"]["is_valid"].iloc[0]
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_pipeline_done" in events
-    assert "activity_missing_value" in events
+    events = logger_stub.messages()
+    assert any(event.startswith("Successfully exported") for event in events)
+    assert any("missing numeric values" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -1060,8 +1065,8 @@ def test_get_activity_run_skip_existing(
     rc = get_activity_data.run(cfg, args)
 
     assert rc == 0
-    events = [event for _, event, _ in logger_stub.events]
-    assert "pipeline_skip_existing" in events
+    events = logger_stub.messages()
+    assert any("Skipping pipeline execution" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -1077,7 +1082,7 @@ def test_get_activity_run_failure(
 
     def _failing_run(config: Config, args: argparse.Namespace) -> int:
         get_activity_data.logger.error(
-            "activity_pipeline_failed", output=str(args.final_out), exit_code=1
+            f"Activity pipeline failed after processing 0 identifiers. Intended output path was '{args.final_out}'. Exit code 1."
         )
         return 1
 
@@ -1093,8 +1098,8 @@ def test_get_activity_run_failure(
     rc = get_activity_data.run(cfg, args)
 
     assert rc == 1
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_pipeline_failed" in events
+    events = logger_stub.messages()
+    assert any("Activity pipeline failed" in event for event in events)
 
 
 @pytest.mark.e2e
@@ -1175,17 +1180,17 @@ def test_get_activity_run_retry_and_idempotent(
 
     assert rc == 0
     assert call_counter["count"] == 2
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_fetch_retry" in events
-    assert "activity_pipeline_done" in events
+    events = logger_stub.messages()
+    assert any("Retrying" in event for event in events)
+    assert any(event.startswith("Successfully exported") for event in events)
     assert output_csv in written
 
     args.skip_existing = True
     rc_second = get_activity_data.run(cfg, args)
 
     assert rc_second == 0
-    events_second = [event for _, event, _ in logger_stub.events]
-    assert "pipeline_skip_existing" in events_second
+    events_second = logger_stub.messages()
+    assert any("Skipping pipeline execution" in event for event in events_second)
 
 
 @pytest.mark.e2e
@@ -1256,8 +1261,8 @@ def test_get_activity_run_workers_offset_and_non_csv(
     rc = get_activity_data.run(cfg, args)
 
     assert rc == 0
-    events = [event for _, event, _ in logger_stub.events]
-    assert "activity_pipeline_done" in events
-    assert any(event_name == "process_offset" for _, event_name, _ in logger_stub.events)
+    events = logger_stub.messages()
+    assert any(event.startswith("Successfully exported") for event in events)
+    assert any("Skipping the first" in event for event in events)
     assert captured["workers"] == max(1, cfg.activity.workers)
     assert output_csv.exists()

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -42,6 +42,11 @@ class _RecordingLogger:
     def error(self, event: str, **kwargs: object) -> None:
         self.events.append(("error", event, dict(kwargs)))
 
+    def messages(self, level: str | None = None) -> list[str]:
+        if level is None:
+            return [event for _, event, _ in self.events]
+        return [event for lvl, event, _ in self.events if lvl == level]
+
 
 @pytest.fixture()
 def activity_resource_dir(snapshot_resource: Path) -> Path:
@@ -179,19 +184,14 @@ def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_pat
 
     exit_code = get_activity_data.run_chembl(cfg, args)
 
-    activity_events = [event for _, event, _ in logger_stub.events]
-
     assert exit_code == 0
     assert {path for path, _ in written} == {output_csv}
-    assert set(activity_events).issuperset(
-        {
-            "activity_pipeline_start",
-            "activity_pipeline_done",
-            "records_dropped",
-            "schema_validate_start",
-            "schema_validate_done",
-        }
-    )
+    messages = logger_stub.messages()
+    assert any(message.startswith("Starting activity data pipeline") for message in messages)
+    assert any(message.startswith("Loaded activity configuration") for message in messages)
+    assert any("Filtered activity records" in message for message in messages)
+    assert any(message.startswith("Successfully exported") for message in messages)
+    assert {"schema_validate_start", "schema_validate_done"}.issubset(set(messages))
     assert captured.activities == [("ACT1", "ACT2", "ACT3")]
     assert captured.testitems
 
@@ -224,10 +224,9 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
 
     exit_code = get_activity_data.run_chembl(cfg, args)
 
-    activity_events = [event for _, event, _ in logger_stub.events]
-
     assert exit_code == 1
-    assert "read_fail" in activity_events
+    activity_events = logger_stub.messages()
+    assert any("Failed to read activity identifiers" in event for event in activity_events)
     assert not output_csv.exists()
 
 
@@ -250,10 +249,9 @@ def test_activity_pipeline__malformed_values(activity_resource_dir: Path, cfg, t
 
     exit_code = get_activity_data.run_chembl(cfg, args)
 
-    activity_events = [event for _, event, _ in logger_stub.events]
-
     assert exit_code == 1
     assert not written
+    activity_events = logger_stub.messages()
     assert "validation_failed" in activity_events
     failure_path = output_csv.with_name("activities_failure_cases.csv")
     assert failure_path.exists()
@@ -263,8 +261,9 @@ def test_activity_pipeline__malformed_values(activity_resource_dir: Path, cfg, t
     failure_cases = " ".join(str(value) for value in failure_df["failure_case"])
     assert "not-a-number" in failure_cases
     assert ">=" in failure_cases
-    error_events = {event for level, event, _ in logger_stub.events if level == "error"}
-    assert {"validation_failed", "activity_pipeline_failed"}.issubset(error_events)
+    error_events = set(logger_stub.messages(level="error"))
+    assert "validation_failed" in error_events
+    assert any("Activity pipeline failed" in event for event in error_events)
 
 
 @pytest.mark.integration
@@ -293,10 +292,10 @@ def test_activity_pipeline__deduplicates_identifiers(activity_resource_dir: Path
     assert len(written) == 1
     written_df = written[0][1]
     assert written_df["activity_id"].tolist() == ["ACT1", "ACT2", "ACT3"]
-    info_events = {event for _, event, _ in logger_stub.events}
-    assert "records_dropped" in info_events
+    info_events = set(logger_stub.messages())
+    assert any("Filtered activity records" in event for event in info_events)
     assert "schema_validate_done" in info_events
-    warning_events = {event for level, event, _ in logger_stub.events if level == "warning"}
+    warning_events = set(logger_stub.messages(level="warning"))
     assert "read_ids_dropped_na_markers" not in warning_events
 
 

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -59,6 +59,11 @@ class _RecordingLogger:
     def error(self, event: str, **kwargs: object) -> None:
         self.events.append(("error", event, dict(kwargs)))
 
+    def messages(self, level: str | None = None) -> list[str]:
+        if level is None:
+            return [event for _, event, _ in self.events]
+        return [event for lvl, event, _ in self.events if lvl == level]
+
 
 @pytest.mark.parametrize(
     "invocation, expected",
@@ -100,9 +105,9 @@ def test_run_chembl__dry_run_short_circuits(cfg, tmp_path, monkeypatch) -> None:
     exit_code = get_activity_data.run_chembl(cfg, args)
 
     assert exit_code == 0
-    assert ("info", "dry_run", {"limit": 7}) in [
-        (level, event, context) for level, event, context in logger_stub.events
-    ]
+    messages = [event for _, event, _ in logger_stub.events]
+    assert any("Dry-run mode enabled" in message for message in messages)
+    assert any("up to 7 identifiers" in message for message in messages)
 
 
 @pytest.mark.parametrize(
@@ -260,7 +265,7 @@ def test_run_chembl__offset_and_workers(monkeypatch, cfg, tmp_path) -> None:
     assert exit_code == 0
     assert captured["workers"] == max(1, cfg.activity.workers)
     events = [event for _, event, _ in logger_stub.events]
-    assert "process_offset" in events
+    assert any("Skipping the first" in event for event in events)
 
 
 @pytest.mark.parametrize(
@@ -285,7 +290,7 @@ def test_run_chembl__read_ids_failures(error_factory, cfg, tmp_path, monkeypatch
 
     assert exit_code == 1
     events = [event for _, event, _ in logger_stub.events]
-    assert "read_fail" in events
+    assert any("Failed to read activity identifiers" in event for event in events)
 
 
 def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> None:
@@ -339,7 +344,7 @@ def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> 
 
     assert exit_code == 1
     error_events = [event for level, event, _ in logger_stub.events if level == "error"]
-    assert "activity_pipeline_failed" in error_events
+    assert any("Activity pipeline failed" in event for event in error_events)
 
 
 def test_main__dry_run_skip_limit(monkeypatch, tmp_path, capsys) -> None:
@@ -358,7 +363,7 @@ def test_main__dry_run_skip_limit(monkeypatch, tmp_path, capsys) -> None:
 
     assert exit_code == 0
     events = [event for _, event, _ in logger_stub.events]
-    assert "pipeline_skip_limit" in events
+    assert any("Pipeline exit requested" in event for event in events)
 
 
 def test_activity_columns__cover_extended_requirements() -> None:


### PR DESCRIPTION
## Summary
- replace token-based logging in the activity pipeline with descriptive sentences for each major stage and warning
- adjust unit, integration, and e2e tests to assert on the new log text and add helpers for inspecting messages

## Testing
- pytest tests/unit/test_get_activity_data.py
- pytest tests/integration/test_get_activity_data_pipeline.py
- pytest tests/e2e/test_get_cli_pipelines.py -k activity

------
https://chatgpt.com/codex/tasks/task_e_68e3da0a66b08324bfd46ce7fd38b395