### PR TITLE
Handle document QA mismatches gracefully

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -642,7 +642,23 @@ def _finalise_export(
     if exit_code == 0:
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
         if csv_path.name.startswith("output.document_"):
-            _maybe_run_document_postprocessing(csv_path)
+            try:
+                _maybe_run_document_postprocessing(csv_path)
+            except RuntimeError as exc:
+                logger.error(
+                    "document_postprocess_qa_mismatch",
+                    error=str(exc),
+                    path=str(csv_path),
+                )
+                exit_code = 1
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.error(
+                    "document_postprocess_qa_error",
+                    error=str(exc),
+                    path=str(csv_path),
+                    exc_info=exc,
+                )
+                exit_code = 1
 
     doc_quality_cfg = getattr(cfg.system, "doc_quality", None)
     quality_hook = build_table_quality_hook(

--- a/tests/unit/test_get_document_data.py
+++ b/tests/unit/test_get_document_data.py
@@ -233,3 +233,86 @@ def test_run__propagates_timeout(cfg: Config, tmp_path: Path, monkeypatch: pytes
 
     assert exit_code == 0
     assert called == [42.5]
+
+
+def test_finalise_export__qa_mismatch_sets_exit_code(
+    cfg: Config,
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_csv = tmp_path / "output.document_20250101.csv"
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("document_chembl_id\n", encoding="utf-8")
+
+    frame = get_document_data.build_dataframe(
+        [],
+        columns=get_document_data.DOCUMENT_SCHEMA_COLUMNS,
+        fill_missing=False,
+    )
+
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        **kwargs: Any,
+    ) -> Path:
+        frames = list(chunks)
+        if frames:
+            combined = pd.concat(frames, ignore_index=True)
+        else:
+            combined = pd.DataFrame(columns=kwargs.get("col_order", []))
+        resolved = Path(path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        combined.to_csv(resolved, index=False)
+        return resolved
+
+    monkeypatch.setattr(
+        get_document_data,
+        "write_csv_chunks_deterministic",
+        fake_write_csv_chunks,
+    )
+
+    def fake_postprocess_export(path: Path, *, cfg: Any) -> Path:  # noqa: ARG001
+        return Path(path)
+
+    monkeypatch.setattr(
+        get_document_data.document_export_postprocessing,
+        "postprocess_export_file",
+        fake_postprocess_export,
+    )
+
+    finalise_calls: list[dict[str, Any]] = []
+
+    def fake_finalise_csv_output(**kwargs: Any) -> None:
+        finalise_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        get_document_data,
+        "finalise_csv_output",
+        fake_finalise_csv_output,
+    )
+
+    def fail_postprocessing(path: Path) -> None:  # noqa: ARG001
+        raise RuntimeError("QA mismatches")
+
+    monkeypatch.setattr(
+        get_document_data,
+        "_maybe_run_document_postprocessing",
+        fail_postprocessing,
+    )
+
+    exit_code = get_document_data._finalise_export(
+        frame,
+        output_csv,
+        cfg,
+        input_csv=input_csv,
+    )
+
+    assert exit_code == 1
+    assert (
+        "error",
+        "document_postprocess_qa_mismatch",
+        {"error": "QA mismatches", "path": str(output_csv)},
+    ) in logger_stub.events
+    assert finalise_calls, "finalise_csv_output should still be invoked"


### PR DESCRIPTION
## Summary
- ensure the document export CLI treats QA mismatches as a logged error and continues cleanup instead of raising
- add a unit test that exercises the new QA mismatch handling in `_finalise_export`

## Testing
- pytest tests/unit/test_get_document_data.py::test_finalise_export__qa_mismatch_sets_exit_code

------
https://chatgpt.com/codex/tasks/task_e_68e4b0ddfd688324b35fa5aba0534aef