### PR TITLE
Add adaptive retry for ChEMBL target fetches

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1885,9 +1885,37 @@
           "minimum": 0,
           "title": "Offset",
           "type": "integer"
+        },
+        "batch_retry": {
+          "$ref": "#/$defs/TargetChemblBatchRetryCfg"
         }
       },
       "title": "TargetChemblCfg",
+      "type": "object"
+    },
+    "TargetChemblBatchRetryCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "title": "Enable",
+          "type": "boolean"
+        },
+        "shrink_factor": {
+          "default": 0.5,
+          "exclusiveMinimum": 0,
+          "exclusiveMaximum": 1,
+          "title": "Shrink Factor",
+          "type": "number"
+        },
+        "min_size": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Min Size",
+          "type": "integer"
+        }
+      },
+      "title": "TargetChemblBatchRetryCfg",
       "type": "object"
     },
     "TargetIupharCfg": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -122,6 +122,11 @@ sources:
           chunk_size: 5
           timeout: 30.0
           limit: null
+          offset: 0
+          batch_retry:
+            enable: true
+            shrink_factor: 0.5
+            min_size: 1
         iuphar:
           target_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
           family_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv"

--- a/library/config.py
+++ b/library/config.py
@@ -1251,6 +1251,17 @@ class TargetUniprotCfg(_BaseModel):
     offset: int = Field(0, ge=0)
 
 
