### PR TITLE
Fix relative library links in English and Russian docs

### DIFF
--- a/docs/en/CONFIG.md
+++ b/docs/en/CONFIG.md
@@ -2,7 +2,7 @@
 
 The pipelines load configuration from three layers (lowest precedence first):
 
-1. Built-in defaults defined in [`library/config/models.py`](../library/config/models.py).
+1. Built-in defaults defined in [`library/config/models.py`](../../library/config/models.py).
 2. YAML files (`config/config.yaml` plus optional overrides such as
    `config/config.local.yaml`).
 3. Environment variables and CLI arguments.
@@ -308,5 +308,5 @@ Controls post-processing of activity tables.
 | `limit` | `null` | Optional cap on processed rows. |
 
 For further customisation consult the Pydantic models in
-[`library/config/models.py`](../library/config/models.py); the documentation above mirrors the
+[`library/config/models.py`](../../library/config/models.py); the documentation above mirrors the
 available fields and their default values.

--- a/docs/en/OUTPUT.md
+++ b/docs/en/OUTPUT.md
@@ -21,7 +21,7 @@ These artefacts support reproducibility and downstream QA pipelines.
 
 ## Document export (`documents`)
 
-Schema: [`library/schemas/documents.py`](../library/schemas/documents.py).
+Schema: [`library/schemas/documents.py`](../../library/schemas/documents.py).
 
 ### ChEMBL base columns
 
@@ -121,7 +121,7 @@ E-utilities payload and may contain structured lists encoded as strings.
 
 ## Target export (`targets`)
 
-Schema: [`library/schemas/targets.py`](../library/schemas/targets.py). Column
+Schema: [`library/schemas/targets.py`](../../library/schemas/targets.py). Column
 order follows `TARGETS_COLUMN_ORDER`.
 
 ### Core identifiers and naming
@@ -218,7 +218,7 @@ order follows `TARGETS_COLUMN_ORDER`.
 
 ## Assay export (`assays`)
 
-Schema: [`library/schemas/assays.py`](../library/schemas/assays.py).
+Schema: [`library/schemas/assays.py`](../../library/schemas/assays.py).
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -246,7 +246,7 @@ Schema: [`library/schemas/assays.py`](../library/schemas/assays.py).
 
 ## Activity export (`activities`)
 
-Schema: [`library/schemas/activities.py`](../library/schemas/activities.py).
+Schema: [`library/schemas/activities.py`](../../library/schemas/activities.py).
 
 | Column | Type | Validation |
 |--------|------|-----------|
@@ -280,7 +280,7 @@ Schema: [`library/schemas/activities.py`](../library/schemas/activities.py).
 
 ## Test item export (`testitems`)
 
-Schema: [`library/schemas/testitems.py`](../library/schemas/testitems.py).
+Schema: [`library/schemas/testitems.py`](../../library/schemas/testitems.py).
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -306,7 +306,7 @@ Schema: [`library/schemas/testitems.py`](../library/schemas/testitems.py).
 
 ## Tissue export (`tissues`)
 
-Schema: [`library/schemas/tissues.py`](../library/schemas/tissues.py). Column
+Schema: [`library/schemas/tissues.py`](../../library/schemas/tissues.py). Column
 ordering follows `TISSUES_COLUMN_ORDER`.
 
 ### Columns
@@ -338,7 +338,7 @@ ordering follows `TISSUES_COLUMN_ORDER`.
 
 ## Cell line export (`cellline`)
 
-Schema: [`library/schemas/celllines.py`](../library/schemas/celllines.py). The
+Schema: [`library/schemas/celllines.py`](../../library/schemas/celllines.py). The
 columns follow `CELL_LINE_COLUMN_ORDER` and include the pipeline metadata
 (`pipeline_version`, `timestamp_utc`).
 

--- a/docs/en/guides/FAQ.md
+++ b/docs/en/guides/FAQ.md
@@ -8,7 +8,7 @@ corresponding remediation steps. The Russian counterpart lives at
 
 `get_document_data` accepts a `--mode` flag (`chembl`, `pubmed`, `all`) and
 refuses to run without it. The parser eventually calls
-[`prepare_io_paths`](../../library/cli/parser.py) which expects the mode to be set
+[`prepare_io_paths`](../../../library/cli/parser.py) which expects the mode to be set
 when building log messages. Supply `--mode` explicitly or use the positional
 alias (`python scripts/get_document_data.py all ...`).
 

