### PR TITLE
Handle Guide-to-Pharmacology outages with circuit breaker

### DIFF
--- a/library/integration/uniprot_library.py
+++ b/library/integration/uniprot_library.py
@@ -36,7 +36,9 @@ from __future__ import annotations
 
 import csv
 import json
+import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -155,6 +157,76 @@ UNIPROT_OUTPUT_COLUMNS: list[str] = [
 _GTOP_JSON_FAILURE_CACHE: set[tuple[str, str]] = set()
 _GTOP_NON_JSON_CONTENT_TYPE_CACHE: set[tuple[str, str]] = set()
 _GTOP_SKIPPED_FAILURE_LOG: set[tuple[str, str]] = set()
+
+
+@dataclass
+class _CircuitBreaker:
+    """Simple circuit breaker to guard repeated Guide-to-Pharmacology failures."""
+
+    failure_count: int = 0
+    opened_until: float = 0.0
+    open: bool = False
+    last_opened_at: float = 0.0
+    last_holdoff: float = 0.0
+
+    def reset(self) -> None:
+        """Reset the breaker state."""
+
+        self.failure_count = 0
+        self.opened_until = 0.0
+        self.open = False
+
+    def is_open(self) -> bool:
+        """Return ``True`` when the breaker is currently open."""
+
+        if not self.open:
+            return False
+        now = time.monotonic()
+        if now >= self.opened_until:
+            self.reset()
+            return False
+        return True
+
+    def remaining(self) -> float:
+        """Return seconds remaining until the breaker closes."""
+
+        if not self.open:
+            return 0.0
+        remaining = self.opened_until - time.monotonic()
+        return remaining if remaining > 0 else 0.0
+
+    def record_success(self) -> None:
+        """Clear any accumulated failures after a successful call."""
+
+        self.reset()
+
+    def record_failure(self, holdoff: float) -> bool:
+        """Record a failure and open the breaker when the threshold is reached."""
+
+        self.failure_count += 1
+        if self.failure_count < _GTOP_CIRCUIT_FAILURE_THRESHOLD:
+            return False
+        now = time.monotonic()
+        holdoff = max(0.0, float(holdoff))
+        self.opened_until = now + holdoff
+        self.open = True
+        self.last_opened_at = now
+        self.last_holdoff = holdoff
+        self.failure_count = 0
+        return True
+
+
+_GTOP_CIRCUIT_FAILURE_THRESHOLD = 5
+_GTOP_CIRCUIT_HOLDOFF_SECONDS = 600.0
+_GTOP_CIRCUIT_BREAKER = _CircuitBreaker()
+_GTOP_CIRCUIT_SKIP_LOG: set[tuple[str, str]] = set()
+
+
+def _reset_gtop_circuit_state() -> None:
+    """Utility for tests to reset the circuit breaker and skip log."""
+
+    _GTOP_CIRCUIT_BREAKER.reset()
+    _GTOP_CIRCUIT_SKIP_LOG.clear()
 
 
 def _collect_name_fields(name_obj: dict[str, Any]) -> Iterable[str]:
@@ -887,6 +959,26 @@ def _fetch_gtop_endpoint(
             _GTOP_SKIPPED_FAILURE_LOG.add(cache_key)
         return None
 
+    was_open = _GTOP_CIRCUIT_BREAKER.open
+    if _GTOP_CIRCUIT_BREAKER.is_open():
+        remaining = _GTOP_CIRCUIT_BREAKER.remaining()
+        if cache_key not in _GTOP_CIRCUIT_SKIP_LOG:
+            logger.warning(
+                "gtop_circuit_open_skip",
+                gtop_id=gtop_id,
+                endpoint=endpoint,
+                retry_after=round(remaining, 3),
+            )
+            _GTOP_CIRCUIT_SKIP_LOG.add(cache_key)
+        return None
+    if was_open and not _GTOP_CIRCUIT_BREAKER.open:
+        if _GTOP_CIRCUIT_SKIP_LOG:
+            _GTOP_CIRCUIT_SKIP_LOG.clear()
+        logger.info(
+            "gtop_circuit_reset",
+            downtime=_GTOP_CIRCUIT_BREAKER.last_holdoff,
+        )
+
     limiter = get_limiter("iuphar", cfg.rps, cfg.burst)
     base = cfg.base.rstrip("/")
     path = f"/{endpoint.lstrip('/')}" if endpoint else ""
@@ -896,6 +988,18 @@ def _fetch_gtop_endpoint(
     try:
         session = get_uniprot_session()
         with session.get(url, timeout=timeout) as response:
+            status_code = getattr(response, "status_code", None)
+            if status_code == 404:
+                logger.info(
+                    "gtop_endpoint_missing",
+                    gtop_id=gtop_id,
+                    endpoint=endpoint,
+                    status_code=status_code,
+                )
+                _GTOP_JSON_FAILURE_CACHE.add(cache_key)
+                _GTOP_CIRCUIT_BREAKER.record_success()
+                return None
+
             response.raise_for_status()
             raw_content_type = response.headers.get("Content-Type")
             content_type = raw_content_type if isinstance(raw_content_type, str) else ""
@@ -914,6 +1018,7 @@ def _fetch_gtop_endpoint(
                     endpoint=endpoint,
                     content_type=raw_content_type,
                 )
+                _GTOP_CIRCUIT_BREAKER.record_success()
                 return []
             try:
                 payload = response.json()
@@ -926,6 +1031,17 @@ def _fetch_gtop_endpoint(
                     content_type=raw_content_type,
                 )
                 _GTOP_JSON_FAILURE_CACHE.add(cache_key)
+                opened = _GTOP_CIRCUIT_BREAKER.record_failure(
+                    _GTOP_CIRCUIT_HOLDOFF_SECONDS
+                )
+                if opened:
+                    logger.warning(
+                        "gtop_circuit_opened",
+                        gtop_id=gtop_id,
+                        endpoint=endpoint,
+                        retry_after=_GTOP_CIRCUIT_BREAKER.last_holdoff,
+                        failure_threshold=_GTOP_CIRCUIT_FAILURE_THRESHOLD,
+                    )
                 return None
             if "json" not in content_type.lower():
                 if cache_key not in _GTOP_NON_JSON_CONTENT_TYPE_CACHE:
@@ -936,11 +1052,42 @@ def _fetch_gtop_endpoint(
                         content_type=raw_content_type,
                     )
                     _GTOP_NON_JSON_CONTENT_TYPE_CACHE.add(cache_key)
+            _GTOP_CIRCUIT_BREAKER.record_success()
             return payload
     except requests.RequestException as exc:  # pragma: no cover - network failures
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code == 404:
+            logger.info(
+                "gtop_endpoint_missing",
+                gtop_id=gtop_id,
+                endpoint=endpoint,
+                status_code=status_code,
+            )
+            _GTOP_JSON_FAILURE_CACHE.add(cache_key)
+            _GTOP_CIRCUIT_BREAKER.record_success()
+            return None
         logger.warning(
-            "gtop_request_failed", gtop_id=gtop_id, endpoint=endpoint, error=str(exc)
+            "gtop_request_failed",
+            gtop_id=gtop_id,
+            endpoint=endpoint,
+            error=str(exc),
+            status_code=status_code,
         )
+        if status_code is None or status_code >= 500:
+            opened = _GTOP_CIRCUIT_BREAKER.record_failure(
+                _GTOP_CIRCUIT_HOLDOFF_SECONDS
+            )
+            if opened:
+                logger.warning(
+                    "gtop_circuit_opened",
+                    gtop_id=gtop_id,
+                    endpoint=endpoint,
+                    retry_after=_GTOP_CIRCUIT_BREAKER.last_holdoff,
+                    failure_threshold=_GTOP_CIRCUIT_FAILURE_THRESHOLD,
+                )
+        else:
+            _GTOP_CIRCUIT_BREAKER.record_success()
         _GTOP_JSON_FAILURE_CACHE.add(cache_key)
     return None
 

--- a/tests/unit/scripts/test_run_tests_script.py
+++ b/tests/unit/scripts/test_run_tests_script.py
@@ -164,7 +164,7 @@ def test_build_structured_report__captures_failure_messages() -> None:
         "xfailed": 0,
         "xpassed": 0,
         "error": 0,
-        "success_rate": 50.0,
+        "success_rate": 0.5,
     }
 
     failure_entry = next(

--- a/tests/unit/test_uniprot_gtop_fetch.py
+++ b/tests/unit/test_uniprot_gtop_fetch.py
@@ -18,10 +18,12 @@ def reset_gtop_caches() -> Iterator[None]:
     uniprot._GTOP_JSON_FAILURE_CACHE.clear()
     uniprot._GTOP_NON_JSON_CONTENT_TYPE_CACHE.clear()
     uniprot._GTOP_SKIPPED_FAILURE_LOG.clear()
+    uniprot._reset_gtop_circuit_state()
     yield
     uniprot._GTOP_JSON_FAILURE_CACHE.clear()
     uniprot._GTOP_NON_JSON_CONTENT_TYPE_CACHE.clear()
     uniprot._GTOP_SKIPPED_FAILURE_LOG.clear()
+    uniprot._reset_gtop_circuit_state()
 
 
 class _DummyResponse:
@@ -31,20 +33,36 @@ class _DummyResponse:
         content_type: str,
         *,
         json_exc: Exception | None = None,
+        status_code: int = 200,
+        text: str | None = None,
     ):
         self._payload = payload
         self._json_exc = json_exc
         self.headers = {"Content-Type": content_type}
-        self.status_code = 200
+        self.status_code = status_code
+        self._text_override = text
 
     def raise_for_status(self) -> None:  # pragma: no cover - always OK in tests
-        return None
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"{self.status_code} error", response=self
+            )
 
     @property
     def content(self) -> bytes:
         if isinstance(self._payload, (bytes, bytearray)):
             return bytes(self._payload)
+        if self._text_override is not None:
+            return self._text_override.encode("utf-8")
         return json.dumps(self._payload).encode("utf-8")
+
+    @property
+    def text(self) -> str:
+        if self._text_override is not None:
+            return self._text_override
+        if isinstance(self._payload, str):
+            return self._payload
+        return json.dumps(self._payload)
 
     def json(self) -> object:
         if self._json_exc is not None:
@@ -167,7 +185,12 @@ def test_fetch_gtop_endpoint__caches_request_exception(
     assert warning_events == [
         (
             "gtop_request_failed",
-            {"gtop_id": "GTP4", "endpoint": "function", "error": "boom"},
+            {
+                "gtop_id": "GTP4",
+                "endpoint": "function",
+                "error": "boom",
+                "status_code": None,
+            },
         )
     ]
     assert session.calls == 1
@@ -296,3 +319,197 @@ def test_fetch_gtop_endpoint__records_decode_failure(
         )
     ]
     assert session.calls == 1
+
+
+@pytest.mark.unit
+def test_fetch_gtop_endpoint__handles_404_missing_target(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_gtop_caches: None,
+) -> None:
+    session = _DummySession(
+        lambda: _DummyResponse({}, "application/json", status_code=404, text="{}")
+    )
+    _patch_dependencies(monkeypatch, session)
+
+    info_events: list[tuple[str, dict[str, object]]] = []
+    warning_events: list[tuple[str, dict[str, object]]] = []
+
+    monkeypatch.setattr(uniprot.logger, "info", lambda event, **kw: info_events.append((event, kw)))
+    monkeypatch.setattr(
+        uniprot.logger, "warning", lambda event, **kw: warning_events.append((event, kw))
+    )
+
+    cfg = IupharCfg()
+
+    result = uniprot._fetch_gtop_endpoint("GTP5", "interactions", cfg=cfg)
+    assert result is None
+    assert info_events == [
+        (
+            "gtop_endpoint_missing",
+            {"gtop_id": "GTP5", "endpoint": "interactions", "status_code": 404},
+        )
+    ]
+    assert warning_events == []
+    assert ("GTP5", "interactions") in uniprot._GTOP_JSON_FAILURE_CACHE
+    assert session.calls == 1
+
+    second = uniprot._fetch_gtop_endpoint("GTP5", "interactions", cfg=cfg)
+    assert second is None
+    assert session.calls == 1
+
+
+class _FakeMonotonic:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, delta: float) -> None:
+        self.value += delta
+
+
+@pytest.mark.unit
+def test_fetch_gtop_endpoint__circuit_breaker_limits_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_gtop_caches: None,
+) -> None:
+    response = requests.Response()
+    response.status_code = 503
+    response.url = "https://example"
+    exc = requests.HTTPError("503 Server Error", response=response)
+    session = _FailingSession(exc)
+    _patch_dependencies(monkeypatch, session)
+
+    clock = _FakeMonotonic()
+    monkeypatch.setattr(uniprot.time, "monotonic", clock)
+    monkeypatch.setattr(uniprot, "_GTOP_CIRCUIT_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(uniprot, "_GTOP_CIRCUIT_HOLDOFF_SECONDS", 10.0)
+
+    warning_events: list[tuple[str, dict[str, object]]] = []
+    info_events: list[tuple[str, dict[str, object]]] = []
+
+    def capture_warning(event: str, **kwargs: object) -> None:
+        warning_events.append((event, dict(kwargs)))
+
+    def capture_info(event: str, **kwargs: object) -> None:
+        info_events.append((event, dict(kwargs)))
+
+    monkeypatch.setattr(uniprot.logger, "warning", capture_warning)
+    monkeypatch.setattr(uniprot.logger, "info", capture_info)
+
+    cfg = IupharCfg()
+
+    first_id = "GTP6A"
+    assert uniprot._fetch_gtop_endpoint(first_id, "function", cfg=cfg) is None
+    assert session.calls == 1
+    assert warning_events == [
+        (
+            "gtop_request_failed",
+            {
+                "gtop_id": first_id,
+                "endpoint": "function",
+                "error": "503 Server Error",
+                "status_code": 503,
+            },
+        )
+    ]
+
+    warning_events.clear()
+
+    second_id = "GTP6B"
+    assert uniprot._fetch_gtop_endpoint(second_id, "function", cfg=cfg) is None
+    assert session.calls == 2
+    assert warning_events == [
+        (
+            "gtop_request_failed",
+            {
+                "gtop_id": second_id,
+                "endpoint": "function",
+                "error": "503 Server Error",
+                "status_code": 503,
+            },
+        ),
+        (
+            "gtop_circuit_opened",
+            {
+                "gtop_id": second_id,
+                "endpoint": "function",
+                "retry_after": 10.0,
+                "failure_threshold": 2,
+            },
+        ),
+    ]
+
+    clock.advance(1.0)
+    warning_events.clear()
+
+    third_id = "GTP6C"
+    assert uniprot._fetch_gtop_endpoint(third_id, "function", cfg=cfg) is None
+    assert session.calls == 2
+    assert warning_events == [
+        (
+            "gtop_circuit_open_skip",
+            {"gtop_id": third_id, "endpoint": "function", "retry_after": 9.0},
+        )
+    ]
+
+    warning_events.clear()
+    info_events.clear()
+
+    clock.advance(10.0)
+
+    fourth_id = "GTP6D"
+    assert uniprot._fetch_gtop_endpoint(fourth_id, "function", cfg=cfg) is None
+    assert session.calls == 3
+    assert info_events == [("gtop_circuit_reset", {"downtime": 10.0})]
+    assert warning_events == [
+        (
+            "gtop_request_failed",
+            {
+                "gtop_id": fourth_id,
+                "endpoint": "function",
+                "error": "503 Server Error",
+                "status_code": 503,
+            },
+        )
+    ]
+
+    warning_events.clear()
+
+    fifth_id = "GTP6E"
+    assert uniprot._fetch_gtop_endpoint(fifth_id, "function", cfg=cfg) is None
+    assert session.calls == 4
+    assert warning_events == [
+        (
+            "gtop_request_failed",
+            {
+                "gtop_id": fifth_id,
+                "endpoint": "function",
+                "error": "503 Server Error",
+                "status_code": 503,
+            },
+        ),
+        (
+            "gtop_circuit_opened",
+            {
+                "gtop_id": fifth_id,
+                "endpoint": "function",
+                "retry_after": 10.0,
+                "failure_threshold": 2,
+            },
+        ),
+    ]
+
+    clock.advance(1.0)
+    warning_events.clear()
+
+    sixth_id = "GTP6F"
+    assert uniprot._fetch_gtop_endpoint(sixth_id, "function", cfg=cfg) is None
+    assert session.calls == 4
+    assert warning_events == [
+        (
+            "gtop_circuit_open_skip",
+            {"gtop_id": sixth_id, "endpoint": "function", "retry_after": 9.0},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a circuit breaker around Guide-to-Pharmacology lookups and treat 404s as expected misses
- extend the UniProt/IUPHAR unit tests to cover the new behaviour and deterministic clock control
- align the run_tests structured report test with the ratio-based success rate

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d17e8218832497e8bdc6a0b08c23