### PR TITLE
Add declarative post-processing pipeline configurations

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,12 @@
 """Configuration package exposing shared file-system paths."""
 from __future__ import annotations
 
-from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR, SCHEMA_DIR
+from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR, PIPELINE_DIR, SCHEMA_DIR
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/paths.py
+++ b/config/paths.py
@@ -7,5 +7,12 @@ CONFIG_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
 DICTIONARY_DIR = CONFIG_DIR / "dictionary"
 SCHEMA_DIR = CONFIG_DIR / "schema"
+PIPELINE_DIR = CONFIG_DIR / "pipeline"
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "SCHEMA_DIR",
+    "PIPELINE_DIR",
+]

--- a/config/pipeline/activities.yaml
+++ b/config/pipeline/activities.yaml
@@ -1,0 +1,24 @@
+pipeline_version: "2024-05-01"
+steps:
+  - name: compute_bounds
+    enabled: true
+    callable: "library.postprocess.activities.steps:compute_bounds"
+    params:
+      input_csv: "$CHEMBL_DA_BASE_PATH/output/activities/output.activity.csv"
+      rounding_digits: 3
+      clamp_nonnegative: true
+  - name: annotate_targets
+    enabled: true
+    callable: "library.postprocess.activities.steps:annotate_targets"
+    params:
+      dictionary_csv: "$CHEMBL_DA_BASE_PATH/output/targets/targets.csv"
+      fallback_label: "unknown"
+      minimum_confidence: 0.7
+  - name: export_extended
+    enabled: true
+    callable: "library.postprocess.activities.steps:export_extended"
+    params:
+      search_dir: "$CHEMBL_DA_BASE_PATH/output"
+      output_dir: "$CHEMBL_DA_BASE_PATH/output/activities"
+      dictionary_dir: "config/dictionary"
+      timestamp_column: "timestamp_utc"

--- a/config/pipeline/assays.yaml
+++ b/config/pipeline/assays.yaml
@@ -1,0 +1,25 @@
+pipeline_version: "2024-05-01"
+steps:
+  - name: enrich_metadata
+    enabled: true
+    callable: "library.postprocess.assays.steps:enrich_metadata"
+    params:
+      assay_lookup: "$CHEMBL_DA_BASE_PATH/output/assays/assay.lookup.csv"
+      fallback_relationship: "unknown"
+      include_columns:
+        - "assay_chembl_id"
+        - "relationship_type"
+  - name: compute_quality_flags
+    enabled: true
+    callable: "library.postprocess.assays.steps:compute_quality_flags"
+    params:
+      quality_ruleset: "config/schema/document.yaml"
+      strict: false
+      warn_only: true
+  - name: export_summary
+    enabled: true
+    callable: "library.postprocess.assays.steps:export_summary"
+    params:
+      output_dir: "$CHEMBL_DA_BASE_PATH/output/assays"
+      filename: "assay.summary.csv"
+      include_stats: true

--- a/config/pipeline/documents.yaml
+++ b/config/pipeline/documents.yaml
@@ -1,0 +1,25 @@
+pipeline_version: "2024-05-01"
+steps:
+  - name: normalize_documents
+    enabled: true
+    callable: "library.postprocess.documents.steps:normalize_documents"
+    params:
+      input_csv: "$CHEMBL_DA_BASE_PATH/output/documents/output.documents.csv"
+      text_columns:
+        - "title"
+        - "abstract"
+      strip_html: true
+  - name: classify_types
+    enabled: true
+    callable: "library.postprocess.documents.steps:classify_types"
+    params:
+      classifier_model: "config/schema/document.yaml"
+      review_threshold: 0.75
+      experimental_threshold: 0.6
+  - name: export_quality_report
+    enabled: true
+    callable: "library.postprocess.documents.steps:export_quality_report"
+    params:
+      output_dir: "$CHEMBL_DA_BASE_PATH/output/documents"
+      filename: "document.quality.csv"
+      include_logs: true

