### PR TITLE
Add deterministic jitter providers for HTTP clients

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1602,6 +1602,15 @@
             "null"
           ]
         },
+        "jitter_seed": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Jitter Seed",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "status_forcelist": {
           "items": {
             "type": "integer"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -343,6 +343,7 @@ system:
     max_attempts: 4  # HTTP retry attempts (env: CHEMBL_DA_RETRY_MAX_ATTEMPTS)
     backoff_factor: 0.5  # Base delay multiplier (env: CHEMBL_DA_RETRY_BACKOFF_FACTOR)
     backoff_cap: null  # Maximum backoff delay in seconds (env: CHEMBL_DA_RETRY_BACKOFF_CAP)
+    jitter_seed: 0  # Seed for deterministic retry jitter (env: CHEMBL_DA_RETRY_JITTER_SEED)
     status_forcelist:
       - 429  # Too Many Requests
       - 500

--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -41,6 +41,10 @@ class ChemblClient:
     global_limiter:
         Optional system-wide :class:`RateLimiter` enforcing ``Config.rate``
         across all HTTP clients.
+    jitter:
+        Optional callable producing jitter values for retry backoff. When not
+        provided the jitter is derived from ``retry`` using
+        :meth:`library.config.RetryCfg.build_jitter`.
     """
 
     cache: TTLCache[str, dict[str, Any]] = field(init=False)
@@ -59,9 +63,11 @@ class ChemblClient:
         *,
         session: Session | None = None,
         global_limiter: RateLimiter | None = None,
+        jitter: Callable[[float], float] | None = None,
     ) -> None:
         api = api or ApiCfg()
         retry = retry or RetryCfg()
+        self._jitter = jitter if jitter is not None else retry.build_jitter()
         if session is not None:
             def _session_from_argument(provided: Session = session) -> Session:
                 return provided
@@ -314,7 +320,7 @@ class ChemblClient:
                             },
                         )
                         break
-                    delay = _backoff_delay(attempt, cfg, header_delay=None)
+                    delay = _backoff_delay(attempt, cfg, header_delay=None, jitter=self._jitter)
                     _log_retry_delay(request_url, attempt, None, delay)
                     sleep(delay)
                     break
@@ -356,7 +362,9 @@ class ChemblClient:
                         )
                         break
                     header_delay = _retry_after_delay(response)
-                    delay = _backoff_delay(attempt, cfg, header_delay)
+                    delay = _backoff_delay(
+                        attempt, cfg, header_delay, jitter=self._jitter
+                    )
                     _log_retry_delay(request_url, attempt, status, delay, header_delay)
                     sleep(delay)
                     break
@@ -376,7 +384,7 @@ class ChemblClient:
                             },
                         )
                         break
-                    delay = _backoff_delay(attempt, cfg, header_delay=None)
+                    delay = _backoff_delay(attempt, cfg, header_delay=None, jitter=self._jitter)
                     _log_retry_delay(request_url, attempt, None, delay)
                     sleep(delay)
                     break
@@ -479,11 +487,20 @@ def _is_retry_after_applicable(status: int) -> bool:
 
 
 def _backoff_delay(
-    attempt: int, cfg: ApiCfg, header_delay: float | None
+    attempt: int,
+    cfg: ApiCfg,
+    header_delay: float | None,
+    *,
+    jitter: Callable[[float], float] | None = None,
 ) -> float:
     base = cfg.backoff_factor * (2 ** (attempt - 1))
-    jitter = random.uniform(0, cfg.backoff_factor)
-    delay = base + jitter
+    jitter_value = 0.0
+    if cfg.backoff_factor > 0:
+        if jitter is not None:
+            jitter_value = jitter(cfg.backoff_factor)
+        else:
+            jitter_value = random.uniform(0, cfg.backoff_factor)
+    delay = base + jitter_value
     if header_delay is not None:
         delay = max(delay, header_delay)
     return float(delay)

--- a/library/clients/iuphar.py
+++ b/library/clients/iuphar.py
@@ -55,6 +55,7 @@ _session_factory: Callable[[], Session] = _make_session_factory(ApiCfg(), RetryC
 _session_local = threading.local()
 _sessions: set[Session] = set()
 _active_requests = 0
+_jitter_provider: Callable[[float], float] | None = None
 
 
 def _close_sessions(sessions: Iterable[Session]) -> None:
@@ -108,10 +109,15 @@ EXPECTED_FAMILY_COLUMNS: tuple[str, ...] = (
 )
 
 
-def init_session(api: ApiCfg, retry: RetryCfg) -> None:
+def init_session(
+    api: ApiCfg,
+    retry: RetryCfg,
+    *,
+    jitter: Callable[[float], float] | None = None,
+) -> None:
     """Initialise the shared HTTP session used by the IUPHAR client."""
 
-    global _session_factory, _session_local
+    global _session_factory, _session_local, _jitter_provider
 
     factory = _make_session_factory(api, retry)
     with _session_condition:
@@ -121,6 +127,7 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
         _sessions.clear()
         _session_factory = factory
         _session_local = threading.local()
+        _jitter_provider = jitter if jitter is not None else retry.build_jitter()
 
     _close_sessions(old_sessions)
 
@@ -173,6 +180,9 @@ def _download_csv(url: str, cfg: IupharCfg, retry: RetryCfg) -> pd.DataFrame:
     timeout = (cfg.timeout_connect, cfg.timeout_read)
     limiter = get_limiter("iuphar", cfg.rps, cfg.burst)
 
+    with _session_condition:
+        jitter_provider = _jitter_provider
+
     for attempt in range(1, retry.max_attempts + 1):
         limiter.acquire()
         try:
@@ -191,8 +201,14 @@ def _download_csv(url: str, cfg: IupharCfg, retry: RetryCfg) -> pd.DataFrame:
                 )
                 raise
             backoff = retry.backoff_factor * (2 ** (attempt - 1))
-            jitter = random.uniform(0, backoff)
-            sleep(backoff + jitter)
+            if backoff > 0:
+                if jitter_provider is not None:
+                    jitter_value = jitter_provider(backoff)
+                else:
+                    jitter_value = random.uniform(0, backoff)
+            else:
+                jitter_value = 0.0
+            sleep(backoff + jitter_value)
 
     raise RuntimeError("Failed to download CSV")
 
@@ -232,6 +248,9 @@ def _query_gene_symbol(
     timeout = (cfg.timeout_connect, cfg.timeout_read)
     limiter = get_limiter("iuphar", cfg.rps, cfg.burst)
 
+    with _session_condition:
+        jitter_provider = _jitter_provider
+
     for attempt in range(1, retry.max_attempts + 1):
         limiter.acquire()
         try:
@@ -250,8 +269,14 @@ def _query_gene_symbol(
                 )
                 break
             backoff = retry.backoff_factor * (2 ** (attempt - 1))
-            jitter = random.uniform(0, backoff)
-            sleep(backoff + jitter)
+            if backoff > 0:
+                if jitter_provider is not None:
+                    jitter_value = jitter_provider(backoff)
+                else:
+                    jitter_value = random.uniform(0, backoff)
+            else:
+                jitter_value = 0.0
+            sleep(backoff + jitter_value)
     return {}
 
 

--- a/library/clients/pubmed.py
+++ b/library/clients/pubmed.py
@@ -152,6 +152,8 @@ def _retry_delay(
     base_delay: float,
     retry_cfg: RetryCfg | None,
     timeout: float | tuple[float, float] | None,
+    *,
+    jitter: Callable[[float], float] | None = None,
 ) -> float:
     """Calculate the delay before the next retry attempt."""
 
@@ -163,8 +165,11 @@ def _retry_delay(
 
     if retry_cfg is not None and retry_cfg.backoff_factor > 0:
         backoff = compute_backoff_delay(attempt, retry_cfg)
-        jitter = random.uniform(0.0, retry_cfg.backoff_factor)
-        candidate = backoff + jitter
+        if jitter is not None:
+            jitter_value = jitter(retry_cfg.backoff_factor)
+        else:
+            jitter_value = random.uniform(0.0, retry_cfg.backoff_factor)
+        candidate = backoff + jitter_value
         if retry_cfg.backoff_cap is not None:
             candidate = min(candidate, retry_cfg.backoff_cap)
         delay = max(delay, candidate)
@@ -185,6 +190,7 @@ def _do_request(
     method: str = "GET",
     timeout: float | tuple[float, float] = 10,
     retry_cfg: RetryCfg | None = None,
+    jitter: Callable[[float], float] | None = None,
     **kwargs: Any,
 ) -> tuple[dict[str, Any] | str | None, str]:
     """Perform an HTTP request with retry logic."""
@@ -201,7 +207,13 @@ def _do_request(
             retry_delay = (
                 header_delay
                 if header_delay is not None
-                else _retry_delay(attempt, delay, active_retry_cfg, timeout)
+                else _retry_delay(
+                    attempt,
+                    delay,
+                    active_retry_cfg,
+                    timeout,
+                    jitter=jitter,
+                )
             )
             extra["delay"] = retry_delay
             logger.info(event, extra=extra)
@@ -257,6 +269,7 @@ def fetch_pubmed_batch(
     cfg: PubMedCfg | None = None,
     *,
     retry_cfg: RetryCfg | None = None,
+    jitter: Callable[[float], float] | None = None,
 ) -> tuple[str | None, str]:
     """Fetch raw PubMed XML for ``pmids`` using a single request."""
 
@@ -265,6 +278,10 @@ def fetch_pubmed_batch(
     base = cfg.base.rstrip("/")
     url = f"{base}/efetch.fcgi?db=pubmed&id={ids}&retmode=xml"
     timeout = (cfg.timeout_connect, cfg.timeout_read)
+    effective_jitter = jitter
+    if effective_jitter is None and retry_cfg is not None:
+        effective_jitter = retry_cfg.build_jitter()
+
     text, error = _do_request(
         session,
         url,
@@ -273,6 +290,7 @@ def fetch_pubmed_batch(
         retries=cfg.retries,
         timeout=timeout,
         retry_cfg=retry_cfg,
+        jitter=effective_jitter,
     )
     if error:
         return None, error
@@ -288,11 +306,17 @@ def fetch_pubmed(
     cfg: PubMedCfg | None = None,
     *,
     retry_cfg: RetryCfg | None = None,
+    jitter: Callable[[float], float] | None = None,
 ) -> tuple[str | None, str]:
     """Fetch raw PubMed XML for a single PMID."""
 
     text, error = fetch_pubmed_batch(
-        session, [pmid], sleep, cfg=cfg, retry_cfg=retry_cfg
+        session,
+        [pmid],
+        sleep,
+        cfg=cfg,
+        retry_cfg=retry_cfg,
+        jitter=jitter,
     )
     if error:
         return None, error
@@ -302,8 +326,14 @@ def fetch_pubmed(
 class PubMedClient:
     """Thin wrapper around the PubMed HTTP helpers."""
 
-    def __init__(self, cfg: PubMedCfg | None = None) -> None:
+    def __init__(
+        self,
+        cfg: PubMedCfg | None = None,
+        *,
+        jitter: Callable[[float], float] | None = None,
+    ) -> None:
         self.cfg = cfg or PubMedCfg()
+        self._jitter = jitter
 
     def fetch_pubmed_batch(
         self,
@@ -315,8 +345,17 @@ class PubMedClient:
     ) -> tuple[str | None, str]:
         """Retrieve raw XML for ``pmids`` using configured settings."""
 
+        effective_jitter = self._jitter
+        if effective_jitter is None and retry_cfg is not None:
+            effective_jitter = retry_cfg.build_jitter()
+
         return fetch_pubmed_batch(
-            session, pmids, sleep, cfg=self.cfg, retry_cfg=retry_cfg
+            session,
+            pmids,
+            sleep,
+            cfg=self.cfg,
+            retry_cfg=retry_cfg,
+            jitter=effective_jitter,
         )
 
     def fetch_pubmed(
@@ -329,6 +368,15 @@ class PubMedClient:
     ) -> tuple[str | None, str]:
         """Retrieve raw XML for a single PMID."""
 
+        effective_jitter = self._jitter
+        if effective_jitter is None and retry_cfg is not None:
+            effective_jitter = retry_cfg.build_jitter()
+
         return fetch_pubmed(
-            session, pmid, sleep, cfg=self.cfg, retry_cfg=retry_cfg
+            session,
+            pmid,
+            sleep,
+            cfg=self.cfg,
+            retry_cfg=retry_cfg,
+            jitter=effective_jitter,
         )

--- a/library/clients/uniprot.py
+++ b/library/clients/uniprot.py
@@ -48,6 +48,7 @@ _session_local = threading.local()
 _sessions: set[Session] = set()
 _active_requests = 0
 _retry_cfg: RetryCfg = RetryCfg()
+_jitter_provider: Callable[[float], float] | None = None
 
 
 def _close_sessions(sessions: Iterable[Session]) -> None:
@@ -82,10 +83,15 @@ def _session_context() -> Iterator[Session]:
                 _session_condition.notify_all()
 
 
-def init_session(api: ApiCfg, retry: RetryCfg) -> None:
+def init_session(
+    api: ApiCfg,
+    retry: RetryCfg,
+    *,
+    jitter: Callable[[float], float] | None = None,
+) -> None:
     """Initialise the shared HTTP session."""
 
-    global _session_factory, _session_local, _retry_cfg
+    global _session_factory, _session_local, _retry_cfg, _jitter_provider
 
     factory = _make_session_factory(api, retry)
     with _session_condition:
@@ -96,6 +102,7 @@ def init_session(api: ApiCfg, retry: RetryCfg) -> None:
         _session_factory = factory
         _session_local = threading.local()
         _retry_cfg = retry
+        _jitter_provider = jitter if jitter is not None else retry.build_jitter()
 
     _close_sessions(old_sessions)
 
@@ -118,6 +125,7 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
     while True:
         with _session_condition:
             retry_cfg = _retry_cfg.model_copy(deep=True)
+            jitter_provider = _jitter_provider
 
         if attempt > retry_cfg.max_attempts:
             break
@@ -144,8 +152,14 @@ def fetch_uniprot(uniprot_id: str, *, cfg: UniprotCfg) -> dict[str, Any]:
                 ) from exc
 
             backoff = retry_cfg.backoff_factor * (2 ** (attempt - 1))
-            jitter = random.uniform(0, retry_cfg.backoff_factor)
-            delay = backoff + jitter + (cfg.delay if cfg.delay else 0)
+            if retry_cfg.backoff_factor > 0:
+                if jitter_provider is not None:
+                    jitter_value = jitter_provider(retry_cfg.backoff_factor)
+                else:
+                    jitter_value = random.uniform(0, retry_cfg.backoff_factor)
+            else:
+                jitter_value = 0.0
+            delay = backoff + jitter_value + (cfg.delay if cfg.delay else 0)
             if delay > 0:
                 sleep(delay)
 

--- a/library/config.py
+++ b/library/config.py
@@ -16,14 +16,15 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import random
 import re
-import atexit
+import threading
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from importlib import resources
 from pathlib import Path
 from types import UnionType
-from typing import Any, Mapping, Union, get_args, get_origin
+from typing import Any, Callable, Mapping, Union, get_args, get_origin
 
 from dataclasses import dataclass, field
 from urllib.parse import urlparse
@@ -899,6 +900,25 @@ class RetryCfg(_BaseModel):
     status_forcelist: list[StrictInt] = Field(
         default_factory=lambda: [429, 500, 502, 503, 504]
     )
+    jitter_seed: int | None = Field(0, ge=0)
+
+    def build_jitter(self) -> Callable[[float], float] | None:
+        """Return a deterministic jitter provider configured by ``jitter_seed``."""
+
+        if self.jitter_seed is None:
+            return None
+
+        seed = int(self.jitter_seed)
+        rng = random.Random(seed)
+        lock = threading.Lock()
+
+        def _jitter(max_value: float) -> float:
+            if max_value <= 0:
+                return 0.0
+            with lock:
+                return rng.uniform(0.0, max_value)
+
+        return _jitter
 
 
 class ActivityBoundsCfg(_BoolModel):

--- a/tests/unit/test_chembl_client.py
+++ b/tests/unit/test_chembl_client.py
@@ -8,7 +8,8 @@ import pytest
 import requests
 
 from library.clients import ChemblClient
-from library.config import ApiCfg
+from library.clients.chembl import _backoff_delay
+from library.config import ApiCfg, RetryCfg
 
 
 @dataclass
@@ -88,3 +89,24 @@ def test_request_json__falls_back_to_extensionless_endpoint() -> None:
     cached = client.request_json(primary_url, cfg=cfg)
     assert cached == payload
     assert session.calls == [primary_url, fallback_url]
+
+
+@pytest.mark.unit
+def test_backoff_delay__deterministic_jitter() -> None:
+    api_cfg = ApiCfg(backoff_factor=0.5)
+    jitter_one = RetryCfg(jitter_seed=11).build_jitter()
+    jitter_two = RetryCfg(jitter_seed=11).build_jitter()
+
+    assert jitter_one is not None
+    assert jitter_two is not None
+
+    delays_one = [
+        _backoff_delay(attempt, api_cfg, None, jitter=jitter_one)
+        for attempt in range(1, 4)
+    ]
+    delays_two = [
+        _backoff_delay(attempt, api_cfg, None, jitter=jitter_two)
+        for attempt in range(1, 4)
+    ]
+
+    assert delays_one == delays_two

--- a/tests/unit/test_pubmed_client.py
+++ b/tests/unit/test_pubmed_client.py
@@ -8,14 +8,40 @@ from library.config import ApiCfg, RetryCfg, session_with_retry
 
 
 @pytest.mark.unit
-def test_retry_delay__respects_backoff_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_retry_delay__respects_backoff_cap() -> None:
     retry_cfg = RetryCfg(max_attempts=4, backoff_factor=2.0, backoff_cap=3.0)
 
-    monkeypatch.setattr(pubmed.random, "uniform", lambda *args, **kwargs: 0.5)
-
-    delay = pubmed._retry_delay(2, 0.25, retry_cfg, timeout=None)
+    delay = pubmed._retry_delay(
+        2,
+        0.25,
+        retry_cfg,
+        timeout=None,
+        jitter=lambda _: 0.5,
+    )
 
     assert delay == pytest.approx(3.0)
+
+
+@pytest.mark.unit
+def test_retry_delay__deterministic_jitter() -> None:
+    retry_cfg = RetryCfg(max_attempts=4, backoff_factor=1.0, backoff_cap=None, jitter_seed=7)
+    jitter_one = retry_cfg.build_jitter()
+    jitter_two = RetryCfg(max_attempts=4, backoff_factor=1.0, backoff_cap=None, jitter_seed=7).build_jitter()
+
+    assert jitter_one is not None
+    assert jitter_two is not None
+
+    base_delay = 0.25
+    delays_one = [
+        pubmed._retry_delay(attempt, base_delay, retry_cfg, timeout=None, jitter=jitter_one)
+        for attempt in range(1, 4)
+    ]
+    delays_two = [
+        pubmed._retry_delay(attempt, base_delay, retry_cfg, timeout=None, jitter=jitter_two)
+        for attempt in range(1, 4)
+    ]
+
+    assert delays_one == delays_two
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a configurable deterministic jitter provider via `RetryCfg.build_jitter` and expose it through the default configuration
- extend the Chembl, PubMed, UniProt and IUPHAR clients to accept optional jitter callables and default to the configured provider
- cover the deterministic jitter behaviour with unit tests for Chembl and PubMed retry helpers

## Testing
- pytest tests/unit/test_pubmed_client.py tests/unit/test_chembl_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e415353dc48324a1c0fac2fe525746