### PR TITLE
Avoid reloading config while warming parent catalog

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -960,14 +960,13 @@ def _cleanup_failed_step(
         )
 
 
-def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
+def _warm_parent_catalog(cfg: PipelineRunConfig, base_config: Config) -> None:
     """Ensure the molecule parent catalogue cache exists before test item runs."""
 
     from library.integration.molecule_catalog import load_parent_catalog
 
     start_time = time.perf_counter()
-    config: Config = load_config(cfg.config_path, base_path=cfg.base_path)
-    chembl_sources = config.sources.chembl
+    chembl_sources = base_config.sources.chembl
     catalog_cfg = chembl_sources.molecule_catalog
     cache_path = catalog_cfg.cache_path
     sqlite_path = catalog_cfg.sqlite_path
@@ -990,13 +989,15 @@ def _warm_parent_catalog(cfg: PipelineRunConfig) -> None:
     def _catalog_client_factory(context: ETLContext) -> ChemblClient:
         return ChemblClient(
             api=chembl_sources.api,
-            retry=config.system.retry,
+            retry=base_config.system.retry,
             chembl=chembl_sources.cache,
             global_limiter=context.global_limiter,
         )
 
     try:
-        with ETLContext(config, chembl_client_factory=_catalog_client_factory) as context:
+        with ETLContext(
+            base_config, chembl_client_factory=_catalog_client_factory
+        ) as context:
             load_parent_catalog(
                 client=context.chembl_client,
                 api_cfg=chembl_sources.api,
@@ -1458,7 +1459,7 @@ def run_pipeline(
                 )
                 if not should_skip_warm:
                     try:
-                        _warm_parent_catalog(current_cfg)
+                        _warm_parent_catalog(current_cfg, base_config)
                     except TimeoutError as exc:
                         overall_status = 1
                         entry.update(

--- a/tests/e2e/test_get_data_end_to_end.py
+++ b/tests/e2e/test_get_data_end_to_end.py
@@ -258,7 +258,9 @@ def test_get_data_end_to_end__miniature_pipeline(
     config_path.write_text("io:\n  csv_sep: ','\n  csv_encoding: 'utf-8'\n")
 
     monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(base_path))
-    monkeypatch.setattr(get_data, "_warm_parent_catalog", lambda _cfg: None)
+    monkeypatch.setattr(
+        get_data, "_warm_parent_catalog", lambda _cfg, _base: None
+    )
 
     log_streams: deque[io.StringIO] = deque()
 

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -392,10 +392,12 @@ def test_pipeline_subset__testitem_skip_existing_avoids_parent_warm(
         get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="integration")
     )
 
-    warm_calls: list[get_data.PipelineRunConfig] = []
+    warm_calls: list[tuple[get_data.PipelineRunConfig, object]] = []
 
-    def _record_warm(current_cfg: get_data.PipelineRunConfig) -> None:
-        warm_calls.append(current_cfg)
+    def _record_warm(
+        current_cfg: get_data.PipelineRunConfig, base_config: object
+    ) -> None:
+        warm_calls.append((current_cfg, base_config))
 
     monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
     monkeypatch.setattr(get_data, "_PIPELINE_APIS", {"testitem": api}, raising=False)


### PR DESCRIPTION
## Summary
- pass the already loaded base configuration into `_warm_parent_catalog` instead of reloading it
- propagate the updated helper signature through the pipeline runner and associated tests

## Testing
- pytest tests/integration/test_get_data_workflow.py::test_pipeline_subset__testitem_skip_existing_avoids_parent_warm -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d67e9334832498ec2b8c180709ec