### PR TITLE
Add CLI metadata helper and reuse in scripts

### DIFF
--- a/library/cli/metadata.py
+++ b/library/cli/metadata.py
@@ -1,0 +1,50 @@
+"""Helper utilities shared across CLI metadata consumers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from library.config import ConfigMetadata
+
+DEFAULT_OPTION_SOURCE = "unknown"
+"""Default provenance value used when metadata is unavailable."""
+
+OPTION_UNSET = object()
+"""Sentinel value identifying parameters without an explicit override."""
+
+
+def prepare_option(
+    metadata: ConfigMetadata | None,
+    *,
+    argument: str | None = None,
+    path: str | None = None,
+    value: Any = OPTION_UNSET,
+    default_source: str = DEFAULT_OPTION_SOURCE,
+    default_detail: str | None = None,
+) -> dict[str, Any]:
+    """Return metadata entry for an option, handling missing configuration."""
+
+    if metadata is not None:
+        if value is OPTION_UNSET:
+            return metadata.option(
+                argument=argument,
+                path=path,
+                default_source=default_source,
+                default_detail=default_detail,
+            )
+        return metadata.option(
+            argument=argument,
+            path=path,
+            value=value,
+            default_source=default_source,
+            default_detail=default_detail,
+        )
+
+    actual = None if value is OPTION_UNSET else value
+    entry: dict[str, Any] = {"value": actual, "source": default_source}
+    if default_detail is not None:
+        entry["detail"] = default_detail
+    return entry
+
+
+__all__ = ["DEFAULT_OPTION_SOURCE", "OPTION_UNSET", "prepare_option"]

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -47,6 +47,7 @@ from library.cli import (
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command, run_pipeline
 from library.cli.logging import setup_cli_logging
+from library.cli.metadata import prepare_option
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.pipelines.common import add_pipeline_metadata
@@ -67,8 +68,6 @@ __all__ = ["ap", "configure_logger", "main", "run", "run_chembl"]
 
 DEFAULT_INPUT_NAME = "assay.csv"
 DEFAULT_OUTPUT_STEM = "assays"
-
-_OPTION_UNSET = object()
 
 # Backwards compatibility: legacy configs referenced the private
 # ``_ASSAY_MAX_IDS_PER_REQUEST`` constant before it was renamed to
@@ -149,35 +148,6 @@ def remove_assay_output_columns(df: pd.DataFrame) -> pd.DataFrame:
     return cleaned
 
 
-def _option(
-    metadata: ConfigMetadata | None,
-    *,
-    argument: str | None = None,
-    path: str | None = None,
-    value: object = _OPTION_UNSET,
-    default_source: str = "unknown",
-    default_detail: str | None = None,
-) -> dict[str, object]:
-    if metadata is not None:
-        if value is _OPTION_UNSET:
-            return metadata.option(
-                argument=argument,
-                path=path,
-                default_source=default_source,
-                default_detail=default_detail,
-            )
-        return metadata.option(
-            argument=argument,
-            path=path,
-            value=value,
-            default_source=default_source,
-            default_detail=default_detail,
-        )
-    actual = None if value is _OPTION_UNSET else value
-    entry: dict[str, object] = {"value": actual, "source": default_source}
-    if default_detail is not None:
-        entry["detail"] = default_detail
-    return entry
 
 
 def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
@@ -241,31 +211,31 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     output_source = "cli" if getattr(args, "final_out", None) else "derived"
     logger.info(
         "assay_pipeline_start",
-        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
-        output=_option(
+        input=prepare_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=prepare_option(
             metadata_obj,
             value=str(output_path),
             default_source=output_source,
         ),
-        limit=_option(
+        limit=prepare_option(
             metadata_obj,
             argument="limit",
             path="sources.chembl.pipelines.assay.limit",
             value=limit,
         ),
-        offset=_option(
+        offset=prepare_option(
             metadata_obj,
             argument="offset",
             path="sources.chembl.pipelines.assay.offset",
             value=offset,
         ),
-        batch_size=_option(
+        batch_size=prepare_option(
             metadata_obj,
             argument="batch_size",
             path="sources.chembl.pipelines.assay.batch_size",
             value=cfg.assay.batch_size,
         ),
-        timeout=_option(
+        timeout=prepare_option(
             metadata_obj,
             argument="timeout",
             path="sources.chembl.pipelines.assay.timeout",

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -95,6 +95,7 @@ from library.cli import (
     prepare_io_paths,
 )
 from library.cli.logging import setup_cli_logging
+from library.cli.metadata import prepare_option
 from library.cli.utils import run_cli_command
 from library.config import (
     Config,
@@ -129,8 +130,6 @@ from library.schemas import DocumentsSchema, normalize_documents
 DEFAULT_INPUT_NAME = "document.csv"
 DEFAULT_OUTPUT_STEM = "documents"
 
-_OPTION_UNSET = object()
-
 
 class _FallbackPathAction(argparse.Action):
     """Store fallback DOI CSV path under both legacy and new attribute names."""
@@ -146,35 +145,6 @@ class _FallbackPathAction(argparse.Action):
         setattr(namespace, "fallback_doi_csv", values)
 
 
-def _option(
-    metadata: ConfigMetadata | None,
-    *,
-    argument: str | None = None,
-    path: str | None = None,
-    value: object = _OPTION_UNSET,
-    default_source: str = "unknown",
-    default_detail: str | None = None,
-) -> dict[str, object]:
-    if metadata is not None:
-        if value is _OPTION_UNSET:
-            return metadata.option(
-                argument=argument,
-                path=path,
-                default_source=default_source,
-                default_detail=default_detail,
-            )
-        return metadata.option(
-            argument=argument,
-            path=path,
-            value=value,
-            default_source=default_source,
-            default_detail=default_detail,
-        )
-    actual = None if value is _OPTION_UNSET else value
-    entry: dict[str, object] = {"value": actual, "source": default_source}
-    if default_detail is not None:
-        entry["detail"] = default_detail
-    return entry
 _EXPORT_COLUMNS = [
     "PubMed.PMID",
     "PubMed.DOI",
@@ -873,21 +843,21 @@ def run_pubmed(
         fallback_doi_enabled=fallback_enabled,
         fallback_doi_overwrite=fallback_overwrite,
         fallback_doi_path=fallback_path_text,
-        fallback_doi=_option(
+        fallback_doi=prepare_option(
             metadata_obj,
             argument="fallback_doi_enabled",
             path="document.pubmed.fallback_doi_enabled",
             value=fallback_enabled,
             default_source="cli",
         ),
-        fallback_doi_overwrite_meta=_option(
+        fallback_doi_overwrite_meta=prepare_option(
             metadata_obj,
             argument="fallback_doi_overwrite",
             path="document.pubmed.fallback_doi_overwrite",
             value=fallback_overwrite,
             default_source="cli",
         ),
-        fallback_doi_path_meta=_option(
+        fallback_doi_path_meta=prepare_option(
             metadata_obj,
             argument="fallback_doi_path",
             path="document.pubmed.fallback_doi_path",
@@ -1098,32 +1068,32 @@ def run_chembl(
     service = pipeline or DocumentPipeline(cfg)
     logger.info(
         "document_chembl_start",
-        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
-        output=_option(
+        input=prepare_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=prepare_option(
             metadata_obj,
             value=str(output_path),
             default_source=output_source,
         ),
-        limit=_option(
+        limit=prepare_option(
             metadata_obj,
             argument="limit",
             path="sources.chembl.pipelines.document.chembl.limit",
             value=limit,
         ),
-        offset=_option(
+        offset=prepare_option(
             metadata_obj,
             argument="offset",
             path="sources.chembl.pipelines.document.chembl.offset",
             value=offset,
             default_source="cli",
         ),
-        chunk_size=_option(
+        chunk_size=prepare_option(
             metadata_obj,
             argument="chunk_size",
             path="sources.chembl.pipelines.document.chembl.chunk_size",
             value=chunk_size,
         ),
-        timeout=_option(
+        timeout=prepare_option(
             metadata_obj,
             argument="timeout",
             path="sources.chembl.pipelines.document.chembl.timeout",

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -23,39 +23,6 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_NAME = "testitem.csv"
 DEFAULT_OUTPUT_STEM = "testitems"
 
-_OPTION_UNSET = object()
-
-
-def _option(
-    metadata: ConfigMetadata | None,
-    *,
-    argument: str | None = None,
-    path: str | None = None,
-    value: object = _OPTION_UNSET,
-    default_source: str = "unknown",
-    default_detail: str | None = None,
-) -> dict[str, object]:
-    if metadata is not None:
-        if value is _OPTION_UNSET:
-            return metadata.option(
-                argument=argument,
-                path=path,
-                default_source=default_source,
-                default_detail=default_detail,
-            )
-        return metadata.option(
-            argument=argument,
-            path=path,
-            value=value,
-            default_source=default_source,
-            default_detail=default_detail,
-        )
-    actual = None if value is _OPTION_UNSET else value
-    entry: dict[str, object] = {"value": actual, "source": default_source}
-    if default_detail is not None:
-        entry["detail"] = default_detail
-    return entry
-
 
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -74,6 +41,7 @@ from library.cli import LoggerConfig, ConfigMetadata
 from library.cli import build_parser as base_parser
 from library.cli_utils import run_cli_command
 from library.cli.logging import setup_cli_logging
+from library.cli.metadata import prepare_option
 from library.config import (
     ApiCfg,
     Config,
@@ -636,37 +604,37 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     offset_value = getattr(args, "offset", getattr(cfg.testitem, "offset", None))
     logger.info(
         "testitem_pipeline_start",
-        input=_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
-        output=_option(
+        input=prepare_option(metadata_obj, value=str(args.input_csv), default_source="cli"),
+        output=prepare_option(
             metadata_obj,
             value=str(output_path),
             default_source=output_source,
         ),
-        limit=_option(
+        limit=prepare_option(
             metadata_obj,
             argument="limit",
             path="sources.chembl.pipelines.testitem.limit",
             value=limit_value,
         ),
-        offset=_option(
+        offset=prepare_option(
             metadata_obj,
             argument="offset",
             path="sources.chembl.pipelines.testitem.offset",
             value=offset_value,
         ),
-        batch_size=_option(
+        batch_size=prepare_option(
             metadata_obj,
             argument="batch_size",
             path="sources.chembl.pipelines.testitem.batch_size",
             value=getattr(cfg.testitem, "batch_size", None),
         ),
-        timeout=_option(
+        timeout=prepare_option(
             metadata_obj,
             argument="timeout",
             path="sources.chembl.pipelines.testitem.timeout",
             value=getattr(cfg.testitem, "timeout", None),
         ),
-        column=_option(
+        column=prepare_option(
             metadata_obj,
             argument="column",
             path="sources.chembl.pipelines.testitem.column",

--- a/tests/unit/test_cli_metadata.py
+++ b/tests/unit/test_cli_metadata.py
@@ -1,0 +1,52 @@
+"""Unit tests for :mod:`library.cli.metadata`."""
+
+from __future__ import annotations
+
+import pytest
+
+from library.cli.metadata import DEFAULT_OPTION_SOURCE, prepare_option
+from library.config import ConfigMetadata, ConfigSource
+
+
+@pytest.mark.unit
+def test_prepare_option__metadata_absent_uses_defaults() -> None:
+    """Return placeholder metadata when the config snapshot is unavailable."""
+
+    result = prepare_option(None)
+
+    assert result == {"value": None, "source": DEFAULT_OPTION_SOURCE}
+
+
+@pytest.mark.unit
+def test_prepare_option__metadata_absent_applies_value_and_detail() -> None:
+    """Include override information when no metadata object is provided."""
+
+    result = prepare_option(
+        None,
+        value="example",
+        default_source="cli",
+        default_detail="runtime",
+    )
+
+    assert result == {"value": "example", "source": "cli", "detail": "runtime"}
+
+
+@pytest.mark.unit
+def test_prepare_option__metadata_present_respects_snapshot() -> None:
+    """Reuse existing metadata entries and override the value when requested."""
+
+    metadata = ConfigMetadata(
+        snapshot={
+            "assay": {
+                "limit": {"value": 50, "source": "config", "detail": "config.yaml"}
+            }
+        },
+        sources={("assay", "limit"): ConfigSource("config", "config.yaml")},
+        cli_paths={"limit": ("assay", "limit")},
+    )
+
+    default_result = prepare_option(metadata, argument="limit")
+    override_result = prepare_option(metadata, argument="limit", value=100)
+
+    assert default_result == {"value": 50, "source": "config", "detail": "config.yaml"}
+    assert override_result == {"value": 100, "source": "config", "detail": "config.yaml"}


### PR DESCRIPTION
## Summary
- add a shared `prepare_option` helper and supporting constants for CLI metadata handling
- refactor document, assay, and testitem scripts to use the common helper
- add unit coverage for the helper to verify default behaviour and overrides

## Testing
- pytest tests/unit/test_cli_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68e4153381608324b1e54d42c328e105