### PR TITLE
Improve ChEMBL target request resilience

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -969,13 +969,13 @@
           "type": "string"
         },
         "chunk_size": {
-          "default": 5,
+          "default": 3,
           "minimum": 1,
           "title": "Chunk Size",
           "type": "integer"
         },
         "timeout": {
-          "default": 30.0,
+          "default": 90.0,
           "exclusiveMinimum": 0,
           "title": "Timeout",
           "type": "number"
@@ -1749,13 +1749,13 @@
           "type": "string"
         },
         "chunk_size": {
-          "default": 5,
+          "default": 3,
           "minimum": 1,
           "title": "Chunk Size",
           "type": "integer"
         },
         "timeout": {
-          "default": 30.0,
+          "default": 90.0,
           "exclusiveMinimum": 0,
           "title": "Timeout",
           "type": "number"
@@ -1856,13 +1856,13 @@
           "type": "string"
         },
         "chunk_size": {
-          "default": 5,
+          "default": 3,
           "minimum": 1,
           "title": "Chunk Size",
           "type": "integer"
         },
         "timeout": {
-          "default": 30.0,
+          "default": 90.0,
           "exclusiveMinimum": 0,
           "title": "Timeout",
           "type": "number"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,8 +119,8 @@ sources:
           limit: null
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers
-          chunk_size: 5
-          timeout: 30.0
+          chunk_size: 3
+          timeout: 90.0
           limit: null
           offset: 0
           batch_retry:
@@ -136,8 +136,8 @@ sources:
           data_dir: "config/dictionary/_target/_uniprot"
           target_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_target.csv"
           family_csv: "config/dictionary/_target/_IUPHAR/_IUPHAR_family.csv"
-          chunk_size: 5
-          timeout: 30.0
+          chunk_size: 3
+          timeout: 90.0
           uniprot_column: mapping_uniprot_id  # Column containing primary UniProt accession used for merges
           chembl_out: null
           uniprot_out: null

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from itertools import islice
 from dataclasses import dataclass, field
+from time import monotonic
 from types import TracebackType
 from typing import Any, Callable, TypeVar, cast
 from urllib.parse import urlsplit, urlunsplit
@@ -218,6 +219,7 @@ class ChemblClient:
                     extra={"url": request_url, "attempt": attempt, "rps": cfg.rps},
                 )
                 try:
+                    start_time = monotonic()
                     session = self._get_session()
                     with session.get(
                         request_url, timeout=(cfg.timeout_connect, read_timeout)
@@ -226,16 +228,23 @@ class ChemblClient:
                         try:
                             data = cast(dict[str, Any], response.json())
                         except ValueError as exc:
-                            logger.exception("json_error", extra={"url": request_url})
+                            elapsed = monotonic() - start_time
+                            logger.exception(
+                                "json_error",
+                                extra={"url": request_url, "elapsed": elapsed},
+                            )
                             raise ValueError(
                                 f"invalid JSON in response from {request_url}"
                             ) from exc
+                        elapsed = monotonic() - start_time
                         logger.debug(
                             "request_ok",
                             extra={
                                 "url": request_url,
                                 "status": getattr(response, "status_code", None),
                                 "rps": cfg.rps,
+                                "elapsed": elapsed,
+                                "attempt": attempt,
                             },
                         )
                         with self._cache_lock:
@@ -254,15 +263,23 @@ class ChemblClient:
                                     "fallback_url": request_url,
                                     "attempt": attempt,
                                     "rps": cfg.rps,
+                                    "elapsed": elapsed,
                                 },
                             )
                         return data
                 except ValueError as exc:
+                    elapsed = monotonic() - start_time
                     last_exc = exc
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",
-                            extra={"url": request_url, "status": None, "rps": cfg.rps},
+                            extra={
+                                "url": request_url,
+                                "status": None,
+                                "rps": cfg.rps,
+                                "elapsed": elapsed,
+                                "attempt": attempt,
+                            },
                         )
                         break
                     delay = _backoff_delay(attempt, cfg, header_delay=None)
@@ -270,6 +287,7 @@ class ChemblClient:
                     sleep(delay)
                     break
                 except requests.HTTPError as exc:
+                    elapsed = monotonic() - start_time
                     last_exc = exc
                     response = exc.response
                     status = getattr(response, "status_code", None)
@@ -288,13 +306,20 @@ class ChemblClient:
                                 "fallback_url": request_url,
                                 "attempt": attempt,
                                 "rps": cfg.rps,
+                                "elapsed": elapsed,
                             },
                         )
                         continue
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",
-                            extra={"url": request_url, "status": status, "rps": cfg.rps},
+                            extra={
+                                "url": request_url,
+                                "status": status,
+                                "rps": cfg.rps,
+                                "elapsed": elapsed,
+                                "attempt": attempt,
+                            },
                         )
                         break
                     header_delay = _retry_after_delay(response)
