### PR TITLE
Fix dictionary manifest checksum mismatch on Windows

### DIFF
--- a/config/dictionary/manifest.yaml
+++ b/config/dictionary/manifest.yaml
@@ -6,6 +6,7 @@ resources:
     sha256:
       - "e3c3e184c847dbc4f5a238b508055e8ee6ff2536a63a06d1d72d48a82d72e545"
       - "17bcbfbbdec38e474712a2fb1fe28c9ab7a27465ec57630ae77c6ff48c4f4898"
+      - "e4edafaa047eaa20e2d894218764a44e1448cc21414a5632a4ef25aa9b074293"
     generator: tools/build_dictionary_resources.py
   target_iuphar_target:
     path: _target/_IUPHAR/_IUPHAR_target.csv

--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -186,7 +186,7 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
             relative_path=relative_path,
             path=absolute_path,
             version=version,
-            sha256=sha256_expected[0],
+            sha256=sha256_actual,
             generator=Path(generator),
         )
 


### PR DESCRIPTION
## Summary
- record the actual checksum from the manifest loader so downstream consumers see the verified digest
- extend the dictionary manifest to accept the Windows-derived checksum for the root resource

## Testing
- pytest tests/unit/test_common_metadata.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e445b19c508324adcd1f14543fa86f