### PR TITLE
Allow target batch retries to handle chunk timeouts directly

### DIFF
--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -300,8 +300,19 @@ def iter_target_batches(
     mapping_cfg: UniprotMappingCfg,
     chunk_size: int = 5,
     timeout: float | None = None,
+    enable_split_fallback: bool = True,
 ) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
-    """Yield payloads, raw and parsed target data frames for ``ids``."""
+    """Yield payloads, raw and parsed target data frames for ``ids``.
+
+    Parameters
+    ----------
+    enable_split_fallback:
+        When ``True`` (default), a :class:`requests.ReadTimeout` for a chunk
+        results in recursive splitting down to single identifiers. When
+        ``False``, the exception is propagated to the caller so that higher
+        level retry strategies can react, for example by shrinking the chunk
+        size.
+    """
 
     if not ids:
         return
@@ -320,6 +331,7 @@ def iter_target_batches(
             client=client,
             mapping_cfg=mapping_cfg,
             timeout=effective_timeout,
+            enable_split_fallback=enable_split_fallback,
         )
 
 
@@ -331,6 +343,7 @@ def _iter_target_chunk_with_fallback(
     client: ChemblClient,
     mapping_cfg: UniprotMappingCfg,
     timeout: float,
+    enable_split_fallback: bool,
 ) -> Iterator[tuple[list[dict[str, Any]], pd.DataFrame, pd.DataFrame]]:
     """Yield processed records for ``chunk`` with timeout-aware retries."""
 
@@ -340,8 +353,8 @@ def _iter_target_chunk_with_fallback(
     url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
     try:
         data = client.request_json(url, cfg=cfg, timeout=timeout)
-    except ReadTimeout as exc:
-        if len(chunk) <= 1:
+    except requests.ReadTimeout as exc:
+        if len(chunk) <= 1 or not enable_split_fallback:
             raise exc
         logger.warning(
             "chembl_timeout_split",
@@ -359,6 +372,7 @@ def _iter_target_chunk_with_fallback(
                 client=client,
                 mapping_cfg=mapping_cfg,
                 timeout=timeout,
+                enable_split_fallback=enable_split_fallback,
             )
         return
 
@@ -406,6 +420,7 @@ def iter_target_batches_with_retry(
             mapping_cfg=mapping_cfg,
             chunk_size=base_chunk_size,
             timeout=timeout,
+            enable_split_fallback=True,
         ):
             if on_attempt is not None:
                 on_attempt()
@@ -436,6 +451,7 @@ def iter_target_batches_with_retry(
                     mapping_cfg=mapping_cfg,
                     chunk_size=attempt_size,
                     timeout=timeout,
+                    enable_split_fallback=False,
                 ):
                     yield result
             except (requests.RequestException, ValueError) as exc:

--- a/tests/unit/test_chembl_target.py
+++ b/tests/unit/test_chembl_target.py
@@ -93,3 +93,43 @@ def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureF
     assert parsed_ids == ["CHEMBL1", "CHEMBL2"]
 
     assert any(record.getMessage().startswith("chembl_timeout_split") for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_iter_target_batches__propagates_timeout_without_split() -> None:
+    """Disable fallback splitting so that higher level retry logic can react."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=8.0)
+    mapping_cfg = UniprotMappingCfg()
+    timeout = 6.0
+    base = cfg.chembl_base.rstrip("/")
+
+    def _chunk_url(ids: Sequence[str]) -> str:
+        return (
+            f"{base}/target.json?format=json"
+            f"&include=protein_classifications,cross_references"
+            f"&target_chembl_id__in={','.join(ids)}"
+        )
+
+    combined_url = _chunk_url(["CHEMBL10", "CHEMBL11"])
+    responses = {
+        combined_url: requests.ReadTimeout("simulated timeout"),
+        _chunk_url(["CHEMBL10"]): _build_response("CHEMBL10", "Gamma"),
+        _chunk_url(["CHEMBL11"]): _build_response("CHEMBL11", "Delta"),
+    }
+    client = _StubChemblClient(responses)
+
+    with pytest.raises(requests.ReadTimeout):
+        list(
+            iter_target_batches(
+                ["CHEMBL10", "CHEMBL11"],
+                cfg=cfg,
+                client=client,
+                mapping_cfg=mapping_cfg,
+                chunk_size=2,
+                timeout=timeout,
+                enable_split_fallback=False,
+            )
+        )
+
+    assert client.calls == [(combined_url, timeout)]


### PR DESCRIPTION
## Summary
- add an `enable_split_fallback` flag to `iter_target_batches` so callers can opt out of automatic chunk splitting
- propagate the flag through the retry helper to let batch retry logic shrink chunks before falling back to single requests
- cover the new code path with a unit test that exercises the propagated timeout when splitting is disabled

## Testing
- pytest tests/unit/test_chembl_target.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f3a893dc8324a9617cdf24d070ef