### PR TITLE
Refactor CLI bootstrap into shared package

### DIFF
--- a/library/bootstrap/__init__.py
+++ b/library/bootstrap/__init__.py
@@ -1,0 +1,109 @@
+"""Helpers for bootstrapping the project runtime environment."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable
+
+_DEFAULT_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_project_root(origin: str | Path | None = None) -> Path:
+    """Return the repository root for ``origin``.
+
+    Parameters
+    ----------
+    origin:
+        Optional path to a module or package. When ``None`` the bootstrap
+        module location is used.
+    """
+
+    if origin is None:
+        start = _DEFAULT_PROJECT_ROOT
+    else:
+        path = Path(origin).resolve()
+        start = path.parent if path.is_file() else path
+
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return _DEFAULT_PROJECT_ROOT
+
+
+def _iter_module_paths(module: ModuleType) -> Iterable[Path]:
+    """Yield filesystem paths contributing to ``module``."""
+
+    file_attr = getattr(module, "__file__", None)
+    if file_attr:
+        yield Path(file_attr).resolve()
+
+    package_paths = getattr(module, "__path__", None)
+    if package_paths is not None:
+        for package_path in package_paths:
+            yield Path(package_path).resolve()
+
+
+def _is_within_project(path: Path, project_root: Path) -> bool:
+    """Return ``True`` when ``path`` is inside ``project_root``."""
+
+    try:
+        path.relative_to(project_root)
+    except ValueError:
+        return False
+    return True
+
+
+def _should_purge_existing(module: ModuleType | None, project_root: Path) -> bool:
+    """Check whether an existing ``library`` module conflicts with the project."""
+
+    if module is None:
+        return False
+    return not any(_is_within_project(path, project_root) for path in _iter_module_paths(module))
+
+
+def _purge_conflicting_modules(project_root: Path) -> None:
+    """Remove installed ``library`` packages shadowing the repository copy."""
+
+    existing = sys.modules.get("library")
+    if not _should_purge_existing(existing, project_root):
+        return
+
+    for name in list(sys.modules):
+        if name == "library" or name.startswith("library."):
+            del sys.modules[name]
+
+
+def ensure_project_root(origin: str | Path | None = None) -> Path:
+    """Insert the project root into :data:`sys.path`.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved project root.
+    """
+
+    project_root = resolve_project_root(origin)
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+    _purge_conflicting_modules(project_root)
+    return project_root
+
+
+def bootstrap_cli(package: str | None, script_file: str | None) -> Path:
+    """Bootstrap CLI execution for ``script_file``.
+
+    Parameters
+    ----------
+    package:
+        Value of ``__package__`` for the caller.
+    script_file:
+        Value of ``__file__`` for the caller.
+    """
+
+    return ensure_project_root(script_file)
+
+
+__all__ = ["bootstrap_cli", "ensure_project_root", "resolve_project_root"]

--- a/library/utils/bootstrap.py
+++ b/library/utils/bootstrap.py
@@ -1,70 +1,7 @@
-"""Runtime helpers for script execution.
-
-This module ensures that executing a script via ``python scripts/foo.py``
-behaves the same as ``python -m scripts.foo`` by pre-pending the repository
-root (``library/utils/../..``) to :mod:`sys.path`.
-"""
+"""Backward compatible wrapper around :mod:`library.bootstrap`."""
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-from types import ModuleType
-from typing import Iterable
+from library.bootstrap import bootstrap_cli, ensure_project_root, resolve_project_root
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-
-
-def _iter_module_paths(module: ModuleType) -> Iterable[Path]:
-    """Yield filesystem paths that define ``module``."""
-
-    file_attr = getattr(module, "__file__", None)
-    if file_attr:
-        yield Path(file_attr).resolve()
-
-    package_paths = getattr(module, "__path__", None)
-    if package_paths is not None:
-        for package_path in package_paths:
-            yield Path(package_path).resolve()
-
-
-def _is_within_project(path: Path) -> bool:
-    """Return ``True`` when ``path`` belongs to the repository tree."""
-
-    try:
-        path.relative_to(_PROJECT_ROOT)
-    except ValueError:
-        return False
-    return True
-
-
-def _should_purge_existing(module: ModuleType | None) -> bool:
-    """Check whether ``module`` was loaded from outside the project."""
-
-    if module is None:
-        return False
-    for module_path in _iter_module_paths(module):
-        if _is_within_project(module_path):
-            return False
-    return True
-
-
-def _purge_conflicting_modules() -> None:
-    """Remove third-party ``library`` modules shadowing the local package."""
-
-    existing = sys.modules.get("library")
-    if not _should_purge_existing(existing):
-        return
-
-    for name in list(sys.modules):
-        if name == "library" or name.startswith("library."):
-            del sys.modules[name]
-
-
-def ensure_project_root() -> None:
-    """Insert the project root into :data:`sys.path` and purge conflicts."""
-
-    project_root = str(_PROJECT_ROOT)
-    if project_root not in sys.path:
-        sys.path.insert(0, project_root)
-    _purge_conflicting_modules()
+__all__ = ["bootstrap_cli", "ensure_project_root", "resolve_project_root"]

--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -1,0 +1,53 @@
+"""Load the project bootstrap helpers when running scripts directly."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+
+
+def _project_root_from(script_file: str | None) -> Path | None:
+    if not script_file:
+        return None
+    path = Path(script_file).resolve()
+    return path.parent.parent
+
+
+def _load_bootstrap(script_file: str | None) -> ModuleType:
+    module_name = "library.bootstrap"
+    module = sys.modules.get(module_name)
+    if module is not None:
+        return module
+
+    project_root = _project_root_from(script_file)
+    if project_root is not None:
+        project_root_str = str(project_root)
+        if project_root_str not in sys.path:
+            sys.path.insert(0, project_root_str)
+
+    return import_module(module_name)
+
+
+def bootstrap_cli(package: str | None, script_file: str | None) -> None:
+    """Ensure the repository root is available for CLI execution."""
+
+    module = _load_bootstrap(script_file)
+    module.bootstrap_cli(package, script_file)
+
+
+def ensure_project_root(origin: str | Path | None = None) -> Path:
+    """Expose :func:`library.bootstrap.ensure_project_root` for compatibility."""
+
+    script_hint: str | None
+    if origin is None:
+        script_hint = None
+    else:
+        script_hint = str(origin)
+
+    module = _load_bootstrap(script_hint)
+    return module.ensure_project_root(origin)
+
+
+__all__ = ["bootstrap_cli", "ensure_project_root"]

