### PR TITLE
Fix activity logging directory resolution

### DIFF
--- a/REPORT_activity_log_missing.md
+++ b/REPORT_activity_log_missing.md
@@ -1,0 +1,7 @@
+# Activity log missing investigation
+
+| Potential cause | Confirmed | Comment | Fix |
+|-----------------|-----------|---------|-----|
+| Log directory resolved relative to the working directory when `CHEMBL_DA_BASE_PATH` is a relative path | ✅ | Reproduced by running `scripts/get_activity_data.py` from `scripts/` with `CHEMBL_DA_BASE_PATH=data`, which wrote logs to `scripts/data/logs` instead of the repository-level `data/logs`. | Normalise the log directory against the project root so relative paths are anchored consistently. |
+| Logger misconfiguration or missing handlers | ❌ | `setup_cli_logging` attaches a `FileHandler` and `logger.handlers` contains the expected entry during runs. | No change required. |
+| File permissions or missing directories | ❌ | `setup_cli_logging` creates the directory with `mkdir(parents=True, exist_ok=True)`; failures would raise an exception. | No change required. |

--- a/library/cli/logging.py
+++ b/library/cli/logging.py
@@ -13,7 +13,17 @@ from typing import IO, Iterator
 
 from ..common.logging_setup import LoggerConfig
 
-_DEFAULT_LOG_DIR = Path(__file__).resolve().parents[2] / "data" / "logs"
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_LOG_DIR = _PROJECT_ROOT / "data" / "logs"
+
+
+def _normalize_log_dir(path: Path | str) -> Path:
+    """Return an absolute path for the requested log directory."""
+
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (_PROJECT_ROOT / candidate).resolve()
 
 
 def _default_log_dir() -> Path:
@@ -21,7 +31,8 @@ def _default_log_dir() -> Path:
 
     env_base = os.environ.get("CHEMBL_DA_BASE_PATH")
     if env_base:
-        return Path(env_base).expanduser() / "logs"
+        base_dir = _normalize_log_dir(env_base)
+        return (base_dir / "logs").resolve()
     return _DEFAULT_LOG_DIR
 
 
@@ -50,7 +61,10 @@ def setup_cli_logging(
 ) -> Iterator[CLILoggingContext]:
     """Configure logging to mirror output to a file and the console."""
 
-    resolved_dir = Path(log_dir) if log_dir is not None else _default_log_dir()
+    if log_dir is not None:
+        resolved_dir = _normalize_log_dir(log_dir)
+    else:
+        resolved_dir = _default_log_dir()
     resolved_dir.mkdir(parents=True, exist_ok=True)
 
     if date_str:

