### PR TITLE
Fix target pipeline timeout handling

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -340,7 +340,7 @@ def _iter_target_chunk_with_fallback(
     url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
     try:
         data = client.request_json(url, cfg=cfg, timeout=timeout)
-    except ReadTimeout as exc:
+    except requests.ReadTimeout as exc:
         if len(chunk) <= 1:
             raise exc
         logger.warning(

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -439,6 +439,9 @@ def test_fetch_uniprot__missing_output_creates_placeholder(
         level == "warning"
         and event == "missing_iuphar_output_file"
         and payload["path"] == str(output_csv)
+        for level, event, payload in logger_stub.events
+    )
+
     output_csv = tmp_path / "output_uniprot.csv"
     chembl_df = pd.DataFrame(
         {"target_chembl_id": ["CHEMBL1"], "uniprot_id": ["P12345"]}


### PR DESCRIPTION
## Summary
- handle target pipeline timeout retries using the requests.ReadTimeout type
- repair the iuphar placeholder unit test assertion on missing output logging

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3f5380e488324b5401209e259b01b