### PR TITLE
Use pipeline registry defaults in CLI commands

### DIFF
--- a/library/pipelines/registry.py
+++ b/library/pipelines/registry.py
@@ -39,6 +39,7 @@ class PipelineStep:
     output_flag: str = "--final-out"
     extra_args: tuple[str, ...] = ()
     supports_dry_run: bool = False
+    callable_path: str = ""
 
     def build_arguments(self, cfg: Any, output_path: Path | None = None) -> list[str]:
         """Return CLI arguments forwarded to the wrapped ``main`` function."""
@@ -174,7 +175,35 @@ def _build_step(entry: PipelineStepDefinition) -> PipelineStep:
         output_flag=output_flag,
         extra_args=extra_args,
         supports_dry_run=supports_dry_run,
+        callable_path=dotted,
     )
+
+
+def get_pipeline_step(
+    identifier: str | Callable[[Sequence[str] | None], int],
+    *,
+    source: Path | str | Iterable[PipelineStepDefinition] | Mapping[str, object] | None = None,
+) -> PipelineStep:
+    """Return the registry entry matching ``identifier``.
+
+    Parameters
+    ----------
+    identifier:
+        Pipeline name, callable reference (``module:attr``) or the actual callable
+        exported by the CLI module.
+    source:
+        Optional registry source forwarded to :func:`load_pipeline_registry`.
+    """
+
+    steps = load_pipeline_registry(source)
+    for step in steps:
+        if isinstance(identifier, str):
+            if identifier in {step.name, step.callable_path}:
+                return step
+        else:
+            if step.main is identifier:
+                return step
+    raise LookupError(f"pipeline step not found for identifier: {identifier!r}")
 
 
 def _resolve_callable(dotted: str) -> Callable[[Sequence[str] | None], int]:
