### PR TITLE
Handle ChEMBL test item timeouts with chunk retries

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -217,7 +217,7 @@ def _fetch_testitem_chunk(
     client: ChemblClient,
     timeout: float,
 ) -> list[pd.DataFrame]:
-    """Fetch data for ``identifiers`` with adaptive splitting on HTTP 400."""
+    """Fetch data for ``identifiers`` with adaptive splitting on HTTP 400/timeouts."""
 
     pending: list[list[str]] = [list(identifiers)]
     frames: list[pd.DataFrame] = []
@@ -271,6 +271,24 @@ def _fetch_testitem_chunk(
                 if first:
                     pending.append(first)
                 continue
+            if _is_retryable_chunk_error(exc) and len(current) > 1:
+                midpoint = max(1, len(current) // 2)
+                first = current[:midpoint]
+                second = current[midpoint:]
+                logger.warning(
+                    "chunk_retry_split",
+                    extra={
+                        "stage": "chunk_split",
+                        "chunk_key": chunk_key,
+                        "size": len(current),
+                        "error": exc.__class__.__name__,
+                    },
+                )
+                if second:
+                    pending.append(second)
+                if first:
+                    pending.append(first)
+                continue
             raise
         if chunk_frames:
             frames.append(pd.concat(chunk_frames, ignore_index=True))
@@ -282,6 +300,22 @@ def _fetch_testitem_chunk(
                 "chunk_skip", extra={"stage": "chunk_skip", "chunk_key": chunk_key}
             )
     return frames
+
+
+def _is_retryable_chunk_error(exc: requests.RequestException) -> bool:
+    """Return ``True`` when *exc* indicates a transient connection failure."""
+
+    if isinstance(exc, requests.Timeout):
+        return True
+    message_parts = [str(exc)]
+    cause = getattr(exc, "__cause__", None)
+    context = getattr(exc, "__context__", None)
+    for detail in (cause, context):
+        if detail is not None:
+            message_parts.append(str(detail))
+    combined = " ".join(part for part in message_parts if part)
+    lowered = combined.lower()
+    return any(token in lowered for token in ("timed out", "timeout", "temporarily unavailable"))
 
 
 def get_assay(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
+
 import pytest
-from requests import HTTPError, ReadTimeout, Response
+from requests import ConnectionError, HTTPError, ReadTimeout, Response
+from urllib.parse import parse_qs, urlparse
 
 from library.config import ApiCfg
-from library.pipelines.assay.chembl_assay import get_assays
+from library.pipelines.assay.chembl_assay import get_assays, get_testitem
 
 
 class _StubClient:
@@ -113,3 +115,74 @@ def test_get_assays__recovers_from_request_exception() -> None:
     assert any("assay_chembl_id__in" in call for call in client.calls)
     assert sum("assay_chembl_id=CHEMBL1" in call for call in client.calls) == 1
     assert sum("assay_chembl_id=CHEMBL2" in call for call in client.calls) == 1
+
+
+@pytest.mark.unit
+def test_get_testitem__splits_chunk_on_timeout() -> None:
+    """Timeout failures trigger chunk splitting and retries."""
+
+    def _timeout_exc() -> ConnectionError:
+        return ConnectionError(
+            "HTTPSConnectionPool(host='www.ebi.ac.uk', port=443): Read timed out."
+        )
+
+    payloads: dict[tuple[str, ...], dict[str, Any] | Callable[[], Exception]] = {
+        ("CHEMBL1", "CHEMBL2", "CHEMBL3"): _timeout_exc,
+        ("CHEMBL1",): {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL1", "pref_name": "One"},
+            ],
+            "page_meta": {},
+        },
+        ("CHEMBL2", "CHEMBL3"): {
+            "molecules": [
+                {"molecule_chembl_id": "CHEMBL2", "pref_name": "Two"},
+                {"molecule_chembl_id": "CHEMBL3", "pref_name": "Three"},
+            ],
+            "page_meta": {},
+        },
+    }
+
+    class _TimeoutStub:
+        def __init__(
+            self,
+            mapping: dict[tuple[str, ...], dict[str, Any] | Callable[[], Exception]],
+        ) -> None:
+            self._mapping = mapping
+            self.calls: list[str] = []
+
+        def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None) -> dict[str, Any]:
+            del cfg, timeout
+            self.calls.append(url)
+            parsed = urlparse(url)
+            ids_param = parse_qs(parsed.query).get("molecule_chembl_id__in", [""])[0]
+            identifiers = tuple(filter(None, ids_param.split(",")))
+            response = self._mapping[identifiers]
+            if callable(response):
+                response = response()
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    client = _TimeoutStub(payloads)
+    cfg = ApiCfg()
+
+    df = get_testitem(
+        ["CHEMBL1", "CHEMBL2", "CHEMBL3"],
+        cfg=cfg,
+        client=client,  # type: ignore[arg-type]
+        chunk_size=3,
+    )
+
+    assert sorted(df["molecule_chembl_id"].dropna().tolist()) == [
+        "CHEMBL1",
+        "CHEMBL2",
+        "CHEMBL3",
+    ]
+    assert any(
+        "molecule_chembl_id__in=CHEMBL1,CHEMBL2,CHEMBL3" in call for call in client.calls
+    )
+    assert any("molecule_chembl_id__in=CHEMBL1" in call for call in client.calls)
+    assert any(
+        "molecule_chembl_id__in=CHEMBL2,CHEMBL3" in call for call in client.calls
+    )


### PR DESCRIPTION
## Summary
- split failing ChEMBL test item chunks when a transient timeout/connection issue occurs
- add timeout-aware helper to recognise retryable errors and log the new retry split event
- cover the new behaviour with a unit test that simulates a timeout and verifies chunk replays

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py


------
https://chatgpt.com/codex/tasks/task_e_68e3ec302f10832492d65ff0911be779