### PR TITLE
Ignore bytecode files in dictionary resource hashing

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -28,6 +28,9 @@ _IGNORED_FILENAMES = {
     ".DS_Store",
 }
 
+_IGNORED_DIRNAMES = {"__pycache__"}
+_IGNORED_SUFFIXES = {".pyc", ".pyo"}
+
 
 class DictionaryManifestError(RuntimeError):
     """Raised when the dictionary manifest cannot be parsed or validated."""
@@ -71,6 +74,10 @@ def _compute_sha256(path: Path) -> str:
             if child.is_dir():
                 continue
             if child.name == _MANIFEST_FILENAME and child.parent == path:
+                continue
+            if any(part in _IGNORED_DIRNAMES for part in child.relative_to(path).parts):
+                continue
+            if child.suffix in _IGNORED_SUFFIXES:
                 continue
             if child.name in _IGNORED_FILENAMES or child.name.startswith("._"):
                 continue

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -39,3 +39,24 @@ def test_compute_sha256__ignores_crlf_in_directories(tmp_path: Path) -> None:
     (crlf_dir / "nested" / "more.csv").write_bytes("x\r\ny\r\n".encode("utf-8"))
 
     assert dictionaries._compute_sha256(lf_dir) == dictionaries._compute_sha256(crlf_dir)
+
+
+@pytest.mark.unit
+def test_compute_sha256__ignores_bytecode_artifacts(tmp_path: Path) -> None:
+    """Ensure cached Python bytecode files do not affect resource checksums."""
+
+    root = tmp_path / "dictionary"
+    root.mkdir()
+
+    data_file = root / "data.csv"
+    data_file.write_text("id\n1\n", encoding="utf-8")
+
+    expected = dictionaries._compute_sha256(root)
+
+    pycache = root / "__pycache__"
+    pycache.mkdir()
+    (pycache / "module.cpython-313.pyc").write_bytes(b"\x00\x01")
+    (pycache / "module.pyo").write_bytes(b"\x02\x03")
+    (root / "standalone.pyc").write_bytes(b"\x04\x05")
+
+    assert dictionaries._compute_sha256(root) == expected


### PR DESCRIPTION
## Summary
- ignore Python bytecode artifacts when computing dictionary resource checksums so transient files do not break manifest validation
- extend dictionary resource checksum tests to cover cached bytecode while keeping newline stability checks

## Testing
- pytest tests/unit/test_dictionary_resources.py


------
https://chatgpt.com/codex/tasks/task_e_68e43dbd24a4832489b93a7bc7c129c8