### PR TITLE
Handle missing UniProt candidates in target pipeline

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -2803,12 +2803,38 @@ def fetch_uniprot(
         unique=len(plan.unique_records),
         candidate_columns=plan.candidate_columns,
     )
-    if plan.unique_records:
-        id_df = pd.DataFrame(plan.unique_records, dtype=object)
-    else:
-        id_df = pd.DataFrame(
-            columns=["uniprot_id", "original_id", "source_column"], dtype=object
+    if not plan.unique_records:
+        logger.info(
+            "fetch_uniprot_no_candidates",
+            output=str(output_csv),
+            rows=len(plan.row_index),
+            candidate_columns=plan.candidate_columns,
         )
+        empty_df = pd.DataFrame(
+            {
+                "uniprot_id": pd.Series(dtype=object),
+                "original_id": pd.Series(dtype=object),
+                "source_column": pd.Series(dtype=object),
+                "mapping_uniprot_id": pd.Series(dtype=object),
+            }
+        )
+        write_csv_deterministic(
+            empty_df,
+            output_csv,
+            col_order=[
+                "uniprot_id",
+                "original_id",
+                "source_column",
+                "mapping_uniprot_id",
+            ],
+            key_cols=["uniprot_id"],
+            sep=cfg.io.csv_sep,
+            encoding=cfg.io.csv_encoding,
+            cfg=cfg,
+        )
+        return empty_df
+
+    id_df = pd.DataFrame(plan.unique_records, dtype=object)
 
     id_df = id_df.copy()
     id_df["__query_order"] = range(len(id_df))

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -333,6 +333,58 @@ def test_run_uniprot__doc_quality_reports(
     )
 
 
+def test_fetch_uniprot__no_candidates_writes_empty_output(
+    cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_csv = tmp_path / "output_uniprot.csv"
+    chembl_df = pd.DataFrame({"target_chembl_id": ["CHEMBL1"]})
+
+    plan = get_target_data._UniprotQueryPlan(
+        unique_records=[],
+        row_candidates=[[] for _ in chembl_df.index],
+        row_index=list(chembl_df.index),
+        candidate_columns=[],
+    )
+
+    monkeypatch.setattr(
+        get_target_data,
+        "_build_uniprot_query_plan",
+        lambda *_: plan,
+    )
+
+    def _unexpected(*_: object, **__: object) -> None:  # pragma: no cover - defensive
+        raise AssertionError("run_uniprot should not be invoked when no candidates are found")
+
+    monkeypatch.setattr(get_target_data, "run_uniprot", _unexpected)
+
+    result = get_target_data.fetch_uniprot(cfg, chembl_df, output_csv)
+
+    assert output_csv.exists()
+    pd.testing.assert_frame_equal(
+        result,
+        pd.DataFrame(
+            {
+                "uniprot_id": pd.Series(dtype=object),
+                "original_id": pd.Series(dtype=object),
+                "source_column": pd.Series(dtype=object),
+                "mapping_uniprot_id": pd.Series(dtype=object),
+            }
+        ),
+        check_index_type=False,
+    )
+
+    written = pd.read_csv(
+        output_csv, sep=cfg.io.csv_sep, encoding=cfg.io.csv_encoding, dtype=str
+    )
+    assert list(written.columns) == [
+        "uniprot_id",
+        "original_id",
+        "source_column",
+        "mapping_uniprot_id",
+    ]
+    assert written.empty
+
+
 def test_run__delegates_to_handler(
     cfg: Config,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- ensure the target pipeline writes a deterministic empty UniProt export when no candidate accessions are available
- cover the no-candidate scenario with a unit test that validates the generated CSV and return value

## Testing
- pytest tests/unit/test_get_target_data.py::test_fetch_uniprot__no_candidates_writes_empty_output -q

------
https://chatgpt.com/codex/tasks/task_e_68e3e4fdcf288324b14b64373d9b6d81