### PR TITLE
Handle PubMed timeout overrides

### DIFF
--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -183,6 +183,14 @@ _EXPORT_SORT_FALLBACK = [
 _EXPORT_STREAM_CHUNK_SIZE = 10_000
 
 
+def _resolve_timeout(value: float | None, default: float) -> float:
+    """Return ``default`` when ``value`` is ``None`` otherwise the float value."""
+
+    if value is None:
+        return float(default)
+    return float(value)
+
+
 def _iter_export_chunks(df: pd.DataFrame, *, chunk_size: int) -> Iterable[pd.DataFrame]:
     """Yield export-ready DataFrame chunks from ``df``."""
 
@@ -1000,7 +1008,8 @@ def run_chembl(
             args.final_out = output_path
         setattr(args, "output_csv", output_path)
     chunk_size = getattr(args, "chunk_size", chembl_defaults.chunk_size)
-    timeout = getattr(args, "timeout", chembl_defaults.timeout)
+    timeout = _resolve_timeout(getattr(args, "timeout", None), chembl_defaults.timeout)
+    setattr(args, "timeout", timeout)
     metadata_obj = getattr(args, "_config_metadata", None)
     if not isinstance(metadata_obj, ConfigMetadata):
         metadata_obj = None
@@ -1078,13 +1087,14 @@ def run_chembl(
                 cfg=cfg.api,
                 client=client,
                 chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
-                timeout=getattr(args, "timeout", chembl_defaults.timeout),
+                timeout=timeout,
             )
         except (requests.RequestException, ValueError) as exc:
             logger.error(
                 "chembl_documents_fetch_failed",
                 error=str(exc), exc_info=exc,
                 chunk_size=getattr(args, "chunk_size", chembl_defaults.chunk_size),
+                timeout=timeout,
             )
             return 1
         if "doi" in df.columns:
@@ -1200,17 +1210,32 @@ def run_all(
         setattr(args, "output_csv", output_path)
     fallback_enabled = getattr(args, "fallback_doi_enabled", False)
     fallback_path_arg = getattr(args, "fallback_doi_path", None)
+    chembl_chunk_size = getattr(
+        args, "chembl_chunk_size", all_defaults.chunk_size
+    )
+    setattr(args, "chembl_chunk_size", chembl_chunk_size)
+    chembl_timeout_value = getattr(args, "chembl_timeout", None)
+    if chembl_timeout_value is None:
+        chembl_timeout_value = getattr(args, "timeout", None)
+    chembl_timeout = _resolve_timeout(chembl_timeout_value, all_defaults.timeout)
+    setattr(args, "chembl_timeout", chembl_timeout)
+    pubmed_timeout_value = getattr(args, "pubmed_timeout", None)
+    if pubmed_timeout_value is None:
+        pubmed_timeout_value = getattr(args, "timeout", None)
+    pubmed_timeout = _resolve_timeout(pubmed_timeout_value, PUBMED_DEFAULTS.timeout)
+    setattr(args, "pubmed_timeout", pubmed_timeout)
     logger.info(
         "document_all_start",
         input=str(args.input_csv),
         output=str(output_path),
         limit=limit,
         offset=offset,
-        chembl_chunk_size=getattr(args, "chembl_chunk_size", all_defaults.chunk_size),
+        chembl_chunk_size=chembl_chunk_size,
         pubmed_workers=getattr(args, "pubmed_workers", all_defaults.workers),
         pubmed_batch_size=getattr(args, "pubmed_batch_size", all_defaults.batch_size),
         pubmed_sleep=getattr(args, "pubmed_sleep", all_defaults.sleep),
-        chembl_timeout=getattr(args, "chembl_timeout", all_defaults.timeout),
+        chembl_timeout=chembl_timeout,
+        pubmed_timeout=pubmed_timeout,
         fallback_doi_enabled=fallback_enabled,
         fallback_doi_overwrite=getattr(args, "fallback_doi_overwrite", False),
         fallback_doi_path=str(fallback_path_arg) if fallback_path_arg else None,
@@ -1277,12 +1302,8 @@ def run_all(
                 ids_for_fetch,
                 cfg=cfg.api,
                 client=client,
-                chunk_size=getattr(
-                    args, "chembl_chunk_size", all_defaults.chunk_size
-                ),
-                timeout=getattr(
-                    args, "chembl_timeout", all_defaults.timeout
-                ),
+                chunk_size=chembl_chunk_size,
+                timeout=chembl_timeout,
             )
     except (requests.RequestException, ValueError) as exc:
         logger.error(
@@ -1290,7 +1311,8 @@ def run_all(
             ids=sample_ids,
             error=str(exc), exc_info=exc,
             output=str(output_path),
-            chunk_size=getattr(args, "chembl_chunk_size", all_defaults.chunk_size),
+            chunk_size=chembl_chunk_size,
+            timeout=chembl_timeout,
         )
         return 1
     if limit_counter is not None:
@@ -1483,15 +1505,23 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     mode = getattr(args, "mode", None)
     if mode in (None, ""):
         mode = getattr(args, "command", None)
-    timeout_value = None
+    chembl_timeout_override: float | None = None
+    pubmed_timeout_override: float | None = None
     if mode == "chembl":
-        timeout_value = getattr(args, "timeout", None)
+        chembl_timeout_override = getattr(args, "timeout", None)
+    elif mode == "pubmed":
+        pubmed_timeout_override = getattr(args, "timeout", None)
     elif mode == "all":
-        timeout_value = getattr(args, "chembl_timeout", None)
-        if timeout_value is None:
-            timeout_value = getattr(args, "timeout", None)
-    if timeout_value is not None:
-        cfg.api.timeout_read = timeout_value
+        chembl_timeout_override = getattr(args, "chembl_timeout", None)
+        if chembl_timeout_override is None:
+            chembl_timeout_override = getattr(args, "timeout", None)
+        pubmed_timeout_override = getattr(args, "pubmed_timeout", None)
+        if pubmed_timeout_override is None:
+            pubmed_timeout_override = getattr(args, "timeout", None)
+    if chembl_timeout_override is not None:
+        cfg.api.timeout_read = float(chembl_timeout_override)
+    if pubmed_timeout_override is not None:
+        cfg.pubmed.timeout_read = float(pubmed_timeout_override)
     if args.skip_existing and output_path.exists() and not args.force:
         logger.info("pipeline_skip_existing", output=str(output_path))
         return 0
@@ -1634,7 +1664,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
     single_group.add_argument(
         "--timeout",
         type=float,
-        default=CHEMBL_DEFAULTS.timeout,
+        default=None,
         help=(
             "HTTP read timeout in seconds (defaults: chembl/all="
             f"{CHEMBL_DEFAULTS.timeout}, pubmed={PUBMED_DEFAULTS.timeout})"
@@ -1657,7 +1687,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--chembl-timeout",
         dest="chembl_timeout",
         type=float,
-        default=ALL_DEFAULTS.timeout,
+        default=None,
         help=(
             "Timeout in seconds for ChEMBL requests when running in all mode "
             f"(default: {ALL_DEFAULTS.timeout})"
@@ -1700,7 +1730,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, LoggerConfig]:
         "--pubmed-timeout",
         dest="pubmed_timeout",
         type=float,
-        default=PUBMED_DEFAULTS.timeout,
+        default=None,
         help=(
             "Timeout in seconds for PubMed requests when running in all mode "
             f"(default: {PUBMED_DEFAULTS.timeout})"

--- a/tests/unit/test_cli_get_document_data.py
+++ b/tests/unit/test_cli_get_document_data.py
@@ -78,6 +78,7 @@ def test_build_parser__pubmed_defaults() -> None:
     assert args.limit is None
     assert args.fallback_doi_csv is None
     assert args.offset == 0
+    assert args.timeout is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_get_document_data.py
+++ b/tests/unit/test_get_document_data.py
@@ -235,6 +235,134 @@ def test_run__propagates_timeout(cfg: Config, tmp_path: Path, monkeypatch: pytes
     assert called == [42.5]
 
 
+def test_run__pubmed_timeout_override_updates_config(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("PMID\n123\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    recorded: dict[str, float] = {}
+
+    def fake_pubmed(cfg_obj: Config, args: argparse.Namespace, *, pipeline=None) -> int:  # noqa: ARG001
+        recorded["pubmed"] = cfg_obj.pubmed.timeout_read
+        recorded["api"] = cfg_obj.api.timeout_read
+        return 0
+
+    monkeypatch.setitem(get_document_data.MODE_HANDLERS, "pubmed", fake_pubmed)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        skip_existing=False,
+        force=False,
+        command="pubmed",
+        mode="pubmed",
+        func=fake_pubmed,
+        timeout=25.0,
+        fallback_doi_enabled=False,
+        fallback_doi_overwrite=False,
+        fallback_doi_path=None,
+    )
+
+    previous_api_timeout = cfg.api.timeout_read
+
+    exit_code = get_document_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert recorded["pubmed"] == pytest.approx(25.0)
+    assert recorded["api"] == pytest.approx(previous_api_timeout)
+
+
+def test_run__all_mode_pubmed_timeout_option_updates_config(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id\n1\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    recorded: dict[str, float] = {}
+
+    def fake_all(cfg_obj: Config, args: argparse.Namespace, *, pipeline=None) -> int:  # noqa: ARG001
+        recorded["pubmed"] = cfg_obj.pubmed.timeout_read
+        recorded["api"] = cfg_obj.api.timeout_read
+        recorded["pubmed_arg"] = args.pubmed_timeout
+        recorded["chembl_arg"] = getattr(args, "chembl_timeout", None)
+        return 0
+
+    monkeypatch.setitem(get_document_data.MODE_HANDLERS, "all", fake_all)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        skip_existing=False,
+        force=False,
+        command="all",
+        mode="all",
+        func=fake_all,
+        timeout=None,
+        pubmed_timeout=33.0,
+        chembl_timeout=None,
+        fallback_doi_enabled=False,
+        fallback_doi_overwrite=False,
+        fallback_doi_path=None,
+    )
+
+    exit_code = get_document_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert recorded["pubmed"] == pytest.approx(33.0)
+    assert recorded["pubmed_arg"] == pytest.approx(33.0)
+    assert recorded["api"] == pytest.approx(cfg.api.timeout_read)
+
+
+def test_run__all_mode_timeout_fallback_updates_pubmed(
+    cfg: Config,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id\n1\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    recorded: dict[str, float] = {}
+
+    def fake_all(cfg_obj: Config, args: argparse.Namespace, *, pipeline=None) -> int:  # noqa: ARG001
+        recorded["pubmed"] = cfg_obj.pubmed.timeout_read
+        recorded["pubmed_arg"] = args.pubmed_timeout
+        return 0
+
+    monkeypatch.setitem(get_document_data.MODE_HANDLERS, "all", fake_all)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        skip_existing=False,
+        force=False,
+        command="all",
+        mode="all",
+        func=fake_all,
+        timeout=41.0,
+        pubmed_timeout=None,
+        chembl_timeout=None,
+        fallback_doi_enabled=False,
+        fallback_doi_overwrite=False,
+        fallback_doi_path=None,
+    )
+
+    exit_code = get_document_data.run(cfg, args)
+
+    assert exit_code == 0
+    assert recorded["pubmed"] == pytest.approx(41.0)
+    value = recorded["pubmed_arg"]
+    if value is not None:
+        assert value == pytest.approx(41.0)
+
+
 def test_finalise_export__qa_mismatch_sets_exit_code(
     cfg: Config,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- ensure CLI timeout overrides propagate to the PubMed configuration and ChEMBL pipeline logging
- update the combined document pipeline to normalise timeout arguments before logging and execution
- extend CLI and runtime unit tests to cover the new timeout handling

## Testing
- pytest tests/unit/test_get_document_data.py tests/unit/test_cli_get_document_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e60c0f948324af4c25d2b086a128