### PR TITLE
Normalize dictionary hashes on Windows

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -74,7 +74,8 @@ def _compute_sha256(path: Path) -> str:
                 continue
             if child.name in _IGNORED_FILENAMES or child.name.startswith("._"):
                 continue
-            hasher.update(str(child.relative_to(path)).encode("utf-8"))
+            relative = child.relative_to(path).as_posix()
+            hasher.update(relative.encode("utf-8"))
             data = _normalise_text_newlines(child.read_bytes())
             hasher.update(data)
         return hasher.hexdigest()


### PR DESCRIPTION
## Summary
- ensure dictionary resource hashing uses POSIX-style relative paths
- avoid checksum mismatches on Windows platforms when loading bundled dictionaries

## Testing
- pytest -q *(fails: ImportError while loading conftest due to existing SyntaxError in library/config/loader.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e435c31bc08324bc18a2e00916eedc