### PR TITLE
Add post-processing pipeline configuration loader and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifneq ($(ENV_FILES),)
   export $(shell sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' $(ENV_FILES))
 endif
 
-.PHONY: init lint test smoke test-report build release clean
+.PHONY: init lint test smoke test-report build release clean validate-config-postprocessing
 
 init: $(PYTHON_BIN)
 
@@ -48,4 +48,7 @@ release: build
 	$(PYTHON_BIN) -m twine check dist/*
 
 clean:
-	rm -rf $(VENV) build dist .mypy_cache .pytest_cache
+        rm -rf $(VENV) build dist .mypy_cache .pytest_cache
+
+validate-config-postprocessing: $(PYTHON_BIN)
+	$(PYTHON_BIN) tools/postprocessing_config.py validate

--- a/config.schema.json
+++ b/config.schema.json
@@ -2259,6 +2259,131 @@
       "title": "TestitemMoleculeEnrichmentCfg",
       "type": "object"
     },
+    "PostprocessStepDefaultsCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "continue_on_error": {
+          "default": false,
+          "title": "Continue On Error",
+          "type": "boolean"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "kwargs": {
+          "default": {},
+          "title": "Kwargs",
+          "type": "object"
+        },
+        "gates": {
+          "default": [],
+          "items": {
+            "pattern": "^[A-Za-z0-9_.-]+$",
+            "type": "string"
+          },
+          "title": "Gates",
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "title": "PostprocessStepDefaultsCfg",
+      "type": "object"
+    },
+    "PostprocessStepCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "pattern": "^[A-Za-z0-9_.-]+$",
+          "title": "Id",
+          "type": "string"
+        },
+        "callable": {
+          "pattern": "^[A-Za-z0-9_.:]+$",
+          "title": "Callable",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "continue_on_error": {
+          "default": false,
+          "title": "Continue On Error",
+          "type": "boolean"
+        },
+        "gates": {
+          "items": {
+            "pattern": "^[A-Za-z0-9_.-]+$",
+            "type": "string"
+          },
+          "title": "Gates",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "kwargs": {
+          "title": "Kwargs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "PostprocessStepCfg",
+      "type": "object"
+    },
+    "PostprocessPipelineCfg": {
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
+        },
+        "defaults": {
+          "additionalProperties": false,
+          "properties": {
+            "step": {
+              "$ref": "#/$defs/PostprocessStepDefaultsCfg"
+            }
+          },
+          "title": "Defaults",
+          "type": "object"
+        },
+        "flags": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {},
+          "title": "Flags",
+          "type": "object"
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/$defs/PostprocessStepCfg"
+          },
+          "minItems": 0,
+          "title": "Steps",
+          "type": "array"
+        }
+      },
+      "required": [
+        "steps"
+      ],
+      "title": "PostprocessPipelineCfg",
+      "type": "object"
+    },
     "UniprotCfg": {
       "additionalProperties": false,
       "properties": {

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,20 @@
 """Configuration package exposing shared file-system paths."""
 from __future__ import annotations
 
-from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR, SCHEMA_DIR
+from .paths import (
+    CONFIG_DIR,
+    CONFIG_SCHEMA_PATH,
+    DEFAULT_CONFIG_PATH,
+    DICTIONARY_DIR,
+    POSTPROCESSING_CONFIG_DIR,
+    SCHEMA_DIR,
+)
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "CONFIG_SCHEMA_PATH",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "POSTPROCESSING_CONFIG_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/paths.py
+++ b/config/paths.py
@@ -7,5 +7,14 @@ CONFIG_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
 DICTIONARY_DIR = CONFIG_DIR / "dictionary"
 SCHEMA_DIR = CONFIG_DIR / "schema"
+POSTPROCESSING_CONFIG_DIR = CONFIG_DIR / "postprocessing"
+CONFIG_SCHEMA_PATH = CONFIG_DIR.parent / "config.schema.json"
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "SCHEMA_DIR",
+    "POSTPROCESSING_CONFIG_DIR",
+    "CONFIG_SCHEMA_PATH",
+]

--- a/config/postprocessing/defaults.yaml
+++ b/config/postprocessing/defaults.yaml
@@ -1,0 +1,25 @@
+version: 1
+
+# Default pipeline shared by post-processing tables. Individual tables can
+# override steps, extend the sequence or redefine feature flags.
+defaults:
+  step:
+    enabled: true
+    continue_on_error: false
+    kwargs: {}
+    gates: []
+
+flags:
+  run_quality_checks: false
+
+steps:
+  - id: ensure-string-columns
+    description: "Coerce textual export columns to the canonical string dtype."
+    callable: library.postprocessing.helpers:ensure_string_columns
+    kwargs:
+      columns: []
+  - id: run-quality-checks
+    description: "Placeholder QA hook gated by the run_quality_checks flag."
+    callable: library.postprocessing.pipeline:passthrough
+    gates:
+      - run_quality_checks

--- a/config/postprocessing/target.yaml
+++ b/config/postprocessing/target.yaml
@@ -1,0 +1,21 @@
+version: 1
+
+flags:
+  run_quality_checks: false
+  include_cellularity: true
+
+steps:
+  - id: ensure-string-columns
+    kwargs:
+      columns:
+        - target_chembl_id
+        - pref_name
+        - organism
+  - id: finalize-targets
+    description: "Normalise, reorder and enrich the target export."
+    callable: library.pipelines.target.postprocessing:finalise_targets
+  - id: ensure-cellularity
+    description: "Ensure the canonical cellularity column is present and normalised."
+    callable: library.postprocessing.cellularity:ensure_cellularity
+    gates:
+      - include_cellularity

--- a/library/config/__init__.py
+++ b/library/config/__init__.py
@@ -147,3 +147,25 @@ __all__ = [
     "_mask_secrets",
     "_serialize_paths",
 ]
+
+from .postprocessing import (  # noqa: E402  - imported late to avoid cycles
+    POSTPROCESSING_CONFIG_DIR,
+    PostprocessingConfigError,
+    PostprocessingPipeline,
+    PostprocessingStep,
+    diff_postprocessing_pipeline,
+    list_postprocessing_tables,
+    load_postprocessing_pipeline,
+    validate_postprocessing_config,
+)
+
+__all__ += [
+    "POSTPROCESSING_CONFIG_DIR",
+    "PostprocessingConfigError",
+    "PostprocessingPipeline",
+    "PostprocessingStep",
+    "diff_postprocessing_pipeline",
+    "list_postprocessing_tables",
+    "load_postprocessing_pipeline",
+    "validate_postprocessing_config",
+]

--- a/library/config/postprocessing.py
+++ b/library/config/postprocessing.py
@@ -1,0 +1,601 @@
+"""Loader and validation helpers for post-processing pipeline configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Sequence
+
+import json
+import sys
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+
+from config.paths import CONFIG_SCHEMA_PATH, POSTPROCESSING_CONFIG_DIR
+
+__all__ = [
+    "POSTPROCESSING_CONFIG_DIR",
+    "PostprocessingConfigError",
+    "PostprocessingPipeline",
+    "PostprocessingStep",
+    "diff_postprocessing_pipeline",
+    "list_postprocessing_tables",
+    "load_postprocessing_pipeline",
+    "main",
+    "validate_postprocessing_config",
+]
+
+
+SCHEMA_DEFINITION_REF = "#/$defs/PostprocessPipelineCfg"
+_STEP_DEFAULT_KEYS = {
+    "enabled",
+    "continue_on_error",
+    "kwargs",
+    "gates",
+    "description",
+}
+
+
+class PostprocessingConfigError(RuntimeError):
+    """Raised when post-processing configuration parsing fails."""
+
+
+@dataclass(frozen=True, slots=True)
+class PostprocessingStep:
+    """Description of a post-processing step declared in the pipeline config."""
+
+    identifier: str
+    callable: str
+    enabled: bool = True
+    continue_on_error: bool = False
+    description: str | None = None
+    gates: tuple[str, ...] = field(default_factory=tuple)
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass guard
+        object.__setattr__(self, "gates", tuple(self.gates))
+        object.__setattr__(self, "kwargs", MappingProxyType(dict(self.kwargs)))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serialisable representation of the step."""
+
+        payload: dict[str, Any] = {
+            "id": self.identifier,
+            "callable": self.callable,
+            "enabled": self.enabled,
+            "continue_on_error": self.continue_on_error,
+        }
+        if self.description is not None:
+            payload["description"] = self.description
+        if self.gates:
+            payload["gates"] = list(self.gates)
+        if self.kwargs:
+            payload["kwargs"] = {key: self.kwargs[key] for key in sorted(self.kwargs)}
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class PostprocessingPipeline:
+    """Merged configuration describing the post-processing pipeline."""
+
+    version: int
+    flags: Mapping[str, bool]
+    steps: tuple[PostprocessingStep, ...]
+    step_defaults: Mapping[str, Any]
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass guard
+        object.__setattr__(self, "flags", MappingProxyType(dict(self.flags)))
+        object.__setattr__(self, "steps", tuple(self.steps))
+        object.__setattr__(self, "step_defaults", MappingProxyType(dict(self.step_defaults)))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON/YAML compatible representation of the pipeline."""
+
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "flags": dict(self.flags),
+            "steps": [step.as_dict() for step in self.steps],
+        }
+        if self.step_defaults:
+            defaults: dict[str, Any] = {}
+            for key, value in self.step_defaults.items():
+                if key == "kwargs" and isinstance(value, Mapping):
+                    defaults[key] = {k: value[k] for k in sorted(value)}
+                else:
+                    defaults[key] = value
+            payload["defaults"] = {"step": defaults}
+        return payload
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Return YAML content from *path* ensuring the top-level is a mapping."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive I/O guard
+        raise PostprocessingConfigError(f"unable to read config: {path!s}") from exc
+
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise PostprocessingConfigError(
+            f"failed to parse YAML configuration at {path!s}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise PostprocessingConfigError(
+            f"top-level structure in {path!s} must be a mapping"
+        )
+    return data
+
+
+@lru_cache(maxsize=None)
+def _load_schema(schema_path: Path) -> Draft202012Validator:
+    """Return the JSON schema validator for the post-processing config."""
+
+    try:
+        schema_text = schema_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive I/O guard
+        raise PostprocessingConfigError(
+            f"unable to read JSON schema: {schema_path!s}"
+        ) from exc
+
+    try:
+        schema_data = json.loads(schema_text)
+    except json.JSONDecodeError as exc:
+        raise PostprocessingConfigError(
+            f"invalid JSON schema at {schema_path!s}: {exc}"
+        ) from exc
+
+    scope: dict[str, Any] = {"$ref": SCHEMA_DEFINITION_REF}
+    defs = schema_data.get("$defs")
+    if isinstance(defs, dict):
+        scope["$defs"] = defs
+    return Draft202012Validator(scope, format_checker=FormatChecker())
+
+
+def _validate_schema(instance: Mapping[str, Any], schema_path: Path) -> None:
+    """Validate *instance* against the post-processing schema."""
+
+    validator = _load_schema(schema_path)
+    try:
+        validator.validate(instance)
+    except JsonSchemaValidationError as exc:  # pragma: no cover - schema guard
+        raise PostprocessingConfigError(str(exc)) from exc
+
+
+def _merge_step_defaults(
+    base: Mapping[str, Any], override: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Return combined defaults for a step."""
+
+    merged: dict[str, Any] = {}
+    for source in (base, override):
+        defaults_section = source.get("defaults")
+        if not isinstance(defaults_section, Mapping):
+            continue
+        step_section = defaults_section.get("step")
+        if not isinstance(step_section, Mapping):
+            continue
+        for key, value in step_section.items():
+            if key not in _STEP_DEFAULT_KEYS:
+                continue
+            if key == "kwargs" and isinstance(value, Mapping):
+                current = merged.setdefault("kwargs", {})
+                if isinstance(current, Mapping):
+                    merged_kwargs = dict(current)
+                else:  # pragma: no cover - defensive branch
+                    merged_kwargs = {}
+                merged_kwargs.update(dict(value))
+                merged["kwargs"] = merged_kwargs
+                continue
+            if key == "gates" and isinstance(value, Sequence):
+                merged[key] = list(value)
+                continue
+            merged[key] = value
+    if "gates" in merged and not isinstance(merged["gates"], list):
+        merged["gates"] = []
+    return merged
+
+
+def _index_steps(steps: Sequence[Mapping[str, Any]]) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    """Return the step order and index for *steps* ensuring unique identifiers."""
+
+    order: list[str] = []
+    index: dict[str, dict[str, Any]] = {}
+    for raw in steps:
+        if not isinstance(raw, Mapping):
+            raise PostprocessingConfigError("step entries must be mappings")
+        identifier = raw.get("id")
+        if not isinstance(identifier, str) or not identifier:
+            raise PostprocessingConfigError("each step must declare a non-empty 'id'")
+        if identifier in index:
+            raise PostprocessingConfigError(
+                f"duplicate step identifier encountered: {identifier}"
+            )
+        order.append(identifier)
+        index[identifier] = dict(raw)
+    return order, index
+
+
+def _merge_mapping(a: Mapping[str, Any], b: Mapping[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = dict(a)
+    for key, value in b.items():
+        if key in result and isinstance(result[key], Mapping) and isinstance(value, Mapping):
+            result[key] = _merge_mapping(result[key], value)
+            continue
+        result[key] = value
+    return result
+
+
+def _merge_steps(
+    base_steps: Sequence[Mapping[str, Any]],
+    override_steps: Sequence[Mapping[str, Any]],
+    step_defaults: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    base_order, base_index = _index_steps(base_steps)
+    override_order, override_index = _index_steps(override_steps)
+
+    merged_steps: list[dict[str, Any]] = []
+    for identifier in base_order:
+        base = base_index[identifier]
+        override = override_index.get(identifier)
+        merged = dict(step_defaults)
+        merged.update(base)
+        if override is not None:
+            merged = _merge_mapping(merged, override)
+        merged_steps.append(_normalise_step(merged))
+
+    for identifier in override_order:
+        if identifier in base_index:
+            continue
+        override = override_index[identifier]
+        merged = dict(step_defaults)
+        merged.update(override)
+        merged_steps.append(_normalise_step(merged))
+
+    return merged_steps
+
+
+def _normalise_step(step: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalise gate and kwargs entries for *step*."""
+
+    normalised = dict(step)
+    gates = normalised.get("gates", [])
+    if isinstance(gates, Sequence) and not isinstance(gates, (str, bytes)):
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for gate in gates:
+            if isinstance(gate, str) and gate and gate not in seen:
+                seen.add(gate)
+                ordered.append(gate)
+        normalised["gates"] = ordered
+    else:
+        normalised.pop("gates", None)
+
+    kwargs = normalised.get("kwargs", {})
+    if isinstance(kwargs, Mapping):
+        normalised["kwargs"] = dict(kwargs)
+    else:
+        normalised.pop("kwargs", None)
+    return normalised
+
+
+def _ensure_step_callable(step: Mapping[str, Any]) -> str:
+    callable_ref = step.get("callable")
+    if not isinstance(callable_ref, str) or not callable_ref.strip():
+        identifier = step.get("id", "<unknown>")
+        raise PostprocessingConfigError(
+            f"pipeline step '{identifier}' must define a callable"
+        )
+    return callable_ref
+
+
+def _build_steps(
+    steps: Sequence[Mapping[str, Any]],
+    *,
+    flags: Mapping[str, bool],
+) -> tuple[PostprocessingStep, ...]:
+    built: list[PostprocessingStep] = []
+    for raw in steps:
+        identifier = raw.get("id")
+        if not isinstance(identifier, str):
+            raise PostprocessingConfigError("pipeline step is missing an identifier")
+        callable_ref = _ensure_step_callable(raw)
+        enabled = bool(raw.get("enabled", True))
+        continue_on_error = bool(raw.get("continue_on_error", False))
+        description = raw.get("description")
+        gates_raw = raw.get("gates", [])
+        gates: list[str] = []
+        if isinstance(gates_raw, Sequence) and not isinstance(gates_raw, (str, bytes)):
+            for gate in gates_raw:
+                if not isinstance(gate, str) or not gate:
+                    continue
+                if gate not in flags:
+                    raise PostprocessingConfigError(
+                        f"pipeline step '{identifier}' references unknown gate '{gate}'"
+                    )
+                if gate not in gates:
+                    gates.append(gate)
+        kwargs = raw.get("kwargs", {})
+        mapping_kwargs: Mapping[str, Any]
+        if isinstance(kwargs, Mapping):
+            mapping_kwargs = dict(kwargs)
+        else:
+            mapping_kwargs = {}
+        built.append(
+            PostprocessingStep(
+                identifier=identifier,
+                callable=callable_ref,
+                enabled=enabled,
+                continue_on_error=continue_on_error,
+                description=description if isinstance(description, str) else None,
+                gates=tuple(gates),
+                kwargs=mapping_kwargs,
+            )
+        )
+    return tuple(built)
+
+
+def _merge_flags(base: Mapping[str, Any], override: Mapping[str, Any]) -> dict[str, bool]:
+    merged: dict[str, bool] = {}
+    for source in (base.get("flags"), override.get("flags")):
+        if not isinstance(source, Mapping):
+            continue
+        for key, value in source.items():
+            if isinstance(key, str) and key:
+                merged[key] = bool(value)
+    return merged
+
+
+def load_postprocessing_pipeline(
+    table: str | None,
+    *,
+    base_dir: Path | str | None = None,
+    schema_path: Path | str | None = None,
+) -> PostprocessingPipeline:
+    """Return the merged pipeline configuration for *table*.
+
+    When *table* is :data:`None`, only the default configuration is returned.
+    """
+
+    config_dir = Path(base_dir) if base_dir is not None else POSTPROCESSING_CONFIG_DIR
+    schema_file = Path(schema_path) if schema_path is not None else CONFIG_SCHEMA_PATH
+
+    default_path = config_dir / "defaults.yaml"
+    if not default_path.exists():
+        raise PostprocessingConfigError(
+            f"missing default pipeline configuration at {default_path!s}"
+        )
+    defaults = _load_yaml_mapping(default_path)
+    _validate_schema(defaults, schema_file)
+
+    if table is None:
+        effective = defaults
+    else:
+        override_path = config_dir / f"{table}.yaml"
+        if not override_path.exists():
+            raise PostprocessingConfigError(
+                f"missing pipeline configuration for '{table}' at {override_path!s}"
+            )
+        overrides = _load_yaml_mapping(override_path)
+        _validate_schema(overrides, schema_file)
+        effective = {
+            "version": overrides.get("version", defaults.get("version", 1)),
+        }
+        effective["flags"] = _merge_flags(defaults, overrides)
+        step_defaults = _merge_step_defaults(defaults, overrides)
+        base_steps = defaults.get("steps", [])
+        override_steps = overrides.get("steps", [])
+        if not isinstance(base_steps, Sequence) or isinstance(base_steps, (str, bytes)):
+            raise PostprocessingConfigError("default pipeline 'steps' must be a sequence")
+        if not isinstance(override_steps, Sequence) or isinstance(
+            override_steps, (str, bytes)
+        ):
+            raise PostprocessingConfigError("override pipeline 'steps' must be a sequence")
+        merged_steps = _merge_steps(base_steps, override_steps, step_defaults)
+        effective["steps"] = merged_steps
+        if step_defaults:
+            effective["defaults"] = {"step": step_defaults}
+    if table is None:
+        step_defaults = _merge_step_defaults(defaults, {})
+        flags = _merge_flags(defaults, {})
+        steps_raw = defaults.get("steps", [])
+        if not isinstance(steps_raw, Sequence) or isinstance(steps_raw, (str, bytes)):
+            raise PostprocessingConfigError("default pipeline 'steps' must be a sequence")
+        merged_steps = _merge_steps(steps_raw, [], step_defaults)
+        effective = {
+            "version": defaults.get("version", 1),
+            "flags": flags,
+            "steps": merged_steps,
+        }
+        if step_defaults:
+            effective["defaults"] = {"step": step_defaults}
+
+    _validate_schema(effective, schema_file)
+
+    flags = effective.get("flags", {})
+    if not isinstance(flags, Mapping):
+        flags = {}
+    steps_raw = effective.get("steps", [])
+    if not isinstance(steps_raw, Sequence) or isinstance(steps_raw, (str, bytes)):
+        raise PostprocessingConfigError("pipeline 'steps' must be a sequence")
+    step_defaults = effective.get("defaults", {}).get("step", {})
+    if not isinstance(step_defaults, Mapping):
+        step_defaults = {}
+
+    steps = _build_steps(steps_raw, flags=flags)
+    version = effective.get("version", 1)
+    if not isinstance(version, int):
+        raise PostprocessingConfigError("pipeline 'version' must be an integer")
+
+    return PostprocessingPipeline(
+        version=version,
+        flags=dict(flags),
+        steps=steps,
+        step_defaults=dict(step_defaults),
+    )
+
+
+def list_postprocessing_tables(
+    base_dir: Path | str | None = None,
+) -> list[str]:
+    """Return available table configuration names in *base_dir*."""
+
+    config_dir = Path(base_dir) if base_dir is not None else POSTPROCESSING_CONFIG_DIR
+    if not config_dir.exists():
+        return []
+    tables: list[str] = []
+    for path in sorted(config_dir.glob("*.yaml")):
+        if path.name == "defaults.yaml":
+            continue
+        tables.append(path.stem)
+    return tables
+
+
+def validate_postprocessing_config(
+    *,
+    tables: Sequence[str] | None = None,
+    base_dir: Path | str | None = None,
+    schema_path: Path | str | None = None,
+) -> list[str]:
+    """Validate pipeline configuration files returning processed table names."""
+
+    config_dir = Path(base_dir) if base_dir is not None else POSTPROCESSING_CONFIG_DIR
+    schema_file = Path(schema_path) if schema_path is not None else CONFIG_SCHEMA_PATH
+
+    available = list_postprocessing_tables(config_dir)
+    target_tables: Sequence[str]
+    if tables:
+        target_tables = tables
+    else:
+        target_tables = available
+
+    processed: list[str] = []
+    if not target_tables:
+        # Still validate defaults so configuration errors are reported early.
+        load_postprocessing_pipeline(None, base_dir=config_dir, schema_path=schema_file)
+        return processed
+
+    for table in target_tables:
+        load_postprocessing_pipeline(table, base_dir=config_dir, schema_path=schema_file)
+        processed.append(table)
+    return processed
+
+
+def diff_postprocessing_pipeline(
+    table: str,
+    *,
+    base_dir: Path | str | None = None,
+    schema_path: Path | str | None = None,
+) -> str:
+    """Return a textual diff between defaults and the *table* configuration."""
+
+    config_dir = Path(base_dir) if base_dir is not None else POSTPROCESSING_CONFIG_DIR
+    schema_file = Path(schema_path) if schema_path is not None else CONFIG_SCHEMA_PATH
+
+    default_pipeline = load_postprocessing_pipeline(
+        None, base_dir=config_dir, schema_path=schema_file
+    )
+    table_pipeline = load_postprocessing_pipeline(
+        table, base_dir=config_dir, schema_path=schema_file
+    )
+
+    default_yaml = yaml.safe_dump(
+        default_pipeline.as_dict(), sort_keys=False, allow_unicode=True
+    ).splitlines(keepends=True)
+    table_yaml = yaml.safe_dump(
+        table_pipeline.as_dict(), sort_keys=False, allow_unicode=True
+    ).splitlines(keepends=True)
+
+    from difflib import unified_diff
+
+    diff = unified_diff(
+        default_yaml,
+        table_yaml,
+        fromfile="defaults",
+        tofile=table,
+    )
+    return "".join(diff)
+
+
+def _build_parser() -> "argparse.ArgumentParser":  # pragma: no cover - CLI glue
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="postprocessing-config",
+        description="Validate and inspect post-processing pipeline configuration.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=POSTPROCESSING_CONFIG_DIR,
+        help="Directory containing post-processing pipeline YAML files.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=CONFIG_SCHEMA_PATH,
+        help="Path to config.schema.json containing the post-processing schema.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="Validate one or more table configurations."
+    )
+    validate_parser.add_argument(
+        "tables",
+        nargs="*",
+        help="Table names to validate; defaults to all available tables.",
+    )
+
+    diff_parser = subparsers.add_parser(
+        "diff", help="Show merged configuration diff for a table."
+    )
+    diff_parser.add_argument("table", help="Table name to diff against defaults.")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover - CLI glue
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    config_dir = args.config_dir
+    schema_path = args.schema
+
+    if args.command == "validate":
+        tables = args.tables or None
+        processed = validate_postprocessing_config(
+            tables=tables,
+            base_dir=config_dir,
+            schema_path=schema_path,
+        )
+        if processed:
+            joined = ", ".join(processed)
+            print(f"Validated post-processing configs: {joined}")
+        else:
+            print("Validated post-processing defaults")
+        return 0
+
+    if args.command == "diff":
+        diff_text = diff_postprocessing_pipeline(
+            args.table, base_dir=config_dir, schema_path=schema_path
+        )
+        if not diff_text:
+            print("No differences between defaults and table configuration")
+        else:
+            sys.stdout.write(diff_text)
+        return 0
+
+    parser.error(f"Unknown command: {args.command}")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(main())

--- a/library/postprocessing/pipeline.py
+++ b/library/postprocessing/pipeline.py
@@ -1,0 +1,19 @@
+"""Helpers for declarative post-processing pipeline execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+def passthrough(frame: pd.DataFrame, **_: Any) -> pd.DataFrame:
+    """Return *frame* unchanged.
+
+    The helper acts as a placeholder callable for configurable pipeline steps
+    that may be overridden by table-specific configurations.  Accepting
+    ``**kwargs`` keeps the callable signature compatible with future
+    extensions that may inject additional keyword parameters.
+    """
+
+    return frame

--- a/tests/unit/config/test_postprocessing_pipeline.py
+++ b/tests/unit/config/test_postprocessing_pipeline.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from config import CONFIG_SCHEMA_PATH
+from library.config.postprocessing import (
+    PostprocessingConfigError,
+    diff_postprocessing_pipeline,
+    list_postprocessing_tables,
+    load_postprocessing_pipeline,
+    main,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")
+
+
+def _prepare_config(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "postprocessing"
+    config_dir.mkdir()
+
+    _write(
+        config_dir / "defaults.yaml",
+        """
+        version: 1
+        defaults:
+          step:
+            enabled: true
+            continue_on_error: false
+            kwargs:
+              columns: []
+        flags:
+          qa_checks: true
+        steps:
+          - id: ensure-columns
+            callable: library.postprocessing.pipeline:passthrough
+            kwargs:
+              columns: []
+          - id: run-qa
+            callable: library.postprocessing.pipeline:passthrough
+            gates:
+              - qa_checks
+        """,
+    )
+
+    _write(
+        config_dir / "target.yaml",
+        """
+        version: 2
+        flags:
+          qa_checks: false
+          include_cellularity: true
+        steps:
+          - id: ensure-columns
+            kwargs:
+              columns:
+                - pref_name
+          - id: finalize
+            description: "Finalize export"
+            callable: library.postprocessing.pipeline:passthrough
+            gates:
+              - include_cellularity
+        """,
+    )
+    return config_dir
+
+
+@pytest.mark.unit
+def test_load_postprocessing_pipeline__merges_defaults_and_overrides(tmp_path: Path) -> None:
+    config_dir = _prepare_config(tmp_path)
+
+    pipeline = load_postprocessing_pipeline(
+        "target", base_dir=config_dir, schema_path=CONFIG_SCHEMA_PATH
+    )
+
+    assert pipeline.version == 2
+    assert pipeline.flags == {"qa_checks": False, "include_cellularity": True}
+    assert [step.identifier for step in pipeline.steps] == [
+        "ensure-columns",
+        "run-qa",
+        "finalize",
+    ]
+    ensure_step, qa_step, finalize_step = pipeline.steps
+    assert ensure_step.kwargs["columns"] == ["pref_name"]
+    assert qa_step.gates == ("qa_checks",)
+    assert finalize_step.gates == ("include_cellularity",)
+
+
+@pytest.mark.unit
+def test_load_postprocessing_pipeline__raises_for_unknown_gate(tmp_path: Path) -> None:
+    config_dir = _prepare_config(tmp_path)
+    _write(
+        config_dir / "target.yaml",
+        """
+        steps:
+          - id: ensure-columns
+            callable: library.postprocessing.pipeline:passthrough
+            gates:
+              - undefined_gate
+        """,
+    )
+
+    with pytest.raises(PostprocessingConfigError) as excinfo:
+        load_postprocessing_pipeline(
+            "target", base_dir=config_dir, schema_path=CONFIG_SCHEMA_PATH
+        )
+
+    assert "unknown gate" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_load_postprocessing_pipeline__rejects_new_step_without_callable(tmp_path: Path) -> None:
+    config_dir = _prepare_config(tmp_path)
+    _write(
+        config_dir / "target.yaml",
+        """
+        steps:
+          - id: ensure-columns
+            kwargs:
+              columns:
+                - pref_name
+          - id: missing-callable
+        """,
+    )
+
+    with pytest.raises(PostprocessingConfigError) as excinfo:
+        load_postprocessing_pipeline(
+            "target", base_dir=config_dir, schema_path=CONFIG_SCHEMA_PATH
+        )
+
+    assert "must define a callable" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_postprocessing_config_cli__validate_and_diff(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_dir = _prepare_config(tmp_path)
+
+    exit_code = main(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--schema",
+            str(CONFIG_SCHEMA_PATH),
+            "validate",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Validated post-processing configs: target" in captured.out
+
+    exit_code = main(
+        [
+            "--config-dir",
+            str(config_dir),
+            "--schema",
+            str(CONFIG_SCHEMA_PATH),
+            "diff",
+            "target",
+        ]
+    )
+    diff_output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "--- defaults" in diff_output
+    assert "+++ target" in diff_output
+
+
+@pytest.mark.unit
+def test_list_postprocessing_tables__discovers_yaml_files(tmp_path: Path) -> None:
+    config_dir = _prepare_config(tmp_path)
+    (config_dir / "extra.txt").write_text("ignored", encoding="utf-8")
+
+    tables = list_postprocessing_tables(config_dir)
+
+    assert tables == ["target"]
+
+
+@pytest.mark.unit
+def test_diff_postprocessing_pipeline__empty_when_matching(tmp_path: Path) -> None:
+    config_dir = _prepare_config(tmp_path)
+    _write(
+        config_dir / "target.yaml",
+        """
+        version: 1
+        flags:
+          qa_checks: true
+        steps:
+          - id: ensure-columns
+            callable: library.postprocessing.pipeline:passthrough
+            kwargs:
+              columns: []
+          - id: run-qa
+            callable: library.postprocessing.pipeline:passthrough
+            gates:
+              - qa_checks
+        """,
+    )
+
+    diff_output = diff_postprocessing_pipeline(
+        "target", base_dir=config_dir, schema_path=CONFIG_SCHEMA_PATH
+    )
+
+    assert diff_output.strip() == ""

--- a/tools/postprocessing_config.py
+++ b/tools/postprocessing_config.py
@@ -1,0 +1,17 @@
+"""CLI proxy for validating post-processing pipeline configuration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from library.config.postprocessing import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend the configuration schema and add default/target YAML files for the post-processing pipeline
- implement a schema-backed loader with validation, diff, and CLI support for post-processing steps
- wire up supporting helpers, CLI wrapper, and unit tests plus a Makefile target for config validation

## Testing
- `pytest tests/unit/config/test_postprocessing_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68e4f717c1e483248a4858f85f39da6b