### PR TITLE
Add manual cleanup registration to ETLContext

### DIFF
--- a/library/orchestration/context.py
+++ b/library/orchestration/context.py
@@ -53,6 +53,20 @@ class ETLContext:
     def _register_cleanup(self, closer: Callable[[], None]) -> None:
         self._closers.append(closer)
 
+    def register_cleanup(self, closer: Callable[[], None]) -> None:
+        """Register ``closer`` to be executed when the context closes.
+
+        The helper provides a public escape hatch for code that needs to tie
+        additional resources to the lifecycle of the :class:`ETLContext`.
+        Callers must ensure that ``closer`` is idempotent because it may be
+        invoked multiple times when the context is reused across ``with``
+        statements.
+        """
+
+        if self._closed:
+            raise RuntimeError("Cannot register cleanup on closed context")
+        self._register_cleanup(closer)
+
     def close(self) -> None:
         if self._closed:
             return

--- a/tests/unit/orchestration/test_context.py
+++ b/tests/unit/orchestration/test_context.py
@@ -31,3 +31,28 @@ def test_etl_context_recreates_client_after_close(stub_etl_context):
     assert first is not second
     assert len(clients) == 2
     assert all(client.close_calls == 1 for client in clients)
+
+
+@pytest.mark.unit
+def test_etl_context_custom_cleanup(stub_etl_context):
+    context, clients = stub_etl_context
+
+    cleanup_calls: list[str] = []
+
+    with context as active:
+        active.register_cleanup(lambda: cleanup_calls.append("cleanup"))
+        _ = active.chembl_client
+
+    assert cleanup_calls == ["cleanup"]
+    assert clients and clients[0].close_calls == 1
+
+
+@pytest.mark.unit
+def test_etl_context_register_cleanup_after_close(stub_etl_context):
+    context, _ = stub_etl_context
+
+    with context:
+        pass
+
+    with pytest.raises(RuntimeError):
+        context.register_cleanup(lambda: None)


### PR DESCRIPTION
## Summary
- expose a public `ETLContext.register_cleanup` helper for tying extra resource finalizers to the context lifecycle
- guard against registering cleanup callbacks once the context is closed
- extend unit coverage to exercise the new helper and failure path

## Testing
- pytest tests/unit/orchestration/test_context.py *(fails: library/config/loader.py has a syntax error before tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68e43c2e6104832480f3a9854a7a052e