### PR TITLE
Support dictionary checksum overrides

### DIFF
--- a/config/dictionary/manifest.variants.yaml
+++ b/config/dictionary/manifest.variants.yaml
@@ -1,0 +1,5 @@
+version: 1
+resources:
+  dictionary_root:
+    sha256:
+      - "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"

--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -22,6 +22,7 @@ __all__ = [
 ]
 
 _MANIFEST_FILENAME = "manifest.yaml"
+_VARIANT_OVERRIDES_FILENAME = "manifest.variants.yaml"
 _IGNORED_FILENAMES = {
     "thumbs.db",
     "ehthumbs.db",
@@ -156,6 +157,67 @@ def _manifest_path(base_dir: Path | None = None) -> Path:
     return (root / _MANIFEST_FILENAME).resolve()
 
 
+def _variant_overrides_path(base_dir: Path | None = None) -> Path:
+    root = DICTIONARY_DIR if base_dir is None else Path(base_dir)
+    return (root / _VARIANT_OVERRIDES_FILENAME).resolve()
+
+
+def _load_variant_overrides(base_dir: Path | None = None) -> Mapping[str, tuple[str, ...]]:
+    """Return checksum overrides declared in ``manifest.variants.yaml``.
+
+    The optional override file mirrors the ``manifest.yaml`` structure but only
+    exposes the ``sha256`` allow-list.  It provides a lightweight mechanism for
+    shipping platform-specific checksum variants without modifying the primary
+    manifest (which would otherwise churn whenever a new Git/Windows
+    combination introduces a different hash).
+    """
+
+    overrides_path = _variant_overrides_path(base_dir)
+    if not overrides_path.exists():
+        return {}
+
+    with overrides_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    resources = data.get("resources")
+    if not isinstance(resources, Mapping):
+        raise DictionaryManifestError(
+            "Variant manifest 'resources' section must be a mapping"
+        )
+
+    parsed: dict[str, tuple[str, ...]] = {}
+    for name, meta in resources.items():
+        if not isinstance(meta, Mapping):
+            raise DictionaryManifestError(
+                f"Invalid variant manifest entry for {name!r}"
+            )
+
+        sha256_value = meta.get("sha256")
+        if isinstance(sha256_value, str):
+            sha256_values = [sha256_value]
+        elif isinstance(sha256_value, (list, tuple)):
+            sha256_values = []
+            for idx, candidate in enumerate(sha256_value):
+                if not isinstance(candidate, str):
+                    raise DictionaryManifestError(
+                        "Variant manifest entry for"
+                        f" {name!r} has a non-string 'sha256' value at index {idx}"
+                    )
+                sha256_values.append(candidate)
+            if not sha256_values:
+                raise DictionaryManifestError(
+                    f"Variant manifest entry for {name!r} declares an empty 'sha256' list"
+                )
+        else:
+            raise DictionaryManifestError(
+                f"Variant manifest entry for {name!r} is missing 'sha256' values"
+            )
+
+        parsed[name] = tuple(sha256_values)
+
+    return parsed
+
+
 def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryResource]:
     manifest_path = _manifest_path(base_dir)
     if not manifest_path.exists():
@@ -169,6 +231,7 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
         raise DictionaryManifestError("Manifest 'resources' section must be a mapping")
 
     manifest_root = manifest_path.parent
+    variant_overrides = _load_variant_overrides(manifest_root)
     parsed: dict[str, DictionaryResource] = {}
     for name, meta in resources.items():
         if not isinstance(meta, Mapping):
@@ -203,6 +266,10 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
             raise DictionaryManifestError(
                 f"Resource {name!r} is missing a string or list 'sha256'"
             )
+        for candidate in variant_overrides.get(name, ()):  # pragma: no branch
+            if candidate not in sha256_expected_list:
+                sha256_expected_list.append(candidate)
+
         for candidate in _KNOWN_CHECKSUM_VARIANTS.get(name, ()):  # pragma: no branch
             if candidate not in sha256_expected_list:
                 sha256_expected_list.append(candidate)

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -113,6 +113,22 @@ def test_manifest_allows_windows_textmode_checksum() -> None:
     manifest_path = Path("config/dictionary/manifest.yaml")
     manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
 
-    sha256_values = manifest["resources"]["dictionary_root"]["sha256"]
+    manifest_sha = manifest["resources"]["dictionary_root"]["sha256"]
+    if isinstance(manifest_sha, str):
+        sha256_values = {manifest_sha}
+    else:
+        sha256_values = set(manifest_sha)
 
-    assert "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a" in sha256_values
+    variants_path = Path("config/dictionary/manifest.variants.yaml")
+    if variants_path.exists():
+        variant_data = yaml.safe_load(variants_path.read_text(encoding="utf-8"))
+        variant_values = variant_data.get("resources", {}).get("dictionary_root", {}).get("sha256", [])
+        if isinstance(variant_values, str):
+            sha256_values.add(variant_values)
+        else:
+            sha256_values.update(variant_values)
+
+    assert (
+        "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"
+        in sha256_values
+    )

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
-
 import pytest
 import yaml
 
@@ -77,6 +75,52 @@ def test_parse_manifest__accepts_known_checksum_variants(tmp_path: Path, monkeyp
     resources = dictionaries._parse_manifest(base_dir=manifest_dir)
 
     assert resources["dictionary_root"].sha256 == "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"
+
+
+@pytest.mark.unit
+def test_parse_manifest__accepts_override_checksums(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Variant manifest allow-lists should extend checksum validation."""
+
+    manifest_dir = tmp_path / "dictionary"
+    manifest_dir.mkdir()
+
+    manifest_payload = {
+        "version": 1,
+        "resources": {
+            "dictionary_root": {
+                "path": ".",
+                "version": "test",
+                "sha256": ["baseline"],
+                "generator": "tests/generator.py",
+            }
+        },
+    }
+    (manifest_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(manifest_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    variant_payload = {
+        "version": 1,
+        "resources": {
+            "dictionary_root": {"sha256": ["override"]},
+        },
+    }
+    (manifest_dir / "manifest.variants.yaml").write_text(
+        yaml.safe_dump(variant_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(dictionaries, "_compute_sha256", lambda path: "override")
+
+    resources = dictionaries._parse_manifest(base_dir=manifest_dir)
+
+    assert resources["dictionary_root"].sha256 == "override"
+
+
+@pytest.mark.unit
 def test_manifest_allows_latest_windows_sha256() -> None:
     """The dictionary manifest accepts the hash produced by new Git versions."""
 


### PR DESCRIPTION
## Summary
- extend the dictionary loader to read checksum allow-lists from an optional `manifest.variants.yaml` alongside the main manifest
- ship a default override for the latest Windows directory hash and cover it with unit tests

## Testing
- pytest tests/unit/test_resources_dictionaries.py tests/unit/test_dictionary_resources.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e44ebd7bec83248cf25b9de6c9ca7d