### PR TITLE
Fix NameError handling target chunk timeouts

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -10,6 +10,7 @@ from typing import Any, Callable
 
 import pandas as pd
 import requests
+from requests.exceptions import ReadTimeout
 
 from library.clients import ChemblClient, _chunked
 from ...config import ApiCfg, TargetChemblBatchRetryCfg, UniprotMappingCfg


### PR DESCRIPTION
## Summary
- import the missing ReadTimeout exception for the target batch timeout fallback logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3f4dbbff08324aa22b929e0bedc88