### PR TITLE
Add timeout-aware chunk splitting for activity fetches

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -961,58 +961,108 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
         def fetch_chunk(chunk_ids: Sequence[str]) -> pd.DataFrame:
             nonlocal last_error_extra, last_error_context
-            attempts = max(1, retry_cfg.max_attempts)
-            for attempt in range(1, attempts + 1):
-                try:
-                    result = cl.get_activities(
-                        chunk_ids,
-                        cfg=cfg.api,
-                        client=client,
-                        chunk_size=cfg.activity.batch_size,
-                        timeout=cfg.activity.timeout,
-                        **extra_kwargs,
-                    )
-                except (requests.RequestException, ValueError) as exc:
-                    error_message = str(exc)
-                    context = {
-                        "chunk_ids": list(chunk_ids),
-                        "chunk_size": len(chunk_ids),
-                        "attempt": attempt,
-                        "max_attempts": attempts,
-                        "batch_size": cfg.activity.batch_size,
-                        "timeout": cfg.activity.timeout,
-                    }
-                    log_context = {k: v for k, v in context.items() if k != "chunk_ids"}
-                    last_error_extra = {
-                        "msg": error_message,
-                        "chunk_ids": context["chunk_ids"],
-                    }
-                    last_error_context = dict(log_context)
-                    if attempt >= attempts:
-                        logger.error(
-                            "activity_fetch_failed",
+
+            timeout_error_types = (
+                requests.Timeout,
+                requests.ReadTimeout,
+                requests.ConnectTimeout,
+                requests.exceptions.RetryError,
+            )
+
+            def _is_timeout_error(exc: Exception) -> bool:
+                if isinstance(exc, timeout_error_types):
+                    return True
+                message = str(exc).strip().lower()
+                if not message:
+                    return False
+                return "timed out" in message or "timeout" in message
+
+            def _fetch(ids: Sequence[str], *, depth: int = 0) -> pd.DataFrame:
+                nonlocal last_error_extra, last_error_context
+
+                attempts = max(1, retry_cfg.max_attempts)
+                id_list = [str(identifier) for identifier in ids]
+
+                for attempt in range(1, attempts + 1):
+                    try:
+                        result = cl.get_activities(
+                            id_list,
+                            cfg=cfg.api,
+                            client=client,
+                            chunk_size=cfg.activity.batch_size,
+                            timeout=cfg.activity.timeout,
+                            **extra_kwargs,
+                        )
+                    except (requests.RequestException, ValueError) as exc:
+                        error_message = str(exc)
+                        context = {
+                            "chunk_ids": list(id_list),
+                            "chunk_size": len(id_list),
+                            "attempt": attempt,
+                            "max_attempts": attempts,
+                            "batch_size": cfg.activity.batch_size,
+                            "timeout": cfg.activity.timeout,
+                        }
+                        log_context = {
+                            key: value for key, value in context.items() if key != "chunk_ids"
+                        }
+                        last_error_extra = {
+                            "msg": error_message,
+                            "chunk_ids": context["chunk_ids"],
+                        }
+                        last_error_context = dict(log_context)
+                        if attempt >= attempts:
+                            if len(id_list) > 1 and _is_timeout_error(exc):
+                                split_context = dict(log_context)
+                                split_context["depth"] = depth
+                                logger.warning(
+                                    "activity_fetch_split",
+                                    extra=last_error_extra,
+                                    **split_context,
+                                )
+                                midpoint = max(1, len(id_list) // 2)
+                                left_ids = tuple(id_list[:midpoint])
+                                right_ids = tuple(id_list[midpoint:])
+                                frames: list[pd.DataFrame] = []
+                                if left_ids:
+                                    frames.append(_fetch(left_ids, depth=depth + 1))
+                                if right_ids:
+                                    frames.append(_fetch(right_ids, depth=depth + 1))
+                                if frames:
+                                    combined = pd.concat(
+                                        frames, ignore_index=True, sort=False
+                                    )
+                                else:
+                                    combined = pd.DataFrame(columns=ACTIVITY_COLUMNS)
+                                last_error_extra = None
+                                last_error_context = {}
+                                return combined
+                            logger.error(
+                                "activity_fetch_failed",
+                                extra=last_error_extra,
+                                error=error_message,
+                                **log_context,
+                            )
+                            chunk_failures.add_failure(id_list, error_message)
+                            raise PipelineError("chunk_fetch_failed")
+                        delay = compute_backoff_delay(attempt, retry_cfg)
+                        logger.warning(
+                            "activity_fetch_retry",
                             extra=last_error_extra,
-                            error=error_message,
+                            delay=delay,
                             **log_context,
                         )
-                        chunk_failures.add_failure(chunk_ids, error_message)
-                        raise PipelineError("chunk_fetch_failed")
-                    delay = compute_backoff_delay(attempt, retry_cfg)
-                    logger.warning(
-                        "activity_fetch_retry",
-                        extra=last_error_extra,
-                        delay=delay,
-                        **log_context,
-                    )
-                    if delay > 0:
-                        sleep(delay)
-                else:
-                    last_error_extra = None
-                    last_error_context = {}
-                    return _ensure_molecule_pref_name(
-                        result, cfg=cfg, client=client, cache=pref_name_cache
-                    )
-            return pd.DataFrame(columns=ACTIVITY_COLUMNS)
+                        if delay > 0:
+                            sleep(delay)
+                    else:
+                        last_error_extra = None
+                        last_error_context = {}
+                        return _ensure_molecule_pref_name(
+                            result, cfg=cfg, client=client, cache=pref_name_cache
+                        )
+                return pd.DataFrame(columns=ACTIVITY_COLUMNS)
+
+            return _fetch(chunk_ids, depth=0)
 
         worker_count = getattr(cfg.activity, "workers", 1) or 1
         fetch_config = ChunkedFetchConfig(

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -51,14 +51,29 @@ class _MemoryLogger:
     def __init__(self) -> None:
         self.events: list[tuple[str, str, dict[str, object]]] = []
 
-    def info(self, event: str, **kwargs: object) -> None:
-        self.events.append(("info", event, dict(kwargs)))
+    def _record(
+        self,
+        level: str,
+        event: str,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> None:
+        payload = dict(kwargs)
+        if args:
+            payload["args"] = args
+        self.events.append((level, event, payload))
 
-    def warning(self, event: str, **kwargs: object) -> None:
-        self.events.append(("warning", event, dict(kwargs)))
+    def info(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("info", event, args, dict(kwargs))
 
-    def error(self, event: str, **kwargs: object) -> None:
-        self.events.append(("error", event, dict(kwargs)))
+    def warning(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("warning", event, args, dict(kwargs))
+
+    def error(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("error", event, args, dict(kwargs))
+
+    def debug(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("debug", event, args, dict(kwargs))
 
 
 def _patch_logger(monkeypatch: pytest.MonkeyPatch, module: object) -> _MemoryLogger:
@@ -347,6 +362,109 @@ def test_get_activity_cli__retry_and_idempotent(
     done_events = [event for _, event, _ in logger_stub.events]
     assert done_events.count("activity_pipeline_done") >= 1
     assert not any(event == "activity_pipeline_failed" for event in done_events)
+
+
+@pytest.mark.e2e
+def test_get_activity_cli__timeout_split_recovers(
+    tmp_path: Path,
+    cfg: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_activity_cfg(cfg)
+    cfg.activity.batch_size = 4
+    cfg.retry.max_attempts = 2
+    input_csv = tmp_path / "activities.csv"
+    input_csv.write_text(
+        "activity_id\nACT1\nACT2\nACT3\nACT4\n",
+        encoding="utf-8",
+    )
+    output_csv = tmp_path / "out" / "activities.csv"
+
+    activity_rows = {
+        "ACT1": {
+            "activity_id": "ACT1",
+            "molecule_chembl_id": "CHEMBL1",
+            "assay_chembl_id": "ASSAY1",
+            "standard_value": 1.0,
+            "standard_units": "nM",
+            "standard_type": "IC50",
+            "relation": "=",
+            "molecule_pref_name": "Compound 1",
+        },
+        "ACT2": {
+            "activity_id": "ACT2",
+            "molecule_chembl_id": "CHEMBL2",
+            "assay_chembl_id": "ASSAY2",
+            "standard_value": 2.0,
+            "standard_units": "nM",
+            "standard_type": "IC50",
+            "relation": "=",
+            "molecule_pref_name": "Compound 2",
+        },
+        "ACT3": {
+            "activity_id": "ACT3",
+            "molecule_chembl_id": "CHEMBL3",
+            "assay_chembl_id": "ASSAY3",
+            "standard_value": 3.0,
+            "standard_units": "nM",
+            "standard_type": "IC50",
+            "relation": "=",
+            "molecule_pref_name": "Compound 3",
+        },
+        "ACT4": {
+            "activity_id": "ACT4",
+            "molecule_chembl_id": "CHEMBL4",
+            "assay_chembl_id": "ASSAY4",
+            "standard_value": 4.0,
+            "standard_units": "nM",
+            "standard_type": "IC50",
+            "relation": "=",
+            "molecule_pref_name": "Compound 4",
+        },
+    }
+
+    call_log: list[tuple[str, ...]] = []
+
+    def _fake_get_activities(chunk_ids: Iterable[str], **_: object) -> pd.DataFrame:
+        identifiers = [str(item) for item in chunk_ids]
+        call_log.append(tuple(identifiers))
+        if len(identifiers) > 1:
+            raise requests.ReadTimeout("simulated timeout")
+        row = activity_rows[identifiers[0]]
+        return pd.DataFrame([row])
+
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
+    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(get_activity_data, "sleep", lambda *_args, **_kwargs: None)
+
+    written = _install_activity_writer(monkeypatch)
+    logger_stub = _patch_logger(monkeypatch, get_activity_data)
+    _patch_activity_cli(monkeypatch, cfg)
+
+    args = [
+        "--input",
+        str(input_csv),
+        "--final-out",
+        str(output_csv),
+        "--batch-size",
+        "4",
+    ]
+
+    exit_code = get_activity_data.main(args)
+
+    assert exit_code == 0
+    assert output_csv.exists()
+    result = pd.read_csv(output_csv)
+    assert list(result["activity_id"]) == ["ACT1", "ACT2", "ACT3", "ACT4"]
+    assert len(written) == 1
+
+    events = [event for _, event, _ in logger_stub.events]
+    assert "activity_fetch_split" in events
+    assert "activity_pipeline_done" in events
+    assert not any(event == "activity_pipeline_failed" for event in events)
+
+    assert call_log[0] == ("ACT1", "ACT2", "ACT3", "ACT4")
+    assert any(len(ids) == 1 for ids in call_log)
 
 
 @pytest.mark.e2e

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -34,17 +34,29 @@ class _RecordingLogger:
     def __init__(self) -> None:
         self.events: list[tuple[str, str, dict[str, object]]] = []
 
-    def debug(self, event: str, **kwargs: object) -> None:
-        self.events.append(("debug", event, dict(kwargs)))
+    def _record(
+        self,
+        level: str,
+        event: str,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> None:
+        payload = dict(kwargs)
+        if args:
+            payload["args"] = args
+        self.events.append((level, event, payload))
 
-    def info(self, event: str, **kwargs: object) -> None:
-        self.events.append(("info", event, dict(kwargs)))
+    def debug(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("debug", event, args, dict(kwargs))
 
-    def warning(self, event: str, **kwargs: object) -> None:
-        self.events.append(("warning", event, dict(kwargs)))
+    def info(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("info", event, args, dict(kwargs))
 
-    def error(self, event: str, **kwargs: object) -> None:
-        self.events.append(("error", event, dict(kwargs)))
+    def warning(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("warning", event, args, dict(kwargs))
+
+    def error(self, event: str, *args: object, **kwargs: object) -> None:
+        self._record("error", event, args, dict(kwargs))
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- split timed-out activity fetch batches into smaller subsets before failing and log the split attempts
- cover the timeout splitting behaviour with an end-to-end CLI test and make the in-test loggers accept positional arguments
- update the integration logger stub so positional logging arguments do not crash the deterministic pipeline harness

## Testing
- pytest tests/e2e/test_get_cli_pipelines.py -k timeout_split_recovers -q
- pytest tests/integration/test_get_activity_data_pipeline.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e3ec8dd92c8324baf35238cd8b38ba