### PR TITLE
Disable urllib3 retries for shared sessions

### DIFF
--- a/library/config/runtime.py
+++ b/library/config/runtime.py
@@ -29,12 +29,27 @@ def session_with_retry(api: ApiCfg, retry: RetryCfg) -> Session:
     """Return an HTTP session configured for retries and user agent."""
 
     session = Session()
+    # Disable urllib3-level retries to avoid duplicate retry loops and noisy
+    # connection pool warnings.  All HTTP retry logic is implemented by the
+    # higher-level clients (for example :class:`ChemblClient`) where the
+    # behaviour is deterministic and centrally logged.  Leaving retries
+    # enabled in ``HTTPAdapter`` leads to retries that we cannot observe or
+    # control, and in offline environments this manifests as repeated
+    # ``NameResolutionError`` warnings from urllib3.  Setting every retry
+    # counter to ``0`` keeps adapter configuration predictable while still
+    # exposing metadata such as ``backoff_max`` for introspection in tests.
     retry_kwargs: dict[str, Any] = {
-        "total": max(0, retry.max_attempts - 1),
+        "total": 0,
+        "connect": 0,
+        "read": 0,
+        "redirect": 0,
+        "status": 0,
+        "other": 0,
         "backoff_factor": retry.backoff_factor,
         "status_forcelist": retry.status_forcelist,
         "allowed_methods": None,
         "raise_on_status": False,
+        "raise_on_redirect": False,
     }
     if retry.backoff_cap is not None:
         retry_kwargs["backoff_max"] = retry.backoff_cap

--- a/tests/unit/test_pubmed_client.py
+++ b/tests/unit/test_pubmed_client.py
@@ -56,3 +56,20 @@ def test_session_with_retry__uses_backoff_cap() -> None:
 
     assert isinstance(max_retries, urllib3_retry.Retry)
     assert max_retries.backoff_max == pytest.approx(7.5)
+
+
+@pytest.mark.unit
+def test_session_with_retry__disables_urllib3_retries() -> None:
+    api_cfg = ApiCfg()
+    retry_cfg = RetryCfg(max_attempts=4, backoff_factor=1.0, backoff_cap=None)
+
+    with session_with_retry(api_cfg, retry_cfg) as session:
+        adapter = session.get_adapter("https://")
+        max_retries = adapter.max_retries
+
+    assert isinstance(max_retries, urllib3_retry.Retry)
+    assert max_retries.total == 0
+    assert max_retries.connect == 0
+    assert max_retries.read == 0
+    assert max_retries.redirect == 0
+    assert max_retries.status == 0


### PR DESCRIPTION
## Summary
- disable urllib3-level retries in the shared session factory to avoid duplicated retry loops and noisy connection pool warnings
- add a regression test that checks the adapter exposes zero retry counters

## Testing
- pytest tests/unit/test_pubmed_client.py


------
https://chatgpt.com/codex/tasks/task_e_68e4fa6248648324b0fe7a6186b8eab7