### PR TITLE
Update documentation to reflect activity terminus of orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ flowchart LR
     B -->|enrich| C[Target pipeline]
     C -->|link| D[Assay pipeline]
     D -->|hydrate| E[Test item pipeline]
-    E -->|map| G[Tissue pipeline]
-    G -->|join| F[Activity pipeline]
+    E -->|join| F[Activity pipeline]
     B -.->|citations| F
     C -.->|targets| F
     style F fill:#dfeaff,stroke:#1e3a8a,stroke-width:2px
@@ -28,8 +27,10 @@ flowchart LR
 
 Each pipeline is idempotent and can be executed independently. The
 [`get-data`](./scripts/get_data.py) orchestrator reuses the same configuration
-and logging options to run the Document → Target → Assay → Test item → Tissue →
-Activity sequence automatically while producing consistent outputs.
+and logging options to run the Document → Target → Assay → Test item → Activity
+sequence automatically while producing consistent outputs. The tissue pipeline
+remains available as a standalone step that operators can execute manually
+before the activity run when tissue enrichment is required.
 
 ## Repository layout
 
@@ -85,7 +86,7 @@ python scripts/get_data.py \
 | Target | `python scripts/get_target_data.py all --input data/input/target.csv --final-out output/targets.csv --chembl-chunk-size 10 --uniprot-data-dir cache/uniprot --raw-out output/targets_raw.parquet --raw-format parquet` | Sub-commands (`uniprot`, `chembl`, `iuphar`, `all`) accept prefixed overrides and optional raw exports. |
 | Assay | `python scripts/get_assay_data.py --input data/input/assay.csv --final-out output/assays.csv --chunk-size 25 --timeout 45` | Requires the assay, taxonomy and target dictionaries under `config/dictionary` to enrich `assay_group`, `assay_strain`, `year` and `accession` before normalisation; shares global options plus per-request chunk size and timeout tuning. |
 | Test item | `python scripts/get_testitem_data.py --input data/input/testitem.csv --final-out output/testitems.csv --request-limit 500 --hierarchy-path config/dictionary/_testitem/molecule_hierarchy.csv` | Provides parent-molecule enrichment controls and request throttling (`--request-limit`, `--batch-size`, `--dry-run`). |
-| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. |
+| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. Run separately before `get_activity_data` when tissue lookups are required. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --final-out output/cellline.csv --batch-size 20 --limit 100` | Retrieves ChEMBL cell line records, normalises nullable identifiers and enforces deterministic ordering. |
 | Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --action-type-enabled --bounds-enabled --quality-threshold warn` | Toggles enrichment hooks (`--action-type-enabled`, `--bounds-enabled`), derived bounds and QA thresholds. |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -19,8 +19,7 @@ flowchart LR
     B -->|enrich| C[Target pipeline]
     C -->|link| D[Assay pipeline]
     D -->|hydrate| E[Test item pipeline]
-    E -->|map| G[Tissue pipeline]
-    G -->|join| F[Activity pipeline]
+    E -->|join| F[Activity pipeline]
     B -.->|citations| F
     C -.->|targets| F
     style F fill:#dfeaff,stroke:#1e3a8a,stroke-width:2px
@@ -28,8 +27,10 @@ flowchart LR
 
 Each pipeline is idempotent and can be executed independently. The
 [`get-data`](./scripts/get_data.py) orchestrator reuses the same configuration
-and logging options to run the Document → Target → Assay → Test item → Tissue →
-Activity sequence automatically while producing consistent outputs.
+and logging options to run the Document → Target → Assay → Test item → Activity
+sequence automatically while producing consistent outputs. The tissue pipeline
+remains available as a standalone step that operators can execute manually
+before the activity run when tissue enrichment is required.
 
 ## Repository layout
 
