### PR TITLE
Allow post-processing for non-canonical target CSV exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ is produced by `library.postprocessing.target.process_targets`, a direct port of
 the original Power Query workbook that keeps every row byte-identical. Refer to
 the [output reference](./docs/en/OUTPUT.md) for the complete specification.
 
+Custom file names such as `targets.csv` still trigger this post-processing
+chain, so downstream helpers are generated even when the export deviates from
+the canonical `output.target_<stamp>.csv` pattern.
+
 ## Documentation
 
 All guides are provided in English and Russian. The structure is mirrored across

--- a/README_EN.md
+++ b/README_EN.md
@@ -98,6 +98,10 @@ emits helper lookups named `organism.output.target_<stamp>.csv`,
 [`docs/OUTPUT_TARGETS_RU.md`](./docs/OUTPUT_TARGETS_RU.md). Refer to the
 [output reference](./docs/en/OUTPUT.md) for the complete specification.
 
+Custom file names such as `targets.csv` still trigger the post-processing
+chain, so helper lookups are emitted even when the export deviates from the
+canonical `output.target_<stamp>.csv` pattern.
+
 ## Documentation
 
 All guides are provided in English and Russian. The structure is mirrored across

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -331,8 +331,10 @@ def _is_supported_target_export(path: Path) -> bool:
     if target_pp._matches_expected_input_name(export_name):
         return True
 
+    export_lower = export_name.lower()
+
     if path.suffix.lower() != ".csv":
-        if not export_name.lower().endswith(".csv"):
+        if not export_lower.endswith(".csv"):
             return False
         logger.info(
             "target_postprocess_noncanonical_name",
@@ -346,8 +348,9 @@ def _is_supported_target_export(path: Path) -> bool:
         "target_postprocess_noncanonical_name",
         path=str(path),
         reason="noncanonical_filename",
+        canonical=export_name,
     )
-    return False
+    return True
 
 
 def _postprocess_isoform_export(

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -80,6 +80,7 @@ def test_keyboard_aliases__cases(command: str) -> None:
         ("targets_20251005_normalized.csv", True),
         ("output.targets_20251005.csv.tmp", True),
         (".output.targets_20251005.csv_normalized.tmp", True),
+        ("targets.csv", True),
         ("out.csv", False),
         ("out_chembl.csv", False),
         ("out_uniprot.csv", False),
@@ -576,7 +577,7 @@ def test_postprocess_organism_export__failure(
     ) in logger_stub.events
 
 
-def test_postprocess_isoform_export__skips_for_custom_name(
+def test_postprocess_isoform_export__runs_for_custom_name(
     cfg: Config,
     tmp_path: Path,
     logger_stub: _MemoryLogger,
@@ -585,27 +586,36 @@ def test_postprocess_isoform_export__skips_for_custom_name(
     source = tmp_path / "custom_export.csv"
     source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
-    def _unexpected(*_: object, **__: object) -> None:  # pragma: no cover - defensive
-        raise AssertionError("isoform post-processing should be skipped")
+    called: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    monkeypatch.setattr(get_target_data.target_pp, "process_targets", _unexpected)
+    def _record(*args: object, **kwargs: object) -> str:
+        called.append((args, dict(kwargs)))
+        return str(source)
+
+    monkeypatch.setattr(get_target_data.target_pp, "process_targets", _record)
 
     result = get_target_data._postprocess_isoform_export(source, cfg=cfg)
 
-    assert result is None
+    assert result == source
+    assert called == [((str(source),), {"verbose": True})]
     assert (
         "info",
-        "target_isoform_postprocess_skipped",
-        {"path": str(source), "reason": "unsupported_export_name"},
+        "target_isoform_postprocess_done",
+        {"path": str(source), "source": str(source)},
     ) in logger_stub.events
 
 
+@pytest.mark.parametrize(
+    "filename",
+    ["output.target_20250101.csv", "targets.csv"],
+)
 def test_postprocess_target_exports__chains_helpers(
     cfg: Config,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    filename: str,
 ) -> None:
-    source = tmp_path / "output.target_20250101.csv"
+    source = tmp_path / filename
     source.write_text("target_chembl_id\nCHEMBL1\n", encoding="utf-8")
 
     call_order: list[str] = []


### PR DESCRIPTION
## Summary
- treat arbitrary `.csv` target exports as supported so helper pipelines run
- cover custom filenames in unit tests and assert isoform post-processing executes
- document that non-canonical `.csv` outputs still generate helper artefacts

## Testing
- pytest tests/unit/test_get_target_data.py -k postprocess -q

------
https://chatgpt.com/codex/tasks/task_e_68e400820368832484df311ffce55f76