### PR TITLE
Add CLI logging options to run_tests

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,21 +1,26 @@
 """Run the test suite and produce structured JSON and Markdown reports."""
 from __future__ import annotations
 
+import argparse
 import json
+import logging
 import platform
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 import pytest
+
+from library.cli import configure_logger, create_logger_config
+from library.cli.logging import setup_cli_logging
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 REPORTS_DIR = ROOT_DIR / "reports"
 RAW_REPORT_FILE = REPORTS_DIR / "pytest_raw_report.json"
 REPORT_FILE = REPORTS_DIR / "test_report.json"
-LOG_FILE = REPORTS_DIR / "test_run.log"
 SUMMARY_FILE = REPORTS_DIR / "test_summary.md"
 COVERAGE_DIR = REPORTS_DIR / "coverage"
 COVERAGE_XML = COVERAGE_DIR / "coverage.xml"
@@ -45,7 +50,16 @@ _BASE_PYTEST_COMMAND: list[str] = [
 _DEFAULT_TEST_TARGETS: tuple[str, ...] = tuple(
     str(path) for path in TEST_DIRECTORIES if path.exists()
 )
-PYTEST_COMMAND: tuple[str, ...] = tuple(_BASE_PYTEST_COMMAND + list(_DEFAULT_TEST_TARGETS))
+
+
+logger = logging.getLogger("run_tests")
+
+
+def _relative_to_root(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
 
 
 def ensure_reports_directory() -> None:
@@ -55,17 +69,34 @@ def ensure_reports_directory() -> None:
     COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def run_pytest() -> int:
-    """Execute pytest and capture combined output in the log file."""
+def run_pytest(command: Sequence[str]) -> int:
+    """Execute ``command`` and stream output through the configured logger."""
 
-    with LOG_FILE.open("w", encoding="utf-8") as log_file:
-        result = subprocess.run(
-            PYTEST_COMMAND,
-            stdout=log_file,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
-    return result.returncode
+    logger.debug("Executing pytest command: %s", " ".join(shlex.quote(part) for part in command))
+
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    assert process.stdout is not None  # for mypy; Popen(..., stdout=PIPE)
+    with process.stdout:
+        for raw_line in process.stdout:
+            line = raw_line.rstrip()
+            if line:
+                logger.info(line)
+            else:
+                logger.info("")
+
+    return_code = process.wait()
+    if return_code != 0:
+        logger.error("Pytest exited with non-zero status: %s", return_code)
+    else:
+        logger.debug("Pytest exited successfully")
+    return return_code
 
 
 def _load_raw_report() -> dict[str, Any]:
@@ -273,7 +304,7 @@ def build_summary_markdown(report: dict[str, Any]) -> str:
     ]
 
     failure_rows = [
-        (test["nodeid"], (test.get("error") or "See reports/test_run.log"))
+        (test["nodeid"], (test.get("error") or "See logs/run_tests_<date>.log"))
         for test in tests
         if test.get("status") in {"failed", "error"}
     ]
@@ -293,20 +324,90 @@ def write_summary(report: dict[str, Any]) -> None:
     SUMMARY_FILE.write_text(build_summary_markdown(report), encoding="utf-8")
 
 
-def main() -> int:
-    ensure_reports_directory()
-    exit_code = run_pytest()
-    raw_report = _load_raw_report()
-    structured = build_structured_report(raw_report, exit_code)
-    write_json_report(structured)
-    write_summary(structured)
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the test suite and emit structured reports."
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Base logging level (default: INFO)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Shortcut for --log-level=DEBUG",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="Date token forwarded to the log file suffix (format: YYYYMMDD)",
+    )
+    parser.add_argument(
+        "pytest_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to pytest (use '--' before them)",
+    )
+    return parser.parse_args(argv)
 
-    print(f"Pytest finished with exit code {exit_code}.")
-    print(f"Log saved to {LOG_FILE.relative_to(ROOT_DIR)}.")
-    if RAW_REPORT_FILE.exists():
-        print(f"Raw report available at {RAW_REPORT_FILE.relative_to(ROOT_DIR)}.")
-    print(f"Structured report written to {REPORT_FILE.relative_to(ROOT_DIR)}.")
-    print(f"Summary written to {SUMMARY_FILE.relative_to(ROOT_DIR)}.")
+
+def _extract_pytest_args(args: Sequence[str] | None) -> list[str]:
+    if not args:
+        return []
+    if args and args[0] == "--":
+        return list(args[1:])
+    return list(args)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    level = str(args.log_level or "INFO").upper()
+    if args.verbose:
+        level = "DEBUG"
+
+    log_cfg = create_logger_config(level)
+
+    with setup_cli_logging("run_tests", log_cfg, args.date) as logging_ctx:
+        configure_logger(logging_ctx.log_cfg)
+
+        ensure_reports_directory()
+
+        pytest_command = list(_BASE_PYTEST_COMMAND)
+        pytest_command.extend(
+            [
+                "--log-file",
+                str(logging_ctx.log_path),
+                "--log-file-level",
+                logging_ctx.log_cfg.level,
+            ]
+        )
+        pytest_command.extend(_DEFAULT_TEST_TARGETS)
+        pytest_command.extend(_extract_pytest_args(args.pytest_args))
+
+        exit_code = run_pytest(pytest_command)
+
+        raw_report = _load_raw_report()
+        structured = build_structured_report(raw_report, exit_code)
+        write_json_report(structured)
+        write_summary(structured)
+
+        log_path = _relative_to_root(logging_ctx.log_path)
+        logger.info("Pytest finished with exit code %s", exit_code)
+        logger.info("Log saved to %s", log_path)
+        if RAW_REPORT_FILE.exists():
+            logger.info(
+                "Raw report available at %s",
+                _relative_to_root(RAW_REPORT_FILE),
+            )
+        logger.info(
+            "Structured report written to %s",
+            _relative_to_root(REPORT_FILE),
+        )
+        logger.info(
+            "Summary written to %s",
+            _relative_to_root(SUMMARY_FILE),
+        )
+
     return exit_code
 
 

--- a/tests/unit/scripts/test_run_tests.py
+++ b/tests/unit/scripts/test_run_tests.py
@@ -1,0 +1,124 @@
+"""Unit tests for :mod:`scripts.run_tests`."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Sequence
+
+import pytest
+
+from library.cli import LoggerConfig
+from scripts import run_tests
+
+
+@pytest.mark.unit
+def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    reports_dir = tmp_path / "reports"
+    coverage_dir = reports_dir / "coverage"
+    raw_report_file = reports_dir / "pytest_raw_report.json"
+    report_file = reports_dir / "test_report.json"
+    summary_file = reports_dir / "test_summary.md"
+
+    monkeypatch.setattr(run_tests, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(run_tests, "REPORTS_DIR", reports_dir, raising=False)
+    monkeypatch.setattr(run_tests, "RAW_REPORT_FILE", raw_report_file, raising=False)
+    monkeypatch.setattr(run_tests, "REPORT_FILE", report_file, raising=False)
+    monkeypatch.setattr(run_tests, "SUMMARY_FILE", summary_file, raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_DIR", coverage_dir, raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_XML", coverage_dir / "coverage.xml", raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_HTML", coverage_dir / "html", raising=False)
+
+    base_command: list[str] = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--json-report",
+        "--json-report-file",
+        str(raw_report_file),
+        "--durations=0",
+        "--cov=library",
+        "--cov=scripts",
+        "--cov-report=term",
+        f"--cov-report=xml:{coverage_dir / 'coverage.xml'}",
+        f"--cov-report=html:{coverage_dir / 'html'}",
+        "-vv",
+    ]
+    monkeypatch.setattr(run_tests, "_BASE_PYTEST_COMMAND", base_command, raising=False)
+    monkeypatch.setattr(run_tests, "_DEFAULT_TEST_TARGETS", ("tests/unit",), raising=False)
+    monkeypatch.setattr(run_tests, "_git_output", lambda *args, **kwargs: "stub")
+
+    captured_log_path: Path | None = None
+
+    @contextmanager
+    def _fake_setup(script_name: str, log_cfg: LoggerConfig, date: str | None = None):
+        nonlocal captured_log_path
+        assert script_name == "run_tests"
+        assert date == "20240131"
+        captured_log_path = tmp_path / "logs" / f"run_tests_{date}.log"
+        cloned_cfg = LoggerConfig(
+            level=log_cfg.level,
+            run_id=log_cfg.run_id,
+            redact_secrets=log_cfg.redact_secrets,
+            stream=log_cfg.stream,
+            handlers=list(log_cfg.handlers),
+            logger_name=log_cfg.logger_name,
+        )
+        yield SimpleNamespace(
+            log_path=captured_log_path,
+            log_cfg=cloned_cfg,
+            console_stream=None,
+        )
+
+    captured_commands: list[list[str]] = []
+
+    def _fake_run_pytest(command: Sequence[str]) -> int:
+        captured_commands.append(list(command))
+        return 0
+
+    captured_configs: list[LoggerConfig] = []
+
+    def _fake_configure(cfg: LoggerConfig) -> object:
+        captured_configs.append(cfg)
+        return object()
+
+    monkeypatch.setattr(run_tests, "run_pytest", _fake_run_pytest)
+    monkeypatch.setattr(run_tests, "configure_logger", _fake_configure)
+    monkeypatch.setattr(run_tests, "setup_cli_logging", _fake_setup)
+    monkeypatch.setattr(
+        run_tests,
+        "_load_raw_report",
+        lambda: {"tests": [], "duration": 0.0},
+    )
+
+    exit_code = run_tests.main([
+        "--verbose",
+        "--date",
+        "20240131",
+        "--",
+        "-k",
+        "unit",
+    ])
+
+    assert exit_code == 0
+    assert captured_commands, "run_pytest should be invoked"
+
+    command = captured_commands[-1]
+    assert "--log-file" in command
+    log_path_token = command[command.index("--log-file") + 1]
+    assert captured_log_path is not None
+    expected_log_path = tmp_path / "logs" / "run_tests_20240131.log"
+    assert captured_log_path == expected_log_path
+    assert Path(log_path_token) == captured_log_path
+
+    assert "--log-file-level" in command
+    level_value = command[command.index("--log-file-level") + 1]
+    assert level_value == "DEBUG"
+
+    assert command[-2:] == ["-k", "unit"]
+
+    assert report_file.exists()
+    assert summary_file.exists()
+    assert captured_configs and captured_configs[-1].level == "DEBUG"


### PR DESCRIPTION
## Summary
- extend scripts/run_tests.py with CLI flags for log level, verbosity, and date handling
- initialise logging via setup_cli_logging and stream pytest output through the configured logger
- add unit coverage to confirm verbose mode produces DEBUG logging and the log file path follows the shared convention

## Testing
- pytest tests/unit/scripts/test_run_tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b1d2a3b88324b90b8b4a3782f984