@@ -85,7 +86,7 @@ python scripts/get_data.py \
 | Target | `python scripts/get_target_data.py all --input data/input/target.csv --final-out output/targets.csv --chembl-chunk-size 10 --uniprot-data-dir cache/uniprot --raw-out output/targets_raw.parquet --raw-format parquet` | Sub-commands (`uniprot`, `chembl`, `iuphar`, `all`) accept prefixed overrides and optional raw exports. |
 | Assay | `python scripts/get_assay_data.py --input data/input/assay.csv --final-out output/assays.csv --chunk-size 25 --timeout 45` | Requires the assay, taxonomy and target dictionaries under `config/dictionary` to enrich `assay_group`, `assay_strain`, `year` and `accession` before normalisation; shares global options plus per-request chunk size and timeout tuning. |
 | Test item | `python scripts/get_testitem_data.py --input data/input/testitem.csv --final-out output/testitems.csv --request-limit 500 --hierarchy-path config/dictionary/_testitem/molecule_hierarchy.csv` | Provides parent-molecule enrichment controls and request throttling (`--request-limit`, `--batch-size`, `--dry-run`). |
-| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. |
+| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. Run separately before `get_activity_data` when tissue lookups are required. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --final-out output/cellline.csv --batch-size 20 --limit 100` | Retrieves ChEMBL cell line records, normalises nullable identifiers and enforces deterministic ordering. |
 | Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --action-type-enabled --bounds-enabled --quality-threshold warn` | Toggles enrichment hooks (`--action-type-enabled`, `--bounds-enabled`), derived bounds and QA thresholds. |
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -13,8 +13,7 @@ flowchart LR
     B -->|enrich| C[Target pipeline]
     C -->|link| D[Assay pipeline]
     D -->|hydrate| E[Test item pipeline]
-    E -->|map| G[Tissue pipeline]
-    G -->|join| F[Activity pipeline]
+    E -->|join| F[Activity pipeline]
     B -.->|citations| F
     C -.->|targets| F
     style F fill:#dfeaff,stroke:#1e3a8a,stroke-width:2px
@@ -22,8 +21,10 @@ flowchart LR
 
 Каждый пайплайн идемпотентен и может запускаться независимо. Оркестратор
 [`get-data`](./scripts/get_data.py) использует единую конфигурацию и настройки
-логирования, чтобы выполнить всю цепочку («документы → таргеты → ассайи →
-тестовые объекты → ткани → активности») автоматически и воспроизводимо.
+логирования, чтобы выполнить цепочку («документы → таргеты → ассайи → тестовые
+объекты → активности») автоматически и воспроизводимо. Пайплайн тканей остаётся
+отдельным шагом: при необходимости его запускают вручную до конвейера
+активностей, чтобы подготовить справочные таблицы.
 
 ## Структура репозитория
 
@@ -78,7 +79,7 @@ python scripts/get_data.py \
 | Target | `python scripts/get_target_data.py all --input data/input/target.csv --final-out output/targets.csv --chembl-chunk-size 10 --uniprot-data-dir cache/uniprot --raw-out output/targets_raw.parquet --raw-format parquet` | Подкоманды (`uniprot`, `chembl`, `iuphar`, `all`) принимают префиксные оверрайды и позволяют сохранять «сырые» выгрузки. |
 | Assay | `python scripts/get_assay_data.py --input data/input/assay.csv --final-out output/assays.csv --chunk-size 25 --timeout 45` | Требует словари assay, taxonomy и target в `config/dictionary` для обогащения полей `assay_group`, `assay_strain`, `year` и `accession` перед нормализацией; общие флаги плюс настройка размера пачки и таймаута запросов. |
 | Test item | `python scripts/get_testitem_data.py --input data/input/testitem.csv --final-out output/testitems.csv --request-limit 500 --hierarchy-path config/dictionary/_testitem/molecule_hierarchy.csv` | Управляет обогащением родительских молекул и лимитами запросов (`--request-limit`, `--batch-size`, `--dry-run`). |
-| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Загружает метаданные тканей, объединяет онтологические кросс-ссылки и нормализует синонимы для последующего объединения. |
+| Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Загружает метаданные тканей, объединяет онтологические кросс-ссылки и нормализует синонимы. Запускается отдельно перед `get_activity_data`, когда нужны справочники тканей. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --final-out output/cellline.csv --batch-size 20 --limit 100` | Выгружает данные по клеточным линиям из ChEMBL, нормализует идентификаторы и формирует стабильный CSV. |
 | Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --action-type-enabled --bounds-enabled --quality-threshold warn` | Включает обогащения (`--action-type-enabled`, `--bounds-enabled`), расчёт границ и пороги QA. |
 

