### PR TITLE
Add modular postprocess pipelines for activities, assays, targets, and documents

### DIFF
--- a/library/postprocess/__init__.py
+++ b/library/postprocess/__init__.py
@@ -1,0 +1,5 @@
+"""Postprocessing utilities for curated ChEMBL datasets."""
+
+from . import activities, assays, common, documents, targets
+
+__all__ = ["activities", "assays", "common", "documents", "targets"]

--- a/library/postprocess/activities/__init__.py
+++ b/library/postprocess/activities/__init__.py
@@ -1,0 +1,19 @@
+"""Activities postprocessing pipeline."""
+from .schema import ACTIVITY_SCHEMA, validate_activities
+from .steps import (
+    PIPELINE_STEPS,
+    enrich_activity_quality,
+    finalize_activity_records,
+    normalize_activity_records,
+    run_activity_pipeline,
+)
+
+__all__ = [
+    "ACTIVITY_SCHEMA",
+    "PIPELINE_STEPS",
+    "enrich_activity_quality",
+    "finalize_activity_records",
+    "normalize_activity_records",
+    "run_activity_pipeline",
+    "validate_activities",
+]

--- a/library/postprocess/activities/schema.py
+++ b/library/postprocess/activities/schema.py
@@ -1,0 +1,53 @@
+"""Schema definitions for activity postprocessing outputs."""
+from __future__ import annotations
+
+from library.postprocess.common import DataFrameSchema, validate_schema
+
+ACTIVITY_SCHEMA = DataFrameSchema(
+    required_columns=(
+        "activity_id",
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_value",
+        "standard_units",
+    ),
+    optional_columns=(
+        "data_validity_comment",
+        "activity_comment",
+        "quality_flag",
+        "pipeline_version",
+    ),
+    dtypes={
+        "activity_id": "Int64",
+        "molecule_chembl_id": "string",
+        "assay_chembl_id": "string",
+        "standard_type": "string",
+        "standard_relation": "string",
+        "standard_units": "string",
+    },
+    sort_by=("molecule_chembl_id", "assay_chembl_id", "activity_id"),
+    column_order=(
+        "activity_id",
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_value",
+        "standard_units",
+        "data_validity_comment",
+        "activity_comment",
+        "quality_flag",
+        "pipeline_version",
+    ),
+)
+
+
+def validate_activities(df, *, context: str = "activities"):
+    """Validate ``df`` using :data:`ACTIVITY_SCHEMA`."""
+
+    return validate_schema(df, ACTIVITY_SCHEMA, context=context)
+
+
+__all__ = ["ACTIVITY_SCHEMA", "validate_activities"]

--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,0 +1,86 @@
+"""Transformation steps for the activity postprocessing pipeline."""
+from __future__ import annotations
+
+import pandas as pd
+
+from library.postprocess.common import StepDefinition, run_steps
+
+from .schema import ACTIVITY_SCHEMA, validate_activities
+
+
+def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize string columns and enforce consistent naming."""
+
+    normalised = df.copy(deep=True)
+    normalised.columns = [col.strip().lower() for col in normalised.columns]
+
+    for column in ["standard_type", "standard_relation", "standard_units"]:
+        if column in normalised.columns:
+            normalised[column] = (
+                normalised[column]
+                .astype("string")
+                .str.strip()
+                .str.replace("\s+", " ", regex=True)
+                .str.upper()
+            )
+
+    return normalised
+
+
+def enrich_activity_quality(df: pd.DataFrame) -> pd.DataFrame:
+    """Add deterministic quality flags based on data validity comments."""
+
+    enriched = df.copy(deep=True)
+    if "data_validity_comment" in enriched.columns:
+        comment_series = enriched["data_validity_comment"].fillna("").astype("string")
+        enriched["quality_flag"] = comment_series.str.contains("valid", case=False)
+    else:
+        enriched["quality_flag"] = False
+
+    return enriched
+
+
+def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and reorder the DataFrame according to :data:`ACTIVITY_SCHEMA`."""
+
+    prepared = df.copy(deep=True)
+    if "activity_id" in prepared.columns:
+        prepared["activity_id"] = pd.to_numeric(prepared["activity_id"], errors="coerce").astype(
+            "Int64"
+        )
+    for column in ["molecule_chembl_id", "assay_chembl_id", "standard_type", "standard_relation", "standard_units"]:
+        if column in prepared.columns:
+            prepared[column] = prepared[column].astype("string")
+
+    validated = validate_activities(prepared, context="activity_finalization")
+    return validated
+
+
+PIPELINE_STEPS = [
+    StepDefinition("normalize_activity_records", normalize_activity_records),
+    StepDefinition("enrich_activity_quality", enrich_activity_quality),
+    StepDefinition("finalize_activity_records", finalize_activity_records),
+]
+
+
+def run_activity_pipeline(
+    df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
+) -> pd.DataFrame:
+    """Execute the activity postprocessing steps."""
+
+    return run_steps(
+        df,
+        PIPELINE_STEPS,
+        schema=ACTIVITY_SCHEMA,
+        pipeline_version=pipeline_version,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "PIPELINE_STEPS",
+    "finalize_activity_records",
+    "normalize_activity_records",
+    "run_activity_pipeline",
+    "enrich_activity_quality",
+]

