### PR TITLE
Handle activity chunk fetch timeouts

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -567,19 +567,19 @@ def get_activities(
         return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 
     records: list[pd.DataFrame] = []
+    base_root = cfg.chembl_base.rstrip("/")
+    base_url = f"{base_root}/activity.json"
     base_params: list[tuple[str, str]] = [("format", "json")]
     if ACTIVITY_QUERY_FIELDS:
         base_params.append(("fields", ",".join(ACTIVITY_QUERY_FIELDS)))
-    base_query = urlencode(base_params)
-    base = f"{cfg.chembl_base.rstrip('/')}/activity.json?{base_query}"
-    effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    for chunk in _chunked(valid, chunk_size):
-        chunk_key = ",".join(chunk)
-        logger.info(
-            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
-        )
-        url = f"{base}&activity_id__in={chunk_key}&limit={len(chunk)}"
-        chunk_frames: list[pd.DataFrame] = []
+    join_base = f"{base_root}/"
+
+    def _build_url(extra: dict[str, object]) -> str:
+        params = base_params + [(key, str(value)) for key, value in extra.items()]
+        return f"{base_url}?{urlencode(params)}"
+
+    def _fetch_paginated(url: str) -> list[pd.DataFrame]:
+        frames: list[pd.DataFrame] = []
         next_url: str | None = url
         while next_url:
             data = client.request_json(next_url, cfg=cfg, timeout=effective_timeout)
@@ -587,10 +587,74 @@ def get_activities(
             if items:
                 df_chunk = json_normalize_pyarrow(items)
                 if not df_chunk.empty:
-                    chunk_frames.append(df_chunk)
+                    frames.append(df_chunk)
             page_meta = data.get("page_meta") or {}
             next_token = page_meta.get("next")
-            next_url = urljoin(cfg.chembl_base, next_token) if next_token else None
+            next_url = urljoin(join_base, next_token) if next_token else None
+        return frames
+
+    def _fetch_single(identifier: str) -> list[pd.DataFrame]:
+        if identifier in {"", "#N/A"}:
+            return []
+        try:
+            frames = _fetch_paginated(_build_url({"activity_id": identifier, "limit": 1}))
+        except requests.HTTPError as exc:
+            response = exc.response
+            status = getattr(response, "status_code", None)
+            if status == 404:
+                logger.info(
+                    "activity_missing",
+                    extra={"stage": "chunk_skip", "activity_id": identifier},
+                )
+                return []
+            raise
+        return frames
+
+    effective_timeout = timeout if timeout is not None else cfg.timeout_read
+    for chunk in _chunked(valid, chunk_size):
+        chunk_key = ",".join(chunk)
+        logger.info(
+            "chunk_start", extra={"stage": "chunk_start", "chunk_key": chunk_key}
+        )
+        url = _build_url({"activity_id__in": chunk_key, "limit": len(chunk)})
+        try:
+            chunk_frames = _fetch_paginated(url)
+        except requests.HTTPError as exc:
+            response = exc.response
+            status = getattr(response, "status_code", None)
+            if status == 404:
+                logger.warning(
+                    "chunk_split_retry",
+                    extra={
+                        "stage": "chunk_retry",
+                        "chunk_key": chunk_key,
+                        "chunk_size": len(chunk),
+                        "status": status,
+                    },
+                )
+                chunk_frames = []
+                for identifier in chunk:
+                    chunk_frames.extend(_fetch_single(identifier))
+            else:
+                raise
+        except requests.RequestException as exc:
+            if not _is_retryable_chunk_error(exc):
+                raise
+            logger.warning(
+                "chunk_network_retry",
+                extra={
+                    "stage": "chunk_retry",
+                    "chunk_key": chunk_key,
+                    "chunk_size": len(chunk),
+                    "error": exc.__class__.__name__,
+                },
+            )
+            chunk_frames = []
+            for identifier in chunk:
+                try:
+                    chunk_frames.extend(_fetch_single(identifier))
+                except requests.RequestException:
+                    raise
         if chunk_frames:
             records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -9,7 +9,7 @@ from requests import ConnectionError, HTTPError, ReadTimeout, Response
 from urllib.parse import parse_qs, urlparse
 
 from library.config import ApiCfg
-from library.pipelines.assay.chembl_assay import get_assays, get_testitem
+from library.pipelines.assay.chembl_assay import get_activities, get_assays, get_testitem
 
 
 class _StubClient:
@@ -186,6 +186,49 @@ def test_get_testitem__splits_chunk_on_timeout() -> None:
     assert any(
         "molecule_chembl_id__in=CHEMBL2,CHEMBL3" in call for call in client.calls
     )
+
+
+@pytest.mark.unit
+def test_get_activities__chunk_timeout_falls_back_to_single_requests() -> None:
+    """Chunk-level timeouts trigger per-identifier activity fetches."""
+
+    responders = [
+        ReadTimeout("timeout"),
+        {"activities": [{"activity_id": "ACT1"}], "page_meta": {}},
+        {"activities": [{"activity_id": "ACT2"}], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_activities(["ACT1", "ACT2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert sorted(df["activity_id"]) == ["ACT1", "ACT2"]
+    assert any("activity_id__in" in call for call in client.calls)
+    assert any("activity_id=ACT1" in call for call in client.calls)
+    assert any("activity_id=ACT2" in call for call in client.calls)
+
+
+@pytest.mark.unit
+def test_get_activities__chunk_404_falls_back_to_single_requests() -> None:
+    """404 responses from chunk queries fall back to single fetches."""
+
+    responders = [
+        "HTTP404",
+        {"activities": [{"activity_id": "ACT1"}], "page_meta": {}},
+        {"activities": [], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_activities(["ACT1", "ACT2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert list(df["activity_id"]) == ["ACT1"]
+    assert any("activity_id__in" in call for call in client.calls)
+    assert sum("activity_id=ACT1" in call for call in client.calls) == 1
+    assert sum("activity_id=ACT2" in call for call in client.calls) == 1
+
+
+@pytest.mark.unit
 def test_get_assays__single_timeout_falls_back_to_detail_endpoint() -> None:
     """Single-item timeouts fall back to the detail endpoint."""
 


### PR DESCRIPTION
## Summary
- add chunk-level retry and fallback logic for ChEMBL activity fetches
- request single-activity records when chunk queries return 404 or transient timeouts
- cover the new behaviour with unit tests that assert deterministic fallback semantics

## Testing
- `pytest tests/unit/pipelines/assay/test_chembl_assay.py -q`
- `pytest tests/unit/test_chembl_activity_fetch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e3f0bd67a0832498ce2ef762c0d366