--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -3,6 +3,14 @@
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli, ensure_project_root
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli, ensure_project_root
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
 import hashlib
 import os
@@ -11,16 +19,6 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-
-
-def _ensure_project_root() -> Path:
-    """Return repository root, adding it to ``sys.path`` when required."""
-
-    repo_root = Path(__file__).resolve().parents[1]
-    repo_str = str(repo_root)
-    if repo_str not in sys.path:
-        sys.path.insert(0, repo_str)
-    return repo_root
 
 
 def _hash_file(path: Path) -> str:
@@ -52,7 +50,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    _ensure_project_root()
+    ensure_project_root(__file__)
 
     tmp_dir = Path(tempfile.mkdtemp(prefix="determinism_check_"))
     try:

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -7,8 +7,15 @@ applications or tests.
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
-import sys
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Callable
 from datetime import datetime, timezone
@@ -17,46 +24,6 @@ from functools import partial
 from itertools import islice
 from pathlib import Path
 from time import sleep, perf_counter
-
-try:
-    from library.utils.bootstrap import ensure_project_root
-except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
-    def _is_within(path: Path, root: Path) -> bool:
-        try:
-            path.relative_to(root)
-        except ValueError:
-            return False
-        return True
-
-    def ensure_project_root() -> None:
-        """Add the repository root to ``sys.path`` when executed as a script."""
-
-        project_root = Path(__file__).resolve().parent.parent
-        project_root_str = str(project_root)
-        if project_root_str not in sys.path:
-            sys.path.insert(0, project_root_str)
-
-        existing = sys.modules.get("library")
-        if existing is None:
-            return
-
-        module_paths: list[Path] = []
-        file_attr = getattr(existing, "__file__", None)
-        if file_attr:
-            module_paths.append(Path(file_attr).resolve())
-        package_paths = getattr(existing, "__path__", None)
-        if package_paths is not None:
-            module_paths.extend(Path(p).resolve() for p in package_paths)
-
-        if any(_is_within(path, project_root) for path in module_paths):
-            return
-
-        for name in list(sys.modules):
-            if name == "library" or name.startswith("library."):
-                del sys.modules[name]
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 import pandas as pd
 import requests

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -7,7 +7,14 @@ instead of terminating the interpreter to make orchestration easier.
 
 from __future__ import annotations
 
