### PR TITLE
Handle configuration load failures in orchestrator

### DIFF
--- a/scripts/get_data.py
+++ b/scripts/get_data.py
@@ -49,7 +49,15 @@ from library.cli.logging import setup_cli_logging
 from library.clients import ChemblClient
 from library.orchestration import ETLContext
 from library.common.logging_setup import Logger, LoggerConfig, configure_logger
-from library.config import Config, DEFAULT_CONFIG_PATH, load_config
+from pydantic import ValidationError
+
+from library.config import (
+    Config,
+    ConfigError,
+    ConfigLoaderError,
+    DEFAULT_CONFIG_PATH,
+    load_config,
+)
 from library.pipelines.activity import (
     ActivityPipelineOptions,
     run_pipeline as run_activity_pipeline,
@@ -81,7 +89,6 @@ from library.pipelines.testitem import (
     TestitemPipelineOptions,
     run_pipeline as run_testitem_pipeline,
 )
-from library.config.loader import DEFAULT_CONFIG_PATH
 
 
 _LOGGER: Logger = configure_logger(LoggerConfig())
@@ -1354,7 +1361,12 @@ def run_pipeline(
         return 1
     effective_steps = plan.steps
     external_requirements = plan.external_artifacts
-    base_config = load_config(cfg.config_path, base_path=cfg.base_path)
+    try:
+        base_config = load_config(cfg.config_path, base_path=cfg.base_path)
+    except (ConfigError, ConfigLoaderError, ValidationError) as exc:
+        _LOGGER.error("config_load_failed", error=str(exc), exc_info=exc)
+        _LOGGER.info("pipeline_done", stage="pipeline", exit_code=1)
+        return 1
     overall_status = 0
     run_started_at = datetime.now(UTC)
     run_started_clock = time.perf_counter()

--- a/tests/integration/test_get_data_workflow.py
+++ b/tests/integration/test_get_data_workflow.py
@@ -10,12 +10,13 @@ from typing import Callable
 import pandas as pd
 import pytest
 
-from library.config import Config
+from library.config import Config, ConfigLoaderError
 from library.pipelines.common import PipelineRunResult
 from scripts import get_data, get_target_data
 from tests.helpers import ASSAY_ENRICHMENT_MIN_RATIO
 from tests.helpers.logs import parse_log_lines
 from tests.helpers.manifests import load_latest_manifest, list_manifest_files
+from pydantic import BaseModel, ValidationError
 
 
 def _build_stub_api(
@@ -103,6 +104,17 @@ def _load_manifest(cfg: get_data.PipelineRunConfig) -> dict[str, object]:
     return manifest
 
 
+def _make_validation_error() -> ValidationError:
+    class _DummyModel(BaseModel):
+        value: int
+
+    try:
+        _DummyModel.model_validate({"value": "boom"})
+    except ValidationError as exc:  # pragma: no cover - control flow
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
 @pytest.mark.integration
 def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = _prepare_environment(tmp_path)
@@ -180,6 +192,60 @@ def test_pipeline_subset__schema_and_duplicates(tmp_path: Path, monkeypatch: pyt
     assert manifest_failure["steps"][0]["status"] == "failed"
     assert manifest_failure["steps"][0]["reason"] == "schema_mismatch"
     assert manifest_failure["steps"][0]["output"]["exists"] is False
+
+
+@pytest.mark.integration
+def test_run_pipeline__config_loader_error_handled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _prepare_environment(tmp_path)
+    stream = io.StringIO()
+    logger = get_data.configure_logger(
+        get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="config-error")
+    )
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    error = ConfigLoaderError("failed to load configuration")
+
+    def _raise_config_error(*_args: object, **_kwargs: object) -> Config:
+        raise error
+
+    monkeypatch.setattr(get_data, "load_config", _raise_config_error, raising=False)
+
+    status = get_data.run_pipeline(cfg, steps=())
+
+    assert status == 1
+    log_text = stream.getvalue()
+    assert "config_load_failed" in log_text
+    assert "pipeline_done exit_code=1" in log_text
+    assert list_manifest_files(cfg.base_path) == []
+
+
+@pytest.mark.integration
+def test_run_pipeline__validation_error_handled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _prepare_environment(tmp_path)
+    stream = io.StringIO()
+    logger = get_data.configure_logger(
+        get_data.LoggerConfig(level="DEBUG", stream=stream, run_id="validation-error")
+    )
+    monkeypatch.setattr(get_data, "_LOGGER", logger, raising=False)
+
+    validation_error = _make_validation_error()
+
+    def _raise_validation_error(*_args: object, **_kwargs: object) -> Config:
+        raise validation_error
+
+    monkeypatch.setattr(get_data, "load_config", _raise_validation_error, raising=False)
+
+    status = get_data.run_pipeline(cfg, steps=())
+
+    assert status == 1
+    log_text = stream.getvalue()
+    assert "config_load_failed" in log_text
+    assert "pipeline_done exit_code=1" in log_text
+    assert list_manifest_files(cfg.base_path) == []
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- log and exit cleanly when the orchestrator fails to load configuration during workflow startup
- add integration coverage for config loader and validation error handling in the orchestrator pipeline

## Testing
- pytest tests/integration/test_get_data_workflow.py -k "config_loader_error or validation_error_handled" -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d67a43ac8324be230b7d2a5c7838