### PR TITLE
Remove restricted columns from assay pipeline output

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -70,6 +70,34 @@ DEFAULT_OUTPUT_STEM = "assays"
 _OPTION_UNSET = object()
 
 
+ASSAY_OUTPUT_DROP_COLUMNS: list[str] = [
+    "ASSAY_ID",
+    "Target TYPE",
+    "acts_per_assay_step5",
+    "cited_assay_corr",
+    "error_assay_corr",
+    "higly_correlated_cit",
+    "month",
+    "shuffled_cit",
+    "shuffled_target_assay",
+    "substrate_name",
+    "target_name",
+    "version",
+    "assay_category",
+    "src_assay_id",
+]
+
+
+def remove_assay_output_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` without columns disallowed in ``output.assay_*`` exports."""
+
+    allowed_cols = [column for column in df.columns if column not in ASSAY_OUTPUT_DROP_COLUMNS]
+    cleaned = df.drop(columns=ASSAY_OUTPUT_DROP_COLUMNS, errors="ignore")
+    if allowed_cols:
+        cleaned = cleaned.loc[:, allowed_cols]
+    return cleaned
+
+
 def _option(
     metadata: ConfigMetadata | None,
     *,
@@ -218,11 +246,20 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     def _enrich_with_dictionaries(frame: pd.DataFrame) -> pd.DataFrame:
         return enrich_assay_metadata(frame, dictionary_dir=cfg.resources.dictionary_dir)
 
+    dropped_columns_seen: set[str] = set()
+
+    def _drop_output_columns(frame: pd.DataFrame) -> pd.DataFrame:
+        removed = [column for column in ASSAY_OUTPUT_DROP_COLUMNS if column in frame.columns]
+        if removed:
+            dropped_columns_seen.update(removed)
+        return remove_assay_output_columns(frame)
+
     metadata_hooks = [
         _enrich_with_dictionaries,
         ap.postprocess_assays,
         normalize_assays,
         add_pipeline_metadata,
+        _drop_output_columns,
     ]
 
     validators = [partial(validate_assays, return_result=True)]
@@ -349,6 +386,17 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             )
         finally:
             chunk_failures.save(fetch_failure_path, cfg=cfg)
+
+    dropped_columns_report = [
+        column for column in ASSAY_OUTPUT_DROP_COLUMNS if column in dropped_columns_seen
+    ]
+    if dropped_columns_report:
+        logger.info(
+            "Dropped columns from output.assay_*: %s",
+            ", ".join(dropped_columns_report),
+        )
+    else:
+        logger.info("Dropped columns from output.assay_*: <none>")
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)

--- a/tests/test_assay_output_columns.py
+++ b/tests/test_assay_output_columns.py
@@ -1,0 +1,58 @@
+"""Smoke tests for ensuring unwanted assay columns are excluded from output."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from scripts.get_assay_data import ASSAY_OUTPUT_DROP_COLUMNS, remove_assay_output_columns
+
+
+@pytest.mark.unit
+def test_remove_assay_output_columns__drops_specified_fields() -> None:
+    """The helper removes only the disallowed assay columns preserving order."""
+
+    columns = [
+        "assay_chembl_id",
+        "ASSAY_ID",
+        "Target TYPE",
+        "assay_type",
+        "acts_per_assay_step5",
+        "custom_field",
+    ]
+    values = list(range(len(columns)))
+    frame = pd.DataFrame([values], columns=columns)
+
+    result = remove_assay_output_columns(frame)
+
+    expected_columns = [
+        column for column in columns if column not in ASSAY_OUTPUT_DROP_COLUMNS
+    ]
+
+    assert list(result.columns) == expected_columns
+    pd.testing.assert_frame_equal(
+        result,
+        pd.DataFrame([[0, 3, 5]], columns=expected_columns),
+        check_dtype=False,
+    )
+    assert list(frame.columns) == columns, "original frame must remain unchanged"
+
+
+@pytest.mark.unit
+def test_remove_assay_output_columns__handles_missing_fields() -> None:
+    """Columns absent from the dataframe are ignored without raising errors."""
+
+    frame = pd.DataFrame(
+        [
+            {
+                "assay_chembl_id": "CHEMBL1",
+                "assay_type": "binding",
+                "custom_field": "value",
+            }
+        ]
+    )
+
+    result = remove_assay_output_columns(frame)
+
+    assert list(result.columns) == ["assay_chembl_id", "assay_type", "custom_field"]
+    pd.testing.assert_frame_equal(result, frame, check_like=True)


### PR DESCRIPTION
## Summary
- filter disallowed assay fields at the final metadata stage and log the removed columns
- ensure the helper safely preserves column order while using an allow-list approach
- add smoke coverage validating the helper when columns are present or absent

## Testing
- pytest tests/test_assay_output_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68e3e65ef1a48324aab51d12761f6eb8