### PR TITLE
Make run_tests discover tests dynamically and support exclusions

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -29,12 +29,7 @@ REPO_SLUG = "SatoryKono/ChEMBL_data_acquisition"
 QUALITY_THRESHOLD_PERCENT = 95.0
 QUALITY_FAILURE_EXIT_CODE = 1
 VALIDATION_FAILURE_EXIT_CODE = 11
-TEST_DIRECTORIES = (
-    ROOT_DIR / "tests" / "unit",
-    ROOT_DIR / "tests" / "integration",
-    ROOT_DIR / "tests" / "postprocessing",
-    ROOT_DIR / "tests" / "e2e",
-)
+TESTS_ROOT = ROOT_DIR / "tests"
 _BASE_PYTEST_COMMAND: list[str] = [
     sys.executable,
     "-m",
@@ -50,9 +45,6 @@ _BASE_PYTEST_COMMAND: list[str] = [
     f"--cov-report=html:{COVERAGE_HTML}",
     "-vv",
 ]
-_DEFAULT_TEST_TARGETS: tuple[str, ...] = tuple(
-    str(path) for path in TEST_DIRECTORIES if path.exists()
-)
 
 
 logger = logging.getLogger("run_tests")
@@ -63,6 +55,64 @@ def _relative_to_root(path: Path) -> str:
         return str(path.relative_to(ROOT_DIR))
     except ValueError:
         return str(path)
+
+
+def _normalise_excluded_names(excluded: Iterable[str] | None) -> set[str]:
+    names: set[str] = set()
+    if not excluded:
+        return names
+    for entry in excluded:
+        if not entry:
+            continue
+        candidate = Path(entry).name.strip()
+        if candidate:
+            names.add(candidate)
+    return names
+
+
+def discover_test_targets(
+    root: Path, excluded: Iterable[str] | None = None
+) -> tuple[str, ...]:
+    """Return pytest targets discovered under ``root``.
+
+    Directories listed in ``excluded`` are ignored. When ``root`` contains
+    top-level ``test_*.py`` files, the root itself is added as an explicit
+    target to ensure they are collected.
+    """
+
+    if not root.exists():
+        return ()
+
+    entries = list(root.iterdir())
+    excluded_names = _normalise_excluded_names(excluded)
+
+    directories = [
+        path
+        for path in entries
+        if path.is_dir()
+        and path.name not in excluded_names
+        and not path.name.startswith(".")
+        and path.name != "__pycache__"
+    ]
+    directories.sort(key=lambda item: item.name)
+
+    has_direct_tests = any(
+        path.is_file()
+        and path.suffix == ".py"
+        and path.name.startswith("test_")
+        for path in entries
+    )
+
+    targets: list[str] = []
+    if has_direct_tests:
+        targets.append(str(root))
+
+    targets.extend(str(path) for path in directories)
+
+    if not targets:
+        targets.append(str(root))
+
+    return tuple(targets)
 
 
 def ensure_reports_directory() -> None:
@@ -435,6 +485,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Date token forwarded to the log file suffix (format: YYYYMMDD)",
     )
     parser.add_argument(
+        "--exclude",
+        dest="exclude",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Directory name under the tests/ root to skip (can be provided multiple times)"
+        ),
+    )
+    parser.add_argument(
         "pytest_args",
         nargs=argparse.REMAINDER,
         help="Arguments forwarded to pytest (use '--' before them)",
@@ -472,7 +532,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 logging_ctx.log_cfg.level,
             ]
         )
-        pytest_command.extend(_DEFAULT_TEST_TARGETS)
+
+        test_targets = discover_test_targets(TESTS_ROOT, args.exclude)
+        if not test_targets:
+            logger.warning("No test targets discovered under %s", TESTS_ROOT)
+        pytest_command.extend(test_targets)
         pytest_command.extend(_extract_pytest_args(args.pytest_args))
 
         exit_code = run_pytest(pytest_command)

--- a/tests/unit/scripts/test_run_tests_script.py
+++ b/tests/unit/scripts/test_run_tests_script.py
@@ -23,6 +23,9 @@ def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytes
     raw_report_file = reports_dir / "pytest_raw_report.json"
     report_file = reports_dir / "test_report.json"
     summary_file = reports_dir / "test_summary.md"
