### PR TITLE
Implement dependency-aware scheduler for data pipelines

### DIFF
--- a/library/pipelines/registry.py
+++ b/library/pipelines/registry.py
@@ -25,6 +25,9 @@ class PipelineStepDefinition(TypedDict, total=False):
     output_flag: str
     extra_args: list[str]
     flags: PipelineStepFlags
+    depends_on: list[str]
+    produces: list[str]
+    consumes: list[str]
 
 
 @dataclass(frozen=True)
@@ -39,6 +42,9 @@ class PipelineStep:
     output_flag: str = "--final-out"
     extra_args: tuple[str, ...] = ()
     supports_dry_run: bool = False
+    depends_on: tuple[str, ...] = ()
+    produces: tuple[str, ...] = ()
+    consumes: tuple[str, ...] = ()
 
     def build_arguments(self, cfg: Any, output_path: Path | None = None) -> list[str]:
         """Return CLI arguments forwarded to the wrapped ``main`` function."""
@@ -80,6 +86,7 @@ _DEFAULT_DEFINITIONS: tuple[PipelineStepDefinition, ...] = (
         "input": "document.csv",
         "output": "documents",
         "extra_args": ["--mode", "all"],
+        "produces": ["documents"],
     },
     {
         "name": "target",
@@ -88,18 +95,21 @@ _DEFAULT_DEFINITIONS: tuple[PipelineStepDefinition, ...] = (
         "output": "targets",
         "subcommand": "all",
         "output_flag": "--final-out",
+        "produces": ["targets"],
     },
     {
         "name": "assay",
         "callable": "scripts.get_assay_data:main",
         "input": "assay.csv",
         "output": "assays",
+        "produces": ["assays"],
     },
     {
         "name": "testitem",
         "callable": "scripts.get_testitem_data:main",
         "input": "testitem.csv",
         "output": "testitems",
+        "produces": ["testitems"],
     },
     {
         "name": "activity",
@@ -107,6 +117,8 @@ _DEFAULT_DEFINITIONS: tuple[PipelineStepDefinition, ...] = (
         "input": "activity.csv",
         "output": "activities",
         "flags": {"dry_run": True},
+        "produces": ["activities"],
+        "consumes": ["documents", "targets", "assays", "testitems"],
     },
 )
 
@@ -150,6 +162,25 @@ def _coerce_definitions(data: object) -> Iterable[PipelineStepDefinition]:
     return definitions
 
 
+def _coerce_string_sequence(value: object, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        result: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"pipeline definition field '{field}' must contain strings only"
+                )
+            result.append(item)
+        return tuple(result)
+    raise TypeError(
+        f"pipeline definition field '{field}' must be a string or an iterable of strings"
+    )
+
+
 def _build_step(entry: PipelineStepDefinition) -> PipelineStep:
     name = entry.get("name")
     if not name:
@@ -165,6 +196,10 @@ def _build_step(entry: PipelineStepDefinition) -> PipelineStep:
     extra_args = tuple(entry.get("extra_args", ()))
     flags = entry.get("flags", {})
     supports_dry_run = bool(flags.get("dry_run", False))
+    depends_on = _coerce_string_sequence(entry.get("depends_on"), field="depends_on")
+    produces_raw = entry.get("produces", (output_stem,))
+    produces = _coerce_string_sequence(produces_raw, field="produces")
+    consumes = _coerce_string_sequence(entry.get("consumes"), field="consumes")
     return PipelineStep(
         name=name,
         main=main,
@@ -174,6 +209,9 @@ def _build_step(entry: PipelineStepDefinition) -> PipelineStep:
         output_flag=output_flag,
         extra_args=extra_args,
         supports_dry_run=supports_dry_run,
+        depends_on=depends_on,
+        produces=produces,
+        consumes=consumes,
     )
 
 

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -39,6 +39,7 @@ from collections import deque
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from fnmatch import fnmatch
+from heapq import heappop, heappush
 from pathlib import Path
 
 from typing import Any, Callable, Iterable, IO, Mapping, Sequence
@@ -216,6 +217,17 @@ def _resolve_path(base: Path, candidate: Path) -> Path:
     if expanded.is_absolute():
         return expanded.resolve()
     return (base / expanded).resolve()
+
+
+def _resolve_consumed_artifact_path(cfg: "PipelineRunConfig", artefact: str) -> Path:
+    """Return the filesystem path associated with a consumed artefact name."""
+
+    candidate = Path(artefact)
+    if candidate.is_absolute():
+        return candidate
+    if candidate.suffix:
+        return cfg.output_dir / candidate
+    return cfg.output_dir / f"output.{candidate.name}_{cfg.date_prefix}.csv"
 
 
 def _parse_overrides(
@@ -1164,6 +1176,119 @@ def _write_run_manifest(
         )
 
 
+@dataclass(frozen=True)
+class PipelineExecutionPlan:
+    """Describe the resolved execution order and artefact dependencies."""
+
+    steps: tuple[PipelineStep, ...]
+    dependencies: Mapping[str, frozenset[str]]
+    produced_by: Mapping[str, str]
+    external_artifacts: Mapping[str, tuple[str, ...]]
+
+
+def _build_execution_plan(
+    steps: Sequence[PipelineStep],
+) -> PipelineExecutionPlan:
+    """Return a deterministic execution plan for ``steps``."""
+
+    if not steps:
+        empty_mapping: dict[str, tuple[str, ...]] = {}
+        return PipelineExecutionPlan(
+            steps=(),
+            dependencies={},
+            produced_by={},
+            external_artifacts=empty_mapping,
+        )
+
+    by_name: dict[str, PipelineStep] = {}
+    for step in steps:
+        if step.name in by_name:
+            raise ValueError(f"duplicate pipeline step name: {step.name}")
+        by_name[step.name] = step
+
+    produced_by: dict[str, str] = {}
+    for step in steps:
+        produced = step.produces or (step.output_stem,)
+        for artefact in produced:
+            current = produced_by.get(artefact)
+            if current is not None and current != step.name:
+                raise ValueError(
+                    "artefact '{artefact}' declared by multiple steps".format(
+                        artefact=artefact
+                    )
+                )
+            produced_by[artefact] = step.name
+
+    dependencies: dict[str, set[str]] = {
+        step.name: set(step.depends_on) for step in steps
+    }
+    for step in steps:
+        for artefact in step.consumes:
+            producer = produced_by.get(artefact)
+            if producer is not None and producer != step.name:
+                dependencies[step.name].add(producer)
+
+    missing: list[str] = []
+    for name, deps in dependencies.items():
+        unknown = sorted(dep for dep in deps if dep not in by_name)
+        if unknown:
+            missing.append(f"{name}: {', '.join(unknown)}")
+    if missing:
+        raise ValueError(
+            "pipeline references unknown dependency: " + "; ".join(missing)
+        )
+
+    adjacency: dict[str, set[str]] = {name: set() for name in by_name}
+    indegree: dict[str, int] = {}
+    for name, deps in dependencies.items():
+        indegree[name] = len(deps)
+        for dep in deps:
+            adjacency[dep].add(name)
+
+    order_index = {step.name: index for index, step in enumerate(steps)}
+    queue: list[tuple[int, str]] = []
+    for name, degree in indegree.items():
+        if degree == 0:
+            heappush(queue, (order_index[name], name))
+
+    ordered: list[str] = []
+    while queue:
+        _, current = heappop(queue)
+        ordered.append(current)
+        neighbours = sorted(adjacency[current], key=order_index.__getitem__)
+        for neighbour in neighbours:
+            indegree[neighbour] -= 1
+            if indegree[neighbour] == 0:
+                heappush(queue, (order_index[neighbour], neighbour))
+
+    if len(ordered) != len(steps):
+        remaining = sorted(name for name, degree in indegree.items() if degree > 0)
+        raise ValueError(
+            "cyclic pipeline dependency detected: " + ", ".join(remaining)
+        )
+
+    ordered_steps = tuple(by_name[name] for name in ordered)
+    scheduled = set(ordered)
+    external: dict[str, tuple[str, ...]] = {}
+    for step in ordered_steps:
+        requirements: list[str] = []
+        for artefact in step.consumes:
+            producer = produced_by.get(artefact)
+            if producer is None or producer not in scheduled:
+                requirements.append(artefact)
+        external[step.name] = tuple(requirements)
+
+    frozen_dependencies = {
+        name: frozenset(deps) for name, deps in dependencies.items()
+    }
+    return PipelineExecutionPlan(
+        steps=ordered_steps,
+        dependencies=frozen_dependencies,
+        produced_by=dict(produced_by),
+        external_artifacts=external,
+    )
+
+
 def run_pipeline(
     cfg: PipelineRunConfig,
     *,
@@ -1173,6 +1298,13 @@ def run_pipeline(
     """Execute all configured steps and return the resulting exit status."""
 
     effective_steps = tuple(DEFAULT_PIPELINE_STEPS if steps is None else steps)
+    try:
+        plan = _build_execution_plan(effective_steps)
+    except ValueError as exc:
+        _LOGGER.error("pipeline_schedule_error", error=str(exc))
+        return 1
+    effective_steps = plan.steps
+    external_requirements = plan.external_artifacts
     base_config = load_config(cfg.config_path, base_path=cfg.base_path)
     overall_status = 0
     run_started_at = datetime.now(UTC)
@@ -1180,6 +1312,7 @@ def run_pipeline(
     manifest_entries: list[dict[str, Any]] = []
     failed_index: int | None = None
     last_executed_index = -1
+    completed_steps: set[str] = set()
     _LOGGER.info("pipeline_start", stage="pipeline")
 
     def _prepare_step(
@@ -1217,11 +1350,52 @@ def run_pipeline(
                     started_at=step_started_clock,
                 )
                 last_executed_index = index
+                completed_steps.add(step.name)
                 return StepExecutionResult(
                     exit_code=0,
                     executed=False,
                     status="skipped",
                     reason="dry_run",
+                )
+
+            missing_external: list[tuple[str, Path]] = []
+            required_external = external_requirements.get(step.name, ())
+            if required_external:
+                for artefact in required_external:
+                    candidate = _resolve_consumed_artifact_path(current_cfg, artefact)
+                    if not candidate.exists():
+                        missing_external.append((artefact, candidate))
+            if missing_external:
+                overall_status = 1
+                entry.update(
+                    {
+                        "status": "failed",
+                        "exit_code": overall_status,
+                        "executed": False,
+                        "reason": "dependency_missing",
+                    }
+                )
+                _LOGGER.error(
+                    "step_dependencies_missing",
+                    step=step.name,
+                    missing=[
+                        {"artefact": artefact, "path": str(path)}
+                        for artefact, path in missing_external
+                    ],
+                )
+                _complete_manifest_entry(
+                    entry,
+                    final_output=final_output,
+                    working_output=working_output,
+                    started_at=step_started_clock,
+                )
+                failed_index = index
+                last_executed_index = index
+                return StepExecutionResult(
+                    exit_code=1,
+                    executed=False,
+                    status="failed",
+                    reason="dependency_missing",
                 )
 
             if working_output.exists():
@@ -1392,6 +1566,8 @@ def run_pipeline(
                 started_at=step_started_clock,
             )
             _LOGGER.info("step_done", step=step.name)
+            completed_steps.add(step.name)
+            last_executed_index = index
             return result
 
         return PreparedPipelineStep(step=step, invoke=_invoke)

--- a/tests/e2e/test_get_data_scheduler.py
+++ b/tests/e2e/test_get_data_scheduler.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from library.pipelines.common import PipelineRunResult
+from scripts import get_data
+
+
+def _build_run_config(tmp_path: Path, steps: tuple[get_data.PipelineStep, ...]) -> get_data.PipelineRunConfig:
+    base_path = tmp_path
+    input_dir = base_path / "input"
+    output_dir = base_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    config_path = base_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    return get_data.PipelineRunConfig(
+        base_path=base_path,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        config_path=config_path,
+        date_prefix="20240101",
+        log_level="INFO",
+        limit=None,
+        force=False,
+        skip_existing=False,
+        dry_run=False,
+        input_files={step.name: step.input_filename for step in steps},
+        output_stems={step.name: step.output_stem for step in steps},
+    )
+
+
+def _make_pipeline_api(name: str, executed: list[str]) -> get_data.PipelineApi:
+    def _builder(cfg: get_data.PipelineRunConfig, input_path: Path, output_path: Path) -> SimpleNamespace:
+        return SimpleNamespace(input_csv=input_path, output_csv=output_path)
+
+    def _runner(config: object, options: SimpleNamespace) -> PipelineRunResult:
+        executed.append(name)
+        output_path = Path(options.output_csv)
+        output_path.write_text("value\n1\n", encoding="utf-8")
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=output_path,
+            executed=True,
+            reason=None,
+            written=True,
+        )
+
+    return get_data.PipelineApi(_builder, _runner)
+
+
+@pytest.mark.e2e
+def test_scheduler__selective_run_respects_dependencies(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    steps = (
+        get_data.PipelineStep(
+            name="audit",
+            main=lambda _: 0,
+            input_filename="audit.csv",
+            output_stem="audit",
+            depends_on=("transform",),
+            produces=("audit",),
+            consumes=("transformed",),
+        ),
+        get_data.PipelineStep(
+            name="transform",
+            main=lambda _: 0,
+            input_filename="transform.csv",
+            output_stem="transformed",
+            produces=("transformed",),
+            consumes=("prep",),
+        ),
+    )
+
+    cfg = _build_run_config(tmp_path, steps)
+    (cfg.input_dir / "transform.csv").write_text("id\n1\n", encoding="utf-8")
+    (cfg.input_dir / "audit.csv").write_text("id\n1\n", encoding="utf-8")
+    external = cfg.output_dir / f"output.prep_{cfg.date_prefix}.csv"
+    external.write_text("id\n1\n", encoding="utf-8")
+
+    executed: list[str] = []
+    monkeypatch.setattr(
+        get_data,
+        "_PIPELINE_APIS",
+        {step.name: _make_pipeline_api(step.name, executed) for step in steps},
+        raising=False,
+    )
+    monkeypatch.setattr(get_data, "load_config", lambda *args, **kwargs: SimpleNamespace(), raising=False)
+
+    status = get_data.run_pipeline(cfg, steps=steps)
+    assert status == 0
+    assert executed == ["transform", "audit"]
+
+    transform_output = cfg.output_dir / f"output.transformed_{cfg.date_prefix}.csv"
+    audit_output = cfg.output_dir / f"output.audit_{cfg.date_prefix}.csv"
+    assert transform_output.exists()
+    assert audit_output.exists()
+
+    manifest_path = cfg.base_path / "reports" / "run_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    step_names = [entry["name"] for entry in manifest["steps"]]
+    assert step_names == ["transform", "audit"]
+    assert manifest["run"]["status"] == "success"
+
+
+@pytest.mark.e2e
+def test_scheduler__fails_on_missing_external_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    steps = (
+        get_data.PipelineStep(
+            name="audit",
+            main=lambda _: 0,
+            input_filename="audit.csv",
+            output_stem="audit",
+            depends_on=("transform",),
+            produces=("audit",),
+            consumes=("transformed",),
+        ),
+        get_data.PipelineStep(
+            name="transform",
+            main=lambda _: 0,
+            input_filename="transform.csv",
+            output_stem="transformed",
+            produces=("transformed",),
+            consumes=("prep",),
+        ),
+    )
+
+    cfg = _build_run_config(tmp_path, steps)
+    (cfg.input_dir / "transform.csv").write_text("id\n1\n", encoding="utf-8")
+    (cfg.input_dir / "audit.csv").write_text("id\n1\n", encoding="utf-8")
+
+    executed: list[str] = []
+    monkeypatch.setattr(
+        get_data,
+        "_PIPELINE_APIS",
+        {step.name: _make_pipeline_api(step.name, executed) for step in steps},
+        raising=False,
+    )
+    monkeypatch.setattr(get_data, "load_config", lambda *args, **kwargs: SimpleNamespace(), raising=False)
+
+    status = get_data.run_pipeline(cfg, steps=steps)
+    assert status == 1
+    assert executed == []
+
+    manifest_path = cfg.base_path / "reports" / "run_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["run"]["status"] == "failed"
+    transform_entry = next(entry for entry in manifest["steps"] if entry["name"] == "transform")
+    assert transform_entry["status"] == "failed"
+    assert transform_entry["reason"] == "dependency_missing"
+    assert transform_entry["executed"] is False

--- a/tests/unit/pipelines/test_registry.py
+++ b/tests/unit/pipelines/test_registry.py
@@ -17,23 +17,31 @@ def test_default_registry__exposes_expected_steps() -> None:
     assert document.extra_args == ("--mode", "all")
     assert document.input_filename == "document.csv"
     assert document.output_stem == "documents"
+    assert document.produces == ("documents",)
+    assert document.consumes == ()
 
     target = _step_by_name(steps, "target")
     assert target.subcommand == "all"
     assert target.input_filename == "target.csv"
     assert target.output_stem == "targets"
+    assert target.produces == ("targets",)
+    assert target.consumes == ()
 
     assay = _step_by_name(steps, "assay")
     assert assay.subcommand is None
     assert assay.supports_dry_run is False
+    assert assay.produces == ("assays",)
 
     testitem = _step_by_name(steps, "testitem")
     assert callable(testitem.main)
+    assert testitem.produces == ("testitems",)
 
     activity = _step_by_name(steps, "activity")
     assert activity.supports_dry_run is True
     assert activity.input_filename == "activity.csv"
     assert activity.output_stem == "activities"
+    assert activity.produces == ("activities",)
+    assert activity.consumes == ("documents", "targets", "assays", "testitems")
 
 
 @pytest.mark.unit
@@ -59,6 +67,7 @@ def test_registry_loader__supports_yaml_overrides(tmp_path: Path) -> None:
     assert step.input_filename == "example.csv"
     assert step.output_stem == "examples"
     assert step.supports_dry_run is True
+    assert step.produces == ("examples",)
 
 
 def _step_by_name(steps: tuple[PipelineStep, ...], name: str) -> PipelineStep:


### PR DESCRIPTION
## Summary
- extend pipeline registry definitions with dependency and artefact metadata
- introduce an execution planner in `get_data` that orders steps topologically and checks external artefacts
- add end-to-end coverage for selective execution and missing dependency handling

## Testing
- pytest tests/unit/pipelines/test_registry.py tests/e2e/test_get_data_scheduler.py *(fails: SyntaxError in existing `library/config/loader.py` while importing `tests.conftest`)*

------
https://chatgpt.com/codex/tasks/task_e_68e43250ed6483248d551310000924ee