--- a/patch/fix_logging_get_activity_data.diff
+++ b/patch/fix_logging_get_activity_data.diff
@@ -1,0 +1,139 @@
+diff --git a/REPORT_activity_log_missing.md b/REPORT_activity_log_missing.md
+new file mode 100644
+index 0000000..c8b63bb
+--- /dev/null
++++ b/REPORT_activity_log_missing.md
+@@ -0,0 +1,7 @@
++# Activity log missing investigation
++
++| Potential cause | Confirmed | Comment | Fix |
++|-----------------|-----------|---------|-----|
++| Log directory resolved relative to the working directory when `CHEMBL_DA_BASE_PATH` is a relative path | ✅ | Reproduced by running `scripts/get_activity_data.py` from `scripts/` with `CHEMBL_DA_BASE_PATH=data`, which wrote logs to `scripts/data/logs` instead of the repository-level `data/logs`. | Normalise the log directory against the project root so relative paths are anchored consistently. |
++| Logger misconfiguration or missing handlers | ❌ | `setup_cli_logging` attaches a `FileHandler` and `logger.handlers` contains the expected entry during runs. | No change required. |
++| File permissions or missing directories | ❌ | `setup_cli_logging` creates the directory with `mkdir(parents=True, exist_ok=True)`; failures would raise an exception. | No change required. |
+diff --git a/library/cli/logging.py b/library/cli/logging.py
+index dc1d994..3f8ff3b 100644
+--- a/library/cli/logging.py
++++ b/library/cli/logging.py
+@@ -13,7 +13,17 @@ from typing import IO, Iterator
+ 
+ from ..common.logging_setup import LoggerConfig
+ 
+-_DEFAULT_LOG_DIR = Path(__file__).resolve().parents[2] / "data" / "logs"
++_PROJECT_ROOT = Path(__file__).resolve().parents[2]
++_DEFAULT_LOG_DIR = _PROJECT_ROOT / "data" / "logs"
++
++
++def _normalize_log_dir(path: Path | str) -> Path:
++    """Return an absolute path for the requested log directory."""
++
++    candidate = Path(path).expanduser()
++    if candidate.is_absolute():
++        return candidate.resolve()
++    return (_PROJECT_ROOT / candidate).resolve()
+ 
+ 
+ def _default_log_dir() -> Path:
+@@ -21,7 +31,8 @@ def _default_log_dir() -> Path:
+ 
+     env_base = os.environ.get("CHEMBL_DA_BASE_PATH")
+     if env_base:
+-        return Path(env_base).expanduser() / "logs"
++        base_dir = _normalize_log_dir(env_base)
++        return (base_dir / "logs").resolve()
+     return _DEFAULT_LOG_DIR
+ 
+ 
+@@ -50,7 +61,10 @@ def setup_cli_logging(
+ ) -> Iterator[CLILoggingContext]:
+     """Configure logging to mirror output to a file and the console."""
+ 
+-    resolved_dir = Path(log_dir) if log_dir is not None else _default_log_dir()
++    if log_dir is not None:
++        resolved_dir = _normalize_log_dir(log_dir)
++    else:
++        resolved_dir = _default_log_dir()
+     resolved_dir.mkdir(parents=True, exist_ok=True)
+ 
+     if date_str:
+diff --git a/tests/test_activity_logging.py b/tests/test_activity_logging.py
+new file mode 100644
+index 0000000..efb20ad
+--- /dev/null
++++ b/tests/test_activity_logging.py
+@@ -0,0 +1,75 @@
++from __future__ import annotations
++
++from pathlib import Path
++import shutil
++
++import pytest
++
++from scripts import get_activity_data
++
++
++@pytest.mark.e2e
++def test_activity_logging__relative_env_base_anchored_to_repo_root(
++    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
++) -> None:
++    repo_root = Path(__file__).resolve().parents[1]
++    scripts_dir = repo_root / "scripts"
++    monkeypatch.chdir(scripts_dir)
++
++    relative_base = "activity_logs_tmp"
++    target_base = repo_root / relative_base
++    log_dir = target_base / "logs"
++    if target_base.exists():
++        shutil.rmtree(target_base)
++
++    input_path = tmp_path / "input.csv"
++    input_path.write_text("activity_id\nCHEMBL1\n", encoding="utf-8")
++
++    output_path = tmp_path / "output.csv"
++    config_path = tmp_path / "config.yaml"
++    config_path.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n", encoding="utf-8")
++
++    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", relative_base)
++    monkeypatch.setattr("library.cli.logging._current_date_str", lambda: "20240102")
++
++    def _stub_run_cli_command(
++        *,
++        args: object,
++        parser: object,
++        log_cfg: object,
++        **_: object,
++    ) -> int:
++        get_activity_data.configure_logger(log_cfg)
++        get_activity_data.logger.info(
++            "activity_pipeline_start",
++            input=str(getattr(args, "input_csv", "")),
++        )
++        get_activity_data.logger.info(
++            "activity_pipeline_done",
++            output=str(getattr(args, "final_out", "")),
++        )
++        return 0
++
++    monkeypatch.setattr(get_activity_data, "run_cli_command", _stub_run_cli_command)
++
++    exit_code = get_activity_data.main(
++        [
++            "--config",
++            str(config_path),
++            "--input",
++            str(input_path),
++            "--final-out",
++            str(output_path),
++        ]
++    )
++
++    try:
++        assert exit_code == 0
++        log_path = log_dir / "get_activity_data_20240102.log"
++        assert log_path.exists()
++        content = log_path.read_text(encoding="utf-8")
++        assert "activity_pipeline_start" in content
++        assert "activity_pipeline_done" in content
++    finally:
++        if target_base.exists():
++            shutil.rmtree(target_base)

--- a/tests/test_activity_logging.py
+++ b/tests/test_activity_logging.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+import pytest
+
+from scripts import get_activity_data
+
+
+@pytest.mark.e2e
+def test_activity_logging__relative_env_base_anchored_to_repo_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    scripts_dir = repo_root / "scripts"
+    monkeypatch.chdir(scripts_dir)
+
+    relative_base = "activity_logs_tmp"
+    target_base = repo_root / relative_base
+    log_dir = target_base / "logs"
+    if target_base.exists():
+        shutil.rmtree(target_base)
+
+    input_path = tmp_path / "input.csv"
+    input_path.write_text("activity_id\nCHEMBL1\n", encoding="utf-8")
+
+    output_path = tmp_path / "output.csv"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n", encoding="utf-8")
+
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", relative_base)
+    monkeypatch.setattr("library.cli.logging._current_date_str", lambda: "20240102")
+
+    def _stub_run_cli_command(
+        *,
+        args: object,
+        parser: object,
+        log_cfg: object,
+        **_: object,
+    ) -> int:
+        get_activity_data.configure_logger(log_cfg)
+        get_activity_data.logger.info(
+            "activity_pipeline_start",
+            input=str(getattr(args, "input_csv", "")),
+        )
+        get_activity_data.logger.info(
+            "activity_pipeline_done",
+            output=str(getattr(args, "final_out", "")),
+        )
+        return 0
+
+    monkeypatch.setattr(get_activity_data, "run_cli_command", _stub_run_cli_command)
+
+    exit_code = get_activity_data.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_path),
+            "--final-out",
+            str(output_path),
+        ]
+    )
+
+    try:
+        assert exit_code == 0
+        log_path = log_dir / "get_activity_data_20240102.log"
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        assert "activity_pipeline_start" in content
+        assert "activity_pipeline_done" in content
+    finally:
+        if target_base.exists():
+            shutil.rmtree(target_base)


### PR DESCRIPTION
## Summary
- normalise CLI log directories against the project root so relative bases no longer spill into subdirectories
- add a regression test covering relative `CHEMBL_DA_BASE_PATH` usage and document the investigation outcome
- include the generated patch file for downstream application

## Testing
- pytest tests/test_activity_logging.py tests/test_logging_get_activity_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ecbb8a788324a41f4d3bef4850ce