### PR TITLE
Reset Chembl client session after timeouts

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -38,7 +38,11 @@ class ChemblClient:
         Optional ChEMBL-specific configuration controlling cache TTL and size.
     session:
         Optional pre-configured :class:`requests.Session` instance; primarily
-        intended for tests.
+        intended for tests. Mutually exclusive with ``session_factory``.
+    session_factory:
+        Optional callable returning :class:`requests.Session` objects. When provided,
+        a fresh session is created for each thread-local context and can be used to
+        inject specialised behaviour in tests. Mutually exclusive with ``session``.
     global_limiter:
         Optional system-wide :class:`RateLimiter` enforcing ``Config.rate``
         across all HTTP clients.
@@ -63,13 +67,22 @@ class ChemblClient:
         chembl: ChemblCacheCfg | None = None,
         *,
         session: Session | None = None,
+        session_factory: Callable[[], Session] | None = None,
         global_limiter: RateLimiter | None = None,
         jitter: Callable[[float], float] | None = None,
     ) -> None:
         api = api or ApiCfg()
         retry = retry or RetryCfg()
         self._jitter = jitter if jitter is not None else retry.build_jitter()
-        if session is not None:
+        if session is not None and session_factory is not None:
+            raise ValueError("Pass either session or session_factory, not both")
+        if session_factory is not None:
+
+            def _session_from_factory(factory: Callable[[], Session] = session_factory) -> Session:
+                return factory()
+
+            self._session_factory = _session_from_factory
+        elif session is not None:
             def _session_from_argument(provided: Session = session) -> Session:
                 return provided
 
@@ -139,6 +152,20 @@ class ChemblClient:
     def _register_session(self, session: Session) -> None:
         with self._sessions_lock:
             self._sessions.add(session)
+
+    def _invalidate_session(self, session: Session | None) -> None:
+        if session is None:
+            return
+        with self._sessions_lock:
+            if session in self._sessions:
+                self._sessions.remove(session)
+        close = getattr(session, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("session_close_failed", extra={"session": repr(session)})
+        setattr(self._session_local, "session", None)
 
     def _get_session(self) -> Session:
         session_attr = getattr(self._session_local, "session", None)
@@ -372,6 +399,8 @@ class ChemblClient:
                 except requests.RequestException as exc:
                     elapsed = monotonic() - start_time
                     last_exc = exc
+                    if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
+                        self._invalidate_session(session)
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",

--- a/tests/unit/test_chembl_client.py
+++ b/tests/unit/test_chembl_client.py
@@ -92,6 +92,69 @@ def test_request_json__falls_back_to_extensionless_endpoint() -> None:
 
 
 @pytest.mark.unit
+def test_request_json__resets_session_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout should invalidate the current session before retrying."""
+
+    base = "https://example.test/chembl/api/data"
+    url = f"{base}/assay.json?format=json&assay_chembl_id__in=CHEMBL1&limit=1"
+    payload = {"assays": [{"assay_chembl_id": "CHEMBL1"}]}
+
+    class _TimeoutSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, object]] = []
+            self.closed = False
+
+        def get(self, request_url: str, timeout: object) -> _StubResponse:
+            self.calls.append((request_url, timeout))
+            raise requests.ReadTimeout("timeout")
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _SuccessSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, object]] = []
+            self.closed = False
+
+        def get(self, request_url: str, timeout: object) -> _StubResponse:
+            self.calls.append((request_url, timeout))
+            return _StubResponse(request_url, 200, payload)
+
+        def close(self) -> None:
+            self.closed = True
+
+    timeout_session = _TimeoutSession()
+    success_session = _SuccessSession()
+    created: list[object] = []
+
+    def factory() -> object:
+        index = len(created)
+        session = timeout_session if index == 0 else success_session
+        created.append(session)
+        return session
+
+    client = ChemblClient(session_factory=factory)
+    cfg = ApiCfg(chembl_base=base, timeout_read=5.0, retries=1)
+    monkeypatch.setattr("library.clients.chembl.sleep", lambda delay: None)
+
+    result = client.request_json(url, cfg=cfg)
+
+    assert result == payload
+    assert created == [timeout_session, success_session]
+    assert timeout_session.closed is True
+    assert success_session.closed is False
+    assert [call[0] for call in timeout_session.calls] == [url]
+    assert [call[0] for call in success_session.calls] == [url]
+
+    cached = client.request_json(url, cfg=cfg)
+    assert cached == payload
+    assert created == [timeout_session, success_session]
+    assert len(success_session.calls) == 1
+
+
+@pytest.mark.unit
 def test_backoff_delay__deterministic_jitter() -> None:
     api_cfg = ApiCfg(backoff_factor=0.5)
     jitter_one = RetryCfg(jitter_seed=11).build_jitter()


### PR DESCRIPTION
## Summary
- add support for supplying a session factory to `ChemblClient` and invalidate sessions on timeout/connection errors
- cover the timeout handling with a targeted unit test

## Testing
- pytest tests/unit/test_chembl_client.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e45483764c8324970eaa80839d8a79