### PR TITLE
Improve test report diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,48 @@ must produce:
 - `reports/test_report.json` — machine readable execution log
 - `reports/test_summary.md` — condensed Markdown summary
 
+`test_report.json` always exposes three top-level keys:
+
+```json
+{
+  "meta": {
+    "repo": "SatoryKono/ChEMBL_data_acquisition",
+    "commit": "<SHA>",
+    "branch": "<branch>",
+    "ts_utc": "<ISO8601>",
+    "duration_sec": 0.0,
+    "python": "3.11",
+    "pytest": "<version>",
+    "exit_code": 0
+  },
+  "summary": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "xfailed": 0,
+    "xpassed": 0,
+    "error": 0,
+    "success_rate": 0.0
+  },
+  "tests": [
+    {
+      "nodeid": "tests/unit/test_module.py::test_case",
+      "status": "passed",
+      "duration_ms": 12.3,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    }
+  ]
+}
+```
+
+`test_summary.md` mirrors the counts and, for every failure or error, embeds the
+exact `error` message from the JSON report in a fenced code block. This makes it
+possible to triage failures using only the Markdown artefact.
+
 Smoke runs can use `pytest -q -k "not slow and not e2e"`, while full validation
 uses `pytest -q`. See [`docs/en/development/TESTING.md`](./docs/en/development/TESTING.md)
 for fixtures, determinism requirements and coverage targets.

--- a/README_RU.md
+++ b/README_RU.md
@@ -128,6 +128,48 @@ python scripts/get_data.py \
 - `reports/test_report.json` — машинно читаемый протокол
 - `reports/test_summary.md` — краткое Markdown-резюме
 
+`test_report.json` всегда содержит три корневых секции:
+
+```json
+{
+  "meta": {
+    "repo": "SatoryKono/ChEMBL_data_acquisition",
+    "commit": "<SHA>",
+    "branch": "<branch>",
+    "ts_utc": "<ISO8601>",
+    "duration_sec": 0.0,
+    "python": "3.11",
+    "pytest": "<version>",
+    "exit_code": 0
+  },
+  "summary": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "xfailed": 0,
+    "xpassed": 0,
+    "error": 0,
+    "success_rate": 0.0
+  },
+  "tests": [
+    {
+      "nodeid": "tests/unit/test_module.py::test_case",
+      "status": "passed",
+      "duration_ms": 12.3,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    }
+  ]
+}
+```
+
+`test_summary.md` дублирует агрегированные показатели и для каждого падения или
+ошибки выводит значение поля `error` из JSON в виде блока кода. Этого достаточно,
+чтобы диагностировать проблему, имея только Markdown-отчёт.
+
 Для смоук-прогона подойдёт `pytest -q -k "not slow and not e2e"`, полный набор —
 `pytest -q`. Детали фикстур, требований к детерминизму и целям по покрытию см. в
 [`docs/ru/development/TESTING.md`](./docs/ru/development/TESTING.md).

--- a/reports/test_summary.md
+++ b/reports/test_summary.md
@@ -12,4 +12,4 @@
 |   566 |   566 |     0 |      0 |      0 |      0 |     0 |
 
 ## Failed / Error details
-- none
+- None

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -303,18 +303,24 @@ def build_summary_markdown(report: dict[str, Any]) -> str:
         "## Failed / Error details",
     ]
 
-    failure_rows = [
-        (test["nodeid"], (test.get("error") or "See logs/run_tests_<date>.log"))
-        for test in tests
-        if test.get("status") in {"failed", "error"}
-    ]
+    failure_rows = []
+    for test in tests:
+        status = str(test.get("status", "")).lower()
+        if status not in {"failed", "error"}:
+            continue
+        nodeid = str(test.get("nodeid", "<unknown>"))
+        message = _normalise_message(test.get("error"))
+        failure_rows.append((nodeid, status, message))
 
     if not failure_rows:
         lines.append("- None")
     else:
