### PR TITLE
Clamp oversized activity batch sizes

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -67,7 +67,7 @@ from library import io
 from library.clients import ChemblClient
 from library.common.csv_utils import write_csv_chunks_deterministic  # re-exported for tests
 from library.common.rate_limiter import get_global_limiter
-from library.pipelines.assay.chembl_assay import ACTIVITY_COLUMNS
+from library.pipelines.assay.chembl_assay import ACTIVITY_COLUMNS, MAX_ACTIVITY_CHUNK_SIZE
 from library.pipelines.common import (
     ChunkedFetchConfig,
     CsvWriterConfig,
@@ -1219,6 +1219,19 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     """Execute the activity pipeline handling ``--skip-existing`` semantics."""
 
     start_time = perf_counter()
+
+    batch_size = getattr(cfg.activity, "batch_size", None)
+    if batch_size is not None and batch_size > MAX_ACTIVITY_CHUNK_SIZE:
+        logger.warning(
+            "activity_batch_size_clamped",
+            configured=batch_size,
+            limit=MAX_ACTIVITY_CHUNK_SIZE,
+        )
+        logger.warning(
+            f"Configured batch size {batch_size} exceeds the hard cap of {MAX_ACTIVITY_CHUNK_SIZE}; "
+            f"reducing to {MAX_ACTIVITY_CHUNK_SIZE}."
+        )
+        cfg.activity.batch_size = MAX_ACTIVITY_CHUNK_SIZE
 
     final_out_attr = getattr(args, "final_out", None)
     if final_out_attr in (None, argparse.SUPPRESS):

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -398,6 +398,39 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__batch_size_clamped(cfg, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _configure_cfg(cfg)
+    cfg.activity.batch_size = get_activity_data.MAX_ACTIVITY_CHUNK_SIZE + 5
+
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    output_csv = tmp_path / "activities.csv"
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    captured_batch_sizes: list[int | None] = []
+
+    def _fake_run_chembl(config: object, args: argparse.Namespace) -> int:
+        captured_batch_sizes.append(getattr(config.activity, "batch_size", None))
+        return 0
+
+    monkeypatch.setattr(get_activity_data, "run_chembl", _fake_run_chembl)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert captured_batch_sizes == [get_activity_data.MAX_ACTIVITY_CHUNK_SIZE]
+
+    warning_events = [
+        (level, event, payload)
+        for level, event, payload in logger_stub.events
+        if level == "warning"
+    ]
+    assert any(event == "activity_batch_size_clamped" for _, event, _ in warning_events)
+
 def test_activity_pipeline__malformed_values(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):
     _configure_cfg(cfg)
     input_csv = _copy_resource(activity_resource_dir, "ids_happy.csv", tmp_path)


### PR DESCRIPTION
## Summary
- surface the activity pipeline maximum batch size to the CLI layer and clamp oversized configuration values with warnings
- add an integration regression test covering the oversized batch size guard

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__batch_size_clamped

------
https://chatgpt.com/codex/tasks/task_e_68e40134cd208324b9483b0528f3d768