### PR TITLE
Refactor configuration package layout

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,7 +2,7 @@
 # Values can be overridden via CLI arguments or environment variables.
 # Environment variables follow the ``CHEMBL_DA__SECTION__KEY`` pattern and
 # many keys also provide short aliases such as ``CHEMBL_DA_RPS``.
-# For the complete alias table see ``library/config/models.py``.
+# For the complete alias table see ``library/config/model.py``.
 # Example:
 #   export CHEMBL_DA__SOURCES__CHEMBL__API__CHEMBL_BASE=https://dev.example/chembl
 #   export CHEMBL_DA_BASE=https://dev.example/chembl  # short alias

--- a/docs/en/CONFIG.md
+++ b/docs/en/CONFIG.md
@@ -2,14 +2,14 @@
 
 The pipelines load configuration from three layers (lowest precedence first):
 
-1. Built-in defaults defined in [`library/config/models.py`](../library/config/models.py).
+1. Built-in defaults defined in [`library/config/model.py`](../library/config/model.py).
 2. YAML files (`config/config.yaml` plus optional overrides such as
    `config/config.local.yaml`).
 3. Environment variables and CLI arguments.
 
 Environment variables use the `CHEMBL_DA__SECTION__KEY` pattern, where nested
 keys are joined with double underscores. Short aliases exist for frequently used
-fields (see `_ALIAS_MAP` in `library/config/models.py`).
+fields (see `_ALIAS_MAP` in `library/config/model.py`).
 
 ```bash
 # Example: increase the UniProt rate limit during a smoke run
@@ -39,7 +39,7 @@ system:
     level: INFO
 ```
 
-Fields not listed inherit the defaults from `library/config/models.py`. Create a
+Fields not listed inherit the defaults from `library/config/model.py`. Create a
 `config/config.local.yaml` file to keep environment-specific overrides outside
 version control.
 
@@ -95,7 +95,7 @@ whether user input is required (`Yes` = must be provided explicitly).
 
 ### `sources.chembl.pipelines`
 
-Each pipeline inherits defaults from `library/config/models.py`. All keys are optional
+Each pipeline inherits defaults from `library/config/model.py`. All keys are optional
 and may be overridden via CLI or environment variables.
 
 #### `activity`
@@ -308,5 +308,5 @@ Controls post-processing of activity tables.
 | `limit` | `null` | Optional cap on processed rows. |
 
 For further customisation consult the Pydantic models in
-[`library/config/models.py`](../library/config/models.py); the documentation above mirrors the
+[`library/config/model.py`](../library/config/model.py); the documentation above mirrors the
 available fields and their default values.

--- a/docs/en/architecture/IMPROVEMENT_PROPOSALS.md
+++ b/docs/en/architecture/IMPROVEMENT_PROPOSALS.md
@@ -16,7 +16,7 @@
    - **Expected effect.** Reduced duplication and a consistent CLI surface that is easier to reason about and extend.
 
 4. **Split configuration loading into a package**
-   - **Description.** (Completed) Configuration code now lives in `library/config/models.py`, `library/config/loader.py` and `library/config/runtime.py`, separating schema definitions, loading logic and runtime helpers.
+   - **Description.** (Completed) Configuration code now lives in `library/config/model.py`, `library/config/loader.py` and `library/config/runtime.py`, separating schema definitions, loading logic and runtime helpers.
    - **Problem.** The current module interleaves path normalisation, schema expansion, HTTP session factories and environment overrides in one 1k+ LOC file, reducing readability and testability.
    - **Expected effect.** Clear separation of concerns with focused units that can be unit-tested and reused independently across pipelines.
 

--- a/docs/en/development/LOCAL_SETUP.md
+++ b/docs/en/development/LOCAL_SETUP.md
@@ -45,7 +45,7 @@ make format      # run black and ruff --fix
 | Variable | Purpose |
 |----------|---------|
 | `CHEMBL_DA_BASE_PATH` | Overrides the placeholder used in `config/config.yaml` for relative paths. |
