### PR TITLE
Improve ChEMBL document fetch timeout handling

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,16 +101,16 @@ sources:
           limit: null
         chembl:
           column: "document_chembl_id"
-          chunk_size: 50
-          timeout: 30.0
+          chunk_size: 20
+          timeout: 90.0
           limit: null
         all:
           column: "document_chembl_id"
-          chunk_size: 5
+          chunk_size: 20
           sleep: 5.0
           workers: 1
           batch_size: 5
-          timeout: 30.0
+          timeout: 90.0
           limit: null
       target:
         uniprot:

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from itertools import islice
 from dataclasses import dataclass, field
-from time import monotonic, perf_counter
+from time import monotonic
 from types import TracebackType
 from typing import Any, Callable, TypeVar, cast
 from urllib.parse import urlsplit, urlunsplit
@@ -192,11 +192,23 @@ class ChemblClient:
             cached = self.cache.get(cache_key)
             if cached is not None:
                 logger.debug(
-                    "cache_hit", extra={"url": url, "rps": cfg.rps, "status": "hit"}
+                    "cache_hit",
+                    extra={
+                        "url": url,
+                        "rps": cfg.rps,
+                        "status": "hit",
+                        "timeout": read_timeout,
+                    },
                 )
                 return cast(dict[str, Any], cached)
             logger.debug(
-                "cache_miss", extra={"url": url, "rps": cfg.rps, "status": "miss"}
+                "cache_miss",
+                extra={
+                    "url": url,
+                    "rps": cfg.rps,
+                    "status": "miss",
+                    "timeout": read_timeout,
+                },
             )
 
         last_exc: requests.RequestException | ValueError | None = None
@@ -216,12 +228,16 @@ class ChemblClient:
                     event = "request_start" if attempt == 1 else "request_retry"
                 logger.debug(
                     event,
-                    extra={"url": request_url, "attempt": attempt, "rps": cfg.rps},
+                    extra={
+                        "url": request_url,
+                        "attempt": attempt,
+                        "rps": cfg.rps,
+                        "timeout": read_timeout,
+                    },
                 )
                 try:
                     start_time = monotonic()
                     session = self._get_session()
-                    start_time = perf_counter()
                     with session.get(
                         request_url, timeout=(cfg.timeout_connect, read_timeout)
                     ) as response:
@@ -237,11 +253,18 @@ class ChemblClient:
                             raise ValueError(
                                 f"invalid JSON in response from {request_url}"
                             ) from exc
-                        elapsed = getattr(response, "elapsed", None)
-                        if elapsed is not None and hasattr(elapsed, "total_seconds"):
-                            duration = elapsed.total_seconds()
+                        response_elapsed = getattr(response, "elapsed", None)
+                        response_elapsed_seconds: float | None
+                        if (
+                            response_elapsed is not None
+                            and hasattr(response_elapsed, "total_seconds")
+                        ):
+                            response_elapsed_seconds = float(
+                                response_elapsed.total_seconds()
+                            )
                         else:
-                            duration = perf_counter() - start_time
+                            response_elapsed_seconds = None
+                        duration = monotonic() - start_time
                         logger.debug(
                             "request_ok",
                             extra={
@@ -249,6 +272,8 @@ class ChemblClient:
                                 "status": getattr(response, "status_code", None),
                                 "rps": cfg.rps,
                                 "elapsed": duration,
+                                "response_elapsed": response_elapsed_seconds,
+                                "timeout": read_timeout,
                             },
                         )
                         with self._cache_lock:
@@ -267,7 +292,9 @@ class ChemblClient:
                                     "fallback_url": request_url,
                                     "attempt": attempt,
                                     "rps": cfg.rps,
-                                    "elapsed": elapsed,
+                                    "elapsed": duration,
+                                    "response_elapsed": response_elapsed_seconds,
+                                    "timeout": read_timeout,
                                 },
                             )
                         return data
@@ -283,6 +310,7 @@ class ChemblClient:
                                 "rps": cfg.rps,
                                 "elapsed": elapsed,
                                 "attempt": attempt,
+                                "timeout": read_timeout,
                             },
                         )
                         break
@@ -323,6 +351,7 @@ class ChemblClient:
                                 "rps": cfg.rps,
                                 "elapsed": elapsed,
                                 "attempt": attempt,
+                                "timeout": read_timeout,
                             },
                         )
                         break
@@ -343,6 +372,7 @@ class ChemblClient:
                                 "rps": cfg.rps,
                                 "elapsed": elapsed,
                                 "attempt": attempt,
+                                "timeout": read_timeout,
                             },
                         )
                         break

