### PR TITLE
Fix pandas column projection for document export pipeline

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -121,7 +121,13 @@ class _FallbackPathAction(argparse.Action):
         setattr(namespace, "fallback_doi_csv", values)
 
 
-_EXPORT_COLUMNS: tuple[str, ...] = DOCUMENT_EXPORT_COLUMNS
+# ``DOCUMENT_EXPORT_COLUMNS`` is provided as an immutable tuple in the schema
+# declaration to make accidental mutations unlikely.  Pandas, however, expects a
+# list-like object for column projections and interprets tuples as single column
+# keys (raising ``KeyError`` on recent releases).  Store the export projection as
+# a list locally to keep the deterministic ordering while remaining compatible
+# with pandas' expectations.
+_EXPORT_COLUMNS: list[str] = list(DOCUMENT_EXPORT_COLUMNS)
 
 
 def _resolve_numeric_export_columns() -> tuple[str, ...]:

--- a/tests/unit/test_document_schema_declaration.py
+++ b/tests/unit/test_document_schema_declaration.py
@@ -29,7 +29,7 @@ def test_document_schema_groups__pipeline_alignment() -> None:
 
 @pytest.mark.unit
 def test_document_schema_export__shared_constant() -> None:
-    assert get_document_data._EXPORT_COLUMNS == DOCUMENT_EXPORT_COLUMNS
+    assert get_document_data._EXPORT_COLUMNS == list(DOCUMENT_EXPORT_COLUMNS)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- store the document export column projection as a list to keep pandas column selection working on modern releases
- update the schema alignment test to reflect the list-based projection constant

## Testing
- pytest tests/unit/test_document_schema_declaration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e45ae33454832489123ebb9c186d30