### PR TITLE
Fix dictionary newline normalization for cross-platform manifests

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -55,11 +55,19 @@ def _normalise_text_newlines(data: bytes) -> bytes:
 
     if b"\r" not in data or b"\0" in data:
         return data
-    try:
-        text = data.decode("utf-8")
-    except UnicodeDecodeError:
-        return data
-    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+    # ``bytes.replace`` keeps the original encoding intact, which means that
+    # newline normalisation also works for inputs encoded with legacy codepages
+    # (for example cp1252) that cannot be losslessly decoded as UTF-8.  Git on
+    # Windows transparently converts text files to ``\r\n`` line endings during
+    # checkout, so relying on ``bytes.decode("utf-8")`` would raise
+    # ``UnicodeDecodeError`` for those resources and result in platform-specific
+    # hashes.  Operating directly on the byte sequence guarantees consistent
+    # results without mutating the payload beyond newline handling.
+    normalised = data.replace(b"\r\n", b"\n")
+    if b"\r" in normalised:
+        normalised = normalised.replace(b"\r", b"\n")
+    return normalised
 
 
 def _compute_sha256(path: Path) -> str:

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -20,3 +20,25 @@ def test_compute_sha256__directory_resources(tmp_path: Path) -> None:
     assert isinstance(digest, str)
     assert len(digest) == 64
     assert all(character in "0123456789abcdef" for character in digest)
+
+
+@pytest.mark.unit
+def test_normalise_text_newlines__non_utf8_text() -> None:
+    """Non-UTF8 text with CRLF newlines is normalised consistently."""
+
+    payload = b"Line 1\r\nLine 2\x96\r\n"  # ``\x96`` is cp1252 EN DASH.
+
+    result = dictionaries._normalise_text_newlines(payload)
+
+    assert result == b"Line 1\nLine 2\x96\n"
+
+
+@pytest.mark.unit
+def test_normalise_text_newlines__binary_payload_preserved() -> None:
+    """Binary payloads (identified by NUL bytes) remain untouched."""
+
+    payload = b"\x00binary\r\ncontent"
+
+    result = dictionaries._normalise_text_newlines(payload)
+
+    assert result is payload


### PR DESCRIPTION
## Summary
- ensure dictionary manifest hashing normalises CRLF newlines without assuming UTF-8 decoding
- add regression tests covering non-UTF8 payloads and binary resources

## Testing
- pytest tests/unit/test_resources_dictionaries.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4468fcfc083248a9e8cf0f6020630