### PR TITLE
Improve assay fetch resilience to API timeouts

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -389,6 +389,34 @@ def get_assays(
             next_url = urljoin(join_base, next_token) if next_token else None
         return frames
 
+    def _fallback_single(identifier: str) -> list[pd.DataFrame]:
+        fallback_df = get_assay(
+            identifier,
+            cfg=cfg,
+            client=client,
+            timeout=effective_timeout,
+        )
+        if require_variant_sequence and not fallback_df.empty:
+            sequence_series = fallback_df.get("sequence")
+            if sequence_series is not None:
+                fallback_df = fallback_df[sequence_series.notna()]
+        if fallback_df.empty:
+            return []
+        return [fallback_df]
+
+    def _filter_variant_frames(frames: list[pd.DataFrame]) -> list[pd.DataFrame]:
+        if not require_variant_sequence:
+            return frames
+        filtered_frames: list[pd.DataFrame] = []
+        for frame in frames:
+            sequence_series = frame.get("sequence")
+            if sequence_series is None:
+                continue
+            filtered = frame[sequence_series.notna()]
+            if not filtered.empty:
+                filtered_frames.append(filtered)
+        return filtered_frames
+
     def _fetch_single(identifier: str) -> list[pd.DataFrame]:
         single_url = _build_url({"assay_chembl_id": identifier, "limit": 1})
         try:
@@ -399,31 +427,20 @@ def get_assays(
                 logger.info(
                     "assay_missing", extra={"stage": "chunk_skip", "assay_chembl_id": identifier}
                 )
-                fallback_df = get_assay(
-                    identifier,
-                    cfg=cfg,
-                    client=client,
-                    timeout=effective_timeout,
-                )
-                if require_variant_sequence and not fallback_df.empty:
-                    sequence_series = fallback_df.get("sequence")
-                    if sequence_series is not None:
-                        fallback_df = fallback_df[sequence_series.notna()]
-                if fallback_df.empty:
-                    return []
-                return [fallback_df]
+                return _fallback_single(identifier)
             raise
+        except requests.RequestException as exc:
+            logger.warning(
+                "single_fetch_retry",
+                extra={
+                    "stage": "chunk_retry",
+                    "assay_chembl_id": identifier,
+                    "error": exc.__class__.__name__,
+                },
+            )
+            return _fallback_single(identifier)
         else:
-            if require_variant_sequence and frames:
-                filtered_frames: list[pd.DataFrame] = []
-                for frame in frames:
-                    sequence_series = frame.get("sequence")
-                    if sequence_series is None:
-                        continue
-                    filtered = frame[sequence_series.notna()]
-                    if not filtered.empty:
-                        filtered_frames.append(filtered)
-                frames = filtered_frames
+            frames = _filter_variant_frames(frames)
             return frames
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
     for chunk in _chunked(valid, chunk_size):

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -113,3 +113,29 @@ def test_get_assays__recovers_from_request_exception() -> None:
     assert any("assay_chembl_id__in" in call for call in client.calls)
     assert sum("assay_chembl_id=CHEMBL1" in call for call in client.calls) == 1
     assert sum("assay_chembl_id=CHEMBL2" in call for call in client.calls) == 1
+
+
+@pytest.mark.unit
+def test_get_assays__single_timeout_falls_back_to_detail_endpoint() -> None:
+    """Single-item timeouts fall back to the detail endpoint."""
+
+    responders = [
+        ReadTimeout("timeout"),
+        ReadTimeout("timeout"),
+        {"assay": {"assay_chembl_id": "CHEMBL1", "sequence": "AA"}},
+        {"assays": [{"assay_chembl_id": "CHEMBL2", "sequence": "BB"}], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_assays(
+        ["CHEMBL1", "CHEMBL2"],
+        cfg=cfg,
+        client=client,
+        chunk_size=2,
+        require_variant_sequence=True,
+    )
+
+    assert sorted(df["assay_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    assert any("assay_chembl_id__in" in call for call in client.calls)
+    assert any("/assay/CHEMBL1" in call for call in client.calls)


### PR DESCRIPTION
## Summary
- add a shared helper to reuse variant-sequence filtering for single assay fetches
- fall back to the detail endpoint when list-based assay requests time out and log the retry
- cover the new timeout path with a unit test for get_assays

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ec1704ac8324829ba4af434663b9