+    tests_root = tmp_path / "tests"
+    (tests_root / "new_suite").mkdir(parents=True)
+    (tests_root / "unit").mkdir()
 
     monkeypatch.setattr(run_tests, "ROOT_DIR", tmp_path)
     monkeypatch.setattr(run_tests, "REPORTS_DIR", reports_dir, raising=False)
@@ -32,6 +35,7 @@ def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytes
     monkeypatch.setattr(run_tests, "COVERAGE_DIR", coverage_dir, raising=False)
     monkeypatch.setattr(run_tests, "COVERAGE_XML", coverage_dir / "coverage.xml", raising=False)
     monkeypatch.setattr(run_tests, "COVERAGE_HTML", coverage_dir / "html", raising=False)
+    monkeypatch.setattr(run_tests, "TESTS_ROOT", tests_root, raising=False)
 
     base_command: list[str] = [
         sys.executable,
@@ -49,7 +53,6 @@ def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytes
         "-vv",
     ]
     monkeypatch.setattr(run_tests, "_BASE_PYTEST_COMMAND", base_command, raising=False)
-    monkeypatch.setattr(run_tests, "_DEFAULT_TEST_TARGETS", ("tests/unit",), raising=False)
     monkeypatch.setattr(run_tests, "_git_output", lambda *args, **kwargs: "stub")
 
     captured_log_path: Path | None = None
