### PR TITLE
Restore legacy assay chunk size alias

### DIFF
--- a/library/pipelines/assay/chembl_assay.py
+++ b/library/pipelines/assay/chembl_assay.py
@@ -18,6 +18,13 @@ from ...common.pandas_utils import json_normalize_pyarrow
 # Long", so keep the chunk size at or below this value to avoid retries.
 MAX_ASSAY_CHUNK_SIZE = 25
 
+# ``_ASSAY_MAX_IDS_PER_REQUEST`` used to be the public name for the chunk size
+# limit.  Keep the alias for compatibility with older call sites that still
+# reference it indirectly (for example through ``eval`` of serialized
+# expressions).  The leading underscore mirrors the historical constant name and
+# avoids polluting the public namespace beyond backward compatibility needs.
+_ASSAY_MAX_IDS_PER_REQUEST = MAX_ASSAY_CHUNK_SIZE
+
 MAX_ACTIVITY_CHUNK_SIZE = 20
 
 ASSAY_VARIANT_COLUMN_ALIASES = {

--- a/tests/unit/pipelines/assay/test_chembl_assay.py
+++ b/tests/unit/pipelines/assay/test_chembl_assay.py
@@ -11,6 +11,7 @@ from urllib.parse import parse_qs, urlparse
 from library.config import ApiCfg
 from library.pipelines.assay.chembl_assay import (
     MAX_ASSAY_CHUNK_SIZE,
+    _ASSAY_MAX_IDS_PER_REQUEST,
     get_activities,
     get_assays,
     get_testitem,
@@ -37,6 +38,13 @@ class _StubClient:
         if isinstance(next_response, Exception):
             raise next_response
         raise AssertionError(f"Unexpected responder type: {type(next_response)!r}")
+
+
+@pytest.mark.unit
+def test_assay_chunk_size_alias__matches_limit() -> None:
+    """Compatibility alias keeps the legacy constant available."""
+
+    assert _ASSAY_MAX_IDS_PER_REQUEST == MAX_ASSAY_CHUNK_SIZE
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- restore the legacy `_ASSAY_MAX_IDS_PER_REQUEST` alias so downstream tooling can resolve the assay chunk limit
- add a unit test ensuring the alias tracks `MAX_ASSAY_CHUNK_SIZE`

## Testing
- pytest tests/unit/pipelines/assay/test_chembl_assay.py -k alias -q

------
https://chatgpt.com/codex/tasks/task_e_68e4058b50d88324b52885dfe9d274da