### PR TITLE
Fix NameError for legacy assay batch size constant

### DIFF
--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -36,7 +36,7 @@ from library.postprocessing import enrich_assay_metadata
 from library import cli
 from library import io
 from library.common.csv_utils import write_csv_chunks_deterministic
-from library.pipelines.assay.chembl_assay import ASSAY_COLUMNS
+from library.pipelines.assay.chembl_assay import ASSAY_COLUMNS, MAX_ASSAY_CHUNK_SIZE
 from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
 from library.cli import (
@@ -69,6 +69,14 @@ DEFAULT_INPUT_NAME = "assay.csv"
 DEFAULT_OUTPUT_STEM = "assays"
 
 _OPTION_UNSET = object()
+
+# Backwards compatibility: legacy configs referenced the private
+# ``_ASSAY_MAX_IDS_PER_REQUEST`` constant before it was renamed to
+# :data:`MAX_ASSAY_CHUNK_SIZE`.  Re-expose the alias so that pipelines relying on
+# the old setting fail gracefully instead of raising ``NameError`` during chunk
+# processing.
+ASSAY_MAX_IDS_PER_REQUEST = MAX_ASSAY_CHUNK_SIZE
+_ASSAY_MAX_IDS_PER_REQUEST = MAX_ASSAY_CHUNK_SIZE
 
 _ASSAY_OUTPUT_DROP_COLUMNS = [
     "ASSAY_ID",

--- a/tests/unit/test_get_assay_data.py
+++ b/tests/unit/test_get_assay_data.py
@@ -12,6 +12,7 @@ import requests
 
 from library.cli_utils import run_pipeline as cli_run_pipeline
 from library.config import Config
+from library.pipelines.assay.chembl_assay import MAX_ASSAY_CHUNK_SIZE
 from library.schemas import AssaysSchema
 from scripts import get_assay_data
 
@@ -43,6 +44,14 @@ def logger_stub(monkeypatch: pytest.MonkeyPatch) -> _MemoryLogger:
     logger = _MemoryLogger()
     monkeypatch.setattr(get_assay_data, "logger", logger)
     return logger
+
+
+@pytest.mark.unit
+def test_legacy_assay_max_ids_constant__matches_chunk_size() -> None:
+    """Ensure backwards compatible aliases match the public chunk size limit."""
+
+    assert get_assay_data._ASSAY_MAX_IDS_PER_REQUEST == MAX_ASSAY_CHUNK_SIZE
+    assert get_assay_data.ASSAY_MAX_IDS_PER_REQUEST == MAX_ASSAY_CHUNK_SIZE
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- restore the legacy `_ASSAY_MAX_IDS_PER_REQUEST` alias in `get_assay_data` so older configs no longer raise a NameError
- expose a public alias and cover the compatibility behaviour with a unit test

## Testing
- `pytest tests/unit/test_get_assay_data.py::test_legacy_assay_max_ids_constant__matches_chunk_size -q`


------
https://chatgpt.com/codex/tasks/task_e_68e406d695ac8324a04b50a4e18be131