### PR TITLE
Fix dictionary resource reference handling in config loader

### DIFF
--- a/library/config/loader.py
+++ b/library/config/loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Iterator, Mapping, Sequence
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Mapping as TypingMapping
 
@@ -12,6 +13,7 @@ import yaml
 from pydantic import BaseModel, ValidationError
 
 from ..common.log import logger
+from library.resources.dictionaries import DictionaryManifestError, list_resources
 from config.paths import CONFIG_DIR as _CONFIG_DIR
 from config.paths import DEFAULT_CONFIG_PATH as _DEFAULT_CONFIG_PATH
 from .runtime import configure_rate_limiters
@@ -98,6 +100,10 @@ def _absolutise_path_value(value: Any, base_dir: Path) -> Any:
 
     if value is None:
         return value
+    if isinstance(value, (str, os.PathLike)):
+        candidate = os.fspath(value)
+        if candidate in _dictionary_resource_names():
+            return value
     base_dir = base_dir.resolve()
 
     def _resolve(path: Path) -> Path:
@@ -176,6 +182,17 @@ _OPTIONAL_UNKNOWN_KEYS: frozenset[str] = frozenset(
         "local.io.csv_fallback_separators",
     }
 )
+
+
+@lru_cache(maxsize=1)
+def _dictionary_resource_names() -> frozenset[str]:
+    """Return the set of known dictionary resource identifiers."""
+
+    try:
+        resources = list_resources()
+    except (DictionaryManifestError, FileNotFoundError):
+        return frozenset()
+    return frozenset(resources.keys())
 
 
 def _collect_unknown_keys(

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -5,6 +5,8 @@ import pytest
 import library.config.loader as loader
 from pathlib import Path
 
+from config.paths import DICTIONARY_DIR
+
 from library.config import Config, load_config
 
 
@@ -96,3 +98,31 @@ def test_load_config__metadata_records_cli_override(tmp_path, monkeypatch):
     assert cli_entry == {"value": "DEBUG", "source": "cli", "detail": "--log-level"}
     path_entry = metadata.get("system.log.level")
     assert path_entry["source"] == "cli"
+
+
+@pytest.mark.unit
+def test_load_config__preserves_dictionary_resource_reference(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        """
+        local:
+          resources:
+            dictionary_dir: dictionary_root
+        """.strip()
+    )
+
+    monkeypatch.setattr(loader, "configure_rate_limiters", lambda cfg: None)
+    monkeypatch.setattr(loader, "list_resources", lambda: {"dictionary_root": object()})
+    loader._dictionary_resource_names.cache_clear()
+    monkeypatch.setattr(
+        "library.config.models.resolve_resource_reference",
+        lambda value: DICTIONARY_DIR if value == "dictionary_root" else Path(value),
+    )
+    monkeypatch.setattr(
+        "library.config.models.get_resource_path",
+        lambda name: DICTIONARY_DIR if name == "dictionary_root" else Path(name),
+    )
+
+    cfg = load_config(cfg_path)
+
+    assert cfg.resources.dictionary_dir == DICTIONARY_DIR.resolve()


### PR DESCRIPTION
## Summary
- ensure dictionary resource references are preserved when normalising configuration paths
- add a regression test covering dictionary_root lookups in the config loader

## Testing
- pytest tests/unit/test_config_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68e45139b7908324bbd4f6066b16a43c