### PR TITLE
Fix dictionary checksum hashing order

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -79,6 +79,7 @@ def _compute_sha256(path: Path) -> str:
         # hashes for identical directory contents.  Sorting by the normalised
         # POSIX-style relative path guarantees a deterministic order across all
         # platforms and Python versions.
+        entries: list[tuple[str, Path]] = []
         children = sorted(
             path.rglob("*"),
             key=lambda candidate: candidate.relative_to(path).as_posix(),
@@ -98,7 +99,7 @@ def _compute_sha256(path: Path) -> str:
             relative = child.relative_to(path).as_posix()
             entries.append((relative, child))
 
-        for relative, child in sorted(entries, key=lambda item: item[0]):
+        for relative, child in entries:
             hasher.update(relative.encode("utf-8"))
             data = _normalise_text_newlines(child.read_bytes())
             hasher.update(data)

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.resources import dictionaries
+
+
+@pytest.mark.unit
+def test_compute_sha256__directory_resources(tmp_path: Path) -> None:
+    """Hashing a directory should produce a deterministic SHA256 string."""
+
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "b.txt").write_text("second", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("first", encoding="utf-8")
+
+    digest = dictionaries._compute_sha256(tmp_path)
+
+    assert isinstance(digest, str)
+    assert len(digest) == 64
+    assert all(character in "0123456789abcdef" for character in digest)


### PR DESCRIPTION
## Summary
- initialise directory entry collection when computing dictionary checksums
- avoid redundant resorting when hashing to preserve deterministic ordering
- add a unit test covering directory hashing behaviour for dictionary resources

## Testing
- pytest tests/unit/test_resources_dictionaries.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e442db9f04832492c06eb39591dc73