### PR TITLE
Refactor table quality reporting hooks

### DIFF
--- a/library/integration/pubmed_library.py
+++ b/library/integration/pubmed_library.py
@@ -55,7 +55,7 @@ from ..pubmed import (
 )
 from ..common.rate_limiter import RateLimiter, get_limiter
 from ..cli_utils import MetadataHook, Validator, run_pipeline
-from ..table_quality import analyze_table_quality
+from ..qa.reporting import build_table_quality_hook
 from ..pipelines.common import add_pipeline_metadata
 from ..normalization import normalize_documents
 from ..validation import ValidationResult as SchemaValidationResult
@@ -372,11 +372,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
 
-    def table_quality(destination: Path) -> None:
-        analyze_table_quality(
-            destination,
-            table_name=str(output_path.with_suffix("")),
-        )
+    table_quality = build_table_quality_hook(
+        cfg.system.doc_quality,
+        table_name=output_path.with_suffix(""),
+        destination=output_path.parent,
+    )
 
 
     command = " ".join(["pubmed_library"] + (list(argv) if argv else []))

--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -37,7 +37,7 @@ from library.common.metadata import (
 )
 from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
-from library.qa.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook
 from library.qa.validation import validate_testitems
 from library.schemas import TestitemsSchema, normalize_testitems
 
