### PR TITLE
Centralise pipeline reporting sidecars

### DIFF
--- a/library/cli/utils.py
+++ b/library/cli/utils.py
@@ -33,14 +33,10 @@ from ..cli import (
     prepare_io_paths,
 )
 from ..common.log import logger as default_logger
-from ..common.metadata import (
-    Stats,
-    file_sha256,
-    record_quality_failure,
-    write_meta_yaml,
-)
+from ..common.metadata import Stats, record_quality_failure
 from ..common.sidecar import SidecarErrors
 from ..config import Config, ConfigError, ensure_dirs, print_config
+from ..reporting.run_manifest import finalise_csv_output
 from ..utils.config import DEFAULT_CONFIG_PATH
 
 SchemaT = TypeVar("SchemaT")
@@ -610,15 +606,26 @@ def run_pipeline(
         use_logger.error("write_fail", error="writer returned None", path=str(output_path))
         return 1
 
-    stats: Stats = {
-        "rows_total": rows_total,
-        "rows_kept": rows_kept,
-        "rows_dropped": rows_dropped,
-        "output_sha256": file_sha256(csv_path),
-    }
     extra_stats = stats_extra() if callable(stats_extra) else stats_extra
-    for key, value in (extra_stats or {}).items():
-        stats[key] = value
+    resolved_invocation = invocation_tuple
+
+    extra_metadata: dict[str, object] = {}
+    if failed_metadata_hooks:
+        extra_metadata["metadata_hook_failures"] = sorted(failed_metadata_hooks)
+
+    report = finalise_csv_output(
+        csv_path=csv_path,
+        rows_total=rows_total,
+        rows_kept=rows_kept,
+        command=command_str,
+        config_subset=config_snapshot,
+        inputs=inputs,
+        schema=schema_name,
+        stats_extra=extra_stats or None,
+        invocation=resolved_invocation or None,
+        extra_metadata=extra_metadata or None,
+    )
+    stats = report.stats
 
     if stats_callback is not None:
         try:
@@ -626,22 +633,7 @@ def run_pipeline(
         except Exception:  # pragma: no cover - defensive against user callbacks
             use_logger.exception("stats_callback_failed")
 
-    resolved_invocation = invocation_tuple
-
-    extra_metadata: dict[str, object] = {}
-    if failed_metadata_hooks:
-        extra_metadata["metadata_hook_failures"] = sorted(failed_metadata_hooks)
-
-    meta_path = write_meta_yaml(
-        csv_path=csv_path,
-        command=command_str,
-        config_subset=config_snapshot,
-        inputs=inputs,
-        stats=stats,
-        schema=schema_name,
-        invocation=resolved_invocation or None,
-        extra_metadata=extra_metadata or None,
-    )
+    meta_path = report.meta_path
 
     doc_quality_cfg = getattr(getattr(cfg, "system", None), "doc_quality", None)
     fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))

--- a/library/reporting/__init__.py
+++ b/library/reporting/__init__.py
@@ -1,0 +1,21 @@
+"""Reporting helpers shared across pipeline orchestration code."""
+
+from .run_manifest import (
+    PipelineOutputReport,
+    QualityAnalysisError,
+    QualityReportError,
+    RunManifestError,
+    finalise_csv_output,
+    load_output_report,
+    merge_run_output,
+)
+
+__all__ = [
+    "PipelineOutputReport",
+    "QualityAnalysisError",
+    "QualityReportError",
+    "RunManifestError",
+    "finalise_csv_output",
+    "load_output_report",
+    "merge_run_output",
+]