-        for nodeid, message in failure_rows:
-            compact_message = message.replace("\n", " ").strip()
-            lines.append(f"- `{nodeid}`: {compact_message}")
+        for nodeid, status, message in failure_rows:
+            lines.append(f"- `{nodeid}` ({status})")
+            display_message = message or "<no message>"
+            lines.append("  ```")
+            lines.extend(f"  {line}" for line in display_message.splitlines())
+            lines.append("  ```")
 
     lines.append("")
     return "\n".join(lines)

--- a/tests/unit/scripts/test_run_tests_script.py
+++ b/tests/unit/scripts/test_run_tests_script.py
@@ -122,3 +122,96 @@ def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytes
     assert report_file.exists()
     assert summary_file.exists()
     assert captured_configs and captured_configs[-1].level == "DEBUG"
+
+
+@pytest.mark.unit
+def test_build_structured_report__captures_failure_messages() -> None:
+    raw_report = {
+        "duration": 1.5,
+        "tests": [
+            {
+                "nodeid": "tests/unit/test_example.py::test_failure",
+                "outcome": "failed",
+                "call": {
+                    "duration": 0.25,
+                    "longrepr": "AssertionError: boom\nline 1\nline 2",
+                    "stdout": "",
+                    "stderr": "",
+                    "log": [],
+                },
+            },
+            {
+                "nodeid": "tests/unit/test_example.py::test_success",
+                "outcome": "passed",
+                "call": {
+                    "duration": 0.75,
+                    "stdout": "",
+                    "stderr": "",
+                    "log": [],
+                },
+            },
+        ],
+    }
+
+    structured = run_tests.build_structured_report(raw_report, exit_code=1)
+
+    assert structured["meta"]["exit_code"] == 1
+    assert structured["summary"] == {
+        "total": 2,
+        "passed": 1,
+        "failed": 1,
+        "skipped": 0,
+        "xfailed": 0,
+        "xpassed": 0,
+        "error": 0,
+        "success_rate": 50.0,
+    }
+
+    failure_entry = next(
+        item
+        for item in structured["tests"]
+        if item["nodeid"].endswith("test_failure")
+    )
+    assert failure_entry["status"] == "failed"
+    assert failure_entry["error"] == "AssertionError: boom\nline 1\nline 2"
+
+
+@pytest.mark.unit
+def test_build_summary_markdown__renders_error_messages_from_json() -> None:
+    report = {
+        "meta": {
+            "repo": "demo/repo",
+            "commit": "abc123",
+            "branch": "feature",
+            "ts_utc": "2025-01-01T00:00:00+00:00",
+            "duration_sec": 3.14,
+        },
+        "summary": {
+            "total": 1,
+            "passed": 0,
+            "failed": 1,
+            "skipped": 0,
+            "xfailed": 0,
+            "xpassed": 0,
+            "error": 0,
+            "success_rate": 0.0,
+        },
+        "tests": [
+            {
+                "nodeid": "tests/unit/test_example.py::test_failure",
+                "status": "failed",
+                "duration_ms": 123.0,
+                "stdout": "",
+                "stderr": "",
+                "log": [],
+                "error": "AssertionError: boom\nline 1\nline 2",
+            }
+        ],
+    }
+
+    summary_md = run_tests.build_summary_markdown(report)
+
+    assert "- `tests/unit/test_example.py::test_failure` (failed)" in summary_md
+    assert summary_md.count("```") == 2
+    assert "AssertionError: boom" in summary_md
+    assert "line 1" in summary_md and "line 2" in summary_md


### PR DESCRIPTION
## Summary
- surface failure messages from the structured JSON report directly in the Markdown summary
- document the JSON and Markdown report formats in both README files and refresh the sample summary artefact
- add unit coverage to lock the JSON structure and Markdown failure rendering

## Testing
- pytest tests/unit/scripts/test_run_tests_script.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c5cd2fd08324abc35f24a00bc5c9