### PR TITLE
Fix target timeout handling

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -340,7 +340,7 @@ def _iter_target_chunk_with_fallback(
     url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
     try:
         data = client.request_json(url, cfg=cfg, timeout=timeout)
-    except ReadTimeout as exc:
+    except requests.ReadTimeout as exc:
         if len(chunk) <= 1:
             raise exc
         logger.warning(


### PR DESCRIPTION
## Summary
- ensure target chunk fallback handles request timeouts by catching requests.ReadTimeout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3f42df43483248f1ea8b3a5099718