### PR TITLE
Allow dictionary checksum overrides via manifest allowlist

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 _MANIFEST_FILENAME = "manifest.yaml"
+_MANIFEST_ALLOWLIST_FILENAME = "manifest.allowlist.yaml"
 _IGNORED_FILENAMES = {
     "thumbs.db",
     "ehthumbs.db",
@@ -90,10 +91,67 @@ def _env_checksum_allowlist() -> Mapping[str, tuple[str, ...]]:
     return result
 
 
-def _iter_additional_checksums(name: str) -> tuple[str, ...]:
+def _load_allowlist(base_dir: Path) -> Mapping[str, tuple[str, ...]]:
+    """Return checksum overrides declared in ``manifest.allowlist.yaml``."""
+
+    return _load_allowlist_cached(str(base_dir.resolve()))
+
+
+@lru_cache(maxsize=None)
+def _load_allowlist_cached(root: str) -> Mapping[str, tuple[str, ...]]:
+    base_dir = Path(root)
+    path = (base_dir / _MANIFEST_ALLOWLIST_FILENAME).resolve()
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+
+    if not isinstance(payload, Mapping):
+        raise DictionaryManifestError(
+            f"Allowlist {path} must contain a mapping of resource names to checksums"
+        )
+
+    result: dict[str, tuple[str, ...]] = {}
+    for resource_name, checksums in payload.items():
+        entries: list[str] = []
+        if isinstance(checksums, str):
+            candidate_values = [checksums]
+        elif isinstance(checksums, (list, tuple)):
+            candidate_values = list(checksums)
+        else:
+            raise DictionaryManifestError(
+                "Allowlist entries must be strings or lists of strings;"
+                f" got {type(checksums)!r} for resource {resource_name!r}"
+            )
+
+        for idx, candidate in enumerate(candidate_values):
+            if not isinstance(candidate, str):
+                raise DictionaryManifestError(
+                    "Allowlist checksums must be strings;"
+                    f" resource {resource_name!r} has non-string entry at index {idx}"
+                )
+            value = candidate.strip()
+            if value and value not in entries:
+                entries.append(value)
+
+        if entries:
+            result[resource_name] = tuple(entries)
+
+    return result
+
+
+def _iter_additional_checksums(
+    name: str, *, base_dir: Path | None = None
+) -> tuple[str, ...]:
     """Return allowed checksum variants for ``name`` beyond the manifest."""
 
     variants = list(_KNOWN_CHECKSUM_VARIANTS.get(name, ()))
+    if base_dir is not None:
+        allowlist_variants = _load_allowlist(base_dir).get(name, ())
+        for candidate in allowlist_variants:
+            if candidate not in variants:
+                variants.append(candidate)
     env_variants = _env_checksum_allowlist().get(name, ())
     for candidate in env_variants:
         if candidate not in variants:
@@ -257,7 +315,7 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
             raise DictionaryManifestError(
                 f"Resource {name!r} is missing a string or list 'sha256'"
             )
-        for candidate in _iter_additional_checksums(name):  # pragma: no branch
+        for candidate in _iter_additional_checksums(name, base_dir=manifest_root):  # pragma: no branch
             if candidate not in sha256_expected_list:
                 sha256_expected_list.append(candidate)
         sha256_expected = tuple(sha256_expected_list)

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -77,6 +77,45 @@ def test_parse_manifest__accepts_known_checksum_variants(tmp_path: Path, monkeyp
     resources = dictionaries._parse_manifest(base_dir=manifest_dir)
 
     assert resources["dictionary_root"].sha256 == "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"
+
+
+@pytest.mark.unit
+def test_parse_manifest__allowlist_file_extends_checksums(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A local allowlist file supplements manifest checksum expectations."""
+
+    manifest_dir = tmp_path / "dictionary"
+    manifest_dir.mkdir()
+    manifest_path = manifest_dir / "manifest.yaml"
+    manifest_payload = {
+        "version": 1,
+        "resources": {
+            "dictionary_root": {
+                "path": ".",
+                "version": "test",
+                "sha256": "legacy",
+                "generator": "tests/generator.py",
+            }
+        },
+    }
+    manifest_path.write_text(yaml.safe_dump(manifest_payload, sort_keys=False), encoding="utf-8")
+
+    allowlist_path = manifest_dir / "manifest.allowlist.yaml"
+    allowlist_payload = {"dictionary_root": ["efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"]}
+    allowlist_path.write_text(
+        yaml.safe_dump(allowlist_payload, sort_keys=False), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        dictionaries,
+        "_compute_sha256",
+        lambda path: "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a",
+    )
+
+    resources = dictionaries._parse_manifest(base_dir=manifest_dir)
+
+    assert resources["dictionary_root"].sha256 == "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a"
 def test_manifest_allows_latest_windows_sha256() -> None:
     """The dictionary manifest accepts the hash produced by new Git versions."""
 


### PR DESCRIPTION
## Summary
- load optional `manifest.allowlist.yaml` files alongside dictionary manifests to extend accepted checksums
- reuse the allowlist when parsing dictionary resources and keep support for environment overrides
- add unit coverage ensuring the new allowlist mechanism is honored

## Testing
- pytest tests/unit/test_resources_dictionaries.py

------
https://chatgpt.com/codex/tasks/task_e_68e4515831308324b529a80002108cdb