### PR TITLE
Include exception info in CLI error logs

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -800,7 +800,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         logger.error(
             "read_fail",
             input=str(args.input_csv),
-            error=str(exc),
+            error=str(exc), exc_info=exc,
         )
         logger.error(
             f"Failed to read identifiers from '{args.input_csv}': {exc}"

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -185,7 +185,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
             "read_fail",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(args.input_csv),
         )
         return 1

--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -646,7 +646,7 @@ def _remove_path(path: Path) -> None:
                 "unlink_retry_permission",
                 path=str(path),
                 attempt=attempt,
-                error=str(exc),
+                error=str(exc), exc_info=exc,
             )
             time.sleep(_UNLINK_RETRY_SLEEP_SECONDS)
             continue
@@ -660,7 +660,7 @@ def _remove_path(path: Path) -> None:
                     "unlink_retry_sharing_violation",
                     path=str(path),
                     attempt=attempt,
-                    error=str(exc),
+                    error=str(exc), exc_info=exc,
                 )
                 time.sleep(_UNLINK_RETRY_SLEEP_SECONDS)
                 continue
@@ -998,7 +998,7 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
         _LOGGER.error(
             "parent_catalog_warm_failed",
             elapsed=elapsed,
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             **log_kwargs,
         )
         raise
@@ -1304,7 +1304,7 @@ def run_pipeline(
     try:
         plan = _build_execution_plan(effective_steps)
     except ValueError as exc:
-        _LOGGER.error("pipeline_schedule_error", error=str(exc))
+        _LOGGER.error("pipeline_schedule_error", error=str(exc), exc_info=exc)
         return 1
     effective_steps = plan.steps
     external_requirements = plan.external_artifacts
@@ -1417,7 +1417,7 @@ def run_pipeline(
                             "reason": "parent_catalog_timeout",
                         }
                     )
-                    _LOGGER.error("parent_catalog_warm_timeout", error=str(exc))
+                    _LOGGER.error("parent_catalog_warm_timeout", error=str(exc), exc_info=exc)
                     _complete_manifest_entry(
                         entry,
                         final_output=final_output,
@@ -1442,7 +1442,7 @@ def run_pipeline(
                             "reason": "parent_catalog_error",
                         }
                     )
