### PR TITLE
Handle ChEMBL target read timeouts with configurable retries

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1913,6 +1913,18 @@
           "minimum": 1,
           "title": "Min Size",
           "type": "integer"
+        },
+        "single_timeout_retries": {
+          "default": 2,
+          "minimum": 0,
+          "title": "Single Timeout Retries",
+          "type": "integer"
+        },
+        "single_timeout_delay": {
+          "default": 0.0,
+          "minimum": 0.0,
+          "title": "Single Timeout Delay",
+          "type": "number"
         }
       },
       "title": "TargetChemblBatchRetryCfg",

--- a/library/config.py
+++ b/library/config.py
@@ -1255,6 +1255,8 @@ class TargetChemblBatchRetryCfg(_BoolModel):
     enable: bool = True
     shrink_factor: float = Field(0.5, gt=0, lt=1)
     min_size: int = Field(1, ge=1)
+    single_timeout_retries: int = Field(2, ge=0)
+    single_timeout_delay: float = Field(0.0, ge=0.0)
 
     @field_validator("enable", mode="before")
     @classmethod

--- a/library/pipelines/target/chembl_target.py
+++ b/library/pipelines/target/chembl_target.py
@@ -15,6 +15,7 @@ from requests.exceptions import ReadTimeout
 from library.clients import ChemblClient, _chunked
 from ...config import ApiCfg, TargetChemblBatchRetryCfg, UniprotMappingCfg
 from ...common.log import logger
+from ...common.rate_limiter import sleep
 
 TARGET_FIELDS = [
     "pref_name",
@@ -444,6 +445,10 @@ def iter_target_batches_with_retry(
 
     shrink_factor = retry_cfg.shrink_factor
     min_size = max(1, retry_cfg.min_size)
+    single_retry_limit = max(0, getattr(retry_cfg, "single_timeout_retries", 0))
+    single_retry_delay = max(0.0, getattr(retry_cfg, "single_timeout_delay", 0.0))
+
+    single_retry_counts: dict[tuple[str, ...], int] = {}
 
     buffer: list[str] = []
 
@@ -451,11 +456,37 @@ def iter_target_batches_with_retry(
         queue = list(batch)
         current_size = min(len(queue), base_chunk_size)
 
+        def _should_retry_single(
+            key: tuple[str, ...], exc: Exception
+        ) -> bool:
+            if single_retry_limit <= 0:
+                return False
+            if not isinstance(exc, ReadTimeout):
+                return False
+            attempts = single_retry_counts.get(key, 0)
+            if attempts >= single_retry_limit:
+                return False
+            next_attempt = attempts + 1
+            single_retry_counts[key] = next_attempt
+            log_kwargs = {
+                "chunk_size": len(key),
+                "ids": list(key),
+                "attempt": next_attempt,
+                "max_attempts": single_retry_limit,
+                "error": str(exc),
+            }
+            if single_retry_delay > 0:
+                log_kwargs["delay"] = single_retry_delay
+            effective_logger.warning("chembl_single_retry", **log_kwargs)
+            if single_retry_delay > 0:
+                sleep(single_retry_delay)
+            return True
+
         while queue:
             attempt_size = min(current_size, len(queue))
             if attempt_size <= 0:
                 break
-            attempt_ids = queue[:attempt_size]
+            attempt_ids = tuple(queue[:attempt_size])
             if on_attempt is not None:
                 on_attempt()
             try:
@@ -471,6 +502,8 @@ def iter_target_batches_with_retry(
                     yield result
             except (requests.RequestException, ValueError) as exc:
                 if attempt_size <= min_size:
+                    if _should_retry_single(attempt_ids, exc):
+                        continue
                     raise
                 next_size = int(math.floor(attempt_size * shrink_factor))
                 if next_size < min_size:
@@ -486,6 +519,8 @@ def iter_target_batches_with_retry(
                 )
                 current_size = next_size
                 continue
+            else:
+                single_retry_counts.pop(attempt_ids, None)
             del queue[:attempt_size]
             current_size = min(base_chunk_size, len(queue)) if queue else 0
 

--- a/tests/unit/test_chembl_target_retry.py
+++ b/tests/unit/test_chembl_target_retry.py
@@ -96,3 +96,92 @@ def test_iter_target_batches_with_retry__disabled_propagates(
                 log=logger,
             )
         )
+
+
+@pytest.mark.unit
+def test_iter_target_batches_with_retry__single_timeout_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    attempts: dict[tuple[str, ...], int] = {}
+
+    def fake_iter_target_batches(
+        ids: Iterator[str],
+        *,
+        cfg,
+        client,
+        mapping_cfg,
+        chunk_size: int = 0,
+        timeout: float | None = None,
+        enable_split_fallback: bool = True,
+    ):
+        ids_list = tuple(ids)
+        count = attempts.get(ids_list, 0)
+        attempts[ids_list] = count + 1
+        if ids_list == ("CHEMBL1",) and count < 2:
+            raise requests.ReadTimeout("simulated timeout")
+        payloads = [{"target_chembl_id": ident} for ident in ids_list]
+        raw = pd.DataFrame(payloads)
+        parsed = pd.DataFrame(payloads)
+        yield payloads, raw, parsed
+
+    monkeypatch.setattr(ct, "iter_target_batches", fake_iter_target_batches)
+
+    retry_cfg = cfg.target.chembl.batch_retry
+    retry_cfg.enable = True
+    retry_cfg.shrink_factor = 0.5
+    retry_cfg.min_size = 1
+    retry_cfg.single_timeout_retries = 2
+    retry_cfg.single_timeout_delay = 0.0
+
+    caplog.set_level("WARNING")
+
+    batches = list(
+        ct.iter_target_batches_with_retry(
+            ["CHEMBL1"],
+            cfg=cfg.api,
+            client=cast(object, None),
+            mapping_cfg=cfg.uniprot_mapping,
+            chunk_size=1,
+            timeout=cfg.target.chembl.timeout,
+            retry_cfg=retry_cfg,
+            log=logger,
+        )
+    )
+
+    assert len(batches) == 1
+    assert attempts[("CHEMBL1",)] == 3
+    assert any("chembl_single_retry" in record.message for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_iter_target_batches_with_retry__single_timeout_exhausts(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg,
+) -> None:
+    def fake_iter_target_batches(*args, **kwargs):
+        raise requests.ReadTimeout("repeat timeout")
+
+    monkeypatch.setattr(ct, "iter_target_batches", fake_iter_target_batches)
+
+    retry_cfg = cfg.target.chembl.batch_retry
+    retry_cfg.enable = True
+    retry_cfg.shrink_factor = 0.5
+    retry_cfg.min_size = 1
+    retry_cfg.single_timeout_retries = 1
+    retry_cfg.single_timeout_delay = 0.0
+
+    with pytest.raises(requests.ReadTimeout):
+        list(
+            ct.iter_target_batches_with_retry(
+                ["CHEMBL1"],
+                cfg=cfg.api,
+                client=cast(object, None),
+                mapping_cfg=cfg.uniprot_mapping,
+                chunk_size=1,
+                timeout=cfg.target.chembl.timeout,
+                retry_cfg=retry_cfg,
+                log=logger,
+            )
+        )


### PR DESCRIPTION
## Summary
- add per-target retry handling to the ChEMBL target batch fetcher so single identifier timeouts are retried before failing
- extend the configuration defaults and JSON schema to expose the new retry knobs
- cover the new behaviour with unit tests exercising successful retries and exhaustion

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3fb47e1248324b261046d8defc2d6