--- a/library/postprocess/assays/__init__.py
+++ b/library/postprocess/assays/__init__.py
@@ -1,0 +1,19 @@
+"""Assay postprocessing pipeline."""
+from .schema import ASSAY_SCHEMA, validate_assays
+from .steps import (
+    PIPELINE_STEPS,
+    enrich_assay_flags,
+    finalize_assay_records,
+    normalize_assay_metadata,
+    run_assay_pipeline,
+)
+
+__all__ = [
+    "ASSAY_SCHEMA",
+    "PIPELINE_STEPS",
+    "enrich_assay_flags",
+    "finalize_assay_records",
+    "normalize_assay_metadata",
+    "run_assay_pipeline",
+    "validate_assays",
+]

--- a/library/postprocess/assays/schema.py
+++ b/library/postprocess/assays/schema.py
@@ -1,0 +1,47 @@
+"""Schema specification for assay postprocessing."""
+from __future__ import annotations
+
+from library.postprocess.common import DataFrameSchema, validate_schema
+
+ASSAY_SCHEMA = DataFrameSchema(
+    required_columns=(
+        "assay_chembl_id",
+        "assay_type",
+        "assay_test_type",
+        "description",
+    ),
+    optional_columns=(
+        "assay_format",
+        "target_chembl_id",
+        "confidence_score",
+        "is_confirmatory",
+        "pipeline_version",
+    ),
+    dtypes={
+        "assay_chembl_id": "string",
+        "assay_type": "string",
+        "assay_test_type": "string",
+        "description": "string",
+    },
+    sort_by=("assay_chembl_id",),
+    column_order=(
+        "assay_chembl_id",
+        "assay_type",
+        "assay_test_type",
+        "assay_format",
+        "description",
+        "target_chembl_id",
+        "confidence_score",
+        "is_confirmatory",
+        "pipeline_version",
+    ),
+)
+
+
+def validate_assays(df, *, context: str = "assays"):
+    """Validate ``df`` using :data:`ASSAY_SCHEMA`."""
+
+    return validate_schema(df, ASSAY_SCHEMA, context=context)
+
+
+__all__ = ["ASSAY_SCHEMA", "validate_assays"]

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,0 +1,80 @@
+"""Transformation steps for assay postprocessing."""
+from __future__ import annotations
+
+import pandas as pd
+
+from library.postprocess.common import StepDefinition, run_steps
+
+from .schema import ASSAY_SCHEMA, validate_assays
+
+
+def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize string-based assay descriptors."""
+
+    normalized = df.copy(deep=True)
+    for column in ["assay_type", "assay_test_type", "assay_format"]:
+        if column in normalized.columns:
+            normalized[column] = (
+                normalized[column]
+                .astype("string")
+                .str.strip()
+                .str.replace("\s+", " ", regex=True)
+                .str.upper()
+            )
+    return normalized
+
+
+def enrich_assay_flags(df: pd.DataFrame) -> pd.DataFrame:
+    """Introduce confirmatory flag based on assay type information."""
+
+    enriched = df.copy(deep=True)
+    type_series = enriched.get("assay_type")
+    if type_series is not None:
+        enriched["is_confirmatory"] = type_series.astype("string").str.contains(
+            "CONFIRM", case=False, na=False
+        )
+    else:
+        enriched["is_confirmatory"] = False
+    return enriched
+
+
+def finalize_assay_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Apply schema validation and deterministic ordering."""
+
+    prepared = df.copy(deep=True)
+    for column in ["assay_chembl_id", "assay_type", "assay_test_type", "description"]:
+        if column in prepared.columns:
+            prepared[column] = prepared[column].astype("string")
+
+    validated = validate_assays(prepared, context="assay_finalization")
+    return validated
+
+
+PIPELINE_STEPS = [
+    StepDefinition("normalize_assay_metadata", normalize_assay_metadata),
+    StepDefinition("enrich_assay_flags", enrich_assay_flags),
+    StepDefinition("finalize_assay_records", finalize_assay_records),
+]
+
+
+def run_assay_pipeline(
+    df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
+) -> pd.DataFrame:
+    """Run the assay postprocessing pipeline."""
+
+    return run_steps(
+        df,
+        PIPELINE_STEPS,
+        schema=ASSAY_SCHEMA,
+        pipeline_version=pipeline_version,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "PIPELINE_STEPS",
+    "finalize_assay_records",
+    "normalize_assay_metadata",
+    "run_assay_pipeline",
+    "enrich_assay_flags",
+]

