### PR TITLE
Add regression test for export column projection

### DIFF
--- a/tests/unit/test_document_export_frame.py
+++ b/tests/unit/test_document_export_frame.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from scripts import get_document_data
+
+
+@pytest.mark.unit
+def test_prepare_export_frame__tuple_export_columns(monkeypatch):
+    original_columns = list(get_document_data._EXPORT_COLUMNS)
+    dataframe = pd.DataFrame({"ChEMBL.doi": ["10.1000/example"]})
+
+    monkeypatch.setattr(
+        get_document_data,
+        "_EXPORT_COLUMNS",
+        tuple(original_columns),
+        raising=False,
+    )
+
+    export_frame = get_document_data._prepare_export_frame(dataframe)
+
+    assert list(export_frame.columns) == original_columns
+    assert export_frame.loc[0, "ChEMBL.doi"] == "10.1000/example"
+    assert export_frame.loc[0, "PubMed.PMID"] == ""


### PR DESCRIPTION
## Summary
- add a unit test covering `_prepare_export_frame` when the export column list is supplied as a tuple to prevent regressions in pandas column selection

## Testing
- pytest tests/unit/test_document_export_frame.py

------
https://chatgpt.com/codex/tasks/task_e_68e45c42fa3c8324a884a2cf5b2c71a8