### PR TITLE
Fix dictionary manifest hashing

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -82,6 +82,7 @@ def _compute_sha256(path: Path) -> str:
             path.rglob("*"),
             key=lambda candidate: candidate.relative_to(path).as_posix(),
         )
+        entries: list[tuple[str, Path]] = []
         for child in children:
 
             if child.is_dir():


### PR DESCRIPTION
## Summary
- initialise the list of entries before hashing dictionary resources to ensure deterministic ordering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4421e9a6083248fcad1db38fd5b4b