### PR TITLE
feat: add declarative pipeline registry and CLI overrides

### DIFF
--- a/library/pipelines/registry.py
+++ b/library/pipelines/registry.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence, TypedDict, cast
+
+import yaml
+
+
+class PipelineStepFlags(TypedDict, total=False):
+    """Optional capability flags supported by a pipeline step."""
+
+    dry_run: bool
+
+
+class PipelineStepDefinition(TypedDict, total=False):
+    """Declarative description of a pipeline stage."""
+
+    name: str
+    callable: str
+    input: str
+    output: str
+    subcommand: str | None
+    output_flag: str
+    extra_args: list[str]
+    flags: PipelineStepFlags
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """Runtime representation of a pipeline stage."""
+
+    name: str
+    main: Callable[[Sequence[str] | None], int]
+    input_filename: str
+    output_stem: str
+    subcommand: str | None = None
+    output_flag: str = "--final-out"
+    extra_args: tuple[str, ...] = ()
+    supports_dry_run: bool = False
+
+    def build_arguments(self, cfg: Any, output_path: Path | None = None) -> list[str]:
+        """Return CLI arguments forwarded to the wrapped ``main`` function."""
+
+        input_csv = cfg.input_path(self.name)
+        output_csv = output_path if output_path is not None else cfg.output_path(self.name)
+        args = ["--config", str(cfg.config_path), "--input", str(input_csv)]
+        args.extend([self.output_flag, str(output_csv)])
+        args.extend(["--log-level", cfg.log_level])
+        limit = getattr(cfg, "limit", None)
+        if limit is not None:
+            args.extend(["--limit", str(limit)])
+        if getattr(cfg, "force", False):
+            args.append("--force")
+        if getattr(cfg, "skip_existing", False):
+            args.append("--skip-existing")
+        if getattr(cfg, "dry_run", False) and self.supports_dry_run:
+            args.append("--dry-run")
+        if self.extra_args:
+            args = [*self.extra_args, *args]
+        if self.subcommand is not None:
+            return [self.subcommand, *args]
+        return args
+
+    def expected_output(self, cfg: Any) -> Path:
+        """Return the path where the pipeline will create its CSV artefact."""
+
+        return cfg.output_path(self.name)
+
+    def required_input(self, cfg: Any) -> Path:
+        """Return the CSV that the pipeline expects as input."""
+
+        return cfg.input_path(self.name)
+
+_DEFAULT_DEFINITIONS: tuple[PipelineStepDefinition, ...] = (
+    {
+        "name": "document",
+        "callable": "scripts.get_document_data:main",
+        "input": "document.csv",
+        "output": "documents",
+        "extra_args": ["--mode", "all"],
+    },
+    {
+        "name": "target",
+        "callable": "scripts.get_target_data:main",
+        "input": "target.csv",
+        "output": "targets",
+        "subcommand": "all",
+        "output_flag": "--final-out",
+    },
+    {
+        "name": "assay",
+        "callable": "scripts.get_assay_data:main",
+        "input": "assay.csv",
+        "output": "assays",
+    },
+    {
+        "name": "testitem",
+        "callable": "scripts.get_testitem_data:main",
+        "input": "testitem.csv",
+        "output": "testitems",
+    },
+    {
+        "name": "activity",
+        "callable": "scripts.get_activity_data:main",
+        "input": "activity.csv",
+        "output": "activities",
+        "flags": {"dry_run": True},
+    },
+)
+
+
+def load_pipeline_registry(
+    source: Path | str | Iterable[PipelineStepDefinition] | Mapping[str, object] | None = None,
+) -> tuple[PipelineStep, ...]:
+    """Return pipeline steps loaded from ``source`` or the default registry."""
+
+    definitions: Iterable[PipelineStepDefinition]
+    if source is None:
+        definitions = _DEFAULT_DEFINITIONS
+    elif isinstance(source, (str, Path)):
+        path = Path(source)
+        if not path.exists():
+            raise FileNotFoundError(f"registry file not found: {path}")
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        definitions = _coerce_definitions(data)
+    elif isinstance(source, Mapping):
+        definitions = _coerce_definitions(source)
+    else:
+        definitions = source
+    return tuple(_build_step(entry) for entry in definitions)
+
+
+def _coerce_definitions(data: object) -> Iterable[PipelineStepDefinition]:
+    if data is None:
+        return ()
+    if isinstance(data, Mapping):
+        pipelines = data.get("pipelines")
+        if pipelines is None:
+            raise ValueError("registry mapping must contain a 'pipelines' key")
+        data = pipelines
+    if not isinstance(data, Iterable) or isinstance(data, (str, bytes)):
+        raise TypeError("registry definitions must be an iterable of mappings")
+    definitions: list[PipelineStepDefinition] = []
+    for entry in data:
+        if not isinstance(entry, Mapping):
+            raise TypeError("each pipeline definition must be a mapping")
+        definitions.append(cast(PipelineStepDefinition, dict(entry)))
+    return definitions
+
+
+def _build_step(entry: PipelineStepDefinition) -> PipelineStep:
+    name = entry.get("name")
+    if not name:
+        raise ValueError("pipeline definition missing 'name'")
+    dotted = entry.get("callable")
+    if not dotted:
+        raise ValueError(f"pipeline '{name}' missing 'callable'")
+    main = _resolve_callable(dotted)
+    input_filename = entry.get("input") or f"{name}.csv"
+    output_stem = entry.get("output") or name
+    subcommand = entry.get("subcommand")
+    output_flag = entry.get("output_flag") or "--final-out"
+    extra_args = tuple(entry.get("extra_args", ()))
+    flags = entry.get("flags", {})
+    supports_dry_run = bool(flags.get("dry_run", False))
+    return PipelineStep(
+        name=name,
+        main=main,
+        input_filename=input_filename,
+        output_stem=output_stem,
+        subcommand=subcommand,
+        output_flag=output_flag,
+        extra_args=extra_args,
+        supports_dry_run=supports_dry_run,
+    )
+
+
+def _resolve_callable(dotted: str) -> Callable[[Sequence[str] | None], int]:
+    module_path, _, attribute = dotted.partition(":")
+    if not module_path or not attribute:
+        raise ValueError(f"invalid callable reference: {dotted}")
+    module = import_module(module_path)
+    target = module
+    for part in attribute.split("."):
+        if not hasattr(target, part):
+            raise AttributeError(f"callable '{dotted}' not found")
+        target = getattr(target, part)
+    if not callable(target):
+        raise TypeError(f"resolved object for '{dotted}' is not callable")
+    return target
+
+
+__all__ = [
+    "PipelineStep",
+    "PipelineStepDefinition",
+    "PipelineStepFlags",
+    "load_pipeline_registry",
+]

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -27,11 +27,11 @@ import sys
 import time
 import uuid
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Callable, Iterable, IO, Sequence
+from typing import Iterable, IO, Mapping, Sequence
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -46,39 +46,29 @@ from library.utils.bootstrap import ensure_project_root
 if __package__ in {None, ""}:
     ensure_project_root()
 
