### PR TITLE
Allow overriding dictionary checksums via env allowlist

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -45,6 +47,58 @@ _KNOWN_CHECKSUM_VARIANTS: Mapping[str, tuple[str, ...]] = {
         "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a",
     ),
 }
+
+_ENV_CHECKSUM_ALLOWLIST = "CHEMBL_DICTIONARY_CHECKSUM_ALLOWLIST"
+
+
+@lru_cache(maxsize=1)
+def _env_checksum_allowlist() -> Mapping[str, tuple[str, ...]]:
+    """Return checksum overrides provided through an environment variable."""
+
+    raw = os.environ.get(_ENV_CHECKSUM_ALLOWLIST)
+    if not raw:
+        return {}
+
+    result: dict[str, tuple[str, ...]] = {}
+    for chunk in raw.split(";"):
+        spec = chunk.strip()
+        if not spec:
+            continue
+        if "=" not in spec:
+            warnings.warn(
+                "Ignoring malformed entry in"
+                f" {_ENV_CHECKSUM_ALLOWLIST!r}: {spec!r}",
+                RuntimeWarning,
+            )
+            continue
+        name, checksum_blob = spec.split("=", 1)
+        checksums = tuple(
+            candidate.strip()
+            for candidate in checksum_blob.split(",")
+            if candidate.strip()
+        )
+        if not checksums:
+            warnings.warn(
+                "Ignoring empty checksum list for"
+                f" resource {name!r} declared in {_ENV_CHECKSUM_ALLOWLIST!r}",
+                RuntimeWarning,
+            )
+            continue
+        key = name.strip()
+        existing = result.get(key, ())
+        result[key] = existing + checksums
+    return result
+
+
+def _iter_additional_checksums(name: str) -> tuple[str, ...]:
+    """Return allowed checksum variants for ``name`` beyond the manifest."""
+
+    variants = list(_KNOWN_CHECKSUM_VARIANTS.get(name, ()))
+    env_variants = _env_checksum_allowlist().get(name, ())
+    for candidate in env_variants:
+        if candidate not in variants:
+            variants.append(candidate)
+    return tuple(variants)
 
 
 class DictionaryManifestError(RuntimeError):
@@ -203,7 +257,7 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
             raise DictionaryManifestError(
                 f"Resource {name!r} is missing a string or list 'sha256'"
             )
-        for candidate in _KNOWN_CHECKSUM_VARIANTS.get(name, ()):  # pragma: no branch
+        for candidate in _iter_additional_checksums(name):  # pragma: no branch
             if candidate not in sha256_expected_list:
                 sha256_expected_list.append(candidate)
         sha256_expected = tuple(sha256_expected_list)

--- a/tests/unit/test_dictionaries.py
+++ b/tests/unit/test_dictionaries.py
@@ -1,7 +1,8 @@
-"""Tests for dictionary resource utilities."""
+"""Tests for dictionary manifest validation utilities."""
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path, PureWindowsPath
 
 import pytest
@@ -45,3 +46,79 @@ def test_compute_sha256__independent_of_rglob_order(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "rglob", _reversed_rglob)
 
     assert dictionaries._compute_sha256(base) == expected
+
+
+def _write_manifest(tmp_path, body: str) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_parse_manifest__accepts_known_checksum_variants(tmp_path, monkeypatch):
+    # Arrange
+    _write_manifest(
+        tmp_path,
+        """
+        version: 1
+        resources:
+          dictionary_root:
+            path: .
+            version: "test"
+            sha256:
+              - "deadbeef"
+            generator: tools/build_dictionary_resources.py
+        """,
+    )
+    (tmp_path / "placeholder.txt").write_text("data", encoding="utf-8")
+    monkeypatch.setattr(
+        dictionaries,
+        "_compute_sha256",
+        lambda path: "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a",
+    )
+
+    # Act
+    dictionaries._env_checksum_allowlist.cache_clear()
+    resources = dictionaries._parse_manifest(base_dir=tmp_path)
+
+    # Assert
+    try:
+        assert (
+            resources["dictionary_root"].sha256
+            == "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"
+        )
+    finally:
+        dictionaries._env_checksum_allowlist.cache_clear()
+
+
+@pytest.mark.unit
+def test_parse_manifest__env_allowlist_accepts_unknown_checksum(tmp_path, monkeypatch):
+    # Arrange
+    resource_name = "custom_resource"
+    _write_manifest(
+        tmp_path,
+        f"""
+        version: 1
+        resources:
+          {resource_name}:
+            path: .
+            version: "test"
+            sha256: "baseline"
+            generator: generator.py
+        """,
+    )
+    monkeypatch.setattr(dictionaries, "_compute_sha256", lambda path: "override")
+    dictionaries._env_checksum_allowlist.cache_clear()
+
+    # Act & Assert
+    with pytest.raises(dictionaries.DictionaryManifestError):
+        dictionaries._parse_manifest(base_dir=tmp_path)
+
+    monkeypatch.setenv("CHEMBL_DICTIONARY_CHECKSUM_ALLOWLIST", f"{resource_name}=override")
+    dictionaries._env_checksum_allowlist.cache_clear()
+    resources = dictionaries._parse_manifest(base_dir=tmp_path)
+
+    # Assert
+    try:
+        assert resources[resource_name].sha256 == "override"
+    finally:
+        dictionaries._env_checksum_allowlist.cache_clear()


### PR DESCRIPTION
## Summary
- allow runtime dictionary checksum validation to honour an environment-provided allowlist in addition to baked-in variants
- extend unit coverage to prove both the built-in variant acceptance and the new environment allowlist behaviour

## Testing
- pytest tests/unit/test_dictionaries.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e44e33b35c8324a99d6a9ab31e6f19