### PR TITLE
Refactor orchestrator to use pipeline APIs

### DIFF
--- a/library/pipelines/activity/__init__.py
+++ b/library/pipelines/activity/__init__.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from library.config import Config
+
+from library.pipelines.common import PipelineRunResult
 from .action_properties import (
   annotate_action_properties,
   build_activity_properties,
@@ -9,9 +16,103 @@ from .action_properties import (
 )
 from .activities import get_activities
 
+
+@dataclass(slots=True)
+class ActivityPipelineOptions:
+    """Configuration forwarded to the activity CLI runner."""
+
+    input_csv: Path
+    output_csv: Path
+    limit: int | None = None
+    offset: int = 0
+    timeout: float | None = None
+    batch_size: int | None = None
+    workers: int | None = None
+    dry_run: bool = False
+    skip_existing: bool = False
+    force: bool = False
+
+
+def _update_activity_config(
+    cfg: Config,
+    *,
+    limit: int | None,
+    offset: int,
+    timeout: float | None,
+    batch_size: int | None,
+    workers: int | None,
+) -> None:
+    pipelines = cfg.sources.chembl.pipelines
+    section = pipelines.activity
+    updates: dict[str, object] = {"offset": offset}
+    if limit is not None:
+        updates["limit"] = limit
+    if timeout is not None:
+        updates["timeout"] = timeout
+    if batch_size is not None:
+        updates["batch_size"] = batch_size
+    if workers is not None:
+        updates["workers"] = workers
+    pipelines.activity = section.model_copy(update=updates)
+
+
+def run_pipeline(config: Config, options: ActivityPipelineOptions) -> PipelineRunResult:
+    """Execute the activity pipeline using programmatic options."""
+
+    output_path = Path(options.output_csv)
+    if options.skip_existing and output_path.exists() and not options.force:
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=output_path,
+            executed=False,
+            reason="skip_existing",
+            written=False,
+        )
+
+    from scripts import get_activity_data as activity_cli  # Lazy import for cycles
+
+    cfg = config.model_copy(deep=True)
+    _update_activity_config(
+        cfg,
+        limit=options.limit,
+        offset=options.offset,
+        timeout=options.timeout,
+        batch_size=options.batch_size,
+        workers=options.workers,
+    )
+
+    args = SimpleNamespace(
+        input_csv=Path(options.input_csv),
+        final_out=output_path,
+        output_csv=output_path,
+        limit=options.limit,
+        offset=options.offset,
+        timeout=options.timeout or cfg.activity.timeout,
+        batch_size=options.batch_size or cfg.activity.batch_size,
+        workers=options.workers or getattr(cfg.activity, "workers", 1),
+        skip_existing=options.skip_existing,
+        force=options.force,
+        dry_run=options.dry_run,
+    )
+
+    exit_code = activity_cli.run(cfg, args)
+    reason = None if exit_code == 0 else "pipeline_failed"
+    written = None if exit_code != 0 else True
+    return PipelineRunResult(
+        exit_code=exit_code,
+        output_path=output_path,
+        executed=True,
+        reason=reason,
+        written=written,
+    )
+
+
 __all__ = [
+  "ActivityPipelineOptions",
+  "PipelineRunResult",
   "annotate_action_properties",
   "build_activity_properties",
-  "infer_action_type",
   "get_activities",
+  "infer_action_type",
+  "run_pipeline",
 ]

