### PR TITLE
Handle Chembl read timeout connection errors

### DIFF
--- a/library/clients/chembl.py
+++ b/library/clients/chembl.py
@@ -580,15 +580,32 @@ def _normalise_request_exception(
         return exc
 
     timeout_error = _find_read_timeout_error(exc)
-    if timeout_error is None:
-        return exc
+    if timeout_error is not None:
+        message = str(timeout_error) or "Read timed out."
+        request = getattr(timeout_error, "request", None)
+        if request is None:
+            request = getattr(exc, "request", None)
+        response = getattr(timeout_error, "response", None)
+        if response is None:
+            response = getattr(exc, "response", None)
+        return requests.ReadTimeout(
+            message,
+            request=request,
+            response=response,
+        )
 
-    message = str(timeout_error) or "Read timed out."
-    return requests.ReadTimeout(
-        message,
-        request=getattr(exc, "request", None),
-        response=getattr(exc, "response", None),
-    )
+    if isinstance(exc, requests.ConnectionError):
+        message = str(exc)
+        lowered = message.lower()
+        if "read" in lowered and ("timeout" in lowered or "timed out" in lowered):
+            normalized_message = message or "Read timed out."
+            return requests.ReadTimeout(
+                normalized_message,
+                request=getattr(exc, "request", None),
+                response=getattr(exc, "response", None),
+            )
+
+    return exc
 
 
 def _find_read_timeout_error(exc: BaseException) -> BaseException | None:

--- a/tests/unit/test_chembl_client.py
+++ b/tests/unit/test_chembl_client.py
@@ -11,7 +11,7 @@ from urllib3.connectionpool import HTTPSConnectionPool
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 
 from library.clients import ChemblClient
-from library.clients.chembl import _backoff_delay
+from library.clients.chembl import _backoff_delay, _normalise_request_exception
 from library.config import ApiCfg, RetryCfg
 
 
@@ -193,3 +193,30 @@ def test_backoff_delay__deterministic_jitter() -> None:
     ]
 
     assert delays_one == delays_two
+
+
+@pytest.mark.unit
+def test_normalise_request_exception__read_timeout_message() -> None:
+    connection_error = requests.ConnectionError(
+        "HTTPSConnectionPool(host='www.ebi.ac.uk', port=443): Read timed out."
+    )
+
+    normalised = _normalise_request_exception(connection_error)
+
+    assert normalised is not connection_error
+    assert isinstance(normalised, requests.ReadTimeout)
+    assert "read" in str(normalised).lower()
+
+
+@pytest.mark.unit
+def test_normalise_request_exception__preserves_request_metadata() -> None:
+    timeout = requests.ReadTimeout("Read timed out.")
+    timeout.request = object()  # type: ignore[attr-defined]
+    timeout.response = object()  # type: ignore[attr-defined]
+    exc = requests.ConnectionError(timeout)
+
+    normalised = _normalise_request_exception(exc)
+
+    assert isinstance(normalised, requests.ReadTimeout)
+    assert normalised.request is timeout.request
+    assert normalised.response is timeout.response


### PR DESCRIPTION
## Summary
- normalize Chembl client connection errors that wrap read timeouts so callers receive `requests.ReadTimeout`
- preserve request/response metadata when promoting wrapped timeout exceptions and cover the cases with unit tests

## Testing
- pytest tests/unit/test_chembl_client.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e45a92282883248d7b1e266173dc89