### PR TITLE
Enforce minimum timeout for activity pipeline CLI

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -110,6 +110,7 @@ from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_dela
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
 PROGRAM_NAME = Path(__file__).with_suffix("").name
+MIN_ACTIVITY_TIMEOUT_SECONDS = 60.0
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
     invocation = getattr(args, "invocation", None)
@@ -1220,6 +1221,22 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     start_time = perf_counter()
 
+    timeout = getattr(cfg.activity, "timeout", None)
+    if timeout is not None and timeout < MIN_ACTIVITY_TIMEOUT_SECONDS:
+        logger.warning(
+            "activity_timeout_clamped",
+            provided_timeout=timeout,
+            minimum_timeout=MIN_ACTIVITY_TIMEOUT_SECONDS,
+        )
+        logger.warning(
+            "Configured activity timeout %.3f seconds is below the supported minimum of %.0f "
+            "seconds; using %.0f seconds instead.",
+            timeout,
+            MIN_ACTIVITY_TIMEOUT_SECONDS,
+            MIN_ACTIVITY_TIMEOUT_SECONDS,
+        )
+        cfg.activity.timeout = MIN_ACTIVITY_TIMEOUT_SECONDS
+
     final_out_attr = getattr(args, "final_out", None)
     if final_out_attr in (None, argparse.SUPPRESS):
         legacy_output = getattr(args, "output_csv", None)
@@ -1275,7 +1292,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--timeout",
         type=float,
         default=90.0,
-        help="Timeout in seconds for each HTTP request",
+        help="Timeout in seconds for each HTTP request (minimum 60 seconds enforced)",
     )
     parser.add_argument(
         "--limit",

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -167,6 +167,42 @@ def _make_args(input_csv: Path, output_csv: Path) -> argparse.Namespace:
         dry_run=False,
         invocation=None,
     )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_run__clamps_timeout_below_minimum(cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    cfg.activity.timeout = 15.0
+
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    output_csv = tmp_path / "activities.csv"
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_chembl(local_cfg, local_args):
+        captured["timeout"] = local_cfg.activity.timeout
+        captured["args"] = local_args
+        return 0
+
+    monkeypatch.setattr(get_activity_data, "run_chembl", _fake_run_chembl)
+
+    args = _make_args(input_csv, output_csv)
+    exit_code = get_activity_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert captured["timeout"] == get_activity_data.MIN_ACTIVITY_TIMEOUT_SECONDS
+
+    warning_events = [
+        (level, event)
+        for level, event, _ in logger_stub.events
+        if level == "warning"
+    ]
+    assert ("warning", "activity_timeout_clamped") in warning_events
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
 def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- clamp the activity pipeline timeout to a minimum of 60 seconds with a warning when a lower value is configured
- document the enforced minimum in the --timeout help text for operators
- add an integration test covering the new timeout guard behaviour

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py::test_run__clamps_timeout_below_minimum -q

------
https://chatgpt.com/codex/tasks/task_e_68e40138a5e08324b530bd54f554582b