--- a/library/pipelines/assay/__init__.py
+++ b/library/pipelines/assay/__init__.py
@@ -1,7 +1,14 @@
-"""ChEMBL assay and activity pipeline components."""
+"""ChEMBL assay pipeline components and programmatic runner."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from library.config import Config
+
+from library.pipelines.common import PipelineRunResult
 from .chembl_assay import (
   ACTIVITY_COLUMNS,
   ASSAY_COLUMNS,
@@ -13,14 +20,100 @@ from .chembl_assay import (
 )
 from .postprocessing import postprocess_assays, postprocess_file
 
+
+@dataclass(slots=True)
+class AssayPipelineOptions:
+    """Parameters controlling programmatic assay pipeline execution."""
+
+    input_csv: Path
+    output_csv: Path
+    limit: int | None = None
+    offset: int = 0
+    timeout: float | None = None
+    batch_size: int | None = None
+    skip_existing: bool = False
+    force: bool = False
+
+
+def _update_assay_config(
+    cfg: Config,
+    *,
+    limit: int | None,
+    offset: int,
+    timeout: float | None,
+    batch_size: int | None,
+) -> None:
+    pipelines = cfg.sources.chembl.pipelines
+    section = pipelines.assay
+    updates: dict[str, object] = {"offset": offset}
+    if limit is not None:
+        updates["limit"] = limit
+    if timeout is not None:
+        updates["timeout"] = timeout
+    if batch_size is not None:
+        updates["batch_size"] = batch_size
+    pipelines.assay = section.model_copy(update=updates)
+
+
+def run_pipeline(config: Config, options: AssayPipelineOptions) -> PipelineRunResult:
+    """Execute the assay pipeline with programmatic options."""
+
+    output_path = Path(options.output_csv)
+    if options.skip_existing and output_path.exists() and not options.force:
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=output_path,
+            executed=False,
+            reason="skip_existing",
+            written=False,
+        )
+
+    from scripts import get_assay_data as assay_cli  # Lazy import to avoid cycles
+
+    cfg = config.model_copy(deep=True)
+    _update_assay_config(
+        cfg,
+        limit=options.limit,
+        offset=options.offset,
+        timeout=options.timeout,
+        batch_size=options.batch_size,
+    )
+
+    args = SimpleNamespace(
+        input_csv=Path(options.input_csv),
+        final_out=output_path,
+        output_csv=output_path,
+        limit=options.limit,
+        offset=options.offset,
+        timeout=options.timeout or cfg.assay.timeout,
+        batch_size=options.batch_size or cfg.assay.batch_size,
+        skip_existing=options.skip_existing,
+        force=options.force,
+    )
+
+    exit_code = assay_cli.run(cfg, args)
+    reason = None if exit_code == 0 else "pipeline_failed"
+    written = None if exit_code != 0 else True
+    return PipelineRunResult(
+        exit_code=exit_code,
+        output_path=output_path,
+        executed=True,
+        reason=reason,
+        written=written,
+    )
+
+
 __all__ = [
   "ACTIVITY_COLUMNS",
   "ASSAY_COLUMNS",
   "ASSAY_VARIANT_COLUMN_ALIASES",
+  "AssayPipelineOptions",
+  "PipelineRunResult",
   "get_activities",
   "get_assay",
   "get_assays",
   "get_testitem",
   "postprocess_assays",
   "postprocess_file",
+  "run_pipeline",
 ]

--- a/library/pipelines/common/__init__.py
+++ b/library/pipelines/common/__init__.py
@@ -9,6 +9,7 @@ from .helpers import (
   run_chunked_pipeline,
 )
 from .metadata import add_pipeline_metadata, pipeline_metadata
+from .results import PipelineRunResult
 
 __all__ = [
   "ChunkedFetchConfig",
@@ -17,4 +18,5 @@ __all__ = [
   "pipeline_metadata",
   "prepare_chunked_pipeline",
   "run_chunked_pipeline",
+  "PipelineRunResult",
 ]

--- a/library/pipelines/common/results.py
+++ b/library/pipelines/common/results.py
@@ -1,0 +1,18 @@
+"""Data structures shared by pipeline execution helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class PipelineRunResult:
+    """Summarise the outcome of a programmatic pipeline invocation."""
+
+    exit_code: int
+    output_path: Path
+    executed: bool = True
+    reason: str | None = None
+    written: bool | None = None
+

--- a/library/pipelines/document/__init__.py
+++ b/library/pipelines/document/__init__.py
@@ -2,13 +2,125 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
+
+from library.config import Config
+from library.pipelines.common import PipelineRunResult
 from . import pipeline, postprocessing, type_classifier, type_terms
 from .chembl_document import get_documents
 
