### PR TITLE
Fix determinism check input handling

### DIFF
--- a/scripts/check_determinism.py
+++ b/scripts/check_determinism.py
@@ -12,6 +12,7 @@ bootstrap_cli(__package__, __file__)
 del bootstrap_cli
 
 import argparse
+import csv
 import hashlib
 import os
 import shutil
@@ -29,7 +30,9 @@ def _hash_file(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def _run_activity(limit: int, destination: Path) -> subprocess.CompletedProcess[str]:
+def _run_activity(
+    limit: int, destination: Path, input_csv: Path
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.setdefault("PYTHONHASHSEED", "0")
     cmd = [
@@ -39,14 +42,55 @@ def _run_activity(limit: int, destination: Path) -> subprocess.CompletedProcess[
         str(limit),
         "--final-out",
         str(destination),
+        "--input",
+        str(input_csv),
     ]
     return subprocess.run(cmd, text=True, capture_output=True, env=env)
+
+
+def _default_input_csv(tmp_dir: Path) -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    candidate = repo_root / "data" / "input" / "activity.csv"
+    if candidate.exists():
+        return candidate
+
+    fallback = tmp_dir / "activity.csv"
+    with fallback.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["activity_id"])
+        writer.writerow(["ACT1"])
+        writer.writerow(["ACT2"])
+    return fallback
+
+
+def _report_process_failure(label: str, result: subprocess.CompletedProcess[str]) -> None:
+    sys.stderr.write(f"{label} failed with exit code {result.returncode}\n")
+    if result.stdout:
+        sys.stderr.write("stdout:\n")
+        sys.stderr.write(result.stdout)
+        if not result.stdout.endswith("\n"):
+            sys.stderr.write("\n")
+    if result.stderr:
+        sys.stderr.write("stderr:\n")
+        sys.stderr.write(result.stderr)
+        if not result.stderr.endswith("\n"):
+            sys.stderr.write("\n")
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--limit", type=int, default=10, help="Number of IDs to process"
+    )
+    parser.add_argument(
+        "--input",
+        dest="input_csv",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the identifiers CSV forwarded to get_activity_data. "
+            "Defaults to data/input/activity.csv when available."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -57,16 +101,24 @@ def main(argv: list[str] | None = None) -> int:
         first = tmp_dir / "first.csv"
         second = tmp_dir / "second.csv"
 
-        first_run = _run_activity(args.limit, first)
+        if args.input_csv is not None:
+            input_csv = args.input_csv
+            if not input_csv.exists():
+                sys.stderr.write(
+                    f"Input CSV '{input_csv}' does not exist; determinism check aborted.\n"
+                )
+                return 1
+        else:
+            input_csv = _default_input_csv(tmp_dir)
+
+        first_run = _run_activity(args.limit, first, input_csv)
         if first_run.returncode != 0:
-            sys.stderr.write("first run failed\n")
-            sys.stderr.write(first_run.stderr)
+            _report_process_failure("first run", first_run)
             return 1
 
-        second_run = _run_activity(args.limit, second)
+        second_run = _run_activity(args.limit, second, input_csv)
         if second_run.returncode != 0:
-            sys.stderr.write("second run failed\n")
-            sys.stderr.write(second_run.stderr)
+            _report_process_failure("second run", second_run)
             return 1
 
         if not first.exists() or not second.exists():

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -16,6 +16,7 @@ bootstrap_cli(__package__, __file__)
 del bootstrap_cli
 
 import argparse
+import sys
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Callable
 from datetime import datetime, timezone
@@ -1466,6 +1467,15 @@ class ActivityPipelineCLI(PipelineCLIBase):
             parser.error("--limit must be zero or a positive integer")
         if args.offset < 0:
             parser.error("--offset must be zero or a positive integer")
+        input_path = Path(args.input_csv)
+        if not input_path.exists():
+            message = (
+                f"Input CSV '{input_path}' does not exist. "
+                "Provide --input pointing to a valid identifiers file or "
+                "run the upstream pipeline step to generate it."
+            )
+            sys.stderr.write(message + "\n")
+            return 1
         return None
 
     def get_program_name(self) -> str:

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -384,6 +384,17 @@ def test_main__dry_run_skip_limit(monkeypatch, tmp_path, capsys) -> None:
     assert "pipeline_skip_limit" in events
 
 
+def test_main__missing_input_fails_fast(tmp_path, capsys) -> None:
+    missing = tmp_path / "absent.csv"
+
+    exit_code = get_activity_data.main(["--input", str(missing)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "does not exist" in captured.err
+    assert "Provide --input" in captured.err
+
+
 def test_activity_columns__cover_extended_requirements() -> None:
     required = activity_extended._REQUIRED_COLUMNS
     available = set(ACTIVITY_COLUMNS)


### PR DESCRIPTION
## Summary
- make the determinism smoke test accept a custom input CSV, fall back to repository fixtures, and surface subprocess stderr when runs fail
- validate the presence of the input CSV in `get_activity_data` before launching the pipeline and emit a clear hint when it is missing
- cover the new failure mode with a unit test for the CLI entry point

## Testing
- pytest tests/unit/test_get_activity_data.py


------
https://chatgpt.com/codex/tasks/task_e_68e4b77c2a348324883f388a9e86f4e3