### PR TITLE
Refactor orchestrator to use pipeline APIs

### DIFF
--- a/library/pipelines/activity/__init__.py
+++ b/library/pipelines/activity/__init__.py
@@ -1,17 +1,64 @@
-"""Helpers and orchestrators for the activity data pipeline."""
+"""Helpers and orchestration shims for the activity data pipeline."""
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...config import Config
 from .action_properties import (
-  annotate_action_properties,
-  build_activity_properties,
-  infer_action_type,
+    annotate_action_properties,
+    build_activity_properties,
+    infer_action_type,
 )
 from .activities import get_activities
 
 __all__ = [
-  "annotate_action_properties",
-  "build_activity_properties",
-  "infer_action_type",
-  "get_activities",
+    "ActivityPipelineOptions",
+    "annotate_action_properties",
+    "build_activity_properties",
+    "infer_action_type",
+    "get_activities",
+    "run_pipeline",
 ]
+
+
+@dataclass(slots=True)
+class ActivityPipelineOptions:
+    """Configuration values required to execute the activity pipeline."""
+
+    input_csv: Path
+    output_csv: Path
+    limit: int | None = None
+    offset: int = 0
+    skip_existing: bool = False
+    force: bool = False
+    dry_run: bool = False
+    timeout: float | None = None
+    batch_size: int | None = None
+    workers: int | None = None
+
+
+def run_pipeline(config: Config, options: ActivityPipelineOptions) -> int:
+    """Execute the activity pipeline using the CLI implementation."""
+
+    if options.dry_run:
+        return 0
+
+    from scripts import get_activity_data as _activity_cli
+
+    args = argparse.Namespace(
+        input_csv=Path(options.input_csv),
+        output_csv=Path(options.output_csv),
+        final_out=Path(options.output_csv),
+        limit=options.limit,
+        offset=options.offset,
+        skip_existing=options.skip_existing,
+        force=options.force,
+        dry_run=options.dry_run,
+        timeout=options.timeout,
+        batch_size=options.batch_size,
+        workers=options.workers,
+    )
+    return int(_activity_cli.run(config, args))

--- a/library/pipelines/assay/__init__.py
+++ b/library/pipelines/assay/__init__.py
@@ -1,26 +1,66 @@
-"""ChEMBL assay and activity pipeline components."""
+"""ChEMBL assay pipeline helpers and orchestration utilities."""
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...config import Config
 from .chembl_assay import (
-  ACTIVITY_COLUMNS,
-  ASSAY_COLUMNS,
-  ASSAY_VARIANT_COLUMN_ALIASES,
-  get_activities,
-  get_assay,
-  get_assays,
-  get_testitem,
+    ACTIVITY_COLUMNS,
+    ASSAY_COLUMNS,
+    ASSAY_VARIANT_COLUMN_ALIASES,
+    get_activities,
+    get_assay,
+    get_assays,
+    get_testitem,
 )
 from .postprocessing import postprocess_assays, postprocess_file
 
 __all__ = [
-  "ACTIVITY_COLUMNS",
-  "ASSAY_COLUMNS",
-  "ASSAY_VARIANT_COLUMN_ALIASES",
-  "get_activities",
-  "get_assay",
-  "get_assays",
-  "get_testitem",
-  "postprocess_assays",
-  "postprocess_file",
+    "ACTIVITY_COLUMNS",
+    "ASSAY_COLUMNS",
+    "ASSAY_VARIANT_COLUMN_ALIASES",
+    "AssayPipelineOptions",
+    "get_activities",
+    "get_assay",
+    "get_assays",
+    "get_testitem",
+    "postprocess_assays",
+    "postprocess_file",
+    "run_pipeline",
 ]
+
+
+@dataclass(slots=True)
+class AssayPipelineOptions:
+    """Simple configuration container for the assay pipeline."""
+
+    input_csv: Path
+    output_csv: Path
+    limit: int | None = None
+    offset: int = 0
+    skip_existing: bool = False
+    force: bool = False
+    timeout: float | None = None
+    batch_size: int | None = None
+
+
+def run_pipeline(config: Config, options: AssayPipelineOptions) -> int:
+    """Execute the assay pipeline using the CLI implementation."""
+
+    from scripts import get_assay_data as _assay_cli
+
+    args = argparse.Namespace(
+        input_csv=Path(options.input_csv),
+        output_csv=Path(options.output_csv),
+        final_out=Path(options.output_csv),
+        limit=options.limit,
+        offset=options.offset,
+        skip_existing=options.skip_existing,
+        force=options.force,
+        timeout=options.timeout,
+        batch_size=options.batch_size,
+    )
+    return int(_assay_cli.run(config, args))

