### PR TITLE
Close existing log handlers before reconfiguring logging

### DIFF
--- a/library/common/logging_setup.py
+++ b/library/common/logging_setup.py
@@ -23,6 +23,14 @@ _SECRET_SUFFIXES: tuple[str, ...] = ("token", "key", "secret", "password")
 _FORMAT = "[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s"
 
 
+def _close_handlers(handlers: list[logging.Handler]) -> None:
+    for handler in handlers:
+        try:
+            handler.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+
 def _level_no(name: str) -> int:
     """Return numeric logging level for ``name``.
 
@@ -212,12 +220,14 @@ def configure_logger(cfg: LoggerConfig, replace_root: bool = True) -> Logger:
 
     if replace_root:
         root_logger = logging.getLogger()
+        _close_handlers(list(root_logger.handlers))
         root_logger.handlers = []
         for handler in handlers:
             root_logger.addHandler(handler)
         root_logger.setLevel(level_no)
         logging.captureWarnings(True)
         warnings_logger = logging.getLogger("py.warnings")
+        _close_handlers(list(warnings_logger.handlers))
         warnings_logger.handlers = []
         for handler in handlers:
             warnings_logger.addHandler(handler)
@@ -225,6 +235,7 @@ def configure_logger(cfg: LoggerConfig, replace_root: bool = True) -> Logger:
         warnings_logger.propagate = False
     else:
         target = logging.getLogger(cfg.logger_name)
+        _close_handlers(list(target.handlers))
         target.handlers = []
         for handler in handlers:
             target.addHandler(handler)

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -1,0 +1,36 @@
+import logging
+import warnings
+from unittest import mock
+
+from library.common.logging_setup import LoggerConfig, configure_logger
+
+
+def test_configure_logger__closes_existing_handlers() -> None:
+    root_logger = logging.getLogger()
+    warnings_logger = logging.getLogger("py.warnings")
+
+    original_root_handlers = list(root_logger.handlers)
+    original_warnings_handlers = list(warnings_logger.handlers)
+    original_root_level = root_logger.level
+    original_warnings_level = warnings_logger.level
+    original_warnings_propagate = warnings_logger.propagate
+    was_capturing_warnings = warnings.showwarning is getattr(logging, "_showwarning", object())
+
+    root_handler = mock.create_autospec(logging.FileHandler, instance=True)
+    warnings_handler = mock.create_autospec(logging.FileHandler, instance=True)
+
+    root_logger.handlers = [root_handler]
+    warnings_logger.handlers = [warnings_handler]
+
+    try:
+        configure_logger(LoggerConfig())
+    finally:
+        root_logger.handlers = original_root_handlers
+        root_logger.setLevel(original_root_level)
+        warnings_logger.handlers = original_warnings_handlers
+        warnings_logger.setLevel(original_warnings_level)
+        warnings_logger.propagate = original_warnings_propagate
+        logging.captureWarnings(was_capturing_warnings)
+
+    root_handler.close.assert_called_once_with()
+    warnings_handler.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- ensure configure_logger closes existing handlers on the root and warnings loggers before replacing them
- add a unit test that verifies file handlers are closed during logger reconfiguration

## Testing
- pytest tests/unit/test_logging_setup.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4cf4a0aa88324bcfd1128ec7098c1