### PR TITLE
Fix dictionary manifest checksum validation on Windows

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -40,6 +40,18 @@ class DictionaryResource:
     generator: Path
 
 
+def _normalise_text_newlines(data: bytes) -> bytes:
+    """Return ``data`` with Windows-style newlines converted to ``\n``."""
+
+    if b"\r" not in data or b"\0" in data:
+        return data
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
 def _compute_sha256(path: Path) -> str:
     """Return the SHA256 checksum for ``path``.
 
@@ -53,16 +65,16 @@ def _compute_sha256(path: Path) -> str:
         for child in sorted(path.rglob("*")):
             if child.is_dir():
                 continue
+            if child.name == _MANIFEST_FILENAME and child.parent == path:
+                continue
             hasher.update(str(child.relative_to(path)).encode("utf-8"))
-            with child.open("rb") as handle:
-                for chunk in iter(lambda: handle.read(8192), b""):
-                    hasher.update(chunk)
+            data = _normalise_text_newlines(child.read_bytes())
+            hasher.update(data)
         return hasher.hexdigest()
     if not path.is_file():
         raise FileNotFoundError(f"Dictionary resource missing: {path}")
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(8192), b""):
-            hasher.update(chunk)
+    data = _normalise_text_newlines(path.read_bytes())
+    hasher.update(data)
     return hasher.hexdigest()
 
 

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -1,0 +1,41 @@
+"""Unit tests for :mod:`library.resources.dictionaries`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.resources import dictionaries
+
+
+@pytest.mark.unit
+def test_compute_sha256__ignores_crlf_in_files(tmp_path: Path) -> None:
+    """CRLF newlines should not affect the checksum of individual files."""
+
+    lf_path = tmp_path / "lf.csv"
+    lf_path.write_text("id,name\n1,example\n", encoding="utf-8")
+
+    crlf_path = tmp_path / "crlf.csv"
+    crlf_path.write_bytes("id,name\r\n1,example\r\n".encode("utf-8"))
+
+    assert dictionaries._compute_sha256(lf_path) == dictionaries._compute_sha256(crlf_path)
+
+
+@pytest.mark.unit
+def test_compute_sha256__ignores_crlf_in_directories(tmp_path: Path) -> None:
+    """Directory checksums should be stable across newline conventions."""
+
+    lf_dir = tmp_path / "lf"
+    lf_dir.mkdir()
+    (lf_dir / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (lf_dir / "nested").mkdir()
+    (lf_dir / "nested" / "more.csv").write_text("x\ny\n", encoding="utf-8")
+
+    crlf_dir = tmp_path / "crlf"
+    crlf_dir.mkdir()
+    (crlf_dir / "data.csv").write_bytes("a,b\r\n1,2\r\n".encode("utf-8"))
+    (crlf_dir / "nested").mkdir()
+    (crlf_dir / "nested" / "more.csv").write_bytes("x\r\ny\r\n".encode("utf-8"))
+
+    assert dictionaries._compute_sha256(lf_dir) == dictionaries._compute_sha256(crlf_dir)


### PR DESCRIPTION
## Summary
- normalise newline handling when computing dictionary resource checksums
- ignore the manifest file itself when hashing directory resources to avoid self-referential digests
- add unit tests covering CRLF handling for both files and directories

## Testing
- pytest tests/unit/test_dictionary_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68e429f72e2c8324aa57dacf97adda6a