### PR TITLE
Add compatibility shim for legacy config utilities

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -84,6 +84,7 @@ def _compute_sha256(path: Path) -> str:
             path.rglob("*"),
             key=lambda candidate: candidate.relative_to(path).as_posix(),
         )
+        entries: list[tuple[str, Path]] = []
         for child in children:
 
             if child.is_dir():

--- a/library/utils/__init__.py
+++ b/library/utils/__init__.py
@@ -2,6 +2,22 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 from . import atomic, bootstrap
 
-__all__ = ["atomic", "bootstrap"]
+__all__ = ["atomic", "bootstrap", "config"]
+
+
+def __getattr__(name: str):
+    """Lazily import heavy utility submodules."""
+
+    if name == "config":
+        module = import_module(f"{__name__}.config")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *__all__})

--- a/library/utils/config.py
+++ b/library/utils/config.py
@@ -1,0 +1,38 @@
+"""Compatibility helpers for legacy configuration imports.
+
+Historically the command line tooling exposed configuration utilities from
+``library.utils.config``.  The configuration package was later reorganised
+under :mod:`library.config`, but some scripts and third-party integrations still
+import the old module path.  This shim re-exports the public API from the new
+location so that existing code continues to work.
+"""
+
+from __future__ import annotations
+
+from ..config import (
+    Config,
+    ConfigError,
+    ConfigLoaderError,
+    ConfigMetadata,
+    ConfigSource,
+    ensure_dirs,
+    load_config,
+    load_yaml_config,
+    print_config,
+    resolve_config_path,
+)
+from ..config.loader import DEFAULT_CONFIG_PATH
+
+__all__ = [
+    "Config",
+    "ConfigError",
+    "ConfigLoaderError",
+    "ConfigMetadata",
+    "ConfigSource",
+    "DEFAULT_CONFIG_PATH",
+    "ensure_dirs",
+    "load_config",
+    "load_yaml_config",
+    "print_config",
+    "resolve_config_path",
+]

--- a/tests/unit/test_utils_config.py
+++ b/tests/unit/test_utils_config.py
@@ -1,0 +1,38 @@
+"""Tests for the legacy ``library.utils.config`` compatibility layer."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+def test_utils_config__reexports():
+    utils_config = importlib.import_module("library.utils.config")
+
+    from library.config import (
+        Config,
+        ConfigError,
+        ConfigLoaderError,
+        ConfigMetadata,
+        ConfigSource,
+        ensure_dirs,
+        load_config,
+        load_yaml_config,
+        print_config,
+        resolve_config_path,
+    )
+    from library.config.loader import DEFAULT_CONFIG_PATH
+
+    assert utils_config.Config is Config
+    assert utils_config.ConfigError is ConfigError
+    assert utils_config.ConfigLoaderError is ConfigLoaderError
+    assert utils_config.ConfigMetadata is ConfigMetadata
+    assert utils_config.ConfigSource is ConfigSource
+    assert utils_config.ensure_dirs is ensure_dirs
+    assert utils_config.load_config is load_config
+    assert utils_config.load_yaml_config is load_yaml_config
+    assert utils_config.print_config is print_config
+    assert utils_config.resolve_config_path is resolve_config_path
+    assert utils_config.DEFAULT_CONFIG_PATH == DEFAULT_CONFIG_PATH


### PR DESCRIPTION
## Summary
- add a compatibility module under `library.utils.config` that re-exports the current configuration helpers
- lazily expose the `config` utilities from `library.utils` and repair dictionary hashing bookkeeping
- cover the compatibility shim with a unit test to guard the legacy import path

## Testing
- pytest tests/unit/test_utils_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e443b20ffc832485d7f3cd2c90e71b