### PR TITLE
Fix dictionary hashing to be path separator agnostic

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -67,7 +67,8 @@ def _compute_sha256(path: Path) -> str:
                 continue
             if child.name == _MANIFEST_FILENAME and child.parent == path:
                 continue
-            hasher.update(str(child.relative_to(path)).encode("utf-8"))
+            relative = child.relative_to(path)
+            hasher.update(relative.as_posix().encode("utf-8"))
             data = _normalise_text_newlines(child.read_bytes())
             hasher.update(data)
         return hasher.hexdigest()

--- a/tests/unit/test_dictionaries.py
+++ b/tests/unit/test_dictionaries.py
@@ -1,0 +1,32 @@
+"""Tests for dictionary resource utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path, PureWindowsPath
+
+import pytest
+
+from library.resources import dictionaries
+
+
+def _create_sample_dictionary(tmp_path: Path) -> Path:
+    root = tmp_path / "dictionary"
+    (root / "subdir").mkdir(parents=True)
+    (root / "subdir" / "data.csv").write_text("value\n", encoding="utf-8")
+    (root / "root.txt").write_text("root\n", encoding="utf-8")
+    return root
+
+
+@pytest.mark.unit
+def test_compute_sha256__stable_across_path_separators(tmp_path, monkeypatch):
+    base = _create_sample_dictionary(tmp_path)
+    expected = dictionaries._compute_sha256(base)
+
+    original_relative_to = Path.relative_to
+
+    def _relative_to_windows(self: Path, other: Path):  # pragma: no cover - behaviour covered via assertion
+        return PureWindowsPath(original_relative_to(self, other))
+
+    monkeypatch.setattr(Path, "relative_to", _relative_to_windows)
+
+    assert dictionaries._compute_sha256(base) == expected


### PR DESCRIPTION
## Summary
- normalize relative paths to POSIX form when computing dictionary checksums so manifests remain valid on Windows
- add a unit test ensuring the checksum helper is stable regardless of path separator styles

## Testing
- pytest tests/unit/test_dictionaries.py -q *(fails: ImportError -> SyntaxError in library/config/loader.py prior to test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68e43479790483249572af9f338c4b04