### PR TITLE
Skip document QA when exporting partial datasets

### DIFF
--- a/library/postprocessing/document.py
+++ b/library/postprocessing/document.py
@@ -1195,6 +1195,8 @@ def preprocess_documents_csv(
     ref_document_rel: str = DEFAULT_REF_RELATIVE,
     out_document_rel: str = DEFAULT_OUTPUT_RELATIVE,
     qa_reference_rel: str | None = DEFAULT_QA_REFERENCE_RELATIVE,
+    *,
+    run_qa: bool = True,
 ) -> str:
     base_dir = Path(base_path)
     ref_path = _resolve_relative(base_dir, ref_document_rel)
@@ -1254,7 +1256,7 @@ def preprocess_documents_csv(
                 invalid=invalid_counts["invalid"],
             )
 
-    if qa_reference_rel:
+    if run_qa and qa_reference_rel:
         qa_reference_path = _resolve_relative(base_dir, qa_reference_rel)
         if qa_reference_path.exists():
             qa_module = None

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -441,7 +441,7 @@ def _write_export_chunks(
     )
 
 
-def _maybe_run_document_postprocessing(csv_path: Path) -> None:
+def _maybe_run_document_postprocessing(csv_path: Path, *, skip_qa: bool = False) -> None:
     if not csv_path.name.startswith("output.document_"):
         return
 
@@ -470,7 +470,14 @@ def _maybe_run_document_postprocessing(csv_path: Path) -> None:
         base_path=str(data_dir),
         ref_document_rel=ref_rel_windows,
         out_document_rel=out_rel_windows,
+        run_qa=not skip_qa,
     )
