### PR TITLE
Handle activity fetch timeouts gracefully

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -608,6 +608,16 @@ def get_activities(
                 )
                 return []
             raise
+        except requests.RequestException as exc:
+            logger.warning(
+                "single_fetch_network_skip",
+                extra={
+                    "stage": "chunk_retry",
+                    "activity_id": identifier,
+                    "error": exc.__class__.__name__,
+                },
+            )
+            return []
         return frames
 
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
@@ -651,10 +661,7 @@ def get_activities(
             )
             chunk_frames = []
             for identifier in chunk:
-                try:
-                    chunk_frames.extend(_fetch_single(identifier))
-                except requests.RequestException:
-                    raise
+                chunk_frames.extend(_fetch_single(identifier))
         if chunk_frames:
             records.append(pd.concat(chunk_frames, ignore_index=True))
             logger.info(

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -229,6 +229,26 @@ def test_get_activities__chunk_404_falls_back_to_single_requests() -> None:
 
 
 @pytest.mark.unit
+def test_get_activities__single_timeout_skips_identifier() -> None:
+    """Per-identifier timeouts are logged and skipped."""
+
+    responders = [
+        ReadTimeout("timeout"),
+        ReadTimeout("timeout"),
+        {"activities": [{"activity_id": "ACT2"}], "page_meta": {}},
+    ]
+    client = _StubClient(responders)
+    cfg = ApiCfg()
+
+    df = get_activities(["ACT1", "ACT2"], cfg=cfg, client=client, chunk_size=2)
+
+    assert list(df["activity_id"]) == ["ACT2"]
+    assert any("activity_id__in" in call for call in client.calls)
+    assert sum("activity_id=ACT1" in call for call in client.calls) == 1
+    assert sum("activity_id=ACT2" in call for call in client.calls) == 1
+
+
+@pytest.mark.unit
 def test_get_assays__single_timeout_falls_back_to_detail_endpoint() -> None:
     """Single-item timeouts fall back to the detail endpoint."""
 


### PR DESCRIPTION
## Summary
- skip individual activity identifiers when fallback requests keep timing out
- log per-identifier network skips instead of raising and halting the pipeline
- add a unit test covering the single-request timeout scenario for activities

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py -k get_activities -q

------
https://chatgpt.com/codex/tasks/task_e_68e3f9fbaa548324b46d18d2f4183a02