### PR TITLE
Normalize Chembl client read timeout handling

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -18,6 +18,11 @@ import requests
 from cachetools import TTLCache
 from requests import Session
 
+try:  # pragma: no cover - urllib3 is always available with requests
+    from urllib3.exceptions import ReadTimeoutError as _Urllib3ReadTimeoutError
+except Exception:  # pragma: no cover - defensive fallback
+    _Urllib3ReadTimeoutError = None  # type: ignore[assignment]
+
 from ..config.models import ApiCfg, ChemblCacheCfg, RetryCfg
 from ..config.runtime import session_with_retry
 from ..common.log import logger
@@ -218,7 +223,8 @@ class ChemblClient:
                 },
             )
 
-        last_exc: requests.RequestException | ValueError | None = None
+        last_exc: BaseException | None = None
+        last_exc_cause: BaseException | None = None
         total_attempts = cfg.retries + 1
         fallback_url = _strip_json_suffix(url)
 
@@ -308,6 +314,7 @@ class ChemblClient:
                 except ValueError as exc:
                     elapsed = monotonic() - start_time
                     last_exc = exc
+                    last_exc_cause = None
                     if attempt >= total_attempts:
                         logger.exception(
                             "request_fail",
@@ -328,6 +335,7 @@ class ChemblClient:
                 except requests.HTTPError as exc:
                     elapsed = monotonic() - start_time
                     last_exc = exc
+                    last_exc_cause = None
                     response = exc.response
                     status = getattr(response, "status_code", None)
                     if (
@@ -371,12 +379,14 @@ class ChemblClient:
                     break
                 except requests.RequestException as exc:
                     elapsed = monotonic() - start_time
-                    last_exc = exc
+                    normalized_exc = _normalise_request_exception(exc)
+                    last_exc = normalized_exc
+                    last_exc_cause = exc if normalized_exc is not exc else None
                     if (
                         not used_fallback
                         and fallback_url is not None
                         and fallback_url != request_url
-                        and _should_switch_to_fallback(exc)
+                        and _should_switch_to_fallback(normalized_exc)
                     ):
                         used_fallback = True
                         request_url = fallback_url
@@ -404,12 +414,16 @@ class ChemblClient:
                             },
                         )
                         break
-                    delay = _backoff_delay(attempt, cfg, header_delay=None, jitter=self._jitter)
+                    delay = _backoff_delay(
+                        attempt, cfg, header_delay=None, jitter=self._jitter
+                    )
                     _log_retry_delay(request_url, attempt, None, delay)
                     sleep(delay)
                     break
 
         if last_exc is not None:
+            if last_exc_cause is not None and last_exc is not last_exc_cause:
+                raise last_exc from last_exc_cause
             raise last_exc
         raise RuntimeError(f"Request loop exited unexpectedly for {url}")
 
@@ -555,6 +569,63 @@ def _should_switch_to_fallback(exception: requests.RequestException) -> bool:
             requests.ConnectionError,
         ),
     )
+
+
+def _normalise_request_exception(
+    exc: requests.RequestException,
+) -> requests.RequestException:
+    """Return a timeout-aware variant of ``exc`` when possible."""
+
+    if isinstance(exc, requests.ReadTimeout):
+        return exc
+
+    timeout_error = _find_read_timeout_error(exc)
+    if timeout_error is None:
+        return exc
+
+    message = str(timeout_error) or "Read timed out."
+    return requests.ReadTimeout(
+        message,
+        request=getattr(exc, "request", None),
+        response=getattr(exc, "response", None),
+    )
+
+
+def _find_read_timeout_error(exc: BaseException) -> BaseException | None:
+    """Return the first read-timeout error found in ``exc``'s chain."""
+
+    seen_ids: set[int] = set()
+    current: BaseException | None = exc
+    timeout_types: tuple[type[BaseException], ...]
+    if _Urllib3ReadTimeoutError is None:  # pragma: no cover - defensive
+        timeout_types = (requests.ReadTimeout,)
+    else:
+        timeout_types = (requests.ReadTimeout, _Urllib3ReadTimeoutError)
+
+    while current is not None:
+        current_id = id(current)
+        if current_id in seen_ids:
+            return None
+        seen_ids.add(current_id)
+        if isinstance(current, timeout_types):
+            return current
+        for arg in getattr(current, "args", ()):
+            if isinstance(arg, BaseException) and id(arg) not in seen_ids:
+                nested = _find_read_timeout_error(arg)
+                if nested is not None:
+                    return nested
+        reason = getattr(current, "reason", None)
+        if isinstance(reason, BaseException) and id(reason) not in seen_ids:
+            nested_reason = _find_read_timeout_error(reason)
+            if nested_reason is not None:
+                return nested_reason
+        cause = current.__cause__
+        if isinstance(cause, BaseException):
+            current = cause
+            continue
+        context = current.__context__
+        current = context if isinstance(context, BaseException) else None
+    return None
 
 
 __all__ = ["ChemblClient", "_chunked"]

--- a/tests/unit/test_chembl_client.py
+++ b/tests/unit/test_chembl_client.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import pytest
 import requests
+from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 
 from library.clients import ChemblClient
 from library.clients.chembl import _backoff_delay
@@ -90,6 +93,26 @@ class _TimeoutSession:
         return None
 
 
+class _MaxRetryTimeoutSession:
+    """Raise a wrapped timeout resembling urllib3's ``MaxRetryError``."""
+
+    def __init__(self, primary: str, fallback: str) -> None:
+        self.primary_url = primary
+        self.fallback_url = fallback
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: object) -> _StubResponse:
+        del timeout
+        self.calls.append(url)
+        host = urlsplit(url).netloc or "example.test"
+        pool = HTTPSConnectionPool(host)
+        reason = ReadTimeoutError(pool, url, "Read timed out.")
+        raise requests.ConnectionError(MaxRetryError(pool, url, reason))
+
+    def close(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
 @pytest.mark.unit
 def test_request_json__falls_back_to_extensionless_endpoint() -> None:
     """The client retries with an extensionless URL when a 404 is returned."""
@@ -129,6 +152,25 @@ def test_request_json__falls_back_after_timeout() -> None:
     result = client.request_json(primary_url, cfg=cfg)
 
     assert result == payload
+    assert session.calls == [primary_url, fallback_url]
+
+
+@pytest.mark.unit
+def test_request_json__raises_read_timeout_for_max_retry_chain() -> None:
+    """Connection errors caused by read timeouts surface as ``ReadTimeout``."""
+
+    base = "https://example.test/chembl/api/data"
+    query = "format=json&assay_chembl_id__in=CHEMBL1&limit=1"
+    primary_url = f"{base}/assay.json?{query}"
+    fallback_url = f"{base}/assay?{query}"
+    session = _MaxRetryTimeoutSession(primary_url, fallback_url)
+    client = ChemblClient(session=session)
+    cfg = ApiCfg(chembl_base=base, timeout_read=5.0, retries=0)
+
+    with pytest.raises(requests.ReadTimeout) as excinfo:
+        client.request_json(primary_url, cfg=cfg)
+
+    assert "Read timed out" in str(excinfo.value)
     assert session.calls == [primary_url, fallback_url]
 
 


### PR DESCRIPTION
## Summary
- unwrap urllib3 retry failures in `ChemblClient.request_json` so read timeouts are raised as `requests.ReadTimeout`
- retain the original exception cause when retries are exhausted for clearer diagnostics
- cover the regression with a unit test that simulates a wrapped timeout response

## Testing
- pytest tests/unit/test_chembl_client.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4566d880483249c908c0f85fc8dd7