### PR TITLE
Handle assay chunk timeouts with adaptive splitting

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -426,14 +426,11 @@ def get_assays(
                 frames = filtered_frames
             return frames
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    for chunk in _chunked(valid, chunk_size):
-        chunk_key = ",".join(chunk)
-        logger.info(
-            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
-        )
-        url = _build_url({"assay_chembl_id__in": ",".join(chunk), "limit": len(chunk)})
+    def _fetch_chunk_recursive(chunk_ids: Sequence[str]) -> list[pd.DataFrame]:
+        chunk_key = ",".join(chunk_ids)
+        url = _build_url({"assay_chembl_id__in": chunk_key, "limit": len(chunk_ids)})
         try:
-            chunk_frames = _fetch_chunk(url)
+            return _fetch_chunk(url)
         except requests.HTTPError as exc:
             response = exc.response
             if response is not None and response.status_code == 404:
@@ -442,15 +439,44 @@ def get_assays(
                     extra={
                         "stage": "chunk_retry",
                         "chunk_key": chunk_key,
-                        "chunk_size": len(chunk),
+                        "chunk_size": len(chunk_ids),
                         "status": 404,
                     },
                 )
-                chunk_frames = []
-                for identifier in chunk:
-                    chunk_frames.extend(_fetch_single(identifier))
-            else:
+                frames: list[pd.DataFrame] = []
+                for identifier in chunk_ids:
+                    frames.extend(_fetch_single(identifier))
+                return frames
+            raise
+        except (requests.RequestException, ValueError) as exc:
+            if len(chunk_ids) <= 1:
                 raise
+            logger.warning(
+                "chunk_split_retry",
+                extra={
+                    "stage": "chunk_retry",
+                    "chunk_key": chunk_key,
+                    "chunk_size": len(chunk_ids),
+                    "status": getattr(getattr(exc, "response", None), "status_code", None),
+                },
+                error=str(exc),
+            )
+            midpoint = max(1, len(chunk_ids) // 2)
+            left = tuple(chunk_ids[:midpoint])
+            right = tuple(chunk_ids[midpoint:])
+            frames: list[pd.DataFrame] = []
+            if left:
+                frames.extend(_fetch_chunk_recursive(left))
+            if right:
+                frames.extend(_fetch_chunk_recursive(right))
+            return frames
+
+    for chunk in _chunked(valid, chunk_size):
+        chunk_key = ",".join(chunk)
+        logger.info(
+            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
+        )
+        chunk_frames = _fetch_chunk_recursive(chunk)
         if chunk_frames:
             records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from typing import Any
+
 import pytest
+import requests
 from requests import HTTPError, Response
 
 from library.config import ApiCfg
@@ -20,11 +22,14 @@ class _StubClient:
     def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None) -> dict[str, Any]:
         self.calls.append(url)
         next_response = self._responders.pop(0)
-        if isinstance(next_response, str) and next_response == "HTTP404":
-            response = Response()
-            response.status_code = 404
-            response.url = url
-            raise HTTPError(response=response)
+        if isinstance(next_response, str):
+            if next_response == "HTTP404":
+                response = Response()
+                response.status_code = 404
+                response.url = url
+                raise HTTPError(response=response)
+            if next_response == "TIMEOUT":
+                raise requests.Timeout("simulated timeout")
         if isinstance(next_response, dict):
             return next_response
         raise AssertionError(f"Unexpected responder type: {type(next_response)!r}")
@@ -68,6 +73,25 @@ def test_get_assays__detail_fallback_on_single_404() -> None:
 
     assert list(df["assay_chembl_id"]) == ["CHEMBL1"]
     assert any("/assay/CHEMBL1" in call for call in client.calls)
+
+
+@pytest.mark.unit
+def test_get_assays__splits_chunk_on_timeout() -> None:
+    """Timeouts trigger chunk splitting retries."""
+
+    responders = [
+        "TIMEOUT",
+        {"assays": [{"assay_chembl_id": "CHEMBL1"}], "page_meta": {}},
+        {"assays": [{"assay_chembl_id": "CHEMBL2"}], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_assays(["CHEMBL1", "CHEMBL2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert sorted(df["assay_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    assert any("limit=2" in call for call in client.calls)
+    assert sum(1 for call in client.calls if "limit=1" in call) == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add an adaptive recursive fallback in the assay pipeline so chunk-level request failures split into smaller batches
- extend the assay unit test stub to simulate timeouts and cover the new retry behaviour

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3eb2efc408324832696423e2ceb02