### PR TITLE
Fix UniProt target config indentation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -115,7 +115,7 @@ sources:
       target:
         uniprot:
           column: "uniprot_id"
-        data_dir: "target_uniprot_cache"
+          data_dir: "target_uniprot_cache"
           limit: null
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers


### PR DESCRIPTION
## Summary
- fix the indentation of the UniProt target pipeline configuration so the YAML loader can parse it correctly

## Testing
- not run (missing PyYAML dependency in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4214225d0832496cdb14f5c88f5ac