### PR TITLE
Fix dtype-safe filling for extended activity columns

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -553,7 +553,12 @@ def _ensure_extended_activity_columns(frame: pd.DataFrame) -> pd.DataFrame:
                     if candidate is not None:
                         aligned = candidate.reindex(result.index)
                         filled = _coerce_series_dtype(aligned, dtype)
-                        result.loc[missing_mask, column] = filled.loc[missing_mask]
+                        current = result[column]
+                        # ``Series.mask`` preserves the extension dtype and avoids
+                        # implicit "object" upcasts that would otherwise trigger
+                        # ``FutureWarning`` about incompatible assignments (see
+                        # pandas GH-53964).
+                        result[column] = current.mask(missing_mask, filled)
             continue
         if fallback is not None:
             candidate = fallback(result)


### PR DESCRIPTION
## Summary
- replace direct loc assignments in the extended activity column backfill with Series.mask to preserve extension dtypes and silence pandas FutureWarnings

## Testing
- pytest -q tests/integration/test_activity_extended_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68e3dd4eecc48324b2242b682c68c26e