### PR TITLE
Allow --output CLI flag to target final export file

### DIFF
--- a/library/cli/parser.py
+++ b/library/cli/parser.py
@@ -157,6 +157,7 @@ def add_common_arguments(
     parser.add_argument(
         "--final-out",
         "--out",
+        "--output",
         dest="final_out",
         type=path_argument,
         default=final_default,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -1447,9 +1447,11 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         no_reindex_default: object = False if defaults else argparse.SUPPRESS
         normalize_default: object = False if defaults else argparse.SUPPRESS
         option_actions = parser_obj._option_string_actions
-        if "--final-out" not in option_actions:
+        if not any(alias in option_actions for alias in ("--final-out", "--out", "--output")):
             parser_obj.add_argument(
                 "--final-out",
+                "--out",
+                "--output",
                 dest="final_out",
                 type=path_argument,
                 default=final_default,

--- a/tests/unit/test_get_target_data_cli.py
+++ b/tests/unit/test_get_target_data_cli.py
@@ -77,6 +77,29 @@ def test_resolve_target_parameters__all_global_fallback():
 
 
 @pytest.mark.unit
+def test_prepare_io_paths__output_alias_sets_final_out(tmp_path):
+    parser, _ = get_target_data.build_parser()
+    args = parser.parse_args([
+        "all",
+        "--base-path",
+        str(tmp_path),
+        "--output",
+        "custom.csv",
+    ])
+
+    get_target_data.prepare_io_paths(
+        args,
+        input_default=get_target_data.DEFAULT_INPUT_NAME,
+        output_stem=get_target_data.DEFAULT_OUTPUT_STEM,
+    )
+
+    expected = (tmp_path / "custom.csv").resolve()
+    assert args.final_out == expected
+    assert args.output_csv == expected
+    assert args.output_dir is None
+
+
+@pytest.mark.unit
 def test_target_iuphar_defaults__align_with_cli() -> None:
     cfg = Config()
     defaults = TARGET_MODE_DEFAULTS["iuphar"]


### PR DESCRIPTION
## Summary
- add `--output` as an alias for `--final-out` so the CLI accepts the flag users expect
- ensure sub-command option registration also exposes the alias
- cover the regression with a deterministic unit test exercising `prepare_io_paths`

## Testing
- pytest tests/unit/test_get_target_data_cli.py::test_prepare_io_paths__output_alias_sets_final_out -q
- pytest tests/unit/test_get_target_data_cli.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3f0ec15008324811862a99887a530