--- a/config/pipeline/targets.yaml
+++ b/config/pipeline/targets.yaml
@@ -1,0 +1,27 @@
+pipeline_version: "2024-05-01"
+steps:
+  - name: merge_taxonomy
+    enabled: true
+    callable: "library.postprocess.targets.steps:merge_taxonomy"
+    params:
+      taxonomy_source: "$CHEMBL_DA_BASE_PATH/output/targets/organism.output.targets.csv"
+      lineage_columns:
+        - "lineage_superkingdom"
+        - "lineage_phylum"
+        - "lineage_class"
+  - name: prepare_isoforms
+    enabled: true
+    callable: "library.postprocess.targets.steps:prepare_isoforms"
+    params:
+      isoform_export: "$CHEMBL_DA_BASE_PATH/output/targets/isoform.output.targets.csv"
+      dedupe: true
+      sort_key: "target_chembl_id"
+  - name: emit_helper_exports
+    enabled: true
+    callable: "library.postprocess.targets.steps:emit_helper_exports"
+    params:
+      output_dir: "$CHEMBL_DA_BASE_PATH/output/targets"
+      include_files:
+        - "names.output.targets.csv"
+        - "IUPHAR.output.targets.csv"
+      timestamp_column: "timestamp_utc"

--- a/docs/en/CONFIG.md
+++ b/docs/en/CONFIG.md
@@ -307,6 +307,41 @@ Controls post-processing of activity tables.
 | `thresholds` | `{review:1, experimental:1, unknown:2}` | Score thresholds for classifications. |
 | `limit` | `null` | Optional cap on processed rows. |
 
+## Post-processing pipeline definitions
+
+Declarative post-processing pipelines are stored under `config/pipeline`. Each YAML
+file corresponds to a domain (`activities.yaml`, `assays.yaml`, `documents.yaml`,
+`targets.yaml`) and contains a `pipeline_version` together with a `steps` array. A
+step entry must declare a `name`, enable flag, and the dotted callable reference in
+`library.postprocess.<domain>.steps`. Optional keyword arguments are provided via
+`params` and are exposed to the callable untouched.
+
+Use :func:`library.postprocess.config.load_pipeline_config` to read these files. The
+loader expands `$CHEMBL_DA_BASE_PATH` placeholders using
+`library.config.env._resolve_placeholder_base_path`, which defaults to
+`~/.local/share/chembl-da` when the environment variable is unset. Additional
+environment variables in string values are resolved via `os.path.expandvars`, and
+all files are read with UTF-8 encoding.
+
+Example fragment:
+
+```yaml
+pipeline_version: "2024-05-01"
+steps:
+  - name: export_extended
+    enabled: true
+    callable: "library.postprocess.activities.steps:export_extended"
+    params:
+      search_dir: "$CHEMBL_DA_BASE_PATH/output"
+      output_dir: "$CHEMBL_DA_BASE_PATH/output/activities"
+      dictionary_dir: "config/dictionary"
+```
+
+At runtime the loader returns :class:`~library.postprocess.config.PipelineConfig`
+with the enabled :class:`~library.postprocess.config.PipelineStep` entries. Each
+step exposes `resolve()` for dynamic imports, allowing orchestrators to execute the
+configured callables or inspect their parameters.
+
 For further customisation consult the Pydantic models in
 [`library/config/models.py`](../../library/config/models.py); the documentation above mirrors the
 available fields and their default values.

--- a/library/postprocess/__init__.py
+++ b/library/postprocess/__init__.py
@@ -1,0 +1,18 @@
+"""Helpers for declarative post-processing pipeline definitions."""
+from __future__ import annotations
+
+from .config import (
+    PIPELINE_CONFIG_DIR,
+    PipelineConfig,
+    PipelineConfigError,
+    PipelineStep,
+    load_pipeline_config,
+)
+
+__all__ = [
+    "PIPELINE_CONFIG_DIR",
+    "PipelineConfig",
+    "PipelineConfigError",
+    "PipelineStep",
+    "load_pipeline_config",
+]