-from scripts import (
-    get_activity_data,
-    get_assay_data,
-    get_document_data,
-    get_target_data,
-    get_testitem_data,
-)
-
 from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
 from library.integration.molecule_catalog import load_parent_catalog
+from library.pipelines.registry import PipelineStep, load_pipeline_registry
 from library.utils.config import DEFAULT_CONFIG_PATH
 
 
 _LOGGER: Logger = configure_logger(LoggerConfig())
 
-_DEFAULT_INPUT_FILES = {
-    "document": "document.csv",
-    "target": "target.csv",
-    "assay": "assay.csv",
-    "testitem": "testitem.csv",
-    "activity": "activity.csv",
+DEFAULT_PIPELINE_STEPS: tuple[PipelineStep, ...] = load_pipeline_registry()
+DEFAULT_INPUT_FILES: Mapping[str, str] = {
+    step.name: step.input_filename for step in DEFAULT_PIPELINE_STEPS
+}
+DEFAULT_OUTPUT_STEMS: Mapping[str, str] = {
+    step.name: step.output_stem for step in DEFAULT_PIPELINE_STEPS
 }
 
-_DEFAULT_OUTPUT_STEMS = {
-    "document": "documents",
-    "target": "targets",
-    "assay": "assays",
-    "testitem": "testitems",
-    "activity": "activities",
-}
+# Backwards compatibility for existing callers/tests that patch the legacy names.
+_PIPELINE_STEPS = DEFAULT_PIPELINE_STEPS
+_DEFAULT_INPUT_FILES = DEFAULT_INPUT_FILES
+_DEFAULT_OUTPUT_STEMS = DEFAULT_OUTPUT_STEMS
 
 
 _UNLINK_MAX_ATTEMPTS = 5
@@ -100,86 +90,21 @@ class PipelineRunConfig:
     force: bool
     skip_existing: bool
     dry_run: bool
+    input_files: Mapping[str, str]
+    output_stems: Mapping[str, str]
 
     def input_path(self, name: str) -> Path:
         """Return the fully resolved path for ``name`` in the input directory."""
 
-        filename = _DEFAULT_INPUT_FILES[name]
+        filename = self.input_files[name]
         return self.input_dir / filename
 
     def output_path(self, name: str) -> Path:
         """Return the fully resolved path for ``name`` in the output directory."""
 
-        stem = _DEFAULT_OUTPUT_STEMS[name]
+        stem = self.output_stems[name]
         filename = f"output.{stem}_{self.date_prefix}.csv"
         return self.output_dir / filename
-
-
-@dataclass(frozen=True)
-class PipelineStep:
-    """Describe a single pipeline invocation."""
-
-    name: str
-    main: Callable[[Sequence[str] | None], int]
-    subcommand: str | None
-    extra_args: tuple[str, ...] = ()
-    output_flag: str = "--final-out"
-    supports_dry_run: bool = False
-
-    def build_arguments(
-        self, cfg: PipelineRunConfig, output_path: Path | None = None
-    ) -> list[str]:
-        """Return CLI arguments forwarded to the wrapped ``main`` function."""
-
-        input_csv = cfg.input_path(self.name)
-        output_csv = (
-            output_path if output_path is not None else cfg.output_path(self.name)
-        )
-        args = ["--config", str(cfg.config_path), "--input", str(input_csv)]
-        args.extend([self.output_flag, str(output_csv)])
-        args.extend(["--log-level", cfg.log_level])
-        if cfg.limit is not None:
-            args.extend(["--limit", str(cfg.limit)])
-        if cfg.force:
-            args.append("--force")
-        if cfg.skip_existing:
-            args.append("--skip-existing")
-        if cfg.dry_run and self.supports_dry_run:
-            args.append("--dry-run")
-        if self.extra_args:
-            args = [*self.extra_args, *args]
-        if self.subcommand is not None:
-            return [self.subcommand, *args]
-        return args
-
-    def expected_output(self, cfg: PipelineRunConfig) -> Path:
-        """Return the path where the pipeline will create its CSV artefact."""
-
-        return cfg.output_path(self.name)
-
-    def required_input(self, cfg: PipelineRunConfig) -> Path:
-        """Return the CSV that the pipeline expects as input."""
-
-        return cfg.input_path(self.name)
-
-
-_PIPELINE_STEPS: tuple[PipelineStep, ...] = (
-    PipelineStep(
-        "document",
-        get_document_data.main,
-        None,
-        extra_args=("--mode", "all"),
-    ),
-    PipelineStep(
-        "target",
-        get_target_data.main,
-        "all",
-        output_flag="--final-out",
-    ),
-    PipelineStep("assay", get_assay_data.main, None),
-    PipelineStep("testitem", get_testitem_data.main, None),
-    PipelineStep("activity", get_activity_data.main, None, supports_dry_run=True),
-)
 
 
 def _resolve_path(base: Path, candidate: Path) -> Path:
@@ -189,6 +114,84 @@ def _resolve_path(base: Path, candidate: Path) -> Path:
     if expanded.is_absolute():
         return expanded.resolve()
     return (base / expanded).resolve()
+
+
+def _parse_overrides(
+    values: Sequence[str] | None,
+    *,
+    allow_empty_value: bool = False,
+) -> dict[str, str]:
+    """Parse ``STEP=value`` pairs from the CLI into a dictionary."""
+
+    overrides: dict[str, str] = {}
+    if not values:
+        return overrides
+    for raw in values:
+        if "=" not in raw:
+            raise ValueError(f"invalid override format: {raw!r}")
+        name, value = raw.split("=", 1)
+        key = name.strip()
+        if not key:
+            raise ValueError(f"override missing step name: {raw!r}")
+        if not value and not allow_empty_value:
+            raise ValueError(f"override missing value for step {key!r}")
+        overrides[key] = value
+    return overrides
+
+
+def _resolve_pipeline_steps(args: argparse.Namespace | None = None) -> tuple[PipelineStep, ...]:
+    """Load pipeline definitions applying CLI overrides when provided."""
+
+    registry_source = getattr(args, "pipeline_registry", None)
+    steps = (
+        load_pipeline_registry(registry_source)
+        if registry_source is not None
+        else DEFAULT_PIPELINE_STEPS
+    )
+    steps = tuple(steps)
+
+    input_overrides = _parse_overrides(getattr(args, "override_input", None))
+    output_overrides = _parse_overrides(
+        getattr(args, "override_output_stem", None)
+    )
+    subcommand_overrides = _parse_overrides(
+        getattr(args, "override_subcommand", None), allow_empty_value=True
+    )
+
+    if not input_overrides and not output_overrides and not subcommand_overrides:
+        return steps
+
+    known_steps = {step.name for step in steps}
+    _validate_override_keys(input_overrides, known_steps, "input")
+    _validate_override_keys(output_overrides, known_steps, "output")
+    _validate_override_keys(subcommand_overrides, known_steps, "subcommand")
+
+    mutated: list[PipelineStep] = []
+    for step in steps:
+        updated = step
+        if step.name in input_overrides:
+            updated = replace(updated, input_filename=input_overrides[step.name])
+        if step.name in output_overrides:
+            updated = replace(updated, output_stem=output_overrides[step.name])
+        if step.name in subcommand_overrides:
+            raw_value = subcommand_overrides[step.name]
+            new_subcommand = raw_value if raw_value else None
+            updated = replace(updated, subcommand=new_subcommand)
+        mutated.append(updated)
+    return tuple(mutated)
+
+
+def _validate_override_keys(
+    overrides: Mapping[str, str],
+    known: set[str],
+    kind: str,
+) -> None:
+    """Ensure override keys reference known steps."""
+
+    unknown = sorted(set(overrides) - known)
+    if unknown:
+        joined = ", ".join(unknown)
+        raise ValueError(f"unknown {kind} override for step(s): {joined}")
 
 
 def _configure_logging(
@@ -295,11 +298,44 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
             "including output directory creation"
         ),
     )
