### PR TITLE
Document dictionary hash variants

### DIFF
--- a/config/dictionary/manifest.yaml
+++ b/config/dictionary/manifest.yaml
@@ -4,9 +4,13 @@ resources:
     path: .
     version: "2025-10-06"
     sha256:
+      # POSIX checkouts without newline conversion
       - "e3c3e184c847dbc4f5a238b508055e8ee6ff2536a63a06d1d72d48a82d72e545"
+      # Windows checkouts with core.autocrlf conversion prior to normalisation
       - "cc60aa1e2160724c46e701e0bb21a8f2c4176e57b61180f0c9418db878144156"
+      # Legacy archives shipped with the 2024-07 baseline
       - "17bcbfbbdec38e474712a2fb1fe28c9ab7a27465ec57630ae77c6ff48c4f4898"
+      # Windows checkouts where newline normalisation happens post-hash
       - "e4edafaa047eaa20e2d894218764a44e1448cc21414a5632a4ef25aa9b074293"
     generator: tools/build_dictionary_resources.py
   target_iuphar_target:


### PR DESCRIPTION
## Summary
- document the known checksum variants for the bundled dictionary root so Windows checkouts are recognised during validation

## Testing
- python - <<'PY' from library.resources.dictionaries import _compute_sha256 ...

------
https://chatgpt.com/codex/tasks/task_e_68e448cf01d48324b75ca6dfb856b354