@@ -196,5 +225,6 @@ __all__ = [
     "PipelineStep",
     "PipelineStepDefinition",
     "PipelineStepFlags",
+    "get_pipeline_step",
     "load_pipeline_registry",
 ]

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -40,6 +40,7 @@ from library.pipelines.common import (
     CsvWriterConfig,
     prepare_chunked_pipeline,
 )
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
 from library.cli import (
     LoggerConfig,
@@ -74,10 +75,20 @@ from library.validation import validate_activities
 from library.schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
 from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_delay
 
-DEFAULT_INPUT_NAME = "activity.csv"
-DEFAULT_OUTPUT_STEM = "activities"
 MIN_ACTIVITY_TIMEOUT = 60.0
 PROGRAM_NAME = Path(__file__).with_suffix("").name
+
+
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 def _args_invocation(args: argparse.Namespace) -> tuple[str, ...]:
     invocation = getattr(args, "invocation", None)
@@ -1373,7 +1384,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_dest="batch_size",
     )
     parser.prog = PROGRAM_NAME
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
     parser.add_argument(
         "--timeout",
         type=float,
@@ -1438,8 +1449,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     cli.prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     if args.limit == 0:
         logger.info("pipeline_skip_limit", limit=args.limit)

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -57,14 +57,12 @@ from library.pipelines.common import (
     prepare_chunked_pipeline,
 )
 from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_delay
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
 configure_logger = cli.configure_logger
 
 __all__ = ["ap", "configure_logger", "main", "run", "run_chembl"]
 
-
-DEFAULT_INPUT_NAME = "assay.csv"
-DEFAULT_OUTPUT_STEM = "assays"
 
 # Backwards compatibility: legacy configs referenced the private
 # ``_ASSAY_MAX_IDS_PER_REQUEST`` constant before it was renamed to
@@ -499,6 +497,18 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     return run_chembl(cfg, args)
 
 
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
+
+
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the command-line argument parser.
 
@@ -515,7 +525,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_option="--batch-size",
         size_dest="batch_size",
     )
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
     parser.add_argument(
         "--timeout",
         type=float,
@@ -564,8 +574,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     cli.prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     if args.limit == 0:
         logger.info("pipeline_skip_limit", limit=args.limit)

--- a/scripts/get_cellline_data.py
+++ b/scripts/get_cellline_data.py
@@ -24,10 +24,21 @@ from library.pipelines.cellline import (
     CellLinePipelineOptions,
     run_cellline_pipeline,
 )
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
-DEFAULT_INPUT_NAME = "cellline.csv"
-DEFAULT_OUTPUT_STEM = "cellline"
 MODE_CHOICES: tuple[str, ...] = ("chembl",)
+
+
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
@@ -40,7 +51,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_option="--batch-size",
         size_dest="batch_size",
     )
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
     parser.add_argument(
         "--mode",
         choices=MODE_CHOICES,
@@ -149,8 +160,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     cli.prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     if args.limit == 0:
         logger.info("pipeline_skip_limit", limit=args.limit)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -102,10 +102,19 @@ from library.qa.reporting import build_table_quality_hook
 from library.qa.table_quality import TableQualityProfiler
 from library.schemas import DocumentsSchema, normalize_documents
 from library.schemas.document_spec import DOCUMENT_EXPORT_COLUMNS
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
 
-DEFAULT_INPUT_NAME = "document.csv"
-DEFAULT_OUTPUT_STEM = "documents"
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 
 class _FallbackPathAction(argparse.Action):
@@ -1508,13 +1517,13 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     """Create the argument parser for document utilities."""
 
     root, _, log_cfg = build_root_parser()
-    root.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    root.set_defaults(input_csv=Path(_default_input_name()))
     parser = argparse.ArgumentParser(
         description="Document data utilities",
         parents=[root],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
 
     pipeline_group = parser.add_argument_group("Pipeline selection")
     pipeline_group.add_argument(
@@ -1750,8 +1759,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv_list)
     prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     limit_value = getattr(args, "limit", None)
     if limit_value == 0:

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -74,6 +74,7 @@ from library.qa.reporting import build_table_quality_hook, is_quality_enabled
 from library.validation import ValidationResult
 from library.schemas import TargetsSchema, normalize_targets
 from library.schemas.targets import TARGETS_COLUMN_ORDER
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
 
 from library.postprocessing import target as target_pp
@@ -144,11 +145,21 @@ TARGETS_OBJECT_COLUMNS: set[str] = {
 UNIPROT_MISSING_VALUE = ""
 
 
-DEFAULT_INPUT_NAME = "target.csv"
-DEFAULT_OUTPUT_STEM = "targets"
 RAW_SUFFIX = "_raw"
 NORMALIZED_SUFFIX = "_normalized"
 COMMAND_CHOICES: tuple[str, ...] = ("uniprot", "chembl", "iuphar", "all")
+
+
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 
 _IUPHAR_OVERRIDE_COLUMNS: frozenset[str] = frozenset(
@@ -1517,7 +1528,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     _add_output_arguments(root, defaults=True)
     _add_output_arguments(shared, defaults=False)
 
-    root.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    root.set_defaults(input_csv=Path(_default_input_name()))
     parser = argparse.ArgumentParser(
         description="Target data utilities",
         parents=[root],
@@ -3925,8 +3936,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.command = command_alias
     prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     date_value = getattr(args, "date", None)
     if not isinstance(date_value, str) or not date_value:
@@ -4014,8 +4025,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                     date_token = args_dict.get(
                         "date", datetime.now(timezone.utc).strftime("%Y%m%d")
                     )
+                    stem = _default_output_stem()
                     inferred = Path(args_dict["input_csv"]).with_name(
-                        f"output.{DEFAULT_OUTPUT_STEM}_{date_token}.csv"
+                        f"output.{stem}_{date_token}.csv"
                     )
                     args_dict["final_out"] = inferred
                 else:

--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -26,9 +26,6 @@ import pandas as pd
 
 # ===== Parameters =====
 
-DEFAULT_INPUT_NAME = "testitem.csv"
-DEFAULT_OUTPUT_STEM = "testitems"
-
 
 from library import cli  # noqa: F401 - re-exported for monkeypatching in tests
 from library import io
@@ -82,6 +79,7 @@ from library.testitem_pipeline import (
 )
 from library.testitem_pipeline import catalog as pipeline_catalog
 from library.testitem_pipeline import pubchem as pipeline_pubchem
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
 configure_logger = cli.configure_logger
 
@@ -96,6 +94,18 @@ _load_pubchem_cid_cache = pipeline_pubchem._load_pubchem_cid_cache
 resolve_pubchem_cid = pipeline_pubchem.resolve_pubchem_cid
 
 configure_logger = cli.configure_logger
+
+
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 
 def _resolve_catalog_load_source(
@@ -667,7 +677,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_option="--batch-size",
         size_dest="batch_size",
     )
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
     parser.add_argument(
         "--timeout",
         type=float,
@@ -717,8 +727,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     cli.prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
 
     if args.limit == 0:

--- a/scripts/get_tissue_data.py
+++ b/scripts/get_tissue_data.py
@@ -22,10 +22,21 @@ from library.cli_utils import run_cli_command
 from library.common.log import logger
 from library.config import Config
 from library.pipelines.tissue import TissuePipelineOptions, run_tissue_pipeline
+from library.pipelines.registry import PipelineStep, get_pipeline_step
 
-DEFAULT_INPUT_NAME = "tissue.csv"
-DEFAULT_OUTPUT_STEM = "tissue"
 MODE_CHOICES: tuple[str, ...] = ("chembl",)
+
+
+def _pipeline_step() -> PipelineStep:
+    return get_pipeline_step(f"{__name__}:main")
+
+
+def _default_input_name() -> str:
+    return _pipeline_step().input_filename
+
+
+def _default_output_stem() -> str:
+    return _pipeline_step().output_stem
 
 
 def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
@@ -38,7 +49,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         size_option="--batch-size",
         size_dest="batch_size",
     )
-    parser.set_defaults(input_csv=Path(DEFAULT_INPUT_NAME))
+    parser.set_defaults(input_csv=Path(_default_input_name()))
     parser.add_argument(
         "--mode",
         choices=MODE_CHOICES,
@@ -145,8 +156,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     cli.prepare_io_paths(
         args,
-        input_default=DEFAULT_INPUT_NAME,
-        output_stem=DEFAULT_OUTPUT_STEM,
+        input_default=_default_input_name(),
+        output_stem=_default_output_stem(),
     )
     if args.limit == 0:
         logger.info("pipeline_skip_limit", limit=args.limit)

--- a/tests/unit/test_cli_registry_defaults.py
+++ b/tests/unit/test_cli_registry_defaults.py
@@ -1,0 +1,102 @@
+"""Tests ensuring CLI defaults track the pipeline registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import library.pipelines.registry as registry_module
+from library.pipelines.registry import PipelineStep
+from scripts import get_assay_data
+
+
+def _patch_registry(monkeypatch: pytest.MonkeyPatch, step: PipelineStep) -> None:
+    def _fake_load_pipeline_registry(
+        source: object | None = None,
+    ) -> tuple[PipelineStep, ...]:
+        return (step,)
+
+    monkeypatch.setattr(
+        registry_module, "load_pipeline_registry", _fake_load_pipeline_registry
+    )
+
+
+def _make_assay_step(
+    *,
+    input_filename: str = "registry_assay.csv",
+    output_stem: str = "registry_assays",
+) -> PipelineStep:
+    return PipelineStep(
+        name="assay",
+        main=get_assay_data.main,
+        input_filename=input_filename,
+        output_stem=output_stem,
+        subcommand=None,
+        output_flag="--final-out",
+        extra_args=(),
+        supports_dry_run=False,
+        callable_path="scripts.get_assay_data:main",
+    )
+
+
+@pytest.mark.unit
+def test_assay_cli_defaults__parser_uses_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    step = _make_assay_step(input_filename="patched_assay.csv")
+    _patch_registry(monkeypatch, step)
+
+    parser, _ = get_assay_data.build_parser()
+    args = parser.parse_args([])
+
+    assert args.input_csv == Path(step.input_filename)
+
+
+@pytest.mark.unit
+def test_assay_cli_defaults__main_uses_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    step = _make_assay_step(
+        input_filename="patched_assay_cli.csv",
+        output_stem="patched_assay_output",
+    )
+    _patch_registry(monkeypatch, step)
+
+    captured: dict[str, object] = {}
+    original_prepare = get_assay_data.cli.prepare_io_paths
+
+    def _prepare_io_paths(
+        args,
+        *,
+        input_default: str | Path | None = None,
+        output_stem: str | None = None,
+        **kwargs,
+    ) -> None:
+        captured["input_default"] = input_default
+        captured["output_stem"] = output_stem
+        return original_prepare(
+            args,
+            input_default=input_default,
+            output_stem=output_stem,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(get_assay_data.cli, "prepare_io_paths", _prepare_io_paths)
+    monkeypatch.setattr(get_assay_data, "run_cli_command", lambda **_: 0)
+
+    class _DummyLoggingContext:
+        def __init__(self) -> None:
+            self.log_cfg = get_assay_data.LoggerConfig()
+
+        def __enter__(self) -> "_DummyLoggingContext":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        get_assay_data, "setup_cli_logging", lambda *args, **kwargs: _DummyLoggingContext()
+    )
+
+    exit_code = get_assay_data.main([])
+
+    assert exit_code == 0
+    assert captured["input_default"] == step.input_filename
+    assert captured["output_stem"] == step.output_stem

--- a/tests/unit/test_get_assay_data.py
+++ b/tests/unit/test_get_assay_data.py
@@ -17,6 +17,7 @@ from library.cli_utils import run_pipeline as cli_run_pipeline
 from library.config import Config
 from library.pipelines.assay.chembl_assay import MAX_ASSAY_CHUNK_SIZE
 from library.schemas import AssaysSchema
+from library.pipelines.registry import get_pipeline_step
 from scripts import get_assay_data
 
 
@@ -387,6 +388,7 @@ def test_build_parser__defaults() -> None:
     parser, _ = get_assay_data.build_parser()
     args = parser.parse_args([])
 
-    assert args.input_csv == Path(get_assay_data.DEFAULT_INPUT_NAME)
+    step = get_pipeline_step("assay")
+    assert args.input_csv == Path(step.input_filename)
     assert args.batch_size == parser.get_default("batch_size")
     assert callable(args.func)

--- a/tests/unit/test_get_target_data_cli.py
+++ b/tests/unit/test_get_target_data_cli.py
@@ -6,6 +6,7 @@ import pytest
 
 from library.cli import parser as cli_parser
 from library.config import Config, ConfigMetadata
+from library.pipelines.registry import get_pipeline_step
 from library.pipelines.target.defaults import TARGET_MODE_DEFAULTS
 from scripts import get_target_data
 
@@ -87,10 +88,11 @@ def test_prepare_io_paths__output_alias_sets_final_out(tmp_path):
         "custom.csv",
     ])
 
+    step = get_pipeline_step("target")
     get_target_data.prepare_io_paths(
         args,
-        input_default=get_target_data.DEFAULT_INPUT_NAME,
-        output_stem=get_target_data.DEFAULT_OUTPUT_STEM,
+        input_default=step.input_filename,
+        output_stem=step.output_stem,
     )
 
     expected = (tmp_path / "custom.csv").resolve()


### PR DESCRIPTION
## Summary
- expose pipeline callable identifiers via `PipelineStep` and add a helper for looking up steps by name or callable
- update the acquisition CLIs to pull their default input/output values from the registry instead of hard-coded constants
- cover the new behaviour with unit tests that patch the registry and verify the CLI defaults update automatically

## Testing
- `pytest tests/unit/test_cli_registry_defaults.py tests/unit/test_get_assay_data.py::test_build_parser__defaults tests/unit/test_get_target_data_cli.py::test_prepare_io_paths__output_alias_sets_final_out` *(fails: SyntaxError in library/config/loader.py from pre-existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e4311a41bc8324ae335bb46b7cc0f0