### PR TITLE
Enforce minimum timeout for activity pipeline CLI

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -1245,7 +1245,13 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
             f"Configured timeout {timeout} is below the minimum of {MIN_ACTIVITY_TIMEOUT}; "
             f"increasing to {MIN_ACTIVITY_TIMEOUT}."
         )
-        cfg.activity.timeout = float(MIN_ACTIVITY_TIMEOUT)
+        minimum_timeout = float(MIN_ACTIVITY_TIMEOUT)
+        cfg.activity.timeout = minimum_timeout
+        if hasattr(args, "timeout"):
+            try:
+                args.timeout = float(minimum_timeout)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                args.timeout = minimum_timeout
 
     final_out_attr = getattr(args, "final_out", None)
     if final_out_attr in (None, argparse.SUPPRESS):
@@ -1303,8 +1309,8 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         type=float,
         default=90.0,
         help=(
-            "Timeout in seconds for each HTTP request (a minimum of "
-            f"{int(MIN_ACTIVITY_TIMEOUT)} seconds is enforced)"
+            "Timeout in seconds for each HTTP request (values below "
+            f"{int(MIN_ACTIVITY_TIMEOUT)} seconds are automatically clamped)"
         ),
     )
     parser.add_argument(

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import warnings
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Iterable
 
 import pandas as pd
@@ -199,6 +201,59 @@ def test_activity_pipeline__timeout_clamped_when_below_minimum(cfg, tmp_path, mo
     assert captured_timeout["timeout"] == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
     assert cfg.activity.timeout == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
     assert exit_code == 0
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_activity_pipeline_cli__timeout_argument_clamped(tmp_path, monkeypatch):
+    input_csv = tmp_path / "ids.csv"
+    input_csv.write_text("activity_id\nACT1\n", encoding="utf-8")
+    output_csv = tmp_path / "activities.csv"
+
+    config_path = Path(__file__).resolve().parents[2] / "config" / "config.yaml"
+
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(tmp_path))
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+    monkeypatch.setattr("library.cli.configure_logger", lambda *_: logger_stub)
+    monkeypatch.setattr("library.cli_utils.cli.configure_logger", lambda *_: logger_stub)
+    monkeypatch.setattr(get_activity_data, "configure_logger", lambda *_: logger_stub)
+
+    @contextmanager
+    def fake_setup_cli_logging(script_name, log_cfg, date_str, *, log_dir=None):
+        del script_name, date_str, log_dir
+        yield SimpleNamespace(log_cfg=log_cfg, log_path=tmp_path / "cli.log", console_stream=None)
+
+    monkeypatch.setattr(get_activity_data, "setup_cli_logging", fake_setup_cli_logging)
+
+    captured: dict[str, float | None] = {}
+
+    def _run_chembl_stub(passed_cfg, passed_args):
+        captured["cfg_timeout"] = float(passed_cfg.activity.timeout)
+        captured["args_timeout"] = getattr(passed_args, "timeout", None)
+        return 0
+
+    monkeypatch.setattr(get_activity_data, "run_chembl", _run_chembl_stub)
+
+    exit_code = get_activity_data.main(
+        [
+            "--config",
+            str(config_path),
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_csv),
+            "--timeout",
+            str(get_activity_data.MIN_ACTIVITY_TIMEOUT - 15),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["cfg_timeout"] == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
+    assert captured["args_timeout"] == pytest.approx(get_activity_data.MIN_ACTIVITY_TIMEOUT)
+    warning_events = [event for level, event, _ in logger_stub.events if level == "warning"]
+    assert "activity_timeout_clamped" in warning_events
 @pytest.mark.integration
 @pytest.mark.usefixtures("deterministic_env")
 def test_activity_pipeline__happy_path(activity_resource_dir: Path, cfg, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- clamp activity pipeline timeouts below the enforced minimum and sync CLI help text
- extend integration coverage to ensure CLI-provided timeouts are clamped and warnings emitted

## Testing
- pytest tests/integration/test_get_activity_data_pipeline.py


------
https://chatgpt.com/codex/tasks/task_e_68e406b058ac83248147f6741d00b50d