### PR TITLE
Handle target batch connection errors

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -338,17 +338,29 @@ def _iter_target_chunk_with_fallback(
         return
 
     url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
+    handled_exc: requests.RequestException | None
     try:
         data = client.request_json(url, cfg=cfg, timeout=timeout)
-    except ReadTimeout as exc:
-        if len(chunk) <= 1:
-            raise exc
+    except requests.ReadTimeout as exc:
+        event = "chembl_timeout_split"
+        handled_exc = exc
+    except requests.RequestException as exc:
+        event = "chembl_request_split"
+        handled_exc = exc
+    else:
+        event = ""
+        handled_exc = None
+
+    if event:
+        if len(chunk) <= 1 or handled_exc is None:
+            raise handled_exc
         logger.warning(
-            "chembl_timeout_split",
+            event,
             extra={
                 "chunk_size": len(chunk),
                 "ids": list(chunk),
                 "timeout": timeout,
+                "error": str(handled_exc),
             },
         )
         for identifier in chunk:

--- a/tests/unit/test_chembl_target.py
+++ b/tests/unit/test_chembl_target.py
@@ -93,3 +93,55 @@ def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureF
     assert parsed_ids == ["CHEMBL1", "CHEMBL2"]
 
     assert any(record.getMessage().startswith("chembl_timeout_split") for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_iter_target_batches__splits_chunk_on_connection_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Chunk-level connection errors should fall back to per-ID requests."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=7.0)
+    mapping_cfg = UniprotMappingCfg()
+    timeout = 5.0
+    base = cfg.chembl_base.rstrip("/")
+
+    def _chunk_url(ids: Sequence[str]) -> str:
+        return (
+            f"{base}/target.json?format=json"
+            f"&include=protein_classifications,cross_references"
+            f"&target_chembl_id__in={','.join(ids)}"
+        )
+
+    combined_url = _chunk_url(["CHEMBL1", "CHEMBL2"])
+    responses = {
+        combined_url: requests.ConnectionError("simulated connection reset"),
+        _chunk_url(["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
+        _chunk_url(["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
+    }
+    client = _StubChemblClient(responses)
+
+    with caplog.at_level("WARNING"):
+        batches = list(
+            iter_target_batches(
+                ["CHEMBL1", "CHEMBL2"],
+                cfg=cfg,
+                client=client,
+                mapping_cfg=mapping_cfg,
+                chunk_size=2,
+                timeout=timeout,
+            )
+        )
+
+    assert [call[0] for call in client.calls] == [
+        combined_url,
+        _chunk_url(["CHEMBL1"]),
+        _chunk_url(["CHEMBL2"]),
+    ]
+    assert all(call[1] == timeout for call in client.calls)
+
+    assert len(batches) == 2
+    parsed_ids = [parsed[2]["target_chembl_id"].iat[0] for parsed in batches]
+    assert parsed_ids == ["CHEMBL1", "CHEMBL2"]
+
+    assert any(record.getMessage().startswith("chembl_request_split") for record in caplog.records)


### PR DESCRIPTION
## Summary
- extend target chunk fallback logic to handle generic request failures in addition to read timeouts
- add a unit test ensuring connection errors trigger chunk splitting and logging

## Testing
- pytest tests/unit/test_chembl_target.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3f4a5a35c8324a51025362ad05930