-import sys
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 from pathlib import Path
 from time import sleep
 
@@ -19,16 +26,6 @@ from itertools import islice
 
 import pandas as pd
 import requests
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
-
-from library.utils.bootstrap import ensure_project_root
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 from library.integration import chembl_library as cl
 from library.pipelines.assay import postprocessing as ap

--- a/scripts/get_cellline_data.py
+++ b/scripts/get_cellline_data.py
@@ -1,20 +1,17 @@
+from __future__ import annotations
+
 import argparse
-import sys
-from pathlib import Path
-from typing import Sequence
-
-try:
-    from library.utils.bootstrap import ensure_project_root
-except ModuleNotFoundError:  # pragma: no cover - direct execution fallback
-    def ensure_project_root() -> None:
-        project_root = Path(__file__).resolve().parents[1]
-        project_root_str = str(project_root)
-        if project_root_str not in sys.path:
-            sys.path.insert(0, project_root_str)
-
 
 if __package__ in {None, ""}:
-    ensure_project_root()
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
+from pathlib import Path
+from typing import Sequence
 
 from library import cli, io
 from library.cli import LoggerConfig, configure_logger

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -21,11 +21,18 @@ that the pipelines can be executed programmatically from other callers as well.
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
 import hashlib
 import json
 import logging
-import sys
 import time
 import uuid
 from collections import deque
@@ -35,20 +42,6 @@ from fnmatch import fnmatch
 from pathlib import Path
 
 from typing import Any, Callable, Iterable, IO, Mapping, Sequence
-
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
-if __package__ in {None, ""}:
-    project_root_str = str(_PROJECT_ROOT)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
-from library.utils.bootstrap import ensure_project_root
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -24,6 +24,14 @@ The input file must contain a ``PMID`` column.
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
 import inspect
 import os
@@ -40,42 +48,6 @@ from typing import Any, cast
 import pandas as pd
 import requests
 from pandera.errors import SchemaErrors
-
-try:
-    from library.utils.bootstrap import ensure_project_root
-except ModuleNotFoundError:  # pragma: no cover - environment bootstrap
-    project_root = Path(__file__).resolve().parents[1]
-    project_root_str = str(project_root)
-    if project_root_str not in sys.path:
-        sys.path.insert(0, project_root_str)
-
-    existing = sys.modules.get("library")
-    if existing is not None:
-        module_paths: list[Path] = []
-        file_attr = getattr(existing, "__file__", None)
-        if file_attr:
-            module_paths.append(Path(file_attr).resolve())
-        package_paths = getattr(existing, "__path__", None)
-        if package_paths is not None:
-            module_paths.extend(Path(p).resolve() for p in package_paths)
-
-        def _is_within(path: Path) -> bool:
-            try:
-                path.relative_to(project_root)
-            except ValueError:
-                return False
-            return True
-
-        if not any(_is_within(path) for path in module_paths):
-            for name in list(sys.modules):
-                if name == "library" or name.startswith("library."):
-                    del sys.modules[name]
-
-    from library.utils.bootstrap import ensure_project_root
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 from library import cli
 from library import io

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -12,6 +12,14 @@ Fetch ChEMBL target information for identifiers in ``targets.csv``::
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 # ruff: noqa: E402
 import argparse
 import sys