--- a/library/pipelines/cellline/__init__.py
+++ b/library/pipelines/cellline/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ...config import Config
 from .chembl import (
     CELL_LINE_BASE_COLUMNS,
     CELL_LINE_COLUMN_ORDER,
@@ -24,4 +25,13 @@ __all__ = [
     "prepare_cellline_dataframe",
     "read_cellline_identifiers",
     "run_cellline_pipeline",
+    "run_pipeline",
 ]
+
+
+def run_pipeline(
+    config: Config, options: CellLinePipelineOptions
+) -> CellLinePipelineResult:
+    """Execute the cell line pipeline returning the detailed result."""
+
+    return run_cellline_pipeline(config, options)

--- a/library/pipelines/document/__init__.py
+++ b/library/pipelines/document/__init__.py
@@ -2,13 +2,97 @@
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...config import Config
 from . import pipeline, postprocessing, type_classifier, type_terms
 from .chembl_document import get_documents
 
 __all__ = [
-  "get_documents",
-  "pipeline",
-  "postprocessing",
-  "type_classifier",
-  "type_terms",
+    "DocumentPipelineOptions",
+    "get_documents",
+    "pipeline",
+    "postprocessing",
+    "run_pipeline",
+    "type_classifier",
+    "type_terms",
 ]
+
+
+@dataclass(slots=True)
+class DocumentPipelineOptions:
+    """Settings controlling the document pipeline execution."""
+
+    input_csv: Path
+    output_csv: Path
+    mode: str = "all"
+    limit: int | None = None
+    offset: int = 0
+    skip_existing: bool = False
+    force: bool = False
+    timeout: float | None = None
+    chembl_timeout: float | None = None
+    chembl_chunk_size: int | None = None
+    pubmed_workers: int | None = None
+    pubmed_batch_size: int | None = None
+    pubmed_sleep: float | None = None
+    fallback_doi_enabled: bool = False
+    fallback_doi_path: Path | None = None
+    fallback_doi_overwrite: bool = False
+    fallback_doi_delimiter: str | None = None
+    fallback_doi_encoding: str | None = None
+    fallback_doi_col_pmid: str | None = None
+    fallback_doi_col_doi: str | None = None
+    column: str | None = None
+
+
+def run_pipeline(config: Config, options: DocumentPipelineOptions) -> int:
+    """Execute the requested document pipeline mode using the CLI helpers."""
+
+    from scripts import get_document_data as _document_cli
+
+    mode = (options.mode or "all").strip().lower()
+    handler = _document_cli.MODE_HANDLERS.get(mode)
+    if handler is None:
+        raise ValueError(f"unsupported document pipeline mode: {mode}")
+
+    args = argparse.Namespace(
+        input_csv=Path(options.input_csv),
+        output_csv=Path(options.output_csv),
+        final_out=Path(options.output_csv),
+        limit=options.limit,
+        offset=options.offset,
+        skip_existing=options.skip_existing,
+        force=options.force,
+        mode=mode,
+        command=mode,
+        timeout=options.timeout,
+        chembl_timeout=options.chembl_timeout,
+        chembl_chunk_size=options.chembl_chunk_size,
+        pubmed_workers=options.pubmed_workers,
+        pubmed_batch_size=options.pubmed_batch_size,
+        pubmed_sleep=options.pubmed_sleep,
+        fallback_doi_enabled=options.fallback_doi_enabled,
+        fallback_doi_path=options.fallback_doi_path,
+        fallback_doi_overwrite=options.fallback_doi_overwrite,
+        fallback_doi_delimiter=options.fallback_doi_delimiter,
+        fallback_doi_encoding=options.fallback_doi_encoding,
+        fallback_doi_col_pmid=options.fallback_doi_col_pmid,
+        fallback_doi_col_doi=options.fallback_doi_col_doi,
+        column=options.column,
+    )
+
+    timeout_value: float | None = None
+    if mode == "chembl":
+        timeout_value = options.timeout
+    elif mode == "all":
+        timeout_value = options.chembl_timeout or options.timeout
+    if timeout_value is not None:
+        config.api.timeout_read = timeout_value
+
+    if options.skip_existing and options.output_csv.exists() and not options.force:
+        return 0
+
+    return int(handler(config, args))

--- a/library/pipelines/target/__init__.py
+++ b/library/pipelines/target/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...config import Config
 from . import (
     cellularity,
     helpers,
@@ -14,12 +19,65 @@ from . import (
 from .chembl_target import normalize_reaction_ec_numbers
 
 __all__ = [
-  "normalize_reaction_ec_numbers",
-  "cellularity",
-  "helpers",
-  "multifunctional",
-  "organism_classification",
-  "pipeline",
-  "postprocessing",
-  "protein_classification",
+    "TargetPipelineOptions",
+    "normalize_reaction_ec_numbers",
+    "cellularity",
+    "helpers",
+    "multifunctional",
+    "organism_classification",
+    "pipeline",
+    "postprocessing",
+    "protein_classification",
+    "run_pipeline",
 ]
+
+
+@dataclass(slots=True)
+class TargetPipelineOptions:
+    """Configuration for executing the combined target pipeline."""
+
+    input_csv: Path
+    output_csv: Path
+    command: str = "all"
+    limit: int | None = None
+    offset: int = 0
+    skip_existing: bool = False
+    force: bool = False
+    chunk_size: int | None = None
+    timeout: float | None = None
+
+
+def run_pipeline(config: Config, options: TargetPipelineOptions) -> int:
+    """Execute the requested target pipeline mode using CLI helpers."""
+
+    from scripts import get_target_data as _target_cli
+
+    command = (options.command or "all").strip().lower()
+    handler_map = {
+        "chembl": _target_cli.run_chembl,
+        "uniprot": _target_cli.run_uniprot,
+        "iuphar": _target_cli.run_iuphar,
+        "all": _target_cli.run_all,
+    }
+    handler = handler_map.get(command)
+    if handler is None:
+        raise ValueError(f"unsupported target pipeline command: {command}")
+
+    args = argparse.Namespace(
+        input_csv=Path(options.input_csv),
+        output_csv=Path(options.output_csv),
+        final_out=Path(options.output_csv),
+        limit=options.limit,
+        offset=options.offset,
+        skip_existing=options.skip_existing,
+        force=options.force,
+        command=command,
+        chunk_size=options.chunk_size,
+        timeout=options.timeout,
+        func=handler,
+    )
+
+    if options.skip_existing and options.output_csv.exists() and not options.force:
+        return 0
+
+    return int(handler(config, args))

--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -15,6 +15,7 @@ from importlib.util import find_spec
 
 from . import enrichment as testitem_enrichment
 from .enrichment import enrich
+from ...config import Config
 from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
 
 try:
@@ -111,9 +112,16 @@ __all__ = [
     "query_parent_catalog",
     "read_input_ids",
     "run_testitem_pipeline",
+    "run_pipeline",
     "update_parent_catalog_cache",
     "write_meta_yaml",
     "write_parent_catalog_cache",
 ]
 
 __all__.append("testitem_enrichment")
+
+
+def run_pipeline(config: Config, options: TestitemPipelineOptions) -> int:
+    """Execute the test item pipeline using the shared CLI implementation."""
+
+    return int(run_testitem_pipeline(config, options))

--- a/library/pipelines/tissue/__init__.py
+++ b/library/pipelines/tissue/__init__.py
@@ -1,5 +1,6 @@
 """Helpers for retrieving and processing ChEMBL tissue metadata."""
 
+from ...config import Config
 from .chembl import TISSUE_BASE_COLUMNS, TISSUE_COLUMN_ORDER, get_tissues
 from .pipeline import (
     TissuePipelineOptions,
@@ -16,6 +17,13 @@ __all__ = [
     "prepare_tissue_dataframe",
     "read_tissue_identifiers",
     "run_tissue_pipeline",
+    "run_pipeline",
     "TissuePipelineOptions",
     "TissuePipelineResult",
 ]
+
+
+def run_pipeline(config: Config, options: TissuePipelineOptions) -> TissuePipelineResult:
+    """Execute the tissue pipeline returning the detailed result."""
+
+    return run_tissue_pipeline(config, options)

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -46,19 +46,31 @@ from library.utils.bootstrap import ensure_project_root
 if __package__ in {None, ""}:
     ensure_project_root()
 
-from scripts import (
-    get_activity_data,
-    get_assay_data,
-    get_document_data,
-    get_target_data,
-    get_testitem_data,
-)
-
 from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
 from library.integration.molecule_catalog import load_parent_catalog
+from library.pipelines.activity import (
+    ActivityPipelineOptions,
+    run_pipeline as run_activity_pipeline,
+)
+from library.pipelines.assay import (
+    AssayPipelineOptions,
+    run_pipeline as run_assay_pipeline,
+)
+from library.pipelines.document import (
+    DocumentPipelineOptions,
+    run_pipeline as run_document_pipeline,
+)
+from library.pipelines.target import (
+    TargetPipelineOptions,
+    run_pipeline as run_target_pipeline,
+)
+from library.pipelines.testitem import (
+    TestitemPipelineOptions,
+    run_pipeline as run_testitem_pipeline,
+)
 from library.utils.config import DEFAULT_CONFIG_PATH
 
 
@@ -120,37 +132,9 @@ class PipelineStep:
     """Describe a single pipeline invocation."""
 
     name: str
-    main: Callable[[Sequence[str] | None], int]
-    subcommand: str | None
-    extra_args: tuple[str, ...] = ()
-    output_flag: str = "--final-out"
+    run: Callable[[Config, object], int]
+    options_factory: Callable[[PipelineRunConfig, Path, Path], object]
     supports_dry_run: bool = False
-
-    def build_arguments(
-        self, cfg: PipelineRunConfig, output_path: Path | None = None
-    ) -> list[str]:
-        """Return CLI arguments forwarded to the wrapped ``main`` function."""
-
-        input_csv = cfg.input_path(self.name)
-        output_csv = (
-            output_path if output_path is not None else cfg.output_path(self.name)
-        )
-        args = ["--config", str(cfg.config_path), "--input", str(input_csv)]
-        args.extend([self.output_flag, str(output_csv)])
-        args.extend(["--log-level", cfg.log_level])
-        if cfg.limit is not None:
-            args.extend(["--limit", str(cfg.limit)])
-        if cfg.force:
-            args.append("--force")
-        if cfg.skip_existing:
-            args.append("--skip-existing")
-        if cfg.dry_run and self.supports_dry_run:
-            args.append("--dry-run")
-        if self.extra_args:
-            args = [*self.extra_args, *args]
-        if self.subcommand is not None:
-            return [self.subcommand, *args]
-        return args
 
     def expected_output(self, cfg: PipelineRunConfig) -> Path:
         """Return the path where the pipeline will create its CSV artefact."""
@@ -166,19 +150,62 @@ class PipelineStep:
 _PIPELINE_STEPS: tuple[PipelineStep, ...] = (
     PipelineStep(
         "document",
-        get_document_data.main,
-        None,
-        extra_args=("--mode", "all"),
+        run_document_pipeline,
+        lambda cfg, input_csv, output_csv: DocumentPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            mode="all",
+            limit=cfg.limit,
+            skip_existing=cfg.skip_existing,
+            force=cfg.force,
+        ),
     ),
     PipelineStep(
         "target",
-        get_target_data.main,
-        "all",
-        output_flag="--final-out",
+        run_target_pipeline,
+        lambda cfg, input_csv, output_csv: TargetPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            command="all",
+            limit=cfg.limit,
+            skip_existing=cfg.skip_existing,
+            force=cfg.force,
+        ),
     ),
-    PipelineStep("assay", get_assay_data.main, None),
-    PipelineStep("testitem", get_testitem_data.main, None),
-    PipelineStep("activity", get_activity_data.main, None, supports_dry_run=True),
+    PipelineStep(
+        "assay",
+        run_assay_pipeline,
+        lambda cfg, input_csv, output_csv: AssayPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            limit=cfg.limit,
+            skip_existing=cfg.skip_existing,
+            force=cfg.force,
+        ),
+    ),
+    PipelineStep(
+        "testitem",
+        run_testitem_pipeline,
+        lambda cfg, input_csv, output_csv: TestitemPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            limit=cfg.limit,
+            offset=0,
+        ),
+    ),
+    PipelineStep(
+        "activity",
+        run_activity_pipeline,
+        lambda cfg, input_csv, output_csv: ActivityPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            limit=cfg.limit,
+            skip_existing=cfg.skip_existing,
+            force=cfg.force,
+            dry_run=cfg.dry_run,
+        ),
+        supports_dry_run=True,
+    ),
 )
 
 