--- a/library/postprocess/_utils.py
+++ b/library/postprocess/_utils.py
@@ -1,0 +1,33 @@
+"""Utility helpers shared by post-processing step definitions."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from library.common.log import logger
+
+__all__ = ["build_step_payload"]
+
+
+def _normalize(value: Any) -> Any:
+    """Recursively normalise ``value`` so it can be serialised safely."""
+
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _normalize(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize(item) for item in value)
+    if isinstance(value, set):
+        return sorted(_normalize(item) for item in value)
+    return value
+
+
+def build_step_payload(step: str, **params: Any) -> Mapping[str, Any]:
+    """Return a lightweight description of a configured post-processing step."""
+
+    normalised = {str(key): _normalize(val) for key, val in params.items()}
+    logger.debug("postprocess_step_config", step=step, params=normalised)
+    return {"step": step, "params": normalised}

--- a/library/postprocess/activities/__init__.py
+++ b/library/postprocess/activities/__init__.py
@@ -1,0 +1,6 @@
+"""Activity post-processing helpers."""
+from __future__ import annotations
+
+from .steps import annotate_targets, compute_bounds, export_extended
+
+__all__ = ["annotate_targets", "compute_bounds", "export_extended"]

--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,0 +1,53 @@
+"""Declarative step callables for the activity post-processing pipeline."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from .._utils import build_step_payload
+
+__all__ = ["compute_bounds", "annotate_targets", "export_extended"]
+
+
+def compute_bounds(*, input_csv: str, rounding_digits: int = 3, clamp_nonnegative: bool = True) -> Mapping[str, object]:
+    """Describe the activity bounds computation step."""
+
+    return build_step_payload(
+        "activities.compute_bounds",
+        input_csv=input_csv,
+        rounding_digits=rounding_digits,
+        clamp_nonnegative=clamp_nonnegative,
+    )
+
+
+def annotate_targets(
+    *,
+    dictionary_csv: str,
+    fallback_label: str,
+    minimum_confidence: float,
+) -> Mapping[str, object]:
+    """Describe enrichment of activity rows with target annotations."""
+
+    return build_step_payload(
+        "activities.annotate_targets",
+        dictionary_csv=dictionary_csv,
+        fallback_label=fallback_label,
+        minimum_confidence=minimum_confidence,
+    )
+
+
+def export_extended(
+    *,
+    search_dir: str,
+    output_dir: str,
+    dictionary_dir: str,
+    timestamp_column: str = "timestamp_utc",
+) -> Mapping[str, object]:
+    """Describe exporting the extended activity artefact."""
+
+    return build_step_payload(
+        "activities.export_extended",
+        search_dir=search_dir,
+        output_dir=output_dir,
+        dictionary_dir=dictionary_dir,
+        timestamp_column=timestamp_column,
+    )

