### PR TITLE
Retry Chembl API calls with fallback after timeouts

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -372,6 +372,25 @@ class ChemblClient:
                 except requests.RequestException as exc:
                     elapsed = monotonic() - start_time
                     last_exc = exc
+                    if (
+                        not used_fallback
+                        and fallback_url is not None
+                        and fallback_url != request_url
+                        and _should_switch_to_fallback(exc)
+                    ):
+                        used_fallback = True
+                        request_url = fallback_url
+                        logger.debug(
+                            "request_fallback_switch",
+                            extra={
+                                "original_url": url,
+                                "fallback_url": request_url,
+                                "attempt": attempt,
+                                "rps": cfg.rps,
+                                "elapsed": elapsed,
+                            },
+                        )
+                        continue
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",
@@ -523,6 +542,18 @@ def _log_retry_delay(
             "delay": delay,
             "retry_after": header_delay,
         },
+    )
+
+
+def _should_switch_to_fallback(exception: requests.RequestException) -> bool:
+    """Return ``True`` when ``exception`` warrants trying the fallback URL."""
+
+    return isinstance(
+        exception,
+        (
+            requests.Timeout,
+            requests.ConnectionError,
+        ),
     )
 
 

--- a/tests/unit/test_chembl_client.py
+++ b/tests/unit/test_chembl_client.py
@@ -68,6 +68,28 @@ class _StubSession:
         return None
 
 
+class _TimeoutSession:
+    """Raise a timeout on the primary URL before succeeding on fallback."""
+
+    def __init__(self, primary: str, fallback: str, payload: dict[str, object]) -> None:
+        self.primary_url = primary
+        self.fallback_url = fallback
+        self.payload = payload
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: object) -> _StubResponse:
+        del timeout
+        self.calls.append(url)
+        if url == self.primary_url:
+            raise requests.ReadTimeout(f"timeout for {url}")
+        if url == self.fallback_url:
+            return _StubResponse(url, 200, self.payload)
+        raise AssertionError(f"Unexpected URL requested: {url}")
+
+    def close(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
 @pytest.mark.unit
 def test_request_json__falls_back_to_extensionless_endpoint() -> None:
     """The client retries with an extensionless URL when a 404 is returned."""
@@ -88,6 +110,25 @@ def test_request_json__falls_back_to_extensionless_endpoint() -> None:
 
     cached = client.request_json(primary_url, cfg=cfg)
     assert cached == payload
+    assert session.calls == [primary_url, fallback_url]
+
+
+@pytest.mark.unit
+def test_request_json__falls_back_after_timeout() -> None:
+    """Connection timeouts trigger the extensionless fallback."""
+
+    base = "https://example.test/chembl/api/data"
+    query = "format=json&assay_chembl_id__in=CHEMBL1&limit=1"
+    primary_url = f"{base}/assay.json?{query}"
+    fallback_url = f"{base}/assay?{query}"
+    payload = {"assays": [{"assay_chembl_id": "CHEMBL1"}]}
+    session = _TimeoutSession(primary_url, fallback_url, payload)
+    client = ChemblClient(session=session)
+    cfg = ApiCfg(chembl_base=base, timeout_read=5.0)
+
+    result = client.request_json(primary_url, cfg=cfg)
+
+    assert result == payload
     assert session.calls == [primary_url, fallback_url]
 
 


### PR DESCRIPTION
## Summary
- allow the Chembl client to switch to the extensionless endpoint after connection timeouts
- add a helper for identifying fallback-worthy exceptions and extend unit coverage for timeout retries

## Testing
- pytest -q tests/unit/test_chembl_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e454f509bc8324bc0d56578f4d682c