--- a/docs/en/architecture/ARCHITECTURE.md
+++ b/docs/en/architecture/ARCHITECTURE.md
@@ -7,8 +7,7 @@ flowchart LR
         A2[get-target-data]
         A3[get-assay-data]
         A4[get-testitem-data]
-        A5[get-tissue-data]
-        A6[get-activity-data]
+        A5[get-activity-data]
         A0[get-data orchestrator]
     end
     subgraph Library
@@ -22,8 +21,8 @@ flowchart LR
         C2[config/dictionary]
     end
 
-    A0 --> A1 & A2 & A3 & A4 & A5 & A6
-    A1 & A2 & A3 & A4 & A5 & A6 --> B2
+    A0 --> A1 & A2 & A3 & A4 & A5
+    A1 & A2 & A3 & A4 & A5 --> B2
     B2 --> B1
     B2 --> B3
     B2 --> B4
@@ -32,14 +31,18 @@ flowchart LR
 ```
 
 The orchestrator initialises shared configuration, logging and rate limiting,
-then invokes each CLI module in order. Pipelines import reusable components from
-`library/`:
+then invokes each CLI module in order up to the activity stage. The tissue
+pipeline runs separately when required so that operators can refresh the
+reference tables before the activity join. Pipelines import reusable components
+from `library/`:
 
 - `library/clients` — HTTP clients with retry and throttling logic for ChEMBL,
   UniProt, PubMed, OpenAlex, CrossRef, PubChem.
 - `library/pipelines` — Fetching, transformation and export logic for each
   entity. Subpackages (`document`, `target`, `assay`, `testitem`, `tissue`,
-  `activity`) expose orchestration primitives reused by the scripts.
+  `activity`) expose orchestration primitives reused by the scripts, even when
+  the orchestration chain executes only the document → target → assay → test
+  item → activity subset.
 - `library/utils` — CLI helpers, deterministic CSV I/O, configuration loaders,
   logging bootstrap and file system utilities.
 - `library/qa` & `library/table_quality.py` — Schema validation, quality
@@ -53,11 +56,12 @@ then invokes each CLI module in order. Pipelines import reusable components from
 | Target | `scripts/get_target_data.py` | ChEMBL `/target`, UniProt, Guide to PHARMACOLOGY, cached dictionaries. | `output.targets_<stamp>.csv` and helper lookups (`organism`, `isoform`, `names`, `IUPHAR`). |
 | Assay | `scripts/get_assay_data.py` | ChEMBL `/assay`. | `output.assays_<stamp>.csv` with QA artefacts. |
 | Test item | `scripts/get_testitem_data.py` | ChEMBL `/molecule`, PubChem PUG-REST. | `output.testitems_<stamp>.csv` and metadata. |
-| Tissue | `scripts/get_tissue_data.py` | ChEMBL `/tissue`, ontology caches (UBERON, EFO, BTO, Caloha, LINCS, CCLE). | `output.tissue_<stamp>.csv` plus quality reports and metadata. |
+| Tissue | `scripts/get_tissue_data.py` | ChEMBL `/tissue`, ontology caches (UBERON, EFO, BTO, Caloha, LINCS, CCLE). | `output.tissue_<stamp>.csv` plus quality reports and metadata; run manually before the activity pipeline when tissue joins are needed. |
 | Activity | `scripts/get_activity_data.py` | ChEMBL `/activity`. | `output.activities_<stamp>.csv` with enrichment columns. |
 
-The orchestrator runs these modules sequentially unless specific stages are
-skipped via CLI flags.
+The orchestrator runs the document → target → assay → test item → activity
+modules sequentially unless specific stages are skipped via CLI flags. Tissue is
+invoked separately.
 
 External services are accessed via token-bucket rate limiters configured by
 `sources.*` blocks. All network calls are wrapped with retry logic defined in

--- a/docs/ru/architecture/ARCHITECTURE.md
+++ b/docs/ru/architecture/ARCHITECTURE.md
@@ -7,8 +7,7 @@ flowchart LR
         A2[get-target-data]
         A3[get-assay-data]
         A4[get-testitem-data]
-        A5[get-tissue-data]
-        A6[get-activity-data]
+        A5[get-activity-data]
         A0[get-data orchestrator]
     end
     subgraph Library
@@ -22,8 +21,8 @@ flowchart LR
         C2[config/dictionary]
     end
 
-    A0 --> A1 & A2 & A3 & A4 & A5 & A6
-    A1 & A2 & A3 & A4 & A5 & A6 --> B2
+    A0 --> A1 & A2 & A3 & A4 & A5
+    A1 & A2 & A3 & A4 & A5 --> B2
     B2 --> B1
     B2 --> B3
     B2 --> B4
@@ -32,12 +31,16 @@ flowchart LR
 ```
 
 Оркестратор инициализирует общую конфигурацию, логирование, лимитеры и по очереди
