### PR TITLE
Fix IUPHAR classification columns being dropped during merge

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -188,6 +188,28 @@ NORMALIZED_SUFFIX = "_normalized"
 COMMAND_CHOICES: tuple[str, ...] = ("uniprot", "chembl", "iuphar", "all")
 
 
+_IUPHAR_OVERRIDE_COLUMNS: frozenset[str] = frozenset(
+    {
+        "target_id",
+        "GuidetoPHARMACOLOGY",
+        "gtop_synonyms",
+        "gtop_natural_ligands_n",
+        "gtop_interactions_n",
+        "gtop_function_text_short",
+        "IUPHAR_family_id",
+        "IUPHAR_type",
+        "IUPHAR_class",
+        "IUPHAR_subclass",
+        "IUPHAR_chain",
+        "IUPHAR_name",
+        "iuphar_name",
+        "full_id_path",
+        "full_name_path",
+        "iuphar_synonyms",
+    }
+)
+
+
 class StoreWithSource(argparse.Action):
     """Store CLI values while tracking their origin."""
 
@@ -3004,6 +3026,26 @@ def fetch_uniprot(
     return df
 
 
+def _prepare_iuphar_merge_frames(
+    combined_df: pd.DataFrame, iuphar_df: pd.DataFrame
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return frames ready for merging IUPHAR classifications."""
+
+    sanitised_combined = combined_df.drop(
+        columns=[col for col in _IUPHAR_OVERRIDE_COLUMNS if col in combined_df.columns],
+        errors="ignore",
+    )
+    existing_cols = set(sanitised_combined.columns)
+    keep_columns: list[str] = ["uniprot_id"]
+    for column in iuphar_df.columns:
+        if column == "uniprot_id":
+            continue
+        if column in _IUPHAR_OVERRIDE_COLUMNS or column not in existing_cols:
+            keep_columns.append(column)
+    trimmed_iuphar = iuphar_df.loc[:, keep_columns].copy()
+    return sanitised_combined, trimmed_iuphar
+
+
 def fetch_iuphar(
     cfg: Config,
     chembl_df: pd.DataFrame,
@@ -3454,9 +3496,7 @@ def fetch_iuphar(
             )
             iuphar_df = iuphar_df.copy()
             iuphar_df.insert(0, "uniprot_id", placeholder)
-    existing_cols = set(combined_df.columns)
-    classification_cols = [c for c in iuphar_df.columns if c not in existing_cols]
-    iuphar_df = iuphar_df[["uniprot_id", *classification_cols]].copy()
+    combined_df, iuphar_df = _prepare_iuphar_merge_frames(combined_df, iuphar_df)
     logger.info("fetch_iuphar_done", rows=len(iuphar_df))
     return combined_df, iuphar_df
 

--- a/tests/unit/test_get_target_data_iuphar.py
+++ b/tests/unit/test_get_target_data_iuphar.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import pytest
+
+from scripts.get_target_data import _prepare_iuphar_merge_frames
+
+
+@pytest.mark.unit
+def test_prepare_iuphar_merge_frames__overrides_iuphar_columns():
+    combined = pd.DataFrame(
+        {
+            "uniprot_id": ["P1", "P2"],
+            "target_id": ["", ""],
+            "GuidetoPHARMACOLOGY": ["", ""],
+            "other": ["x", "y"],
+        }
+    )
+    iuphar = pd.DataFrame(
+        {
+            "uniprot_id": ["P1", "P2"],
+            "target_id": ["T1", "T2"],
+            "GuidetoPHARMACOLOGY": ["G1", "G2"],
+            "IUPHAR_family_id": ["F1", "F2"],
+            "IUPHAR_type": ["Type1", "Type2"],
+            "extra": ["foo", "bar"],
+        }
+    )
+
+    updated_combined, trimmed_iuphar = _prepare_iuphar_merge_frames(combined, iuphar)
+
+    assert "target_id" not in updated_combined.columns
+    assert "GuidetoPHARMACOLOGY" not in updated_combined.columns
+    assert trimmed_iuphar.columns.tolist() == [
+        "uniprot_id",
+        "target_id",
+        "GuidetoPHARMACOLOGY",
+        "IUPHAR_family_id",
+        "IUPHAR_type",
+        "extra",
+    ]
+    assert trimmed_iuphar.loc[0, "target_id"] == "T1"
+    assert trimmed_iuphar.loc[0, "IUPHAR_family_id"] == "F1"
+
+
+@pytest.mark.unit
+def test_prepare_iuphar_merge_frames__keeps_non_override_columns_only_once():
+    combined = pd.DataFrame(
+        {
+            "uniprot_id": ["P1"],
+            "shared": ["chembl"],
+        }
+    )
+    iuphar = pd.DataFrame(
+        {
+            "uniprot_id": ["P1"],
+            "shared": ["iuphar"],
+            "IUPHAR_class": ["Class"],
+        }
+    )
+
+    updated_combined, trimmed_iuphar = _prepare_iuphar_merge_frames(combined, iuphar)
+
+    assert "shared" in updated_combined.columns
+    assert trimmed_iuphar.columns.tolist() == ["uniprot_id", "IUPHAR_class"]


### PR DESCRIPTION
## Summary
- ensure the combined target frame drops placeholder columns so IUPHAR outputs populate the final dataset
- add unit tests covering the IUPHAR merge frame preparation helper

## Testing
- pytest tests/unit/test_get_target_data_iuphar.py


------
https://chatgpt.com/codex/tasks/task_e_68e401b3c1e88324b4cc9fc706b8f0e9