+class TargetChemblBatchRetryCfg(_BoolModel):
+    enable: bool = True
+    shrink_factor: float = Field(0.5, gt=0, lt=1)
+    min_size: int = Field(1, ge=1)
+
+    @field_validator("enable", mode="before")
+    @classmethod
+    def _bools(cls, value: Any) -> bool:
+        return cls._parse_bool(value)
+
+
 class TargetChemblCfg(_BaseModel):
     """Defaults for fetching ChEMBL targets.
 
@@ -1265,6 +1276,9 @@ class TargetChemblCfg(_BaseModel):
 
     limit: int | None = Field(default=None, ge=0)
     offset: int = Field(0, ge=0)
+    batch_retry: TargetChemblBatchRetryCfg = Field(
+        default_factory=lambda: TargetChemblBatchRetryCfg()
+    )
 
 
 

--- a/library/integration/chembl_library.py
+++ b/library/integration/chembl_library.py
@@ -19,6 +19,7 @@ from ..pipelines.target.chembl_target import (
     get_targets_payloads,
     get_targets_raw_frame,
     iter_target_batches,
+    iter_target_batches_with_retry,
 )
 from ..pipelines.tissue import get_tissues
 
@@ -35,6 +36,7 @@ __all__ = [
     "get_targets_payloads",
     "get_targets_raw_frame",
     "iter_target_batches",
+    "iter_target_batches_with_retry",
     "extend_target",
     "_chunked",
 ]

--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Any
+from typing import Any, Callable
 
 import pandas as pd
+import requests
 
 from library.clients import ChemblClient, _chunked
-from ...config import ApiCfg, UniprotMappingCfg
+from ...config import ApiCfg, TargetChemblBatchRetryCfg, UniprotMappingCfg
 from ...common.log import logger
 
 TARGET_FIELDS = [
@@ -331,6 +333,92 @@ def iter_target_batches(
             parsed_frame = parsed_frame.reindex(columns=TARGET_FIELDS)
         yield payloads, raw_frame, parsed_frame
 
+
+def iter_target_batches_with_retry(
+    ids: Iterable[str],
+    *,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    mapping_cfg: UniprotMappingCfg,
+    chunk_size: int = 5,
+    timeout: float | None = None,
+    retry_cfg: TargetChemblBatchRetryCfg | None = None,
+    log: Any | None = None,
+    on_attempt: Callable[[], None] | None = None,
+) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
+    """Yield payloads, raw and parsed frames with adaptive chunk sizing."""
+
+    effective_logger = log or logger
+    base_chunk_size = max(1, chunk_size)
+
+    if retry_cfg is None or not getattr(retry_cfg, "enable", False):
+        for batch in iter_target_batches(
+            ids,
+            cfg=cfg,
+            client=client,
+            mapping_cfg=mapping_cfg,
+            chunk_size=base_chunk_size,
+            timeout=timeout,
+        ):
+            if on_attempt is not None:
+                on_attempt()
+            yield batch
+        return
+
+    shrink_factor = retry_cfg.shrink_factor
+    min_size = max(1, retry_cfg.min_size)
+
+    buffer: list[str] = []
+
+    def _drain_buffer(batch: list[str]) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
+        queue = list(batch)
+        current_size = min(len(queue), base_chunk_size)
+
+        while queue:
+            attempt_size = min(current_size, len(queue))
+            if attempt_size <= 0:
+                break
+            attempt_ids = queue[:attempt_size]
+            if on_attempt is not None:
+                on_attempt()
+            try:
+                for result in iter_target_batches(
+                    attempt_ids,
+                    cfg=cfg,
+                    client=client,
+                    mapping_cfg=mapping_cfg,
+                    chunk_size=attempt_size,
+                    timeout=timeout,
+                ):
+                    yield result
+            except (requests.RequestException, ValueError) as exc:
+                if attempt_size <= min_size:
+                    raise
+                next_size = int(math.floor(attempt_size * shrink_factor))
+                if next_size < min_size:
+                    next_size = min_size
+                if next_size >= attempt_size:
+                    next_size = max(min_size, attempt_size - 1)
+                effective_logger.warning(
+                    "chembl_chunk_retry",
+                    chunk_size=attempt_size,
+                    next_chunk_size=next_size,
+                    remaining=len(queue),
+                    error=str(exc),
+                )
+                current_size = next_size
+                continue
+            del queue[:attempt_size]
+            current_size = min(base_chunk_size, len(queue)) if queue else 0
+
+        batch.clear()
+
+    for target_id in ids:
+        buffer.append(target_id)
+        if len(buffer) >= base_chunk_size:
+            yield from _drain_buffer(buffer)
+    if buffer:
+        yield from _drain_buffer(buffer)
 
 def get_target(
     chembl_target_id: str,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -2189,15 +2189,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     cfg.chembl,
                     global_limiter=global_limiter,
                 ) as client:
-                    for _, raw_chunk, parsed_chunk in cl.iter_target_batches(
+                    def _count_attempt() -> None:
+                        nonlocal chembl_http_requests
+                        chembl_http_requests += 1
+
+                    batch_iter = cl.iter_target_batches_with_retry(
                         counted_ids_iter,
                         cfg=cfg.api,
                         client=client,
                         mapping_cfg=cfg.uniprot_mapping,
                         chunk_size=cfg.target.chembl.chunk_size,
                         timeout=cfg.target.chembl.timeout,
-                    ):
-                        chembl_http_requests += 1
+                        retry_cfg=cfg.target.chembl.batch_retry,
+                        log=logger,
+                        on_attempt=_count_attempt,
+                    )
+                    for _, raw_chunk, parsed_chunk in batch_iter:
                         raw_dump_rows_total += len(raw_chunk)
                         fetched_rows_total += len(parsed_chunk)
                         if raw_chunk.empty:
@@ -2360,15 +2367,22 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                 cfg.chembl,
                 global_limiter=global_limiter,
             ) as client:
-                for _, raw_chunk, parsed_chunk in cl.iter_target_batches(
+                def _count_attempt() -> None:
+                    nonlocal chembl_http_requests
+                    chembl_http_requests += 1
+
+                batch_iter = cl.iter_target_batches_with_retry(
                     counted_ids_iter,
                     cfg=cfg.api,
                     client=client,
                     mapping_cfg=cfg.uniprot_mapping,
                     chunk_size=cfg.target.chembl.chunk_size,
                     timeout=cfg.target.chembl.timeout,
-                ):
-                    chembl_http_requests += 1
+                    retry_cfg=cfg.target.chembl.batch_retry,
+                    log=logger,
+                    on_attempt=_count_attempt,
+                )
+                for _, raw_chunk, parsed_chunk in batch_iter:
                     raw_dump_rows_total += len(raw_chunk)
                     try:
                         raw_dump_writer.write(raw_chunk)

--- a/tests/unit/test_chembl_target_retry.py
+++ b/tests/unit/test_chembl_target_retry.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Iterator, Tuple, cast
+
+import pandas as pd
+import pytest
+import requests
+
+from library.common.log import logger
+from library.pipelines.target import chembl_target as ct
+
+
+@pytest.mark.unit
+def test_iter_target_batches_with_retry__shrinks_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, cfg, caplog: pytest.LogCaptureFixture
+) -> None:
+    calls: list[Tuple[Tuple[str, ...], int]] = []
+
+    def fake_iter_target_batches(
+        ids: Iterator[str],
+        *,
+        cfg,
+        client,
+        mapping_cfg,
+        chunk_size: int = 0,
+        timeout: float | None = None,
+    ):
+        ids_list = tuple(ids)
+        calls.append((ids_list, chunk_size))
+        if chunk_size > 1:
+            raise requests.ReadTimeout("simulated timeout")
+        payloads = [{"target_chembl_id": ident} for ident in ids_list]
+        raw = pd.DataFrame(payloads)
+        parsed = pd.DataFrame(payloads)
+        yield payloads, raw, parsed
+
+    monkeypatch.setattr(ct, "iter_target_batches", fake_iter_target_batches)
+
+    retry_cfg = cfg.target.chembl.batch_retry
+    retry_cfg.enable = True
+    retry_cfg.shrink_factor = 0.5
+    retry_cfg.min_size = 1
+
+    caplog.set_level("WARNING")
+
+    ids = ["CHEMBL1", "CHEMBL2", "CHEMBL3"]
+    batches = list(
+        ct.iter_target_batches_with_retry(
+            ids,
+            cfg=cfg.api,
+            client=cast(object, None),
+            mapping_cfg=cfg.uniprot_mapping,
+            chunk_size=2,
+            timeout=cfg.target.chembl.timeout,
+            retry_cfg=retry_cfg,
+            log=logger,
+        )
+    )
+
+    assert len(batches) == 3
+    collected = {
+        parsed.iloc[0]["target_chembl_id"]
+        for _, _, parsed in batches
+        if not parsed.empty
+    }
+    assert collected == set(ids)
+
+    assert calls[0] == (("CHEMBL1", "CHEMBL2"), 2)
+    assert all(size == 1 for _, size in calls[1:])
+    assert "chembl_chunk_retry" in caplog.text
+
+
+@pytest.mark.unit
+def test_iter_target_batches_with_retry__disabled_propagates(
+    monkeypatch: pytest.MonkeyPatch, cfg
+) -> None:
+    def failing_iter_target_batches(*args, **kwargs):
+        raise requests.ReadTimeout("hard timeout")
+
+    monkeypatch.setattr(ct, "iter_target_batches", failing_iter_target_batches)
+
+    retry_cfg = cfg.target.chembl.batch_retry
+    retry_cfg.enable = False
+
+    with pytest.raises(requests.ReadTimeout):
+        list(
+            ct.iter_target_batches_with_retry(
+                ["CHEMBL1"],
+                cfg=cfg.api,
+                client=cast(object, None),
+                mapping_cfg=cfg.uniprot_mapping,
+                chunk_size=2,
+                timeout=cfg.target.chembl.timeout,
+                retry_cfg=retry_cfg,
+                log=logger,
+            )
+        )


### PR DESCRIPTION
## Summary
- add configuration knobs for adaptive ChEMBL target batch retries and document them in the schema
- introduce `iter_target_batches_with_retry` to shrink batch sizes after timeouts and wire it into the target CLI
- cover the new retry behaviour with deterministic unit tests

## Testing
- `pytest tests/unit/test_chembl_target_retry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e3ef86b1e883248d9448e2c2bff5c4