### PR TITLE
Ensure IUPHAR pipeline honours explicit output path

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -2646,6 +2646,22 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     tmp_path: Path | None = None
     source_csv = args.input_csv
 
+    output_path_candidate = getattr(args, "output_csv", None)
+    if output_path_candidate not in (None, argparse.SUPPRESS):
+        output_path = Path(output_path_candidate)
+        if not isinstance(output_path_candidate, Path):
+            args.output_csv = output_path
+        args.final_out = output_path
+    else:
+        final_out_attr = getattr(args, "final_out", None)
+        if final_out_attr in (None, argparse.SUPPRESS):
+            output_path = Path(io.default_output_path(args.input_csv, cfg.io))
+            args.final_out = output_path
+        else:
+            output_path = Path(final_out_attr)
+            if not isinstance(final_out_attr, Path):
+                args.final_out = output_path
+
     try:
         df_to_process: pd.DataFrame | None = None
         offset = cfg.target.iuphar.offset
@@ -2694,14 +2710,6 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
             family_path=cfg.target.iuphar.family_csv,
             encoding=cfg.io.csv_encoding,
         )
-        final_out_attr = getattr(args, "final_out", None)
-        if final_out_attr in (None, argparse.SUPPRESS):
-            output_path = Path(io.default_output_path(args.input_csv, cfg.io))
-            args.final_out = output_path
-        else:
-            output_path = Path(final_out_attr)
-            if not isinstance(final_out_attr, Path):
-                args.final_out = output_path
         data.map_uniprot_file(
             input_path=source_csv,
             output_path=str(output_path),
@@ -3449,7 +3457,9 @@ def fetch_iuphar(
 
         iuphar_input = Path(tmp.name)
 
-    iuphar_args = argparse.Namespace(input_csv=iuphar_input, output_csv=output_csv)
+    iuphar_args = argparse.Namespace(
+        input_csv=iuphar_input, output_csv=output_csv, final_out=output_csv
+    )
     orig_target = cfg.target.iuphar.target_csv
     orig_family = cfg.target.iuphar.family_csv
     cfg.target.iuphar.target_csv = cfg.target.all.target_csv

--- a/tests/integration/test_target_pipeline_iuphar.py
+++ b/tests/integration/test_target_pipeline_iuphar.py
@@ -1,0 +1,102 @@
+"""Integration tests for target pipeline IUPHAR integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.config import Config
+from scripts import get_target_data
+
+
+@pytest.mark.integration
+def test_target_pipeline__iuphar_columns_populated(
+    tmp_path: Path, cfg: Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure the pipeline writes the requested IUPHAR output path."""
+
+    cfg.io.csv_sep = ","
+    cfg.io.csv_encoding = "utf-8"
+    cfg.target.all.uniprot_column = "uniprot_id"
+    cfg.target.iuphar.target_csv = tmp_path / "iuphar_targets.csv"
+    cfg.target.iuphar.family_csv = tmp_path / "iuphar_families.csv"
+    cfg.target.all.target_csv = cfg.target.iuphar.target_csv
+    cfg.target.all.family_csv = cfg.target.iuphar.family_csv
+
+    chembl_df = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1"],
+            "uniprot_id": ["P12345"],
+            "mapping_uniprot_id": ["P12345"],
+            "pref_name": ["Alpha"],
+        }
+    )
+    uniprot_df = pd.DataFrame(
+        {
+            "uniprot_id": ["P12345"],
+            "mapping_uniprot_id": ["P12345"],
+            "molecular_function": ["binding"],
+        }
+    )
+
+    output_csv = tmp_path / "output.targets_iuphar.csv"
+    expected_payload = {
+        "uniprot_id": ["P12345"],
+        "iuphar_target_id": ["TGT-001"],
+        "iuphar_family_id": ["FAM-123"],
+        "iuphar_type": ["Type"],
+        "iuphar_class": ["Class"],
+        "iuphar_subclass": ["Subclass"],
+        "iuphar_chain": ["Chain"],
+        "iuphar_name": ["Example"],
+        "iuphar_full_id_path": ["TGT-001#FAM-123"],
+        "iuphar_full_name_path": ["Example#Family"],
+    }
+    captured_paths: list[Path] = []
+
+    class _StubIUPHARData:
+        def map_uniprot_file(
+            self,
+            input_path: str | Path,
+            output_path: str | Path,
+            *,
+            encoding: str = "utf-8",
+            sep: str = ",",
+        ) -> pd.DataFrame:
+            captured_paths.append(Path(output_path))
+            frame = pd.DataFrame(expected_payload)
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            frame.to_csv(output_path, index=False, encoding=encoding, sep=sep)
+            return frame
+
+    class _StubIUPHARFactory:
+        @classmethod
+        def from_files(
+            cls,
+            target_path: str | Path,
+            family_path: str | Path,
+            *,
+            encoding: str = "utf-8",
+        ) -> _StubIUPHARData:
+            return _StubIUPHARData()
+
+    monkeypatch.setattr(get_target_data.ii, "IUPHARData", _StubIUPHARFactory)
+
+    combined_df, iuphar_df = get_target_data.fetch_iuphar(
+        cfg, chembl_df, uniprot_df, output_csv
+    )
+
+    assert captured_paths == [output_csv]
+    assert output_csv.exists()
+
+    written = pd.read_csv(output_csv, dtype=str)
+    for column, values in expected_payload.items():
+        assert column in written.columns
+        assert list(written[column]) == values
+        assert column in iuphar_df.columns
+        assert list(iuphar_df[column]) == values
+
+    assert "uniprot_id" in combined_df.columns
+    assert list(combined_df["uniprot_id"]) == ["P12345"]


### PR DESCRIPTION
## Summary
- ensure the IUPHAR CLI honours an explicit output path passed via `--output-csv`
- pass the resolved output path through fetch_iuphar and add a regression test covering the pipeline wiring

## Testing
- pytest tests/integration/test_target_pipeline_iuphar.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4085c3d608324baab8cb21ad31a3b