@@ -27,50 +35,6 @@ from pathlib import Path
 from typing import IO, Any, cast
 
 from datetime import datetime, timezone
-
-try:
-    from library.utils.bootstrap import ensure_project_root
-except ModuleNotFoundError:  # pragma: no cover - fallback for direct execution
-    import sys
-    from pathlib import Path
-
-    def _is_within(path: Path, root: Path) -> bool:
-        try:
-            path.relative_to(root)
-        except ValueError:
-            return False
-        return True
-
-    def ensure_project_root() -> None:
-        """Add the repository root to ``sys.path`` when the package is missing."""
-
-        project_root = Path(__file__).resolve().parent.parent
-        project_root_str = str(project_root)
-        if project_root_str not in sys.path:
-            sys.path.insert(0, project_root_str)
-
-        existing = sys.modules.get("library")
-        if existing is None:
-            return
-
-        module_paths: list[Path] = []
-        file_attr = getattr(existing, "__file__", None)
-        if file_attr:
-            module_paths.append(Path(file_attr).resolve())
-        package_paths = getattr(existing, "__path__", None)
-        if package_paths is not None:
-            module_paths.extend(Path(p).resolve() for p in package_paths)
-
-        if any(_is_within(path, project_root) for path in module_paths):
-            return
-
-        for name in list(sys.modules):
-            if name == "library" or name.startswith("library."):
-                del sys.modules[name]
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 import pandas as pd
 import requests

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -9,8 +9,15 @@ that still include the misspelled parent identifier column.
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
-import sys
 from pathlib import Path
 from typing import Hashable, MutableMapping, NamedTuple, Sequence, cast
 
@@ -19,19 +26,9 @@ import pandas as pd
 
 # ===== Parameters =====
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_NAME = "testitem.csv"
 DEFAULT_OUTPUT_STEM = "testitems"
 
-
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-from library.utils.bootstrap import ensure_project_root
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 from library import cli  # noqa: F401 - re-exported for monkeypatching in tests
 from library import io

--- a/scripts/get_tissue_data.py
+++ b/scripts/get_tissue_data.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
+if __package__ in {None, ""}:
+    from _bootstrap import bootstrap_cli
+else:  # pragma: no cover - executed when imported as a package module
+    from ._bootstrap import bootstrap_cli
+
+bootstrap_cli(__package__, __file__)
+del bootstrap_cli
+
 import argparse
-import sys
 from pathlib import Path
 from typing import Sequence
-
-try:
-    from library.utils.bootstrap import ensure_project_root
-except ModuleNotFoundError:  # pragma: no cover - direct execution fallback
-    def ensure_project_root() -> None:
-        project_root = Path(__file__).resolve().parents[1]
-        project_root_str = str(project_root)
-        if project_root_str not in sys.path:
-            sys.path.insert(0, project_root_str)
-
-
-if __package__ in {None, ""}:
-    ensure_project_root()
 
 from library import cli, io
 from library.cli import LoggerConfig, configure_logger


### PR DESCRIPTION
## Summary
- add a dedicated `library.bootstrap` package that exposes reusable helpers for resolving the project root and purging conflicting imports
- route script execution through a shared `scripts/_bootstrap.py` loader so every CLI uses the same bootstrap logic instead of inlined fallbacks
- update CLI modules to rely on the shared bootstrap utilities and re-export them through `library.utils.bootstrap`

## Testing
- pytest tests/unit/test_get_activity_data.py *(fails: dictionary manifest checksum mismatch when constructing Config)*

------
https://chatgpt.com/codex/tasks/task_e_68e423427d0c8324b35678a56716b81c