### PR TITLE
Add adaptive chunk splitting for assay fetch retries

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from time import sleep
 
 import argparse
+from collections import deque
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import partial
 from itertools import islice
@@ -338,44 +339,76 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
         def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
             attempts = max(1, retry_cfg.max_attempts)
-            for attempt in range(1, attempts + 1):
-                try:
-                    return cl.get_assays(
-                        chunk_ids,
-                        cfg=cfg.api,
-                        client=client,
-                        chunk_size=cfg.assay.batch_size,
-                        timeout=cfg.assay.timeout,
-                    )
-                except (requests.RequestException, ValueError) as exc:
-                    error_message = str(exc)
-                    context = {
-                        "chunk_ids": list(chunk_ids),
-                        "chunk_size": len(chunk_ids),
-                        "attempt": attempt,
-                        "max_attempts": attempts,
-                        "batch_size": cfg.assay.batch_size,
-                        "timeout": cfg.assay.timeout,
-                    }
-                    log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
-                    if attempt >= attempts:
-                        logger.error(
-                            "assay_fetch_failed",
+            pending: deque[list[str]] = deque([list(chunk_ids)])
+            frames: list[pd.DataFrame] = []
+
+            while pending:
+                current = pending.popleft()
+                if not current:
+                    continue
+
+                for attempt in range(1, attempts + 1):
+                    try:
+                        frame = cl.get_assays(
+                            current,
+                            cfg=cfg.api,
+                            client=client,
+                            chunk_size=min(cfg.assay.batch_size, len(current)),
+                            timeout=cfg.assay.timeout,
+                        )
+                    except (requests.RequestException, ValueError) as exc:
+                        error_message = str(exc)
+                        context = {
+                            "chunk_ids": list(current),
+                            "chunk_size": len(current),
+                            "attempt": attempt,
+                            "max_attempts": attempts,
+                            "batch_size": cfg.assay.batch_size,
+                            "timeout": cfg.assay.timeout,
+                        }
+                        log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
+
+                        if attempt >= attempts:
+                            if len(current) > 1:
+                                split_index = max(1, len(current) // 2)
+                                left = current[:split_index]
+                                right = current[split_index:]
+                                logger.warning(
+                                    "assay_fetch_split",
+                                    extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                                    **log_context,
+                                )
+                                if right:
+                                    pending.appendleft(right)
+                                if left:
+                                    pending.appendleft(left)
+                                break
+
+                            logger.error(
+                                "assay_fetch_failed",
+                                extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
+                                error=error_message,
+                                **log_context,
+                            )
+                            chunk_failures.add_failure(current, error_message)
+                            break
+
+                        delay = compute_backoff_delay(attempt, retry_cfg)
+                        logger.warning(
+                            "assay_fetch_retry",
                             extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
-                            error=error_message,
+                            delay=delay,
                             **log_context,
                         )
-                        chunk_failures.add_failure(chunk_ids, error_message)
-                        return pd.DataFrame(columns=ASSAY_COLUMNS)
-                    delay = compute_backoff_delay(attempt, retry_cfg)
-                    logger.warning(
-                        "assay_fetch_retry",
-                        extra={"msg": error_message, "chunk_ids": context["chunk_ids"]},
-                        delay=delay,
-                        **log_context,
-                    )
-                    if delay > 0:
-                        sleep(delay)
+                        if delay > 0:
+                            sleep(delay)
+                    else:
+                        frames.append(frame)
+                        break
+
+            if frames:
+                return pd.concat(frames, ignore_index=True)
+
             return pd.DataFrame(columns=ASSAY_COLUMNS)
 
         fetch_config = ChunkedFetchConfig(

--- a/tests/unit/test_get_assay_data.py
+++ b/tests/unit/test_get_assay_data.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Sequence
 
 import pandas as pd
 import pytest
+import requests
 
 from library.cli_utils import run_pipeline as cli_run_pipeline
 from library.config import Config
@@ -150,6 +151,92 @@ def test_run_chembl__successful_execution(
         assert any(event == "process_offset" for _, event, _ in logger_stub.events)
     assert any(event == "process_limit" for _, event, _ in logger_stub.events)
 
+
+@pytest.mark.unit
+def test_run_chembl__splits_chunk_on_timeout(
+    cfg: Config,
+    minimal_args: argparse.Namespace,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg.assay.limit = None
+    cfg.assay.batch_size = 4
+    cfg.retry.max_attempts = 2
+    cfg.retry.backoff_factor = 0
+
+    def fake_read_ids(path: Path, *, column: str, cfg: Any) -> Iterable[str]:
+        return iter(["CHEMBL100", "CHEMBL200"])
+
+    class FakeClient:
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class FakeTracker:
+        def __init__(self) -> None:
+            self._failures: list[tuple[list[str], str]] = []
+
+        def add_failure(self, chunk_ids: Iterable[str], error: str) -> None:
+            self._failures.append((list(chunk_ids), error))
+
+        def save(self, path: Path, *, cfg: Config) -> None:
+            self.saved_path = path
+
+        def stats(self) -> dict[str, object]:
+            return {"failures": len(self._failures)}
+
+    tracker = FakeTracker()
+    call_history: list[list[str]] = []
+
+    def fake_get_assays(
+        identifiers: Sequence[str],
+        *,
+        cfg: Any,
+        client: Any,
+        chunk_size: int,
+        timeout: float,
+    ) -> pd.DataFrame:
+        call_history.append(list(identifiers))
+        if len(identifiers) > 1:
+            raise requests.ReadTimeout("timeout while fetching chunk")
+        return pd.DataFrame({"assay_chembl_id": list(identifiers)})
+
+    def fake_prepare_chunked_pipeline(**kwargs: object):
+        fetch_chunk = kwargs["fetch_chunk"]
+
+        def fetcher() -> Iterable[pd.DataFrame]:
+            yield fetch_chunk(["CHEMBL100", "CHEMBL200"])
+
+        def writer(**_: object) -> Path:
+            return minimal_args.final_out
+
+        return fetcher, writer
+
+    def fake_run_pipeline(*, fetcher: Callable[[], Iterable[pd.DataFrame]], **kwargs: object) -> int:
+        list(fetcher())
+        if "stats_callback" in kwargs:
+            kwargs["stats_callback"]({})
+        return 0
+
+    monkeypatch.setattr(get_assay_data.io, "read_ids", fake_read_ids)
+    monkeypatch.setattr(get_assay_data, "ChemblClient", lambda *_, **__: FakeClient())
+    monkeypatch.setattr(get_assay_data, "ChunkFailureTracker", lambda: tracker)
+    monkeypatch.setattr(get_assay_data.cl, "get_assays", fake_get_assays)
+    monkeypatch.setattr(get_assay_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
+    monkeypatch.setattr(get_assay_data, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(get_assay_data, "sleep", lambda *_: None)
+
+    exit_code = get_assay_data.run_chembl(cfg, minimal_args)
+
+    assert exit_code == 0
+    assert call_history[0] == ["CHEMBL100", "CHEMBL200"]
+    assert call_history.count(["CHEMBL100", "CHEMBL200"]) == 2
+    assert ["CHEMBL100"] in call_history
+    assert ["CHEMBL200"] in call_history
+    assert tracker._failures == []
+    assert any(event == "assay_fetch_split" for _, event, _ in logger_stub.events)
 
 def test_run__skip_existing_returns_zero(
     cfg: Config,


### PR DESCRIPTION
## Summary
- add adaptive retry handling for assay fetches that splits timed-out chunks into smaller batches
- ensure chunk failures are only recorded for irrecoverable single-assay errors while preserving retry logging
- cover the new behaviour with a unit test exercising the chunk splitting path

## Testing
- pytest tests/unit/test_get_assay_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ecd235948324b332abc73854e264