+    if skip_qa:
+        logger.info(
+            "document_postprocess_qa_skipped_partial",
+            output=str(csv_path),
+            reason="partial_run",
+        )
 
 
 def _finalise_export(
@@ -481,6 +488,7 @@ def _finalise_export(
     input_csv: Path,
     key_columns: Sequence[str] | None = None,
     chunk_size: int | None = None,
+    partial_run: bool = False,
 ) -> int:
     """Validate input frames and write CSV/metadata artefacts."""
 
@@ -643,7 +651,10 @@ def _finalise_export(
         logger.info("write_done", rows=rows_kept, path=str(csv_path))
         if csv_path.name.startswith("output.document_"):
             try:
-                _maybe_run_document_postprocessing(csv_path)
+                _maybe_run_document_postprocessing(
+                    csv_path,
+                    skip_qa=partial_run,
+                )
             except RuntimeError as exc:
                 logger.error(
                     "document_postprocess_qa_mismatch",
@@ -816,6 +827,8 @@ def run_pubmed(
         pmids = pmids_limited
         limit_counter = get_limit_count
 
+    partial_run = (limit is not None) or (offset > 0)
+
     fallback_state: FallbackDoiState | None = None
     if fallback_enabled:
         fallback_path = fallback_path_arg
@@ -910,6 +923,7 @@ def run_pubmed(
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "batch_size", pubmed_defaults.batch_size),
+            partial_run=partial_run,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         logger.error(
@@ -1057,6 +1071,7 @@ def run_chembl(
             ids = limited_ids
             limit_counter = get_limit_count
 
+        partial_run = (limit is not None) or (offset > 0)
         try:
             df = cl.get_documents(
                 ids,
@@ -1083,6 +1098,7 @@ def run_chembl(
             input_csv=Path(args.input_csv),
             key_columns=["document_chembl_id"],
             chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
+            partial_run=partial_run,
         )
         if exit_code == 0:
             logger.info("document_chembl_done", output=str(output_path))
@@ -1160,6 +1176,7 @@ def run_all(
         ids_source = ids_limited
         limit_counter = get_limit_count
 
+    partial_run = (limit is not None) or (offset > 0)
     iterator = iter(ids_source)
     sample_size = getattr(args, "chembl_chunk_size", all_defaults.chunk_size)
     sample_ids = list(islice(iterator, sample_size))
@@ -1308,6 +1325,7 @@ def run_all(
             chunk_size=getattr(
                 args, "chembl_chunk_size", all_defaults.chunk_size
             ),
+            partial_run=partial_run,
         )
         if fallback_state is not None:
             logger.info(
@@ -1414,6 +1432,7 @@ def run_all(
         input_csv=Path(args.input_csv),
         key_columns=["document_chembl_id"],
         chunk_size=getattr(args, "chembl_chunk_size", all_defaults.chunk_size),
+        partial_run=partial_run,
     )
     if fallback_state is not None:
         logger.info(

--- a/tests/unit/test_get_document_data.py
+++ b/tests/unit/test_get_document_data.py
@@ -293,7 +293,8 @@ def test_finalise_export__qa_mismatch_sets_exit_code(
         fake_finalise_csv_output,
     )
 
-    def fail_postprocessing(path: Path) -> None:  # noqa: ARG001
+    def fail_postprocessing(path: Path, *, skip_qa: bool = False) -> None:  # noqa: ARG001
+        assert skip_qa is False
         raise RuntimeError("QA mismatches")
 
     monkeypatch.setattr(
@@ -316,3 +317,107 @@ def test_finalise_export__qa_mismatch_sets_exit_code(
         {"error": "QA mismatches", "path": str(output_csv)},
     ) in logger_stub.events
     assert finalise_calls, "finalise_csv_output should still be invoked"
+
+
+def test_finalise_export__partial_run_skips_qa(
+    cfg: Config,
+    tmp_path: Path,
+    logger_stub: _MemoryLogger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "data"
+    reference_dir = data_dir / "input" / "full"
+    reference_dir.mkdir(parents=True, exist_ok=True)
+    (reference_dir / "document.csv").write_text("reference", encoding="utf-8")
+
+    output_csv = data_dir / "output" / "document" / "output.document_20250101.csv"
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("document_chembl_id\nCHEMBL1\n", encoding="utf-8")
+
+    frame = get_document_data.build_dataframe(
+        [{"document_chembl_id": "CHEMBL1"}],
+        columns=get_document_data.DOCUMENT_SCHEMA_COLUMNS,
+        fill_missing=False,
+    )
+
+    def fake_write_csv_chunks(
+        chunks: Iterable[pd.DataFrame],
+        path: Path,
+        **kwargs: Any,
+    ) -> Path:
+        frames = list(chunks)
+        if frames:
+            combined = pd.concat(frames, ignore_index=True)
+        else:
+            combined = pd.DataFrame(columns=kwargs.get("col_order", []))
+        resolved = Path(path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        combined.to_csv(resolved, index=False)
+        return resolved
+
+    monkeypatch.setattr(
+        get_document_data,
+        "write_csv_chunks_deterministic",
+        fake_write_csv_chunks,
+    )
+
+    def fake_postprocess_export(path: Path, *, cfg: Any) -> Path:  # noqa: ARG001
+        return Path(path)
+
+    monkeypatch.setattr(
+        get_document_data.document_export_postprocessing,
+        "postprocess_export_file",
+        fake_postprocess_export,
+    )
+
+    monkeypatch.setattr(
+        get_document_data,
+        "finalise_csv_output",
+        lambda **_: None,
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_preprocess(
+        base_path: str,
+        ref_document_rel: str = "",
+        out_document_rel: str = "",
+        qa_reference_rel: str | None = None,
+        *,
+        run_qa: bool = True,
+    ) -> str:  # noqa: ARG001
+        captured.update(
+            {
+                "base_path": base_path,
+                "ref_rel": ref_document_rel,
+                "out_rel": out_document_rel,
+                "run_qa": run_qa,
+            }
+        )
+        return str(Path(base_path) / "output" / "document" / "preprocessed.csv")
+
+    monkeypatch.setattr(
+        get_document_data,
+        "preprocess_documents_csv",
+        fake_preprocess,
+    )
+
+    exit_code = get_document_data._finalise_export(
+        frame,
+        output_csv,
+        cfg,
+        input_csv=input_csv,
+        key_columns=["document_chembl_id"],
+        partial_run=True,
+    )
+
+    assert exit_code == 0
+    assert captured.get("run_qa") is False
+    assert captured.get("base_path") == str(data_dir)
+    assert (
+        "info",
+        "document_postprocess_qa_skipped_partial",
+        {"output": str(output_csv), "reason": "partial_run"},
+    ) in logger_stub.events


### PR DESCRIPTION
## Summary
- allow `preprocess_documents_csv` to skip QA execution while still writing harmonised outputs
- propagate a partial-run flag from the document CLI when limits or offsets are applied so QA is skipped intentionally
- extend unit coverage to assert the QA skip path and updated invocation contract

## Testing
- pytest tests/unit/test_get_document_data.py -k "finalise_export" -q
- pytest tests/unit/postprocessing/test_document_postprocessing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4b791acfc832480d56b81073eaa93