### PR TITLE
Drop legacy assay columns before export

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -69,6 +69,48 @@ DEFAULT_OUTPUT_STEM = "assays"
 
 _OPTION_UNSET = object()
 
+_ASSAY_OUTPUT_DROP_COLUMNS = [
+    "ASSAY_ID",
+    "Target TYPE",
+    "acts_per_assay_step5",
+    "cited_assay_corr",
+    "error_assay_corr",
+    "higly_correlated_cit",
+    "month",
+    "shuffled_cit",
+    "shuffled_target_assay",
+    "substrate_name",
+    "target_name",
+    "version",
+    "assay_category",
+    "src_assay_id",
+]
+
+
+def _drop_assay_output_columns(frame: pd.DataFrame) -> pd.DataFrame:
+    """Remove disallowed columns from the final assay output."""
+
+    allowed_cols = [
+        column for column in frame.columns if column not in _ASSAY_OUTPUT_DROP_COLUMNS
+    ]
+    dropped_present = [
+        column for column in _ASSAY_OUTPUT_DROP_COLUMNS if column in frame.columns
+    ]
+
+    # ``errors='ignore'`` guarantees the pipeline remains stable if a column is absent.
+    trimmed = frame.drop(columns=_ASSAY_OUTPUT_DROP_COLUMNS, errors="ignore")
+    trimmed = trimmed.loc[:, allowed_cols]
+
+    dropped_display = ", ".join(dropped_present) if dropped_present else "<none>"
+    logger.log(
+        "INFO",
+        "get_assay_data",
+        msg=f"Dropped columns from output.assay_*: {dropped_display}",
+        dropped_columns=dropped_present,
+    )
+
+    return trimmed
+
 
 def _option(
     metadata: ConfigMetadata | None,
@@ -223,6 +265,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         ap.postprocess_assays,
         normalize_assays,
         add_pipeline_metadata,
+        _drop_assay_output_columns,
     ]
 
     validators = [partial(validate_assays, return_result=True)]

--- a/tests/test_assay_output_columns.py
+++ b/tests/test_assay_output_columns.py
@@ -1,0 +1,56 @@
+"""Smoke tests for assay output column filtering."""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+import pytest
+
+from scripts.get_assay_data import _drop_assay_output_columns
+
+
+@pytest.mark.unit
+def test_drop_assay_output_columns__removes_and_preserves_order(caplog: pytest.LogCaptureFixture) -> None:
+    """The whitelist keeps column order while dropping the disallowed set."""
+
+    source_columns = [
+        "assay_chembl_id",
+        "ASSAY_ID",
+        "assay_type",
+        "Target TYPE",
+        "version",
+        "substrate_name",
+        "custom_field",
+    ]
+    frame = pd.DataFrame([
+        ["A", "legacy-1", "type-1", "primary", "1.0", "substrate", "value"],
+        ["B", "legacy-2", "type-2", "backup", "2.0", "substrate", "other"],
+    ], columns=source_columns)
+
+    caplog.set_level(logging.INFO)
+
+    filtered = _drop_assay_output_columns(frame)
+
+    assert list(filtered.columns) == [
+        "assay_chembl_id",
+        "assay_type",
+        "custom_field",
+    ]
+    pd.testing.assert_frame_equal(
+        filtered,
+        pd.DataFrame(
+            [
+                ["A", "type-1", "value"],
+                ["B", "type-2", "other"],
+            ],
+            columns=["assay_chembl_id", "assay_type", "custom_field"],
+        ),
+    )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "Dropped columns from output.assay_*: ASSAY_ID, Target TYPE, substrate_name, version"
+        in message
+        for message in messages
+    )


### PR DESCRIPTION
## Summary
- strip the legacy assay columns at the end of get_assay_data pipeline and log the removal
- add a smoke test that ensures the disallowed columns are absent from the exported frame

## Testing
- pytest tests/test_assay_output_columns.py


------
https://chatgpt.com/codex/tasks/task_e_68e3e4d854dc8324a384b50f1325bcfa