### PR TITLE
Fix deterministic document export column projection

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -306,17 +306,13 @@ def _prepare_export_frame(df: pd.DataFrame) -> pd.DataFrame:
     for target, sources in _EXPORT_COALESCE_SOURCES.items():
         frame[target] = _coalesce_columns(frame, sources)
 
-    for column in _EXPORT_COLUMNS:
-        if column not in frame.columns:
-            frame[column] = ""
-
-    # ``_EXPORT_COLUMNS`` is defined as a tuple for immutability, but pandas expects
-    # a list-like object when selecting multiple columns.  Using a tuple now raises a
-    # ``KeyError`` on recent pandas releases because it is interpreted as a single
-    # column label instead of a sequence of labels.  Convert the tuple to a list to
-    # keep the deterministic ordering while remaining compatible with all pandas
-    # versions.
-    return frame[list(_EXPORT_COLUMNS)]
+    # ``DataFrame.reindex`` guarantees that all expected columns exist while keeping the
+    # deterministic ordering defined by ``_EXPORT_COLUMNS``.  Missing columns are filled
+    # with empty strings which mirrors the legacy behaviour of manually initialising
+    # them in a loop.  Returning the reindexed frame avoids the ``KeyError`` raised by
+    # ``frame[_EXPORT_COLUMNS]`` on newer pandas releases where a tuple of column names
+    # is interpreted as a single label rather than a sequence.
+    return frame.reindex(columns=list(_EXPORT_COLUMNS), fill_value="")
 
 
 def _iter_export_chunks(


### PR DESCRIPTION
## Summary
- ensure `_prepare_export_frame` reindexes the export dataframe using the declared column order
- avoid tuple-based column selection that raises a KeyError on newer pandas versions

## Testing
- pytest tests/unit/test_document_schema_declaration.py


------
https://chatgpt.com/codex/tasks/task_e_68e45bee62b48324a180bd7f886683db