### PR TITLE
Fix Git repo root detection and add coverage

### DIFF
--- a/library/common/git.py
+++ b/library/common/git.py
@@ -19,9 +19,20 @@ from .log import logger
 
 
 def _repo_root() -> Path:
-    """Return the repository root used for Git metadata."""
+    """Return the repository root used for Git metadata.
 
-    return Path(__file__).resolve().parent.parent
+    The helper walks up from the current module location until it finds a
+    directory that looks like the project root (containing either a ``.git``
+    directory or a ``pyproject.toml`` file).  This makes the lookup robust to
+    the package being imported from different working directories or when the
+    module resides deeper in the source tree than expected.
+    """
+
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists() or (candidate / "pyproject.toml").is_file():
+            return candidate
+    return current
 
 
 def _resolve_git_dir(repo_root: Path) -> Path | None:

--- a/library/git_utils.py
+++ b/library/git_utils.py
@@ -19,9 +19,20 @@ from .common.log import logger
 
 
 def _repo_root() -> Path:
-    """Return the repository root used for Git metadata."""
+    """Return the repository root used for Git metadata.
 
-    return Path(__file__).resolve().parent.parent
+    The helper walks up from the current module location until it encounters a
+    directory that contains Git metadata (``.git``) or the project manifest
+    (``pyproject.toml``).  This mirrors the behaviour in
+    :mod:`library.common.git` and keeps the lookup resilient to different import
+    locations.
+    """
+
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists() or (candidate / "pyproject.toml").is_file():
+            return candidate
+    return current
 
 
 def _resolve_git_dir(repo_root: Path) -> Path | None:

--- a/tests/unit/test_git_utils.py
+++ b/tests/unit/test_git_utils.py
@@ -7,6 +7,24 @@ from pathlib import Path
 import pytest
 
 
+def _expected_repo_root() -> Path:
+    current = Path(__file__).resolve().parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists() or (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise AssertionError("Unable to determine repository root for tests")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", ["library.git_utils", "library.common.git"])
+def test_repo_root__detects_project_root(module_name: str) -> None:
+    """``_repo_root`` should resolve to the actual repository root."""
+
+    module = importlib.import_module(module_name)
+
+    assert module._repo_root() == _expected_repo_root()
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize("module_name", ["library.git_utils", "library.common.git"])
 def test_git_sha__missing_git_directory_logged_as_info(


### PR DESCRIPTION
## Summary
- make the Git helpers locate the repository root by walking upwards until `.git` or `pyproject.toml` is found
- mirror the behaviour in both `library.common.git` and `library.git_utils`
- add a unit test that asserts `_repo_root` resolves to the actual project root

## Testing
- `pytest -q` *(fails: SyntaxError in tests/test_assay_output_columns.py due to misplaced from __future__ import)*
- `pytest tests/unit/test_git_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e3ef58ef708324a9db1a83976f46fa