### PR TITLE
Fix dictionary manifest hashing on Windows

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -40,7 +40,7 @@ class DictionaryResource:
     generator: Path
 
 
-def _compute_sha256(path: Path) -> str:
+def _compute_sha256(path: Path, *, exclude: tuple[Path, ...] = ()) -> str:
     """Return the SHA256 checksum for ``path``.
 
     Directories are hashed by iterating over files in lexicographic order and
@@ -49,17 +49,25 @@ def _compute_sha256(path: Path) -> str:
     """
 
     hasher = hashlib.sha256()
+    excluded = {item.resolve() for item in exclude}
     if path.is_dir():
-        for child in sorted(path.rglob("*")):
+        for child in sorted(
+            path.rglob("*"), key=lambda child: child.relative_to(path).as_posix()
+        ):
             if child.is_dir():
                 continue
-            hasher.update(str(child.relative_to(path)).encode("utf-8"))
+            if child.resolve() in excluded:
+                continue
+            relative = child.relative_to(path).as_posix()
+            hasher.update(relative.encode("utf-8"))
             with child.open("rb") as handle:
                 for chunk in iter(lambda: handle.read(8192), b""):
                     hasher.update(chunk)
         return hasher.hexdigest()
     if not path.is_file():
         raise FileNotFoundError(f"Dictionary resource missing: {path}")
+    if path.resolve() in excluded:
+        raise FileNotFoundError(f"Excluded dictionary resource: {path}")
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(8192), b""):
             hasher.update(chunk)
@@ -110,7 +118,8 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
         if name in parsed:
             raise DictionaryManifestError(f"Duplicate manifest entry: {name}")
 
-        sha256_actual = _compute_sha256(absolute_path)
+        exclude = (manifest_path,) if absolute_path == manifest_root else ()
+        sha256_actual = _compute_sha256(absolute_path, exclude=exclude)
         if sha256_actual != sha256_expected:
             raise DictionaryManifestError(
                 "Checksum mismatch for resource"

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from library.resources import dictionaries
+
+
+@pytest.mark.unit
+def test_parse_manifest__ignores_manifest_in_checksum(tmp_path):
+    dictionary_dir = tmp_path / "dictionary"
+    dictionary_dir.mkdir()
+
+    data_file = dictionary_dir / "data.csv"
+    data_file.write_text("id\n1\n", encoding="utf-8")
+
+    manifest_path = dictionary_dir / "manifest.yaml"
+
+    data_sha = dictionaries._compute_sha256(data_file)
+    root_sha = dictionaries._compute_sha256(
+        dictionary_dir, exclude=(manifest_path,)
+    )
+
+    manifest_template = textwrap.dedent(
+        """
+        version: 1
+        resources:
+          dictionary_root:
+            path: .
+            version: "1.0"
+            sha256: "{root_sha}"
+            generator: tools/build_dictionary_resources.py
+          sample_table:
+            path: data.csv
+            version: "1.0"
+            sha256: "{data_sha}"
+            generator: tools/build_dictionary_resources.py
+        """
+    )
+    manifest_path.write_text(
+        manifest_template.format(root_sha=root_sha, data_sha=data_sha),
+        encoding="utf-8",
+    )
+
+    resources = dictionaries._parse_manifest(base_dir=dictionary_dir)
+
+    assert resources["dictionary_root"].sha256 == root_sha
+    assert resources["sample_table"].sha256 == data_sha
+
+    mutated_manifest = manifest_template.format(
+        root_sha="deadbeef" * 8, data_sha=data_sha
+    )
+    manifest_path.write_text(mutated_manifest, encoding="utf-8")
+
+    with pytest.raises(dictionaries.DictionaryManifestError):
+        dictionaries._parse_manifest(base_dir=dictionary_dir)


### PR DESCRIPTION
## Summary
- normalize dictionary resource checksum computation to ignore the manifest file and use POSIX paths for deterministic hashes
- add a unit test covering manifest parsing with the dictionary_root resource

## Testing
- pytest tests/unit/test_dictionary_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68e429f8588c83248dd0500cb543752a