-| `CHEMBL_DA_*` | Short aliases for configuration overrides (see `library/config/models.py`). |
+| `CHEMBL_DA_*` | Short aliases for configuration overrides (see `library/config/model.py`). |
 | `HTTP_PROXY` / `HTTPS_PROXY` | Proxy configuration when running behind corporate networks. |
 
 Store sensitive values in `.env` (loaded by `python-dotenv` when present).

--- a/docs/ru/CONFIG.md
+++ b/docs/ru/CONFIG.md
@@ -2,13 +2,13 @@
 
 Конфигурация загружается из трёх слоёв (по возрастанию приоритета):
 
-1. Значения по умолчанию, определённые в [`library/config/models.py`](../library/config/models.py).
+1. Значения по умолчанию, определённые в [`library/config/model.py`](../library/config/model.py).
 2. YAML-файлы (`config/config.yaml` и необязательный `config/config.local.yaml`).
 3. Переменные окружения и аргументы CLI.
 
 Переменные окружения используют схему `CHEMBL_DA__РАЗДЕЛ__КЛЮЧ`, вложенные ключи
 соединяются двойным подчёркиванием. Для распространённых параметров доступны
-короткие алиасы (см. `_ALIAS_MAP` в `library/config/models.py`).
+короткие алиасы (см. `_ALIAS_MAP` в `library/config/model.py`).
 
 ```bash
 # Пример: увеличить лимит UniProt во время smoke-теста
@@ -297,5 +297,5 @@ system:
 | `thresholds` | `{review:1, experimental:1, unknown:2}` | Пороговые значения. |
 | `limit` | `null` | Ограничение по числу строк. |
 
-Подробности и дополнительные поля см. в [`library/config/models.py`](../library/config/models.py);
+Подробности и дополнительные поля см. в [`library/config/model.py`](../library/config/model.py);
 данный документ синхронизирован с актуальными моделями.

--- a/docs/ru/development/LOCAL_SETUP.md
+++ b/docs/ru/development/LOCAL_SETUP.md
@@ -44,7 +44,7 @@ make format
 | Переменная | Назначение |
 |------------|------------|
 | `CHEMBL_DA_BASE_PATH` | Базовый путь для плейсхолдера в `config/config.yaml`. |
-| `CHEMBL_DA_*` | Алиасы конфигурации (см. `library/config/models.py`). |
+| `CHEMBL_DA_*` | Алиасы конфигурации (см. `library/config/model.py`). |
 | `HTTP_PROXY` / `HTTPS_PROXY` | Прокси в корпоративных сетях. |
 
 Чувствительные значения храните в `.env` (подхватывается `python-dotenv`).

--- a/library/config/__init__.py
+++ b/library/config/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .models import (
+from .model import (
     ActivityActionTypeCfg,
     ActivityBoundsCfg,
     ActivityCfg,

--- a/library/config/env.py
+++ b/library/config/env.py
@@ -1,0 +1,259 @@
+"""Environment utilities for configuration loading."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping as TypingMapping
+
+import yaml
+from pydantic import BaseModel
+from pydantic_core import ErrorDetails
+
+from ..common.log import logger
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for typing
+    from .model import Config
+
+__all__ = [
+    "_normalize_base_path",
+    "_default_base_path",
+    "_default_cache_home",
+    "_resolve_placeholder_base_path",
+    "_expand_config_placeholders",
+    "_coerce_integral_numbers",
+    "_parse_env_value",
+    "_format_env_error_message",
+    "_format_env_error",
+    "_normalize_env_errors",
+    "_apply_env_overrides",
+    "_set_by_path",
+]
+
+
+def _config_model() -> type["Config"]:
+    from .model import Config
+
+    return Config
+
+
+def _alias_map() -> dict[str, tuple[str, ...]]:
+    from .model import _ALIAS_MAP
+
+    return _ALIAS_MAP
+
+
+def _normalize_base_path(value: Path | str) -> Path:
+    """Return *value* coerced into an absolute :class:`~pathlib.Path`."""
+
+    candidate = Path(value).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (Path.cwd() / candidate).resolve()
+
+
+def _default_base_path() -> Path:
+    """Return the default data directory used for placeholder expansion."""
+
+    env_override = os.environ.get("CHEMBL_DA_BASE_PATH")
+    if env_override:
+        return _normalize_base_path(env_override)
+    return (Path.home() / ".local" / "share" / "chembl-da").resolve()
+
+
+def _default_cache_home() -> Path:
+    """Return the default cache directory for local artefacts."""
+
+    return (Path.home() / ".cache" / "chembl-da").resolve()
+
+
+def _resolve_placeholder_base_path(base_path: Path | str | None) -> Path:
+    """Return the base path used for ``$CHEMBL_DA_BASE_PATH`` placeholders."""
+
+    if base_path is not None:
+        return _normalize_base_path(base_path)
+    return _default_base_path()
+
+
+def _expand_config_placeholders(data: Any, *, base_path: Path) -> Any:
+    """Expand configuration placeholders in ``data`` using *base_path*."""
+
+    replacements = {"$CHEMBL_DA_BASE_PATH": str(base_path)}
+
+    def _expand(value: Any) -> Any:
+        if isinstance(value, dict):
+            for key, current in value.items():
+                value[key] = _expand(current)
+            return value
+        if isinstance(value, list):
+            for idx, current in enumerate(value):
+                value[idx] = _expand(current)
+            return value
+        if isinstance(value, tuple):
+            return tuple(_expand(item) for item in value)
+        if isinstance(value, str):
+            replaced = value
+            for marker, target in replacements.items():
+                replaced = replaced.replace(marker, target)
+            replaced = os.path.expandvars(replaced)
+            replaced = os.path.expanduser(replaced)
+            return replaced
+        return value
+
+    return _expand(data)
+
+
+def _set_by_path(data: dict[str, Any], path: Sequence[str], value: Any) -> None:
+    cur: dict[str, Any] = data
+    for key in path[:-1]:
+        if key not in cur or not isinstance(cur[key], dict):
+            cur[key] = {}
+        cur = cur[key]
+    cur[path[-1]] = value
+
+
+def _is_valid_path(path: Sequence[str]) -> bool:
+    model: type[BaseModel] | None = _config_model()
+    for part in path:
+        if model is None or part not in model.model_fields:
+            return False
+        field = model.model_fields[part].annotation
+        model = (
+            field if isinstance(field, type) and issubclass(field, BaseModel) else None
+        )
+    return True
+
+
+def _coerce_integral_numbers(value: Any) -> Any:
+    """Return *value* with floats that represent integers converted to ``int``."""
+
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else value
+    if isinstance(value, list):
+        return [_coerce_integral_numbers(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_coerce_integral_numbers(item) for item in value)
+    if isinstance(value, dict):
+        return {key: _coerce_integral_numbers(val) for key, val in value.items()}
+    return value
+
+
+def _parse_env_value(env_key: str, raw_value: str) -> Any:
+    """Normalise *raw_value* from environment variable *env_key*."""
+
+    if raw_value == "":
+        return ""
+    if raw_value and raw_value.strip() == "":
+        return raw_value
+    try:
+        value = yaml.safe_load(raw_value)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive logging
+        logger.debug(
+            "treating %s as plain string due to YAML parse error: %s",
+            env_key,
+            exc,
+        )
+        return raw_value
+    return _coerce_integral_numbers(value)
+
+
+def _format_error_location(loc: Sequence[Any] | None) -> str:
+    if not loc:
+        return ""
+    parts: list[str] = []
+    for part in loc:
+        if isinstance(part, int):
+            if parts:
+                parts[-1] = f"{parts[-1]}[{part}]"
+            else:
+                parts.append(f"[{part}]")
+        else:
+            parts.append(str(part))
+    return ".".join(parts)
+
+
+def _format_env_error_message(error: TypingMapping[str, Any]) -> str:
+    """Convert a Pydantic error dictionary into a concise human message."""
+
+    error_type = error.get("type")
+    ctx: dict[str, Any] = error.get("ctx") or {}
+    if error_type == "greater_than_equal" and "ge" in ctx:
+        return f"must be ≥{ctx['ge']}"
+    if error_type == "greater_than" and "gt" in ctx:
+        return f"must be >{ctx['gt']}"
+    if error_type == "less_than_equal" and "le" in ctx:
+        return f"must be ≤{ctx['le']}"
+    if error_type == "less_than" and "lt" in ctx:
+        return f"must be <{ctx['lt']}"
+    if error_type == "int_parsing":
+        return "must be an integer"
+    if error_type == "float_parsing":
+        return "must be a number"
+    if error_type == "string_type":
+        return "must be a string"
+    if error_type == "bool_parsing":
+        return "must be a boolean"
+    if error_type == "finite_number":
+        return "must be finite"
+    return str(error.get("msg", "invalid value"))
+
+
+def _format_env_error(env_key: str, error: TypingMapping[str, Any]) -> str:
+    """Return a human readable error string for *env_key* based on *error*."""
+
+    message = _format_env_error_message(error)
+    loc = error.get("loc")
+    location = _format_error_location(loc) if isinstance(loc, Sequence) else ""
+    if location:
+        return f"{env_key} ({location}) {message}".strip()
+    return f"{env_key} {message}".strip()
+
+
+def _normalize_env_errors(
+    errors: Sequence[ErrorDetails], overrides: TypingMapping[tuple[str, ...], str]
+) -> tuple[list[str], int]:
+    """Return formatted messages for validation *errors* caused by overrides."""
+
+    messages: list[str] = []
+    handled = 0
+    for error in errors:
+        loc = error.get("loc", ())
+        if not isinstance(loc, Sequence):
+            continue
+        str_path = [str(part).lower() for part in loc if isinstance(part, str)]
+        env_key: str | None = None
+        for index in range(len(str_path), 0, -1):
+            candidate = tuple(str_path[:index])
+            match = overrides.get(candidate)
+            if match:
+                env_key = match
+                break
+        if not env_key:
+            continue
+        handled += 1
+        messages.append(_format_env_error(env_key, error))
+    return messages, handled
+
+
+def _apply_env_overrides(data: dict[str, Any]) -> dict[tuple[str, ...], str]:
+    prefix = "CHEMBL_DA"
+    overrides: dict[tuple[str, ...], str] = {}
+    alias_map = _alias_map()
+    for env_key, env_val in os.environ.items():
+        key = env_key.upper()
+        if key in alias_map:
+            path = alias_map[key]
+        elif key.startswith(prefix + "__"):
+            path = key[len(prefix) + 2 :].split("__")
+        else:
+            continue
+        parts = [p.lower() for p in path]
+        if not _is_valid_path(parts):
+            logger.warning(f"Environment variable {key} ignored")
+            continue
+        value = _parse_env_value(key, env_val)
+        _set_by_path(data, parts, value)
+        overrides[tuple(parts)] = key
+    return overrides
+

--- a/library/config/loader.py
+++ b/library/config/loader.py
@@ -10,17 +10,22 @@ from typing import Any, Mapping as TypingMapping
 
 import yaml
 from pydantic import BaseModel, ValidationError
-from pydantic_core import ErrorDetails
 
 from ..common.log import logger
 from ..utils.config import ConfigLoaderError, load_yaml_config
-from .models import (
+from .env import (
+    _apply_env_overrides,
+    _expand_config_placeholders,
+    _normalize_env_errors,
+    _resolve_placeholder_base_path,
+    _set_by_path,
+)
+from .model import (
     Config,
     ConfigMetadata,
     ConfigSource,
     ConfigError,
     _CONFIG_PATH_FIELDS,
-    _ALIAS_MAP,
 )
 from .runtime import configure_rate_limiters
 
@@ -80,66 +85,6 @@ def _absolutise_config_paths(data: Mapping[str, Any], base_dir: Path) -> None:
             current[final_key] = _absolutise_path_value(value, base_dir)
 
 
-def _normalize_base_path(value: Path | str) -> Path:
-    """Return *value* coerced into an absolute :class:`~pathlib.Path`."""
-
-    candidate = Path(value).expanduser()
-    if candidate.is_absolute():
-        return candidate.resolve()
-    return (Path.cwd() / candidate).resolve()
-
-
-def _default_base_path() -> Path:
-    """Return the default data directory used for placeholder expansion."""
-
-    env_override = os.environ.get("CHEMBL_DA_BASE_PATH")
-    if env_override:
-        return _normalize_base_path(env_override)
-    return (Path.home() / ".local" / "share" / "chembl-da").resolve()
-
-
-def _default_cache_home() -> Path:
-    """Return the default cache directory for local artefacts."""
-
-    return (Path.home() / ".cache" / "chembl-da").resolve()
-
-
-def _expand_config_placeholders(data: Any, *, base_path: Path) -> Any:
-    """Expand configuration placeholders in ``data`` using *base_path*."""
-
-    replacements = {"$CHEMBL_DA_BASE_PATH": str(base_path)}
-
-    def _expand(value: Any) -> Any:
-        if isinstance(value, dict):
-            for key, current in value.items():
-                value[key] = _expand(current)
-            return value
-        if isinstance(value, list):
-            for idx, current in enumerate(value):
-                value[idx] = _expand(current)
-            return value
-        if isinstance(value, tuple):
-            return tuple(_expand(item) for item in value)
-        if isinstance(value, str):
-            replaced = value
-            for marker, target in replacements.items():
-                replaced = replaced.replace(marker, target)
-            replaced = os.path.expandvars(replaced)
-            replaced = os.path.expanduser(replaced)
-            return replaced
-        return value
-
-    return _expand(data)
-
-
-def _resolve_placeholder_base_path(base_path: Path | str | None) -> Path:
-    """Return the base path used for ``$CHEMBL_DA_BASE_PATH`` placeholders."""
-
-    if base_path is not None:
-        return _normalize_base_path(base_path)
-    return _default_base_path()
-
-
 def _iter_leaf_items(
     data: Any, prefix: tuple[str, ...] = ()
 ) -> Iterator[tuple[tuple[str, ...], Any]]:
@@ -173,159 +118,6 @@ def _build_snapshot(
             entry["detail"] = source.detail
         snapshot[key_str] = entry
     return snapshot
-
-
-def _coerce_integral_numbers(value: Any) -> Any:
-    """Return *value* with floats that represent integers converted to ``int``."""
-
-    if isinstance(value, float):
-        return int(value) if value.is_integer() else value
-    if isinstance(value, list):
-        return [_coerce_integral_numbers(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_coerce_integral_numbers(item) for item in value)
-    if isinstance(value, dict):
-        return {key: _coerce_integral_numbers(val) for key, val in value.items()}
-    return value
-
-
-def _set_by_path(data: dict[str, Any], path: list[str], value: Any) -> None:
-    cur: dict[str, Any] = data
-    for key in path[:-1]:
-        if key not in cur or not isinstance(cur[key], dict):
-            cur[key] = {}
-        cur = cur[key]
-    cur[path[-1]] = value
-
-
-def _is_valid_path(path: list[str]) -> bool:
-    model: type[BaseModel] | None = Config
-    for part in path:
-        if model is None or part not in model.model_fields:
-            return False
-        field = model.model_fields[part].annotation
-        model = (
-            field if isinstance(field, type) and issubclass(field, BaseModel) else None
-        )
-    return True
-
-
-def _apply_env_overrides(data: dict[str, Any]) -> dict[tuple[str, ...], str]:
-    prefix = "CHEMBL_DA"
-    overrides: dict[tuple[str, ...], str] = {}
-    for env_key, env_val in os.environ.items():
-        key = env_key.upper()
-        if key in _ALIAS_MAP:
-            path = _ALIAS_MAP[key]
-        elif key.startswith(prefix + "__"):
-            path = key[len(prefix) + 2 :].split("__")
-        else:
-            continue
-        parts = [p.lower() for p in path]
-        if not _is_valid_path(parts):
-            logger.warning(f"Environment variable {key} ignored")
-            continue
-        value = _parse_env_value(key, env_val)
-        _set_by_path(data, parts, value)
-        overrides[tuple(parts)] = key
-    return overrides
-
-
-def _parse_env_value(env_key: str, raw_value: str) -> Any:
-    """Normalize *raw_value* from environment variable *env_key*."""
-
-    if raw_value == "":
-        return ""
-    if raw_value and raw_value.strip() == "":
-        return raw_value
-    try:
-        value = yaml.safe_load(raw_value)
-    except yaml.YAMLError as exc:
-        logger.debug(
-            "treating %s as plain string due to YAML parse error: %s",
-            env_key,
-            exc,
-        )
-        return raw_value
-    return _coerce_integral_numbers(value)
-
-
-def _format_error_location(loc: Sequence[Any] | None) -> str:
-    if not loc:
-        return ""
-    parts: list[str] = []
-    for part in loc:
-        if isinstance(part, int):
-            if parts:
-                parts[-1] = f"{parts[-1]}[{part}]"
-            else:
-                parts.append(f"[{part}]")
-        else:
-            parts.append(str(part))
-    return ".".join(parts)
-
-
-def _format_env_error_message(error: Mapping[str, Any]) -> str:
-    """Convert a Pydantic error dictionary into a concise human message."""
-
-    error_type = error.get("type")
-    ctx: dict[str, Any] = error.get("ctx") or {}
-    if error_type == "greater_than_equal" and "ge" in ctx:
-        return f"must be ≥{ctx['ge']}"
-    if error_type == "greater_than" and "gt" in ctx:
-        return f"must be >{ctx['gt']}"
-    if error_type == "less_than_equal" and "le" in ctx:
-        return f"must be ≤{ctx['le']}"
-    if error_type == "less_than" and "lt" in ctx:
-        return f"must be <{ctx['lt']}"
-    if error_type == "int_parsing":
-        return "must be an integer"
-    if error_type == "float_parsing":
-        return "must be a number"
-    if error_type == "string_type":
-        return "must be a string"
-    if error_type == "bool_parsing":
-        return "must be a boolean"
-    if error_type == "finite_number":
-        return "must be finite"
-    return str(error.get("msg", "invalid value"))
-
-
-def _format_env_error(env_key: str, error: Mapping[str, Any]) -> str:
-    """Return a human readable error string for *env_key* based on *error*."""
-
-    message = _format_env_error_message(error)
-    loc = error.get("loc")
-    location = _format_error_location(loc) if isinstance(loc, Sequence) else ""
-    if location:
-        return f"{env_key} ({location}) {message}".strip()
-    return f"{env_key} {message}".strip()
-
-
-def _normalize_env_errors(
-    errors: Sequence[ErrorDetails], overrides: TypingMapping[tuple[str, ...], str]
-) -> tuple[list[str], int]:
-    """Return formatted messages for validation *errors* caused by overrides."""
-
-    messages: list[str] = []
-    handled = 0
-    for error in errors:
-        loc = error.get("loc", ())
-        if not isinstance(loc, Sequence):
-            continue
-        str_path = [str(part).lower() for part in loc if isinstance(part, str)]
-        env_key: str | None = None
-        for index in range(len(str_path), 0, -1):
-            candidate = tuple(str_path[:index])
-            match = overrides.get(candidate)
-            if match:
-                env_key = match
-                break
-        if not env_key:
-            continue
-        messages.append(_format_env_error(env_key, error))
-        handled += 1
-    return messages, handled
 
 
 _OPTIONAL_UNKNOWN_KEYS: frozenset[str] = frozenset(

--- a/library/config/model.py
+++ b/library/config/model.py
@@ -91,19 +91,19 @@ atexit.register(_RESOURCE_STACK.close)
 
 
 def _default_base_path() -> Path:
-    """Return the default base directory delegated to :mod:`loader`."""
+    """Return the default base directory delegated to :mod:`env`."""
 
-    from . import loader
+    from . import env
 
-    return loader._default_base_path()
+    return env._default_base_path()
 
 
 def _default_cache_home() -> Path:
-    """Return the default cache directory delegated to :mod:`loader`."""
+    """Return the default cache directory delegated to :mod:`env`."""
 
-    from . import loader
+    from . import env
 
-    return loader._default_cache_home()
+    return env._default_cache_home()
 
 _UNSET = object()
 

--- a/library/config/runtime.py
+++ b/library/config/runtime.py
@@ -9,7 +9,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from ..common.rate_limiter import configure_limiter_cache
-from .models import ApiCfg, Config, CrossRefCfg, OpenAlexCfg, RetryCfg
+from .model import ApiCfg, Config, CrossRefCfg, OpenAlexCfg, RetryCfg
 
 __all__ = [
     "configure_rate_limiters",

--- a/tests/integration/test_config_public_api.py
+++ b/tests/integration/test_config_public_api.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.integration
+def test_config_public_api__reexports():
+    package = importlib.import_module("library.config")
+    model = importlib.import_module("library.config.model")
+    loader = importlib.import_module("library.config.loader")
+    runtime = importlib.import_module("library.config.runtime")
+
+    assert package.Config is model.Config
+    assert package.ConfigMetadata is model.ConfigMetadata
+    assert package.load_config is loader.load_config
+    assert package.ensure_dirs is loader.ensure_dirs
+    assert package.session_with_retry is runtime.session_with_retry

--- a/tests/unit/test_config_env.py
+++ b/tests/unit/test_config_env.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from library.config.env import (
+    _apply_env_overrides,
+    _expand_config_placeholders,
+    _resolve_placeholder_base_path,
+)
+
+
+@pytest.mark.unit
+def test_apply_env_overrides__alias(monkeypatch):
+    monkeypatch.setenv("CHEMBL_DA_LOG_LEVEL", "DEBUG")
+    data = {"system": {"log": {"level": "INFO"}}}
+
+    overrides = _apply_env_overrides(data)
+
+    assert data["system"]["log"]["level"] == "DEBUG"
+    assert overrides[("system", "log", "level")] == "CHEMBL_DA_LOG_LEVEL"
+
+
+@pytest.mark.unit
+def test_resolve_placeholder_base_path__env_override(monkeypatch, tmp_path):
+    base = tmp_path / "chembl"
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(base))
+
+    resolved = _resolve_placeholder_base_path(None)
+
+    assert resolved == base.resolve()
+
+
+@pytest.mark.unit
+def test_expand_config_placeholders__replaces_marker(tmp_path):
+    base = tmp_path / "chembl"
+    base.mkdir()
+    data = {"paths": {"output": "$CHEMBL_DA_BASE_PATH/results"}}
+
+    expanded = _expand_config_placeholders(data, base_path=base)
+
+    assert expanded["paths"]["output"] == str(base / "results")

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -27,10 +27,10 @@ def test_load_config__resolves_relative_paths_and_calls_runtime(tmp_path, monkey
 
     monkeypatch.setattr(loader, "configure_rate_limiters", fake_configure)
     monkeypatch.setattr(
-        "library.config.models.get_resource_path", lambda name: tmp_path / name
+        "library.config.model.get_resource_path", lambda name: tmp_path / name
     )
     monkeypatch.setattr(
-        "library.config.models.resolve_resource_reference",
+        "library.config.model.resolve_resource_reference",
         lambda value: Path(value),
     )
 
@@ -48,10 +48,10 @@ def test_load_config__metadata_records_cli_override(tmp_path, monkeypatch):
 
     monkeypatch.setattr(loader, "configure_rate_limiters", lambda cfg: None)
     monkeypatch.setattr(
-        "library.config.models.get_resource_path", lambda name: tmp_path / name
+        "library.config.model.get_resource_path", lambda name: tmp_path / name
     )
     monkeypatch.setattr(
-        "library.config.models.resolve_resource_reference",
+        "library.config.model.resolve_resource_reference",
         lambda value: Path(value),
     )
 


### PR DESCRIPTION
## Summary
- move the configuration models into library/config/model.py and split environment helpers into library/config/env.py
- update the loader and runtime modules plus documentation to reference the new paths and maintain package re-exports
- extend configuration tests with new env coverage and a public API integration check

## Testing
- pytest tests/unit/test_config_env.py tests/unit/test_config_loader.py tests/integration/test_config_public_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e4277e77d8832497c31440ba631ab8