+
+@dataclass(slots=True)
+class DocumentPipelineOptions:
+    """Configuration for executing the document pipeline programmatically."""
+
+    input_csv: Path
+    output_csv: Path
+    mode: Literal["chembl", "pubmed", "all"] = "all"
+    limit: int | None = None
+    offset: int = 0
+    force: bool = False
+    skip_existing: bool = False
+    fallback_doi_enabled: bool = False
+    fallback_doi_path: Path | None = None
+    fallback_doi_overwrite: bool = False
+    fallback_doi_delimiter: str | None = None
+    fallback_doi_encoding: str | None = None
+    fallback_doi_col_pmid: str = "PMID"
+    fallback_doi_col_doi: str = "DOI"
+
+
+def _update_document_section(
+    cfg: Config,
+    mode: Literal["chembl", "pubmed", "all"],
+    *,
+    limit: int | None,
+    offset: int,
+) -> None:
+    section = getattr(cfg.sources.chembl.pipelines.document, mode)
+    updates: dict[str, object] = {"offset": offset}
+    if limit is not None:
+        updates["limit"] = limit
+    setattr(
+        cfg.sources.chembl.pipelines.document,
+        mode,
+        section.model_copy(update=updates),
+    )
+
+
+def run_pipeline(config: Config, options: DocumentPipelineOptions) -> PipelineRunResult:
+    """Run the document pipeline using programmatic options."""
+
+    output_path = Path(options.output_csv)
+    if options.skip_existing and output_path.exists() and not options.force:
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=output_path,
+            executed=False,
+            reason="skip_existing",
+            written=False,
+        )
+
+    from scripts import get_document_data as document_cli  # Lazy import to avoid cycles
+
+    cfg = config.model_copy(deep=True)
+    _update_document_section(
+        cfg,
+        options.mode,
+        limit=options.limit,
+        offset=options.offset,
+    )
+
+    if options.mode == "chembl":
+        runner = document_cli.run_chembl
+    elif options.mode == "pubmed":
+        runner = document_cli.run_pubmed
+    elif options.mode == "all":
+        runner = document_cli.run_all
+    else:  # pragma: no cover - defensive guard
+        msg = f"unsupported document pipeline mode: {options.mode}"
+        raise ValueError(msg)
+
+    args = SimpleNamespace(
+        input_csv=Path(options.input_csv),
+        final_out=output_path,
+        output_csv=output_path,
+        skip_existing=options.skip_existing,
+        force=options.force,
+        limit=options.limit,
+        offset=options.offset,
+        fallback_doi_enabled=options.fallback_doi_enabled,
+        fallback_doi_path=options.fallback_doi_path,
+        fallback_doi_overwrite=options.fallback_doi_overwrite,
+        fallback_doi_delimiter=options.fallback_doi_delimiter,
+        fallback_doi_encoding=options.fallback_doi_encoding,
+        fallback_doi_col_pmid=options.fallback_doi_col_pmid,
+        fallback_doi_col_doi=options.fallback_doi_col_doi,
+        mode=options.mode,
+        command=options.mode,
+    )
+
+    exit_code = int(runner(cfg, args))
+    reason = None if exit_code == 0 else "pipeline_failed"
+    return PipelineRunResult(
+        exit_code=exit_code,
+        output_path=output_path,
+        executed=True,
+        reason=reason,
+        written=None,
+    )
+
+
 __all__ = [
+  "DocumentPipelineOptions",
+  "PipelineRunResult",
   "get_documents",
   "pipeline",
   "postprocessing",
+  "run_pipeline",
   "type_classifier",
   "type_terms",
 ]