@@ -964,16 +964,13 @@ def finalize_output(
 
     doc_quality_cfg = cfg.system.doc_quality
     fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=output.with_suffix(""),
+        destination=output.parent,
+    )
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                csv_path,
-                table_name=str(output.with_suffix("")),
-                destination_dir=output.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+        table_quality(csv_path)
     except Exception as exc:
         tb = traceback.format_exc()
         record_quality_failure(

--- a/library/qa/reporting.py
+++ b/library/qa/reporting.py
@@ -1,0 +1,95 @@
+"""Helpers for configuring reusable table-quality reporting hooks."""
+
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .table_quality import analyze_table_quality
+
+TableQualitySubject = Any
+TableQualityHook = Callable[[TableQualitySubject], None]
+
+__all__ = [
+    "TableQualityHook",
+    "TableQualitySubject",
+    "build_table_quality_hook",
+    "is_quality_enabled",
+]
+
+
+def _cfg_value(cfg: Any, key: str, default: Any = None) -> Any:
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return cfg.get(key, default)
+    return getattr(cfg, key, default)
+
+
+def _normalise_columns(columns: Any) -> tuple[str, ...] | None:
+    if columns is None:
+        return None
+    if isinstance(columns, str):
+        return (columns,)
+    if isinstance(columns, Sequence):
+        return tuple(str(column) for column in columns)
+    raise TypeError("include/exclude columns must be a sequence of strings or None")
+
+
+def _normalise_table_name(table_name: str | Path) -> str:
+    name = str(table_name)
+    if not name:
+        raise ValueError("table_name must be a non-empty string")
+    return name
+
+
+def _resolve_destination(
+    destination: Path | str | None,
+    table_name: str | Path,
+) -> Path:
+    if destination is not None:
+        return Path(destination)
+    try:
+        path = Path(table_name)
+    except (TypeError, ValueError):
+        return Path(".")
+    parent = path.parent
+    return parent if str(parent) else Path(".")
+
+
+def is_quality_enabled(cfg: Any) -> bool:
+    """Return ``True`` if table-quality profiling is enabled for ``cfg``."""
+
+    return bool(_cfg_value(cfg, "enable", False))
+
+
+def build_table_quality_hook(
+    cfg: Any,
+    *,
+    table_name: str | Path,
+    destination: Path | str | None = None,
+) -> TableQualityHook:
+    """Return a callable that executes :func:`analyze_table_quality` when enabled."""
+
+    if not is_quality_enabled(cfg):
+        return _noop_table_quality
+
+    table_name_str = _normalise_table_name(table_name)
+    destination_dir = _resolve_destination(destination, table_name)
+    include_columns = _normalise_columns(_cfg_value(cfg, "include_columns"))
+    exclude_columns = _normalise_columns(_cfg_value(cfg, "exclude_columns"))
+    sample_rows = _cfg_value(cfg, "sample_rows")
+
+    return partial(
+        analyze_table_quality,
+        table_name=table_name_str,
+        destination_dir=destination_dir,
+        sample_rows=sample_rows,
+        include_columns=include_columns,
+        exclude_columns=exclude_columns,
+    )
+
+
+def _noop_table_quality(_: TableQualitySubject) -> None:
+    return None

--- a/library/reporting/run_manifest.py
+++ b/library/reporting/run_manifest.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Mapping, MutableMapping, Sequence
 import yaml
 
 from ..common.metadata import Stats, file_sha256, write_meta_yaml
+from ..qa.reporting import TableQualityHook
 from ..qa.table_quality import TableQualityProfiler, analyze_table_quality
 
 
@@ -136,6 +137,7 @@ def finalise_csv_output(
     quality_config: Any | None = None,
     quality_table_name: str | None = None,
     quality_destination: Path | None = None,
+    quality_hook: TableQualityHook | None = None,
 ) -> PipelineOutputReport:
     """Write metadata and optional quality artefacts for ``csv_path``."""
 
@@ -168,7 +170,13 @@ def finalise_csv_output(
         resolved_quality_path = destination
         quality_sha = file_sha256(destination)
 
-    if quality_profiler is not None and bool(_cfg_value(quality_config, "enable", False)):
+    quality_subject = quality_profiler if quality_profiler is not None else path
+    if quality_hook is not None:
+        try:
+            quality_hook(quality_subject)
+        except Exception as exc:  # pragma: no cover - propagated to caller
+            raise QualityAnalysisError(str(exc)) from exc
+    elif quality_profiler is not None and bool(_cfg_value(quality_config, "enable", False)):
         table_name = quality_table_name or path.with_suffix("").name
         destination_dir = quality_destination or path.parent
         try:

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -40,7 +40,7 @@ from library.metadata import (
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook
 from library.validation import validate_testitems
 from library.schemas import TestitemsSchema, normalize_testitems
 
@@ -1113,16 +1113,13 @@ def finalize_output(
 
     doc_quality_cfg = cfg.system.doc_quality
     fatal_quality_error = bool(getattr(doc_quality_cfg, "fatal_on_error", False))
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=output.with_suffix(""),
+        destination=output.parent,
+    )
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                csv_path,
-                table_name=str(output.with_suffix("")),
-                destination_dir=output.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+        table_quality(csv_path)
     except Exception as exc:
         tb = traceback.format_exc()
         record_quality_failure(

--- a/library/utils/cli_tools/get_input_initialisation.py
+++ b/library/utils/cli_tools/get_input_initialisation.py
@@ -43,7 +43,7 @@ from library.cli import (
 )
 from library.config import Config, ConfigError, ensure_dirs, print_config
 from library.common.log import logger
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:
@@ -107,16 +107,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         doc_quality_cfg = cfg.system.doc_quality
         for entity, path in paths.items():
             logger.info("profiling", entity=entity)
-            if not doc_quality_cfg.enable:
-                continue
-            analyze_table_quality(
-                path,
-                table_name=path.stem,
-                destination_dir=report_dir,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
+            table_quality = build_table_quality_hook(
+                doc_quality_cfg,
+                table_name=path.with_suffix(""),
+                destination=report_dir,
             )
+            table_quality(path)
 
         logger.info("save_done", tables=len(paths), path=str(out_dir))
         return 0

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -69,7 +69,7 @@ from library.processing.activity import (
     compute_activity_bounds,
 )
 from library.postprocessing.activity_extended import process_activity_extended
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook
 from library.validation import validate_activities
 from library.schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
 from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_delay
@@ -964,19 +964,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
 
 
     doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(Path(output_path).with_suffix("")),
-            destination_dir=Path(output_path).parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-
-        def table_quality(_: Path) -> None:
-            return None
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=Path(output_path).with_suffix(""),
+        destination=Path(output_path).parent,
+    )
 
     rate_cfg = cfg.rate
     global_limiter = None

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -48,7 +48,7 @@ from library.cli.metadata import prepare_option
 from library.config import Config, _serialize_paths
 from library.common.log import logger
 from library.pipelines.common import add_pipeline_metadata
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook
 from library.validation import validate_assays
 from library.schemas import AssaysSchema, normalize_assays
 from library.pipelines.common import (
@@ -284,18 +284,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     validators = [partial(validate_assays, return_result=True)]
 
     doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(output_path.with_suffix("")),
-            destination_dir=output_path.parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-        def table_quality(_: Path) -> None:
-            return None
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=output_path.with_suffix(""),
+        destination=output_path.parent,
+    )
 
     rate_cfg = cfg.rate
     global_limiter = None

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -98,6 +98,7 @@ from library.postprocessing.document import preprocess_documents_csv
 from library.pipelines.common import add_pipeline_metadata
 from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
+from library.qa.reporting import build_table_quality_hook
 from library.qa.table_quality import TableQualityProfiler
 from library.schemas import DocumentsSchema, normalize_documents
 from library.schemas.document_spec import DOCUMENT_EXPORT_COLUMNS
@@ -637,6 +638,11 @@ def _finalise_export(
             _maybe_run_document_postprocessing(csv_path)
 
     doc_quality_cfg = getattr(cfg.system, "doc_quality", None)
+    quality_hook = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=csv_path.with_suffix(""),
+        destination=csv_path.parent,
+    )
     try:
         finalise_csv_output(
             csv_path=csv_path,
@@ -650,9 +656,7 @@ def _finalise_export(
             quality_builder=build_quality_report,
             quality_path=csv_path.with_suffix(".quality.json"),
             quality_profiler=quality_profiler,
-            quality_config=doc_quality_cfg,
-            quality_table_name=csv_path.with_suffix("").name,
-            quality_destination=csv_path.parent,
+            quality_hook=quality_hook,
         )
     except QualityReportError as exc:
         destination = exc.path or csv_path.with_suffix(".quality.json")

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -29,7 +29,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 import math
 from inspect import signature
-from functools import partial
 from itertools import islice
 from pathlib import Path
 from typing import IO, Any, cast
@@ -71,7 +70,7 @@ from library.common.log import logger
 from library.metadata import Stats, file_sha256, write_meta_yaml
 from library.pipelines.common import add_pipeline_metadata
 from library import SidecarErrors
-from library.table_quality import analyze_table_quality
+from library.qa.reporting import build_table_quality_hook, is_quality_enabled
 from library.validation import ValidationResult
 from library.schemas import TargetsSchema, normalize_targets
 from library.schemas.targets import TARGETS_COLUMN_ORDER
@@ -2042,19 +2041,16 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     doc_quality_cfg = cfg.system.doc_quality
     try:
-        if doc_quality_cfg.enable:
+        if is_quality_enabled(doc_quality_cfg):
             if export_path is None:
                 raise RuntimeError("export path not available for quality analysis")
             resolved_export_path = export_path.resolve()
-            quality_table_name = resolved_export_path.stem
-            analyze_table_quality(
-                out_df,
-                table_name=quality_table_name,
-                destination_dir=resolved_export_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
+            table_quality = build_table_quality_hook(
+                doc_quality_cfg,
+                table_name=resolved_export_path.with_suffix(""),
+                destination=resolved_export_path.parent,
             )
+            table_quality(out_df)
     except Exception as exc:
         quality_log_path: Path | None = None
         if resolved_export_path is not None:
@@ -2514,18 +2510,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         f"{normalized_output.stem}_failure_cases.csv"
     )
     doc_quality_cfg = cfg.system.doc_quality
-    if doc_quality_cfg.enable:
-        table_quality = partial(
-            analyze_table_quality,
-            table_name=str(final_output.with_suffix("")),
-            destination_dir=final_output.parent,
-            sample_rows=doc_quality_cfg.sample_rows,
-            include_columns=doc_quality_cfg.include_columns,
-            exclude_columns=doc_quality_cfg.exclude_columns,
-        )
-    else:
-        def table_quality(_: Path) -> None:
-            return None
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=final_output.with_suffix(""),
+        destination=final_output.parent,
+    )
 
     metadata_hooks = [add_pipeline_metadata, _prepare_chunk]
     if not normalize_at_export:
@@ -2693,16 +2682,13 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
     doc_quality_cfg = cfg.system.doc_quality
+    table_quality = build_table_quality_hook(
+        doc_quality_cfg,
+        table_name=output_path.with_suffix(""),
+        destination=output_path.parent,
+    )
     try:
-        if doc_quality_cfg.enable:
-            analyze_table_quality(
-                output_path,
-                table_name=str(output_path.with_suffix("")),
-                destination_dir=output_path.parent,
-                sample_rows=doc_quality_cfg.sample_rows,
-                include_columns=doc_quality_cfg.include_columns,
-                exclude_columns=doc_quality_cfg.exclude_columns,
-            )
+        table_quality(output_path)
     except Exception as exc:
         logger.exception(
             "quality_report_failed",
@@ -3749,16 +3735,13 @@ def validate_and_write(
         )
     else:
         doc_quality_cfg = cfg.system.doc_quality
+        table_quality = build_table_quality_hook(
+            doc_quality_cfg,
+            table_name=output.with_suffix(""),
+            destination=output.parent,
+        )
         try:
-            if doc_quality_cfg.enable:
-                analyze_table_quality(
-                    final_df,
-                    table_name=str(output.with_suffix("")),
-                    destination_dir=output.parent,
-                    sample_rows=doc_quality_cfg.sample_rows,
-                    include_columns=doc_quality_cfg.include_columns,
-                    exclude_columns=doc_quality_cfg.exclude_columns,
-                )
+            table_quality(final_df)
         except Exception as exc:
             logger.exception(
                 "quality_report_failed",


### PR DESCRIPTION
## Summary
- centralise table-quality hook creation in `library/qa/reporting.py`
- update activity, assay, target, document, and test item pipelines to reuse the shared hook logic
- allow `finalise_csv_output` to consume a quality hook and integrate it with document reporting

## Testing
- pytest tests/unit/test_run_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68e429f49bcc8324b792bd97489a2815