-вызвает CLI для каждой сущности. Внутри используются общие компоненты `library/`:
+вызвает CLI до этапа активностей. Пайплайн тканей запускается отдельно при
+необходимости, чтобы подготовить справочники перед объединением активностей.
+Внутри используются общие компоненты `library/`:
 
 - `library/clients` — HTTP-клиенты с ретраями и лимитами для ChEMBL, UniProt,
   PubMed, OpenAlex, CrossRef, PubChem.
 - `library/pipelines` — логика загрузки, трансформации и экспорта по
   сущностям (`document`, `target`, `assay`, `testitem`, `tissue`, `activity`).
+  Даже если оркестратор проходит только «документы → таргеты → ассайи → тестовые
+  объекты → активности», все подпакеты доступны для ручного запуска.
 - `library/utils` — вспомогательные утилиты: CLI-бустрап, детерминированное I/O,
   загрузка конфигурации.
 - `library/qa` и `library/table_quality.py` — валидация Pandera, профили качества,
@@ -51,11 +54,12 @@ flowchart LR
 | Target | `scripts/get_target_data.py` | ChEMBL `/target`, UniProt, Guide to PHARMACOLOGY, локальные словари. | `output.targets_<stamp>.csv` и вспомогательные таблицы (`organism`, `isoform`, `names`, `IUPHAR`). |
 | Assay | `scripts/get_assay_data.py` | ChEMBL `/assay`. | `output.assays_<stamp>.csv` с QC-артефактами. |
 | Test item | `scripts/get_testitem_data.py` | ChEMBL `/molecule`, PubChem PUG-REST. | `output.testitems_<stamp>.csv` и метаданные. |
-| Tissue | `scripts/get_tissue_data.py` | ChEMBL `/tissue`, онтологии UBERON, EFO, BTO, Caloha, LINCS, CCLE. | `output.tissue_<stamp>.csv` и отчёты качества. |
+| Tissue | `scripts/get_tissue_data.py` | ChEMBL `/tissue`, онтологии UBERON, EFO, BTO, Caloha, LINCS, CCLE. | `output.tissue_<stamp>.csv` и отчёты качества; запускается вручную перед пайплайном активностей, если нужны связи по тканям. |
 | Activity | `scripts/get_activity_data.py` | ChEMBL `/activity`. | `output.activities_<stamp>.csv` с обогащениями. |
 
-Оркестратор выполняет эти скрипты последовательно, если отдельные этапы не
-отключены флагами CLI.
+Оркестратор выполняет последовательно «документы → таргеты → ассайи → тестовые
+объекты → активности», если отдельные этапы не отключены флагами CLI. Пайплайн
+тканей запускается отдельно.
 
 Внешние сервисы вызываются через токен-бакетные лимитеры (`sources.*`), все
 запросы проходят через `system.retry`.


### PR DESCRIPTION
## Summary
- update the bilingual READMEs to show the orchestrator chain ending at the activity pipeline and note tissue as a manual step
- clarify the English and Russian architecture diagrams and tables so the get-data orchestrator no longer links to the tissue pipeline
- ensure references across the architecture docs consistently describe tissue as a standalone run before activity joins when required

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e413de7c288324bee0e686bb486b21