### PR TITLE
Improve logging setup for test runners

### DIFF
--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -14,6 +14,10 @@ from typing import Any, Sequence
 import pytest
 
 
+from library.common.logging_setup import LoggerConfig, configure_logger
+from library.cli.logging import setup_cli_logging
+
+
 SUCCESS_RATE_THRESHOLD = 0.95
 
 
@@ -168,6 +172,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Execute pytest with reporting helpers.")
     parser.add_argument("--suite", default="full", help="Label for the executed suite (used in log naming).")
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging for the CLI and pytest log capture.",
+    )
+    parser.add_argument(
         "--report-dir",
         default="reports",
         type=Path,
@@ -187,38 +196,46 @@ def main(argv: list[str] | None = None) -> int:
 
     report_dir: Path = args.report_dir
     report_dir.mkdir(parents=True, exist_ok=True)
-    logs_dir = report_dir / "logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-
-    log_path = logs_dir / f"{args.suite}.log"
 
     if "PYTHONHASHSEED" not in os.environ:
         os.environ["PYTHONHASHSEED"] = "0"
 
-    pytest_args = ["tests", f"--log-file={log_path}", "--log-file-level=DEBUG", "--maxfail=0"]
-    if args.pytest_args:
-        pytest_args.extend(args.pytest_args)
+    level = "DEBUG" if args.verbose else "INFO"
+    base_logger_cfg = LoggerConfig(level=level, logger_name="run_test_suite")
 
-    plugin = JsonReportPlugin(log_path)
-    pytest_exit_code = pytest.main(pytest_args, plugins=[plugin])
-    exit_code = int(pytest_exit_code)
+    with setup_cli_logging("run_test_suite", base_logger_cfg) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
 
-    results = plugin.results
-    summary = summarize_results(results)
+        log_path = logging_ctx.log_path
+        pytest_args = [
+            "tests",
+            f"--log-file={log_path}",
+            f"--log-file-level={logging_ctx.log_cfg.level}",
+            "--maxfail=0",
+        ]
+        if args.pytest_args:
+            pytest_args.extend(args.pytest_args)
 
-    if summary["success_rate"] < SUCCESS_RATE_THRESHOLD:
-        logger.error(
-            "Success rate %.2f%% is below the required threshold of %.2f%%",
-            summary["success_rate"] * 100,
-            SUCCESS_RATE_THRESHOLD * 100,
-        )
-        if exit_code == 0:
-            exit_code = 1
+        plugin = JsonReportPlugin(log_path)
+        pytest_exit_code = pytest.main(pytest_args, plugins=[plugin])
+        exit_code = int(pytest_exit_code)
 
-    json_path = report_dir / "test_report.json"
-    summary_path = report_dir / "test_summary.md"
-    _write_json(json_path, results, exit_code, summary)
-    _write_summary(summary_path, results, exit_code, summary)
+        results = plugin.results
+        summary = summarize_results(results)
+
+        if summary["success_rate"] < SUCCESS_RATE_THRESHOLD:
+            logger.error(
+                "Success rate %.2f%% is below the required threshold of %.2f%%",
+                summary["success_rate"] * 100,
+                SUCCESS_RATE_THRESHOLD * 100,
+            )
+            if exit_code == 0:
+                exit_code = 1
+
+        json_path = report_dir / "test_report.json"
+        summary_path = report_dir / "test_summary.md"
+        _write_json(json_path, results, exit_code, summary)
+        _write_summary(summary_path, results, exit_code, summary)
 
     return int(exit_code)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,10 +38,10 @@ Install dependencies (see the repository `README.md`) and run the suite via the 
 python tests/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `passed / total`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `passed / total`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success. All invocations also configure structured logging via `tests/run_tests.py` – log events are mirrored to `data/logs/run_tests_<YYYYMMDD>.log` (or the directory defined by `CHEMBL_DA_BASE_PATH`). Pass `--verbose` to lift the logger to DEBUG and forward the same verbosity to pytest’s log capture.
 
 
-To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tests/run_tests.py --pytest-args -m unit`.
+To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tests/run_tests.py --pytest-args -m unit`. Combine `--verbose` with the forwarding flag to observe detailed DEBUG events in both the console and the generated log file.
 
 Individual modules can be targeted by pointing pytest at a directory, for example `pytest tests/unit` or `pytest tests/integration -k enrich` to filter by test name.
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -16,6 +16,10 @@ from typing import Any
 import pytest
 
 
+from library.common.logging_setup import LoggerConfig, configure_logger
+from library.cli.logging import setup_cli_logging
+
+
 REPO_NAME = "SatoryKono/ChEMBL_data_acquisition"
 
 SUCCESS_RATE_THRESHOLD = 0.95
@@ -244,6 +248,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Additional arguments forwarded to pytest",
     )
     parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging for the CLI and pytest log capture.",
