### PR TITLE
Fix assay source lookup encoding handling

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -74,6 +74,7 @@ from library.processing.activity import (
     compute_activity_bounds,
 )
 from library.postprocessing.activity_extended import process_activity_extended
+from library.postprocessing import helpers as postprocessing_helpers
 from library.qa.reporting import build_table_quality_hook
 from library.validation import validate_activities
 from library.schemas import ActivitiesSchema, configure_activity_schema, normalize_activities
@@ -403,11 +404,7 @@ def _load_assay_src_lookup(dictionary_dir: Path | str | None) -> dict[str, str]:
 
     candidate = Path(dictionary_dir) / "_assay" / "assay.csv"
     try:
-        frame = pd.read_csv(
-            candidate,
-            usecols=["assay_chembl_id", "src_assay_id"],
-            dtype="string",
-        )
+        frame = postprocessing_helpers.read_csv_with_fallbacks(candidate)
     except FileNotFoundError:
         logger.warning(
             f"Assay lookup file '{candidate}' was not found; src_assay_id enrichment will be skipped."
@@ -428,6 +425,18 @@ def _load_assay_src_lookup(dictionary_dir: Path | str | None) -> dict[str, str]:
             f"Reading assay lookup file '{candidate}' failed due to an OS error: {exc}"
         )
         return {}
+
+    required_columns = {"assay_chembl_id", "src_assay_id"}
+    missing_columns = required_columns.difference(frame.columns)
+    if missing_columns:
+        logger.warning(
+            "Assay lookup file '%s' is missing required columns: %s; src_assay_id enrichment will be skipped.",
+            candidate,
+            ", ".join(sorted(missing_columns)),
+        )
+        return {}
+
+    frame = frame.loc[:, ["assay_chembl_id", "src_assay_id"]]
 
     if frame.empty:
         return {}

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -16,6 +16,7 @@ import yaml
 
 from dataclasses import dataclass
 
+from config.paths import DICTIONARY_DIR
 from scripts import get_activity_data
 from library.resources.dictionaries import get_resource
 
@@ -694,3 +695,13 @@ def test_activity_pipeline__fills_compound_name_from_pref_name(cfg, tmp_path, mo
     fill_mask = compound_series.notna() & compound_series.str.strip().ne("")
     fill_rate = fill_mask.sum() / len(compound_series)
     assert fill_rate >= 0.95
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("deterministic_env")
+def test_load_assay_src_lookup__real_dictionary_includes_known_assays() -> None:
+    lookup = get_activity_data._load_assay_src_lookup(DICTIONARY_DIR)
+
+    assert lookup.get("CHEMBL1762864") == "357280"
+    assert lookup.get("CHEMBL1762866") == "357284"
+    assert all(str(key).strip() and str(value).strip() for key, value in lookup.items())
+


### PR DESCRIPTION
## Summary
- load the assay source lookup using the shared CSV helper so BOM-prefixed headers are normalised
- add an integration regression test that exercises the real dictionary fixture and checks known src_assay_id values

## Testing
- `pytest tests/integration/test_get_activity_data_pipeline.py::test_load_assay_src_lookup__real_dictionary_includes_known_assays -q`


------
https://chatgpt.com/codex/tasks/task_e_68e459e237048324a6bd48bb9476dfd4