+    parser.add_argument(
+        "--pipeline-registry",
+        type=Path,
+        default=None,
+        help="Optional YAML file describing pipeline step definitions",
+    )
+    parser.add_argument(
+        "--override-input",
+        action="append",
+        metavar="STEP=FILENAME",
+        default=[],
+        help="Override the input CSV filename for a pipeline step",
+    )
+    parser.add_argument(
+        "--override-output-stem",
+        action="append",
+        metavar="STEP=STEM",
+        default=[],
+        help="Override the output filename stem for a pipeline step",
+    )
+    parser.add_argument(
+        "--override-subcommand",
+        action="append",
+        metavar="STEP=SUBCOMMAND",
+        default=[],
+        help="Override the CLI subcommand used to invoke a pipeline step",
+    )
     return parser.parse_args(argv)
 
 
-def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
+def _prepare_config(
+    args: argparse.Namespace, steps: Sequence[PipelineStep] | None = None
+) -> PipelineRunConfig:
     """Validate CLI inputs and construct :class:`PipelineRunConfig`."""
+
+    effective_steps = tuple(DEFAULT_PIPELINE_STEPS if steps is None else steps)
+    input_files = {step.name: step.input_filename for step in effective_steps}
+    output_stems = {step.name: step.output_stem for step in effective_steps}
 
     base_path = args.base_path.expanduser().resolve()
     input_dir = _resolve_path(base_path, args.input_dir)