+    )
+    parser.add_argument(
         "--json",
         type=Path,
         default=Path("reports/test_report.json"),
@@ -257,26 +266,37 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    level = "DEBUG" if args.verbose else "INFO"
+    base_logger_cfg = LoggerConfig(level=level, logger_name="run_tests")
+
     collector = ReportCollector()
-    pytest_args = ["-q"]
-    if args.pytest_args:
-        pytest_args.extend(args.pytest_args)
 
-    pytest_exit_code = pytest.main(pytest_args, plugins=[collector])
-    exit_code = int(pytest_exit_code)
+    with setup_cli_logging("run_tests", base_logger_cfg) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
 
-    data = _build_json(collector, report_path=args.json)
-    _write_markdown(args.markdown, data)
+        pytest_args = [
+            "-q",
+            f"--log-file={logging_ctx.log_path}",
+            f"--log-file-level={logging_ctx.log_cfg.level}",
+        ]
+        if args.pytest_args:
+            pytest_args.extend(args.pytest_args)
 
-    success_rate_ratio = data["summary"]["success_rate"]
-    if success_rate_ratio < SUCCESS_RATE_THRESHOLD:
-        logger.error(
-            "Success rate %.2f%% is below the required threshold of %.2f%%",
-            success_rate_ratio * 100,
-            SUCCESS_RATE_THRESHOLD * 100,
-        )
-        if exit_code == 0:
-            exit_code = 1
+        pytest_exit_code = pytest.main(pytest_args, plugins=[collector])
+        exit_code = int(pytest_exit_code)
+
+        data = _build_json(collector, report_path=args.json)
+        _write_markdown(args.markdown, data)
+
+        success_rate_ratio = data["summary"]["success_rate"]
+        if success_rate_ratio < SUCCESS_RATE_THRESHOLD:
+            logger.error(
+                "Success rate %.2f%% is below the required threshold of %.2f%%",
+                success_rate_ratio * 100,
+                SUCCESS_RATE_THRESHOLD * 100,
+            )
+            if exit_code == 0:
+                exit_code = 1
 
     return exit_code
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import contextmanager
+import io
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -53,9 +56,37 @@ def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
 def test_main__returns_error_when_success_rate_below_threshold(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    log_path = tmp_path / "suite.log"
+
+    captured_cfgs: list[run_test_suite.LoggerConfig] = []
+
+    def fake_configure_logger(cfg: run_test_suite.LoggerConfig, *_: object, **__: object) -> object:
+        captured_cfgs.append(cfg)
+        return object()
+
+    @contextmanager
+    def fake_setup_cli_logging(script_name: str, log_cfg: run_test_suite.LoggerConfig, *_: object, **__: object):
+        assert script_name == "run_test_suite"
+        stream = io.StringIO()
+        cloned_cfg = run_test_suite.LoggerConfig(
+            level=log_cfg.level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=stream,
+            handlers=list(log_cfg.handlers),
+            logger_name=log_cfg.logger_name,
+        )
+        yield SimpleNamespace(log_path=log_path, log_cfg=cloned_cfg, console_stream=stream)
+
+    monkeypatch.setattr(run_test_suite, "configure_logger", fake_configure_logger)
+    monkeypatch.setattr(run_test_suite, "setup_cli_logging", fake_setup_cli_logging)
+
     def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
         log_path = str(plugin._log_path)
+        assert captured_cfgs, "configure_logger should be called before pytest executes"
+        assert f"--log-file={log_path}" in pytest_args
+        assert f"--log-file-level={captured_cfgs[-1].level}" in pytest_args
         plugin._results = {
             **{
                 f"tests::pass_{index}": run_test_suite.TestResult(
@@ -85,6 +116,8 @@ def test_main__returns_error_when_success_rate_below_threshold(
     assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.95)
     assert exit_code == 1
     assert "below the required threshold" in caplog.text
+    assert captured_cfgs and captured_cfgs[-1].level == "INFO"
+    assert captured_cfgs[-1].logger_name == "run_test_suite"
 
     report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
     assert report_payload["summary"]["success_rate"] < run_test_suite.SUCCESS_RATE_THRESHOLD
@@ -94,9 +127,35 @@ def test_main__returns_error_when_success_rate_below_threshold(
 def test_main__passes_when_success_rate_meets_threshold(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    log_path = tmp_path / "suite.log"
+    captured_cfgs: list[run_test_suite.LoggerConfig] = []
+
+    def fake_configure_logger(cfg: run_test_suite.LoggerConfig, *_: object, **__: object) -> object:
+        captured_cfgs.append(cfg)
+        return object()
+
+    @contextmanager
+    def fake_setup_cli_logging(script_name: str, log_cfg: run_test_suite.LoggerConfig, *_: object, **__: object):
+        assert script_name == "run_test_suite"
+        stream = io.StringIO()
+        cloned_cfg = run_test_suite.LoggerConfig(
+            level=log_cfg.level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=stream,
+            handlers=list(log_cfg.handlers),
+            logger_name=log_cfg.logger_name,
+        )
+        yield SimpleNamespace(log_path=log_path, log_cfg=cloned_cfg, console_stream=stream)
+
+    monkeypatch.setattr(run_test_suite, "configure_logger", fake_configure_logger)
+    monkeypatch.setattr(run_test_suite, "setup_cli_logging", fake_setup_cli_logging)
+
     def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
         plugin: run_test_suite.JsonReportPlugin = plugins[0]
         log_path = str(plugin._log_path)
+        assert captured_cfgs, "configure_logger should be called before pytest executes"
+        assert f"--log-file={log_path}" in pytest_args
         plugin._results = {
             **{
                 f"tests::pass_{index}": run_test_suite.TestResult(
@@ -121,10 +180,11 @@ def test_main__passes_when_success_rate_meets_threshold(
     monkeypatch.setattr(run_test_suite.pytest, "main", fake_pytest_main)
 
     caplog.set_level(logging.ERROR)
-    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
+    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo", "--verbose"])
 
     assert exit_code == 0
     assert "below the required threshold" not in caplog.text
+    assert captured_cfgs and captured_cfgs[-1].level == "DEBUG"
 
     report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
     assert report_payload["summary"]["success_rate"] >= run_test_suite.SUCCESS_RATE_THRESHOLD

--- a/tests/unit/tools/test_run_tests.py
+++ b/tests/unit/tools/test_run_tests.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from contextlib import contextmanager
+import io
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -39,6 +42,7 @@ def _make_record(nodeid: str, status: str) -> run_tests.TestRecord:
 def test_build_json__stores_fractional_success_rate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _install_fake_cli_logging(monkeypatch, tmp_path)
     monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
 
     collector = run_tests.ReportCollector()
@@ -73,6 +77,7 @@ def test_build_json__stores_fractional_success_rate(
 def test_build_json__uses_full_success_for_empty_suite(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _install_fake_cli_logging(monkeypatch, tmp_path)
     monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
 
     collector = run_tests.ReportCollector()
@@ -95,12 +100,16 @@ def test_build_json__uses_full_success_for_empty_suite(
 def test_main__downgrades_exit_code_when_threshold_not_met(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    log_path, captured_cfgs = _install_fake_cli_logging(monkeypatch, tmp_path)
     monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
 
     def _fake_pytest_main(pytest_args: list[str], plugins: list[object]) -> int:
         assert plugins, "Collector plugin must be provided"
         collector = plugins[0]
         assert isinstance(collector, run_tests.ReportCollector)
+        assert captured_cfgs, "configure_logger should be called before pytest executes"
+        assert f"--log-file={log_path}" in pytest_args
+        assert f"--log-file-level={captured_cfgs[-1].level}" in pytest_args
 
         collector.start_time = 0.0
         collector.end_time = 0.5
@@ -134,3 +143,57 @@ def test_main__downgrades_exit_code_when_threshold_not_met(
 
     markdown_text = markdown_path.read_text(encoding="utf-8")
     assert "Success rate: 50.00%" in markdown_text
+    assert captured_cfgs[-1].level == "INFO"
+
+
+@pytest.mark.unit
+def test_main__verbose_propagates_debug_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_path, captured_cfgs = _install_fake_cli_logging(monkeypatch, tmp_path)
+    monkeypatch.setattr(run_tests, "_git_output", _stub_git_output)
+
+    def _fake_pytest_main(pytest_args: list[str], plugins: list[object]) -> int:
+        assert f"--log-file={log_path}" in pytest_args
+        assert f"--log-file-level=DEBUG" in pytest_args
+        return 0
+
+    monkeypatch.setattr(run_tests.pytest, "main", _fake_pytest_main)
+
+    exit_code = run_tests.main([
+        "--json",
+        str(tmp_path / "report.json"),
+        "--markdown",
+        str(tmp_path / "summary.md"),
+        "--verbose",
+    ])
+
+    assert exit_code == 0
+    assert captured_cfgs and captured_cfgs[-1].level == "DEBUG"
+
+
+def _install_fake_cli_logging(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[Path, list[run_tests.LoggerConfig]]:
+    log_path = tmp_path / "run_tests.log"
+    captured_cfgs: list[run_tests.LoggerConfig] = []
+
+    def _fake_configure(cfg: run_tests.LoggerConfig, *_: object, **__: object) -> object:
+        captured_cfgs.append(cfg)
+        return object()
+
+    @contextmanager
+    def _fake_setup(script_name: str, log_cfg: run_tests.LoggerConfig, *_: object, **__: object):
+        assert script_name == "run_tests"
+        stream = io.StringIO()
+        cloned_cfg = run_tests.LoggerConfig(
+            level=log_cfg.level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=stream,
+            handlers=list(log_cfg.handlers),
+            logger_name=log_cfg.logger_name,
+        )
+        yield SimpleNamespace(log_path=log_path, log_cfg=cloned_cfg, console_stream=stream)
+
+    monkeypatch.setattr(run_tests, "configure_logger", _fake_configure)
+    monkeypatch.setattr(run_tests, "setup_cli_logging", _fake_setup)
+    return log_path, captured_cfgs


### PR DESCRIPTION
## Summary
- configure `scripts/run_test_suite.py` to use the shared CLI logging helpers and expose a `--verbose` toggle
- apply the same logging flow to `tests/run_tests.py`, forwarding the log file path to pytest and documenting the behaviour
- extend the unit tests for both wrappers to cover the logging plumbing and verbose mode

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py tests/unit/tools/test_run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e414707f0483249f921064721411b2