### PR TITLE
Enforce minimum timeout for activity pipeline

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -109,6 +109,7 @@ from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_dela
 
 DEFAULT_INPUT_NAME = "activity.csv"
 DEFAULT_OUTPUT_STEM = "activities"
+MIN_ACTIVITY_TIMEOUT = 60.0
 PROGRAM_NAME = Path(__file__).with_suffix("").name
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
@@ -1233,6 +1234,19 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         )
         cfg.activity.batch_size = MAX_ACTIVITY_CHUNK_SIZE
 
+    timeout = getattr(cfg.activity, "timeout", None)
+    if timeout is not None and timeout < MIN_ACTIVITY_TIMEOUT:
+        logger.warning(
+            "activity_timeout_clamped",
+            configured=timeout,
+            minimum=MIN_ACTIVITY_TIMEOUT,
+        )
+        logger.warning(
+            f"Configured timeout {timeout} is below the minimum of {MIN_ACTIVITY_TIMEOUT}; "
+            f"increasing to {MIN_ACTIVITY_TIMEOUT}."
+        )
+        cfg.activity.timeout = float(MIN_ACTIVITY_TIMEOUT)
+
     final_out_attr = getattr(args, "final_out", None)
     if final_out_attr in (None, argparse.SUPPRESS):
         legacy_output = getattr(args, "output_csv", None)
@@ -1288,7 +1302,10 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--timeout",
         type=float,
         default=90.0,
-        help="Timeout in seconds for each HTTP request",
+        help=(
+            "Timeout in seconds for each HTTP request (a minimum of "
+            f"{int(MIN_ACTIVITY_TIMEOUT)} seconds is enforced)"
+        ),
     )
     parser.add_argument(
         "--limit",

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -167,6 +167,38 @@ def _make_args(input_csv: Path, output_csv: Path) -> argparse.Namespace:
         dry_run=False,
         invocation=None,
     )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, monkeypatch):
+    _configure_cfg(cfg)
+    cfg.activity.timeout = get_activity_data.MIN_ACTIVITY_TIMEOUT - 5
+
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    output_csv = tmp_path / "activities.csv"
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    captured_timeout: dict[str, float] = {}
+
+    def _run_chembl_stub(passed_cfg, _passed_args):
+        captured_timeout["timeout"] = float(passed_cfg.activity.timeout)
+        return 0
+
+    monkeypatch.setattr(get_activity_data, "run_chembl", _run_chembl_stub)
+
+    args = _make_args(input_csv, output_csv)
+
+    exit_code = get_activity_data.run(cfg, args)
+
+    warning_events = [event for level, event, _ in logger_stub.events if level == "warning"]
+    assert "activity_timeout_clamped" in warning_events
+    assert captured_timeout["timeout"] == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
+    assert cfg.activity.timeout == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
+    assert exit_code == 0
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
 def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- enforce a minimum 60 second timeout when running the activity pipeline, logging when a lower value is provided
- document the enforced minimum in the --timeout CLI help text
- add an integration test to verify the timeout clamp behaviour

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py::test_activity_pipeline__timeout_clamped_when_below_minimum


------
https://chatgpt.com/codex/tasks/task_e_68e4024a8cd88324b5aeca278376479d