### PR TITLE
Normalize CLI target export filenames

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -268,6 +268,10 @@ def _normalise_target_export_name(path: Path) -> str:
     name = path.name
     lowered_name = name.lower()
 
+    while lowered_name.startswith("."):
+        name = name[1:]
+        lowered_name = name.lower()
+
     for suffix in _TEMPORARY_EXPORT_SUFFIXES:
         suffix_lower = suffix.lower()
         while lowered_name.endswith(suffix_lower):
@@ -286,7 +290,16 @@ def _normalise_target_export_name(path: Path) -> str:
             lowered_name = name.lower()
             break
 
-    return name
+    canonical = name.lower()
+
+    if canonical.startswith("output.") and not target_pp._matches_expected_input_name(
+        canonical
+    ):
+        candidate = canonical[len("output.") :]
+        if target_pp._matches_expected_input_name(candidate):
+            canonical = candidate
+
+    return canonical
 
 
 def _export_stem(name: str) -> str:

--- a/tests/unit/test_target_isoform.py
+++ b/tests/unit/test_target_isoform.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+from pathlib import Path
+
 from library.postprocessing.target import isoform
+from scripts import get_target_data
 
 
 @pytest.mark.unit
@@ -96,3 +99,62 @@ def test_matches_expected_input_name__supports_modern_exports(filename: str) -> 
     """Modern ``out*.csv`` exports are accepted for isoform processing."""
 
     assert isoform._matches_expected_input_name(filename)
+
+
+@pytest.mark.unit
+def test_is_supported_target_export__accepts_cli_default(tmp_path: Path) -> None:
+    """The CLI default ``output.targets_*.csv`` export is supported."""
+
+    path = tmp_path / "output.targets_20250101.csv"
+    path.write_text("target_chembl_id\n", encoding="utf-8")
+
+    assert get_target_data._is_supported_target_export(path)
+
+
+@pytest.mark.unit
+def test_postprocess_target_exports__runs_helpers_for_cli_default(
+    tmp_path: Path, cfg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All target post-processing helpers run for the CLI default export."""
+
+    source = tmp_path / "output.targets_20250101.csv"
+    source.write_text("target_chembl_id\n", encoding="utf-8")
+
+    calls: list[str] = []
+
+    def _organism_stub(source: Path, *, cfg) -> None:  # pragma: no cover - simple stub
+        calls.append("organism")
+        return None
+
+    def _isoform_stub(
+        source: Path,
+        *,
+        cfg,
+        context=None,
+        ambiguous_classifications=None,
+    ) -> None:
+        calls.append("isoform")
+        return None
+
+    def _names_stub(source: Path, *, cfg) -> None:  # pragma: no cover - simple stub
+        calls.append("names")
+        return None
+
+    def _iuphar_stub(source: Path, *, verbose: bool = True) -> None:  # pragma: no cover - stub
+        calls.append("iuphar")
+        return None
+
+    monkeypatch.setattr(get_target_data, "_postprocess_organism_export", _organism_stub)
+    monkeypatch.setattr(get_target_data, "_postprocess_isoform_export", _isoform_stub)
+    monkeypatch.setattr(get_target_data, "_postprocess_names_export", _names_stub)
+    monkeypatch.setattr(get_target_data, "_postprocess_iuphar_export", _iuphar_stub)
+
+    get_target_data._postprocess_target_exports(
+        source,
+        cfg=cfg,
+        context=None,
+        ambiguous_classifications=None,
+        verbose=True,
+    )
+
+    assert calls == ["organism", "isoform", "names", "iuphar"]


### PR DESCRIPTION
## Summary
- normalise target export filenames so CLI-generated `output.*` artefacts match the expected post-processing patterns
- extend the isoform unit tests to cover the default CLI export and verify downstream helpers are invoked

## Testing
- pytest tests/unit/test_target_isoform.py tests/unit/test_get_target_data.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e3fa558e688324922d3de8236d0eb2