### PR TITLE
Accept undated output.targets exports

### DIFF
--- a/library/postprocessing/target/isoform.py
+++ b/library/postprocessing/target/isoform.py
@@ -79,6 +79,12 @@ _INPUT_NAME_RULES: Tuple[Tuple[re.Pattern[str], str], ...] = (
         "output.targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
     ),
     (
+        re.compile(
+            r"output\.targets(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"
+        ),
+        "output.targets[_<suffixes>][_normalized].csv",
+    ),
+    (
         re.compile(r"targets_\d{8}(?:_[A-Za-z0-9]+)*(?:_normalized)?\.csv\Z"),
         "targets_<YYYYMMDD>[<_suffixes>][_normalized].csv",
     ),

--- a/tests/unit/test_target_isoform.py
+++ b/tests/unit/test_target_isoform.py
@@ -93,10 +93,12 @@ def test_transform__missing_identifier_columns_warns_and_returns_empty_result():
         "out_chembl.csv",
         "out_normalized.csv",
         "out_uniprot.csv",
+        "output.targets.csv",
+        "output.targets_normalized.csv",
     ],
 )
 def test_matches_expected_input_name__supports_modern_exports(filename: str) -> None:
-    """Modern ``out*.csv`` exports are accepted for isoform processing."""
+    """Modern aggregated exports are accepted for isoform processing."""
 
     assert isoform._matches_expected_input_name(filename)
 


### PR DESCRIPTION
## Summary
- allow the isoform post-processing pipeline to accept undated `output.targets*.csv` exports
- extend unit coverage to verify the new filename patterns

## Testing
- pytest tests/unit/test_target_isoform.py -k matches -q

------
https://chatgpt.com/codex/tasks/task_e_68e40b91f2a08324a52a3fd42cec44c9