@@ -303,11 +328,18 @@ class ChemblClient:
                     sleep(delay)
                     break
                 except requests.RequestException as exc:
+                    elapsed = monotonic() - start_time
                     last_exc = exc
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",
-                            extra={"url": request_url, "status": None, "rps": cfg.rps},
+                            extra={
+                                "url": request_url,
+                                "status": None,
+                                "rps": cfg.rps,
+                                "elapsed": elapsed,
+                                "attempt": attempt,
+                            },
                         )
                         break
                     delay = _backoff_delay(attempt, cfg, header_delay=None)

--- a/library/config.py
+++ b/library/config.py
@@ -1271,8 +1271,8 @@ class TargetChemblCfg(_BaseModel):
 
     column: str = "target_chembl_id"
 
-    chunk_size: int = Field(5, ge=1)
-    timeout: float = Field(30.0, gt=0)
+    chunk_size: int = Field(3, ge=1)
+    timeout: float = Field(90.0, gt=0)
 
     limit: int | None = Field(default=None, ge=0)
     offset: int = Field(0, ge=0)
@@ -1307,8 +1307,8 @@ class TargetAllCfg(_BaseModel):
     family_csv: Path = (
         DICTIONARY_DIR / "_target" / "_IUPHAR" / "_IUPHAR_family.csv"
     )
-    chunk_size: int = Field(5, ge=1)
-    timeout: float = Field(30.0, gt=0)
+    chunk_size: int = Field(3, ge=1)
+    timeout: float = Field(90.0, gt=0)
     uniprot_column: str = "uniprot_id"
     chembl_out: Path | None = None
     uniprot_out: Path | None = None

--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -6,6 +6,7 @@ import json
 import math
 import re
 from collections.abc import Iterable, Iterator, Sequence
+from time import monotonic
 from typing import Any, Callable
 
 import pandas as pd
@@ -353,19 +354,23 @@ def _iter_target_chunk_with_fallback(
 
     url = f"{base_url}&target_chembl_id__in={','.join(chunk)}"
     handled_exc: requests.RequestException | None
+    start_time = monotonic()
     try:
         data = client.request_json(url, cfg=cfg, timeout=timeout)
     except requests.ReadTimeout as exc:
+        elapsed = monotonic() - start_time
         if len(chunk) <= 1 or not enable_split_fallback:
             raise exc
         event = "chembl_timeout_split"
         handled_exc = exc
     except requests.RequestException as exc:
+        elapsed = monotonic() - start_time
         event = "chembl_request_split"
         handled_exc = exc
     else:
         event = ""
         handled_exc = None
+        elapsed = monotonic() - start_time
 
     if event:
         if len(chunk) <= 1 or handled_exc is None:
@@ -377,6 +382,7 @@ def _iter_target_chunk_with_fallback(
                 "ids": list(chunk),
                 "timeout": timeout,
                 "error": str(handled_exc),
+                "elapsed": elapsed,
             },
         )
         for identifier in chunk:
@@ -398,6 +404,16 @@ def _iter_target_chunk_with_fallback(
         if isinstance(item, (dict, list))
     ]
     payloads = [payload for payload in payloads if payload]
+    logger.debug(
+        "chembl_target_chunk_ok",
+        extra={
+            "chunk_size": len(chunk),
+            "ids": list(chunk),
+            "timeout": timeout,
+            "elapsed": elapsed,
+            "records": len(payloads),
+        },
+    )
     if not payloads:
         return
     raw_frame = _normalise_target_payloads(payloads)

--- a/library/pipelines/target/defaults.py
+++ b/library/pipelines/target/defaults.py
@@ -20,8 +20,8 @@ class ModeDefaults:
 TARGET_MODE_DEFAULTS: Mapping[str, ModeDefaults] = {
     "chembl": ModeDefaults(
         column="target_chembl_id",
-        chunk_size=5,
-        timeout=30.0,
+        chunk_size=3,
+        timeout=90.0,
         limit=None,
         offset=0,
     ),
@@ -41,8 +41,8 @@ TARGET_MODE_DEFAULTS: Mapping[str, ModeDefaults] = {
     ),
     "all": ModeDefaults(
         column="target_chembl_id",
-        chunk_size=5,
-        timeout=30.0,
+        chunk_size=3,
+        timeout=90.0,
         limit=None,
         offset=0,
     ),


### PR DESCRIPTION
## Summary
- document the slow `/target.json` response that exceeds the previous 30s read timeout and treat it as an upstream latency issue
- raise the default ChEMBL target timeout to 90s, shrink the default batch size, and surface these defaults in the config schema/CLI defaults
- add detailed timing diagnostics to the ChEMBL client and target chunk iterator so we can observe retry behaviour and chunk durations when timeouts occur

## Testing
- pytest -q tests/unit/test_chembl_target.py tests/unit/test_chembl_target_retry.py tests/unit/test_get_target_data_cli.py *(fails: SyntaxError in tests/unit/test_chembl_target.py, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fa37a05c8324b3d8574357a229d1