### PR TITLE
Propagate target subcommand overrides through orchestrator

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -127,10 +127,11 @@ def _build_document_options(
 def _build_target_options(
     cfg: "PipelineRunConfig", input_path: Path, output_path: Path
 ) -> TargetPipelineOptions:
+    command = cfg.subcommand_for("target") or "all"
     return TargetPipelineOptions(
         input_csv=input_path,
         output_csv=output_path,
-        command="all",
+        command=command,
         limit=cfg.limit,
         force=cfg.force,
     )
@@ -194,6 +195,7 @@ class PipelineRunConfig:
     dry_run: bool
     input_files: Mapping[str, str]
     output_stems: Mapping[str, str]
+    subcommands: Mapping[str, str | None]
 
     def input_path(self, name: str) -> Path:
         """Return the fully resolved path for ``name`` in the input directory."""
@@ -207,6 +209,11 @@ class PipelineRunConfig:
         stem = self.output_stems[name]
         filename = f"output.{stem}_{self.date_prefix}.csv"
         return self.output_dir / filename
+
+    def subcommand_for(self, name: str) -> str | None:
+        """Return the configured subcommand for ``name`` if available."""
+
+        return self.subcommands.get(name)
 
 
 def _resolve_path(base: Path, candidate: Path) -> Path:
@@ -449,6 +456,7 @@ def _prepare_config(
     effective_steps = tuple(DEFAULT_PIPELINE_STEPS if steps is None else steps)
     input_files = {step.name: step.input_filename for step in effective_steps}
     output_stems = {step.name: step.output_stem for step in effective_steps}
+    subcommands = {step.name: step.subcommand for step in effective_steps}
 
     base_path = args.base_path.expanduser().resolve()
     input_dir = _resolve_path(base_path, args.input_dir)
@@ -484,6 +492,7 @@ def _prepare_config(
         dry_run=dry_run,
         input_files=input_files,
         output_stems=output_stems,
+        subcommands=subcommands,
     )
 
 

--- a/tests/e2e/test_get_data_scheduler.py
+++ b/tests/e2e/test_get_data_scheduler.py
@@ -18,6 +18,7 @@ def _build_run_config(tmp_path: Path, steps: tuple[get_data.PipelineStep, ...]) 
     output_dir.mkdir()
     config_path = base_path / "config.yaml"
     config_path.write_text("{}", encoding="utf-8")
+    subcommands = {step.name: step.subcommand for step in steps}
     return get_data.PipelineRunConfig(
         base_path=base_path,
         input_dir=input_dir,
@@ -31,6 +32,7 @@ def _build_run_config(tmp_path: Path, steps: tuple[get_data.PipelineStep, ...]) 
         dry_run=False,
         input_files={step.name: step.input_filename for step in steps},
         output_stems={step.name: step.output_stem for step in steps},
+        subcommands=subcommands,
     )
 
 

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -74,6 +74,7 @@ def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
     config_path.write_text("io:\n  csv_sep: ','\n", encoding="utf-8")
     input_files = dict(get_data.DEFAULT_INPUT_FILES)
     output_stems = dict(get_data.DEFAULT_OUTPUT_STEMS)
+    subcommands = {step.name: step.subcommand for step in get_data.DEFAULT_PIPELINE_STEPS}
     return get_data.PipelineRunConfig(
         base_path=base_path,
         input_dir=input_dir,
@@ -87,6 +88,7 @@ def _prepare_environment(tmp_path: Path) -> get_data.PipelineRunConfig:
         dry_run=False,
         input_files=input_files,
         output_stems=output_stems,
+        subcommands=subcommands,
     )
 
 

--- a/tests/unit/test_get_data.py
+++ b/tests/unit/test_get_data.py
@@ -23,6 +23,7 @@ def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
     output_dir.mkdir()
     input_files = dict(get_data.DEFAULT_INPUT_FILES)
     output_stems = dict(get_data.DEFAULT_OUTPUT_STEMS)
+    subcommands = {step.name: step.subcommand for step in get_data.DEFAULT_PIPELINE_STEPS}
     for name, filename in input_files.items():
         target = input_dir / filename
         target.write_text("id\nplaceholder\n", encoding="utf-8")
@@ -41,6 +42,7 @@ def _make_config(tmp_path: Path) -> get_data.PipelineRunConfig:
         dry_run=False,
         input_files=input_files,
         output_stems=output_stems,
+        subcommands=subcommands,
     )
 
 
@@ -199,6 +201,83 @@ def test_resolve_pipeline_steps__applies_overrides() -> None:
     assert mapping["document"].input_filename == "doc.csv"
     assert mapping["activity"].output_stem == "custom"
     assert mapping["target"].subcommand is None
+
+
+@pytest.mark.unit
+def test_override_subcommand__target_pipeline_uses_selected_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_path = tmp_path
+    input_dir = base_path / "input"
+    output_dir = base_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    config_path = base_path / "config.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    (input_dir / "target.csv").write_text("target_chembl_id\nT1\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        base_path=base_path,
+        input_dir=Path("input"),
+        output_dir=Path("output"),
+        config=config_path,
+        date_prefix="20240214",
+        log_level="INFO",
+        limit=None,
+        force=False,
+        skip_existing=False,
+        dry_run=False,
+        verbose=False,
+        pipeline_registry=None,
+        override_input=[],
+        override_output_stem=[],
+        override_subcommand=["target=chembl"],
+    )
+
+    resolved_steps = get_data._resolve_pipeline_steps(args)
+    target_only = tuple(step for step in resolved_steps if step.name == "target")
+    cfg = get_data._prepare_config(args, target_only)
+    assert cfg.subcommand_for("target") == "chembl"
+
+    captured: list[str] = []
+
+    def _build_options(
+        run_cfg: get_data.PipelineRunConfig, input_path: Path, output_path: Path
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            input_csv=input_path,
+            output_csv=output_path,
+            command=run_cfg.subcommand_for("target") or "all",
+        )
+
+    def _runner(_: get_data.Config, options: SimpleNamespace) -> PipelineRunResult:
+        captured.append(options.command)
+        destination = Path(options.output_csv)
+        destination.write_text("target_chembl_id\nT1\n", encoding="utf-8")
+        return PipelineRunResult(
+            exit_code=0,
+            output_path=destination,
+            executed=True,
+            reason=None,
+            written=True,
+        )
+
+    stream = io.StringIO()
+    logger = get_data.configure_logger(
+        get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="unit_override")
+    )
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+    monkeypatch.setattr(
+        get_data,
+        "_PIPELINE_APIS",
+        {"target": get_data.PipelineApi(_build_options, _runner)},
+        raising=False,
+    )
+    monkeypatch.setattr(get_data, "load_config", lambda *args, **kwargs: SimpleNamespace(), raising=False)
+
+    status = get_data.run_pipeline(cfg, steps=target_only)
+    assert status == 0
+    assert captured == ["chembl"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- store selected pipeline subcommands in `PipelineRunConfig` so overrides are preserved
- build target pipeline options with the configured subcommand when invoking the API runner
- update supporting tests and add coverage for the `--override-subcommand target=chembl` case

## Testing
- pytest tests/unit/test_get_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c6ad452083248f965fcadc072fc9