--- a/docs/ru/CONFIG.md
+++ b/docs/ru/CONFIG.md
@@ -2,7 +2,7 @@
 
 Конфигурация загружается из трёх слоёв (по возрастанию приоритета):
 
-1. Значения по умолчанию, определённые в [`library/config/models.py`](../library/config/models.py).
+1. Значения по умолчанию, определённые в [`library/config/models.py`](../../library/config/models.py).
 2. YAML-файлы (`config/config.yaml` и необязательный `config/config.local.yaml`).
 3. Переменные окружения и аргументы CLI.
 
@@ -297,5 +297,5 @@ system:
 | `thresholds` | `{review:1, experimental:1, unknown:2}` | Пороговые значения. |
 | `limit` | `null` | Ограничение по числу строк. |
 
-Подробности и дополнительные поля см. в [`library/config/models.py`](../library/config/models.py);
+Подробности и дополнительные поля см. в [`library/config/models.py`](../../library/config/models.py);
 данный документ синхронизирован с актуальными моделями.

--- a/docs/ru/OUTPUT.md
+++ b/docs/ru/OUTPUT.md
@@ -17,7 +17,7 @@
 
 ## Таблица документов (`documents`)
 
-Схема: [`library/schemas/documents.py`](../library/schemas/documents.py).
+Схема: [`library/schemas/documents.py`](../../library/schemas/documents.py).
 
 ### Базовые поля ChEMBL
 
@@ -115,7 +115,7 @@
 
 ## Таблица таргетов (`targets`)
 
-Схема: [`library/schemas/targets.py`](../library/schemas/targets.py). Порядок
+Схема: [`library/schemas/targets.py`](../../library/schemas/targets.py). Порядок
 колонок соответствует `TARGETS_COLUMN_ORDER`.
 
 ### Идентификаторы и наименования
@@ -205,7 +205,7 @@
 
 ## Таблица ассайев (`assays`)
 
-Схема: [`library/schemas/assays.py`](../library/schemas/assays.py).
+Схема: [`library/schemas/assays.py`](../../library/schemas/assays.py).
 
 | Колонка | Тип | Описание |
 |---------|-----|----------|
@@ -233,7 +233,7 @@
 
 ## Таблица активностей (`activities`)
 
-Схема: [`library/schemas/activities.py`](../library/schemas/activities.py).
+Схема: [`library/schemas/activities.py`](../../library/schemas/activities.py).
 
 | Колонка | Тип | Проверка |
 |---------|-----|----------|
@@ -267,7 +267,7 @@
 
 ## Таблица тестовых объектов (`testitems`)
 
-Схема: [`library/schemas/testitems.py`](../library/schemas/testitems.py).
+Схема: [`library/schemas/testitems.py`](../../library/schemas/testitems.py).
 
 | Колонка | Тип | Описание |
 |---------|-----|----------|
@@ -293,7 +293,7 @@
 
 ## Таблица тканей (`tissues`)
 
-Схема: [`library/schemas/tissues.py`](../library/schemas/tissues.py). Порядок
+Схема: [`library/schemas/tissues.py`](../../library/schemas/tissues.py). Порядок
 колонок задаётся `TISSUES_COLUMN_ORDER`.
 
 ### Колонки
@@ -324,7 +324,7 @@
 
 ## Экспорт клеточных линий (`cellline`)
 
-Схема описана в [`library/schemas/celllines.py`](../library/schemas/celllines.py);
+Схема описана в [`library/schemas/celllines.py`](../../library/schemas/celllines.py);
 порядок колонок соответствует `CELL_LINE_COLUMN_ORDER` и включает служебные
 поля `pipeline_version`, `timestamp_utc`.
 

--- a/docs/ru/guides/FAQ.md
+++ b/docs/ru/guides/FAQ.md
@@ -7,7 +7,7 @@
 
 `get_document_data` требует явного указания флага `--mode` (`chembl`, `pubmed`,
 `all`). Парсер в итоге вызывает
-[`prepare_io_paths`](../../library/cli/parser.py), которому нужен режим при
+[`prepare_io_paths`](../../../library/cli/parser.py), которому нужен режим при
 формировании логов. Передайте `--mode` или используйте позиционный алиас
 (`python scripts/get_document_data.py all ...`).
 


### PR DESCRIPTION
## Summary
- update English docs to reference library modules with correct relative paths
- mirror the same link fixes in the Russian documentation for consistency

## Testing
- python - <<'PY' ... (verified that each adjusted link resolves to an existing file)


------
https://chatgpt.com/codex/tasks/task_e_68e45ffe796c83248fad6f6f54f8e24f