### PR TITLE
Fix target uniprot pipeline config indentation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -115,7 +115,7 @@ sources:
       target:
         uniprot:
           column: "uniprot_id"
-        data_dir: "target_uniprot_cache"
+          data_dir: "target_uniprot_cache"
           limit: null
         chembl:
           column: "target_chembl_id"  # Column containing ChEMBL target identifiers


### PR DESCRIPTION
## Summary
- fix the indentation of the target pipeline's UniProt cache settings so they are scoped to the UniProt mapping

## Testing
- python -c "import sitecustomize, scripts.get_target_data as mod; import sys; sys.exit(mod.main(['uniprot','--config','config/config.yaml','--print-config']))" > /tmp/cli_output.txt

------
https://chatgpt.com/codex/tasks/task_e_68e422e5d43883249a5b2fd0bd063bc3