### PR TITLE
Update log formatting to bracketed structure

### DIFF
--- a/library/utils/logger.py
+++ b/library/utils/logger.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable
 __all__ = ["get_logger", "StructuredLogger"]
 
 
-_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s :: %(message)s"
+_LOG_FORMAT = "[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s"
 _LOG_DIR = Path("logs")
 
 

--- a/tests/helpers/logs.py
+++ b/tests/helpers/logs.py
@@ -8,10 +8,10 @@ from typing import Any, Iterable
 
 
 _NEW_PATTERN = re.compile(
-    r"^(?P<timestamp>.+?)\s\[(?P<level>[^\]]+)\]\s(?P<name>[^\s]+)\s::\s(?P<message>.*)$"
+    r"^\[(?P<timestamp>[^\]]+)\]\s\[(?P<level>[^\]]+)\]\s\[(?P<name>[^\]]+)\]\s(?P<message>.*)$"
 )
 _LEGACY_PATTERN = re.compile(
-    r"^\[(?P<timestamp>[^\]]+)\]\s\[(?P<level>[^\]]+)\]\s\[(?P<name>[^\]]+)\]\s(?P<message>.*)$"
+    r"^(?P<timestamp>.+?)\s\[(?P<level>[^\]]+)\]\s(?P<name>[^\s]+)\s::\s(?P<message>.*)$"
 )
 
 
@@ -26,7 +26,7 @@ def _extract_parts(line: str) -> dict[str, str] | None:
 
 
 def parse_log_lines(text: str) -> list[dict[str, Any]]:
-    """Parse log lines formatted as ``[ts] [LEVEL] [name] message``."""
+    """Parse log lines in modern or legacy structured formats."""
 
     entries: list[dict[str, Any]] = []
     for raw_line in text.splitlines():


### PR DESCRIPTION
## Summary
- update the structured logger format to emit bracketed timestamp, level, and logger name fields
- adjust the log parsing helper to recognize both the new bracketed layout and the legacy format

## Testing
- pytest -q tests/unit/test_csv_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e45fd810588324aee458a69b04de5e