-                    _LOGGER.error("parent_catalog_warm_error", error=str(exc))
+                    _LOGGER.error("parent_catalog_warm_error", error=str(exc), exc_info=exc)
                     _complete_manifest_entry(
                         entry,
                         final_output=final_output,
@@ -1640,13 +1640,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             steps = _resolve_pipeline_steps(args)
         except (FileNotFoundError, OSError, TypeError, ValueError) as exc:
-            _LOGGER.error("registry_error", error=str(exc))
+            _LOGGER.error("registry_error", error=str(exc), exc_info=exc)
             status = 1
         else:
             try:
                 cfg = _prepare_config(args, steps)
             except (FileNotFoundError, OSError, ValueError) as exc:
-                _LOGGER.error("configuration_error", error=str(exc))
+                _LOGGER.error("configuration_error", error=str(exc), exc_info=exc)
                 status = 1
             else:
                 status = run_pipeline(cfg, steps=steps)

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -536,7 +536,7 @@ def _finalise_export(
                     "document_validation_failed",
                     failure_count=len(exc.failure_cases),
                     failure_path=str(failure_path),
-                    error=str(exc),
+                    error=str(exc), exc_info=exc,
                 )
                 validated = getattr(exc, "validated_data", ordered)
                 exit_code = 1
@@ -594,7 +594,7 @@ def _finalise_export(
             encoding=cfg.io.csv_encoding,
         )
     except OSError as exc:
-        logger.error("csv_write_failed", error=str(exc), path=str(output))
+        logger.error("csv_write_failed", error=str(exc), exc_info=exc, path=str(output))
         return 1
 
     try:
@@ -605,7 +605,7 @@ def _finalise_export(
     except (OSError, ValueError, pd.errors.ParserError) as exc:
         logger.error(
             "document_export_postprocess_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(csv_path),
         )
         exit_code = 1
@@ -669,7 +669,7 @@ def _finalise_export(
         destination = exc.path or csv_path.with_suffix(".quality.json")
         logger.error(
             "quality_report_write_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(destination),
         )
         return 1
@@ -785,7 +785,7 @@ def run_pubmed(
         context = service.build_missing_input_context(Path(args.input_csv))
         logger.error(
             "input_read_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(args.input_csv),
             **context,
         )
@@ -826,7 +826,7 @@ def run_pubmed(
         except (FileNotFoundError, pd.errors.ParserError, UnicodeError, OSError) as exc:
             logger.error(
                 "fallback_doi_read_failed",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 path=str(fallback_path),
                 delimiter=delimiter,
                 encoding=encoding,
@@ -842,7 +842,7 @@ def run_pubmed(
         except ValueError as exc:
             logger.error(
                 "fallback_doi_invalid",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 path=str(fallback_path),
             )
             return 1
@@ -898,7 +898,7 @@ def run_pubmed(
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error(
             "pubmed_pipeline_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             output=str(output_path),
         )
         return 1
@@ -1024,7 +1024,7 @@ def run_chembl(
             context = service.build_missing_input_context(Path(args.input_csv))
             logger.error(
                 "input_read_failed",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 path=str(args.input_csv),
                 **context,
             )
@@ -1052,7 +1052,7 @@ def run_chembl(
         except (requests.RequestException, ValueError) as exc:
             logger.error(
                 "chembl_documents_fetch_failed",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
             )
             return 1
@@ -1126,7 +1126,7 @@ def run_all(
         context = service.build_missing_input_context(Path(args.input_csv))
         logger.error(
             "input_read_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(args.input_csv),
             **context,
         )
@@ -1209,7 +1209,7 @@ def run_all(
         except (FileNotFoundError, pd.errors.ParserError, UnicodeError, OSError) as exc:
             logger.error(
                 "fallback_doi_read_failed",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 path=str(fallback_path),
                 delimiter=delimiter,
                 encoding=encoding,
@@ -1225,7 +1225,7 @@ def run_all(
         except ValueError as exc:
             logger.error(
                 "fallback_doi_invalid",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 path=str(fallback_path),
             )
             return 1
@@ -1255,7 +1255,7 @@ def run_all(
         logger.error(
             "chembl_documents_fetch_failed",
             ids=sample_ids,
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             output=str(output_path),
             chunk_size=getattr(args, "chembl_chunk_size", all_defaults.chunk_size),
         )
@@ -1378,7 +1378,7 @@ def run_all(
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error(
             "pubmed_pipeline_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             output=str(output_path),
         )
         return 1

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -2059,7 +2059,7 @@ def run_uniprot(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error(
             "uniprot_processing_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             input=str(args.input_csv),
             output=str(output_path) if output_path is not None else None,
         )
@@ -2140,7 +2140,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError) as exc:
         logger.error(
             "read_fail",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             path=str(args.input_csv),
         )
         return 1
@@ -2229,7 +2229,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             except (requests.RequestException, ValueError) as exc:
                 logger.error(
                     "chembl_fetch_failed",
-                    error=str(exc),
+                    error=str(exc), exc_info=exc,
                     chunk_size=cfg.target.chembl.chunk_size,
                     timeout=cfg.target.chembl.timeout,
                 )
@@ -2279,7 +2279,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             except OSError as exc:
                 logger.error(
                     "raw_to_final_copy_failed",
-                    error=str(exc),
+                    error=str(exc), exc_info=exc,
                     source=str(raw_destination),
                     destination=str(destination),
                 )
@@ -2401,7 +2401,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                     except OSError as exc:
                         logger.error(
                             "raw_dump_failed",
-                            error=str(exc),
+                            error=str(exc), exc_info=exc,
                             path=str(raw_destination),
                         )
                         raise PipelineError(str(exc)) from exc
@@ -2412,7 +2412,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         except (requests.RequestException, ValueError) as exc:
             logger.error(
                 "chembl_fetch_failed",
-                error=str(exc),
+                error=str(exc), exc_info=exc,
                 chunk_size=cfg.target.chembl.chunk_size,
                 timeout=cfg.target.chembl.timeout,
             )
@@ -2559,7 +2559,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     try:
         raw_dump_writer.finalize()
     except OSError as exc:
-        logger.error("raw_dump_failed", error=str(exc), path=str(raw_destination))
+        logger.error("raw_dump_failed", error=str(exc), exc_info=exc, path=str(raw_destination))
         return 1
 
     if limit is not None:
@@ -2689,7 +2689,7 @@ def run_iuphar(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error(
             "iuphar_processing_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             input=str(source_csv),
             target_csv=str(cfg.target.iuphar.target_csv),
             family_csv=str(cfg.target.iuphar.family_csv),
@@ -3857,7 +3857,7 @@ def run_all(cfg: Config, args: argparse.Namespace) -> int:
     except (FileNotFoundError, ValueError, OSError, RuntimeError) as exc:
         logger.error(
             "pipeline_step_failed",
-            error=str(exc),
+            error=str(exc), exc_info=exc,
             step="all",
             input=str(args.input_csv),
             output=str(final_output),
@@ -4045,7 +4045,7 @@ class TargetPipelineCLI(PipelineCLIBase):
                 )
         except PipelineError as exc:
             exit_code = 2
-            logger.error("pipeline_error", error=str(exc))
+            logger.error("pipeline_error", error=str(exc), exc_info=exc)
             print(f"[ERROR] {exc}", file=console_stream, flush=True)
         return exit_code
 


### PR DESCRIPTION
## Summary
- include `exc_info` on CLI error logs so stack traces are preserved across document, target, activity, assay, and pipeline workflows
- update pipeline orchestration errors to provide exception context when scheduling, configuration, or catalog warming fails

## Testing
- pytest -q tests/e2e/test_cli_logging_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68e45fcba2d88324891ec3e5bdbe31d0