### PR TITLE
Handle Chembl batch timeouts with chunk fallback

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
 import pandas as pd
+from requests import ReadTimeout
 
 from library.clients import ChemblClient, _chunked
 from ...config import ApiCfg, UniprotMappingCfg
@@ -311,25 +312,72 @@ def iter_target_batches(
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
 
     for chunk in _chunked(ids, chunk_size):
-        url = f"{base}&target_chembl_id__in={','.join(chunk)}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("targets") or data.get("target") or []
-        payloads = [
-            _extract_target_payload(item)
-            for item in items
-            if isinstance(item, (dict, list))
-        ]
-        payloads = [payload for payload in payloads if payload]
-        if not payloads:
-            continue
-        raw_frame = _normalise_target_payloads(payloads)
-        records = [_parse_target_record(payload, mapping_cfg) for payload in payloads]
-        parsed_frame = pd.DataFrame(records)
-        if parsed_frame.empty:
-            parsed_frame = pd.DataFrame(columns=TARGET_FIELDS)
-        else:
-            parsed_frame = parsed_frame.reindex(columns=TARGET_FIELDS)
-        yield payloads, raw_frame, parsed_frame
+        yield from _iter_target_chunk_with_fallback(
+            chunk,
+            base_url=base,
+            cfg=cfg,
+            client=client,
+            mapping_cfg=mapping_cfg,
+            timeout=effective_timeout,
+        )
+
+
+def _iter_target_chunk_with_fallback(
+    chunk: Sequence[str],
+    *,
+    base_url: str,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    mapping_cfg: UniprotMappingCfg,
+    timeout: float,
+) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
+    """Yield processed records for ``chunk`` with timeout-aware retries."""
+
+    if not chunk:
+        return
+
+    url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
+    try:
+        data = client.request_json(url, cfg=cfg, timeout=timeout)
+    except ReadTimeout as exc:
+        if len(chunk) <= 1:
+            raise exc
+        logger.warning(
+            "chembl_timeout_split",
+            extra={
+                "chunk_size": len(chunk),
+                "ids": list(chunk),
+                "timeout": timeout,
+            },
+        )
+        for identifier in chunk:
+            yield from _iter_target_chunk_with_fallback(
+                [identifier],
+                base_url=base_url,
+                cfg=cfg,
+                client=client,
+                mapping_cfg=mapping_cfg,
+                timeout=timeout,
+            )
+        return
+
+    items = data.get("targets") or data.get("target") or []
+    payloads = [
+        _extract_target_payload(item)
+        for item in items
+        if isinstance(item, (dict, list))
+    ]
+    payloads = [payload for payload in payloads if payload]
+    if not payloads:
+        return
+    raw_frame = _normalise_target_payloads(payloads)
+    records = [_parse_target_record(payload, mapping_cfg) for payload in payloads]
+    parsed_frame = pd.DataFrame(records)
+    if parsed_frame.empty:
+        parsed_frame = pd.DataFrame(columns=TARGET_FIELDS)
+    else:
+        parsed_frame = parsed_frame.reindex(columns=TARGET_FIELDS)
+    yield payloads, raw_frame, parsed_frame
 
 
 def get_target(

--- a/tests/unit/test_chembl_target.py
+++ b/tests/unit/test_chembl_target.py
@@ -1,0 +1,95 @@
+"""Unit tests for the ChEMBL target helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+import requests
+
+from library.config import ApiCfg, UniprotMappingCfg
+from library.pipelines.target.chembl_target import iter_target_batches
+
+
+class _StubChemblClient:
+    """Deterministic stub that mimics :class:`ChemblClient`."""
+
+    def __init__(self, responses: dict[str, object]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, float | None]] = []
+
+    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None = None) -> dict:
+        del cfg  # Unused in the stub.
+        self.calls.append((url, timeout))
+        response = self._responses[url]
+        if isinstance(response, Exception):
+            raise response
+        assert isinstance(response, dict)
+        return response
+
+
+def _build_response(target_id: str, pref_name: str) -> dict[str, object]:
+    return {
+        "targets": [
+            {
+                "target_chembl_id": target_id,
+                "pref_name": pref_name,
+                "target_type": "SINGLE PROTEIN",
+                "tax_id": 9606,
+                "species_group_flag": 1,
+                "target_components": [],
+                "protein_classifications": [],
+                "cross_references": [],
+            }
+        ]
+    }
+
+
+@pytest.mark.unit
+def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureFixture) -> None:
+    """The iterator should split large chunks when a read timeout occurs."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=12.0)
+    mapping_cfg = UniprotMappingCfg()
+    timeout = 9.5
+    base = cfg.chembl_base.rstrip("/")
+
+    def _chunk_url(ids: Sequence[str]) -> str:
+        return (
+            f"{base}/target.json?format=json"
+            f"&include=protein_classifications,cross_references"
+            f"&target_chembl_id__in={','.join(ids)}"
+        )
+
+    combined_url = _chunk_url(["CHEMBL1", "CHEMBL2"])
+    responses = {
+        combined_url: requests.ReadTimeout("simulated timeout"),
+        _chunk_url(["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
+        _chunk_url(["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
+    }
+    client = _StubChemblClient(responses)
+
+    with caplog.at_level("WARNING"):
+        batches = list(
+            iter_target_batches(
+                ["CHEMBL1", "CHEMBL2"],
+                cfg=cfg,
+                client=client,
+                mapping_cfg=mapping_cfg,
+                chunk_size=2,
+                timeout=timeout,
+            )
+        )
+
+    assert [call[0] for call in client.calls] == [
+        combined_url,
+        _chunk_url(["CHEMBL1"]),
+        _chunk_url(["CHEMBL2"]),
+    ]
+    assert all(call[1] == timeout for call in client.calls)
+
+    assert len(batches) == 2
+    parsed_ids = [parsed[2]["target_chembl_id"].iat[0] for parsed in batches]
+    assert parsed_ids == ["CHEMBL1", "CHEMBL2"]
+
+    assert any(record.getMessage().startswith("chembl_timeout_split") for record in caplog.records)


### PR DESCRIPTION
## Summary
- split Chembl target batches into singletons when a read timeout occurs
- log the fallback and reuse the existing parsing flow for each identifier
- cover the timeout fallback with a deterministic unit test

## Testing
- pytest tests/unit/test_chembl_target.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3ef0416dc83248b22c663ff004b57