### PR TITLE
Fix dictionary checksum mismatch on Windows

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -67,7 +67,8 @@ def _compute_sha256(path: Path) -> str:
 
     hasher = hashlib.sha256()
     if path.is_dir():
-        for child in sorted(path.rglob("*")):
+        entries: list[tuple[str, Path]] = []
+        for child in path.rglob("*"):
             if child.is_dir():
                 continue
             if child.name == _MANIFEST_FILENAME and child.parent == path:
@@ -75,6 +76,9 @@ def _compute_sha256(path: Path) -> str:
             if child.name in _IGNORED_FILENAMES or child.name.startswith("._"):
                 continue
             relative = child.relative_to(path).as_posix()
+            entries.append((relative, child))
+
+        for relative, child in sorted(entries, key=lambda item: item[0]):
             hasher.update(relative.encode("utf-8"))
             data = _normalise_text_newlines(child.read_bytes())
             hasher.update(data)

--- a/tests/unit/test_dictionaries.py
+++ b/tests/unit/test_dictionaries.py
@@ -30,3 +30,18 @@ def test_compute_sha256__stable_across_path_separators(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "relative_to", _relative_to_windows)
 
     assert dictionaries._compute_sha256(base) == expected
+
+
+@pytest.mark.unit
+def test_compute_sha256__independent_of_rglob_order(tmp_path, monkeypatch):
+    base = _create_sample_dictionary(tmp_path)
+    expected = dictionaries._compute_sha256(base)
+
+    original_rglob = Path.rglob
+
+    def _reversed_rglob(self: Path, pattern: str):  # pragma: no cover - behaviour asserted below
+        return iter(list(original_rglob(self, pattern))[::-1])
+
+    monkeypatch.setattr(Path, "rglob", _reversed_rglob)
+
+    assert dictionaries._compute_sha256(base) == expected


### PR DESCRIPTION
## Summary
- ensure dictionary checksum calculation sorts manifest entries by their relative paths for cross-platform stability
- add a regression test confirming the hash is independent from the filesystem traversal order

## Testing
- pytest tests/unit/test_dictionaries.py


------
https://chatgpt.com/codex/tasks/task_e_68e43f12038083249b253898669ed027