### PR TITLE
Fix incorrect config imports for CLI utilities

### DIFF
--- a/library/cli/utils.py
+++ b/library/cli/utils.py
@@ -38,7 +38,6 @@ from ..common.sidecar import SidecarErrors
 from ..config import Config, ConfigError, ensure_dirs, print_config
 from ..config.loader import DEFAULT_CONFIG_PATH
 from ..reporting.run_manifest import finalise_csv_output
-from ..utils.config import DEFAULT_CONFIG_PATH
 from .pipeline_definition import (
     Fetcher,
     MetadataHook,

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -82,8 +82,6 @@ from library.pipelines.testitem import (
 )
 from library.config.loader import DEFAULT_CONFIG_PATH
 
-from library.utils.config import DEFAULT_CONFIG_PATH
-
 
 _LOGGER: Logger = configure_logger(LoggerConfig())
 


### PR DESCRIPTION
## Summary
- remove stale DEFAULT_CONFIG_PATH imports from the deprecated library.utils.config module
- rely on the canonical library.config.loader.DEFAULT_CONFIG_PATH in CLI helpers and the aggregator script

## Testing
- pytest -q *(fails: test_activity_logging__relative_env_base_anchored_to_repo_root currently red in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e4415215e88324ae3505a56440087c