### PR TITLE
Fix ChemblClient retry monotonic import

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from itertools import islice
 from dataclasses import dataclass, field
-from time import perf_counter
+from time import monotonic, perf_counter
 from types import TracebackType
 from typing import Any, Callable, TypeVar, cast
 from urllib.parse import urlsplit, urlunsplit


### PR DESCRIPTION
## Summary
- add the missing `monotonic` import to `ChemblClient` so retry timing utilities can call it safely

## Testing
- pytest tests/unit/test_chembl_client.py::test_request_json__falls_back_to_extensionless_endpoint -q

------
https://chatgpt.com/codex/tasks/task_e_68e400df0ca88324ab62f38c0d46e6be