### PR TITLE
Adjust success rate scale in reports

### DIFF
--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -229,7 +229,7 @@ def _make_report_writer(step_count: int) -> Callable[[Path], None]:
             "- Branch: test\n"
             f"- Timestamp (UTC): {timestamp}\n"
             "- Duration: 0.0 s\n"
-            "- Success rate: 100.0%\n\n"
+            "- Success rate: 100.00%\n\n"
             "| total | passed | failed | skipped | xfailed | xpassed | error |\n"
             "|------:|-------:|-------:|--------:|--------:|--------:|------:|\n"
             f"|{step_count:6d}|{step_count:7d}|{0:7d}|{0:8d}|{0:8d}|{0:8d}|{0:6d}|\n"
@@ -466,7 +466,7 @@ def test_get_data_end_to_end__miniature_pipeline(
     assert report_payload["summary"]["total"] == 5
     assert report_payload["summary"]["passed"] == 5
     summary_md = summary_md_path.read_text(encoding="utf-8")
-    assert "Success rate: 100.0%" in summary_md
+    assert "Success rate: 100.00%" in summary_md
     assert "|     5|      5|" in summary_md
 
     new_date_prefix = "20240103"

--- a/tests/unit/scripts/test_run_tests_script.py
+++ b/tests/unit/scripts/test_run_tests_script.py
@@ -164,7 +164,7 @@ def test_build_structured_report__captures_failure_messages() -> None:
         "xfailed": 0,
         "xpassed": 0,
         "error": 0,
-        "success_rate": 50.0,
+        "success_rate": 0.5,
     }
 
     failure_entry = next(


### PR DESCRIPTION
## Summary
- update the run_tests unit fixture to assert fractional success rate values in the structured report
- align the E2E test fixtures with the markdown formatter that renders success rate as a percentage with two decimals

## Testing
- pytest tests/unit/scripts/test_run_tests_script.py
- pytest tests/e2e/test_get_data_end_to_end.py -k miniature_pipeline

------
https://chatgpt.com/codex/tasks/task_e_68e4cf5282888324aca5d106aeda0ab8