### PR TITLE
Fix dictionary checksum computation ordering

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -84,6 +84,7 @@ def _compute_sha256(path: Path) -> str:
             path.rglob("*"),
             key=lambda candidate: candidate.relative_to(path).as_posix(),
         )
+        entries: list[tuple[str, Path]] = []
         for child in children:
 
             if child.is_dir():
@@ -99,7 +100,7 @@ def _compute_sha256(path: Path) -> str:
             relative = child.relative_to(path).as_posix()
             entries.append((relative, child))
 
-        for relative, child in sorted(entries, key=lambda item: item[0]):
+        for relative, child in entries:
             hasher.update(relative.encode("utf-8"))
             data = _normalise_text_newlines(child.read_bytes())
             hasher.update(data)


### PR DESCRIPTION
## Summary
- initialise the directory entry list before computing dictionary resource checksums
- preserve the sorted traversal order so the manifest checksum matches generated values

## Testing
- pytest tests/unit/test_dictionary_resources.py -k compute --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68e44374fbe48324aaec42e93db82478