@@ -561,6 +588,54 @@ def _cleanup_empty_directories(path: Path, *, root: Path) -> None:
         current = parent
 
 
+def _describe_options(options: object, input_path: Path, output_path: Path) -> dict[str, object]:
+    """Return a serialisable summary of pipeline options for logging."""
+
+    return {
+        "input": str(getattr(options, "input_csv", input_path)),
+        "output": str(getattr(options, "output_csv", output_path)),
+        "limit": getattr(options, "limit", None),
+        "mode": getattr(options, "mode", None),
+        "command": getattr(options, "command", getattr(options, "subcommand", None)),
+        "skip_existing": getattr(options, "skip_existing", None),
+        "force": getattr(options, "force", None),
+    }
+
+
+def _apply_limit_override(
+    config: Config, step_name: str, options: object, limit: int | None
+) -> None:
+    """Propagate orchestrator-level limits into pipeline-specific configuration."""
+
+    if limit is None:
+        return
+
+    if step_name == "document":
+        mode = getattr(options, "mode", "all")
+        if mode == "chembl":
+            config.document.chembl.limit = limit
+        elif mode == "pubmed":
+            config.document.pubmed.limit = limit
+        else:
+            config.document.all.limit = limit
+    elif step_name == "target":
+        command = getattr(options, "command", "all")
+        if command == "chembl":
+            config.target.chembl.limit = limit
+        elif command == "uniprot":
+            config.target.uniprot.limit = limit
+        elif command == "iuphar":
+            config.target.iuphar.limit = limit
+        else:
+            config.target.all.limit = limit
+    elif step_name == "assay":
+        config.assay.limit = limit
+    elif step_name == "testitem":
+        config.testitem.limit = limit
+    elif step_name == "activity":
+        config.activity.limit = limit
+
+
 def _run_step(
     step: PipelineStep,
     cfg: PipelineRunConfig,
@@ -577,16 +652,22 @@ def _run_step(
         _LOGGER.info("step_skipped_existing", step=step.name, path=str(final_output))
         return StepExecutionResult(exit_code=0, executed=False)
 
-    arguments = step.build_arguments(cfg, output_path=working_output)
-    _LOGGER.debug("step_arguments", step=step.name, arguments=arguments)
+    local_cfg = load_config(cfg.config_path, base_path=cfg.base_path)
+    options = step.options_factory(cfg, input_path, working_output)
+    _LOGGER.debug(
+        "step_options",
+        step=step.name,
+        options=_describe_options(options, input_path, working_output),
+    )
+    _apply_limit_override(local_cfg, step.name, options, cfg.limit)
     try:
-        exit_code = step.main(arguments)
+        exit_code = step.run(local_cfg, options)
     except SystemExit as exc:
         exit_code = _coerce_exit_code(exc.code)
         return StepExecutionResult(exit_code=exit_code, executed=True)
     except BaseException:
         raise
-    return StepExecutionResult(exit_code=exit_code, executed=True)
+    return StepExecutionResult(exit_code=int(exit_code), executed=True)
 
 
 def _finalize_step_success(

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -7,6 +7,7 @@ import json
 import shutil
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC
 from functools import lru_cache
 from pathlib import Path
@@ -21,6 +22,17 @@ from tests.helpers.logs import parse_log_file, parse_log_lines
 
 
 PipelineFunc = Callable[[list[str]], int]
+
+
+@dataclass
+class StubPipelineOptions:
+    input_csv: Path
+    output_csv: Path
+    limit: int | None
+    skip_existing: bool = False
+    force: bool = False
+    mode: str | None = None
+    subcommand: str | None = None
 
 
 def _build_stub_pipeline(
@@ -94,6 +106,43 @@ def _build_stub_pipeline(
         return 0
 
     return _main
+
+
+def _wrap_cli_pipeline(
+    main: PipelineFunc,
+    *,
+    accept_subcommand: bool = False,
+    accept_mode: bool = False,
+) -> Callable[[get_data.Config, StubPipelineOptions], int]:
+    """Return a runner bridging CLI-style stubs with the new pipeline API."""
+
+    def _run(_: get_data.Config, options: StubPipelineOptions) -> int:
+        argv: list[str] = []
+        if accept_subcommand and options.subcommand is not None:
+            argv.append(options.subcommand)
+        if accept_mode and options.mode is not None:
+            argv.extend(["--mode", options.mode])
+        argv.extend(
+            [
+                "--config",
+                "stub-config.yaml",
+                "--input",
+                str(options.input_csv),
+                "--final-out",
+                str(options.output_csv),
+                "--log-level",
+                "INFO",
+            ]
+        )
+        if options.limit is not None:
+            argv.extend(["--limit", str(options.limit)])
+        if options.force:
+            argv.append("--force")
+        if options.skip_existing:
+            argv.append("--skip-existing")
+        return main(argv)
+
+    return _run
 
 
 def _documents_transform(frame: pd.DataFrame, logger: get_data.Logger) -> pd.DataFrame:
@@ -281,72 +330,110 @@ def test_get_data_end_to_end__miniature_pipeline(
     monkeypatch.setattr(get_data, "configure_logger", _configure_logger_stub)
 
     report_writer = _make_report_writer(5)
+    document_main = _build_stub_pipeline(
+        "document",
+        "document_chembl_id",
+        ["document_chembl_id", "title", "pubmed_id"],
+        _documents_transform,
+        accept_mode=True,
+    )
+    target_main = _build_stub_pipeline(
+        "target",
+        "target_chembl_id",
+        ["target_chembl_id", "target_name", "organism"],
+        _targets_transform,
+        accept_subcommand=True,
+    )
+    assay_main = _build_stub_pipeline(
+        "assay",
+        "assay_chembl_id",
+        [
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+        ],
+        _assays_transform,
+    )
+    testitem_main = _build_stub_pipeline(
+        "testitem",
+        "molecule_chembl_id",
+        ["molecule_chembl_id", "preferred_name"],
+        _testitems_transform,
+    )
+    activity_main = _build_stub_pipeline(
+        "activity",
+        "activity_id",
+        [
+            "activity_id",
+            "assay_chembl_id",
+            "molecule_chembl_id",
+            "standard_value",
+            "standard_units",
+        ],
+        _activities_transform,
+        optional_columns=["force_failure"],
+        post_process=report_writer,
+    )
+
     stub_steps = (
         get_data.PipelineStep(
             "document",
-            _build_stub_pipeline(
-                "document",
-                "document_chembl_id",
-                ["document_chembl_id", "title", "pubmed_id"],
-                _documents_transform,
-                accept_mode=True,
+            _wrap_cli_pipeline(document_main, accept_mode=True),
+            lambda cfg, input_csv, output_csv: StubPipelineOptions(
+                input_csv=input_csv,
+                output_csv=output_csv,
+                limit=cfg.limit,
+                skip_existing=cfg.skip_existing,
+                force=cfg.force,
+                mode="all",
             ),
-            None,
-            extra_args=("--mode", "all"),
         ),
         get_data.PipelineStep(
             "target",
-            _build_stub_pipeline(
-                "target",
-                "target_chembl_id",
-                ["target_chembl_id", "target_name", "organism"],
-                _targets_transform,
-                accept_subcommand=True,
+            _wrap_cli_pipeline(target_main, accept_subcommand=True),
+            lambda cfg, input_csv, output_csv: StubPipelineOptions(
+                input_csv=input_csv,
+                output_csv=output_csv,
+                limit=cfg.limit,
+                skip_existing=cfg.skip_existing,
+                force=cfg.force,
+                subcommand="all",
             ),
-            "all",
         ),
         get_data.PipelineStep(
             "assay",
-            _build_stub_pipeline(
-                "assay",
-                "assay_chembl_id",
-                [
-                    "assay_chembl_id",
-                    "target_chembl_id",
-                    "document_chembl_id",
-                    "description",
-                ],
-                _assays_transform,
+            _wrap_cli_pipeline(assay_main),
+            lambda cfg, input_csv, output_csv: StubPipelineOptions(
+                input_csv=input_csv,
+                output_csv=output_csv,
+                limit=cfg.limit,
+                skip_existing=cfg.skip_existing,
+                force=cfg.force,
             ),
-            None,
         ),
         get_data.PipelineStep(
             "testitem",
-            _build_stub_pipeline(
-                "testitem",
-                "molecule_chembl_id",
-                ["molecule_chembl_id", "preferred_name"],
-                _testitems_transform,
+            _wrap_cli_pipeline(testitem_main),
+            lambda cfg, input_csv, output_csv: StubPipelineOptions(
+                input_csv=input_csv,
+                output_csv=output_csv,
+                limit=cfg.limit,
+                skip_existing=cfg.skip_existing,
+                force=cfg.force,
             ),
-            None,
         ),
         get_data.PipelineStep(
             "activity",
-            _build_stub_pipeline(
-                "activity",
-                "activity_id",
-                [
-                    "activity_id",
-                    "assay_chembl_id",
-                    "molecule_chembl_id",
-                    "standard_value",
-                    "standard_units",
-                ],
-                _activities_transform,
-                optional_columns=["force_failure"],
-                post_process=report_writer,
+            _wrap_cli_pipeline(activity_main),
+            lambda cfg, input_csv, output_csv: StubPipelineOptions(
+                input_csv=input_csv,
+                output_csv=output_csv,
+                limit=cfg.limit,
+                skip_existing=cfg.skip_existing,
+                force=cfg.force,
             ),
-            None,
+            supports_dry_run=True,
         ),
     )
     monkeypatch.setattr(get_data, "_PIPELINE_STEPS", stub_steps, raising=False)
@@ -394,7 +481,7 @@ def test_get_data_end_to_end__miniature_pipeline(
     assert events["document_duplicates_dropped"].get("level") == "WARNING"
     assert "activity_missing_value" in events
     assert events["activity_missing_value"].get("level") == "ERROR"
-    assert not any(record.get("event") == "step_arguments" for record in logs)
+    assert not any(record.get("event") == "step_options" for record in logs)
 
     expected_dir = Path(__file__).resolve().parents[1] / "resources" / "expected_get_data"
     key_columns = {
@@ -428,7 +515,7 @@ def test_get_data_end_to_end__miniature_pipeline(
             and record.get("data", {}).get("step") == step_name
             for record in repeat_logs
         )
-    assert not any(record.get("event") == "step_arguments" for record in repeat_logs)
+    assert not any(record.get("event") == "step_options" for record in repeat_logs)
 
     hashes_after = {name: sha256_file(path) for name, path in output_paths.items()}
     assert hashes_before == hashes_after
@@ -436,12 +523,12 @@ def test_get_data_end_to_end__miniature_pipeline(
     verbose_argv = [*argv, "--verbose"]
     verbose_exit_code, verbose_logs = _invoke(verbose_argv)
     assert verbose_exit_code == 0
-    assert any(record.get("event") == "step_arguments" for record in verbose_logs)
+    assert any(record.get("event") == "step_options" for record in verbose_logs)
     assert any(record.get("level") == "DEBUG" for record in verbose_logs)
     verbose_hashes = {name: sha256_file(path) for name, path in output_paths.items()}
     assert hashes_before == verbose_hashes
     verbose_file_records = parse_log_file(orchestrator_log)
-    assert any(entry.get("event") == "step_arguments" for entry in verbose_file_records)
+    assert any(entry.get("event") == "step_options" for entry in verbose_file_records)
 
     reports_dir = base_path / "reports"
     report_json_path = reports_dir / "test_report.json"

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import io
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable
 
@@ -10,6 +10,10 @@ import pandas as pd
 import pytest
 
 from library.config import Config
+from library.pipelines.target import (
+    TargetPipelineOptions,
+    run_pipeline as run_target_pipeline,
+)
 from scripts import get_data, get_target_data
 from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 from tests.helpers.logs import parse_log_lines
@@ -20,18 +24,18 @@ def _build_stub_step(
     required_columns: list[str],
     key_column: str,
     on_execute: Callable[[pd.DataFrame, Path], int],
-) -> Callable[[list[str]], int]:
-    def _main(argv: list[str]) -> int:
-        parser = argparse.ArgumentParser(prog="stub")
-        parser.add_argument("--config", required=True)
-        parser.add_argument("--input", required=True)
-        parser.add_argument("--final-out", required=True)
-        parser.add_argument("--log-level")
-        parser.add_argument("--limit", type=int, default=None)
-        parser.add_argument("--force", action="store_true")
-        parser.add_argument("--skip-existing", action="store_true")
-        args, _ = parser.parse_known_args(argv)
-        frame = pd.read_csv(Path(args.input))
+) -> tuple[
+    Callable[[Config, object], int],
+    Callable[[get_data.PipelineRunConfig, Path, Path], object],
+]:
+    @dataclass
+    class _Options:
+        input_csv: Path
+        output_csv: Path
+        limit: int | None
+
+    def _run(_: Config, options: _Options) -> int:
+        frame = pd.read_csv(options.input_csv)
         missing = [col for col in required_columns if col not in frame.columns]
         if missing:
             get_data._LOGGER.error("schema_mismatch", missing=missing)
@@ -45,9 +49,14 @@ def _build_stub_step(
                 count=int(duplicates.sum()),
             )
             frame = frame.loc[~duplicates].copy()
-        return on_execute(frame, Path(args.final_out))
+        return on_execute(frame, options.output_csv)
 
-    return _main
+    def _factory(
+        cfg: get_data.PipelineRunConfig, input_csv: Path, output_csv: Path
+    ) -> _Options:
+        return _Options(input_csv=input_csv, output_csv=output_csv, limit=cfg.limit)
+
+    return _run, _factory
 
 
 def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
@@ -98,15 +107,12 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
         rows.to_csv(destination, index=False)
         return 0
 
-    step = get_data.PipelineStep(
-        "document",
-        _build_stub_step(
-            required_columns=["document_chembl_id", "title", "pubmed_id"],
-            key_column="document_chembl_id",
-            on_execute=_on_execute,
-        ),
-        None,
+    run_step, options_factory = _build_stub_step(
+        required_columns=["document_chembl_id", "title", "pubmed_id"],
+        key_column="document_chembl_id",
+        on_execute=_on_execute,
     )
+    step = get_data.PipelineStep("document", run_step, options_factory)
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
@@ -155,15 +161,12 @@ def test_pipeline_subset__skip_existing_and_force(tmp_path: Path, monkeypatch: p
         destination.write_text("target_chembl_id\nT1\nT2\n", encoding="utf-8")
         return 0
 
-    step = get_data.PipelineStep(
-        "target",
-        _build_stub_step(
-            required_columns=["target_chembl_id", "name", "organism"],
-            key_column="target_chembl_id",
-            on_execute=_on_execute,
-        ),
-        None,
+    run_step, options_factory = _build_stub_step(
+        required_columns=["target_chembl_id", "name", "organism"],
+        key_column="target_chembl_id",
+        on_execute=_on_execute,
     )
+    step = get_data.PipelineStep("target", run_step, options_factory)
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
@@ -240,20 +243,17 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
         enriched.to_csv(destination, index=False, columns=columns)
         return 0
 
-    step = get_data.PipelineStep(
-        "assay",
-        _build_stub_step(
-            required_columns=[
-                "assay_chembl_id",
-                "target_chembl_id",
-                "document_chembl_id",
-                "description",
-            ],
-            key_column="assay_chembl_id",
-            on_execute=_on_execute,
-        ),
-        None,
+    run_step, options_factory = _build_stub_step(
+        required_columns=[
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+        ],
+        key_column="assay_chembl_id",
+        on_execute=_on_execute,
     )
+    step = get_data.PipelineStep("assay", run_step, options_factory)
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
@@ -356,7 +356,18 @@ def test_pipeline_subset__target_postprocess_sidecars(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
 
-    step = get_data.PipelineStep("target", get_target_data.main, "all")
+    step = get_data.PipelineStep(
+        "target",
+        run_target_pipeline,
+        lambda cfg_obj, input_csv, output_csv: TargetPipelineOptions(
+            input_csv=input_csv,
+            output_csv=output_csv,
+            command="all",
+            limit=cfg_obj.limit,
+            skip_existing=cfg_obj.skip_existing,
+            force=cfg_obj.force,
+        ),
+    )
 
     monkeypatch.setattr(get_data, "_PIPELINE_STEPS", (step,), raising=False)
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)

--- a/tests/unit/test_get_data.py
+++ b/tests/unit/test_get_data.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import argparse
 import io
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence
 
 import pytest
 
@@ -125,11 +125,10 @@ def test_pipeline_step_registration__expected_shape() -> None:
     steps = get_data._PIPELINE_STEPS
     names = [step.name for step in steps]
     assert names == ["document", "target", "assay", "testitem", "activity"]
-    assert steps[0].extra_args == ("--mode", "all")
-    assert steps[1].subcommand == "all"
     assert steps[-1].supports_dry_run is True
     for step in steps:
-        assert callable(step.main)
+        assert callable(step.run)
+        assert callable(step.options_factory)
 
 
 @pytest.mark.unit
@@ -160,20 +159,27 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
     cfg = _make_config(tmp_path)
     failure_calls: list[Sequence[str]] = []
 
-    def _success(argv: Sequence[str]) -> int:
-        final_out = Path(argv[argv.index("--final-out") + 1])
-        final_out.parent.mkdir(parents=True, exist_ok=True)
-        final_out.write_text("id\n1\n", encoding="utf-8")
+    @dataclass
+    class _Options:
+        input_csv: Path
+        output_csv: Path
+
+    def _success(_cfg: get_data.Config, options: _Options) -> int:
+        options.output_csv.parent.mkdir(parents=True, exist_ok=True)
+        options.output_csv.write_text("id\n1\n", encoding="utf-8")
         return 0
 
-    def _failure(argv: Sequence[str]) -> int:
-        failure_calls.append(tuple(argv))
+    def _failure(_cfg: get_data.Config, options: _Options) -> int:
+        failure_calls.append((options.input_csv, options.output_csv))
         return 2
 
+    def _factory(_: get_data.PipelineRunConfig, input_csv: Path, output_csv: Path) -> _Options:
+        return _Options(input_csv=input_csv, output_csv=output_csv)
+
     steps = (
-        get_data.PipelineStep("document", _success, None),
-        get_data.PipelineStep("target", _failure, None),
-        get_data.PipelineStep("assay", _success, None),
+        get_data.PipelineStep("document", _success, _factory),
+        get_data.PipelineStep("target", _failure, _factory),
+        get_data.PipelineStep("assay", _success, _factory),
     )
 
     stream = io.StringIO()
@@ -196,10 +202,20 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
 def test_run_pipeline__handles_step_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _make_config(tmp_path)
 
-    def _raising(argv: Sequence[str]) -> int:  # pragma: no cover - executed via pipeline
+    @dataclass
+    class _Options:
+        input_csv: Path
+        output_csv: Path
+
+    def _factory(_: get_data.PipelineRunConfig, input_csv: Path, output_csv: Path) -> _Options:
+        return _Options(input_csv=input_csv, output_csv=output_csv)
+
+    def _raising(
+        _cfg: get_data.Config, _options: _Options
+    ) -> int:  # pragma: no cover - executed via pipeline
         raise RuntimeError("malformed output")
 
-    steps = (get_data.PipelineStep("document", _raising, None),)
+    steps = (get_data.PipelineStep("document", _raising, _factory),)
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit")


### PR DESCRIPTION
## Summary
- add Config-aware run_pipeline wrappers across the activity, assay, document, target, testitem, cell line and tissue modules
- refactor scripts/get_data.py to construct pipeline option objects, apply limit overrides and log structured step options before invoking the new APIs
- update unit, integration and end-to-end tests to stub the new interfaces and validate verbose logging expectations

## Testing
- pytest tests/unit/test_get_data.py
- pytest tests/integration/test_get_data_workflow.py
- pytest tests/e2e/test_get_data_end_to_end.py

------
https://chatgpt.com/codex/tasks/task_e_68e415319a648324a882e3a6e7c61a4c