### PR TITLE
Allow overriding dictionary checksum validation

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import logging
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -21,6 +23,8 @@ __all__ = [
     "resolve_resource_reference",
 ]
 
+_LOGGER = logging.getLogger(__name__)
+
 _MANIFEST_FILENAME = "manifest.yaml"
 _IGNORED_FILENAMES = {
     "Thumbs.db",
@@ -30,6 +34,8 @@ _IGNORED_FILENAMES = {
 
 _IGNORED_DIRNAMES = {"__pycache__"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
+
+_CHECKSUM_OVERRIDE_ENV = "CHEMBL_DICTIONARY_ALLOW_MISMATCH"
 
 
 class DictionaryManifestError(RuntimeError):
@@ -46,6 +52,12 @@ class DictionaryResource:
     version: str
     sha256: str
     generator: Path
+
+def _allow_checksum_override() -> bool:
+    """Return ``True`` when checksum validation is explicitly disabled."""
+
+    value = os.getenv(_CHECKSUM_OVERRIDE_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _normalise_text_newlines(data: bytes) -> bytes:
@@ -143,10 +155,21 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
 
         sha256_actual = _compute_sha256(absolute_path)
         if sha256_actual != sha256_expected:
-            raise DictionaryManifestError(
-                "Checksum mismatch for resource"
-                f" {name!r}: expected {sha256_expected}, got {sha256_actual}"
-            )
+            if _allow_checksum_override():
+                _LOGGER.warning(
+                    "dictionary_checksum_mismatch",
+                    extra={
+                        "resource": name,
+                        "expected": sha256_expected,
+                        "actual": sha256_actual,
+                        "path": str(absolute_path),
+                    },
+                )
+            else:
+                raise DictionaryManifestError(
+                    "Checksum mismatch for resource"
+                    f" {name!r}: expected {sha256_expected}, got {sha256_actual}"
+                )
 
         parsed[name] = DictionaryResource(
             name=name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ if str(ROOT) not in sys.path:
 import numpy as np
 import pandas as pd
 import pytest
-import yaml
 
 from config.paths import DICTIONARY_DIR
 from library.config import Config
@@ -85,54 +84,13 @@ def deterministic_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 def relax_dictionary_manifest_checks() -> None:
     """Allow dictionary metadata lookup even when bundled samples diverge."""
 
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("CHEMBL_DICTIONARY_ALLOW_MISMATCH", "1")
     try:
-        dictionary_resources.list_resources()
-    except dictionary_resources.DictionaryManifestError:
-        manifest_path = DICTIONARY_DIR / "manifest.yaml"
-        try:
-            manifest_data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
-        except OSError:
-            yield
-            return
-
-        resources = manifest_data.get("resources")
-        if not isinstance(resources, dict):
-            yield
-            return
-
-        original_get_resource = dictionary_resources.get_resource
-
-        def _safe_get_resource(name: str, *, base_dir: Path | None = None):
-            try:
-                return original_get_resource(name, base_dir=base_dir)
-            except dictionary_resources.DictionaryManifestError:
-                entry = resources.get(name)
-                if not isinstance(entry, dict):
-                    raise
-                path_value = entry.get("path")
-                version = entry.get("version")
-                sha256 = entry.get("sha256")
-                generator = entry.get("generator", "")
-                if not isinstance(path_value, str) or not isinstance(version, str) or not isinstance(sha256, str):
-                    raise
-                root = Path(base_dir) if base_dir is not None else DICTIONARY_DIR
-                resolved_path = (root / path_value).resolve()
-                return dictionary_resources.DictionaryResource(
-                    name=name,
-                    relative_path=Path(path_value),
-                    path=resolved_path,
-                    version=version,
-                    sha256=sha256,
-                    generator=Path(generator),
-                )
-
-        dictionary_resources.get_resource = _safe_get_resource
-        try:
-            yield
-        finally:
-            dictionary_resources.get_resource = original_get_resource
-    else:
         yield
+    finally:
+        dictionary_resources._load_manifest.cache_clear()
+        monkeypatch.undo()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_dictionaries.py
+++ b/tests/unit/test_dictionaries.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path, PureWindowsPath
 
 import pytest
+import yaml
 
 from library.resources import dictionaries
 
@@ -45,3 +47,54 @@ def test_compute_sha256__independent_of_rglob_order(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "rglob", _reversed_rglob)
 
     assert dictionaries._compute_sha256(base) == expected
+
+
+@pytest.fixture()
+def _temporary_manifest(tmp_path: Path) -> Path:
+    resource_path = tmp_path / "data.csv"
+    resource_path.write_text("value\n", encoding="utf-8")
+    manifest = {
+        "version": 1,
+        "resources": {
+            "example": {
+                "path": "data.csv",
+                "version": "test",
+                "sha256": "deadbeef",
+                "generator": "tests",
+            }
+        },
+    }
+    (tmp_path / "manifest.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    return tmp_path
+
+
+def _clear_manifest_cache() -> None:
+    dictionaries._load_manifest.cache_clear()
+
+
+@pytest.mark.unit
+def test_manifest_checksum_mismatch__raises_without_override(
+    _temporary_manifest: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_manifest_cache()
+    monkeypatch.delenv("CHEMBL_DICTIONARY_ALLOW_MISMATCH", raising=False)
+    with pytest.raises(dictionaries.DictionaryManifestError):
+        dictionaries.get_resource("example", base_dir=_temporary_manifest)
+
+
+@pytest.mark.unit
+def test_manifest_checksum_mismatch__logs_warning_with_override(
+    _temporary_manifest: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _clear_manifest_cache()
+    monkeypatch.setenv("CHEMBL_DICTIONARY_ALLOW_MISMATCH", "1")
+    with caplog.at_level(logging.WARNING):
+        resource = dictionaries.get_resource("example", base_dir=_temporary_manifest)
+    assert resource.name == "example"
+    assert resource.path == (_temporary_manifest / "data.csv").resolve()
+    assert any(
+        record.message == "dictionary_checksum_mismatch" and record.resource == "example"
+        for record in caplog.records
+    )
+    monkeypatch.delenv("CHEMBL_DICTIONARY_ALLOW_MISMATCH", raising=False)
+    _clear_manifest_cache()


### PR DESCRIPTION
## Summary
- add an environment-controlled override to continue when bundled dictionary checksums do not match
- simplify the test harness to rely on the override instead of patching and cover the new behavior with unit tests

## Testing
- pytest tests/unit/test_dictionaries.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e440cab8688324912db597194c30f5