--- a/library/postprocess/common/__init__.py
+++ b/library/postprocess/common/__init__.py
@@ -1,0 +1,29 @@
+"""Shared utilities for postprocessing pipelines."""
+from . import logging
+from .io import clone_dataframe, ensure_dataframe
+from .schema import DataFrameSchema, coerce_types, validate_schema
+from .types import (
+    ImportResolutionError,
+    SchemaValidationError,
+    StepDefinition,
+    StepError,
+    StepFn,
+    StepIterable,
+)
+from .utils import run_steps
+
+__all__ = [
+    "DataFrameSchema",
+    "ImportResolutionError",
+    "SchemaValidationError",
+    "StepDefinition",
+    "StepError",
+    "StepFn",
+    "StepIterable",
+    "clone_dataframe",
+    "coerce_types",
+    "ensure_dataframe",
+    "logging",
+    "run_steps",
+    "validate_schema",
+]

--- a/library/postprocess/common/import_utils.py
+++ b/library/postprocess/common/import_utils.py
@@ -1,0 +1,48 @@
+"""Helpers for resolving dotted import paths for pipeline configuration."""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from .types import ImportResolutionError
+
+
+def resolve_dotted_path(path: str) -> Any:
+    """Return the object referenced by ``path``.
+
+    Parameters
+    ----------
+    path:
+        Dotted path in the form ``"package.module:attribute"`` or
+        ``"package.module.attribute"``.
+    """
+
+    module_path: str
+    attribute: str | None
+
+    if ":" in path:
+        module_path, attribute = path.split(":", 1)
+    else:
+        parts = path.split(".")
+        if len(parts) < 2:
+            raise ImportResolutionError(f"Invalid dotted path '{path}'")
+        module_path = ".".join(parts[:-1])
+        attribute = parts[-1]
+
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+        raise ImportResolutionError(f"Cannot import module '{module_path}'") from exc
+
+    if attribute is None:
+        return module
+
+    try:
+        return getattr(module, attribute)
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise ImportResolutionError(
+            f"Module '{module_path}' has no attribute '{attribute}'"
+        ) from exc
+
+
+__all__ = ["resolve_dotted_path"]

--- a/library/postprocess/common/io.py
+++ b/library/postprocess/common/io.py
@@ -1,0 +1,40 @@
+"""I/O helpers for converting objects into :class:`pandas.DataFrame` instances."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+import pandas as pd
+
+
+def ensure_dataframe(data: object, *, copy: bool = False) -> pd.DataFrame:
+    """Ensure that ``data`` is a :class:`~pandas.DataFrame` instance.
+
+    Parameters
+    ----------
+    data:
+        Any object that can be converted to a DataFrame.
+    copy:
+        Whether to return a defensive copy of the input DataFrame.
+    """
+
+    if isinstance(data, pd.DataFrame):
+        return data.copy(deep=True) if copy else data
+
+    if isinstance(data, Mapping):
+        return pd.DataFrame(data)
+
+    if isinstance(data, (Sequence, Iterable)):
+        return pd.DataFrame(list(data))
+
+    raise TypeError(f"Unsupported input for ensure_dataframe: {type(data)!r}")
+
+
+def clone_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a deep copy of ``df`` ensuring metadata is preserved."""
+
+    clone = df.copy(deep=True)
+    clone.attrs.update(df.attrs)
+    return clone
+
+
+__all__ = ["clone_dataframe", "ensure_dataframe"]

