### PR TITLE
Fix dictionary checksum handling for OS metadata

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -23,13 +23,14 @@ __all__ = [
 
 _MANIFEST_FILENAME = "manifest.yaml"
 _IGNORED_FILENAMES = {
-    "Thumbs.db",
+    "thumbs.db",
+    "ehthumbs.db",
     "desktop.ini",
-    ".DS_Store",
-    ".Rhistory",
+    ".ds_store",
+    ".rhistory",
 }
 
-_IGNORED_DIRNAMES = {"__pycache__"}
+_IGNORED_DIRNAMES = {"__pycache__", ".ipynb_checkpoints"}
 _IGNORED_SUFFIXES = {".pyc", ".pyo"}
 _SHA256_WILDCARD = "*"
 
@@ -65,6 +66,47 @@ def _normalise_text_newlines(data: bytes) -> bytes:
     return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
 
 
+def _should_ignore_file(candidate: Path, *, root: Path) -> bool:
+    """Return ``True`` when ``candidate`` should be excluded from hashing."""
+
+    if candidate.name.startswith("._"):
+        return True
+
+    if candidate.name.casefold() in _IGNORED_FILENAMES:
+        return True
+
+    if candidate.suffix.casefold() in _IGNORED_SUFFIXES:
+        return True
+
+    relative_parts = candidate.relative_to(root).parts
+    if any(part.casefold() in _IGNORED_DIRNAMES for part in relative_parts):
+        return True
+
+    return False
+
+
+def _iter_resource_entries(path: Path) -> list[tuple[str, Path]]:
+    """Return sorted file entries for hashing a dictionary resource."""
+
+    entries: list[tuple[str, Path]] = []
+    children = sorted(
+        path.rglob("*"),
+        key=lambda candidate: candidate.relative_to(path).as_posix(),
+    )
+
+    for child in children:
+        if child.is_dir():
+            continue
+        if child.name == _MANIFEST_FILENAME and child.parent == path:
+            continue
+        if _should_ignore_file(child, root=path):
+            continue
+        relative = child.relative_to(path).as_posix()
+        entries.append((relative, child))
+
+    return entries
+
+
 def _compute_sha256(path: Path) -> str:
     """Return the SHA256 checksum for ``path``.
 
@@ -83,26 +125,7 @@ def _compute_sha256(path: Path) -> str:
         # hashes for identical directory contents.  Sorting by the normalised
         # POSIX-style relative path guarantees a deterministic order across all
         # platforms and Python versions.
-        entries: list[tuple[str, Path]] = []
-        children = sorted(
-            path.rglob("*"),
-            key=lambda candidate: candidate.relative_to(path).as_posix(),
-        )
-        entries: list[tuple[str, Path]] = []
-        for child in children:
-
-            if child.is_dir():
-                continue
-            if child.name == _MANIFEST_FILENAME and child.parent == path:
-                continue
-            if any(part in _IGNORED_DIRNAMES for part in child.relative_to(path).parts):
-                continue
-            if child.suffix in _IGNORED_SUFFIXES:
-                continue
-            if child.name in _IGNORED_FILENAMES or child.name.startswith("._"):
-                continue
-            relative = child.relative_to(path).as_posix()
-            entries.append((relative, child))
+        entries = _iter_resource_entries(path)
 
         for relative, child in entries:
             hasher.update(relative.encode("utf-8"))

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -63,6 +63,33 @@ def test_compute_sha256__ignores_bytecode_artifacts(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_compute_sha256__ignores_os_metadata_case_insensitively(tmp_path: Path) -> None:
+    """Common OS metadata files must not impact directory checksums."""
+
+    root = tmp_path / "dictionary"
+    root.mkdir()
+    (root / "data.csv").write_text("id\n1\n", encoding="utf-8")
+
+    expected = dictionaries._compute_sha256(root)
+
+    metadata_files = [
+        "Thumbs.db",
+        "thumbs.db",
+        "DESKTOP.INI",
+        "EhThumbs.DB",
+    ]
+    for name in metadata_files:
+        (root / name).write_bytes(b"\x00\x01")
+
+    (root / "MODULE.PYC").write_bytes(b"\x02\x03")
+    pycache = root / "SubDir" / "__PyCache__"
+    pycache.mkdir(parents=True)
+    (pycache / "ignored.pyc").write_bytes(b"\x04\x05")
+
+    assert dictionaries._compute_sha256(root) == expected
+
+
+@pytest.mark.unit
 def test_compute_sha256__normalises_crlf_in_non_utf8_files(tmp_path: Path) -> None:
     """CRLF handling must be deterministic for legacy encodings (e.g. Latin-1)."""
 


### PR DESCRIPTION
## Summary
- ignore common OS metadata and notebook cache files when hashing dictionary resources to keep checksums stable on Windows and macOS
- refactor directory hashing helper logic and add regression coverage for case-insensitive metadata names

## Testing
- pytest tests/unit/test_dictionary_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68e44a2333908324ae262ea37fbb1807