@@ -121,9 +124,108 @@ def test_run_tests__verbose_creates_debug_log(tmp_path: Path, monkeypatch: pytes
 
     assert command[-2:] == ["-k", "unit"]
 
+    discovered = command[len(base_command) + 4 : -2]
+    assert discovered == [
+        str(tests_root / "new_suite"),
+        str(tests_root / "unit"),
+    ]
+
     assert report_file.exists()
     assert summary_file.exists()
     assert captured_configs and captured_configs[-1].level == "DEBUG"
+
+
+@pytest.mark.unit
+def test_run_tests__exclude_directories_from_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reports_dir = tmp_path / "reports"
+    coverage_dir = reports_dir / "coverage"
+    raw_report_file = reports_dir / "pytest_raw_report.json"
+    report_file = reports_dir / "test_report.json"
+    summary_file = reports_dir / "test_summary.md"
+    tests_root = tmp_path / "tests"
+    (tests_root / "experimental").mkdir(parents=True)
+    (tests_root / "helpers").mkdir()
+    (tests_root / "unit").mkdir()
+
+    monkeypatch.setattr(run_tests, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(run_tests, "REPORTS_DIR", reports_dir, raising=False)
+    monkeypatch.setattr(run_tests, "RAW_REPORT_FILE", raw_report_file, raising=False)
+    monkeypatch.setattr(run_tests, "REPORT_FILE", report_file, raising=False)
+    monkeypatch.setattr(run_tests, "SUMMARY_FILE", summary_file, raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_DIR", coverage_dir, raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_XML", coverage_dir / "coverage.xml", raising=False)
+    monkeypatch.setattr(run_tests, "COVERAGE_HTML", coverage_dir / "html", raising=False)
+    monkeypatch.setattr(run_tests, "TESTS_ROOT", tests_root, raising=False)
+    monkeypatch.setattr(run_tests, "_git_output", lambda *args, **kwargs: "stub")
+
+    base_command: list[str] = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--json-report",
+        "--json-report-file",
+        str(raw_report_file),
+        "--durations=0",
+        "--cov=library",
+        "--cov=scripts",
+        "--cov-report=term",
+        f"--cov-report=xml:{coverage_dir / 'coverage.xml'}",
+        f"--cov-report=html:{coverage_dir / 'html'}",
+        "-vv",
+    ]
+    monkeypatch.setattr(run_tests, "_BASE_PYTEST_COMMAND", base_command, raising=False)
+
+    captured_commands: list[list[str]] = []
+
+    def _fake_run_pytest(command: Sequence[str]) -> int:
+        captured_commands.append(list(command))
+        return 0
+
+    monkeypatch.setattr(run_tests, "run_pytest", _fake_run_pytest)
+    monkeypatch.setattr(run_tests, "configure_logger", lambda *_: object())
+
+    @contextmanager
+    def _fake_setup(script_name: str, log_cfg: LoggerConfig, date: str | None = None):
+        assert script_name == "run_tests"
+        yield SimpleNamespace(
+            log_path=tmp_path / "logs" / "run_tests.log",
+            log_cfg=LoggerConfig(
+                level=log_cfg.level,
+                run_id=log_cfg.run_id,
+                redact_secrets=log_cfg.redact_secrets,
+                stream=log_cfg.stream,
+                handlers=list(log_cfg.handlers),
+                logger_name=log_cfg.logger_name,
+            ),
+            console_stream=None,
+        )
+
+    monkeypatch.setattr(run_tests, "setup_cli_logging", _fake_setup)
+    monkeypatch.setattr(
+        run_tests,
+        "_load_raw_report",
+        lambda: {"tests": [], "duration": 0.0},
+    )
+
+    exit_code = run_tests.main([
+        "--exclude",
+        "experimental",
+        "--exclude",
+        "helpers",
+    ])
+
+    assert exit_code == 0
+    assert captured_commands, "run_pytest should be invoked"
+
+    command = captured_commands[-1]
+    assert command[: len(base_command)] == base_command
+    assert str(tests_root / "unit") in command
+    assert str(tests_root / "experimental") not in command
+    assert str(tests_root / "helpers") not in command
+    assert report_file.exists()
+    assert summary_file.exists()
 
 
 @pytest.mark.unit
@@ -231,6 +333,8 @@ def test_main__returns_exit_code_one_when_quality_gate_fails(
     raw_report_file = reports_dir / "pytest_raw_report.json"
     report_file = reports_dir / "test_report.json"
     summary_file = reports_dir / "test_summary.md"
+    tests_root = tmp_path / "tests"
+    (tests_root / "unit").mkdir(parents=True)
 
     monkeypatch.setattr(run_tests, "ROOT_DIR", tmp_path, raising=False)
     monkeypatch.setattr(run_tests, "REPORTS_DIR", reports_dir, raising=False)
@@ -240,6 +344,7 @@ def test_main__returns_exit_code_one_when_quality_gate_fails(
     monkeypatch.setattr(run_tests, "COVERAGE_DIR", coverage_dir, raising=False)
     monkeypatch.setattr(run_tests, "COVERAGE_XML", coverage_dir / "coverage.xml", raising=False)
     monkeypatch.setattr(run_tests, "COVERAGE_HTML", coverage_dir / "html", raising=False)
+    monkeypatch.setattr(run_tests, "TESTS_ROOT", tests_root, raising=False)
 
     base_command = [
         sys.executable,
@@ -251,7 +356,6 @@ def test_main__returns_exit_code_one_when_quality_gate_fails(
         "--durations=0",
     ]
     monkeypatch.setattr(run_tests, "_BASE_PYTEST_COMMAND", base_command, raising=False)
-    monkeypatch.setattr(run_tests, "_DEFAULT_TEST_TARGETS", ("tests/unit",), raising=False)
 
     captured_commands: list[list[str]] = []
 
@@ -323,6 +427,7 @@ def test_main__returns_exit_code_one_when_quality_gate_fails(
     assert exit_code == 1
     assert "below the required 95.00% threshold" in caplog.text
     assert captured_commands, "run_pytest should be invoked"
+    assert str(tests_root / "unit") in captured_commands[-1]
 
     payload = json.loads(report_file.read_text(encoding="utf-8"))
     assert payload["summary"]["success_rate"] == pytest.approx(0.94)


### PR DESCRIPTION
## Summary
- discover pytest targets dynamically from the tests/ root and allow excluding directories via a new CLI flag
- extend the run_tests wrapper tests to cover dynamic discovery and exclusion handling

## Testing
- pytest tests/unit/scripts/test_run_tests_script.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d22c474c8324bcc5817af0c111f9