### PR TITLE
Add ETL context limiter test and tidy target imports

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -50,9 +50,6 @@ from library.pipelines.target import postprocessing as tp
 from library.pipelines.target.defaults import ModeDefaults, TARGET_MODE_DEFAULTS
 
 from library.orchestration import ETLContext
-
-from library.clients import ChemblClient
-from library.common.rate_limiter import get_global_limiter
 from library.cli.pipeline_definition import normalise_definition
 from library.cli_utils import PipelineError, run_cli_command, run_pipeline
 from library.pipelines.target.chembl_target import normalize_reaction_ec_numbers

--- a/tests/unit/orchestration/test_context.py
+++ b/tests/unit/orchestration/test_context.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from library.orchestration import ETLContext
+
 
 @pytest.mark.unit
 def test_etl_context_reuses_single_client(stub_etl_context):
@@ -31,3 +33,19 @@ def test_etl_context_recreates_client_after_close(stub_etl_context):
     assert first is not second
     assert len(clients) == 2
     assert all(client.close_calls == 1 for client in clients)
+
+
+@pytest.mark.unit
+def test_etl_context_global_limiter(cfg):
+    cfg.rate.global_rps = 5
+    cfg.rate.global_burst = 7
+
+    with ETLContext(cfg) as context:
+        limiter = context.global_limiter
+        assert limiter is not None
+        assert limiter.rps == cfg.rate.global_rps
+        assert limiter.burst == cfg.rate.global_burst
+        assert context.global_limiter is limiter
+
+    with ETLContext(cfg) as reopened:
+        assert reopened.global_limiter is limiter


### PR DESCRIPTION
## Summary
- add coverage to ensure `ETLContext` exposes and reuses the configured global rate limiter
- remove obsolete Chembl client imports from the target CLI after adopting `ETLContext`

## Testing
- pytest tests/unit/orchestration/test_context.py


------
https://chatgpt.com/codex/tasks/task_e_68e43cb3fe9c83248b215c156ee8a8aa