### PR TITLE
Refactor CLI entry points to use shared pipeline base

### DIFF
--- a/library/cli/__init__.py
+++ b/library/cli/__init__.py
@@ -1,5 +1,6 @@
 """Command-line interface utilities."""
 
+from .base import PipelineCLIBase
 from .logging import setup_cli_logging
 from .parser import (
     Logger,
@@ -25,6 +26,7 @@ __all__ = [
     "build_root_parser",
     "configure_logger",
     "create_logger_config",
+    "PipelineCLIBase",
     "setup_cli_logging",
     "prepare_io_paths",
     "path_argument",

--- a/library/cli/base.py
+++ b/library/cli/base.py
@@ -1,0 +1,122 @@
+"""Base classes for command-line pipeline entry points."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .logging import CLILoggingContext, setup_cli_logging
+from .parser import Logger, LoggerConfig, configure_logger
+from ..common.log import logger as default_logger
+
+
+class PipelineCLIBase:
+    """Template for command-line interfaces orchestrating data pipelines."""
+
+    def build_parser(self) -> tuple[argparse.ArgumentParser, LoggerConfig]:
+        """Return the argument parser and default logger configuration."""
+
+        raise NotImplementedError
+
+    def prepare_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+        args: argparse.Namespace,
+        argv: Sequence[str] | None,
+    ) -> argparse.Namespace:
+        """Hook executed after parsing command line arguments."""
+
+        return args
+
+    def handle_pre_run(
+        self, parser: argparse.ArgumentParser, args: argparse.Namespace
+    ) -> int | None:
+        """Return an exit code to abort execution before running the pipeline."""
+
+        return None
+
+    def get_program_name(self) -> str:
+        """Return the identifier used when creating log files."""
+
+        return Path(__file__).with_suffix("").name
+
+    def get_logging_date(self, args: argparse.Namespace) -> str | None:
+        """Return the date token forwarded to :func:`setup_cli_logging`."""
+
+        return getattr(args, "date", None)
+
+    def get_logger(self) -> Logger:
+        """Return the logger instance used for pipeline level events."""
+
+        return default_logger
+
+    def get_config_mapping(self) -> Mapping[str, str]:
+        """Return CLI-to-config attribute mappings forwarded to the loader."""
+
+        return {}
+
+    def get_base_parser(
+        self, parser: argparse.ArgumentParser
+    ) -> argparse.ArgumentParser | None:
+        """Return the root parser forwarded to :func:`run_cli_command`."""
+
+        del parser
+        return None
+
+    def run_pipeline(self, cfg: Any, args: argparse.Namespace) -> int:
+        """Execute the pipeline logic for the concrete implementation."""
+
+        raise NotImplementedError
+
+    def on_logging_ready(self, logging_ctx: CLILoggingContext) -> None:
+        """Hook executed after log handlers have been initialised."""
+
+    def execute(
+        self,
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+        logging_ctx: CLILoggingContext,
+    ) -> int:
+        """Execute the pipeline using :func:`run_cli_command`."""
+
+        from ..cli_utils import run_cli_command
+
+        return run_cli_command(
+            args=args,
+            parser=parser,
+            base_parser=self.get_base_parser(parser),
+            log_cfg=logging_ctx.log_cfg,
+            mapping=dict(self.get_config_mapping()),
+            run=self.run_pipeline,
+            logger=self.get_logger(),
+        )
+
+    def after_run(self, log_cfg: LoggerConfig, exit_code: int) -> int:
+        """Finalisation hook executed once the CLI run finishes."""
+
+        configure_logger(log_cfg)
+        return exit_code
+
+    def main(self, argv: Sequence[str] | None = None) -> int:
+        """Entry point mirroring the previous function-based CLI contract."""
+
+        parser, log_cfg = self.build_parser()
+        args = parser.parse_args(argv)
+        args = self.prepare_arguments(parser, args, argv)
+        exit_code = self.handle_pre_run(parser, args)
+        if exit_code is not None:
+            return exit_code
+
+        program_name = self.get_program_name()
+        date_token = self.get_logging_date(args)
+
+        with setup_cli_logging(program_name, log_cfg, date_token) as logging_ctx:
+            self.on_logging_ready(logging_ctx)
+            exit_code = self.execute(args, parser, logging_ctx)
+
+        return self.after_run(log_cfg, exit_code)
+
+
+__all__ = ["PipelineCLIBase"]

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -42,12 +42,14 @@ from library.pipelines.common import (
 )
 
 from library.cli import (
+    Logger,
     LoggerConfig,
     positive_int,
 )
 from library.cli import (
     build_parser as base_parser,
 )
+from library.cli.base import PipelineCLIBase
 from library.cli_utils import (
     PipelineError,
     resolve_invocation,
@@ -1360,7 +1362,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return run_chembl(cfg, args)
 
 
-def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser.
 
     Returns
@@ -1416,68 +1418,75 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     return parser, log_cfg
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Execute the activity pipeline with optional argument overrides.
+class ActivityPipelineCLI(PipelineCLIBase):
+    """CLI adapter for the activity data pipeline."""
 
-    Parameters
-    ----------
-    argv : Sequence[str] | None, optional
-        Command-line arguments to parse. When ``None`` the values from
-        :data:`sys.argv` are used.
+    def build_parser(self) -> tuple[argparse.ArgumentParser, LoggerConfig]:
+        return _build_parser_impl()
 
-    Returns
-    -------
-    int
-        ``0`` on success, non-zero otherwise. Errors are logged with
-        structured context for easier diagnosis.
-
-    Raises
-    ------
-    SystemExit
-        Raised when argument parsing fails, mirroring ``argparse`` behaviour.
-    """
-    parser, log_cfg = build_parser()
-    args = parser.parse_args(argv)
-    args.invocation = resolve_invocation(parser.prog, argv)
-
-    cli.prepare_io_paths(
-        args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
-    )
-    if args.limit == 0:
-        logger.info("pipeline_skip_limit", limit=args.limit)
-        logger.info("Limit set to 0; exiting before starting the activity pipeline.")
-        return 0
-    if args.limit is not None and args.limit < 0:
-        # Reject negative limits early to provide clear CLI feedback.
-        parser.error("--limit must be zero or a positive integer")
-    if args.offset < 0:
-        parser.error("--offset must be zero or a positive integer")
-
-    with setup_cli_logging(
-        Path(__file__).with_suffix("").name,
-        log_cfg,
-        getattr(args, "date", None),
-    ) as logging_ctx:
-        exit_code = run_cli_command(
-            args=args,
-            parser=parser,
-            log_cfg=logging_ctx.log_cfg,
-            mapping={
-                "timeout": "activity.timeout",
-                "column": "activity.column",
-                "batch_size": "activity.batch_size",
-                "limit": "activity.limit",
-                "offset": "activity.offset",
-                "dry_run": "activity.dry_run",
-                "workers": "activity.workers",
-            },
-            run=run,
-            logger=logger,
+    def prepare_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+        args: argparse.Namespace,
+        argv: Sequence[str] | None,
+    ) -> argparse.Namespace:
+        args.invocation = resolve_invocation(parser.prog, argv)
+        cli.prepare_io_paths(
+            args,
+            input_default=DEFAULT_INPUT_NAME,
+            output_stem=DEFAULT_OUTPUT_STEM,
         )
-    configure_logger(log_cfg)
-    return exit_code
+        return args
+
+    def handle_pre_run(
+        self, parser: argparse.ArgumentParser, args: argparse.Namespace
+    ) -> int | None:
+        if args.limit == 0:
+            logger.info("pipeline_skip_limit", limit=args.limit)
+            logger.info(
+                "Limit set to 0; exiting before starting the activity pipeline."
+            )
+            return 0
+        if args.limit is not None and args.limit < 0:
+            parser.error("--limit must be zero or a positive integer")
+        if args.offset < 0:
+            parser.error("--offset must be zero or a positive integer")
+        return None
+
+    def get_program_name(self) -> str:
+        return Path(__file__).with_suffix("").name
+
+    def get_logger(self) -> Logger:
+        return logger
+
+    def get_config_mapping(self) -> Mapping[str, str]:
+        return {
+            "timeout": "activity.timeout",
+            "column": "activity.column",
+            "batch_size": "activity.batch_size",
+            "limit": "activity.limit",
+            "offset": "activity.offset",
+            "dry_run": "activity.dry_run",
+            "workers": "activity.workers",
+        }
+
+    def run_pipeline(self, cfg: Config, args: argparse.Namespace) -> int:
+        return run(cfg, args)
+
+
+_CLI = ActivityPipelineCLI()
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Expose parser construction for existing imports."""
+
+    return _CLI.build_parser()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate to :class:`ActivityPipelineCLI` for backwards compatibility."""
+
+    return _CLI.main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -37,11 +37,13 @@ from library.pipelines.assay.chembl_assay import ASSAY_COLUMNS, MAX_ASSAY_CHUNK_
 from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
 from library.cli import (
+    Logger,
     LoggerConfig,
     ConfigMetadata,
     configure_logger,
 )
 from library.cli import build_parser as base_parser
+from library.cli.base import PipelineCLIBase
 from library.cli_utils import run_cli_command, run_pipeline
 from library.cli.logging import setup_cli_logging
 from library.cli.metadata import prepare_option
@@ -505,7 +507,7 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return run_chembl(cfg, args)
 
 
-def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser.
 
     Returns
@@ -546,58 +548,69 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     return parser, log_cfg
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Execute the assay pipeline with optional argument overrides.
+class AssayPipelineCLI(PipelineCLIBase):
+    """CLI adapter delegating to the existing assay pipeline helpers."""
 
-    Parameters
-    ----------
-    argv : Sequence[str] | None, optional
-        Command-line arguments to parse. When ``None`` the process arguments
-        from :data:`sys.argv` are used.
+    def build_parser(self) -> tuple[argparse.ArgumentParser, LoggerConfig]:
+        return _build_parser_impl()
 
-    Returns
-    -------
-    int
-        ``0`` on success, non-zero otherwise. Failures are logged with context
-        describing the failing section.
-
-    Raises
-    ------
-    SystemExit
-        Raised when invalid command-line options are supplied.
-    """
-    parser, log_cfg = build_parser()
-    args = parser.parse_args(argv)
-    cli.prepare_io_paths(
-        args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
-    )
-    if args.limit == 0:
-        logger.info("pipeline_skip_limit", limit=args.limit)
-        return 0
-    if args.limit is not None and args.limit < 0:
-        parser.error("--limit must be zero or a positive integer")
-    if args.offset < 0:
-        parser.error("--offset must be zero or a positive integer")
-    with setup_cli_logging(
-        Path(__file__).with_suffix("").name, log_cfg, getattr(args, "date", None)
-    ) as logging_ctx:
-        exit_code = run_cli_command(
-            args=args,
-            parser=parser,
-            log_cfg=logging_ctx.log_cfg,
-            mapping={
-                "timeout": "assay.timeout",
-                "column": "assay.column",
-                "batch_size": "assay.batch_size",
-                "limit": "assay.limit",
-            },
-            run=run,
-            logger=logger,
+    def prepare_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+        args: argparse.Namespace,
+        argv: Sequence[str] | None,
+    ) -> argparse.Namespace:
+        del parser, argv
+        cli.prepare_io_paths(
+            args,
+            input_default=DEFAULT_INPUT_NAME,
+            output_stem=DEFAULT_OUTPUT_STEM,
         )
-    configure_logger(log_cfg)
-    return exit_code
+        return args
+
+    def handle_pre_run(
+        self, parser: argparse.ArgumentParser, args: argparse.Namespace
+    ) -> int | None:
+        if args.limit == 0:
+            logger.info("pipeline_skip_limit", limit=args.limit)
+            return 0
+        if args.limit is not None and args.limit < 0:
+            parser.error("--limit must be zero or a positive integer")
+        if args.offset < 0:
+            parser.error("--offset must be zero or a positive integer")
+        return None
+
+    def get_program_name(self) -> str:
+        return Path(__file__).with_suffix("").name
+
+    def get_logger(self) -> Logger:
+        return logger
+
+    def get_config_mapping(self) -> Mapping[str, str]:
+        return {
+            "timeout": "assay.timeout",
+            "column": "assay.column",
+            "batch_size": "assay.batch_size",
+            "limit": "assay.limit",
+        }
+
+    def run_pipeline(self, cfg: Config, args: argparse.Namespace) -> int:
+        return run(cfg, args)
+
+
+_CLI = AssayPipelineCLI()
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Expose parser creation for legacy tests importing the function."""
+
+    return _CLI.build_parser()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate to :class:`AssayPipelineCLI` for backwards compatibility."""
+
+    return _CLI.main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -54,6 +54,7 @@ from library.common.rate_limiter import get_global_limiter
 from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.pipelines.target.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
+    Logger,
     LoggerConfig,
     build_root_parser,
     configure_logger,
@@ -61,7 +62,8 @@ from library.cli import (
     positive_int,
     prepare_io_paths,
 )
-from library.cli.logging import setup_cli_logging
+from library.cli.base import PipelineCLIBase
+from library.cli.logging import CLILoggingContext, setup_cli_logging
 from library.config import (
     Config,
     _serialize_paths,
@@ -1422,7 +1424,7 @@ def _save_snapshot(df: pd.DataFrame, base: Path, step: str, cfg: Config) -> Path
         index += 1
 
 
-def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create and return the top-level CLI argument parser.
 
     The command line interface is organised into sub-commands for retrieving
@@ -3910,53 +3912,53 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return int(result)
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Command line entry point using :class:`Config` for defaults.
+class TargetPipelineCLI(PipelineCLIBase):
+    """CLI adapter orchestrating the target data pipelines."""
 
-    Parameters
-    ----------
-    argv : Sequence[str] | None, optional
-        Command-line arguments to parse. When ``None`` the values from
-        :data:`sys.argv` are used.
+    def build_parser(self) -> tuple[argparse.ArgumentParser, LoggerConfig]:
+        return _build_parser_impl()
 
-    Returns
-    -------
-    int
-        ``0`` when the selected target pipeline succeeds, non-zero otherwise.
+    def prepare_arguments(
+        self,
+        parser: argparse.ArgumentParser,
+        args: argparse.Namespace,
+        argv: Sequence[str] | None,
+    ) -> argparse.Namespace:
+        del argv
+        command_alias = COMMAND_ALIAS_TO_CANONICAL.get(getattr(args, "command", ""))
+        if command_alias is not None:
+            setattr(args, "_command_keyboard_alias", args.command)
+            args.command = command_alias
+        prepare_io_paths(
+            args,
+            input_default=DEFAULT_INPUT_NAME,
+            output_stem=DEFAULT_OUTPUT_STEM,
+        )
+        date_value = getattr(args, "date", None)
+        if not isinstance(date_value, str) or not date_value:
+            date_value = datetime.now(timezone.utc).strftime("%Y%m%d")
+            setattr(args, "date", date_value)
+        return args
 
-    Raises
-    ------
-    SystemExit
-        Raised when invalid command-line options are provided to the parser.
-    """
-    parser, log_cfg = build_parser()
-    args = parser.parse_args(argv)
-    command_alias = COMMAND_ALIAS_TO_CANONICAL.get(getattr(args, "command", ""))
-    if command_alias is not None:
-        setattr(args, "_command_keyboard_alias", args.command)
-        args.command = command_alias
-    prepare_io_paths(
-        args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
-    )
-    date_value = getattr(args, "date", None)
-    if not isinstance(date_value, str) or not date_value:
-        date_value = datetime.now(timezone.utc).strftime("%Y%m%d")
-        setattr(args, "date", date_value)
-    exit_code = 0
+    def get_program_name(self) -> str:
+        return Path(__file__).with_suffix("").name
 
-    with setup_cli_logging(
-        Path(__file__).with_suffix("").name, log_cfg, date_value
-    ) as logging_ctx:
+    def get_logger(self) -> Logger:
+        return logger
+
+    def execute(
+        self,
+        args: argparse.Namespace,
+        parser: argparse.ArgumentParser,
+        logging_ctx: CLILoggingContext,
+    ) -> int:
         configure_logger(logging_ctx.log_cfg)
         console_stream = logging_ctx.console_stream
-        log_path = logging_ctx.log_path
+        exit_code = 0
         try:
-
             limit_value = getattr(args, "limit", None)
             subparser_map = getattr(parser, "subparsers_map", {})
-            subparser = subparser_map.get(args.command, parser)
+            subparser = subparser_map.get(getattr(args, "command", None), parser)
             if limit_value is not None and limit_value < 1:
                 subparser.error("--limit must be a positive integer")
             offset_value = getattr(args, "offset", 0)
@@ -4047,10 +4049,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_code = 2
             logger.error("pipeline_error", error=str(exc))
             print(f"[ERROR] {exc}", file=console_stream, flush=True)
-    configure_logger(log_cfg)
+        return exit_code
 
 
-    return exit_code
+_CLI = TargetPipelineCLI()
+
+
+def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
+    """Expose parser creation for backwards compatibility."""
+
+    return _CLI.build_parser()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate to :class:`TargetPipelineCLI` for backwards compatibility."""
+
+    return _CLI.main(argv)
+
+
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 import requests
 
+from library.cli.base import PipelineCLIBase
 from library.config import Config
 from library import cli_utils
 from scripts import (
@@ -80,6 +81,25 @@ def _patch_logger(monkeypatch: pytest.MonkeyPatch, module: object) -> _MemoryLog
     logger = _MemoryLogger()
     monkeypatch.setattr(module, "logger", logger)
     return logger
+
+
+@pytest.mark.parametrize(
+    "module",
+    [get_assay_data, get_activity_data, get_target_data],
+)
+def test_cli_wrappers_delegate_to_cli_instance(
+    monkeypatch: pytest.MonkeyPatch, module: object
+) -> None:
+    """Ensure module-level helpers forward to :class:`PipelineCLIBase` instances."""
+
+    assert isinstance(module._CLI, PipelineCLIBase)
+    sentinel_parser = ("parser", "log")
+    sentinel_exit = object()
+    monkeypatch.setattr(module._CLI, "build_parser", lambda: sentinel_parser)
+    monkeypatch.setattr(module._CLI, "main", lambda argv=None: sentinel_exit)
+
+    assert module.build_parser() is sentinel_parser
+    assert module.main([]) is sentinel_exit
 
 
 class _DummyChemblClient:


### PR DESCRIPTION
## Summary
- introduce `PipelineCLIBase` to encapsulate common CLI orchestration steps
- refactor the assay, activity, and target scripts to delegate to the shared base class
- extend CLI end-to-end tests to ensure module wrappers forward to the new class implementation

## Testing
- pytest tests/e2e/test_get_cli_pipelines.py::test_cli_wrappers_delegate_to_cli_instance -q *(fails: dictionary manifest mismatch in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42780f8f4832490de9a943f231f8e