### PR TITLE
Refactor CLI pipeline configuration around a reusable definition

### DIFF
--- a/library/cli/pipeline_definition.py
+++ b/library/cli/pipeline_definition.py
@@ -1,0 +1,164 @@
+"""Data structures describing reusable pipeline configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Mapping, Sequence, TypeVar, Protocol
+from pathlib import Path
+
+import pandas as pd
+
+from ..common.metadata import Stats
+
+
+SchemaT = TypeVar("SchemaT")
+
+
+class ValidationResult(Protocol):
+    """Protocol describing the return type of validator callables."""
+
+    data: pd.DataFrame
+    failure_cases: pd.DataFrame
+
+
+class Validator(Protocol):
+    """Callable interface for data frame validators."""
+
+    def __call__(self, df: pd.DataFrame) -> ValidationResult:  # pragma: no cover - Protocol
+        ...
+
+
+MetadataHook = Callable[[pd.DataFrame], pd.DataFrame]
+Writer = Callable[[Iterable[pd.DataFrame], Path, Sequence[str] | None, Sequence[str]], Path]
+TableQualityHook = Callable[[Path], None]
+Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
+
+
+@dataclass(slots=True)
+class PipelineDefinition:
+    """Configuration bundle describing how :func:`run_pipeline` should behave."""
+
+    schema: SchemaT | None
+    schema_name: str
+    writer: Writer
+    validators: Sequence[Validator] = field(default_factory=tuple)
+    metadata_hooks: Sequence[MetadataHook] = field(default_factory=tuple)
+    command: str | None = None
+    invocation: Sequence[str] | None = None
+    config_snapshot: Mapping[str, object] = field(default_factory=dict)
+    inputs: Mapping[str, object] = field(default_factory=dict)
+    key_columns: Sequence[str] = field(default_factory=tuple)
+    table_quality: TableQualityHook | None = None
+    stats_extra: Mapping[str, object] | Callable[[], Mapping[str, object]] | None = None
+    stats_callback: Callable[[Stats], None] | None = None
+    strict_mode: bool = False
+    dictionary_resources: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple normalisation
+        self.validators = tuple(self.validators)
+        self.metadata_hooks = tuple(self.metadata_hooks)
+        if self.invocation is not None:
+            self.invocation = tuple(self.invocation)
+        self.key_columns = tuple(self.key_columns)
+        if self.dictionary_resources is not None:
+            self.dictionary_resources = tuple(self.dictionary_resources)
+
+    @classmethod
+    def from_legacy_kwargs(
+        cls,
+        *,
+        schema: SchemaT | None,
+        schema_name: str,
+        writer: Writer,
+        validators: Sequence[Validator] | None = None,
+        metadata_hooks: Sequence[MetadataHook] | None = None,
+        command: str | None = None,
+        invocation: Sequence[str] | None = None,
+        config_snapshot: Mapping[str, object] | None = None,
+        inputs: Mapping[str, object] | None = None,
+        key_columns: Sequence[str] | None = None,
+        table_quality: TableQualityHook | None = None,
+        stats_extra: Mapping[str, object] | Callable[[], Mapping[str, object]] | None = None,
+        stats_callback: Callable[[Stats], None] | None = None,
+        strict_mode: bool = False,
+        dictionary_resources: Sequence[str] | None = None,
+    ) -> "PipelineDefinition":
+        """Construct a :class:`PipelineDefinition` using legacy keyword arguments."""
+
+        if table_quality is None:
+            raise TypeError("'table_quality' must be provided when using legacy arguments")
+
+        return cls(
+            schema=schema,
+            schema_name=schema_name,
+            writer=writer,
+            validators=validators or (),
+            metadata_hooks=metadata_hooks or (),
+            command=command,
+            invocation=invocation,
+            config_snapshot=dict(config_snapshot or {}),
+            inputs=dict(inputs or {}),
+            key_columns=tuple(key_columns or ()),
+            table_quality=table_quality,
+            stats_extra=stats_extra,
+            stats_callback=stats_callback,
+            strict_mode=strict_mode,
+            dictionary_resources=dictionary_resources,
+        )
+
+
+LEGACY_DEFINITION_KEYS = {
+    "schema",
+    "schema_name",
+    "writer",
+    "validators",
+    "metadata_hooks",
+    "command",
+    "invocation",
+    "config_snapshot",
+    "inputs",
+    "key_columns",
+    "table_quality",
+    "stats_extra",
+    "stats_callback",
+    "strict_mode",
+    "dictionary_resources",
+}
+
+
+def normalise_definition(
+    definition: PipelineDefinition | None,
+    extra_kwargs: Mapping[str, object],
+) -> PipelineDefinition:
+    """Return a :class:`PipelineDefinition` using legacy keyword fallbacks."""
+
+    if definition is not None:
+        if extra_kwargs:
+            unexpected = ", ".join(sorted(extra_kwargs))
+            raise TypeError(
+                "run_pipeline received unexpected legacy keyword arguments: "
+                f"{unexpected}"
+            )
+        return definition
+
+    remaining = dict(extra_kwargs)
+    legacy_args: dict[str, object] = {}
+    for key in LEGACY_DEFINITION_KEYS:
+        if key in remaining:
+            legacy_args[key] = remaining.pop(key)
+
+    if remaining:
+        unexpected = ", ".join(sorted(remaining))
+        raise TypeError(
+            "run_pipeline received unexpected keyword arguments: "
+            f"{unexpected}"
+        )
+
+    try:
+        return PipelineDefinition.from_legacy_kwargs(**legacy_args)
+    except TypeError as exc:  # pragma: no cover - mirrors legacy errors
+        raise TypeError(
+            "run_pipeline requires a PipelineDefinition or the legacy keyword "
+            "arguments (schema, schema_name, writer, table_quality, ...)."
+        ) from exc
+

--- a/library/cli/utils.py
+++ b/library/cli/utils.py
@@ -15,7 +15,7 @@ import sys
 import traceback
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Protocol, TypeVar, overload
+from typing import overload
 
 import shlex
 
@@ -39,31 +39,15 @@ from ..config import Config, ConfigError, ensure_dirs, print_config
 from ..config.loader import DEFAULT_CONFIG_PATH
 from ..reporting.run_manifest import finalise_csv_output
 from ..utils.config import DEFAULT_CONFIG_PATH
-
-SchemaT = TypeVar("SchemaT")
-
-class ValidationResult(Protocol):
-    """Protocol describing the return type of validator callables."""
-
-    data: pd.DataFrame
-    failure_cases: pd.DataFrame
-
-
-class Validator(Protocol):
-    """Callable interface for data frame validators."""
-
-    def __call__(
-        self, df: pd.DataFrame
-    ) -> ValidationResult:  # pragma: no cover - Protocol
-        ...
-
-
-MetadataHook = Callable[[pd.DataFrame], pd.DataFrame]
-Writer = Callable[
-    [Iterable[pd.DataFrame], Path, Sequence[str] | None, Sequence[str]], Path
-]
-TableQualityHook = Callable[[Path], None]
-Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
+from .pipeline_definition import (
+    Fetcher,
+    MetadataHook,
+    PipelineDefinition,
+    TableQualityHook,
+    Validator,
+    Writer,
+    normalise_definition,
+)
 
 
 def _callable_name(func: Callable[..., object]) -> str:
@@ -74,7 +58,6 @@ def _callable_name(func: Callable[..., object]) -> str:
 
 class PipelineError(RuntimeError):
     """Raised when a pipeline step encounters a fatal error."""
-
 
 
 def resolve_invocation(
@@ -211,81 +194,38 @@ def _as_iterable(
 
 def run_pipeline(
     *,
+    definition: PipelineDefinition | None = None,
     fetcher: Fetcher,
-    schema: SchemaT | None,
-    schema_name: str,
-    validators: Sequence[Validator] | None,
-    metadata_hooks: Sequence[MetadataHook] | None,
-    writer: Writer,
     output_path: Path,
     failure_path: Path,
-    command: str | None = None,
-    invocation: Sequence[str] | None = None,
-    config_snapshot: Mapping[str, object],
-    inputs: Mapping[str, object],
-    key_columns: Sequence[str],
-    table_quality: TableQualityHook,
     cfg: Config | None = None,
-    stats_extra: (
-        Mapping[str, object] | Callable[[], Mapping[str, object]] | None
-    ) = None,
     logger: Logger | None = None,
-    stats_callback: Callable[[Stats], None] | None = None,
+    **legacy_kwargs: object,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
 
     Parameters
     ----------
+    definition:
+        Pipeline configuration bundle describing schema, validators, metadata
+        hooks and writer behaviour. When omitted, the legacy keyword arguments
+        from older call-sites are used to construct a temporary definition for
+        backwards compatibility.
     fetcher:
         Callable returning an iterable of raw :class:`pandas.DataFrame`
         objects.  Each frame represents a chunk of data retrieved from an
         upstream service.
-    schema:
-        Pandera schema describing the expected output columns.  The helper
-        inspects ``schema.columns`` to determine required and optional fields
-        as well as to construct the preferred column order.
-    schema_name:
-        Human readable name of ``schema`` persisted in the metadata file.
-    validators:
-        Sequence of callables returning Pandera ``ValidationResult`` objects.
-        Every validated chunk is passed through each validator in order.
-    metadata_hooks:
-        Callables applied sequentially to every chunk before validation.
-    writer:
-        Function responsible for serialising the validated chunks to ``CSV``.
-        It receives the chunk iterator, destination path, final column order
-        and the subset of ``key_columns`` present in the output.
     output_path:
         Destination ``CSV`` file.
     failure_path:
         Path for persisting validation failure cases.
-    command:
-        Command used to launch the pipeline.  Stored in metadata output.
-    invocation:
-        Optional command invocation captured as a sequence of arguments. When
-        provided it is persisted to metadata alongside the joined ``command``
-        string.
-    config_snapshot:
-        Mapping of configuration values persisted to metadata.
-    inputs:
-        Mapping of input file descriptions persisted to metadata.
-    key_columns:
-        Preferred key columns used when sorting deterministic output.  Only
-        columns present in the final dataset are forwarded to ``writer``.
-    table_quality:
-        Callable invoked after writing the CSV to compute quality metrics.
     cfg:
         Optional application configuration forwarded to sidecar metadata.
-    stats_extra:
-        Optional mapping or callable returning a mapping of additional
-        statistics merged into the metadata output. Intended for
-        pipeline-specific diagnostics such as fetch failures.
     logger:
         Optional logger.  Defaults to :data:`library.common.log.logger` when omitted.
-    stats_callback:
-        Optional callable invoked with the final ``stats`` mapping prior to
-        metadata serialisation. Use this to capture summary statistics for
-        external reporting without mutating the persisted metadata.
+    legacy_kwargs:
+        Deprecated keyword arguments matching the historical signature. When
+        provided they are converted into a :class:`PipelineDefinition`.
 
     Returns
     -------
@@ -296,6 +236,23 @@ def run_pipeline(
     """
 
     use_logger = logger or default_logger