--- a/library/postprocess/assays/__init__.py
+++ b/library/postprocess/assays/__init__.py
@@ -1,0 +1,6 @@
+"""Assay post-processing helpers."""
+from __future__ import annotations
+
+from .steps import compute_quality_flags, enrich_metadata, export_summary
+
+__all__ = ["compute_quality_flags", "enrich_metadata", "export_summary"]

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,0 +1,56 @@
+"""Declarative step callables for assay post-processing."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from .._utils import build_step_payload
+
+__all__ = ["enrich_metadata", "compute_quality_flags", "export_summary"]
+
+
+def enrich_metadata(
+    *,
+    assay_lookup: str,
+    fallback_relationship: str,
+    include_columns: Sequence[str] | None = None,
+) -> Mapping[str, object]:
+    """Describe assay metadata enrichment from lookup tables."""
+
+    return build_step_payload(
+        "assays.enrich_metadata",
+        assay_lookup=assay_lookup,
+        fallback_relationship=fallback_relationship,
+        include_columns=tuple(include_columns) if include_columns is not None else (),
+    )
+
+
+def compute_quality_flags(
+    *,
+    quality_ruleset: str,
+    strict: bool,
+    warn_only: bool,
+) -> Mapping[str, object]:
+    """Describe computing boolean QA flags for assay exports."""
+
+    return build_step_payload(
+        "assays.compute_quality_flags",
+        quality_ruleset=quality_ruleset,
+        strict=strict,
+        warn_only=warn_only,
+    )
+
+
+def export_summary(
+    *,
+    output_dir: str,
+    filename: str,
+    include_stats: bool = True,
+) -> Mapping[str, object]:
+    """Describe exporting aggregate assay statistics."""
+
+    return build_step_payload(
+        "assays.export_summary",
+        output_dir=output_dir,
+        filename=filename,
+        include_stats=include_stats,
+    )

--- a/library/postprocess/config.py
+++ b/library/postprocess/config.py
@@ -1,0 +1,177 @@
+"""Load and normalise declarative post-processing pipeline definitions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable, Iterator, Mapping, Sequence
+
+import yaml
+
+from config.paths import PIPELINE_DIR as _PIPELINE_DIR
+from library.config.env import _expand_config_placeholders, _resolve_placeholder_base_path
+
+__all__ = [
+    "PIPELINE_CONFIG_DIR",
+    "PipelineConfig",
+    "PipelineConfigError",
+    "PipelineStep",
+    "load_pipeline_config",
+]
+
+PIPELINE_CONFIG_DIR = _PIPELINE_DIR
+
+
+class PipelineConfigError(RuntimeError):
+    """Raised when a pipeline configuration file cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """Enabled step definition declared in a pipeline configuration file."""
+
+    name: str
+    callable_path: str
+    params: Mapping[str, Any]
+
+    def resolve(self) -> Callable[..., Any]:
+        """Return the callable referenced by :attr:`callable_path`."""
+
+        module_name, _, attribute = self.callable_path.partition(":")
+        if not module_name or not attribute:
+            raise PipelineConfigError(
+                f"invalid callable reference '{self.callable_path}' for step '{self.name}'"
+            )
+        try:
+            module = import_module(module_name)
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise PipelineConfigError(
+                f"module '{module_name}' for step '{self.name}' cannot be imported"
+            ) from exc
+        try:
+            return getattr(module, attribute)
+        except AttributeError as exc:  # pragma: no cover - defensive
+            raise PipelineConfigError(
+                f"callable '{self.callable_path}' for step '{self.name}' is not importable"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Top-level representation of a pipeline configuration file."""
+
+    pipeline_version: str
+    steps: tuple[PipelineStep, ...]
+    path: Path
+
+    def iter_callables(self) -> Iterator[Callable[..., Any]]:
+        """Yield callables for enabled steps in declaration order."""
+
+        for step in self.steps:
+            yield step.resolve()
+
+
+def load_pipeline_config(
+    domain: str,
+    *,
+    path: str | Path | None = None,
+    base_path: str | Path | None = None,
+) -> PipelineConfig:
+    """Return post-processing pipeline configuration for ``domain``."""
+
+    config_path = _resolve_config_path(domain, path)
+    data = _load_yaml(config_path)
+    expanded = _expand_config_placeholders(
+        data,
+        base_path=_resolve_placeholder_base_path(base_path),
+    )
+    pipeline_version = expanded.get("pipeline_version")
+    if not isinstance(pipeline_version, str) or not pipeline_version.strip():
+        raise PipelineConfigError(
+            f"pipeline configuration '{config_path}' is missing a non-empty 'pipeline_version'"
+        )
+
+    raw_steps = expanded.get("steps", [])
+    if not isinstance(raw_steps, Sequence):
+        raise PipelineConfigError(
+            f"pipeline configuration '{config_path}' must define 'steps' as a sequence"
+        )
+
+    steps: list[PipelineStep] = []
+    for entry in raw_steps:
+        if not isinstance(entry, Mapping):
+            raise PipelineConfigError(
+                f"pipeline configuration '{config_path}' contains a non-mapping step entry"
+            )
+        enabled = entry.get("enabled", True)
+        if not enabled:
+            continue
+        name = entry.get("name")
+        callable_path = entry.get("callable")
+        params = entry.get("params", {})
+        if not isinstance(name, str) or not name.strip():
+            raise PipelineConfigError(
+                f"pipeline configuration '{config_path}' has an enabled step without a string 'name'"
+            )
+        if not isinstance(callable_path, str) or not callable_path.strip():
+            raise PipelineConfigError(
+                f"pipeline configuration '{config_path}' step '{name}' is missing a 'callable'"
+            )
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise PipelineConfigError(
+                f"pipeline configuration '{config_path}' step '{name}' has non-mapping 'params'"
+            )
+        steps.append(
+            PipelineStep(
+                name=name,
+                callable_path=callable_path,
+                params=_freeze_params(params),
+            )
+        )
+
+    return PipelineConfig(
+        pipeline_version=pipeline_version,
+        steps=tuple(steps),
+        path=config_path,
+    )
+
+
+def _resolve_config_path(domain: str, path: str | Path | None) -> Path:
+    if path is not None:
+        return Path(path).expanduser().resolve()
+    candidate = PIPELINE_CONFIG_DIR / f"{domain}.yaml"
+    return candidate.resolve()
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise PipelineConfigError(f"pipeline configuration file not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise PipelineConfigError(f"failed to parse YAML at {path}: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise PipelineConfigError(
+            f"pipeline configuration '{path}' must contain a top-level mapping"
+        )
+    return data
+
+
+def _freeze_params(params: Mapping[str, Any]) -> Mapping[str, Any]:
+    def _convert(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(key): _convert(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [_convert(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(_convert(item) for item in value)
+        if isinstance(value, set):
+            return sorted(_convert(item) for item in value)
+        return value
+
+    materialised = {str(key): _convert(val) for key, val in params.items()}
+    return MappingProxyType(materialised)

--- a/library/postprocess/documents/__init__.py
+++ b/library/postprocess/documents/__init__.py
@@ -1,0 +1,6 @@
+"""Document post-processing helpers."""
+from __future__ import annotations
+
+from .steps import classify_types, export_quality_report, normalize_documents
+
+__all__ = ["classify_types", "export_quality_report", "normalize_documents"]

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -1,0 +1,56 @@
+"""Declarative step callables for document post-processing."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from .._utils import build_step_payload
+
+__all__ = ["normalize_documents", "classify_types", "export_quality_report"]
+
+
+def normalize_documents(
+    *,
+    input_csv: str,
+    text_columns: Sequence[str],
+    strip_html: bool,
+) -> Mapping[str, object]:
+    """Describe normalising textual document columns."""
+
+    return build_step_payload(
+        "documents.normalize_documents",
+        input_csv=input_csv,
+        text_columns=tuple(text_columns),
+        strip_html=strip_html,
+    )
+
+
+def classify_types(
+    *,
+    classifier_model: str,
+    review_threshold: float,
+    experimental_threshold: float,
+) -> Mapping[str, object]:
+    """Describe applying document type classification thresholds."""
+
+    return build_step_payload(
+        "documents.classify_types",
+        classifier_model=classifier_model,
+        review_threshold=review_threshold,
+        experimental_threshold=experimental_threshold,
+    )
+
+
+def export_quality_report(
+    *,
+    output_dir: str,
+    filename: str,
+    include_logs: bool,
+) -> Mapping[str, object]:
+    """Describe exporting QA reports for document tables."""
+
+    return build_step_payload(
+        "documents.export_quality_report",
+        output_dir=output_dir,
+        filename=filename,
+        include_logs=include_logs,
+    )

--- a/library/postprocess/targets/__init__.py
+++ b/library/postprocess/targets/__init__.py
@@ -1,0 +1,6 @@
+"""Target post-processing helpers."""
+from __future__ import annotations
+
+from .steps import emit_helper_exports, merge_taxonomy, prepare_isoforms
+
+__all__ = ["emit_helper_exports", "merge_taxonomy", "prepare_isoforms"]

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -1,0 +1,54 @@
+"""Declarative step callables for target post-processing."""
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from .._utils import build_step_payload
+
+__all__ = ["merge_taxonomy", "prepare_isoforms", "emit_helper_exports"]
+
+
+def merge_taxonomy(
+    *,
+    taxonomy_source: str,
+    lineage_columns: Sequence[str],
+) -> Mapping[str, object]:
+    """Describe aligning target taxonomy helpers."""
+
+    return build_step_payload(
+        "targets.merge_taxonomy",
+        taxonomy_source=taxonomy_source,
+        lineage_columns=tuple(lineage_columns),
+    )
+
+
+def prepare_isoforms(
+    *,
+    isoform_export: str,
+    dedupe: bool,
+    sort_key: str,
+) -> Mapping[str, object]:
+    """Describe preparing isoform projections."""
+
+    return build_step_payload(
+        "targets.prepare_isoforms",
+        isoform_export=isoform_export,
+        dedupe=dedupe,
+        sort_key=sort_key,
+    )
+
+
+def emit_helper_exports(
+    *,
+    output_dir: str,
+    include_files: Sequence[str],
+    timestamp_column: str,
+) -> Mapping[str, object]:
+    """Describe emitting auxiliary helper exports for targets."""
+
+    return build_step_payload(
+        "targets.emit_helper_exports",
+        output_dir=output_dir,
+        include_files=tuple(include_files),
+        timestamp_column=timestamp_column,
+    )

--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -74,6 +74,7 @@ from library.processing.activity import (
     apply_activity_annotations,
     compute_activity_bounds,
 )
+from library.postprocess.config import PipelineConfigError, load_pipeline_config
 from library.postprocessing.activity_extended import process_activity_extended
 from library.postprocessing import helpers as postprocessing_helpers
 from library.qa.reporting import build_table_quality_hook
@@ -772,6 +773,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
         limit=limit,
         offset=offset,
     )
+    _log_activity_postprocess_pipeline()
     logger.info(
         f"Starting activity pipeline with input '{args.input_csv}' and output '{output_path}'."
     )
@@ -1376,6 +1378,25 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         )
         return 0
     return run_chembl(cfg, args)
+
+
+def _log_activity_postprocess_pipeline() -> None:
+    """Emit debug logging describing the declarative post-processing pipeline."""
+
+    try:
+        pipeline_cfg = load_pipeline_config("activities")
+    except PipelineConfigError as exc:
+        logger.debug(
+            "activity_postprocess_config_unavailable",
+            error=str(exc),
+        )
+        return
+
+    logger.debug(
+        "activity_postprocess_pipeline_config",
+        version=pipeline_cfg.pipeline_version,
+        steps=[step.callable_path for step in pipeline_cfg.steps],
+    )
 
 
 def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -30,6 +30,7 @@ import requests
 
 from library.integration import chembl_library as cl
 from library.pipelines.assay import postprocessing as ap
+from library.postprocess.config import PipelineConfigError, load_pipeline_config
 from library.postprocessing import enrich_assay_metadata
 from library import cli
 from library import io
@@ -245,6 +246,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
             value=cfg.assay.timeout,
         ),
     )
+    _log_assay_postprocess_pipeline()
     if offset:
         ids_iter = islice(ids_iter, offset, None)
         logger.info("process_offset", offset=offset)
@@ -497,6 +499,25 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         logger.info("pipeline_skip_existing", output=str(output_path))
         return 0
     return run_chembl(cfg, args)
+
+
+def _log_assay_postprocess_pipeline() -> None:
+    """Emit debug information about the assay post-processing pipeline."""
+
+    try:
+        pipeline_cfg = load_pipeline_config("assays")
+    except PipelineConfigError as exc:
+        logger.debug(
+            "assay_postprocess_config_unavailable",
+            error=str(exc),
+        )
+        return
+
+    logger.debug(
+        "assay_postprocess_pipeline_config",
+        version=pipeline_cfg.pipeline_version,
+        steps=[step.callable_path for step in pipeline_cfg.steps],
+    )
 
 
 def _build_parser_impl() -> tuple[argparse.ArgumentParser, LoggerConfig]:

--- a/scripts/get_document_data.py
+++ b/scripts/get_document_data.py
@@ -55,6 +55,7 @@ from library.common.csv_utils import write_csv_chunks_deterministic
 from library.integration import chembl_library as cl
 from library.document_defaults import ALL_DEFAULTS, CHEMBL_DEFAULTS, PUBMED_DEFAULTS
 from library.pipelines.document import postprocessing as dp
+from library.postprocess.config import PipelineConfigError, load_pipeline_config
 from library.postprocessing import document as document_export_postprocessing
 from library.orchestration import ETLContext
 from library.cli import (
@@ -450,6 +451,7 @@ def _write_export_chunks(
 
 
 def _maybe_run_document_postprocessing(csv_path: Path, *, skip_qa: bool = False) -> None:
+    _log_document_postprocess_pipeline()
     if not csv_path.name.startswith("output.document_"):
         return
 
@@ -486,6 +488,25 @@ def _maybe_run_document_postprocessing(csv_path: Path, *, skip_qa: bool = False)
             output=str(csv_path),
             reason="partial_run",
         )
+
+
+def _log_document_postprocess_pipeline() -> None:
+    """Emit debug information about the document post-processing pipeline."""
+
+    try:
+        pipeline_cfg = load_pipeline_config("documents")
+    except PipelineConfigError as exc:
+        logger.debug(
+            "document_postprocess_config_unavailable",
+            error=str(exc),
+        )
+        return
+
+    logger.debug(
+        "document_postprocess_pipeline_config",
+        version=pipeline_cfg.pipeline_version,
+        steps=[step.callable_path for step in pipeline_cfg.steps],
+    )
 
 
 def _finalise_export(

--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -45,6 +45,7 @@ from library import io
 from library.integration import chembl_library as cl
 from library.integration import iuphar_library as ii
 from library.integration import uniprot_library as uu
+from library.postprocess.config import PipelineConfigError, load_pipeline_config
 from library.pipelines.target import protein_classification as pc
 from library.pipelines.target import postprocessing as tp
 from library.pipelines.target.defaults import ModeDefaults, TARGET_MODE_DEFAULTS
@@ -741,6 +742,7 @@ def _postprocess_target_exports(
 ) -> None:
     """Run all target post-processing helpers for ``source`` export."""
 
+    _log_target_postprocess_pipeline()
     if not _is_supported_target_export(source):
         logger.info(
             "target_postprocess_skipped",
@@ -758,6 +760,25 @@ def _postprocess_target_exports(
     )
     _postprocess_names_export(source, cfg=cfg)
     _postprocess_iuphar_export(source, verbose=verbose)
+
+
+def _log_target_postprocess_pipeline() -> None:
+    """Emit debug information about the target post-processing pipeline."""
+
+    try:
+        pipeline_cfg = load_pipeline_config("targets")
+    except PipelineConfigError as exc:
+        logger.debug(
+            "target_postprocess_config_unavailable",
+            error=str(exc),
+        )
+        return
+
+    logger.debug(
+        "target_postprocess_pipeline_config",
+        version=pipeline_cfg.pipeline_version,
+        steps=[step.callable_path for step in pipeline_cfg.steps],
+    )
 
 
 def _resolve_parameter(

--- a/tests/unit/postprocessing/test_pipeline_config.py
+++ b/tests/unit/postprocessing/test_pipeline_config.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import textwrap
+
+import pytest
+
+from library.postprocess.config import PipelineConfigError, PipelineStep, load_pipeline_config
+
+
+def test_load_pipeline_config__expands_base_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base_dir = tmp_path / "data"
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(base_dir))
+
+    cfg = load_pipeline_config("activities")
+
+    assert cfg.pipeline_version
+    assert any(step.name == "compute_bounds" for step in cfg.steps)
+
+    compute_step = next(step for step in cfg.steps if step.name == "compute_bounds")
+    input_path = compute_step.params["input_csv"]
+    expected = (base_dir / "output" / "activities" / "output.activity.csv").resolve()
+    assert Path(input_path).resolve() == expected
+
+
+def test_pipeline_step__resolves_callable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CHEMBL_DA_BASE_PATH", str(tmp_path))
+
+    cfg = load_pipeline_config("assays")
+    step = cfg.steps[0]
+    callable_obj = step.resolve()
+    result = callable_obj(**dict(step.params))
+
+    assert isinstance(result, dict)
+    assert result["step"].startswith("assays.")
+    assert set(result["params"]).issuperset(step.params.keys())
+
+
+def test_load_pipeline_config__skips_disabled_steps(tmp_path: Path) -> None:
+    config_text = textwrap.dedent(
+        """
+        pipeline_version: "test"
+        steps:
+          - name: active
+            enabled: true
+            callable: "library.postprocess.activities.steps:compute_bounds"
+            params:
+              input_csv: "in.csv"
+              rounding_digits: 2
+              clamp_nonnegative: false
+          - name: disabled
+            enabled: false
+            callable: "library.postprocess.activities.steps:annotate_targets"
+            params:
+              dictionary_csv: "targets.csv"
+              fallback_label: "unknown"
+              minimum_confidence: 0.5
+        """
+    ).strip()
+    config_path = tmp_path / "pipeline.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    cfg = load_pipeline_config("activities", path=config_path)
+
+    assert [step.name for step in cfg.steps] == ["active"]
+
+    with pytest.raises(PipelineConfigError):
+        PipelineStep(name="broken", callable_path="not:callable", params={}).resolve()


### PR DESCRIPTION
## Summary
- add declarative pipeline definitions for activities, assays, documents, and targets under `config/pipeline`
- introduce the `library.postprocess` package with a UTF-8 safe loader, reusable step helpers, and exports for pipeline configs
- surface pipeline metadata in the `get_*` scripts, document the new configs, and cover the loader with unit tests

## Testing
- pytest tests/unit/postprocessing/test_pipeline_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e4fa0d0b308324b35a090ce06f65df