### PR TITLE
feat(qa): centralize table quality reporting

### DIFF
--- a/library/integration/pubmed_library.py
+++ b/library/integration/pubmed_library.py
@@ -55,7 +55,7 @@ from ..pubmed import (
 )
 from ..common.rate_limiter import RateLimiter, get_limiter
 from ..cli_utils import MetadataHook, Validator, run_pipeline
-from ..table_quality import analyze_table_quality
+from ..qa.reporting import TableQualityReporter
 from ..pipelines.common import add_pipeline_metadata
 from ..normalization import normalize_documents
 from ..validation import ValidationResult as SchemaValidationResult
@@ -372,10 +372,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
 
+    quality_reporter = TableQualityReporter.from_config(cfg)
+
     def table_quality(destination: Path) -> None:
-        analyze_table_quality(
+        quality_reporter.run(
             destination,
             table_name=str(output_path.with_suffix("")),
+            destination_dir=output_path.parent,
         )
 
 

--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -37,7 +37,7 @@ from library.common.metadata import (
 )
 from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
-from library.qa.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 from library.qa.validation import validate_testitems
 from library.schemas import TestitemsSchema, normalize_testitems
 
@@ -962,18 +962,13 @@ def finalize_output(
         schema="TestitemsSchema",
     )
 
-    doc_quality_cfg = cfg.system.doc_quality
-    fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
+    quality_reporter = TableQualityReporter.from_config(cfg)
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                csv_path,
-                table_name=str(output.with_suffix("")),
-                destination_dir=output.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+        quality_reporter.run(
+            csv_path,
+            table_name=str(output.with_suffix("")),
+            destination_dir=output.parent,
+        )
     except Exception as exc:
         tb = traceback.format_exc()
         record_quality_failure(
@@ -981,7 +976,7 @@ def finalize_output(
             error=str(exc),
             error_type=exc.__class__.__name__,
             traceback=tb,
-            fatal=fatal_quality_error,
+            fatal=quality_reporter.fatal_on_error,
         )
         log_kwargs = {
             "error": str(exc),
@@ -989,10 +984,10 @@ def finalize_output(
             "path": str(output),
             "traceback": tb,
         }
-        if fatal_quality_error:
+        if quality_reporter.fatal_on_error:
             log_kwargs["fatal"] = True
         logger.warning("quality_report_failed", **log_kwargs)
-        if fatal_quality_error:
+        if quality_reporter.fatal_on_error:
             return 1
 
     return exit_code

--- a/library/qa/reporting.py
+++ b/library/qa/reporting.py
@@ -1,0 +1,135 @@
+"""Helpers for configuring table-quality reporting.
+
+This module centralises construction of table-quality hooks used across
+pipelines.  Individual scripts configure a :class:`TableQualityReporter`
+instance and then either build a hook compatible with
+``library.cli_utils.run_pipeline`` or run the analysis directly on cached
+profilers.  Consolidating this logic ensures all entry points share the
+same configuration defaults (for example sampling options and the
+``fatal_on_error`` flag).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+from .table_quality import TableQualityProfiler, analyze_table_quality
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from library.config import Config, DocQualityCfg
+
+
+TableQualityHook = Callable[[Path], None]
+TableQualitySource = (
+    pd.DataFrame | str | Path | Iterable[pd.DataFrame] | TableQualityProfiler
+)
+
+
+def _as_doc_quality_cfg(
+    cfg: Config | DocQualityCfg | None,
+) -> DocQualityCfg | None:
+    """Return the ``DocQualityCfg`` instance extracted from ``cfg``."""
+
+    if cfg is None:
+        return None
+
+    if hasattr(cfg, "enable") and hasattr(cfg, "sample_rows"):
+        # ``cfg`` already behaves like ``DocQualityCfg``
+        return cfg  # type: ignore[return-value]
+
+    system_cfg = getattr(cfg, "system", None)
+    if system_cfg is None:
+        return None
+    return getattr(system_cfg, "doc_quality", None)
+
+
+def _normalise_columns(columns: Iterable[str] | None) -> tuple[str, ...] | None:
+    if columns is None:
+        return None
+    return tuple(columns)
+
+
+@dataclass(frozen=True)
+class TableQualityReporter:
+    """Configure and execute table-quality analysis."""
+
+    enabled: bool = False
+    sample_rows: int | None = None
+    include_columns: tuple[str, ...] | None = None
+    exclude_columns: tuple[str, ...] | None = None
+    fatal_on_error: bool = False
+
+    @classmethod
+    def from_config(
+        cls, cfg: Config | DocQualityCfg | None
+    ) -> "TableQualityReporter":
+        doc_quality_cfg = _as_doc_quality_cfg(cfg)
+        if doc_quality_cfg is None:
+            return cls()
+        return cls(
+            enabled=bool(getattr(doc_quality_cfg, "enable", False)),
+            sample_rows=getattr(doc_quality_cfg, "sample_rows", None),
+            include_columns=_normalise_columns(
+                getattr(doc_quality_cfg, "include_columns", None)
+            ),
+            exclude_columns=_normalise_columns(
+                getattr(doc_quality_cfg, "exclude_columns", None)
+            ),
+            fatal_on_error=bool(getattr(doc_quality_cfg, "fatal_on_error", False)),
+        )
+
+    def build_hook(
+        self, *, table_name: str, destination_dir: Path | str
+    ) -> TableQualityHook:
+        """Return a callable suitable for ``run_pipeline`` hooks."""
+
+        if not self.enabled:
+            return _noop_quality_hook
+
+        resolved_name = str(table_name)
+        destination = Path(destination_dir)
+
+        def _hook(path: Path) -> None:
+            analyze_table_quality(
+                path,
+                table_name=resolved_name,
+                destination_dir=destination,
+                sample_rows=self.sample_rows,
+                include_columns=self.include_columns,
+                exclude_columns=self.exclude_columns,
+            )
+
+        return _hook
+
+    def run(
+        self,
+        table: TableQualitySource,
+        *,
+        table_name: str,
+        destination_dir: Path | str,
+    ) -> tuple[pd.DataFrame, pd.DataFrame] | None:
+        """Execute table-quality analysis when enabled."""
+
+        if not self.enabled:
+            return None
+
+        return analyze_table_quality(
+            table,
+            table_name=table_name,
+            destination_dir=destination_dir,
+            sample_rows=self.sample_rows,
+            include_columns=self.include_columns,
+            exclude_columns=self.exclude_columns,
+        )
+
+
+def _noop_quality_hook(_: Path) -> None:
+    return None
+
+
+__all__ = ["TableQualityHook", "TableQualityReporter", "TableQualitySource"]

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -40,7 +40,7 @@ from library.metadata import (
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 from library.validation import validate_testitems
 from library.schemas import TestitemsSchema, normalize_testitems
 
@@ -1111,18 +1111,13 @@ def finalize_output(
         schema="TestitemsSchema",
     )
 
-    doc_quality_cfg = cfg.system.doc_quality
-    fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
+    quality_reporter = TableQualityReporter.from_config(cfg)
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                csv_path,
-                table_name=str(output.with_suffix("")),
-                destination_dir=output.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+        quality_reporter.run(
+            csv_path,
+            table_name=str(output.with_suffix("")),
+            destination_dir=output.parent,
+        )
     except Exception as exc:
         tb = traceback.format_exc()
         record_quality_failure(
@@ -1130,7 +1125,7 @@ def finalize_output(
             error=str(exc),
             error_type=exc.__class__.__name__,
             traceback=tb,
-            fatal=fatal_quality_error,
+            fatal=quality_reporter.fatal_on_error,
         )
         log_kwargs = {
             "error": str(exc),
@@ -1138,10 +1133,10 @@ def finalize_output(
             "path": str(output),
             "traceback": tb,
         }
-        if fatal_quality_error:
+        if quality_reporter.fatal_on_error:
             log_kwargs["fatal"] = True
         logger.warning("quality_report_failed", **log_kwargs)
-        if fatal_quality_error:
+        if quality_reporter.fatal_on_error:
             return 1
 
     return exit_code

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -43,7 +43,7 @@ from library.cli import (
 )
 from library.config import Config, ConfigError, ensure_dirs, print_config
 from library.common.log import logger
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -104,19 +104,26 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("generate_quality_reports")
         report_dir = out_dir / "data_validity_report"
         report_dir.mkdir(parents=True, exist_ok=True)
-        doc_quality_cfg = cfg.system.doc_quality
+        quality_reporter = TableQualityReporter.from_config(cfg)
         for entity, path in paths.items():
             logger.info("profiling", entity=entity)
-            if not doc_quality_cfg.enable:
-                continue
-            analyze_table_quality(
-                path,
-                table_name=path.stem,
-                destination_dir=report_dir,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+            try:
+                quality_reporter.run(
+                    path,
+                    table_name=path.stem,
+                    destination_dir=report_dir,
+                )
+            except Exception as exc:
+                log_kwargs = {
+                    "error": str(exc),
+                    "path": str(path),
+                    "exc": exc,
+                }
+                if quality_reporter.fatal_on_error:
+                    log_kwargs["fatal"] = True
+                logger.exception("quality_report_failed", **log_kwargs)
+                if quality_reporter.fatal_on_error:
+                    return 1
 
         logger.info("save_done", tables=len(paths), path=str(out_dir))
         return 0

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -102,7 +102,7 @@ from library.processing.activity import (
     compute_activity_bounds,
 )
 from library.postprocessing.activity_extended import process_activity_extended
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 from library.validation import validate_activities
 from library.schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
 from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_delay
@@ -996,20 +996,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
 
-    doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(Path(output_path).with_suffix("")),
-            destination_dir=Path(output_path).parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-
-        def table_quality(_: Path) -> None:
-            return None
+    quality_reporter = TableQualityReporter.from_config(cfg)
+    table_quality = quality_reporter.build_hook(
+        table_name=str(Path(output_path).with_suffix("")),
+        destination_dir=Path(output_path).parent,
+    )
 
     rate_cfg = cfg.rate
     global_limiter = None

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -51,7 +51,7 @@ from library.cli.metadata import prepare_option
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.pipelines.common import add_pipeline_metadata
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 from library.validation import validate_assays
 from library.schemas import AssaysSchema, normalize_assays
 from library.pipelines.common import (
@@ -286,19 +286,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
     validators = [partial(validate_assays, return_result=True)]
 
-    doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(output_path.with_suffix("")),
-            destination_dir=output_path.parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-        def table_quality(_: Path) -> None:
-            return None
+    quality_reporter = TableQualityReporter.from_config(cfg)
+    table_quality = quality_reporter.build_hook(
+        table_name=str(output_path.with_suffix("")),
+        destination_dir=output_path.parent,
+    )
 
     rate_cfg = cfg.rate
     global_limiter = None

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -123,7 +123,8 @@ from library.postprocessing.document import preprocess_documents_csv
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
-from library.qa.table_quality import TableQualityProfiler, analyze_table_quality
+from library.qa.reporting import TableQualityReporter
+from library.qa.table_quality import TableQualityProfiler
 from library.schemas import DocumentsSchema, normalize_documents
 from library.schemas.document_spec import DOCUMENT_EXPORT_COLUMNS
 
@@ -688,24 +689,20 @@ def _finalise_export(
         )
         return 1
 
-    doc_quality_cfg = cfg.system.doc_quality
+    quality_reporter = TableQualityReporter.from_config(cfg)
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                quality_profiler,
-                table_name=csv_path.with_suffix("").name,
-                destination_dir=csv_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
-    except Exception as exc:
-        logger.exception(
-            "quality_report_generation_failed",
-            error=str(exc),
-            exc=exc,
+        quality_reporter.run(
+            quality_profiler,
+            table_name=csv_path.with_suffix("").name,
+            destination_dir=csv_path.parent,
         )
-        return 1
+    except Exception as exc:
+        log_kwargs = {"error": str(exc), "exc": exc}
+        if quality_reporter.fatal_on_error:
+            log_kwargs["fatal"] = True
+        logger.exception("quality_report_generation_failed", **log_kwargs)
+        if quality_reporter.fatal_on_error:
+            return 1
     return exit_code
 
 

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -107,7 +107,7 @@ from library.common.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipelines.common import add_pipeline_metadata
 from library import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import TableQualityReporter
 from library.validation import ValidationResult
 from library.schemas import TargetsSchema, normalize_targets
 from library.schemas.targets import TARGETS_COLUMN_ORDER
@@ -2076,20 +2076,16 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             output=str(output_path) if output_path is not None else None,
         )
         return 1
-    doc_quality_cfg = cfg.system.doc_quality
+    quality_reporter = TableQualityReporter.from_config(cfg)
     try:
-        if doc_quality_cfg.enable:
+        if quality_reporter.enabled:
             if export_path is None:
                 raise RuntimeError("export path not available for quality analysis")
             resolved_export_path = export_path.resolve()
-            quality_table_name = resolved_export_path.stem
-            analyze_table_quality(
+            quality_reporter.run(
                 out_df,
-                table_name=quality_table_name,
+                table_name=resolved_export_path.stem,
                 destination_dir=resolved_export_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
             )
     except Exception as exc:
         quality_log_path: Path | None = None
@@ -2099,13 +2095,16 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
             quality_log_path = export_path.resolve()
         elif output_path is not None:
             quality_log_path = output_path.resolve()
-        logger.exception(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(quality_log_path) if quality_log_path is not None else None,
-            exc=exc,
-        )
-        return 1
+        log_kwargs = {
+            "error": str(exc),
+            "path": str(quality_log_path) if quality_log_path is not None else None,
+            "exc": exc,
+        }
+        if quality_reporter.fatal_on_error:
+            log_kwargs["fatal"] = True
+        logger.exception("quality_report_failed", **log_kwargs)
+        if quality_reporter.fatal_on_error:
+            return 1
     return 0
 
 
@@ -2549,19 +2548,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     failure_path = normalized_output.with_name(
         f"{normalized_output.stem}_failure_cases.csv"
     )
-    doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(final_output.with_suffix("")),
-            destination_dir=final_output.parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-        def table_quality(_: Path) -> None:
-            return None
+    quality_reporter = TableQualityReporter.from_config(cfg)
+    table_quality = quality_reporter.build_hook(
+        table_name=str(final_output.with_suffix("")),
+        destination_dir=final_output.parent,
+    )
 
     metadata_hooks = [add_pipeline_metadata, _prepare_chunk]
     if not normalize_at_export:
@@ -2728,25 +2719,20 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     finally:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
-    doc_quality_cfg = cfg.system.doc_quality
+    quality_reporter = TableQualityReporter.from_config(cfg)
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                output_path,
-                table_name=str(output_path.with_suffix("")),
-                destination_dir=output_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
-    except Exception as exc:
-        logger.exception(
-            "quality_report_failed",
-            error=str(exc),
-            path=str(output_path),
-            exc=exc,
+        quality_reporter.run(
+            output_path,
+            table_name=str(output_path.with_suffix("")),
+            destination_dir=output_path.parent,
         )
-        return 1
+    except Exception as exc:
+        log_kwargs = {"error": str(exc), "path": str(output_path), "exc": exc}
+        if quality_reporter.fatal_on_error:
+            log_kwargs["fatal"] = True
+        logger.exception("quality_report_failed", **log_kwargs)
+        if quality_reporter.fatal_on_error:
+            return 1
     return 0
 
 
@@ -3784,25 +3770,20 @@ def validate_and_write(
             table=str(output.with_suffix("")),
         )
     else:
-        doc_quality_cfg = cfg.system.doc_quality
+        quality_reporter = TableQualityReporter.from_config(cfg)
         try:
-            if doc_quality_cfg.enable:
-                analyze_table_quality(
-                    final_df,
-                    table_name=str(output.with_suffix("")),
-                    destination_dir=output.parent,
-                    sample_rows=doc_quality_cfg.sample_rows,
-                    include_columns=doc_quality_cfg.include_columns,
-                    exclude_columns=doc_quality_cfg.exclude_columns,
-                )
-        except Exception as exc:
-            logger.exception(
-                "quality_report_failed",
-                error=str(exc),
-                path=str(output),
-                exc=exc,
+            quality_reporter.run(
+                final_df,
+                table_name=str(output.with_suffix("")),
+                destination_dir=output.parent,
             )
-            return 1
+        except Exception as exc:
+            log_kwargs = {"error": str(exc), "path": str(output), "exc": exc}
+            if quality_reporter.fatal_on_error:
+                log_kwargs["fatal"] = True
+            logger.exception("quality_report_failed", **log_kwargs)
+            if quality_reporter.fatal_on_error:
+                return 1
     logger.info("validate_write_done", rows=len(final_df))
     return exit_code
 

--- a/tests/integration/test_finalize_output.py
+++ b/tests/integration/test_finalize_output.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Callable
 
 import pandas as pd
 import pytest
@@ -220,13 +221,26 @@ def test_finalize_output__quality_report_failure_non_fatal(
     stats_supplier = _StatsSupplier(_base_stats())
     recorded: list[dict[str, object]] = []
 
-    def fake_analyze(*_args: object, **_kwargs: object) -> None:
-        raise RuntimeError("quality failed")
+    class _FailingReporter:
+        enabled = True
+
+        def __init__(self) -> None:
+            self.fatal_on_error = cfg.system.doc_quality.fatal_on_error
+
+        @classmethod
+        def from_config(cls, _cfg) -> "_FailingReporter":
+            return cls()
+
+        def build_hook(self, **_: object) -> Callable[[Path], None]:
+            return lambda *_args, **_kwargs: None
+
+        def run(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("quality failed")
 
     def capture_failure(*_args: object, **kwargs: object) -> None:
         recorded.append(kwargs)
 
-    monkeypatch.setattr(cli, "analyze_table_quality", fake_analyze)
+    monkeypatch.setattr(cli, "TableQualityReporter", _FailingReporter)
     monkeypatch.setattr(cli, "record_quality_failure", capture_failure)
 
     exit_code = cli.finalize_output(
@@ -255,10 +269,23 @@ def test_finalize_output__quality_report_failure_fatal(
     output_path = tmp_path / "quality_fatal.csv"
     stats_supplier = _StatsSupplier(_base_stats())
 
-    def fake_analyze(*_args: object, **_kwargs: object) -> None:
-        raise RuntimeError("quality failed")
+    class _FailingReporter:
+        enabled = True
 
-    monkeypatch.setattr(cli, "analyze_table_quality", fake_analyze)
+        def __init__(self) -> None:
+            self.fatal_on_error = cfg.system.doc_quality.fatal_on_error
+
+        @classmethod
+        def from_config(cls, _cfg) -> "_FailingReporter":
+            return cls()
+
+        def build_hook(self, **_: object) -> Callable[[Path], None]:
+            return lambda *_args, **_kwargs: None
+
+        def run(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("quality failed")
+
+    monkeypatch.setattr(cli, "TableQualityReporter", _FailingReporter)
 
     exit_code = cli.finalize_output(
         [chunk],

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Callable, Iterable, Sequence
 
 import pandas as pd
 from types import SimpleNamespace
@@ -308,22 +308,38 @@ def test_run_uniprot__doc_quality_reports(
     )
 
     captured: dict[str, object] = {}
+    doc_quality_cfg = cfg.system.doc_quality
 
-    def _fake_analyze(
-        df: pd.DataFrame,
-        *,
-        table_name: str,
-        destination_dir: Path,
-        sample_rows: int | None,
-        include_columns: Sequence[str] | None,
-        exclude_columns: Sequence[str] | None,
-    ) -> None:
-        captured["table_name"] = table_name
-        captured["destination_dir"] = destination_dir
-        captured["sample_rows"] = sample_rows
-        captured["df"] = df.copy()
+    class _ReporterStub:
+        fatal_on_error = False
+        enabled = True
 
-    monkeypatch.setattr(get_target_data, "analyze_table_quality", _fake_analyze)
+        @classmethod
+        def from_config(cls, _cfg: Config) -> "_ReporterStub":
+            return cls()
+
+        def build_hook(
+            self, *, table_name: str, destination_dir: Path
+        ) -> Callable[[Path], None]:
+            def _hook(_: Path) -> None:
+                captured["table_name"] = table_name
+                captured["destination_dir"] = destination_dir
+
+            return _hook
+
+        def run(
+            self,
+            table: pd.DataFrame,
+            *,
+            table_name: str,
+            destination_dir: Path,
+        ) -> None:
+            captured["table_name"] = table_name
+            captured["destination_dir"] = destination_dir
+            captured["sample_rows"] = doc_quality_cfg.sample_rows
+            captured["df"] = table.copy()
+
+    monkeypatch.setattr(get_target_data, "TableQualityReporter", _ReporterStub)
 
     args = argparse.Namespace(input_csv=input_csv, final_out=output_csv)
 


### PR DESCRIPTION
## Summary
- add a reusable `TableQualityReporter` helper to configure table-quality hooks in one place
- refactor activity, assay, target, document, PubMed, and test item pipelines to use the reporter and honour `fatal_on_error`
- update CLI utilities and tests to exercise the new reporting layer

## Testing
- pytest tests/unit/test_get_target_data.py::test_run_uniprot__doc_quality_reports tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_non_fatal tests/integration/test_finalize_output.py::test_finalize_output__quality_report_failure_fatal *(fails: dictionary manifest missing in test resources)*
- pytest tests/unit/test_get_target_data.py::test_run_uniprot__doc_quality_reports *(fails: dictionary manifest missing in test resources)*

------
https://chatgpt.com/codex/tasks/task_e_68e4235f580c832492c033d298b46628