+
+    definition = normalise_definition(definition, legacy_kwargs)
+
+    schema = definition.schema
+    schema_name = definition.schema_name
+    metadata_hooks = list(definition.metadata_hooks)
+    validators = list(definition.validators)
+    writer = definition.writer
+    config_snapshot = dict(definition.config_snapshot)
+    inputs = dict(definition.inputs)
+    key_columns = list(definition.key_columns)
+    table_quality = definition.table_quality or (lambda _: None)
+    stats_extra = definition.stats_extra
+    stats_callback = definition.stats_callback
+    strict_mode = bool(definition.strict_mode)
+    invocation_tuple = tuple(str(part) for part in (definition.invocation or ()))
+    command = definition.command
 
     # NOTE:
     # ``output_path`` and ``failure_path`` are provided as keyword-only
@@ -311,22 +268,6 @@ def run_pipeline(
     output_path = Path(output_path_value)
     failure_path = Path(failure_path_value)
 
-    # NOTE:
-    # ``invocation`` is an optional parameter which, in practice, might be
-    # omitted by older call-sites.  When that happens Python still provides the
-    # default ``None`` value, however certain execution environments (for
-    # example when the function is referenced through ``functools.partial`` or
-    # dynamically inspected) have been observed to trigger ``NameError`` while
-    # the default is being resolved.  To keep the metadata handling resilient we
-    # retrieve the argument from ``locals()`` instead of referencing the name
-    # directly which guarantees the lookup succeeds even when the optimiser
-    # elides the symbol.
-    invocation_value = locals().get("invocation")
-
-    invocation_tuple: tuple[str, ...] = ()
-    if invocation_value is not None:
-        invocation_tuple = tuple(str(part) for part in invocation_value)
-
     if command is not None:
         command_str = command
     elif invocation_tuple:
@@ -334,8 +275,8 @@ def run_pipeline(
     else:
         raise ValueError("run_pipeline requires either 'command' or 'invocation'")
 
-    metadata_hooks = list(metadata_hooks or [])
-    validators = list(validators or [])
+    # ``definition`` already normalises metadata hooks and validators to tuples
+    # so converting to ``list`` above is sufficient for mutation.
 
     if schema is not None:
         required_cols = {

--- a/library/cli_utils.py
+++ b/library/cli_utils.py
@@ -15,7 +15,7 @@ import sys
 import traceback
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Protocol, TypeVar, overload
+from typing import overload
 
 import shlex
 
@@ -37,31 +37,15 @@ from .common.log import logger as default_logger
 from .metadata import Stats, file_sha256, write_meta_yaml, record_quality_failure
 from .sidecar import SidecarErrors
 from .config.loader import DEFAULT_CONFIG_PATH
-
-SchemaT = TypeVar("SchemaT")
-
-class ValidationResult(Protocol):
-    """Protocol describing the return type of validator callables."""
-
-    data: pd.DataFrame
-    failure_cases: pd.DataFrame
-
-
-class Validator(Protocol):
-    """Callable interface for data frame validators."""
-
-    def __call__(
-        self, df: pd.DataFrame
-    ) -> ValidationResult:  # pragma: no cover - Protocol
-        ...
-
-
-MetadataHook = Callable[[pd.DataFrame], pd.DataFrame]
-Writer = Callable[
-    [Iterable[pd.DataFrame], Path, Sequence[str] | None, Sequence[str]], Path
-]
-TableQualityHook = Callable[[Path], None]
-Fetcher = Callable[[], Iterable[pd.DataFrame] | pd.DataFrame]
+from .cli.pipeline_definition import (
+    Fetcher,
+    MetadataHook,
+    PipelineDefinition,
+    TableQualityHook,
+    Validator,
+    Writer,
+    normalise_definition,
+)
 
 
 def _callable_name(func: Callable[..., object]) -> str:
@@ -221,90 +205,38 @@ def _as_iterable(
 
 def run_pipeline(
     *,
+    definition: PipelineDefinition | None = None,
     fetcher: Fetcher,
-    schema: SchemaT | None,
-    schema_name: str,
-    validators: Sequence[Validator] | None,
-    metadata_hooks: Sequence[MetadataHook] | None,
-    writer: Writer,
     output_path: Path,
     failure_path: Path,
-    command: str | None = None,
-    invocation: Sequence[str] | None = None,
-    config_snapshot: Mapping[str, object],
-    inputs: Mapping[str, object],
-    key_columns: Sequence[str],
-    table_quality: TableQualityHook,
     cfg: Config | None = None,
-    stats_extra: (
-        Mapping[str, object] | Callable[[], Mapping[str, object]] | None
-    ) = None,
-    strict_mode: bool = False,
     logger: Logger | None = None,
-    stats_callback: Callable[[Stats], None] | None = None,
-    dictionary_resources: Sequence[str] | None = None,
+    **legacy_kwargs: object,
 ) -> int:
     """Execute a data pipeline and write deterministic CSV output.
 
     Parameters
     ----------
+    definition:
+        Pipeline configuration bundle describing schema, validators, metadata
+        hooks and writer behaviour. When omitted, the legacy keyword arguments
+        from older call-sites are used to construct a temporary definition for
+        backwards compatibility.
     fetcher:
         Callable returning an iterable of raw :class:`pandas.DataFrame`
         objects.  Each frame represents a chunk of data retrieved from an
         upstream service.
-    schema:
-        Pandera schema describing the expected output columns.  The helper
-        inspects ``schema.columns`` to determine required and optional fields
-        as well as to construct the preferred column order.
-    schema_name:
-        Human readable name of ``schema`` persisted in the metadata file.
-    validators:
-        Sequence of callables returning Pandera ``ValidationResult`` objects.
-        Every validated chunk is passed through each validator in order.
-    metadata_hooks:
-        Callables applied sequentially to every chunk before validation.
-    writer:
-        Function responsible for serialising the validated chunks to ``CSV``.
-        It receives the chunk iterator, destination path, final column order
-        and the subset of ``key_columns`` present in the output.
     output_path:
         Destination ``CSV`` file.
     failure_path:
         Path for persisting validation failure cases.
-    command:
-        Command used to launch the pipeline.  Stored in metadata output.
-    invocation:
-        Optional command invocation captured as a sequence of arguments. When
-        provided it is persisted to metadata alongside the joined ``command``
-        string.
-    config_snapshot:
-        Mapping of configuration values persisted to metadata.
-    inputs:
-        Mapping of input file descriptions persisted to metadata.
-    key_columns:
-        Preferred key columns used when sorting deterministic output.  Only
-        columns present in the final dataset are forwarded to ``writer``.
-    table_quality:
-        Callable invoked after writing the CSV to compute quality metrics.
     cfg:
         Optional application configuration forwarded to sidecar metadata.
-    stats_extra:
-        Optional mapping or callable returning a mapping of additional
-        statistics merged into the metadata output. Intended for
-        pipeline-specific diagnostics such as fetch failures.
     logger:
         Optional logger.  Defaults to :data:`library.common.log.logger` when omitted.
-    stats_callback:
-        Optional callable invoked with the final ``stats`` mapping prior to
-        metadata serialisation. Use this to capture summary statistics for
-        external reporting without mutating the persisted metadata.
-    strict_mode:
-        When ``True``, metadata hook failures abort processing instead of
-        logging a warning and continuing.
-    dictionary_resources:
-        Optional sequence of dictionary manifest identifiers consumed by the
-        pipeline.  When provided, the metadata sidecar records the declared
-        version and SHA256 checksum for each resource.
+    legacy_kwargs:
+        Deprecated keyword arguments matching the historical signature. When
+        provided they are converted into a :class:`PipelineDefinition`.
 
     Returns
     -------
@@ -315,6 +247,24 @@ def run_pipeline(
     """
 
     use_logger = logger or default_logger
+
+    definition = normalise_definition(definition, legacy_kwargs)
+
+    schema = definition.schema
+    schema_name = definition.schema_name
+    metadata_hooks = list(definition.metadata_hooks)
+    validators = list(definition.validators)
+    writer = definition.writer
+    config_snapshot = dict(definition.config_snapshot)
+    inputs = dict(definition.inputs)
+    key_columns = list(definition.key_columns)
+    table_quality = definition.table_quality or (lambda _: None)
+    stats_extra = definition.stats_extra
+    stats_callback = definition.stats_callback
+    strict_mode = bool(definition.strict_mode)
+    invocation_tuple = tuple(str(part) for part in (definition.invocation or ()))
+    command = definition.command
+    dictionary_resources = tuple(definition.dictionary_resources or ()) or None
 
     # NOTE:
     # ``output_path`` and ``failure_path`` are provided as keyword-only
@@ -330,31 +280,12 @@ def run_pipeline(
     output_path = Path(output_path_value)
     failure_path = Path(failure_path_value)
 
-    # NOTE:
-    # ``invocation`` is an optional parameter which, in practice, might be
-    # omitted by older call-sites.  When that happens Python still provides the
-    # default ``None`` value, however certain execution environments (for
-    # example when the function is referenced through ``functools.partial`` or
-    # dynamically inspected) have been observed to trigger ``NameError`` while
-    # the default is being resolved.  To keep the metadata handling resilient we
-    # retrieve the argument from ``locals()`` instead of referencing the name
-    # directly which guarantees the lookup succeeds even when the optimiser
-    # elides the symbol.
-    invocation_value = locals().get("invocation")
-
-    invocation_tuple: tuple[str, ...] = ()
-    if invocation_value is not None:
-        invocation_tuple = tuple(str(part) for part in invocation_value)
-
     if command is not None:
         command_str = command
     elif invocation_tuple:
         command_str = " ".join(shlex.quote(part) for part in invocation_tuple)
     else:
         raise ValueError("run_pipeline requires either 'command' or 'invocation'")
-
-    metadata_hooks = list(metadata_hooks or [])
-    validators = list(validators or [])
 
     if schema is not None:
         schema_columns_dict = getattr(schema, "columns", {})

--- a/library/integration/pubmed_library.py
+++ b/library/integration/pubmed_library.py
@@ -52,6 +52,7 @@ from ..pubmed import (
     text_or_none,
 )
 from ..common.rate_limiter import RateLimiter, get_limiter
+from ..cli.pipeline_definition import PipelineDefinition
 from ..cli_utils import MetadataHook, Validator, run_pipeline
 from ..qa.reporting import build_table_quality_hook
 from ..pipelines.common import add_pipeline_metadata
@@ -380,20 +381,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     command = " ".join(["pubmed_library"] + (list(argv) if argv else []))
     config_snapshot = _serialize_paths(cfg.to_dict())
     inputs = {"input_csv": str(args.input_csv)}
-    exit_code = run_pipeline(
-        fetcher=fetcher,
+    definition = PipelineDefinition(
         schema=_PUBMED_SCHEMA,
         schema_name="PubMedDocumentsSchema",
         validators=validators,
         metadata_hooks=metadata_hooks,
         writer=writer,
-        output_path=output_path,
-        failure_path=failure_path,
         command=command,
         config_snapshot=config_snapshot,
         inputs=inputs,
         key_columns=["PubMed.PMID"],
         table_quality=table_quality,
+    )
+    exit_code = run_pipeline(
+        definition=definition,
+        fetcher=fetcher,
+        output_path=output_path,
+        failure_path=failure_path,
         cfg=cfg,
         logger=logger,
     )

--- a/library/pipelines/common/helpers.py
+++ b/library/pipelines/common/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, TypeVar
 
 import pandas as pd
 
+from ...cli.pipeline_definition import normalise_definition
 from ...cli_utils import PipelineError, run_pipeline
 from ...clients import _chunked
 
@@ -181,8 +182,26 @@ def run_chunked_pipeline(
         csv_writer=csv_writer,
     )
 
+    params = dict(pipeline_kwargs)
+    try:
+        output_path = params.pop("output_path")
+        failure_path = params.pop("failure_path")
+    except KeyError as exc:  # pragma: no cover - defensive validation
+        missing = exc.args[0]
+        raise TypeError(f"run_pipeline missing required argument: {missing}") from exc
+
+    cfg = params.pop("cfg", None)
+    logger = params.pop("logger", None)
+    definition = params.pop("definition", None)
+    params.setdefault("writer", writer)
+
+    pipeline_definition = normalise_definition(definition, params)
+
     return run_pipeline(
+        definition=pipeline_definition,
         fetcher=fetcher,
-        writer=writer,
-        **pipeline_kwargs,
+        output_path=output_path,
+        failure_path=failure_path,
+        cfg=cfg,
+        logger=logger,
     )

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -48,6 +48,7 @@ from library.cli import (
 from library.cli import (
     build_parser as base_parser,
 )
+from library.cli.pipeline_definition import PipelineDefinition
 from library.cli_utils import (
     PipelineError,
     resolve_invocation,
@@ -1134,28 +1135,31 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             pipeline_stats = dict(stats)
 
         try:
-            exit_code = run_pipeline(
-                fetcher=fetcher,
+            definition = PipelineDefinition(
                 schema=ActivitiesSchema,
                 schema_name="ActivitiesSchema",
                 validators=validators,
                 metadata_hooks=metadata_hooks,
                 writer=writer,
-                output_path=output_path,
-                failure_path=failure_path,
                 command=" ".join(_args_invocation(args)),
                 config_snapshot=_serialize_paths(cfg.to_dict()),
                 inputs={"input_csv": str(args.input_csv)},
                 key_columns=["activity_id"],
                 table_quality=table_quality,
-                cfg=cfg,
                 stats_extra=chunk_failures.stats,
-                logger=logger,
                 stats_callback=_capture_stats,
                 dictionary_resources=(
                     "dictionary_root",
                     "target_types",
                 ),
+            )
+            exit_code = run_pipeline(
+                definition=definition,
+                fetcher=fetcher,
+                output_path=output_path,
+                failure_path=failure_path,
+                cfg=cfg,
+                logger=logger,
             )
         except Exception:
             logger.exception("Activity pipeline execution failed during chunked processing.")

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -42,6 +42,7 @@ from library.cli import (
     configure_logger,
 )
 from library.cli import build_parser as base_parser
+from library.cli.pipeline_definition import PipelineDefinition
 from library.cli_utils import run_cli_command, run_pipeline
 from library.cli.logging import setup_cli_logging
 from library.cli.metadata import prepare_option
@@ -409,25 +410,28 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             pipeline_stats = dict(stats)
 
         try:
-            exit_code = run_pipeline(
-                fetcher=fetcher,
+            definition = PipelineDefinition(
                 schema=AssaysSchema,
                 schema_name="AssaysSchema",
                 validators=validators,
                 metadata_hooks=metadata_hooks,
                 writer=writer,
-                output_path=output_path,
-                failure_path=failure_path,
                 command=" ".join(sys.argv),
                 config_snapshot=_serialize_paths(cfg.to_dict()),
                 inputs={"input_csv": str(args.input_csv)},
                 key_columns=["assay_chembl_id"],
                 table_quality=table_quality,
-                cfg=cfg,
                 stats_extra=chunk_failures.stats,
-                logger=logger,
                 stats_callback=_capture_stats,
                 dictionary_resources=("dictionary_root",),
+            )
+            exit_code = run_pipeline(
+                definition=definition,
+                fetcher=fetcher,
+                output_path=output_path,
+                failure_path=failure_path,
+                cfg=cfg,
+                logger=logger,
             )
         finally:
             chunk_failures.save(fetch_failure_path, cfg=cfg)

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -50,6 +50,7 @@ from library.pipelines.target import postprocessing as tp
 from library.pipelines.target.defaults import ModeDefaults, TARGET_MODE_DEFAULTS
 from library.clients import ChemblClient
 from library.common.rate_limiter import get_global_limiter
+from library.cli.pipeline_definition import normalise_definition
 from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.pipelines.target.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
@@ -125,7 +126,29 @@ def _run_pipeline_with_meta(**kwargs: object) -> int:
     """Invoke :func:`run_pipeline` with project-specific metadata writer."""
 
     with _override_cli_meta_writer():
-        return run_pipeline(**kwargs)
+        params = dict(kwargs)
+        try:
+            fetcher = params.pop("fetcher")
+            output_path = params.pop("output_path")
+            failure_path = params.pop("failure_path")
+        except KeyError as exc:  # pragma: no cover - defensive validation
+            missing = exc.args[0]
+            raise TypeError(f"run_pipeline missing required argument: {missing}") from exc
+
+        cfg = params.pop("cfg", None)
+        logger = params.pop("logger", None)
+        definition = params.pop("definition", None)
+
+        pipeline_definition = normalise_definition(definition, params)
+
+        return run_pipeline(
+            definition=pipeline_definition,
+            fetcher=fetcher,
+            output_path=output_path,
+            failure_path=failure_path,
+            cfg=cfg,
+            logger=logger,
+        )
 
 TARGETS_REQUIRED_COLUMNS: set[str] = {
     name for name, column in TargetsSchema.columns.items() if column.required

--- a/tests/integration/test_assay_cli_quality.py
+++ b/tests/integration/test_assay_cli_quality.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -169,15 +169,30 @@ def test_get_assay_cli__clamps_batch_size(
                 frames.append(fetch_chunk(chunk))
             return frames
 
-        def _writer(frames: list[pd.DataFrame]) -> None:
-            written_frames.extend(frames)
+        def _writer(
+            frames: Iterable[pd.DataFrame],
+            destination: Path,
+            col_order: Sequence[str] | None,
+            key_cols: Sequence[str],
+        ) -> Path:
+            del col_order, key_cols
+            chunk_list = list(frames)
+            written_frames.extend(chunk_list)
+            return Path(destination)
 
         return _fetcher, _writer
 
-    def _fake_run_pipeline(*, fetcher, writer, **kwargs) -> int:
-        del kwargs
+    def _fake_run_pipeline(
+        *,
+        definition,
+        fetcher,
+        output_path,
+        failure_path,
+        **kwargs,
+    ) -> int:
+        del failure_path, kwargs
         frames = fetcher()
-        writer(frames)
+        definition.writer(frames, output_path, None, ())
         return 0
 
     def _fake_read_ids(path: Path, *, column: str, cfg) -> Iterator[str]:

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -348,7 +348,8 @@ def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> 
         get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline
     )
 
-    def fake_run_pipeline(*, fetcher, writer, **kwargs):
+    def fake_run_pipeline(*, definition, fetcher, output_path, failure_path, **kwargs):
+        del definition, output_path, failure_path, kwargs
         list(fetcher())
         return 1
 

--- a/tests/unit/test_get_assay_data.py
+++ b/tests/unit/test_get_assay_data.py
@@ -144,8 +144,17 @@ def test_run_chembl__successful_execution(
 
         return fetcher, writer
 
-    def fake_run_pipeline(**kwargs: object) -> int:
-        kwargs["stats_callback"]({"rows_total": 2, "rows_kept": 2, "rows_dropped": 0})
+    def fake_run_pipeline(
+        *,
+        definition,
+        fetcher,
+        output_path,
+        failure_path,
+        **kwargs: object,
+    ) -> int:
+        del fetcher, output_path, failure_path, kwargs
+        if definition.stats_callback is not None:
+            definition.stats_callback({"rows_total": 2, "rows_kept": 2, "rows_dropped": 0})
         return 0
 
     monkeypatch.setattr(get_assay_data.io, "read_ids", fake_read_ids)
@@ -221,15 +230,30 @@ def test_run_chembl__splits_chunk_on_timeout(
         def fetcher() -> Iterable[pd.DataFrame]:
             yield fetch_chunk(["CHEMBL100", "CHEMBL200"])
 
-        def writer(**_: object) -> Path:
+        def writer(
+            frames: Iterable[pd.DataFrame],
+            destination: Path,
+            col_order: Sequence[str] | None,
+            key_cols: Sequence[str],
+        ) -> Path:
+            del destination, col_order, key_cols
+            list(frames)
             return minimal_args.final_out
 
         return fetcher, writer
 
-    def fake_run_pipeline(*, fetcher: Callable[[], Iterable[pd.DataFrame]], **kwargs: object) -> int:
+    def fake_run_pipeline(
+        *,
+        definition,
+        fetcher: Callable[[], Iterable[pd.DataFrame]],
+        output_path: Path,
+        failure_path: Path,
+        **kwargs: object,
+    ) -> int:
+        del output_path, failure_path, kwargs
         list(fetcher())
-        if "stats_callback" in kwargs:
-            kwargs["stats_callback"]({})
+        if definition.stats_callback is not None:
+            definition.stats_callback({})
         return 0
 
     monkeypatch.setattr(get_assay_data.io, "read_ids", fake_read_ids)


### PR DESCRIPTION
## Summary
- add a shared `PipelineDefinition` dataclass for CLI pipeline metadata and legacy conversion helpers
- update CLI run helpers and scripts to build pipeline definitions and forward them to `run_pipeline`
- adjust integration and unit tests to exercise the new API while preserving backwards compatibility

## Testing
- `pytest tests/unit/test_get_activity_data.py tests/unit/test_get_assay_data.py tests/integration/test_assay_cli_quality.py -q` *(fails: pre-existing SyntaxError in library/config/loader.py)*


------
https://chatgpt.com/codex/tasks/task_e_68e4311fb198832494e86bd2a31106d4