### PR TITLE
Fix ChEMBL target fallback unit tests

### DIFF
--- a/tests/unit/test_chembl_target.py
+++ b/tests/unit/test_chembl_target.py
@@ -8,7 +8,10 @@ import pytest
 import requests
 
 from library.config import ApiCfg, UniprotMappingCfg
-from library.pipelines.target.chembl_target import iter_target_batches
+from library.pipelines.target.chembl_target import (
+    TARGET_INCLUDE_PARAMS,
+    iter_target_batches,
+)
 
 
 class _StubChemblClient:
@@ -45,6 +48,16 @@ def _build_response(target_id: str, pref_name: str) -> dict[str, object]:
     }
 
 
+def _chunk_url(cfg: ApiCfg, ids: Sequence[str]) -> str:
+    base = cfg.chembl_base.rstrip("/")
+    joined_ids = ",".join(ids)
+    return (
+        f"{base}/target.json?format=json"
+        f"&include={TARGET_INCLUDE_PARAMS}"
+        f"&target_chembl_id__in={joined_ids}"
+    )
+
+
 @pytest.mark.unit
 def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureFixture) -> None:
     """The iterator should split large chunks when a read timeout occurs."""
@@ -52,20 +65,12 @@ def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureF
     cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=12.0)
     mapping_cfg = UniprotMappingCfg()
     timeout = 9.5
-    base = cfg.chembl_base.rstrip("/")
 
-    def _chunk_url(ids: Sequence[str]) -> str:
-        return (
-            f"{base}/target.json?format=json"
-            f"&include=protein_classifications,cross_references"
-            f"&target_chembl_id__in={','.join(ids)}"
-        )
-
-    combined_url = _chunk_url(["CHEMBL1", "CHEMBL2"])
+    combined_url = _chunk_url(cfg, ["CHEMBL1", "CHEMBL2"])
     responses = {
         combined_url: requests.ReadTimeout("simulated timeout"),
-        _chunk_url(["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
-        _chunk_url(["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
+        _chunk_url(cfg, ["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
+        _chunk_url(cfg, ["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
     }
     client = _StubChemblClient(responses)
 
@@ -83,8 +88,8 @@ def test_iter_target_batches__splits_chunk_on_timeout(caplog: pytest.LogCaptureF
 
     assert [call[0] for call in client.calls] == [
         combined_url,
-        _chunk_url(["CHEMBL1"]),
-        _chunk_url(["CHEMBL2"]),
+        _chunk_url(cfg, ["CHEMBL1"]),
+        _chunk_url(cfg, ["CHEMBL2"]),
     ]
     assert all(call[1] == timeout for call in client.calls)
 
@@ -102,28 +107,9 @@ def test_iter_target_batches__propagates_timeout_without_split() -> None:
     cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=8.0)
     mapping_cfg = UniprotMappingCfg()
     timeout = 6.0
-def test_iter_target_batches__splits_chunk_on_connection_error(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Chunk-level connection errors should fall back to per-ID requests."""
 
-    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=7.0)
-    mapping_cfg = UniprotMappingCfg()
-    timeout = 5.0
-    base = cfg.chembl_base.rstrip("/")
-
-    def _chunk_url(ids: Sequence[str]) -> str:
-        return (
-            f"{base}/target.json?format=json"
-            f"&include=protein_classifications,cross_references"
-            f"&target_chembl_id__in={','.join(ids)}"
-        )
-
-    combined_url = _chunk_url(["CHEMBL10", "CHEMBL11"])
     responses = {
-        combined_url: requests.ReadTimeout("simulated timeout"),
-        _chunk_url(["CHEMBL10"]): _build_response("CHEMBL10", "Gamma"),
-        _chunk_url(["CHEMBL11"]): _build_response("CHEMBL11", "Delta"),
+        _chunk_url(cfg, ["CHEMBL10", "CHEMBL11"]): requests.ReadTimeout("simulated timeout"),
     }
     client = _StubChemblClient(responses)
 
@@ -131,11 +117,31 @@ def test_iter_target_batches__splits_chunk_on_connection_error(
         list(
             iter_target_batches(
                 ["CHEMBL10", "CHEMBL11"],
-    combined_url = _chunk_url(["CHEMBL1", "CHEMBL2"])
+                cfg=cfg,
+                client=client,
+                mapping_cfg=mapping_cfg,
+                chunk_size=2,
+                timeout=timeout,
+                enable_split_fallback=False,
+            )
+        )
+
+    assert client.calls == [(_chunk_url(cfg, ["CHEMBL10", "CHEMBL11"]), timeout)]
+
+
+@pytest.mark.unit
+def test_iter_target_batches__splits_chunk_on_connection_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Chunk-level connection errors should fall back to per-ID requests."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=7.0)
+    mapping_cfg = UniprotMappingCfg()
+    timeout = 5.0
+
+    combined_url = _chunk_url(cfg, ["CHEMBL1", "CHEMBL2"])
     responses = {
         combined_url: requests.ConnectionError("simulated connection reset"),
-        _chunk_url(["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
-        _chunk_url(["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
+        _chunk_url(cfg, ["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
+        _chunk_url(cfg, ["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
     }
     client = _StubChemblClient(responses)
 
@@ -148,18 +154,13 @@ def test_iter_target_batches__splits_chunk_on_connection_error(
                 mapping_cfg=mapping_cfg,
                 chunk_size=2,
                 timeout=timeout,
-                enable_split_fallback=False,
-            )
-        )
-
-    assert client.calls == [(combined_url, timeout)]
             )
         )
 
     assert [call[0] for call in client.calls] == [
         combined_url,
-        _chunk_url(["CHEMBL1"]),
-        _chunk_url(["CHEMBL2"]),
+        _chunk_url(cfg, ["CHEMBL1"]),
+        _chunk_url(cfg, ["CHEMBL2"]),
     ]
     assert all(call[1] == timeout for call in client.calls)
 

--- a/tests/unit/test_chembl_target_retry.py
+++ b/tests/unit/test_chembl_target_retry.py
@@ -24,7 +24,9 @@ def test_iter_target_batches_with_retry__shrinks_on_timeout(
         mapping_cfg,
         chunk_size: int = 0,
         timeout: float | None = None,
+        enable_split_fallback: bool = True,
     ):
+        del enable_split_fallback
         ids_list = tuple(ids)
         calls.append((ids_list, chunk_size))
         if chunk_size > 1:


### PR DESCRIPTION
## Summary
- rebuild the ChEMBL target unit tests to use a shared URL builder and cover timeout/connection fallbacks deterministically
- ensure retry unit tests accept the enable_split_fallback flag when stubbing iter_target_batches

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3fa1338bc83249f46d013b7a0bda1