--- a/library/pipelines/target/__init__.py
+++ b/library/pipelines/target/__init__.py
@@ -1,7 +1,14 @@
-"""Target acquisition pipeline helpers and orchestrators."""
+"""Target acquisition pipeline helpers and programmatic runner."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Literal
+
+from library.config import Config
+from library.pipelines.common import PipelineRunResult
 from . import (
     cellularity,
     helpers,
@@ -13,7 +20,114 @@ from . import (
 )
 from .chembl_target import normalize_reaction_ec_numbers
 
+
+@dataclass(slots=True)
+class TargetPipelineOptions:
+    """Configuration options for executing the target pipeline."""
+
+    input_csv: Path
+    output_csv: Path
+    command: Literal["chembl", "uniprot", "iuphar", "all"] = "all"
+    limit: int | None = None
+    offset: int = 0
+    raw_output: Path | None = None
+    raw_format: str = "csv"
+    no_reindex_raw: bool = False
+    id_columns: tuple[str, ...] | None = None
+    skip_existing: bool = False
+    force: bool = False
+
+
+def _update_target_config(
+    cfg: Config,
+    *,
+    command: str,
+    limit: int | None,
+    offset: int,
+) -> None:
+    target_cfg = cfg.sources.chembl.pipelines.target
+
+    def _apply(section_name: str) -> None:
+        section = getattr(target_cfg, section_name)
+        updates: dict[str, object] = {"offset": offset}
+        if limit is not None:
+            updates["limit"] = limit
+        setattr(target_cfg, section_name, section.model_copy(update=updates))
+
+    if command == "all":
+        _apply("all")
+        _apply("chembl")
+        _apply("uniprot")
+        _apply("iuphar")
+    else:
+        _apply(command)
+
+
+def run_pipeline(config: Config, options: TargetPipelineOptions) -> PipelineRunResult:
+    """Execute the target pipeline for the selected command."""
+
+    output_path = Path(options.output_csv)
+    if options.skip_existing and output_path.exists() and not options.force:
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=output_path,
+            executed=False,
+            reason="skip_existing",
+            written=False,
+        )
+
+    from scripts import get_target_data as target_cli  # Lazy import to avoid cycles
+
+    cfg = config.model_copy(deep=True)
+    _update_target_config(
+        cfg,
+        command=options.command,
+        limit=options.limit,
+        offset=options.offset,
+    )
+
+    args = SimpleNamespace(
+        input_csv=Path(options.input_csv),
+        final_out=output_path,
+        output_csv=output_path,
+        raw_out=options.raw_output,
+        raw_format=options.raw_format,
+        no_reindex_raw=options.no_reindex_raw,
+        id_cols=options.id_columns,
+        limit=options.limit,
+        offset=options.offset,
+        command=options.command,
+        skip_existing=False,
+        force=options.force,
+    )
+
+    if options.command == "chembl":
+        runner = target_cli.run_chembl
+    elif options.command == "uniprot":
+        runner = target_cli.run_uniprot
+    elif options.command == "iuphar":
+        runner = target_cli.run_iuphar
+    elif options.command == "all":
+        runner = target_cli.run_all
+    else:  # pragma: no cover - defensive guard
+        msg = f"unsupported target pipeline command: {options.command}"
+        raise ValueError(msg)
+
+    exit_code = int(runner(cfg, args))
+    reason = None if exit_code == 0 else "pipeline_failed"
+    written = None if exit_code != 0 else True
+    return PipelineRunResult(
+        exit_code=exit_code,
+        output_path=output_path,
+        executed=True,
+        reason=reason,
+        written=written,
+    )
+
+
 __all__ = [
+  "TargetPipelineOptions",
+  "PipelineRunResult",
   "normalize_reaction_ec_numbers",
   "cellularity",
   "helpers",
@@ -22,4 +136,5 @@ __all__ = [
   "pipeline",
   "postprocessing",
   "protein_classification",
+  "run_pipeline",
 ]

--- a/library/pipelines/testitem/__init__.py
+++ b/library/pipelines/testitem/__init__.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 # ===== Modules =====
 from importlib import import_module
 from importlib.util import find_spec
+from pathlib import Path
 
+from library.config import Config
+
+from library.pipelines.common import PipelineRunResult
 from . import enrichment as testitem_enrichment
 from .enrichment import enrich
 from library.pipelines.assay.chembl_assay import TESTITEM_PUBCHEM_COLUMNS
@@ -111,9 +115,42 @@ __all__ = [
     "query_parent_catalog",
     "read_input_ids",
     "run_testitem_pipeline",
+    "run_pipeline",
     "update_parent_catalog_cache",
     "write_meta_yaml",
     "write_parent_catalog_cache",
 ]
 
 __all__.append("testitem_enrichment")
+
+
+def run_pipeline(config: Config, options: TestitemPipelineOptions) -> PipelineRunResult:
+    """Execute the test item pipeline and return a common result structure."""
+
+    cfg = config.model_copy(deep=True)
+    pipelines = cfg.sources.chembl.pipelines
+    section = pipelines.testitem
+    updates: dict[str, object] = {}
+    if getattr(options, "limit", None) is not None:
+        updates["limit"] = options.limit
+    if getattr(options, "offset", None) is not None:
+        updates["offset"] = options.offset
+    if updates:
+        pipelines.testitem = section.model_copy(update=updates)
+
+    output_candidate = getattr(options, "output_csv", None)
+    if output_candidate is not None:
+        output_path = Path(output_candidate)
+    else:
+        output_path = Path(options.input_csv)
+
+    exit_code = run_testitem_pipeline(cfg, options)
+    reason = None if exit_code == 0 else "pipeline_failed"
+    written = None if exit_code != 0 else True
+    return PipelineRunResult(
+        exit_code=exit_code,
+        output_path=output_path,
+        executed=True,
+        reason=reason,
+        written=written,
+    )

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -55,7 +55,28 @@ from library.clients import ChemblClient
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
 from library.integration.molecule_catalog import load_parent_catalog
+from library.pipelines.activity import (
+    ActivityPipelineOptions,
+    run_pipeline as run_activity_pipeline,
+)
+from library.pipelines.assay import (
+    AssayPipelineOptions,
+    run_pipeline as run_assay_pipeline,
+)
+from library.pipelines.common import PipelineRunResult
+from library.pipelines.document import (
+    DocumentPipelineOptions,
+    run_pipeline as run_document_pipeline,
+)
 from library.pipelines.registry import PipelineStep, load_pipeline_registry
+from library.pipelines.target import (
+    TargetPipelineOptions,
+    run_pipeline as run_target_pipeline,
+)
+from library.pipelines.testitem import (
+    TestitemPipelineOptions,
+    run_pipeline as run_testitem_pipeline,
+)
 from library.utils.config import DEFAULT_CONFIG_PATH
 
 
@@ -78,6 +99,80 @@ _DEFAULT_OUTPUT_STEMS = DEFAULT_OUTPUT_STEMS
 _UNLINK_MAX_ATTEMPTS = 5
 _UNLINK_RETRY_SLEEP_SECONDS = 0.1
 _WINDOWS_SHARING_VIOLATION = 32
+
+
+@dataclass(frozen=True)
+class PipelineApi:
+    """Describe how to build options and execute a pipeline programmatically."""
+
+    build_options: Callable[["PipelineRunConfig", Path, Path], object]
+    runner: Callable[[Config, object], PipelineRunResult]
+
+
+def _build_document_options(
+    cfg: "PipelineRunConfig", input_path: Path, output_path: Path
+) -> DocumentPipelineOptions:
+    return DocumentPipelineOptions(
+        input_csv=input_path,
+        output_csv=output_path,
+        mode="all",
+        limit=cfg.limit,
+        force=cfg.force,
+    )
+
+
+def _build_target_options(
+    cfg: "PipelineRunConfig", input_path: Path, output_path: Path
+) -> TargetPipelineOptions:
+    return TargetPipelineOptions(
+        input_csv=input_path,
+        output_csv=output_path,
+        command="all",
+        limit=cfg.limit,
+        force=cfg.force,
+    )
+
+
+def _build_assay_options(
+    cfg: "PipelineRunConfig", input_path: Path, output_path: Path
+) -> AssayPipelineOptions:
+    return AssayPipelineOptions(
+        input_csv=input_path,
+        output_csv=output_path,
+        limit=cfg.limit,
+        force=cfg.force,
+    )
+
+
+def _build_testitem_options(
+    cfg: "PipelineRunConfig", input_path: Path, output_path: Path
+) -> TestitemPipelineOptions:
+    return TestitemPipelineOptions(
+        input_csv=input_path,
+        output_csv=output_path,
+        limit=cfg.limit,
+        offset=0,
+    )
+
+
+def _build_activity_options(
+    cfg: "PipelineRunConfig", input_path: Path, output_path: Path
+) -> ActivityPipelineOptions:
+    return ActivityPipelineOptions(
+        input_csv=input_path,
+        output_csv=output_path,
+        limit=cfg.limit,
+        force=cfg.force,
+    )
+
+
+_PIPELINE_APIS: Mapping[str, PipelineApi] = {
+    "document": PipelineApi(_build_document_options, run_document_pipeline),
+    "target": PipelineApi(_build_target_options, run_target_pipeline),
+    "assay": PipelineApi(_build_assay_options, run_assay_pipeline),
+    "testitem": PipelineApi(_build_testitem_options, run_testitem_pipeline),
+    "activity": PipelineApi(_build_activity_options, run_activity_pipeline),
+}
 
 
 @dataclass(frozen=True)
@@ -608,6 +703,7 @@ def _cleanup_empty_directories(path: Path, *, root: Path) -> None:
 def _run_step(
     step: PipelineStep,
     cfg: PipelineRunConfig,
+    base_config: Config,
     final_output: Path,
     working_output: Path,
 ) -> StepExecutionResult:
@@ -631,27 +727,55 @@ def _run_step(
             reason="skip_existing",
         )
 
-    arguments = step.build_arguments(cfg, output_path=working_output)
-    _LOGGER.debug("step_arguments", step=step.name, arguments=arguments)
-    try:
-        exit_code = step.main(arguments)
-    except SystemExit as exc:
-        exit_code = _coerce_exit_code(exc.code)
+    if cfg.limit == 0:
+        _LOGGER.info("step_skip_limit", step=step.name, limit=cfg.limit)
+        return StepExecutionResult(
+            exit_code=0,
+            executed=False,
+            status="skipped",
+            reason="limit",
+        )
+
+    api = _PIPELINE_APIS.get(step.name)
+    if api is None:
+        arguments = step.build_arguments(cfg, output_path=working_output)
+        _LOGGER.debug("step_arguments", step=step.name, arguments=arguments)
+        try:
+            exit_code = step.main(arguments)
+        except SystemExit as exc:
+            exit_code = _coerce_exit_code(exc.code)
+            status = "success" if exit_code == 0 else "failed"
+            return StepExecutionResult(
+                exit_code=exit_code,
+                executed=True,
+                status=status,
+                reason="system_exit",
+            )
+        except BaseException:
+            raise
         status = "success" if exit_code == 0 else "failed"
         return StepExecutionResult(
             exit_code=exit_code,
             executed=True,
             status=status,
-            reason="system_exit",
+            reason=None if status == "success" else "non_zero_exit",
         )
-    except BaseException:
-        raise
-    status = "success" if exit_code == 0 else "failed"
+
+    options = api.build_options(cfg, input_path, working_output)
+    result = api.runner(base_config, options)
+    executed = bool(result.executed)
+    if not executed and result.exit_code == 0:
+        status = "skipped"
+    else:
+        status = "success" if result.exit_code == 0 else "failed"
+    reason = result.reason
+    if reason is None and status == "failed":
+        reason = "non_zero_exit"
     return StepExecutionResult(
-        exit_code=exit_code,
-        executed=True,
+        exit_code=result.exit_code,
+        executed=executed,
         status=status,
-        reason=None if status == "success" else "non_zero_exit",
+        reason=reason,
     )
 
 
@@ -1053,6 +1177,7 @@ def run_pipeline(cfg: PipelineRunConfig) -> int:
     """Execute all configured steps and return the resulting exit status."""
 
     effective_steps = tuple(DEFAULT_PIPELINE_STEPS if steps is None else steps)
+    base_config = load_config(cfg.config_path, base_path=cfg.base_path)
     overall_status = 0
     run_started_at = datetime.now(UTC)
     run_started_clock = time.perf_counter()
@@ -1145,7 +1270,7 @@ def run_pipeline(cfg: PipelineRunConfig) -> int:
                 break
 
         try:
-            result = _run_step(step, cfg, final_output, working_output)
+            result = _run_step(step, cfg, base_config, final_output, working_output)
         except SystemExit as exc:  # pragma: no cover - defensive guard
             exit_code = _coerce_exit_code(exc.code)
             entry.update(

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -5,38 +5,42 @@ import io
 import json
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Callable
 
 import pandas as pd
 import pytest
 
 from library.config import Config
+from library.pipelines.common import PipelineRunResult
 from scripts import get_data, get_target_data
 from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 from tests.helpers.logs import parse_log_lines
 
 
-def _build_stub_step(
+def _build_stub_api(
     *,
     required_columns: list[str],
     key_column: str,
     on_execute: Callable[[pd.DataFrame, Path], int],
-) -> Callable[[list[str]], int]:
-    def _main(argv: list[str]) -> int:
-        parser = argparse.ArgumentParser(prog="stub")
-        parser.add_argument("--config", required=True)
-        parser.add_argument("--input", required=True)
-        parser.add_argument("--final-out", required=True)
-        parser.add_argument("--log-level")
-        parser.add_argument("--limit", type=int, default=None)
-        parser.add_argument("--force", action="store_true")
-        parser.add_argument("--skip-existing", action="store_true")
-        args, _ = parser.parse_known_args(argv)
-        frame = pd.read_csv(Path(args.input))
+) -> get_data.PipelineApi:
+    def _builder(
+        cfg: get_data.PipelineRunConfig, input_path: Path, output_path: Path
+    ) -> SimpleNamespace:
+        return SimpleNamespace(input_csv=input_path, output_csv=output_path)
+
+    def _runner(config: Config, options: SimpleNamespace) -> PipelineRunResult:
+        frame = pd.read_csv(Path(options.input_csv))
         missing = [col for col in required_columns if col not in frame.columns]
         if missing:
             get_data._LOGGER.error("schema_mismatch", missing=missing)
-            return 1
+            return PipelineRunResult(
+                exit_code=1,
+                output_path=Path(options.output_csv),
+                executed=True,
+                reason="schema_mismatch",
+                written=False,
+            )
         frame = frame[required_columns].copy()
         frame[key_column] = frame[key_column].astype("string").str.strip()
         duplicates = frame[key_column].duplicated()
@@ -46,9 +50,18 @@ def _build_stub_step(
                 count=int(duplicates.sum()),
             )
             frame = frame.loc[~duplicates].copy()
-        return on_execute(frame, Path(args.final_out))
+        destination = Path(options.output_csv)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        result_code = on_execute(frame, destination)
+        return PipelineRunResult(
+            exit_code=result_code,
+            output_path=destination,
+            executed=True,
+            reason=None if result_code == 0 else "pipeline_failed",
+            written=result_code == 0,
+        )
 
-    return _main
+    return get_data.PipelineApi(_builder, _runner)
 
 
 def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
@@ -109,13 +122,14 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
         rows.to_csv(destination, index=False)
         return 0
 
+    api = _build_stub_api(
+        required_columns=["document_chembl_id", "title", "pubmed_id"],
+        key_column="document_chembl_id",
+        on_execute=_on_execute,
+    )
     step = get_data.PipelineStep(
         name="document",
-        main=_build_stub_step(
-            required_columns=["document_chembl_id", "title", "pubmed_id"],
-            key_column="document_chembl_id",
-            on_execute=_on_execute,
-        ),
+        main=lambda _: 0,
         input_filename="document.csv",
         output_stem="documents",
     )
@@ -125,6 +139,7 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+    monkeypatch.setattr(get_data, "_PIPELINE_APIS", {"document": api}, raising=False)
 
     steps = (step,)
     status = get_data.run_pipeline(cfg, steps=steps)
@@ -152,7 +167,7 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
     manifest_failure = _load_manifest(cfg)
     assert manifest_failure["run"]["exit_code"] == 1
     assert manifest_failure["steps"][0]["status"] == "failed"
-    assert manifest_failure["steps"][0]["reason"] == "non_zero_exit"
+    assert manifest_failure["steps"][0]["reason"] == "schema_mismatch"
     assert manifest_failure["steps"][0]["output"]["exists"] is False
 
 
@@ -177,13 +192,14 @@ def test_pipeline_subset__skip_existing_and_force(tmp_path: Path, monkeypatch: p
         destination.write_text("target_chembl_id\nT1\nT2\n", encoding="utf-8")
         return 0
 
+    api = _build_stub_api(
+        required_columns=["target_chembl_id", "name", "organism"],
+        key_column="target_chembl_id",
+        on_execute=_on_execute,
+    )
     step = get_data.PipelineStep(
         name="target",
-        main=_build_stub_step(
-            required_columns=["target_chembl_id", "name", "organism"],
-            key_column="target_chembl_id",
-            on_execute=_on_execute,
-        ),
+        main=lambda _: 0,
         input_filename="target.csv",
         output_stem="targets",
     )
@@ -195,6 +211,7 @@ def test_pipeline_subset__skip_existing_and_force(tmp_path: Path, monkeypatch: p
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
     steps = (step,)
+    monkeypatch.setattr(get_data, "_PIPELINE_APIS", {"target": api}, raising=False)
     status_first = get_data.run_pipeline(cfg, steps=steps)
     assert status_first == 0
     assert executions == [2]
@@ -275,18 +292,19 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
         enriched.to_csv(destination, index=False, columns=columns)
         return 0
 
+    api = _build_stub_api(
+        required_columns=[
+            "assay_chembl_id",
+            "target_chembl_id",
+            "document_chembl_id",
+            "description",
+        ],
+        key_column="assay_chembl_id",
+        on_execute=_on_execute,
+    )
     step = get_data.PipelineStep(
         name="assay",
-        main=_build_stub_step(
-            required_columns=[
-                "assay_chembl_id",
-                "target_chembl_id",
-                "document_chembl_id",
-                "description",
-            ],
-            key_column="assay_chembl_id",
-            on_execute=_on_execute,
-        ),
+        main=lambda _: 0,
         input_filename="assay.csv",
         output_stem="assays",
     )
@@ -297,6 +315,7 @@ def test_pipeline_subset__retry_after_failure(tmp_path: Path, monkeypatch: pytes
     )
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
+    monkeypatch.setattr(get_data, "_PIPELINE_APIS", {"assay": api}, raising=False)
     steps = (step,)
     first_status = get_data.run_pipeline(cfg, steps=steps)
     assert first_status == 1

--- a/tests/unit/test_get_data.py
+++ b/tests/unit/test_get_data.py
@@ -5,12 +5,14 @@ import io
 import json
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Sequence
 
 import pytest
 
 from scripts import get_data
 from tests.helpers.logs import iter_events, parse_log_lines
+from library.pipelines.common import PipelineRunResult
 
 
 def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
@@ -204,36 +206,47 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
     cfg = _make_config(tmp_path)
     failure_calls: list[Sequence[str]] = []
 
-    def _success(argv: Sequence[str]) -> int:
-        final_out = Path(argv[argv.index("--final-out") + 1])
-        final_out.parent.mkdir(parents=True, exist_ok=True)
-        final_out.write_text("id\n1\n", encoding="utf-8")
-        return 0
+    def _success_runner(_: get_data.Config, options: SimpleNamespace) -> PipelineRunResult:
+        path = Path(options.output_csv)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("id\n1\n", encoding="utf-8")
+        return PipelineRunResult(exit_code=0, output_path=path, executed=True, written=True)
 
-    def _failure(argv: Sequence[str]) -> int:
-        failure_calls.append(tuple(argv))
-        return 2
+    def _failure_runner(_: get_data.Config, options: SimpleNamespace) -> PipelineRunResult:
+        failure_calls.append((str(options.input_csv), str(options.output_csv)))
+        return PipelineRunResult(exit_code=2, output_path=Path(options.output_csv), executed=True)
+
+    def _build_options(
+        cfg: get_data.PipelineRunConfig, input_path: Path, output_path: Path
+    ) -> SimpleNamespace:
+        return SimpleNamespace(input_csv=input_path, output_csv=output_path)
 
     steps = (
         get_data.PipelineStep(
             name="document",
-            main=_success,
+            main=lambda _: 0,
             input_filename="document.csv",
             output_stem="documents",
         ),
         get_data.PipelineStep(
             name="target",
-            main=_failure,
+            main=lambda _: 0,
             input_filename="target.csv",
             output_stem="targets",
         ),
         get_data.PipelineStep(
             name="assay",
-            main=_success,
+            main=lambda _: 0,
             input_filename="assay.csv",
             output_stem="assays",
         ),
     )
+
+    apis = {
+        "document": get_data.PipelineApi(_build_options, _success_runner),
+        "target": get_data.PipelineApi(_build_options, _failure_runner),
+        "assay": get_data.PipelineApi(_build_options, _success_runner),
+    }
 
     stream = io.StringIO()
     logger = get_data.configure_logger(
@@ -241,6 +254,7 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
     )
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
+    monkeypatch.setattr(get_data, "_PIPELINE_APIS", apis, raising=False)
     status = get_data.run_pipeline(cfg, steps=steps)
     assert status == 2
     assert failure_calls, "expected failing step to execute"
@@ -270,23 +284,30 @@ def test_run_pipeline__propagates_step_failure(tmp_path: Path, monkeypatch: pyte
 def test_run_pipeline__handles_step_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _make_config(tmp_path)
 
-    def _raising(argv: Sequence[str]) -> int:  # pragma: no cover - executed via pipeline
+    def _raising_runner(_: get_data.Config, options: SimpleNamespace) -> PipelineRunResult:
         raise RuntimeError("malformed output")
+
+    def _build_options(
+        cfg: get_data.PipelineRunConfig, input_path: Path, output_path: Path
+    ) -> SimpleNamespace:
+        return SimpleNamespace(input_csv=input_path, output_csv=output_path)
 
     steps = (
         get_data.PipelineStep(
             name="document",
-            main=_raising,
+            main=lambda _: 0,
             input_filename="document.csv",
             output_stem="documents",
         ),
     )
+    apis = {"document": get_data.PipelineApi(_build_options, _raising_runner)}
     stream = io.StringIO()
     logger = get_data.configure_logger(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit")
     )
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
 
+    monkeypatch.setattr(get_data, "_PIPELINE_APIS", apis, raising=False)
     status = get_data.run_pipeline(cfg, steps=steps)
     assert status == 1
     manifest = _load_manifest(cfg)


### PR DESCRIPTION
## Summary
- expose new `run_pipeline` entry points and options dataclasses for activity, assay, document, target, and testitem pipelines
- add a shared `PipelineRunResult` structure and have the orchestrator build pipeline options directly instead of shelling out to CLI mains
- update unit and integration smoke tests to exercise the new programmatic pathway and stub pipeline APIs

## Testing
- `pytest tests/unit/test_get_data.py tests/integration/test_get_data_workflow.py` *(fails: DictionaryManifestError due to checksum mismatch loading bundled resources)*

------
https://chatgpt.com/codex/tasks/task_e_68e41e7e664c8324adcf7b83fdb63b85