### PR TITLE
feat: introduce ETLContext for shared Chembl clients

### DIFF
--- a/library/common/dtype_inspector.py
+++ b/library/common/dtype_inspector.py
@@ -24,10 +24,9 @@ from collections.abc import Mapping, Sequence
 import pandas as pd
 
 from ..integration import chembl_library as cl
-from library.clients import ChemblClient
+from library.orchestration import ETLContext
 from ..config import Config
 from .log import logger
-from .rate_limiter import get_global_limiter
 
 # Default sample identifiers for each dataset.  These are deliberately minimal
 # and can be overridden via the ``samples`` argument to :func:`inspect_dtypes`.
@@ -70,14 +69,8 @@ def inspect_dtypes(
     # ``ChemblClient`` manages HTTP connections and retries.  The context
     # manager ensures the underlying ``requests.Session`` is properly closed
     # even if one of the retrieval functions fails.
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
-    with ChemblClient(
-        cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-    ) as client:
+    with ETLContext(cfg) as context:
+        client = context.chembl_client
         df = cl.get_activities(combined["activities"], cfg=cfg.api, client=client)
         results["activities"] = _dtype_map(df)
         logger.info("dtypes", dataset="activities", dtypes=results["activities"])

--- a/library/orchestration/__init__.py
+++ b/library/orchestration/__init__.py
@@ -1,0 +1,5 @@
+"""Orchestration helpers for ETL workflows."""
+
+from .context import ETLContext
+
+__all__ = ["ETLContext"]

--- a/library/orchestration/context.py
+++ b/library/orchestration/context.py
@@ -1,0 +1,93 @@
+"""Runtime helpers for constructing shared ETL resources."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable
+
+from library.clients import ChemblClient
+from library.common.rate_limiter import RateLimiter, get_global_limiter
+from library.config import Config
+
+__all__ = ["ETLContext", "ChemblClientFactory"]
+
+logger = logging.getLogger(__name__)
+
+ChemblClientFactory = Callable[["ETLContext"], ChemblClient]
+
+
+@dataclass
+class ETLContext:
+    """Context manager provisioning shared ETL resources."""
+
+    cfg: Config
+    chembl_client_factory: ChemblClientFactory | None = None
+    _global_limiter: RateLimiter | None = field(init=False, default=None)
+    _chembl_client: ChemblClient | None = field(init=False, default=None)
+    _closers: list[Callable[[], None]] = field(init=False, default_factory=list)
+    _closed: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        self._global_limiter = self._initialise_global_limiter()
+
+    def _initialise_global_limiter(self) -> RateLimiter | None:
+        rate_cfg = getattr(self.cfg, "rate", None)
+        if rate_cfg is None:
+            return None
+        rps = getattr(rate_cfg, "global_rps", None) or 0
+        if rps <= 0:
+            return None
+        burst = getattr(rate_cfg, "global_burst", None)
+        return get_global_limiter(rps, burst)
+
+    def __enter__(self) -> "ETLContext":
+        if self._closed:
+            self._closed = False
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+        return None
+
+    def _register_cleanup(self, closer: Callable[[], None]) -> None:
+        self._closers.append(closer)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        while self._closers:
+            closer = self._closers.pop()
+            try:
+                closer()
+            except Exception:  # pragma: no cover - defensive cleanup
+                logger.warning("etl_context_cleanup_failed", exc_info=True)
+        self._chembl_client = None
+        self._closed = True
+
+    @property
+    def global_limiter(self) -> RateLimiter | None:
+        return self._global_limiter
+
+    def _default_chembl_client_factory(self) -> ChemblClient:
+        return ChemblClient(
+            self.cfg.api,
+            self.cfg.retry,
+            self.cfg.chembl,
+            global_limiter=self._global_limiter,
+        )
+
+    @property
+    def chembl_client(self) -> ChemblClient:
+        if self._closed:
+            raise RuntimeError("ETLContext is closed")
+        if self._chembl_client is None:
+            if self.chembl_client_factory is None:
+                client = self._default_chembl_client_factory()
+            else:
+                client = self.chembl_client_factory(self)
+            close = getattr(client, "close", None)
+            if callable(close):
+                self._register_cleanup(close)
+            self._chembl_client = client
+        return self._chembl_client

--- a/library/pipelines/testitem/cli.py
+++ b/library/pipelines/testitem/cli.py
@@ -35,7 +35,7 @@ from library.common.metadata import (
     write_meta_yaml,
     record_quality_failure,
 )
-from library.common.rate_limiter import get_global_limiter
+from library.orchestration import ETLContext
 from library.common.sidecar import SidecarErrors
 from library.qa.reporting import build_table_quality_hook
 from library.qa.validation import validate_testitems
@@ -547,14 +547,16 @@ def run_testitem_pipeline(
     output_csv = Path(options.output_csv) if options.output_csv is not None else None
     offset = options.offset if options.offset is not None else cfg.testitem.offset
 
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
+    def _client_factory(context: ETLContext) -> ChemblClient:
+        return ChemblClient(
+            api_cfg,
+            cfg.retry,
+            cfg.chembl,
+            global_limiter=context.global_limiter,
+        )
 
-    with ChemblClient(
-        api_cfg, cfg.retry, cfg.chembl, global_limiter=global_limiter
-    ) as client:
+    with ETLContext(cfg, chembl_client_factory=_client_factory) as context:
+        client = context.chembl_client
         read_status, read_result = read_input_ids(
             input_csv,
             column=cfg.testitem.column,

--- a/library/testitem_pipeline/cli.py
+++ b/library/testitem_pipeline/cli.py
@@ -38,7 +38,7 @@ from library.metadata import (
     record_quality_failure,
 )
 from library.pipelines.common import add_pipeline_metadata
-from library.common.rate_limiter import get_global_limiter
+from library.orchestration import ETLContext
 from library import SidecarErrors
 from library.qa.reporting import build_table_quality_hook
 from library.validation import validate_testitems
@@ -640,14 +640,16 @@ def run_testitem_pipeline(
     output_csv = Path(options.output_csv) if options.output_csv is not None else None
     offset = options.offset if options.offset is not None else cfg.testitem.offset
 
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
+    def _client_factory(context: ETLContext) -> ChemblClient:
+        return ChemblClient(
+            api_cfg,
+            cfg.retry,
+            cfg.chembl,
+            global_limiter=context.global_limiter,
+        )
 
-    with ChemblClient(
-        api_cfg, cfg.retry, cfg.chembl, global_limiter=global_limiter
-    ) as client:
+    with ETLContext(cfg, chembl_client_factory=_client_factory) as context:
+        client = context.chembl_client
         read_status, read_result = read_input_ids(
             input_csv,
             column=cfg.testitem.column,

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -31,9 +31,8 @@ import requests
 from library.integration import chembl_library as cl
 from library import cli
 from library import io
-from library.clients import ChemblClient
+from library.orchestration import ETLContext
 from library.common.csv_utils import write_csv_chunks_deterministic  # re-exported for tests
-from library.common.rate_limiter import get_global_limiter
 from library.pipelines.assay.chembl_assay import ACTIVITY_COLUMNS, MAX_ACTIVITY_CHUNK_SIZE
 from library.pipelines.common import (
     ChunkedFetchConfig,
@@ -970,22 +969,13 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         destination=Path(output_path).parent,
     )
 
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
     last_error_extra: dict[str, object] | None = None
     last_error_context: dict[str, object] = {}
 
     pref_name_cache: dict[str, str | None] = {}
 
-    with ChemblClient(
-        cfg.api,
-        cfg.retry,
-        cfg.chembl,
-        global_limiter=global_limiter,
-    ) as client:
+    with ETLContext(cfg) as context:
+        client = context.chembl_client
 
         retry_cfg = cfg.retry
         chunk_failures = ChunkFailureTracker()

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -34,8 +34,7 @@ from library import cli
 from library import io
 from library.common.csv_utils import write_csv_chunks_deterministic
 from library.pipelines.assay.chembl_assay import ASSAY_COLUMNS, MAX_ASSAY_CHUNK_SIZE
-from library.clients import ChemblClient
-from library.common.rate_limiter import get_global_limiter
+from library.orchestration import ETLContext
 from library.cli import (
     LoggerConfig,
     ConfigMetadata,
@@ -290,17 +289,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         destination=output_path.parent,
     )
 
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
-    with ChemblClient(
-        cfg.api,
-        cfg.retry,
-        cfg.chembl,
-        global_limiter=global_limiter,
-    ) as client:
+    with ETLContext(cfg) as context:
+        client = context.chembl_client
 
         retry_cfg = cfg.retry
         chunk_failures = ChunkFailureTracker()

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -45,6 +45,7 @@ from typing import Any, Callable, Iterable, IO, Mapping, Sequence
 
 from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient
+from library.orchestration import ETLContext
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
 from library.config import Config, load_config
 from library.pipelines.activity import (
@@ -966,14 +967,18 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
 
     testitem_cfg = chembl_sources.pipelines.testitem
     _LOGGER.info("parent_catalog_warm_start", **log_kwargs)
-    try:
-        with ChemblClient(
+    def _catalog_client_factory(context: ETLContext) -> ChemblClient:
+        return ChemblClient(
             api=chembl_sources.api,
             retry=config.system.retry,
             chembl=chembl_sources.cache,
-        ) as client:
+            global_limiter=context.global_limiter,
+        )
+
+    try:
+        with ETLContext(config, chembl_client_factory=_catalog_client_factory) as context:
             load_parent_catalog(
-                client=client,
+                client=context.chembl_client,
                 api_cfg=chembl_sources.api,
                 catalog_cfg=catalog_cfg,
                 timeout=testitem_cfg.timeout,

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -56,7 +56,7 @@ from library.integration import chembl_library as cl
 from library.document_defaults import ALL_DEFAULTS, CHEMBL_DEFAULTS, PUBMED_DEFAULTS
 from library.pipelines.document import postprocessing as dp
 from library.postprocessing import document as document_export_postprocessing
-from library.clients import ChemblClient
+from library.orchestration import ETLContext
 from library.cli import (
     LoggerConfig,
     ConfigMetadata,
@@ -96,7 +96,6 @@ from library.reporting.run_manifest import (
 )
 from library.postprocessing.document import preprocess_documents_csv
 from library.pipelines.common import add_pipeline_metadata
-from library.common.rate_limiter import get_global_limiter
 from library.common.sidecar import SidecarErrors
 from library.qa.reporting import build_table_quality_hook
 from library.qa.table_quality import TableQualityProfiler
@@ -1005,14 +1004,8 @@ def run_chembl(
     )
 
     # Configure session for ChEMBL requests
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
-    with ChemblClient(
-        cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-    ) as client:
+    with ETLContext(cfg) as context:
+        client = context.chembl_client
         try:
             ids_iter = io.read_ids(
                 args.input_csv,
@@ -1115,11 +1108,6 @@ def run_all(
         return 1
 
     # Prepare shared session before performing any API calls
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
     try:
         ids_iter = io.read_ids(
             args.input_csv,
@@ -1242,9 +1230,8 @@ def run_all(
         fallback_state.metrics.mark_total_candidates(len(fallback_state.mapping))
 
     try:
-        with ChemblClient(
-            cfg.api, cfg.retry, cfg.chembl, global_limiter=global_limiter
-        ) as client:
+        with ETLContext(cfg) as context:
+            client = context.chembl_client
             doc_df = cl.get_documents(
                 ids_for_fetch,
                 cfg=cfg.api,

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -48,8 +48,7 @@ from library.integration import uniprot_library as uu
 from library.pipelines.target import protein_classification as pc
 from library.pipelines.target import postprocessing as tp
 from library.pipelines.target.defaults import ModeDefaults, TARGET_MODE_DEFAULTS
-from library.clients import ChemblClient
-from library.common.rate_limiter import get_global_limiter
+from library.orchestration import ETLContext
 from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.pipelines.target.chembl_target import normalize_reaction_ec_numbers
 from library.cli import (
@@ -2169,11 +2168,6 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     reindex_raw = not bool(getattr(args, "no_reindex_raw", False))
 
 
-    rate_cfg = cfg.rate
-    global_limiter = None
-    if (rate_cfg.global_rps or 0) > 0:
-        global_limiter = get_global_limiter(rate_cfg.global_rps, rate_cfg.global_burst)
-
     fetched_rows_total = 0
     raw_dump_rows_total = 0
     chembl_http_requests = 0
@@ -2183,12 +2177,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         def _raw_fetcher() -> Iterator[pd.DataFrame]:
             nonlocal fetched_rows_total, raw_dump_rows_total, chembl_http_requests
             try:
-                with ChemblClient(
-                    cfg.api,
-                    cfg.retry,
-                    cfg.chembl,
-                    global_limiter=global_limiter,
-                ) as client:
+                with ETLContext(cfg) as context:
+                    client = context.chembl_client
                     def _count_attempt() -> None:
                         nonlocal chembl_http_requests
                         chembl_http_requests += 1
@@ -2361,12 +2351,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         nonlocal fetched_rows_total, raw_dump_rows_total, chembl_http_requests
 
         try:
-            with ChemblClient(
-                cfg.api,
-                cfg.retry,
-                cfg.chembl,
-                global_limiter=global_limiter,
-            ) as client:
+            with ETLContext(cfg) as context:
+                client = context.chembl_client
                 def _count_attempt() -> None:
                     nonlocal chembl_http_requests
                     chembl_http_requests += 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import yaml
 
 from config.paths import DICTIONARY_DIR
 from library.config import Config
+from library.orchestration import ETLContext
 from library.resources import dictionaries as dictionary_resources
 
 
@@ -157,6 +158,31 @@ def cfg() -> Config:
     config.api.user_agent = "test@example.org"
     config.sources.pubchem.user_agent = "pubchem-contact@example.org"
     return config
+
+
+@pytest.fixture()
+def stub_etl_context(cfg: Config):
+    """Return an :class:`ETLContext` wired with stubbed Chembl clients."""
+
+    class _StubClient:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    created_clients: list[_StubClient] = []
+
+    def _factory(_context: ETLContext) -> _StubClient:
+        client = _StubClient()
+        created_clients.append(client)
+        return client
+
+    context = ETLContext(cfg, chembl_client_factory=_factory)
+    try:
+        yield context, created_clients
+    finally:
+        context.close()
 
 
 @pytest.fixture()

--- a/tests/e2e/test_get_cli_pipelines.py
+++ b/tests/e2e/test_get_cli_pipelines.py
@@ -94,6 +94,9 @@ class _DummyChemblClient:
     def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial helper
         return False
 
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        return None
+
 
 @pytest.fixture()
 def activity_resource_dir(snapshot_resource: Path) -> Path:
@@ -329,7 +332,10 @@ def test_get_activity_cli__retry_and_idempotent(
         mask = chunk_df["activity_id"].astype(str).isin(identifiers)
         return chunk_df.loc[mask].reset_index(drop=True)
 
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
     monkeypatch.setattr(get_activity_data, "sleep", lambda *_args, **_kwargs: None)
 
@@ -434,7 +440,10 @@ def test_get_activity_cli__timeout_split_recovers(
         return pd.DataFrame([row])
 
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data, "sleep", lambda *_args, **_kwargs: None)
 
     written = _install_activity_writer(monkeypatch)
@@ -508,7 +517,10 @@ def test_get_activity_cli__workers_and_offset(
 
         return _fetcher, _writer
 
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
     monkeypatch.setattr(
         get_activity_data,
@@ -588,7 +600,10 @@ def test_get_activity_cli__chembl_identifier_backfill_ratio(
 
     output_csv = tmp_path / "out" / "activities.csv"
 
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
 
     written = _install_activity_writer(monkeypatch)
@@ -649,7 +664,10 @@ def test_get_activity_cli__non_csv_output_path(
         mask = chunk_df["activity_id"].astype(str).isin(identifiers)
         return chunk_df.loc[mask].reset_index(drop=True)
 
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fake_get_activities)
 
     written = _install_activity_writer(monkeypatch)
@@ -1243,7 +1261,10 @@ def test_get_activity_run_retry_and_idempotent(
         return frame.copy()
 
     monkeypatch.setattr(get_activity_data.cl, "get_activities", _fetch_with_retry)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
 
     written: list[Path] = []
 
@@ -1348,7 +1369,10 @@ def test_get_activity_run_workers_offset_and_non_csv(
         return _fetcher, _writer
 
     monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", _prepare_stub)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
 
     args = argparse.Namespace(
         input_csv=input_csv,

--- a/tests/integration/test_assay_cli_quality.py
+++ b/tests/integration/test_assay_cli_quality.py
@@ -111,6 +111,9 @@ def test_get_assay_cli__clamps_batch_size(
         def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401 - context protocol
             return False
 
+        def close(self) -> None:
+            return None
+
         def request_json(
             self,
             url: str,
@@ -184,7 +187,10 @@ def test_get_assay_cli__clamps_batch_size(
         del path, column, cfg
         return iter(identifiers)
 
-    monkeypatch.setattr(get_assay_data, "ChemblClient", _StubChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _StubChemblClient,
+    )
     monkeypatch.setattr(get_assay_data, "ChunkFailureTracker", _StubChunkFailureTracker)
     monkeypatch.setattr(get_assay_data, "prepare_chunked_pipeline", _fake_prepare_chunked_pipeline)
     monkeypatch.setattr(get_assay_data, "run_pipeline", _fake_run_pipeline)

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -31,6 +31,9 @@ class _DummyChemblClient:
     def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial
         return False
 
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        return None
+
 
 class _RecordingLogger:
     """Capture structured events emitted during the pipeline run."""
@@ -111,7 +114,10 @@ def _install_fetch_stubs(
         return testitem_frame.iloc[0:0].copy()
 
     monkeypatch.setattr(get_activity_data.cl, "get_testitem", _fake_get_testitem)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     return _FetchCapture(captured_activities, captured_testitems)
 
 
@@ -500,7 +506,10 @@ def test_activity_pipeline__missing_column_input(activity_resource_dir: Path, cf
     output_csv = tmp_path / "activities.csv"
 
     # Ensure we never reach the fetch stage when validation of inputs fails.
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyChemblClient)
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        _DummyChemblClient,
+    )
     monkeypatch.setattr(get_activity_data.cl, "get_activities", lambda *_, **__: pd.DataFrame())
     monkeypatch.setattr(get_activity_data, "_load_assay_src_lookup", lambda *_: {})
     logger_stub = _RecordingLogger()

--- a/tests/unit/orchestration/test_context.py
+++ b/tests/unit/orchestration/test_context.py
@@ -1,0 +1,33 @@
+"""Tests for :mod:`library.orchestration.context`."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_etl_context_reuses_single_client(stub_etl_context):
+    context, clients = stub_etl_context
+
+    with context as active:
+        first = active.chembl_client
+        second = active.chembl_client
+
+    assert first is second
+    assert clients
+    assert clients[0].close_calls == 1
+
+
+@pytest.mark.unit
+def test_etl_context_recreates_client_after_close(stub_etl_context):
+    context, clients = stub_etl_context
+
+    with context as active:
+        first = active.chembl_client
+
+    with context as active:
+        second = active.chembl_client
+
+    assert first is not second
+    assert len(clients) == 2
+    assert all(client.close_calls == 1 for client in clients)

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -43,6 +43,9 @@ class _DummyClient:
     def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial helper
         return False
 
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        return None
+
 
 class _RecordingLogger:
     """Capture structured log events emitted by :mod:`get_activity_data`."""
@@ -270,7 +273,7 @@ def test_run_chembl__offset_and_workers(monkeypatch, cfg, tmp_path) -> None:
         return _fetcher, _writer
 
     monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+    monkeypatch.setattr("library.orchestration.context.ChemblClient", _DummyClient)
     logger_stub = _RecordingLogger()
     monkeypatch.setattr(get_activity_data, "logger", logger_stub)
 
@@ -296,7 +299,7 @@ def test_run_chembl__read_ids_failures(error_factory, cfg, tmp_path, monkeypatch
         raise error_factory()
 
     monkeypatch.setattr(get_activity_data.io, "read_ids", _raise)
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+    monkeypatch.setattr("library.orchestration.context.ChemblClient", _DummyClient)
     logger_stub = _RecordingLogger()
     monkeypatch.setattr(get_activity_data, "logger", logger_stub)
 
@@ -315,7 +318,7 @@ def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> 
         "read_ids",
         lambda *_args, **_kwargs: iter(["ACT1"]),
     )
-    monkeypatch.setattr(get_activity_data, "ChemblClient", _DummyClient)
+    monkeypatch.setattr("library.orchestration.context.ChemblClient", _DummyClient)
 
     def fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
         def _fetcher() -> Iterable[pd.DataFrame]:

--- a/tests/unit/test_get_assay_data.py
+++ b/tests/unit/test_get_assay_data.py
@@ -123,6 +123,9 @@ def test_run_chembl__successful_execution(
         def __exit__(self, exc_type, exc, tb) -> None:
             return None
 
+        def close(self) -> None:
+            return None
+
     class FakeTracker:
         def __init__(self) -> None:
             self.stats: dict[str, object] = {"failures": 0}
@@ -149,7 +152,10 @@ def test_run_chembl__successful_execution(
         return 0
 
     monkeypatch.setattr(get_assay_data.io, "read_ids", fake_read_ids)
-    monkeypatch.setattr(get_assay_data, "ChemblClient", lambda *args, **kwargs: FakeClient())
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        lambda *args, **kwargs: FakeClient(),
+    )
     monkeypatch.setattr(get_assay_data, "ChunkFailureTracker", lambda: tracker)
     monkeypatch.setattr(get_assay_data.cl, "get_assays", lambda *args, **kwargs: pd.DataFrame({"assay_chembl_id": ["CHEMBL1"]}))
     monkeypatch.setattr(get_assay_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
@@ -184,6 +190,9 @@ def test_run_chembl__splits_chunk_on_timeout(
             return self
 
         def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def close(self) -> None:
             return None
 
     class FakeTracker:
@@ -233,7 +242,10 @@ def test_run_chembl__splits_chunk_on_timeout(
         return 0
 
     monkeypatch.setattr(get_assay_data.io, "read_ids", fake_read_ids)
-    monkeypatch.setattr(get_assay_data, "ChemblClient", lambda *_, **__: FakeClient())
+    monkeypatch.setattr(
+        "library.orchestration.context.ChemblClient",
+        lambda *_, **__: FakeClient(),
+    )
     monkeypatch.setattr(get_assay_data, "ChunkFailureTracker", lambda: tracker)
     monkeypatch.setattr(get_assay_data.cl, "get_assays", fake_get_assays)
     monkeypatch.setattr(get_assay_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)


### PR DESCRIPTION
## Summary
- add a reusable ETLContext helper that centralises Chembl client construction and global rate limiter wiring
- migrate the activity, assay, document, target and test item pipelines to acquire Chembl clients from ETLContext
- extend the test suite with a stub ETLContext fixture, new context unit tests, and updated stubs that close cleanly

## Testing
- pytest tests/unit/orchestration/test_context.py -q *(fails: SyntaxError in existing library/config/loader.py during import)*

------
https://chatgpt.com/codex/tasks/task_e_68e4322b00e483248f9c26787844b42c