### PR TITLE
Handle partial document QA mismatches gracefully

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -818,6 +818,23 @@ def _format_windows_path(path: Path) -> str:
     return WINDOWS_PATH_SEPARATOR.join(path.parts)
 
 
+def _safe_int(value: Any) -> int:
+    """Best-effort conversion of *value* to ``int``.
+
+    Conversion errors yield ``0`` to keep QA bookkeeping resilient when
+    optional metrics are missing from the report payload.
+    """
+
+    try:
+        if value is None:
+            return 0
+        if isinstance(value, bool):
+            return int(value)
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 # ---------------------------------------------------------------------------
 # Data loading helpers
 # ---------------------------------------------------------------------------
@@ -1310,16 +1327,52 @@ def preprocess_documents_csv(
                             status = str(qa_metrics.get("status", "")).upper()
                             report_json = qa_metrics.get("report_json")
                             diff_path = qa_metrics.get("diff_path")
+                            issues_raw = qa_metrics.get("issues") or []
+                            issues = [str(issue) for issue in issues_raw if issue]
+                            missing_rows = qa_metrics.get("missing_rows") or {}
+                            python_only = _safe_int(missing_rows.get("python_only"))
+                            m_only = _safe_int(missing_rows.get("m_only"))
+                            diff_rows = _safe_int(qa_metrics.get("diff_rows"))
+
+                            def _subset_issue(label: str) -> bool:
+                                lowered = label.lower()
+                                return (
+                                    "python-only keys detected" in lowered
+                                    or "m-output-only keys detected" in lowered
+                                )
+
+                            tolerated_subset = (
+                                status == "FAIL"
+                                and diff_rows == 0
+                                and (python_only > 0 or m_only > 0)
+                                and all(_subset_issue(issue) for issue in issues)
+                            )
+
                             if status == "PASS":
                                 logger.info(
                                     "document_postprocess_qa_passed",
                                     report=str(report_json) if report_json else None,
+                                    status=status,
+                                )
+                            elif tolerated_subset:
+                                logger.warning(
+                                    "document_postprocess_qa_skipped_subset",
+                                    report=str(report_json) if report_json else None,
+                                    diff=str(diff_path) if diff_path else None,
+                                    status=status,
+                                    missing_reference=m_only,
+                                    extra_output=python_only,
+                                    reference_rows=len(ref_frame),
+                                    output_rows=total_rows,
+                                    issues=issues or None,
                                 )
                             else:
                                 logger.error(
                                     "document_postprocess_qa_failed",
                                     report=str(report_json) if report_json else None,
                                     diff=str(diff_path) if diff_path else None,
+                                    status=status,
+                                    issues=issues or None,
                                 )
                                 msg = "Document post-processing QA mismatches detected"
                                 raise RuntimeError(msg)

--- a/tests/unit/postprocessing/test_document_postprocessing.py
+++ b/tests/unit/postprocessing/test_document_postprocessing.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from library.postprocessing import document as document_module
+
+
+def _install_stub_qa(monkeypatch: pytest.MonkeyPatch, metrics: dict[str, object]) -> None:
+    """Patch :mod:`importlib` to return a stub QA module with *metrics*."""
+
+    class _StubCrosswalk:
+        @staticmethod
+        def load(path: Path) -> object:  # pragma: no cover - behaviour is trivial
+            return object()
+
+    stub_module = types.SimpleNamespace(
+        Crosswalk=_StubCrosswalk,
+        CROSSWALK_PATH=str(Path("stub_crosswalk.yaml")),
+        DEFAULT_DIFF_LIMIT=100,
+        DEFAULT_REPORT_DIR=Path("output") / "document",
+        run_document_postprocessing_check=lambda **kwargs: metrics,
+    )
+
+    original_import = importlib.import_module
+
+    def _fake_import(name: str, package: str | None = None):
+        if name in {
+            "qa.check_document_postprocessing",
+            "library.qa.check_document_postprocessing",
+        }:
+            return stub_module
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import)
+
+
+def _setup_frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    reference = pd.DataFrame(
+        {
+            "document_chembl_id": ["DOC1", "DOC2"],
+            "primary_pubmed_id": ["PM1", "PM2"],
+        }
+    )
+    output = pd.DataFrame(
+        {
+            "document_chembl_id": ["DOC1"],
+            "primary_pubmed_id": ["PM1"],
+        }
+    )
+    harmonised = pd.DataFrame(
+        {
+            "document_chembl_id": ["DOC1"],
+            "primary_pubmed_id": ["PM1"],
+            "invalid": [False],
+            "invalid.doi": [False],
+            "invalid.PMID": [False],
+            "invalid.reference": [False],
+        }
+    )
+    return reference, output, harmonised
+
+
+@pytest.mark.unit
+def test_preprocess_documents_csv__qa_subset_missing_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    data_dir = tmp_path / "data"
+    (data_dir / "input" / "full").mkdir(parents=True)
+    (data_dir / "output" / "document").mkdir(parents=True)
+    (data_dir / "input" / "full" / "document.csv").write_text("reference", encoding="utf-8")
+    (data_dir / "output" / "document" / "output.document_20250101.csv").write_text(
+        "output",
+        encoding="utf-8",
+    )
+
+    reference, output, harmonised = _setup_frames()
+
+    monkeypatch.setattr(document_module, "_load_reference_document", lambda path: reference)
+    monkeypatch.setattr(document_module, "_load_output_document", lambda path: output)
+    monkeypatch.setattr(document_module, "_harmonise_documents", lambda *_: harmonised)
+
+    metrics = {
+        "status": "FAIL",
+        "report_json": str(data_dir / "output" / "document" / "report.json"),
+        "diff_path": None,
+        "issues": ["1 M-output-only keys detected"],
+        "missing_rows": {"python_only": 0, "m_only": 1},
+        "diff_rows": 0,
+    }
+    _install_stub_qa(monkeypatch, metrics)
+
+    caplog.set_level(logging.INFO)
+
+    result = document_module.preprocess_documents_csv(
+        base_path=str(data_dir),
+        ref_document_rel="input\\full\\document.csv",
+        out_document_rel="output\\document\\output.document_20250101.csv",
+    )
+
+    expected_path = data_dir / "output" / "document" / "preprocessed_output.document_20250101.csv"
+    assert Path(result) == expected_path
+    assert expected_path.exists()
+
+    assert any(
+        "document_postprocess_qa_skipped_subset" in record.message for record in caplog.records
+    )
+
+
+@pytest.mark.unit
+def test_preprocess_documents_csv__qa_failure_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "data"
+    (data_dir / "input" / "full").mkdir(parents=True)
+    (data_dir / "output" / "document").mkdir(parents=True)
+    (data_dir / "input" / "full" / "document.csv").write_text("reference", encoding="utf-8")
+    (data_dir / "output" / "document" / "output.document_20250101.csv").write_text(
+        "output",
+        encoding="utf-8",
+    )
+
+    reference, output, harmonised = _setup_frames()
+
+    monkeypatch.setattr(document_module, "_load_reference_document", lambda path: reference)
+    monkeypatch.setattr(document_module, "_load_output_document", lambda path: output)
+    monkeypatch.setattr(document_module, "_harmonise_documents", lambda *_: harmonised)
+
+    metrics = {
+        "status": "FAIL",
+        "report_json": str(data_dir / "output" / "document" / "report.json"),
+        "diff_path": str(data_dir / "output" / "document" / "diff.csv"),
+        "issues": ["Match rate for preferred below threshold (0.0000% < 99.50%)"],
+        "missing_rows": {"python_only": 0, "m_only": 0},
+        "diff_rows": 1,
+    }
+    _install_stub_qa(monkeypatch, metrics)
+
+    with pytest.raises(RuntimeError):
+        document_module.preprocess_documents_csv(
+            base_path=str(data_dir),
+            ref_document_rel="input\\full\\document.csv",
+            out_document_rel="output\\document\\output.document_20250101.csv",
+        )


### PR DESCRIPTION
## Summary
- allow document post-processing QA to degrade gracefully when failures are solely due to missing rows, logging a structured warning instead of aborting the pipeline
- add unit tests that cover the subset-skipping path and ensure other QA failures still raise errors

## Testing
- pytest tests/unit/postprocessing/test_document_postprocessing.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e4b0a928a083248fd09fcc3cd03543