--- a/library/postprocess/common/logging.py
+++ b/library/postprocess/common/logging.py
@@ -1,0 +1,34 @@
+"""Logging utilities for postprocessing pipelines."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+_DEFAULT_LOGGER_NAME = "chembl.postprocess"
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a configured logger for postprocessing steps.
+
+    The logger defaults to :mod:`chembl.postprocess` and ensures that
+    double-configuration is avoided when used inside notebooks or CLI tools.
+    """
+
+    logger_name = name or _DEFAULT_LOGGER_NAME
+    logger = logging.getLogger(logger_name)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+    logger.propagate = False
+    return logger
+
+
+__all__ = ["get_logger"]

--- a/library/postprocess/common/schema.py
+++ b/library/postprocess/common/schema.py
@@ -1,0 +1,106 @@
+"""Utilities for declaratively defining and validating DataFrame schemas."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Sequence
+
+import pandas as pd
+
+from .types import SchemaValidationError
+
+
+@dataclass(frozen=True)
+class DataFrameSchema:
+    """Declarative schema for postprocessing outputs."""
+
+    required_columns: Sequence[str] = field(default_factory=tuple)
+    optional_columns: Sequence[str] = field(default_factory=tuple)
+    dtypes: Mapping[str, str | type] = field(default_factory=dict)
+    sort_by: Sequence[str] | None = None
+    column_order: Sequence[str] | None = None
+
+    def all_columns(self) -> Sequence[str]:
+        ordered = list(self.required_columns) + list(self.optional_columns)
+        if self.column_order:
+            # Column order might include columns not listed above (derived fields).
+            seen: set[str] = set()
+            ordered = []
+            for col in self.column_order:
+                if col not in seen:
+                    ordered.append(col)
+                    seen.add(col)
+        return ordered
+
+
+def _missing_columns(df: pd.DataFrame, expected: Iterable[str]) -> list[str]:
+    return [col for col in expected if col not in df.columns]
+
+
+def validate_schema(df: pd.DataFrame, schema: DataFrameSchema, *, context: str) -> pd.DataFrame:
+    """Validate ``df`` against ``schema`` and return a defensive copy."""
+
+    missing_required = _missing_columns(df, schema.required_columns)
+    if missing_required:
+        raise SchemaValidationError(
+            context,
+            f"missing required columns: {', '.join(sorted(missing_required))}",
+        )
+
+    if schema.dtypes:
+        mismatched: list[str] = []
+        for column, expected_type in schema.dtypes.items():
+            if column not in df.columns:
+                continue
+            dtype = df[column].dtype
+            if isinstance(expected_type, str):
+                expected_name = expected_type
+                if dtype.name != expected_type:
+                    mismatched.append(f"{column} (expected {expected_name}, got {dtype})")
+            else:
+                expected_dtype = pd.api.types.pandas_dtype(expected_type)
+                expected_name = str(expected_dtype)
+                if not pd.api.types.is_dtype_equal(dtype, expected_dtype):
+                    mismatched.append(f"{column} (expected {expected_name}, got {dtype})")
+        if mismatched:
+            raise SchemaValidationError(
+                context,
+                "; ".join(mismatched),
+            )
+
+    ordered_df = df.copy(deep=True)
+
+    if schema.column_order:
+        ordered_columns = [col for col in schema.column_order if col in ordered_df.columns]
+        remaining = sorted(col for col in ordered_df.columns if col not in ordered_columns)
+        ordered_df = ordered_df.loc[:, ordered_columns + remaining]
+
+    if schema.sort_by:
+        sort_cols = [col for col in schema.sort_by if col in ordered_df.columns]
+        if sort_cols:
+            ordered_df = ordered_df.sort_values(sort_cols, kind="mergesort").reset_index(drop=True)
+
+    return ordered_df
+
+
+def coerce_types(df: pd.DataFrame, schema: DataFrameSchema) -> pd.DataFrame:
+    """Attempt to coerce columns according to ``schema.dtypes``."""
+
+    coerced = df.copy(deep=True)
+    for column, expected_type in schema.dtypes.items():
+        if column not in coerced.columns:
+            continue
+        try:
+            if isinstance(expected_type, str):
+                coerced[column] = coerced[column].astype(expected_type)
+            else:
+                coerced[column] = coerced[column].astype(expected_type)
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError(
+                column,
+                f"failed to coerce to {expected_type!r}: {exc}",
+                cause=exc,
+            ) from exc
+    return coerced
+
+
+__all__ = ["DataFrameSchema", "coerce_types", "validate_schema"]

--- a/library/postprocess/common/types.py
+++ b/library/postprocess/common/types.py
@@ -1,0 +1,58 @@
+"""Shared type hints and dataclasses for postprocessing steps."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Protocol
+
+import pandas as pd
+
+
+class StepFn(Protocol):
+    """Protocol describing a pure DataFrame transformation."""
+
+    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return a new :class:`pandas.DataFrame` derived from ``df``."""
+
+
+@dataclass(frozen=True)
+class StepDefinition:
+    """Metadata describing a transformation step."""
+
+    name: str
+    func: StepFn
+    description: Optional[str] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
+        if not callable(self.func):
+            raise TypeError("StepDefinition.func must be callable")
+
+
+class StepError(RuntimeError):
+    """Base error raised when a step fails."""
+
+    def __init__(self, step_name: str, message: str, *, cause: Optional[BaseException] = None):
+        self.step_name = step_name
+        self.cause = cause
+        error_message = f"Step '{step_name}' failed: {message}"
+        super().__init__(error_message)
+
+
+class SchemaValidationError(StepError):
+    """Raised when a DataFrame does not comply with the expected schema."""
+
+
+class ImportResolutionError(RuntimeError):
+    """Raised when a dotted import path cannot be resolved."""
+
+
+StepIterable = Iterable[StepDefinition]
+
+
+__all__ = [
+    "ImportResolutionError",
+    "SchemaValidationError",
+    "StepDefinition",
+    "StepError",
+    "StepFn",
+    "StepIterable",
+]

--- a/library/postprocess/common/utils.py
+++ b/library/postprocess/common/utils.py
@@ -1,0 +1,72 @@
+"""Pipeline orchestration utilities for postprocessing transformations."""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import pandas as pd
+
+from . import logging as logging_utils
+from .io import clone_dataframe, ensure_dataframe
+from .schema import DataFrameSchema, validate_schema
+from .types import SchemaValidationError, StepDefinition, StepError, StepIterable
+
+
+def run_steps(
+    df: pd.DataFrame,
+    steps: StepIterable,
+    *,
+    schema: DataFrameSchema | None = None,
+    pipeline_version: str | None = None,
+    logger=None,
+) -> pd.DataFrame:
+    """Execute ``steps`` sequentially returning the processed DataFrame."""
+
+    log = logger or logging_utils.get_logger()
+    current = ensure_dataframe(df, copy=True)
+    if pipeline_version is not None:
+        current.attrs["pipeline_version"] = pipeline_version
+
+    for step in steps:
+        log.info("Starting step %s", step.name)
+        before_columns = list(current.columns)
+        before_shape = current.shape
+        try:
+            next_df = step.func(clone_dataframe(current))
+        except SchemaValidationError:
+            raise
+        except StepError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise StepError(step.name, str(exc), cause=exc) from exc
+
+        if not isinstance(next_df, pd.DataFrame):
+            raise StepError(step.name, "step did not return a pandas.DataFrame")
+
+        next_df = ensure_dataframe(next_df, copy=True)
+        if pipeline_version is not None:
+            next_df.attrs["pipeline_version"] = pipeline_version
+
+        added_columns = [col for col in next_df.columns if col not in before_columns]
+        removed_columns = [col for col in before_columns if col not in next_df.columns]
+        log.info(
+            "Completed step %s | rows=%s->%s | cols=%s->%s | +%s | -%s",
+            step.name,
+            before_shape[0],
+            next_df.shape[0],
+            before_shape[1],
+            next_df.shape[1],
+            ",".join(added_columns) or "-",
+            ",".join(removed_columns) or "-",
+        )
+        current = next_df
+
+    if schema is not None:
+        log.info("Validating final schema (%s)", schema.__class__.__name__)
+        current = validate_schema(current, schema, context="pipeline")
+        if pipeline_version is not None:
+            current.attrs["pipeline_version"] = pipeline_version
+
+    return current
+
+
+__all__ = ["run_steps"]

--- a/library/postprocess/documents/__init__.py
+++ b/library/postprocess/documents/__init__.py
@@ -1,0 +1,19 @@
+"""Document postprocessing pipeline."""
+from .schema import DOCUMENT_SCHEMA, validate_documents
+from .steps import (
+    PIPELINE_STEPS,
+    enrich_document_publication_year,
+    finalize_document_records,
+    normalize_document_fields,
+    run_document_pipeline,
+)
+
+__all__ = [
+    "DOCUMENT_SCHEMA",
+    "PIPELINE_STEPS",
+    "enrich_document_publication_year",
+    "finalize_document_records",
+    "normalize_document_fields",
+    "run_document_pipeline",
+    "validate_documents",
+]

--- a/library/postprocess/documents/schema.py
+++ b/library/postprocess/documents/schema.py
@@ -1,0 +1,47 @@
+"""Schema specification for document postprocessing."""
+from __future__ import annotations
+
+from library.postprocess.common import DataFrameSchema, validate_schema
+
+DOCUMENT_SCHEMA = DataFrameSchema(
+    required_columns=(
+        "document_chembl_id",
+        "title",
+        "doc_type",
+    ),
+    optional_columns=(
+        "year",
+        "doi",
+        "journal",
+        "abstract",
+        "publication_year",
+        "pipeline_version",
+    ),
+    dtypes={
+        "document_chembl_id": "string",
+        "title": "string",
+        "doc_type": "string",
+        "publication_year": "Int64",
+    },
+    sort_by=("document_chembl_id",),
+    column_order=(
+        "document_chembl_id",
+        "title",
+        "doc_type",
+        "year",
+        "publication_year",
+        "doi",
+        "journal",
+        "abstract",
+        "pipeline_version",
+    ),
+)
+
+
+def validate_documents(df, *, context: str = "documents"):
+    """Validate ``df`` using :data:`DOCUMENT_SCHEMA`."""
+
+    return validate_schema(df, DOCUMENT_SCHEMA, context=context)
+
+
+__all__ = ["DOCUMENT_SCHEMA", "validate_documents"]

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -1,0 +1,77 @@
+"""Transformation steps for document postprocessing."""
+from __future__ import annotations
+
+import pandas as pd
+
+from library.postprocess.common import StepDefinition, run_steps
+
+from .schema import DOCUMENT_SCHEMA, validate_documents
+
+
+def normalize_document_fields(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize whitespace and casing for textual document fields."""
+
+    normalized = df.copy(deep=True)
+    normalized.columns = [col.strip().lower() for col in normalized.columns]
+    for column in ["title", "journal", "doc_type"]:
+        if column in normalized.columns:
+            normalized[column] = normalized[column].astype("string").str.strip()
+    return normalized
+
+
+def enrich_document_publication_year(df: pd.DataFrame) -> pd.DataFrame:
+    """Create a deterministic ``publication_year`` column."""
+
+    enriched = df.copy(deep=True)
+    if "year" in enriched.columns:
+        enriched["publication_year"] = pd.to_numeric(
+            enriched["year"], errors="coerce"
+        ).astype("Int64")
+    else:
+        enriched["publication_year"] = pd.Series([pd.NA] * len(enriched), dtype="Int64")
+    return enriched
+
+
+def finalize_document_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and order the DataFrame according to :data:`DOCUMENT_SCHEMA`."""
+
+    prepared = df.copy(deep=True)
+    for column in ["document_chembl_id", "title", "doc_type"]:
+        if column in prepared.columns:
+            prepared[column] = prepared[column].astype("string")
+
+    if "publication_year" in prepared.columns:
+        prepared["publication_year"] = prepared["publication_year"].astype("Int64")
+
+    validated = validate_documents(prepared, context="document_finalization")
+    return validated
+
+
+PIPELINE_STEPS = [
+    StepDefinition("normalize_document_fields", normalize_document_fields),
+    StepDefinition("enrich_document_publication_year", enrich_document_publication_year),
+    StepDefinition("finalize_document_records", finalize_document_records),
+]
+
+
+def run_document_pipeline(
+    df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
+) -> pd.DataFrame:
+    """Run the document postprocessing pipeline."""
+
+    return run_steps(
+        df,
+        PIPELINE_STEPS,
+        schema=DOCUMENT_SCHEMA,
+        pipeline_version=pipeline_version,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "PIPELINE_STEPS",
+    "finalize_document_records",
+    "normalize_document_fields",
+    "run_document_pipeline",
+    "enrich_document_publication_year",
+]

--- a/library/postprocess/targets/__init__.py
+++ b/library/postprocess/targets/__init__.py
@@ -1,0 +1,19 @@
+"""Target postprocessing pipeline."""
+from .schema import TARGET_SCHEMA, validate_targets
+from .steps import (
+    PIPELINE_STEPS,
+    enrich_target_synonyms,
+    finalize_target_records,
+    normalize_target_fields,
+    run_target_pipeline,
+)
+
+__all__ = [
+    "PIPELINE_STEPS",
+    "TARGET_SCHEMA",
+    "enrich_target_synonyms",
+    "finalize_target_records",
+    "normalize_target_fields",
+    "run_target_pipeline",
+    "validate_targets",
+]

--- a/library/postprocess/targets/schema.py
+++ b/library/postprocess/targets/schema.py
@@ -1,0 +1,44 @@
+"""Schema specification for target postprocessing."""
+from __future__ import annotations
+
+from library.postprocess.common import DataFrameSchema, validate_schema
+
+TARGET_SCHEMA = DataFrameSchema(
+    required_columns=(
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+    ),
+    optional_columns=(
+        "organism",
+        "target_class",
+        "protein_family",
+        "synonyms",
+        "pipeline_version",
+    ),
+    dtypes={
+        "target_chembl_id": "string",
+        "pref_name": "string",
+        "target_type": "string",
+    },
+    sort_by=("target_chembl_id",),
+    column_order=(
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+        "organism",
+        "target_class",
+        "protein_family",
+        "synonyms",
+        "pipeline_version",
+    ),
+)
+
+
+def validate_targets(df, *, context: str = "targets"):
+    """Validate ``df`` using :data:`TARGET_SCHEMA`."""
+
+    return validate_schema(df, TARGET_SCHEMA, context=context)
+
+
+__all__ = ["TARGET_SCHEMA", "validate_targets"]

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -1,0 +1,79 @@
+"""Transformation steps for target postprocessing."""
+from __future__ import annotations
+
+import pandas as pd
+
+from library.postprocess.common import StepDefinition, run_steps
+
+from .schema import TARGET_SCHEMA, validate_targets
+
+
+def normalize_target_fields(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize leading/trailing whitespace and ensure upper-case identifiers."""
+
+    normalized = df.copy(deep=True)
+    if "target_chembl_id" in normalized.columns:
+        normalized["target_chembl_id"] = (
+            normalized["target_chembl_id"].astype("string").str.strip().str.upper()
+        )
+    for column in ["pref_name", "organism"]:
+        if column in normalized.columns:
+            normalized[column] = normalized[column].astype("string").str.strip()
+    return normalized
+
+
+def enrich_target_synonyms(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure synonyms column is deterministically ordered."""
+
+    enriched = df.copy(deep=True)
+    if "synonyms" in enriched.columns:
+        enriched["synonyms"] = (
+            enriched["synonyms"].fillna("")
+            .astype("string")
+            .apply(
+                lambda value: ", ".join(sorted(part.strip() for part in value.split(",") if part.strip()))
+            )
+        )
+    return enriched
+
+
+def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
+
+    prepared = df.copy(deep=True)
+    for column in ["target_chembl_id", "pref_name", "target_type"]:
+        if column in prepared.columns:
+            prepared[column] = prepared[column].astype("string")
+
+    validated = validate_targets(prepared, context="target_finalization")
+    return validated
+
+
+PIPELINE_STEPS = [
+    StepDefinition("normalize_target_fields", normalize_target_fields),
+    StepDefinition("enrich_target_synonyms", enrich_target_synonyms),
+    StepDefinition("finalize_target_records", finalize_target_records),
+]
+
+
+def run_target_pipeline(
+    df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
+) -> pd.DataFrame:
+    """Run the target postprocessing pipeline."""
+
+    return run_steps(
+        df,
+        PIPELINE_STEPS,
+        schema=TARGET_SCHEMA,
+        pipeline_version=pipeline_version,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "PIPELINE_STEPS",
+    "finalize_target_records",
+    "normalize_target_fields",
+    "run_target_pipeline",
+    "enrich_target_synonyms",
+]


### PR DESCRIPTION
## Summary
- add a dedicated postprocess package with common dataframe utilities, schema validation, and logging helpers
- implement activity, assay, target, and document pipelines with normalization, enrichment, and finalization steps
- ensure deterministic ordering, strict schema validation, and pipeline version propagation across steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4fa0cfd388324aebd6661da5911d5