### PR TITLE
Fix config loader env imports to avoid Windows SyntaxError

### DIFF
--- a/library/config/loader.py
+++ b/library/config/loader.py
@@ -15,13 +15,11 @@ from ..common.log import logger
 from config.paths import CONFIG_DIR as _CONFIG_DIR
 from config.paths import DEFAULT_CONFIG_PATH as _DEFAULT_CONFIG_PATH
 from .runtime import configure_rate_limiters
-from .env import (
-    _apply_env_overrides,
-    _expand_config_placeholders,
-    _normalize_env_errors,
-    _resolve_placeholder_base_path,
-    _set_by_path,
-)
+from .env import _apply_env_overrides
+from .env import _expand_config_placeholders
+from .env import _normalize_env_errors
+from .env import _resolve_placeholder_base_path
+from .env import _set_by_path
 from .models import Config, ConfigError, ConfigMetadata, ConfigSource, _CONFIG_PATH_FIELDS
 
 __all__ = [


### PR DESCRIPTION
## Summary
- split the config loader environment helper imports into discrete statements to avoid parser issues on certain environments

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'library.utils.config')*

------
https://chatgpt.com/codex/tasks/task_e_68e43d771da88324a8a5ba0b4e9f1a78