### PR TITLE
Handle ChEMBL molecule timeouts by splitting chunks

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode, urljoin
 
 import pandas as pd
 import requests
+from urllib3.exceptions import ReadTimeoutError
 
 from library.clients import ChemblClient, _chunked
 from ...config import ApiCfg, TESTITEM_FIELD_DEFAULTS
@@ -253,6 +254,23 @@ def _fetch_testitem_chunk(
         except requests.RequestException as exc:
             response = getattr(exc, "response", None)
             status_code = response.status_code if response is not None else None
+            if _is_timeout_exception(exc) and len(current) > 1:
+                midpoint = max(1, len(current) // 2)
+                first = current[:midpoint]
+                second = current[midpoint:]
+                logger.warning(
+                    "chunk_timeout_split",
+                    extra={
+                        "stage": "chunk_split",
+                        "chunk_key": chunk_key,
+                        "size": len(current),
+                    },
+                )
+                if second:
+                    pending.append(second)
+                if first:
+                    pending.append(first)
+                continue
             if status_code == 400 and len(current) > 1:
                 midpoint = max(1, len(current) // 2)
                 first = current[:midpoint]
@@ -282,6 +300,25 @@ def _fetch_testitem_chunk(
                 "chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key}
             )
     return frames
+
+
+def _is_timeout_exception(error: BaseException | None) -> bool:
+    """Return ``True`` if *error* or its chain indicates a timeout."""
+
+    if error is None:
+        return False
+    if isinstance(error, (requests.Timeout, TimeoutError, ReadTimeoutError)):
+        return True
+    for arg in getattr(error, "args", ()):
+        if isinstance(arg, (requests.Timeout, TimeoutError, ReadTimeoutError)):
+            return True
+    cause = getattr(error, "__cause__", None)
+    if cause is not None and _is_timeout_exception(cause):
+        return True
+    context = getattr(error, "__context__", None)
+    if context is not None and _is_timeout_exception(context):
+        return True
+    return False
 
 
 def get_assay(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -7,7 +7,7 @@ import pytest
 from requests import HTTPError, ReadTimeout, Response
 
 from library.config import ApiCfg
-from library.pipelines.assay.chembl_assay import get_assays
+from library.pipelines.assay.chembl_assay import get_assays, get_testitem
 
 
 class _StubClient:
@@ -113,3 +113,52 @@ def test_get_assays__recovers_from_request_exception() -> None:
     assert any("assay_chembl_id__in" in call for call in client.calls)
     assert sum("assay_chembl_id=CHEMBL1" in call for call in client.calls) == 1
     assert sum("assay_chembl_id=CHEMBL2" in call for call in client.calls) == 1
+
+
+@pytest.mark.unit
+def test_get_testitem__splits_chunk_on_timeout() -> None:
+    """Chunk-level timeouts trigger adaptive splitting."""
+
+    responders = [
+        ReadTimeout("timeout"),
+        {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL1"},
+                {"molecule_chembl_id": "CHEMBL2"},
+            ],
+            "page_meta": {},
+        },
+        {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL3"},
+                {"molecule_chembl_id": "CHEMBL4"},
+            ],
+            "page_meta": {},
+        },
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_testitem(
+        ["CHEMBL1", "CHEMBL2", "CHEMBL3", "CHEMBL4"],
+        cfg=cfg,
+        client=client,
+        chunk_size=4,
+    )
+
+    assert sorted(df["molecule_chembl_id"].dropna().tolist()) == [
+        "CHEMBL1",
+        "CHEMBL2",
+        "CHEMBL3",
+        "CHEMBL4",
+    ]
+    assert any(
+        "molecule_chembl_id__in=CHEMBL1,CHEMBL2,CHEMBL3,CHEMBL4" in call
+        for call in client.calls
+    )
+    assert any(
+        "molecule_chembl_id__in=CHEMBL1,CHEMBL2" in call for call in client.calls
+    )
+    assert any(
+        "molecule_chembl_id__in=CHEMBL3,CHEMBL4" in call for call in client.calls
+    )


### PR DESCRIPTION
## Summary
- detect timeouts when fetching ChEMBL test item pages and split batches before retrying
- add unit coverage to ensure chunk-level timeouts recover with smaller requests

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py -k get_testitem -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ec45ba5c8324ad94ee5e9607912c