@@ -333,6 +369,8 @@ def _prepare_config(args: argparse.Namespace) -> PipelineRunConfig:
         force=args.force,
         skip_existing=args.skip_existing,
         dry_run=dry_run,
+        input_files=input_files,
+        output_stems=output_stems,
     )
 
 
@@ -821,12 +859,15 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
     _LOGGER.info("parent_catalog_warm_done", elapsed=elapsed, **log_kwargs)
 
 
-def run_pipeline(cfg: PipelineRunConfig) -> int:
+def run_pipeline(
+    cfg: PipelineRunConfig, steps: Sequence[PipelineStep] | None = None
+) -> int:
     """Execute all configured steps and return the resulting exit status."""
 
+    effective_steps = tuple(DEFAULT_PIPELINE_STEPS if steps is None else steps)
     overall_status = 0
     _LOGGER.info("pipeline_start", stage="pipeline")
-    for step in _PIPELINE_STEPS:
+    for step in effective_steps:
         _LOGGER.info("step_start", step=step.name)
         if cfg.dry_run:
             _LOGGER.info("step_skip_dry_run", step=step.name)
@@ -924,16 +965,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         _LOGGER = logger
 
         try:
-            cfg = _prepare_config(args)
-        except (FileNotFoundError, OSError, ValueError) as exc:
-            _LOGGER.error("configuration_error", error=str(exc))
+            steps = _resolve_pipeline_steps(args)
+        except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
+            _LOGGER.error("registry_error", error=str(exc))
             status = 1
         else:
-            status = run_pipeline(cfg)
-            if status != 0:
-                _LOGGER.error("workflow_failed", exit_code=status)
+            try:
+                cfg = _prepare_config(args, steps)
+            except (FileNotFoundError, OSError, ValueError) as exc:
+                _LOGGER.error("configuration_error", error=str(exc))
+                status = 1
             else:
-                _LOGGER.info("workflow_succeeded")
+                status = run_pipeline(cfg, steps=steps)
+                if status != 0:
+                    _LOGGER.error("workflow_failed", exit_code=status)
+                else:
+                    _LOGGER.info("workflow_succeeded")
 
     return status
 

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -283,31 +283,34 @@ def test_get_data_end_to_end__miniature_pipeline(
     report_writer = _make_report_writer(5)
     stub_steps = (
         get_data.PipelineStep(
-            "document",
-            _build_stub_pipeline(
+            name="document",
+            main=_build_stub_pipeline(
                 "document",
                 "document_chembl_id",
                 ["document_chembl_id", "title", "pubmed_id"],
                 _documents_transform,
                 accept_mode=True,
             ),
-            None,
+            input_filename="document.csv",
+            output_stem="documents",
             extra_args=("--mode", "all"),
         ),
         get_data.PipelineStep(
-            "target",
-            _build_stub_pipeline(
+            name="target",
+            main=_build_stub_pipeline(
                 "target",
                 "target_chembl_id",
                 ["target_chembl_id", "target_name", "organism"],
                 _targets_transform,
                 accept_subcommand=True,
             ),
-            "all",
+            input_filename="target.csv",
+            output_stem="targets",
+            subcommand="all",
         ),
         get_data.PipelineStep(
-            "assay",
-            _build_stub_pipeline(
+            name="assay",
+            main=_build_stub_pipeline(
                 "assay",
                 "assay_chembl_id",
                 [
@@ -318,21 +321,23 @@ def test_get_data_end_to_end__miniature_pipeline(
                 ],
                 _assays_transform,
             ),
-            None,
+            input_filename="assay.csv",
+            output_stem="assays",
         ),
         get_data.PipelineStep(
-            "testitem",
-            _build_stub_pipeline(
+            name="testitem",
+            main=_build_stub_pipeline(
                 "testitem",
                 "molecule_chembl_id",
                 ["molecule_chembl_id", "preferred_name"],
                 _testitems_transform,
             ),
-            None,
+            input_filename="testitem.csv",
+            output_stem="testitems",
         ),
         get_data.PipelineStep(
-            "activity",
-            _build_stub_pipeline(
+            name="activity",
+            main=_build_stub_pipeline(
                 "activity",
                 "activity_id",
                 [
@@ -346,10 +351,11 @@ def test_get_data_end_to_end__miniature_pipeline(
                 optional_columns=["force_failure"],
                 post_process=report_writer,
             ),
-            None,
+            input_filename="activity.csv",
+            output_stem="activities",
         ),
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", stub_steps, raising=False)
+    monkeypatch.setattr(get_data, "_resolve_pipeline_steps", lambda _: stub_steps)
 
     date_prefix = "20240102"
 
@@ -405,7 +411,7 @@ def test_get_data_end_to_end__miniature_pipeline(
         "activity": "activity_id",
     }
     output_paths: dict[str, Path] = {}
-    for step_name, stem in get_data._DEFAULT_OUTPUT_STEMS.items():
+    for step_name, stem in get_data.DEFAULT_OUTPUT_STEMS.items():
         final_path = output_dir / f"output.{stem}_{date_prefix}.csv"
         output_paths[step_name] = final_path
         assert final_path.exists(), f"expected output for {step_name} missing"
@@ -479,7 +485,7 @@ def test_get_data_end_to_end__miniature_pipeline(
     assert new_exit_code == 0
     new_log_path = log_dir / f"get_data_{new_date_prefix}.log"
     assert new_log_path.exists()
-    for step_name, stem in get_data._DEFAULT_OUTPUT_STEMS.items():
+    for step_name, stem in get_data.DEFAULT_OUTPUT_STEMS.items():
         new_path = output_dir / f"output.{stem}_{new_date_prefix}.csv"
         assert new_path.exists()
 

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -58,6 +58,8 @@ def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
     output_dir.mkdir()
     config_path = base_path / "config.yaml"
     config_path.write_text("io:\n  csv_sep: ','\n", encoding="utf-8")
+    input_files = dict(get_data.DEFAULT_INPUT_FILES)
+    output_stems = dict(get_data.DEFAULT_OUTPUT_STEMS)
     return get_data.PipelineRunConfig(
         base_path=base_path,
         input_dir=input_dir,
@@ -69,6 +71,8 @@ def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
         force=False,
         skip_existing=False,
         dry_run=False,
+        input_files=input_files,
+        output_stems=output_stems,
     )
 
 
@@ -99,23 +103,24 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
         return 0
 
     step = get_data.PipelineStep(
-        "document",
-        _build_stub_step(
+        name="document",
+        main=_build_stub_step(
             required_columns=["document_chembl_id", "title", "pubmed_id"],
             key_column="document_chembl_id",
             on_execute=_on_execute,
         ),
-        None,
+        input_filename="document.csv",
+        output_stem="documents",
     )
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
-    status = get_data.run_pipeline(cfg)
+    steps = (step,)
+    status = get_data.run_pipeline(cfg, steps=steps)
     assert status == 0
     assert output_payload, "expected pipeline to write output"
     output_frame = output_payload[0]
@@ -128,7 +133,7 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
     stream.truncate(0)
     stream.seek(0)
 
-    status_malformed = get_data.run_pipeline(cfg)
+    status_malformed = get_data.run_pipeline(cfg, steps=steps)
     assert status_malformed == 1
     logs = parse_log_lines(stream.getvalue())
     assert any(record.get("event") == "schema_mismatch" for record in logs)
@@ -156,35 +161,36 @@ def test_pipeline_subset__skip_existing_and_force(tmp_path: Path, monkeypatch: p
         return 0
 
     step = get_data.PipelineStep(
-        "target",
-        _build_stub_step(
+        name="target",
+        main=_build_stub_step(
             required_columns=["target_chembl_id", "name", "organism"],
             key_column="target_chembl_id",
             on_execute=_on_execute,
         ),
-        None,
+        input_filename="target.csv",
+        output_stem="targets",
     )
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
-    status_first = get_data.run_pipeline(cfg)
+    steps = (step,)
+    status_first = get_data.run_pipeline(cfg, steps=steps)
     assert status_first == 0
     assert executions == [2]
 
     cfg_skip = replace(cfg, skip_existing=True)
-    status_skip = get_data.run_pipeline(cfg_skip)
+    status_skip = get_data.run_pipeline(cfg_skip, steps=steps)
     assert status_skip == 0
     assert executions == [2]
     logs = parse_log_lines(stream.getvalue())
     assert any(record.get("event") == "step_skipped_existing" for record in logs)
 
     cfg_force = replace(cfg, skip_existing=True, force=True)
-    status_force = get_data.run_pipeline(cfg_force)
+    status_force = get_data.run_pipeline(cfg_force, steps=steps)
     assert status_force == 0
     assert executions == [2, 2]
 
@@ -241,8 +247,8 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
         return 0
 
     step = get_data.PipelineStep(
-        "assay",
-        _build_stub_step(
+        name="assay",
+        main=_build_stub_step(
             required_columns=[
                 "assay_chembl_id",
                 "target_chembl_id",
@@ -252,17 +258,18 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
             key_column="assay_chembl_id",
             on_execute=_on_execute,
         ),
-        None,
+        input_filename="assay.csv",
+        output_stem="assays",
     )
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
-    first_status = get_data.run_pipeline(cfg)
+    steps = (step,)
+    first_status = get_data.run_pipeline(cfg, steps=steps)
     assert first_status == 1
     working = get_data._temporary_output_path(step.expected_output(cfg))
     assert not working.exists()
@@ -270,7 +277,7 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
     assert sentinel.exists()
 
     sentinel.unlink()
-    second_status = get_data.run_pipeline(cfg)
+    second_status = get_data.run_pipeline(cfg, steps=steps)
     assert second_status == 0
     final_output = step.expected_output(cfg)
     assert final_output.exists()
@@ -356,9 +363,14 @@ def test_pipeline_subset__target_postprocess_sidecars(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
 
-    step = get_data.PipelineStep("target", get_target_data.main, "all")
+    step = get_data.PipelineStep(
+        name="target",
+        main=get_target_data.main,
+        input_filename="target.csv",
+        output_stem="targets",
+        subcommand="all",
+    )
 
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
     monkeypatch.setattr(get_target_data, "run_all", _stub_run_all)
     monkeypatch.setattr(
@@ -370,7 +382,7 @@ def test_pipeline_subset__target_postprocess_sidecars(
     monkeypatch.setattr(get_target_data, "_postprocess_names_export", _fake_names)
     monkeypatch.setattr(get_target_data, "_postprocess_iuphar_export", _fake_iuphar)
 
-    status = get_data.run_pipeline(cfg)
+    status = get_data.run_pipeline(cfg, steps=(step,))
 
     assert status == 0
     assert call_order == ["organism", "isoform", "names", "iuphar"]

--- a/tests/unit/pipelines/test_registry.py
+++ b/tests/unit/pipelines/test_registry.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.pipelines.registry import PipelineStep, load_pipeline_registry
+
+
+@pytest.mark.unit
+def test_default_registry__exposes_expected_steps() -> None:
+    steps = load_pipeline_registry()
+    names = [step.name for step in steps]
+    assert names == ["document", "target", "assay", "testitem", "activity"]
+
+    document = _step_by_name(steps, "document")
+    assert document.extra_args == ("--mode", "all")
+    assert document.input_filename == "document.csv"
+    assert document.output_stem == "documents"
+
+    target = _step_by_name(steps, "target")
+    assert target.subcommand == "all"
+    assert target.input_filename == "target.csv"
+    assert target.output_stem == "targets"
+
+    assay = _step_by_name(steps, "assay")
+    assert assay.subcommand is None
+    assert assay.supports_dry_run is False
+
+    testitem = _step_by_name(steps, "testitem")
+    assert callable(testitem.main)
+
+    activity = _step_by_name(steps, "activity")
+    assert activity.supports_dry_run is True
+    assert activity.input_filename == "activity.csv"
+    assert activity.output_stem == "activities"
+
+
+@pytest.mark.unit
+def test_registry_loader__supports_yaml_overrides(tmp_path: Path) -> None:
+    registry_path = tmp_path / "pipelines.yaml"
+    registry_path.write_text(
+        """
+        pipelines:
+          - name: example
+            callable: scripts.get_document_data:main
+            input: example.csv
+            output: examples
+            flags:
+              dry_run: true
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    steps = load_pipeline_registry(registry_path)
+    assert [step.name for step in steps] == ["example"]
+    [step] = steps
+    assert step.input_filename == "example.csv"
+    assert step.output_stem == "examples"
+    assert step.supports_dry_run is True
+
+
+def _step_by_name(steps: tuple[PipelineStep, ...], name: str) -> PipelineStep:
+    for step in steps:
+        if step.name == name:
+            return step
+    raise AssertionError(f"step {name!r} not found")

--- a/tests/unit/test_get_data.py
+++ b/tests/unit/test_get_data.py
@@ -17,7 +17,9 @@ def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
     output_dir = base_path / "output"
     input_dir.mkdir()
     output_dir.mkdir()
-    for name, filename in get_data._DEFAULT_INPUT_FILES.items():
+    input_files = dict(get_data.DEFAULT_INPUT_FILES)
+    output_stems = dict(get_data.DEFAULT_OUTPUT_STEMS)
+    for name, filename in input_files.items():
         target = input_dir / filename
         target.write_text("id\nplaceholder\n", encoding="utf-8")
     config_path = base_path / "config.yaml"
@@ -33,6 +35,8 @@ def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
         force=False,
         skip_existing=False,
         dry_run=False,
+        input_files=input_files,
+        output_stems=output_stems,
     )
 
 
@@ -52,6 +56,10 @@ def test_parse_args__defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert args.force is False
     assert args.skip_existing is False
     assert args.dry_run is False
+    assert args.pipeline_registry is None
+    assert args.override_input == []
+    assert args.override_output_stem == []
+    assert args.override_subcommand == []
 
 
 @pytest.mark.unit
@@ -77,6 +85,14 @@ def test_parse_args__custom_paths(tmp_path: Path) -> None:
             "--skip-existing",
             "--dry-run",
             "--verbose",
+            "--pipeline-registry",
+            str(tmp_path / "registry.yaml"),
+            "--override-input",
+            "document=document_custom.csv",
+            "--override-output-stem",
+            "target=custom_targets",
+            "--override-subcommand",
+            "target=sync",
         ]
     )
     assert args.base_path == base
@@ -90,6 +106,10 @@ def test_parse_args__custom_paths(tmp_path: Path) -> None:
     assert args.force is True
     assert args.skip_existing is True
     assert args.dry_run is True
+    assert args.pipeline_registry == tmp_path / "registry.yaml"
+    assert args.override_input == ["document=document_custom.csv"]
+    assert args.override_output_stem == ["target=custom_targets"]
+    assert args.override_subcommand == ["target=sync"]
 
 
 @pytest.mark.unit
@@ -122,7 +142,7 @@ def test_prepare_config__verbose_overrides_level(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_pipeline_step_registration__expected_shape() -> None:
-    steps = get_data._PIPELINE_STEPS
+    steps = get_data.DEFAULT_PIPELINE_STEPS
     names = [step.name for step in steps]
     assert names == ["document", "target", "assay", "testitem", "activity"]
     assert steps[0].extra_args == ("--mode", "all")
@@ -156,6 +176,22 @@ def test_configure_logging__invalid_level() -> None:
 
 
 @pytest.mark.unit
+def test_resolve_pipeline_steps__applies_overrides() -> None:
+    args = argparse.Namespace(
+        pipeline_registry=None,
+        override_input=["document=doc.csv"],
+        override_output_stem=["activity=custom"],
+        override_subcommand=["target="],
+    )
+
+    steps = get_data._resolve_pipeline_steps(args)
+    mapping = {step.name: step for step in steps}
+    assert mapping["document"].input_filename == "doc.csv"
+    assert mapping["activity"].output_stem == "custom"
+    assert mapping["target"].subcommand is None
+
+
+@pytest.mark.unit
 def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _make_config(tmp_path)
     failure_calls: list[Sequence[str]] = []
@@ -171,19 +207,33 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
         return 2
 
     steps = (
-        get_data.PipelineStep("document", _success, None),
-        get_data.PipelineStep("target", _failure, None),
-        get_data.PipelineStep("assay", _success, None),
+        get_data.PipelineStep(
+            name="document",
+            main=_success,
+            input_filename="document.csv",
+            output_stem="documents",
+        ),
+        get_data.PipelineStep(
+            name="target",
+            main=_failure,
+            input_filename="target.csv",
+            output_stem="targets",
+        ),
+        get_data.PipelineStep(
+            name="assay",
+            main=_success,
+            input_filename="assay.csv",
+            output_stem="assays",
+        ),
     )
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit")
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", steps, raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
-    status = get_data.run_pipeline(cfg)
+    status = get_data.run_pipeline(cfg, steps=steps)
     assert status == 2
     assert failure_calls, "expected failing step to execute"
     records = parse_log_lines(stream.getvalue())
@@ -199,15 +249,21 @@ def test_run_pipeline__handles_step_exception(tmp_path: Path, monkeypatch: pytes
     def _raising(argv: Sequence[str]) -> int:  # pragma: no cover - executed via pipeline
         raise RuntimeError("malformed output")
 
-    steps = (get_data.PipelineStep("document", _raising, None),)
+    steps = (
+        get_data.PipelineStep(
+            name="document",
+            main=_raising,
+            input_filename="document.csv",
+            output_stem="documents",
+        ),
+    )
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit")
     )
-    monkeypatch.setattr(get_data, "_PIPELINE_STEPS", steps, raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
-    status = get_data.run_pipeline(cfg)
+    status = get_data.run_pipeline(cfg, steps=steps)
     assert status == 1
     records = parse_log_lines(stream.getvalue())
     assert any(entry["event"] == "step_exception" for entry in records)


### PR DESCRIPTION
## Summary
- add a declarative registry in `library/pipelines/registry.py` with default metadata and YAML loading
- update `scripts/get_data.py` to build pipeline steps from the registry and support CLI overrides for inputs, outputs, and subcommands
- refresh unit, integration, and e2e tests plus add a registry unit test to cover the new metadata entrypoint

## Testing
- pytest tests/unit/test_get_data.py tests/unit/pipelines/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68e41531722c8324a107c30cf3170b1a