### PR TITLE
Clamp assay chunk size to ChEMBL request limit

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -13,6 +13,11 @@ from ...config import ApiCfg, TESTITEM_FIELD_DEFAULTS
 from ...common.log import logger
 from ...common.pandas_utils import json_normalize_pyarrow
 
+# ChEMBL bulk endpoints accept at most 25 identifiers per request when using
+# ``__in`` filters. Requests above this threshold return HTTP 414 "URI Too
+# Long", so keep the chunk size at or below this value to avoid retries.
+MAX_ASSAY_CHUNK_SIZE = 25
+
 MAX_ACTIVITY_CHUNK_SIZE = 20
 
 ASSAY_VARIANT_COLUMN_ALIASES = {
@@ -479,7 +484,7 @@ def get_assays(
             frames = _filter_variant_frames(frames)
             return frames
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    effective_chunk_size = min(chunk_size, _ASSAY_MAX_IDS_PER_REQUEST)
+    effective_chunk_size = min(int(chunk_size), MAX_ASSAY_CHUNK_SIZE)
     if effective_chunk_size <= 0:
         raise ValueError("chunk_size must be positive")
     if effective_chunk_size < chunk_size:
@@ -488,6 +493,7 @@ def get_assays(
             extra={
                 "requested_chunk_size": chunk_size,
                 "effective_chunk_size": effective_chunk_size,
+                "limit": MAX_ASSAY_CHUNK_SIZE,
                 "stage": "chunk_prepare",
             },
         )

--- a/tests/integration/test_assay_cli_quality.py
+++ b/tests/integration/test_assay_cli_quality.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterator, Sequence
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
 import pytest
 
 from library.config import Config
+from library.pipelines.assay.chembl_assay import MAX_ASSAY_CHUNK_SIZE
 from scripts import get_assay_data
 from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 
@@ -84,3 +87,129 @@ def test_get_assay_cli__enrichment_quality(
     quality_columns = ["assay_strain", "assay_group", "year", "accession"]
     completeness = 1.0 - result[quality_columns].isna().mean()
     assert (completeness >= ASSAY_ENRICHMENT_MIN_RATIO).all(), completeness.to_dict()
+
+
+@pytest.mark.integration
+def test_get_assay_cli__clamps_batch_size(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cfg: Config
+) -> None:
+    cfg.assay.batch_size = MAX_ASSAY_CHUNK_SIZE * 2
+
+    identifiers = [
+        f"CHEMBL{i}"
+        for i in range(1, MAX_ASSAY_CHUNK_SIZE + 4)
+    ]
+    request_chunk_sizes: list[int] = []
+
+    class _StubChemblClient:
+        def __init__(self, *args, **kwargs) -> None:
+            del args, kwargs
+
+        def __enter__(self) -> "_StubChemblClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401 - context protocol
+            return False
+
+        def request_json(
+            self,
+            url: str,
+            *,
+            cfg: Config,
+            timeout: float | None,
+        ) -> dict[str, object]:
+            del cfg, timeout
+            parsed = urlparse(url)
+            params = parse_qs(parsed.query)
+            ids_param = params.get("assay_chembl_id__in")
+            if ids_param:
+                identifiers_chunk = [value for value in ids_param[0].split(",") if value]
+                request_chunk_sizes.append(len(identifiers_chunk))
+                return {
+                    "assays": [
+                        {"assay_chembl_id": identifier}
+                        for identifier in identifiers_chunk
+                    ],
+                    "page_meta": {},
+                }
+            identifier_param = params.get("assay_chembl_id")
+            if identifier_param:
+                identifier = identifier_param[0]
+                return {
+                    "assays": [{"assay_chembl_id": identifier}],
+                    "page_meta": {},
+                }
+            return {"assays": [], "page_meta": {}}
+
+    class _StubChunkFailureTracker:
+        def __init__(self) -> None:
+            self.stats: dict[str, object] = {}
+
+        def add_failure(self, chunk_ids: Sequence[str], error_message: str) -> None:
+            del chunk_ids, error_message
+
+        def save(self, path: Path, cfg: Config) -> None:
+            del path, cfg
+
+    written_frames: list[pd.DataFrame] = []
+
+    def _fake_prepare_chunked_pipeline(
+        *,
+        fetch_config,
+        fetch_chunk,
+        csv_writer,
+    ):
+        del csv_writer
+        ids_list = list(fetch_config.ids)
+
+        def _fetcher():
+            frames: list[pd.DataFrame] = []
+            for start in range(0, len(ids_list), fetch_config.chunk_size):
+                chunk = ids_list[start : start + fetch_config.chunk_size]
+                frames.append(fetch_chunk(chunk))
+            return frames
+
+        def _writer(frames: list[pd.DataFrame]) -> None:
+            written_frames.extend(frames)
+
+        return _fetcher, _writer
+
+    def _fake_run_pipeline(*, fetcher, writer, **kwargs) -> int:
+        del kwargs
+        frames = fetcher()
+        writer(frames)
+        return 0
+
+    def _fake_read_ids(path: Path, *, column: str, cfg) -> Iterator[str]:
+        del path, column, cfg
+        return iter(identifiers)
+
+    monkeypatch.setattr(get_assay_data, "ChemblClient", _StubChemblClient)
+    monkeypatch.setattr(get_assay_data, "ChunkFailureTracker", _StubChunkFailureTracker)
+    monkeypatch.setattr(get_assay_data, "prepare_chunked_pipeline", _fake_prepare_chunked_pipeline)
+    monkeypatch.setattr(get_assay_data, "run_pipeline", _fake_run_pipeline)
+    monkeypatch.setattr(get_assay_data.io, "read_ids", _fake_read_ids)
+
+    input_csv = tmp_path / "assay_ids.csv"
+    input_csv.write_text("assay_chembl_id\n" + "\n".join(identifiers), encoding="utf-8")
+    output_csv = tmp_path / "assays.csv"
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        skip_existing=False,
+        force=False,
+        offset=0,
+        limit=None,
+        batch_size=cfg.assay.batch_size,
+        timeout=cfg.assay.timeout,
+    )
+
+    exit_code = get_assay_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert request_chunk_sizes, "Expected get_assays to perform batched requests"
+    assert max(request_chunk_sizes) == MAX_ASSAY_CHUNK_SIZE
+    remainder = len(identifiers) - MAX_ASSAY_CHUNK_SIZE
+    assert sorted(request_chunk_sizes) == sorted([MAX_ASSAY_CHUNK_SIZE, remainder])
+    assert written_frames, "Expected writer to receive frames"

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -9,7 +9,12 @@ from requests import ConnectionError, HTTPError, ReadTimeout, Response
 from urllib.parse import parse_qs, urlparse
 
 from library.config import ApiCfg
-from library.pipelines.assay.chembl_assay import get_activities, get_assays, get_testitem
+from library.pipelines.assay.chembl_assay import (
+    MAX_ASSAY_CHUNK_SIZE,
+    get_activities,
+    get_assays,
+    get_testitem,
+)
 
 
 class _StubClient:
@@ -119,18 +124,26 @@ def test_get_assays__recovers_from_request_exception() -> None:
 
 @pytest.mark.unit
 def test_get_assays__clamps_large_chunks() -> None:
-    """Requests are split when more than 25 assay IDs are provided."""
+    """Requests exceeding the API limit are split across multiple calls."""
 
+    first_chunk_ids = [f"CHEMBL{i}" for i in range(1, MAX_ASSAY_CHUNK_SIZE + 1)]
+    remainder_ids = [
+        f"CHEMBL{i}"
+        for i in range(
+            MAX_ASSAY_CHUNK_SIZE + 1,
+            MAX_ASSAY_CHUNK_SIZE + 6,
+        )
+    ]
     responders = [
         {
             "assays": [
-                {"assay_chembl_id": f"CHEMBL{i}"} for i in range(1, 26)
+                {"assay_chembl_id": identifier} for identifier in first_chunk_ids
             ],
             "page_meta": {},
         },
         {
             "assays": [
-                {"assay_chembl_id": f"CHEMBL{i}"} for i in range(26, 31)
+                {"assay_chembl_id": identifier} for identifier in remainder_ids
             ],
             "page_meta": {},
         },
@@ -138,8 +151,13 @@ def test_get_assays__clamps_large_chunks() -> None:
     client = _StubClient(responders)
     cfg = ApiCfg()
 
-    identifiers = [f"CHEMBL{i}" for i in range(1, 31)]
-    df = get_assays(identifiers, cfg=cfg, client=client, chunk_size=50)
+    identifiers = first_chunk_ids + remainder_ids
+    df = get_assays(
+        identifiers,
+        cfg=cfg,
+        client=client,
+        chunk_size=MAX_ASSAY_CHUNK_SIZE * 3,
+    )
 
     assert sorted(df["assay_chembl_id"]) == sorted(identifiers)
     chunk_sizes = []
@@ -149,7 +167,12 @@ def test_get_assays__clamps_large_chunks() -> None:
         if ids_param:
             chunk_sizes.append(len(ids_param.split(",")))
 
-    assert chunk_sizes == [25, 5]
+    expected_chunk_sizes = [MAX_ASSAY_CHUNK_SIZE]
+    remainder = len(remainder_ids)
+    if remainder:
+        expected_chunk_sizes.append(remainder)
+
+    assert chunk_sizes == expected_chunk_sizes
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a module-level constant for the ChEMBL assay chunk limit and clamp requests to it
- expand unit and integration coverage to verify oversized batch handling from the library and CLI wrappers

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py tests/integration/test_assay_cli_quality.py

------
https://chatgpt.com/codex/tasks/task_e_68e4008f7c4083248d2b5d6f9a627014