### PR TITLE
Refactor pipeline orchestration to use workflow helper

### DIFF
--- a/library/orchestration/workflow.py
+++ b/library/orchestration/workflow.py
@@ -1,0 +1,92 @@
+"""Helpers to execute prepared pipeline steps without invoking CLI parsers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterator, Sequence, TYPE_CHECKING
+
+from library.pipelines.registry import PipelineStep
+
+if TYPE_CHECKING:  # pragma: no cover - imports used only for typing
+    from scripts.get_data import PipelineRunConfig
+
+
+@dataclass(frozen=True)
+class StepExecutionResult:
+    """Summarize the outcome of invoking a pipeline step."""
+
+    exit_code: int
+    executed: bool
+    status: str
+    reason: str | None = None
+
+
+StepCallable = Callable[
+    ["PipelineRunConfig", Path, Path, Path], StepExecutionResult
+]
+
+
+@dataclass(frozen=True)
+class PreparedPipelineStep:
+    """Couple :class:`PipelineStep` metadata with an execution callable."""
+
+    step: PipelineStep
+    invoke: StepCallable
+
+
+@dataclass(frozen=True)
+class WorkflowStepResult:
+    """Container describing the outcome of a prepared pipeline step."""
+
+    step: PipelineStep
+    input_path: Path
+    final_output: Path
+    working_output: Path
+    result: StepExecutionResult
+
+
+def temporary_output_path(output_path: Path) -> Path:
+    """Return the path used for intermediate artefacts of ``output_path``."""
+
+    return output_path.with_name(f".{output_path.name}.tmp")
+
+
+def execute_workflow(
+    cfg: "PipelineRunConfig",
+    steps: Sequence[PreparedPipelineStep],
+) -> Iterator[WorkflowStepResult]:
+    """Execute ``steps`` sequentially and yield their results.
+
+    The provided callables are expected to handle the step invocation without
+    triggering command-line parsing. ``execute_workflow`` computes the
+    filesystem paths that each callable would typically derive from CLI
+    arguments and passes them directly, ensuring deterministic execution order
+    and consistent input/output handling.
+    """
+
+    for prepared in steps:
+        step = prepared.step
+        input_path = step.required_input(cfg)
+        final_output = step.expected_output(cfg)
+        working_output = temporary_output_path(final_output)
+        result = prepared.invoke(cfg, input_path, final_output, working_output)
+        yield WorkflowStepResult(
+            step=step,
+            input_path=input_path,
+            final_output=final_output,
+            working_output=working_output,
+            result=result,
+        )
+        if result.exit_code != 0:
+            break
+
+
+__all__ = [
+    "PreparedPipelineStep",
+    "StepCallable",
+    "StepExecutionResult",
+    "WorkflowStepResult",
+    "execute_workflow",
+    "temporary_output_path",
+]

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -47,7 +47,6 @@ from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
-from library.integration.molecule_catalog import load_parent_catalog
 from library.pipelines.activity import (
     ActivityPipelineOptions,
     run_pipeline as run_activity_pipeline,
@@ -55,6 +54,12 @@ from library.pipelines.activity import (
 from library.pipelines.assay import (
     AssayPipelineOptions,
     run_pipeline as run_assay_pipeline,
+)
+from library.orchestration.workflow import (
+    PreparedPipelineStep,
+    StepExecutionResult,
+    execute_workflow,
+    temporary_output_path,
 )
 from library.pipelines.common import PipelineRunResult
 from library.pipelines.document import (
@@ -470,22 +475,6 @@ def _prepare_config(
     )
 
 
-@dataclass(frozen=True)
-class StepExecutionResult:
-    """Summarize the outcome of invoking a pipeline step."""
-
-    exit_code: int
-    executed: bool
-    status: str
-    reason: str | None = None
-
-
-def _temporary_output_path(output_path: Path) -> Path:
-    """Return the path used for intermediate artefacts of ``output_path``."""
-
-    return output_path.with_name(f".{output_path.name}.tmp")
-
-
 def _failure_sentinel_path(output_path: Path) -> Path:
     """Return the sentinel path recorded when a pipeline step fails."""
 
@@ -701,12 +690,12 @@ def _run_step(
     step: PipelineStep,
     cfg: PipelineRunConfig,
     base_config: Config,
+    input_path: Path,
     final_output: Path,
     working_output: Path,
 ) -> StepExecutionResult:
     """Execute ``step`` with ``cfg`` returning the resulting exit code."""
 
-    input_path = step.required_input(cfg)
     if not input_path.exists():
         _LOGGER.error("step_input_missing", step=step.name, path=str(input_path))
         return StepExecutionResult(
@@ -952,6 +941,8 @@ def _cleanup_failed_step(
 def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
     """Ensure the molecule parent catalogue cache exists before test item runs."""
 
+    from library.integration.molecule_catalog import load_parent_catalog
+
     start_time = time.perf_counter()
     config: Config = load_config(cfg.config_path, base_path=cfg.base_path)
     chembl_sources = config.sources.chembl
@@ -1112,7 +1103,7 @@ def _pending_manifest_entry(step: PipelineStep, cfg: PipelineRunConfig) -> dict[
     """Return a manifest entry for ``step`` that has not been executed."""
 
     final_output = step.expected_output(cfg)
-    working_output = _temporary_output_path(final_output)
+    working_output = temporary_output_path(final_output)
     entry: dict[str, Any] = {
         "name": step.name,
         "status": "pending",
@@ -1172,7 +1163,11 @@ def _write_run_manifest(
         )
 
 
-def run_pipeline(cfg: PipelineRunConfig) -> int:
+def run_pipeline(
+    cfg: PipelineRunConfig,
+    *,
+    steps: Sequence[PipelineStep] | None = None,
+) -> int:
 
     """Execute all configured steps and return the resulting exit status."""
 
@@ -1183,188 +1178,234 @@ def run_pipeline(cfg: PipelineRunConfig) -> int:
     run_started_clock = time.perf_counter()
     manifest_entries: list[dict[str, Any]] = []
     failed_index: int | None = None
+    last_executed_index = -1
     _LOGGER.info("pipeline_start", stage="pipeline")
 
-    for index, step in enumerate(_PIPELINE_STEPS):
-        final_output = step.expected_output(cfg)
-        working_output = _temporary_output_path(final_output)
-        sentinel_path = _failure_sentinel_path(final_output)
-        entry: dict[str, Any] = {
-            "name": step.name,
-            "status": "pending",
-            "exit_code": None,
-            "executed": False,
-            "reason": None,
-            "started_at": datetime.now(UTC).isoformat(),
-            "completed_at": None,
-            "duration_sec": None,
-            "output": _describe_file(final_output),
-            "sidecars": _describe_sidecars(final_output, working_output),
-        }
-        manifest_entries.append(entry)
+    def _prepare_step(
+        step: PipelineStep,
+        entry: dict[str, Any],
+        index: int,
+    ) -> PreparedPipelineStep:
+        def _invoke(
+            current_cfg: PipelineRunConfig,
+            input_path: Path,
+            final_output: Path,
+            working_output: Path,
+        ) -> StepExecutionResult:
+            nonlocal overall_status, failed_index, last_executed_index
 
-        _LOGGER.info("step_start", step=step.name)
-        step_started_clock = time.perf_counter()
+            sentinel_path = _failure_sentinel_path(final_output)
+            entry["started_at"] = datetime.now(UTC).isoformat()
+            step_started_clock = time.perf_counter()
+            _LOGGER.info("step_start", step=step.name)
 
-        if cfg.dry_run:
-            _LOGGER.info("step_skip_dry_run", step=step.name)
-            entry.update(
-                {
-                    "status": "skipped",
-                    "exit_code": 0,
-                    "executed": False,
-                    "reason": "dry_run",
-                }
-            )
-            _complete_manifest_entry(
-                entry,
-                final_output=final_output,
-                working_output=working_output,
-                started_at=step_started_clock,
-            )
-            continue
+            if current_cfg.dry_run:
+                _LOGGER.info("step_skip_dry_run", step=step.name)
+                entry.update(
+                    {
+                        "status": "skipped",
+                        "exit_code": 0,
+                        "executed": False,
+                        "reason": "dry_run",
+                    }
+                )
+                _complete_manifest_entry(
+                    entry,
+                    final_output=final_output,
+                    working_output=working_output,
+                    started_at=step_started_clock,
+                )
+                last_executed_index = index
+                return StepExecutionResult(
+                    exit_code=0,
+                    executed=False,
+                    status="skipped",
+                    reason="dry_run",
+                )
 
-        if working_output.exists():
-            _remove_path(working_output)
+            if working_output.exists():
+                _remove_path(working_output)
 
-        if step.name == "testitem":
+            if step.name == "testitem":
+                try:
+                    _warm_parent_catalog(current_cfg)
+                except TimeoutError as exc:
+                    overall_status = 1
+                    entry.update(
+                        {
+                            "status": "failed",
+                            "exit_code": overall_status,
+                            "executed": False,
+                            "reason": "parent_catalog_timeout",
+                        }
+                    )
+                    _LOGGER.error("parent_catalog_warm_timeout", error=str(exc))
+                    _complete_manifest_entry(
+                        entry,
+                        final_output=final_output,
+                        working_output=working_output,
+                        started_at=step_started_clock,
+                    )
+                    failed_index = index
+                    last_executed_index = index
+                    return StepExecutionResult(
+                        exit_code=1,
+                        executed=False,
+                        status="failed",
+                        reason="parent_catalog_timeout",
+                    )
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    overall_status = 1
+                    entry.update(
+                        {
+                            "status": "failed",
+                            "exit_code": overall_status,
+                            "executed": False,
+                            "reason": "parent_catalog_error",
+                        }
+                    )
+                    _LOGGER.error("parent_catalog_warm_error", error=str(exc))
+                    _complete_manifest_entry(
+                        entry,
+                        final_output=final_output,
+                        working_output=working_output,
+                        started_at=step_started_clock,
+                    )
+                    failed_index = index
+                    last_executed_index = index
+                    return StepExecutionResult(
+                        exit_code=1,
+                        executed=False,
+                        status="failed",
+                        reason="parent_catalog_error",
+                    )
+
             try:
-                _warm_parent_catalog(cfg)
-            except TimeoutError as exc:
-                overall_status = 1
+                result = _run_step(
+                    step,
+                    current_cfg,
+                    base_config,
+                    input_path,
+                    final_output,
+                    working_output,
+                )
+            except SystemExit as exc:  # pragma: no cover - defensive guard
+                exit_code = _coerce_exit_code(exc.code)
                 entry.update(
                     {
                         "status": "failed",
-                        "exit_code": overall_status,
-                        "executed": False,
-                        "reason": "parent_catalog_timeout",
+                        "exit_code": exit_code,
+                        "executed": True,
+                        "reason": "system_exit",
                     }
                 )
-                _LOGGER.error("parent_catalog_warm_timeout", error=str(exc))
+                _LOGGER.error("step_system_exit", step=step.name, exit_code=exit_code)
+                _cleanup_failed_step(
+                    final_output,
+                    working_output,
+                    sentinel_path,
+                    executed=True,
+                )
                 _complete_manifest_entry(
                     entry,
                     final_output=final_output,
                     working_output=working_output,
                     started_at=step_started_clock,
                 )
+                overall_status = exit_code
                 failed_index = index
-                break
-            except Exception as exc:  # pragma: no cover - defensive guard
-                overall_status = 1
+                last_executed_index = index
+                return StepExecutionResult(
+                    exit_code=exit_code,
+                    executed=True,
+                    status="failed",
+                    reason="system_exit",
+                )
+            except BaseException as exc:  # pragma: no cover - defensive guard
                 entry.update(
                     {
                         "status": "failed",
-                        "exit_code": overall_status,
-                        "executed": False,
-                        "reason": "parent_catalog_error",
+                        "exit_code": 1,
+                        "executed": True,
+                        "reason": "exception",
                     }
                 )
-                _LOGGER.error("parent_catalog_warm_error", error=str(exc))
+                _LOGGER.exception("step_exception", step=step.name, error=str(exc))
+                _cleanup_failed_step(
+                    final_output,
+                    working_output,
+                    sentinel_path,
+                    executed=True,
+                )
                 _complete_manifest_entry(
                     entry,
                     final_output=final_output,
                     working_output=working_output,
                     started_at=step_started_clock,
                 )
+                overall_status = 1
                 failed_index = index
-                break
+                last_executed_index = index
+                return StepExecutionResult(
+                    exit_code=1,
+                    executed=True,
+                    status="failed",
+                    reason="exception",
+                )
 
-        try:
-            result = _run_step(step, cfg, base_config, final_output, working_output)
-        except SystemExit as exc:  # pragma: no cover - defensive guard
-            exit_code = _coerce_exit_code(exc.code)
             entry.update(
                 {
-                    "status": "failed",
-                    "exit_code": exit_code,
-                    "executed": True,
-                    "reason": "system_exit",
+                    "exit_code": result.exit_code,
+                    "executed": result.executed,
+                    "reason": result.reason,
                 }
             )
-            _LOGGER.error("step_system_exit", step=step.name, exit_code=exit_code)
-            _cleanup_failed_step(
-                final_output,
-                working_output,
-                sentinel_path,
-                executed=True,
-            )
-            _complete_manifest_entry(
-                entry,
-                final_output=final_output,
-                working_output=working_output,
-                started_at=step_started_clock,
-            )
-            overall_status = exit_code
-            failed_index = index
-            break
-        except BaseException as exc:  # pragma: no cover - defensive guard
-            entry.update(
-                {
-                    "status": "failed",
-                    "exit_code": 1,
-                    "executed": True,
-                    "reason": "exception",
-                }
-            )
-            _LOGGER.exception("step_exception", step=step.name, error=str(exc))
-            _cleanup_failed_step(
-                final_output,
-                working_output,
-                sentinel_path,
-                executed=True,
-            )
-            _complete_manifest_entry(
-                entry,
-                final_output=final_output,
-                working_output=working_output,
-                started_at=step_started_clock,
-            )
-            overall_status = 1
-            failed_index = index
-            break
 
-        entry.update(
-            {
-                "exit_code": result.exit_code,
-                "executed": result.executed,
-                "reason": result.reason,
-            }
-        )
+            last_executed_index = index
 
-        if result.exit_code != 0:
-            _LOGGER.error("step_failed", step=step.name, exit_code=result.exit_code)
+            if result.exit_code != 0:
+                _LOGGER.error("step_failed", step=step.name, exit_code=result.exit_code)
+                entry["status"] = result.status
+                _cleanup_failed_step(
+                    final_output,
+                    working_output,
+                    sentinel_path,
+                    executed=result.executed,
+                )
+                _complete_manifest_entry(
+                    entry,
+                    final_output=final_output,
+                    working_output=working_output,
+                    started_at=step_started_clock,
+                )
+                overall_status = result.exit_code
+                failed_index = index
+                return result
+
             entry["status"] = result.status
-            _cleanup_failed_step(
-                final_output,
-                working_output,
-                sentinel_path,
-                executed=result.executed,
-            )
+            _finalize_step_success(final_output, working_output, sentinel_path)
             _complete_manifest_entry(
                 entry,
                 final_output=final_output,
                 working_output=working_output,
                 started_at=step_started_clock,
             )
-            overall_status = result.exit_code
-            failed_index = index
-            break
+            _LOGGER.info("step_done", step=step.name)
+            return result
 
-        entry["status"] = result.status
-        _finalize_step_success(final_output, working_output, sentinel_path)
-        _complete_manifest_entry(
-            entry,
-            final_output=final_output,
-            working_output=working_output,
-            started_at=step_started_clock,
-        )
-        _LOGGER.info("step_done", step=step.name)
-    else:
+        return PreparedPipelineStep(step=step, invoke=_invoke)
+
+    prepared_steps: list[PreparedPipelineStep] = []
+    for index, step in enumerate(effective_steps):
+        entry = _pending_manifest_entry(step, cfg)
+        manifest_entries.append(entry)
+        prepared_steps.append(_prepare_step(step, entry, index))
+
+    for _ in execute_workflow(cfg, prepared_steps):
+        pass
+
+    if failed_index is None and last_executed_index + 1 == len(effective_steps):
         _LOGGER.info("workflow_complete")
-
-    if failed_index is not None and failed_index + 1 < len(_PIPELINE_STEPS):
-        for step in _PIPELINE_STEPS[failed_index + 1 :]:
-            manifest_entries.append(_pending_manifest_entry(step, cfg))
 
     run_completed_at = datetime.now(UTC)
     duration_seconds = time.perf_counter() - run_started_clock
@@ -1439,3 +1480,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     raise SystemExit(main())
+
+def _temporary_output_path(output_path: Path) -> Path:
+    """Backward compatible alias for :func:`temporary_output_path`."""
+
+    return temporary_output_path(output_path)
+

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,0 +1,180 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from library.orchestration.workflow import (
+    PreparedPipelineStep,
+    StepExecutionResult,
+    execute_workflow,
+    temporary_output_path,
+)
+from library.pipelines.registry import PipelineStep
+
+@dataclass
+class _ConfigStub:
+    base_path: Path
+    input_dir: Path
+    output_dir: Path
+    config_path: Path
+    date_prefix: str
+    log_level: str
+    limit: int | None
+    force: bool
+    skip_existing: bool
+    dry_run: bool
+    input_files: dict[str, str]
+    output_stems: dict[str, str]
+
+    def input_path(self, name: str) -> Path:
+        return self.input_dir / self.input_files[name]
+
+    def output_path(self, name: str) -> Path:
+        stem = self.output_stems[name]
+        return self.output_dir / f"output.{stem}_{self.date_prefix}.csv"
+
+
+def _make_config(tmp_path: Path) -> _ConfigStub:
+    base_path = tmp_path
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    config_path = tmp_path / "config.yaml"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    config_path.write_text("{}", encoding="utf-8")
+    return _ConfigStub(
+        base_path=base_path,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        config_path=config_path,
+        date_prefix="20240101",
+        log_level="INFO",
+        limit=None,
+        force=False,
+        skip_existing=False,
+        dry_run=False,
+        input_files={"doc": "document.csv", "target": "target.csv"},
+        output_stems={"doc": "documents", "target": "targets"},
+    )
+
+
+@pytest.mark.unit
+def test_execute_workflow__passes_resolved_paths(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    (cfg.input_dir / "document.csv").write_text("id\n1\n", encoding="utf-8")
+
+    step = PipelineStep(
+        name="doc",
+        main=lambda args: 0,
+        input_filename="document.csv",
+        output_stem="documents",
+    )
+
+    calls: List[tuple[_ConfigStub, Path, Path, Path]] = []
+
+    def runner(
+        cfg_arg: _ConfigStub,
+        input_path: Path,
+        final_output: Path,
+        working_output: Path,
+    ) -> StepExecutionResult:
+        calls.append((cfg_arg, input_path, final_output, working_output))
+        return StepExecutionResult(exit_code=0, executed=True, status="success")
+
+    prepared = PreparedPipelineStep(step=step, invoke=runner)
+
+    results = list(execute_workflow(cfg, [prepared]))
+
+    assert len(results) == 1
+    [call] = calls
+    assert call[0] is cfg
+    assert call[1] == cfg.input_dir / "document.csv"
+    expected_output = cfg.output_dir / "output.documents_20240101.csv"
+    assert call[2] == expected_output
+    assert call[3] == temporary_output_path(expected_output)
+    result = results[0]
+    assert result.step is step
+    assert result.result.exit_code == 0
+    assert result.result.status == "success"
+
+
+@pytest.mark.unit
+def test_execute_workflow__stops_after_failure(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    (cfg.input_dir / "document.csv").write_text("id\n1\n", encoding="utf-8")
+    (cfg.input_dir / "target.csv").write_text("id\n2\n", encoding="utf-8")
+
+    doc_step = PipelineStep(
+        name="doc",
+        main=lambda args: 0,
+        input_filename="document.csv",
+        output_stem="documents",
+    )
+    target_step = PipelineStep(
+        name="target",
+        main=lambda args: 0,
+        input_filename="target.csv",
+        output_stem="targets",
+    )
+
+    invoked_second = False
+
+    def fail_runner(*args):
+        return StepExecutionResult(exit_code=1, executed=True, status="failed", reason="boom")
+
+    def success_runner(*args):
+        nonlocal invoked_second
+        invoked_second = True
+        return StepExecutionResult(exit_code=0, executed=True, status="success")
+
+    prepared = [
+        PreparedPipelineStep(step=doc_step, invoke=fail_runner),
+        PreparedPipelineStep(step=target_step, invoke=success_runner),
+    ]
+
+    results = list(execute_workflow(cfg, prepared))
+
+    assert len(results) == 1
+    assert results[0].result.exit_code == 1
+    assert invoked_second is False
+
+
+@pytest.mark.unit
+def test_execute_workflow__propagates_exceptions(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    (cfg.input_dir / "document.csv").write_text("id\n1\n", encoding="utf-8")
+    (cfg.input_dir / "target.csv").write_text("id\n2\n", encoding="utf-8")
+
+    doc_step = PipelineStep(
+        name="doc",
+        main=lambda args: 0,
+        input_filename="document.csv",
+        output_stem="documents",
+    )
+    target_step = PipelineStep(
+        name="target",
+        main=lambda args: 0,
+        input_filename="target.csv",
+        output_stem="targets",
+    )
+
+    invoked_second = False
+
+    def error_runner(*args):
+        raise RuntimeError("failure")
+
+    def second_runner(*args):
+        nonlocal invoked_second
+        invoked_second = True
+        return StepExecutionResult(exit_code=0, executed=True, status="success")
+
+    prepared = [
+        PreparedPipelineStep(step=doc_step, invoke=error_runner),
+        PreparedPipelineStep(step=target_step, invoke=second_runner),
+    ]
+
+    with pytest.raises(RuntimeError):
+        list(execute_workflow(cfg, prepared))
+
+    assert invoked_second is False


### PR DESCRIPTION
## Summary
- add a reusable workflow helper that executes prepared pipeline steps without re-running CLI parsers
- refactor `scripts/get_data.run_pipeline` to drive steps through the helper and lazily import the parent catalog loader
- cover the helper with unit tests that assert path handling and failure propagation behaviour

## Testing
- pytest tests/unit/test_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_68e4277082a483249e7bcc808f69edbb