--- a/library/reporting/run_manifest.py
+++ b/library/reporting/run_manifest.py
@@ -1,0 +1,270 @@
+"""Helpers for producing standardised pipeline reporting artefacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+import yaml
+
+from ..common.metadata import Stats, file_sha256, write_meta_yaml
+from ..qa.table_quality import TableQualityProfiler, analyze_table_quality
+
+
+class RunManifestError(RuntimeError):
+    """Base exception for run manifest reporting failures."""
+
+
+class QualityReportError(RunManifestError):
+    """Raised when the quality report cannot be serialised to disk."""
+
+    def __init__(self, message: str, path: Path | None = None) -> None:
+        super().__init__(message)
+        self.path = Path(path) if path is not None else None
+
+
+class QualityAnalysisError(RunManifestError):
+    """Raised when table quality analysis fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineOutputReport:
+    """Container capturing output artefact metadata for a pipeline step."""
+
+    csv_path: Path
+    stats: Stats
+    meta_path: Path
+    meta_sha256: str
+    quality_path: Path | None = None
+    quality_sha256: str | None = None
+
+    def as_manifest_payload(self) -> dict[str, Any]:
+        """Return a serialisable payload summarising the artefact."""
+
+        stats_payload: dict[str, Any] = {}
+        for key, value in self.stats.items():
+            if key in {"rows_total", "rows_kept", "rows_dropped"}:
+                stats_payload[key] = int(value) if value is not None else None
+            else:
+                stats_payload[key] = value
+        payload: dict[str, Any] = {
+            "output_path": str(self.csv_path),
+            "output_sha256": self.stats.get("output_sha256"),
+            "stats": stats_payload,
+            "meta": {
+                "path": str(self.meta_path),
+                "checksum_sha256": self.meta_sha256,
+            },
+        }
+        if self.quality_path is not None:
+            payload["quality"] = {
+                "path": str(self.quality_path),
+                "checksum_sha256": self.quality_sha256,
+            }
+        return payload
+
+
+def _build_stats(
+    csv_path: Path,
+    *,
+    rows_total: int,
+    rows_kept: int,
+    extra: Mapping[str, Any] | None = None,
+) -> Stats:
+    total = int(rows_total)
+    kept = int(rows_kept)
+    dropped = max(total - kept, 0)
+    stats: Stats = {
+        "rows_total": total,
+        "rows_kept": kept,
+        "rows_dropped": dropped,
+        "output_sha256": file_sha256(csv_path),
+    }
+    if extra:
+        for key, value in extra.items():
+            stats[key] = value
+    return stats
+
+
+def _normalise_quality_summary(
+    summary: Any,
+    builder: Callable[[Any], Mapping[str, Any]] | None,
+) -> Mapping[str, Any]:
+    if builder is not None:
+        report = builder(summary)
+        if not isinstance(report, Mapping):
+            raise TypeError("quality report builder must return a mapping")
+        return dict(report)
+    if summary is None:
+        raise TypeError("quality_summary is required when no builder is provided")
+    if isinstance(summary, Mapping):
+        return dict(summary)
+    build = getattr(summary, "build", None)
+    if callable(build):
+        built = build()
+        if isinstance(built, Mapping):
+            return dict(built)
+    raise TypeError("quality_summary must be a mapping or provide a builder")
+
+
+def _cfg_value(cfg: Any, key: str, default: Any = None) -> Any:
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return cfg.get(key, default)
+    return getattr(cfg, key, default)
+
+
+def finalise_csv_output(
+    *,
+    csv_path: Path,
+    rows_total: int,
+    rows_kept: int,
+    command: str,
+    config_subset: Mapping[str, Any],
+    inputs: Mapping[str, Any],
+    schema: str,
+    stats_extra: Mapping[str, Any] | None = None,
+    invocation: Sequence[str] | None = None,
+    extra_metadata: Mapping[str, Any] | None = None,
+    quality_summary: Any | None = None,
+    quality_builder: Callable[[Any], Mapping[str, Any]] | None = None,
+    quality_path: Path | None = None,
+    quality_profiler: TableQualityProfiler | None = None,
+    quality_config: Any | None = None,
+    quality_table_name: str | None = None,
+    quality_destination: Path | None = None,
+) -> PipelineOutputReport:
+    """Write metadata and optional quality artefacts for ``csv_path``."""
+
+    path = Path(csv_path)
+    stats = _build_stats(path, rows_total=rows_total, rows_kept=rows_kept, extra=stats_extra)
+    meta_path = write_meta_yaml(
+        csv_path=path,
+        command=command,
+        config_subset=config_subset,
+        inputs=inputs,
+        stats=stats,
+        schema=schema,
+        invocation=invocation,
+        extra_metadata=extra_metadata,
+    )
+    meta_sha = file_sha256(meta_path)
+
+    resolved_quality_path: Path | None = None
+    quality_sha: str | None = None
+    if quality_summary is not None or quality_builder is not None:
+        report_data = _normalise_quality_summary(quality_summary, quality_builder)
+        destination = Path(quality_path) if quality_path is not None else path.with_suffix(".quality.json")
+        try:
+            destination.write_text(
+                json.dumps(report_data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except (OSError, TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise QualityReportError(str(exc), destination) from exc
+        resolved_quality_path = destination
+        quality_sha = file_sha256(destination)
+
+    if quality_profiler is not None and bool(_cfg_value(quality_config, "enable", False)):
+        table_name = quality_table_name or path.with_suffix("").name
+        destination_dir = quality_destination or path.parent
+        try:
+            analyze_table_quality(
+                quality_profiler,
+                table_name=table_name,
+                destination_dir=destination_dir,
+                sample_rows=_cfg_value(quality_config, "sample_rows"),
+                include_columns=_cfg_value(quality_config, "include_columns"),
+                exclude_columns=_cfg_value(quality_config, "exclude_columns"),
+            )
+        except Exception as exc:  # pragma: no cover - propagated to caller
+            raise QualityAnalysisError(str(exc)) from exc
+
+    return PipelineOutputReport(
+        csv_path=path,
+        stats=stats,
+        meta_path=meta_path,
+        meta_sha256=meta_sha,
+        quality_path=resolved_quality_path,
+        quality_sha256=quality_sha,
+    )
+
+
+def merge_run_output(entry: MutableMapping[str, Any], report: PipelineOutputReport) -> None:
+    """Merge ``report`` statistics into a manifest ``entry`` in place."""
+
+    stats: dict[str, Any] = {}
+    for key, value in report.stats.items():
+        if key in {"rows_total", "rows_kept", "rows_dropped"}:
+            try:
+                stats[key] = int(value)
+            except (TypeError, ValueError):
+                stats[key] = value
+        else:
+            stats[key] = value
+    entry["stats"] = stats
+
+    output = entry.setdefault("output", {})
+    output.setdefault("path", str(report.csv_path))
+    output["checksum_sha256"] = report.stats.get("output_sha256")
+    output["meta_path"] = str(report.meta_path)
+    output["meta_sha256"] = report.meta_sha256
+    if report.quality_path is not None:
+        output["quality_path"] = str(report.quality_path)
+        output["quality_sha256"] = report.quality_sha256
+
+
+def load_output_report(csv_path: Path) -> PipelineOutputReport | None:
+    """Return a :class:`PipelineOutputReport` derived from metadata files."""
+
+    path = Path(csv_path)
+    meta_path = path.with_name(path.name + ".meta.yaml")
+    if not meta_path.exists():
+        return None
+    try:
+        with meta_path.open("r", encoding="utf-8") as fh:
+            meta_data = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError):  # pragma: no cover - defensive parsing
+        return None
+    stats_raw = meta_data.get("stats") if isinstance(meta_data, Mapping) else None
+    if not isinstance(stats_raw, Mapping):
+        return None
+    stats: Stats = {
+        "rows_total": int(stats_raw.get("rows_total", 0)),
+        "rows_kept": int(stats_raw.get("rows_kept", 0)),
+        "rows_dropped": int(stats_raw.get("rows_dropped", 0)),
+        "output_sha256": str(stats_raw.get("output_sha256", "")),
+    }
+    for key, value in stats_raw.items():
+        if key not in stats:
+            stats[key] = value
+    if not stats.get("output_sha256") and path.exists():
+        stats["output_sha256"] = file_sha256(path)
+    meta_sha = file_sha256(meta_path)
+
+    quality_path = path.with_suffix(".quality.json")
+    quality_sha: str | None = None
+    if quality_path.exists():
+        quality_sha = file_sha256(quality_path)
+    return PipelineOutputReport(
+        csv_path=path,
+        stats=stats,
+        meta_path=meta_path,
+        meta_sha256=meta_sha,
+        quality_path=quality_path if quality_path.exists() else None,
+        quality_sha256=quality_sha,
+    )
+
+
+__all__ = [
+    "PipelineOutputReport",
+    "QualityAnalysisError",
+    "QualityReportError",
+    "RunManifestError",
+    "finalise_csv_output",
+    "load_output_report",
+    "merge_run_output",
+]

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -56,6 +56,7 @@ from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
 from library.integration.molecule_catalog import load_parent_catalog
 from library.pipelines.registry import PipelineStep, load_pipeline_registry
+from library.reporting.run_manifest import load_output_report, merge_run_output
 from library.utils.config import DEFAULT_CONFIG_PATH
 
 
@@ -982,6 +983,9 @@ def _complete_manifest_entry(
     entry["duration_sec"] = round(time.perf_counter() - started_at, 6)
     entry["output"] = _describe_file(final_output)
     entry["sidecars"] = _describe_sidecars(final_output, working_output)
+    report = load_output_report(final_output)
+    if report is not None:
+        merge_run_output(entry, report)
 
 
 def _pending_manifest_entry(step: PipelineStep, cfg: PipelineRunConfig) -> dict[str, Any]:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -110,7 +110,6 @@ from library.pipelines.document.pipeline import (
     merge_metadata,
     merge_with_chembl,
     normalise_doi,
-    save_quality_report,
 )
 from library.pipelines.document.service import (
     DocumentPipeline,
@@ -118,12 +117,16 @@ from library.pipelines.document.service import (
     FallbackDoiState,
 )
 from library.common.log import logger
-from library.common.metadata import Stats, file_sha256, write_meta_yaml
+from library.reporting.run_manifest import (
+    QualityAnalysisError,
+    QualityReportError,
+    finalise_csv_output,
+)
 from library.postprocessing.document import preprocess_documents_csv
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
-from library.qa.table_quality import TableQualityProfiler, analyze_table_quality
+from library.qa.table_quality import TableQualityProfiler
 from library.schemas import DocumentsSchema, normalize_documents
 from library.schemas.document_spec import DOCUMENT_EXPORT_COLUMNS
 
@@ -661,45 +664,33 @@ def _finalise_export(
         if csv_path.name.startswith("output.document_"):
             _maybe_run_document_postprocessing(csv_path)
 
-    stats: Stats = {
-        "rows_total": rows_total,
-        "rows_kept": rows_kept,
-        "rows_dropped": rows_dropped,
-        "output_sha256": file_sha256(csv_path),
-    }
-    write_meta_yaml(
-        csv_path=csv_path,
-        command=" ".join(sys.argv),
-        config_subset=_serialize_paths(cfg.to_dict()),
-        inputs={"input_csv": str(input_csv)},
-        stats=stats,
-        schema="DocumentsSchema",
-    )
-
-    quality_path = csv_path.with_suffix(".quality.json")
+    doc_quality_cfg = getattr(cfg.system, "doc_quality", None)
     try:
-        report = build_quality_report(quality_summary)
-        save_quality_report(report, quality_path)
-    except (OSError, TypeError, ValueError) as exc:
+        finalise_csv_output(
+            csv_path=csv_path,
+            rows_total=rows_total,
+            rows_kept=rows_kept,
+            command=" ".join(sys.argv),
+            config_subset=_serialize_paths(cfg.to_dict()),
+            inputs={"input_csv": str(input_csv)},
+            schema="DocumentsSchema",
+            quality_summary=quality_summary,
+            quality_builder=build_quality_report,
+            quality_path=csv_path.with_suffix(".quality.json"),
+            quality_profiler=quality_profiler,
+            quality_config=doc_quality_cfg,
+            quality_table_name=csv_path.with_suffix("").name,
+            quality_destination=csv_path.parent,
+        )
+    except QualityReportError as exc:
+        destination = exc.path or csv_path.with_suffix(".quality.json")
         logger.error(
             "quality_report_write_failed",
             error=str(exc),
-            path=str(quality_path),
+            path=str(destination),
         )
         return 1
-
-    doc_quality_cfg = cfg.system.doc_quality
-    try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                quality_profiler,
-                table_name=csv_path.with_suffix("").name,
-                destination_dir=csv_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
-    except Exception as exc:
+    except QualityAnalysisError as exc:
         logger.exception(
             "quality_report_generation_failed",
             error=str(exc),

--- a/tests/unit/test_run_manifest.py
+++ b/tests/unit/test_run_manifest.py
@@ -1,0 +1,137 @@
+"""Unit tests for :mod:`library.reporting.run_manifest`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from library.reporting import run_manifest
+
+
+@pytest.mark.unit
+def test_finalise_csv_output__writes_metadata_and_quality(tmp_path: Path) -> None:
+    csv_path = tmp_path / "result.csv"
+    csv_path.write_text("id\n1\n2\n", encoding="utf-8")
+
+    report = run_manifest.finalise_csv_output(
+        csv_path=csv_path,
+        rows_total=2,
+        rows_kept=2,
+        command="unit-test",
+        config_subset={"system": {"flag": True}},
+        inputs={"input_csv": "source.csv"},
+        schema="TestSchema",
+        stats_extra={"custom_metric": 3},
+        quality_summary={"rows_total": 2},
+    )
+
+    meta_path = csv_path.with_name("result.csv.meta.yaml")
+    assert meta_path.exists()
+    metadata = yaml.safe_load(meta_path.read_text(encoding="utf-8"))
+    assert metadata["schema"] == "TestSchema"
+    assert metadata["stats"]["rows_total"] == 2
+    assert metadata["stats"]["rows_kept"] == 2
+    assert metadata["stats"]["rows_dropped"] == 0
+    assert metadata["stats"]["custom_metric"] == 3
+
+    quality_path = csv_path.with_suffix(".quality.json")
+    assert quality_path.exists()
+    assert json.loads(quality_path.read_text(encoding="utf-8")) == {"rows_total": 2}
+
+    entry = {"output": {"exists": True}}
+    run_manifest.merge_run_output(entry, report)
+    assert entry["output"]["exists"] is True
+    assert entry["output"]["meta_path"].endswith("result.csv.meta.yaml")
+    assert entry["stats"]["rows_total"] == 2
+    assert entry["stats"]["rows_kept"] == 2
+    assert entry["stats"]["rows_dropped"] == 0
+
+    loaded = run_manifest.load_output_report(csv_path)
+    assert loaded is not None
+    assert loaded.stats["rows_total"] == 2
+    assert loaded.meta_path == meta_path
+
+
+@pytest.mark.unit
+def test_finalise_csv_output__quality_builder(tmp_path: Path) -> None:
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+
+    calls: list[dict[str, int]] = []
+
+    def _builder(summary: dict[str, int]) -> dict[str, int]:
+        calls.append(summary)
+        return {"value": summary["value"]}
+
+    report = run_manifest.finalise_csv_output(
+        csv_path=csv_path,
+        rows_total=1,
+        rows_kept=1,
+        command="builder",
+        config_subset={},
+        inputs={},
+        schema="BuilderSchema",
+        quality_summary={"value": 5},
+        quality_builder=_builder,
+    )
+
+    assert calls == [{"value": 5}]
+    quality_path = report.quality_path
+    assert quality_path is not None
+    assert json.loads(quality_path.read_text(encoding="utf-8")) == {"value": 5}
+
+
+@pytest.mark.unit
+def test_finalise_csv_output__quality_error(tmp_path: Path) -> None:
+    csv_path = tmp_path / "invalid.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+
+    with pytest.raises(run_manifest.QualityReportError) as excinfo:
+        run_manifest.finalise_csv_output(
+            csv_path=csv_path,
+            rows_total=1,
+            rows_kept=1,
+            command="quality",
+            config_subset={},
+            inputs={},
+            schema="ErrorSchema",
+            quality_summary={"bad": {1, 2}},
+        )
+
+    assert excinfo.value.path == csv_path.with_suffix(".quality.json")
+
+
+@pytest.mark.unit
+def test_finalise_csv_output__quality_analysis_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csv_path = tmp_path / "analysis.csv"
+    csv_path.write_text("id\n1\n", encoding="utf-8")
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("quality boom")
+
+    monkeypatch.setattr(run_manifest, "analyze_table_quality", _raise)
+
+    with pytest.raises(run_manifest.QualityAnalysisError):
+        run_manifest.finalise_csv_output(
+            csv_path=csv_path,
+            rows_total=1,
+            rows_kept=1,
+            command="analysis",
+            config_subset={},
+            inputs={},
+            schema="AnalysisSchema",
+            quality_summary={},
+            quality_profiler=object(),
+            quality_config={"enable": True},
+        )
+
+
+@pytest.mark.unit
+def test_load_output_report__missing(tmp_path: Path) -> None:
+    csv_path = tmp_path / "missing.csv"
+    assert run_manifest.load_output_report(csv_path) is None


### PR DESCRIPTION
## Summary
- add a reporting helper module that finalises CSV outputs, writes metadata/quality sidecars, and exposes manifest helpers
- update document and shared CLI flows to rely on the centralised reporting utilities and enrich the orchestrator manifest with stats
- cover the new reporting logic with dedicated unit tests

## Testing
- pytest -q *(fails: Dictionary manifest checksum mismatch in tests environment)*
- pytest tests/unit/test_run_manifest.py


------
https://chatgpt.com/codex/tasks/task_e_68e423b200d883249e3a7c5f99746304