### PR TITLE
Fix export column selection for pandas >=2.2

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -310,7 +310,13 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
         if column not in frame.columns:
             frame[column] = ""
 
-    return frame[_EXPORT_COLUMNS]
+    # ``_EXPORT_COLUMNS`` is defined as a tuple for immutability, but pandas expects
+    # a list-like object when selecting multiple columns.  Using a tuple now raises a
+    # ``KeyError`` on recent pandas releases because it is interpreted as a single
+    # column label instead of a sequence of labels.  Convert the tuple to a list to
+    # keep the deterministic ordering while remaining compatible with all pandas
+    # versions.
+    return frame[list(_EXPORT_COLUMNS)]
 
 
 def _iter_export_chunks(


### PR DESCRIPTION
## Summary
- ensure the document export frame selects columns using a list to avoid pandas treating the tuple of column names as a single label
- document the pandas compatibility reason while preserving deterministic column ordering

## Testing
- pytest tests/unit/test_document_schema_declaration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4589ff0588324a54e820886a05fa6