### PR TITLE
Capture CLI exception tracebacks in logs

### DIFF
--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -142,6 +142,7 @@ def run_cli_command(
             "config_error",
             error=str(exc),
             config=str(getattr(args, "config", "")),
+            exc_info=exc,
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
@@ -162,6 +163,7 @@ def run_cli_command(
             "config_error",
             error=str(exc),
             config=str(config_path),
+            exc_info=exc,
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
@@ -185,6 +187,7 @@ def run_cli_command(
             "config_error",
             error=str(exc),
             config=str(config_path),
+            exc_info=exc,
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
@@ -192,6 +195,7 @@ def run_cli_command(
         use_logger.error(
             "directory_setup_failed",
             error=str(exc),
+            exc_info=exc,
         )
         use_logger.info("pipeline_fail", run_id=log_cfg.run_id)
         return 1
@@ -382,7 +386,7 @@ def run_pipeline(
     except PipelineError:
         return 1
     except Exception as exc:  # pragma: no cover - exercised in integration tests
-        use_logger.error("fetch_failed", error=str(exc))
+        use_logger.error("fetch_failed", error=str(exc), exc_info=exc)
         return 1
 
     class _AbortPipeline(RuntimeError):
@@ -456,6 +460,7 @@ def run_pipeline(
                             chunk_index=chunk_index,
                             rows=chunk_rows_total,
                             strict_mode=strict_mode,
+                            exc_info=exc,
                         )
                         failed_metadata_hooks.add(hook_name)
                         if strict_mode:
@@ -488,6 +493,7 @@ def run_pipeline(
                                     "validation_failed",
                                     failures=len(failure_cases),
                                     path=str(failure_path),
+                                    exc_info=exc,
                                 )
                             validated_chunk = getattr(
                                 exc, "validated_data", validated_chunk
@@ -531,6 +537,7 @@ def run_pipeline(
             use_logger.error(
                 "chunk_processing_failed",
                 error=str(exc),
+                exc_info=exc,
             )
             aborted = True
             raise _AbortPipeline(1) from exc
@@ -549,6 +556,7 @@ def run_pipeline(
                             error_type=exc.__class__.__name__,
                             context="empty_frame",
                             strict_mode=strict_mode,
+                            exc_info=exc,
                         )
                         failed_metadata_hooks.add(hook_name)
                         if strict_mode:
@@ -688,6 +696,7 @@ def run_pipeline(
             "write_fail",
             error=str(exc),
             path=str(output_path),
+            exc_info=exc,
         )
         return 1
 

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,40 @@
+"""Unit tests for :mod:`library.cli_utils`."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import Mock
+
+import pytest
+
+from library import cli_utils
+from library.cli import LoggerConfig
+
+
+@pytest.mark.unit
+def test_run_cli_command__logs_exc_info_on_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``exc_info`` is attached when configuration resolution fails."""
+
+    parser = argparse.ArgumentParser()
+    args = argparse.Namespace(config=object(), verbose=False, log_level=None)
+    log_cfg = LoggerConfig(level="INFO", run_id="test-run", redact_secrets=False)
+
+    logger = Mock()
+    monkeypatch.setattr(cli_utils.cli, "configure_logger", lambda cfg: logger)
+
+    exit_code = cli_utils.run_cli_command(
+        args=args,
+        parser=parser,
+        log_cfg=log_cfg,
+        mapping={},
+        run=lambda *_: 0,
+        logger=logger,
+    )
+
+    assert exit_code == 1
+    error_call = logger.error.call_args
+    assert error_call is not None
+    exc_info = error_call.kwargs.get("exc_info")
+    assert exc_info is not None
+    assert isinstance(exc_info, ValueError)
+    assert error_call.kwargs["error"] == "configuration path must be provided"


### PR DESCRIPTION
## Summary
- attach `exc_info` to CLI error logging paths so failures include tracebacks
- propagate exception context through pipeline error logs
- add a unit test that verifies `run_cli_command` records the exception object

## Testing
- pytest tests/unit/test_cli_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e41462283c83249f8de06814d4f243