### PR TITLE
Handle ChEMBL document timeouts with chunk fallback

### DIFF
--- a/library/pipelines/document/chembl_document.py
+++ b/library/pipelines/document/chembl_document.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
+from time import monotonic
 from typing import Any
 
 import pandas as pd
+import requests
 
-from library.clients import ChemblClient
+from library.clients import ChemblClient, _chunked
+from ...common.log import logger
 from ...config import ApiCfg
 
 DOCUMENT_COLUMNS = [
@@ -61,32 +64,8 @@ def get_documents(
     """
     base = f"{cfg.chembl_base.rstrip('/')}/document.json?format=json"
     effective_timeout = timeout if timeout is not None else cfg.timeout_read
-    records: list[dict[str, Any]] = []
     seen: set[str] = set()
-    chunk: list[str] = []
-
-    def fetch_chunk(chunk_ids: list[str]) -> None:
-        url = f"{base}&document_chembl_id__in={','.join(chunk_ids)}"
-        data = client.request_json(url, cfg=cfg, timeout=effective_timeout)
-        items = data.get("documents") or data.get("document") or []
-        for item in items:
-            record = {
-                "document_chembl_id": item.get("document_chembl_id"),
-                "title": item.get("title"),
-                "abstract": item.get("abstract"),
-                "doi": item.get("doi"),
-                "year": item.get("year"),
-                "journal": item.get("journal_full_title"),
-                "journal_abbrev": item.get("journal"),
-                "volume": item.get("volume"),
-                "issue": item.get("issue"),
-                "first_page": item.get("first_page"),
-                "last_page": item.get("last_page"),
-                "pubmed_id": item.get("pubmed_id"),
-                "authors": item.get("authors"),
-                "source": "ChEMBL",
-            }
-            records.append(record)
+    unique_ids: list[str] = []
 
     for identifier in ids:
         if identifier in INVALID_DOCUMENT_IDS:
@@ -94,19 +73,117 @@ def get_documents(
         if identifier in seen:
             continue
         seen.add(identifier)
-        chunk.append(identifier)
-        if len(chunk) >= chunk_size:
-            fetch_chunk(chunk)
-            chunk = []
+        unique_ids.append(identifier)
 
-    if chunk:
-        fetch_chunk(chunk)
+    if not unique_ids:
+        return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
-    if not seen or not records:
+    records: list[dict[str, Any]] = []
+    for chunk in _chunked(unique_ids, chunk_size):
+        records.extend(
+            _fetch_documents_chunk(
+                chunk,
+                base_url=base,
+                cfg=cfg,
+                client=client,
+                timeout=effective_timeout,
+            )
+        )
+
+    if not records:
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
     df = pd.DataFrame(records)
     return df.reindex(columns=DOCUMENT_COLUMNS)
+
+
+def _fetch_documents_chunk(
+    chunk_ids: Sequence[str],
+    *,
+    base_url: str,
+    cfg: ApiCfg,
+    client: ChemblClient,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    """Return document records for ``chunk_ids`` with timeout-aware fallback."""
+
+    if not chunk_ids:
+        return []
+
+    url = f"{base_url}&document_chembl_id__in={','.join(chunk_ids)}"
+    start_time = monotonic()
+    try:
+        data = client.request_json(url, cfg=cfg, timeout=timeout)
+    except requests.ReadTimeout as exc:
+        if len(chunk_ids) <= 1:
+            raise
+        elapsed = monotonic() - start_time
+        logger.warning(
+            "chembl_document_timeout_split",
+            extra={
+                "chunk_size": len(chunk_ids),
+                "ids": list(chunk_ids),
+                "timeout": timeout,
+                "error": str(exc),
+                "elapsed": elapsed,
+            },
+        )
+        midpoint = max(1, len(chunk_ids) // 2)
+        left = chunk_ids[:midpoint]
+        right = chunk_ids[midpoint:]
+        records: list[dict[str, Any]] = []
+        if left:
+            records.extend(
+                _fetch_documents_chunk(
+                    left,
+                    base_url=base_url,
+                    cfg=cfg,
+                    client=client,
+                    timeout=timeout,
+                )
+            )
+        if right:
+            records.extend(
+                _fetch_documents_chunk(
+                    right,
+                    base_url=base_url,
+                    cfg=cfg,
+                    client=client,
+                    timeout=timeout,
+                )
+            )
+        return records
+    except requests.RequestException:
+        raise
+
+    items = data.get("documents") or data.get("document") or []
+    records = [
+        _normalise_document_record(item)
+        for item in items
+        if isinstance(item, Mapping)
+    ]
+    return [record for record in records if record]
+
+
+def _normalise_document_record(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a normalised document record extracted from ``item``."""
+
+    return {
+        "document_chembl_id": item.get("document_chembl_id"),
+        "title": item.get("title"),
+        "abstract": item.get("abstract"),
+        "doi": item.get("doi"),
+        "year": item.get("year"),
+        "journal": item.get("journal_full_title"),
+        "journal_abbrev": item.get("journal"),
+        "volume": item.get("volume"),
+        "issue": item.get("issue"),
+        "first_page": item.get("first_page"),
+        "last_page": item.get("last_page"),
+        "pubmed_id": item.get("pubmed_id"),
+        "authors": item.get("authors"),
+        "source": "ChEMBL",
+    }
 
 
 __all__ = ["get_documents"]

--- a/tests/unit/pipelines/document/test_chembl_document.py
+++ b/tests/unit/pipelines/document/test_chembl_document.py
@@ -1,0 +1,121 @@
+"""Unit tests for the ChEMBL document fetch helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pandas as pd
+import pytest
+import requests
+
+from library.config import ApiCfg
+from library.pipelines.document.chembl_document import get_documents
+
+
+class _StubChemblClient:
+    """Deterministic stub that mimics :class:`ChemblClient`."""
+
+    def __init__(self, responses: dict[str, object]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, float | None]] = []
+
+    def request_json(self, url: str, *, cfg: ApiCfg, timeout: float | None = None) -> dict:
+        del cfg  # Unused in the stub.
+        self.calls.append((url, timeout))
+        response = self._responses[url]
+        if isinstance(response, Exception):
+            raise response
+        assert isinstance(response, dict)
+        return response
+
+
+def _chunk_url(cfg: ApiCfg, ids: Sequence[str]) -> str:
+    base = cfg.chembl_base.rstrip("/")
+    joined_ids = ",".join(ids)
+    return f"{base}/document.json?format=json&document_chembl_id__in={joined_ids}"
+
+
+def _build_response(identifier: str, title: str) -> dict[str, object]:
+    return {
+        "documents": [
+            {
+                "document_chembl_id": identifier,
+                "title": title,
+                "abstract": "",
+                "doi": "",
+                "year": 2024,
+                "journal_full_title": "Journal",
+                "journal": "J",
+                "volume": "1",
+                "issue": "2",
+                "first_page": "10",
+                "last_page": "20",
+                "pubmed_id": "123",
+                "authors": ["Author"],
+            }
+        ]
+    }
+
+
+@pytest.mark.unit
+def test_get_documents__splits_chunk_on_timeout(caplog: pytest.LogCaptureFixture) -> None:
+    """The helper should split large chunks when a read timeout occurs."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=12.0)
+    timeout = 9.5
+
+    combined_url = _chunk_url(cfg, ["CHEMBL1", "CHEMBL2"])
+    responses = {
+        combined_url: requests.ReadTimeout("simulated timeout"),
+        _chunk_url(cfg, ["CHEMBL1"]): _build_response("CHEMBL1", "Alpha"),
+        _chunk_url(cfg, ["CHEMBL2"]): _build_response("CHEMBL2", "Beta"),
+    }
+    client = _StubChemblClient(responses)
+
+    with caplog.at_level("WARNING"):
+        frame = get_documents(
+            ["CHEMBL1", "CHEMBL2"],
+            cfg=cfg,
+            client=client,
+            chunk_size=2,
+            timeout=timeout,
+        )
+
+    assert [call[0] for call in client.calls] == [
+        combined_url,
+        _chunk_url(cfg, ["CHEMBL1"]),
+        _chunk_url(cfg, ["CHEMBL2"]),
+    ]
+    assert all(call[1] == timeout for call in client.calls)
+
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame["document_chembl_id"]) == ["CHEMBL1", "CHEMBL2"]
+    assert list(frame["title"]) == ["Alpha", "Beta"]
+
+    assert any(
+        record.getMessage().startswith("chembl_document_timeout_split")
+        for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_get_documents__propagates_timeout_for_single_identifier() -> None:
+    """When the chunk is a single identifier the timeout error should bubble up."""
+
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=6.0)
+    timeout = 5.0
+
+    single_url = _chunk_url(cfg, ["CHEMBL1"])
+    responses = {single_url: requests.ReadTimeout("simulated timeout")}
+    client = _StubChemblClient(responses)
+
+    with pytest.raises(requests.ReadTimeout):
+        get_documents(
+            ["CHEMBL1"],
+            cfg=cfg,
+            client=client,
+            chunk_size=1,
+            timeout=timeout,
+        )
+
+    assert client.calls == [(single_url, timeout)]


### PR DESCRIPTION
## Summary
- add a timeout-aware chunk splitter to the ChEMBL document fetcher so large batches retry per identifier
- add unit coverage for the new fallback behaviour and timeout propagation

## Testing
- pytest -q tests/unit/pipelines/document/test_chembl_document.py

------
https://chatgpt.com/codex/tasks/task_e_68e40cb66dcc8324a8c3d3774ce61ace