--- a/library/document_defaults.py
+++ b/library/document_defaults.py
@@ -27,17 +27,17 @@ PUBMED_DEFAULTS = DocumentModeDefaults(
 
 CHEMBL_DEFAULTS = DocumentModeDefaults(
     column="document_chembl_id",
-    chunk_size=5,
-    timeout=30.0,
+    chunk_size=20,
+    timeout=90.0,
 )
 
 ALL_DEFAULTS = DocumentModeDefaults(
     column="document_chembl_id",
     batch_size=50,
-    chunk_size=5,
+    chunk_size=20,
     sleep=5.0,
     workers=1,
-    timeout=30.0,
+    timeout=90.0,
 )
 
 

--- a/library/pipelines/document/chembl_document.py
+++ b/library/pipelines/document/chembl_document.py
@@ -32,6 +32,8 @@ DOCUMENT_COLUMNS = [
 
 INVALID_DOCUMENT_IDS = {"", "#N/A"}
 
+MAX_DOCUMENT_CHUNK_SIZE = 20
+
 
 def get_documents(
     ids: Iterable[str],
@@ -79,7 +81,18 @@ def get_documents(
         return pd.DataFrame(columns=DOCUMENT_COLUMNS)
 
     records: list[dict[str, Any]] = []
-    for chunk in _chunked(unique_ids, chunk_size):
+    effective_chunk_size = max(1, min(chunk_size, MAX_DOCUMENT_CHUNK_SIZE))
+    if effective_chunk_size != chunk_size:
+        logger.info(
+            "chembl_document_chunk_size_capped",
+            extra={
+                "requested": chunk_size,
+                "applied": effective_chunk_size,
+                "max": MAX_DOCUMENT_CHUNK_SIZE,
+            },
+        )
+
+    for chunk in _chunked(unique_ids, effective_chunk_size):
         records.extend(
             _fetch_documents_chunk(
                 chunk,

--- a/tests/unit/pipelines/document/test_chembl_document.py
+++ b/tests/unit/pipelines/document/test_chembl_document.py
@@ -57,6 +57,29 @@ def _build_response(identifier: str, title: str) -> dict[str, object]:
     }
 
 
+def _build_chunk_response(identifiers: Sequence[str]) -> dict[str, object]:
+    return {
+        "documents": [
+            {
+                "document_chembl_id": identifier,
+                "title": f"Title {identifier}",
+                "abstract": "",
+                "doi": "",
+                "year": 2024,
+                "journal_full_title": "Journal",
+                "journal": "J",
+                "volume": "1",
+                "issue": "1",
+                "first_page": "1",
+                "last_page": "2",
+                "pubmed_id": "123",
+                "authors": ["Author"],
+            }
+            for identifier in identifiers
+        ]
+    }
+
+
 @pytest.mark.unit
 def test_get_documents__splits_chunk_on_timeout(caplog: pytest.LogCaptureFixture) -> None:
     """The helper should split large chunks when a read timeout occurs."""
@@ -119,3 +142,37 @@ def test_get_documents__propagates_timeout_for_single_identifier() -> None:
         )
 
     assert client.calls == [(single_url, timeout)]
+
+
+@pytest.mark.unit
+def test_get_documents__caps_large_chunk_size(caplog: pytest.LogCaptureFixture) -> None:
+    cfg = ApiCfg(chembl_base="https://example.test/api", timeout_read=60.0)
+    identifiers = [f"CHEMBL{i}" for i in range(1, 27)]
+
+    first_chunk = identifiers[:20]
+    second_chunk = identifiers[20:]
+    responses = {
+        _chunk_url(cfg, first_chunk): _build_chunk_response(first_chunk),
+        _chunk_url(cfg, second_chunk): _build_chunk_response(second_chunk),
+    }
+    client = _StubChemblClient(responses)
+
+    with caplog.at_level("INFO"):
+        frame = get_documents(
+            identifiers,
+            cfg=cfg,
+            client=client,
+            chunk_size=50,
+            timeout=None,
+        )
+
+    assert [call[0] for call in client.calls] == [
+        _chunk_url(cfg, first_chunk),
+        _chunk_url(cfg, second_chunk),
+    ]
+    assert all(call[1] == cfg.timeout_read for call in client.calls)
+    assert sorted(frame["document_chembl_id"]) == sorted(identifiers)
+    assert any(
+        record.getMessage().startswith("chembl_document_chunk_size_capped")
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- cap document fetch batches at 20 identifiers and surface an info log when capping occurs
- extend ChEMBL client logging with per-request timeout and response timing details, and raise document mode timeouts to 90s in defaults/config
- add a regression test covering the new chunk-size cap to keep batching behaviour deterministic

## Testing
- pytest tests/unit/pipelines/document/test_chembl_document.py
- pytest tests/unit/test_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e410bf3ef48324b39533c041cbc656