### PR TITLE
Fix dictionary checksum normalization for legacy encodings

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -58,7 +58,10 @@ def _normalise_text_newlines(data: bytes) -> bytes:
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError:
-        return data
+        # Fall back to a binary-safe replacement so that legacy encodings
+        # (e.g. Latin-1) still produce deterministic hashes on Windows where
+        # ``git`` may transparently convert ``\n`` to ``\r\n`` during checkout.
+        return data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
     return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
 
 

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -60,3 +60,19 @@ def test_compute_sha256__ignores_bytecode_artifacts(tmp_path: Path) -> None:
     (root / "standalone.pyc").write_bytes(b"\x04\x05")
 
     assert dictionaries._compute_sha256(root) == expected
+
+
+@pytest.mark.unit
+def test_compute_sha256__normalises_crlf_in_non_utf8_files(tmp_path: Path) -> None:
+    """CRLF handling must be deterministic for legacy encodings (e.g. Latin-1)."""
+
+    latin1_bytes_lf = b"id;name\n1;\xb1\n"
+    latin1_bytes_crlf = b"id;name\r\n1;\xb1\r\n"
+
+    lf_path = tmp_path / "latin1_lf.csv"
+    lf_path.write_bytes(latin1_bytes_lf)
+
+    crlf_path = tmp_path / "latin1_crlf.csv"
+    crlf_path.write_bytes(latin1_bytes_crlf)
+
+    assert dictionaries._compute_sha256(lf_path) == dictionaries._compute_sha256(crlf_path)


### PR DESCRIPTION
## Summary
- normalise dictionary checksum inputs even when resources use non-UTF8 encodings so cross-platform hashes match
- add a regression test ensuring CRLF newlines in Latin-1 data yield deterministic SHA256 values

## Testing
- pytest tests/unit/test_dictionary_resources.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e447fc77e48324bff6b084c06dac27