### PR TITLE
Add declarative post-processing pipeline configs

### DIFF
--- a/README_postprocess.md
+++ b/README_postprocess.md
@@ -41,6 +41,19 @@ Follow this checklist to bolt a new export onto the stack:
 4. **Hook reporting**: ensure your CLI entry point (or orchestrated callable) calls `finalise_csv_output` with the schema identifier and any quality profiler/summary objects so metadata and QA artefacts stay in sync. 【F:library/reporting/run_manifest.py†L70-L169】
 5. **Cover it with tests**: add unit coverage for the helper logic, integration tests for file I/O and schema validation, and update e2e fixtures if the table participates in the aggregated run (see testing expectations below). 【F:tests/README.md†L1-L88】
 
+### Declarative pipeline configuration
+
+The active step list for each post-processing domain now lives under `config/pipeline/<domain>.yaml`. These YAML files describe the pipeline version advertised in metadata, the enabled steps and domain-specific parameters that documentation and orchestration hooks may consume. Callables are referenced through dotted import paths such as `library.postprocess.activities.steps:normalize_activity_records` and resolved lazily via `load_pipeline_config`. 【F:config/pipeline/activities.yaml†L1-L34】【F:library/postprocess/common/config.py†L22-L170】
+
+Environment variables can override YAML values using `${VAR}` or `${VAR:-default}` placeholders. For example, `${CHEMBL_ACTIVITY_PIPELINE_VERSION:-auto}` defaults to the installed library version unless `CHEMBL_ACTIVITY_PIPELINE_VERSION` is exported. Similarly, `${POSTPROCESS_LOG_LEVEL:-INFO}` sets the default log level consumed by orchestration. The loader expands these markers with UTF-8 safe reads and normalises `auto`/empty values to fall back to `get_pipeline_version()`. 【F:library/postprocess/common/config.py†L64-L170】【F:library/postprocess/activities/steps.py†L67-L104】
+
+Available overrides:
+
+- `CHEMBL_ACTIVITY_PIPELINE_VERSION`, `CHEMBL_ASSAY_PIPELINE_VERSION`, `CHEMBL_DOCUMENT_PIPELINE_VERSION`, `CHEMBL_TARGET_PIPELINE_VERSION` — override the exported `pipeline_version` per domain; defaults to `auto`.
+- `POSTPROCESS_LOG_LEVEL` — baseline logger verbosity, defaulting to `INFO`.
+
+Each steps module imports its matching configuration, exposing `PIPELINE_CONFIG` and constructing `PIPELINE_STEPS` directly from the YAML definition so future additions require no code edits. 【F:library/postprocess/assays/steps.py†L1-L76】【F:library/postprocess/documents/steps.py†L1-L82】【F:library/postprocess/targets/steps.py†L1-L80】
+
 ## Runtime flow
 
 ```mermaid

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,18 @@
 """Configuration package exposing shared file-system paths."""
 from __future__ import annotations
 
-from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR, SCHEMA_DIR
+from .paths import (
+    CONFIG_DIR,
+    DEFAULT_CONFIG_PATH,
+    DICTIONARY_DIR,
+    PIPELINE_DIR,
+    SCHEMA_DIR,
+)
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/paths.py
+++ b/config/paths.py
@@ -7,5 +7,12 @@ CONFIG_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
 DICTIONARY_DIR = CONFIG_DIR / "dictionary"
 SCHEMA_DIR = CONFIG_DIR / "schema"
+PIPELINE_DIR = CONFIG_DIR / "pipeline"
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/pipeline/activities.yaml
+++ b/config/pipeline/activities.yaml
@@ -1,0 +1,35 @@
+# Default activity post-processing pipeline configuration.
+pipeline_version: "${CHEMBL_ACTIVITY_PIPELINE_VERSION:-auto}"
+enabled_steps:
+  - name: normalize_activity_records
+    callable: "library.postprocess.activities.steps:normalize_activity_records"
+    description: "Trim whitespace and harmonise activity metadata fields."
+    params:
+      relation_normalization: true
+      enforce_uppercase_units: true
+  - name: enrich_activity_quality
+    callable: "library.postprocess.activities.steps:enrich_activity_quality"
+    description: "Derive deterministic quality flags from validity comments."
+    params:
+      quality_terms:
+        - valid
+        - expert curated
+      default_quality_flag: false
+  - name: finalize_activity_records
+    callable: "library.postprocess.activities.steps:finalize_activity_records"
+    description: "Coerce identifiers, align schema ordering and validate outputs."
+    params:
+      enforce_schema: true
+      numeric_identifier_dtype: Int64
+params:
+  defaults:
+    pipeline_version: "${CHEMBL_ACTIVITY_PIPELINE_VERSION:-auto}"
+    log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
+  io:
+    encoding: "utf-8"
+    csv_sep: ","
+  quality:
+    missing_comment_flag: false
+    comment_terms:
+      - valid
+      - curated

--- a/config/pipeline/assays.yaml
+++ b/config/pipeline/assays.yaml
@@ -1,0 +1,33 @@
+# Default assay post-processing pipeline configuration.
+pipeline_version: "${CHEMBL_ASSAY_PIPELINE_VERSION:-auto}"
+enabled_steps:
+  - name: normalize_assay_metadata
+    callable: "library.postprocess.assays.steps:normalize_assay_metadata"
+    description: "Standardise assay descriptors and harmonise categorical values."
+    params:
+      uppercase_categories: true
+      strip_whitespace: true
+  - name: enrich_assay_flags
+    callable: "library.postprocess.assays.steps:enrich_assay_flags"
+    description: "Derive confirmatory flags using configured assay type heuristics."
+    params:
+      confirmatory_terms:
+        - confirm
+        - primary
+      default_flag: false
+  - name: finalize_assay_records
+    callable: "library.postprocess.assays.steps:finalize_assay_records"
+    description: "Apply schema validation and deterministic column ordering."
+    params:
+      enforce_schema: true
+      normalize_identifiers: true
+params:
+  defaults:
+    pipeline_version: "${CHEMBL_ASSAY_PIPELINE_VERSION:-auto}"
+    log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
+  io:
+    encoding: "utf-8"
+    csv_sep: ","
+  flags:
+    default_confirmatory: false
+    fallback_assay_type: unknown

--- a/config/pipeline/documents.yaml
+++ b/config/pipeline/documents.yaml
@@ -1,0 +1,31 @@
+# Default document post-processing pipeline configuration.
+pipeline_version: "${CHEMBL_DOCUMENT_PIPELINE_VERSION:-auto}"
+enabled_steps:
+  - name: normalize_document_fields
+    callable: "library.postprocess.documents.steps:normalize_document_fields"
+    description: "Normalize document metadata and harmonise citation fields."
+    params:
+      trim_whitespace: true
+      normalise_unicode: true
+  - name: enrich_document_publication_year
+    callable: "library.postprocess.documents.steps:enrich_document_publication_year"
+    description: "Backfill publication year using DOI lookups and heuristics."
+    params:
+      fallback_year: 1900
+      prefer_doi_year: true
+  - name: finalize_document_records
+    callable: "library.postprocess.documents.steps:finalize_document_records"
+    description: "Enforce schema ordering and deterministic identifier dtypes."
+    params:
+      enforce_schema: true
+      ensure_unique_ids: true
+params:
+  defaults:
+    pipeline_version: "${CHEMBL_DOCUMENT_PIPELINE_VERSION:-auto}"
+    log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
+  io:
+    encoding: "utf-8"
+    csv_sep: ","
+  enrichment:
+    doi_lookup_timeout: 5
+    enable_fallback_crossref: false

--- a/config/pipeline/targets.yaml
+++ b/config/pipeline/targets.yaml
@@ -1,0 +1,36 @@
+# Default target post-processing pipeline configuration.
+pipeline_version: "${CHEMBL_TARGET_PIPELINE_VERSION:-auto}"
+enabled_steps:
+  - name: normalize_target_fields
+    callable: "library.postprocess.targets.steps:normalize_target_fields"
+    description: "Normalize primary identifiers and canonical target metadata."
+    params:
+      normalize_taxonomy: true
+      fill_missing_identifiers: true
+  - name: enrich_target_synonyms
+    callable: "library.postprocess.targets.steps:enrich_target_synonyms"
+    description: "Aggregate synonym sets across configured source dictionaries."
+    params:
+      synonym_sources:
+        - chembl
+        - gtopdb
+      preferred_separator: "; "
+  - name: finalize_target_records
+    callable: "library.postprocess.targets.steps:finalize_target_records"
+    description: "Validate schema expectations and stabilise column ordering."
+    params:
+      enforce_schema: true
+      sort_by:
+        - target_chembl_id
+params:
+  defaults:
+    pipeline_version: "${CHEMBL_TARGET_PIPELINE_VERSION:-auto}"
+    log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
+  io:
+    encoding: "utf-8"
+    csv_sep: ","
+  enrichment:
+    synonym_priority:
+      - preferred_name
+      - gene_symbol
+    fill_missing_species: true

--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.pipelines.common.metadata import get_pipeline_version
+from library.postprocess.common import run_steps
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
 
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
@@ -56,11 +61,8 @@ def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_activity_records", normalize_activity_records),
-    StepDefinition("enrich_activity_quality", enrich_activity_quality),
-    StepDefinition("finalize_activity_records", finalize_activity_records),
-]
+PIPELINE_CONFIG = load_pipeline_config("activities")
+PIPELINE_STEPS = PIPELINE_CONFIG.step_definitions()
 
 
 def run_activity_pipeline(
@@ -68,16 +70,32 @@ def run_activity_pipeline(
 ) -> pd.DataFrame:
     """Execute the activity postprocessing steps."""
 
+    resolved_version = _resolve_pipeline_version(pipeline_version)
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=ACTIVITY_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=resolved_version,
         logger=logger,
     )
 
 
+def _resolve_pipeline_version(override: str | None) -> str:
+    """Resolve the effective pipeline version for activity postprocessing."""
+
+    candidate = normalize_pipeline_version(override)
+    if candidate is not None:
+        return candidate
+
+    config_candidate = normalize_pipeline_version(PIPELINE_CONFIG.pipeline_version)
+    if config_candidate is not None:
+        return config_candidate
+
+    return get_pipeline_version()
+
+
 __all__ = [
+    "PIPELINE_CONFIG",
     "PIPELINE_STEPS",
     "finalize_activity_records",
     "normalize_activity_records",

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.pipelines.common.metadata import get_pipeline_version
+from library.postprocess.common import run_steps
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
 
 from .schema import ASSAY_SCHEMA, validate_assays
 
@@ -50,11 +55,8 @@ def finalize_assay_records(df: pd.DataFrame) -> pd.DataFrame:
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_assay_metadata", normalize_assay_metadata),
-    StepDefinition("enrich_assay_flags", enrich_assay_flags),
-    StepDefinition("finalize_assay_records", finalize_assay_records),
-]
+PIPELINE_CONFIG = load_pipeline_config("assays")
+PIPELINE_STEPS = PIPELINE_CONFIG.step_definitions()
 
 
 def run_assay_pipeline(
@@ -62,16 +64,30 @@ def run_assay_pipeline(
 ) -> pd.DataFrame:
     """Run the assay postprocessing pipeline."""
 
+    resolved_version = _resolve_pipeline_version(pipeline_version)
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=ASSAY_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=resolved_version,
         logger=logger,
     )
 
 
+def _resolve_pipeline_version(override: str | None) -> str:
+    candidate = normalize_pipeline_version(override)
+    if candidate is not None:
+        return candidate
+
+    config_candidate = normalize_pipeline_version(PIPELINE_CONFIG.pipeline_version)
+    if config_candidate is not None:
+        return config_candidate
+
+    return get_pipeline_version()
+
+
 __all__ = [
+    "PIPELINE_CONFIG",
     "PIPELINE_STEPS",
     "finalize_assay_records",
     "normalize_assay_metadata",

--- a/library/postprocess/common/config.py
+++ b/library/postprocess/common/config.py
@@ -1,0 +1,206 @@
+"""Helpers for loading declarative post-processing pipeline configuration."""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from config.paths import PIPELINE_DIR
+
+from .import_utils import resolve_dotted_path
+from .types import StepDefinition
+
+__all__ = [
+    "ConfiguredStep",
+    "PipelineConfig",
+    "PipelineConfigError",
+    "load_pipeline_config",
+    "normalize_pipeline_version",
+]
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::(-|:-)([^}]*))?\}")
+
+
+class PipelineConfigError(RuntimeError):
+    """Raised when a pipeline configuration file cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class ConfiguredStep:
+    """A post-processing step loaded from the declarative configuration."""
+
+    name: str
+    callable_path: str
+    definition: StepDefinition
+    params: Mapping[str, Any]
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Container holding the resolved pipeline configuration."""
+
+    name: str
+    path: Path
+    pipeline_version: str | None
+    params: Mapping[str, Any]
+    steps: tuple[ConfiguredStep, ...]
+
+    def step_definitions(self) -> tuple[StepDefinition, ...]:
+        """Return the resolved step definitions preserving configuration order."""
+
+        return tuple(step.definition for step in self.steps)
+
+
+def load_pipeline_config(
+    name: str,
+    path: Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> PipelineConfig:
+    """Load the pipeline configuration identified by ``name``.
+
+    Parameters
+    ----------
+    name:
+        Domain identifier, for example ``"activities"`` or ``"targets"``.
+    path:
+        Optional path overriding the default ``config/pipeline/<name>.yaml`` location.
+    env:
+        Mapping used to resolve environment variable placeholders. Defaults to
+        :data:`os.environ` when omitted.
+    """
+
+    config_path = _resolve_config_path(name, path)
+    env_mapping = dict(os.environ if env is None else env)
+
+    try:
+        raw_data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise PipelineConfigError(
+            f"pipeline configuration not found: {config_path}"
+        ) from exc
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive guard
+        raise PipelineConfigError(
+            f"failed to parse pipeline configuration at {config_path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw_data, dict):
+        raise PipelineConfigError("pipeline configuration must be a mapping at the top level")
+
+    expanded = _expand_environment(raw_data, env_mapping)
+
+    pipeline_version = expanded.get("pipeline_version")
+    if pipeline_version is not None and not isinstance(pipeline_version, str):
+        raise PipelineConfigError("'pipeline_version' must be a string when provided")
+
+    params = expanded.get("params") or {}
+    if not isinstance(params, dict):
+        raise PipelineConfigError("'params' must be a mapping when provided")
+
+    enabled_steps = expanded.get("enabled_steps")
+    if not isinstance(enabled_steps, Sequence) or isinstance(enabled_steps, (str, bytes)):
+        raise PipelineConfigError("'enabled_steps' must be a sequence of mappings")
+
+    steps = tuple(_load_step(entry, index) for index, entry in enumerate(enabled_steps))
+
+    return PipelineConfig(
+        name=name,
+        path=config_path,
+        pipeline_version=pipeline_version,
+        params=params,
+        steps=steps,
+    )
+
+
+def normalize_pipeline_version(value: str | None) -> str | None:
+    """Return ``value`` normalised for runtime consumption.
+
+    ``None``, empty strings and the sentinel values ``"auto"`` / ``"default"``
+    become :data:`None`, signalling that callers should fall back to the
+    library-reported pipeline version.
+    """
+
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if candidate.lower() in {"auto", "default"}:
+        return None
+    return candidate
+
+
+def _resolve_config_path(name: str, override: Path | None) -> Path:
+    if override is not None:
+        return Path(override).expanduser().resolve()
+    return (PIPELINE_DIR / f"{name}.yaml").resolve()
+
+
+def _load_step(entry: Any, index: int) -> ConfiguredStep:
+    if not isinstance(entry, dict):
+        raise PipelineConfigError(f"step #{index} must be a mapping")
+
+    name = entry.get("name")
+    callable_path = entry.get("callable")
+    description = entry.get("description")
+    params = entry.get("params") or {}
+
+    if not isinstance(name, str) or not name:
+        raise PipelineConfigError(f"step #{index} missing a valid 'name' string")
+    if not isinstance(callable_path, str) or not callable_path:
+        raise PipelineConfigError(f"step '{name}' missing a 'callable' reference")
+    if description is not None and not isinstance(description, str):
+        raise PipelineConfigError(f"step '{name}' description must be a string when provided")
+    if not isinstance(params, dict):
+        raise PipelineConfigError(f"step '{name}' parameters must be expressed as a mapping")
+
+    func = resolve_dotted_path(callable_path)
+    if not callable(func):  # pragma: no cover - defensive guard
+        raise PipelineConfigError(
+            f"resolved object for step '{name}' is not callable: {callable_path}"
+        )
+
+    definition = StepDefinition(name=name, func=func, description=description)
+    return ConfiguredStep(
+        name=name,
+        callable_path=callable_path,
+        definition=definition,
+        params=params,
+        description=description,
+    )
+
+
+def _expand_environment(value: Any, env: Mapping[str, str]) -> Any:
+    if isinstance(value, dict):
+        return {key: _expand_environment(item, env) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_expand_environment(item, env) for item in value]
+    if isinstance(value, tuple):  # pragma: no cover - handled implicitly via lists
+        return tuple(_expand_environment(item, env) for item in value)
+    if isinstance(value, str):
+        return _expand_string(value, env)
+    return value
+
+
+def _expand_string(template: str, env: Mapping[str, str]) -> str:
+    def _replacement(match: re.Match[str]) -> str:
+        name = match.group(1)
+        operator = match.group(2)
+        default = match.group(3) or ""
+        current = env.get(name)
+        if operator == ":-":
+            return current if current not in (None, "") else default
+        if operator == "-":
+            return current if current is not None else default
+        return current or ""
+
+    expanded = _ENV_VAR_PATTERN.sub(_replacement, template)
+    expanded = os.path.expandvars(expanded)
+    expanded = os.path.expanduser(expanded)
+    return expanded

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.pipelines.common.metadata import get_pipeline_version
+from library.postprocess.common import run_steps
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
 
 from .schema import DOCUMENT_SCHEMA, validate_documents
 
@@ -47,11 +52,8 @@ def finalize_document_records(df: pd.DataFrame) -> pd.DataFrame:
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_document_fields", normalize_document_fields),
-    StepDefinition("enrich_document_publication_year", enrich_document_publication_year),
-    StepDefinition("finalize_document_records", finalize_document_records),
-]
+PIPELINE_CONFIG = load_pipeline_config("documents")
+PIPELINE_STEPS = PIPELINE_CONFIG.step_definitions()
 
 
 def run_document_pipeline(
@@ -59,16 +61,30 @@ def run_document_pipeline(
 ) -> pd.DataFrame:
     """Run the document postprocessing pipeline."""
 
+    resolved_version = _resolve_pipeline_version(pipeline_version)
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=DOCUMENT_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=resolved_version,
         logger=logger,
     )
 
 
+def _resolve_pipeline_version(override: str | None) -> str:
+    candidate = normalize_pipeline_version(override)
+    if candidate is not None:
+        return candidate
+
+    config_candidate = normalize_pipeline_version(PIPELINE_CONFIG.pipeline_version)
+    if config_candidate is not None:
+        return config_candidate
+
+    return get_pipeline_version()
+
+
 __all__ = [
+    "PIPELINE_CONFIG",
     "PIPELINE_STEPS",
     "finalize_document_records",
     "normalize_document_fields",

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.pipelines.common.metadata import get_pipeline_version
+from library.postprocess.common import run_steps
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
 
 from .schema import TARGET_SCHEMA, validate_targets
 
@@ -49,11 +54,8 @@ def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_target_fields", normalize_target_fields),
-    StepDefinition("enrich_target_synonyms", enrich_target_synonyms),
-    StepDefinition("finalize_target_records", finalize_target_records),
-]
+PIPELINE_CONFIG = load_pipeline_config("targets")
+PIPELINE_STEPS = PIPELINE_CONFIG.step_definitions()
 
 
 def run_target_pipeline(
@@ -61,16 +63,30 @@ def run_target_pipeline(
 ) -> pd.DataFrame:
     """Run the target postprocessing pipeline."""
 
+    resolved_version = _resolve_pipeline_version(pipeline_version)
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=TARGET_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=resolved_version,
         logger=logger,
     )
 
 
+def _resolve_pipeline_version(override: str | None) -> str:
+    candidate = normalize_pipeline_version(override)
+    if candidate is not None:
+        return candidate
+
+    config_candidate = normalize_pipeline_version(PIPELINE_CONFIG.pipeline_version)
+    if config_candidate is not None:
+        return config_candidate
+
+    return get_pipeline_version()
+
+
 __all__ = [
+    "PIPELINE_CONFIG",
     "PIPELINE_STEPS",
     "finalize_target_records",
     "normalize_target_fields",

--- a/tests/unit/postprocessing/test_pipeline_config.py
+++ b/tests/unit/postprocessing/test_pipeline_config.py
@@ -1,0 +1,60 @@
+"""Unit tests for declarative post-processing pipeline configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from library.postprocess.common.config import (
+    load_pipeline_config,
+    normalize_pipeline_version,
+)
+
+
+def test_load_pipeline_config__resolves_step_callables(monkeypatch):
+    """The configuration loader returns callables defined in the target module."""
+
+    monkeypatch.delenv("CHEMBL_ACTIVITY_PIPELINE_VERSION", raising=False)
+    cfg = load_pipeline_config("activities")
+
+    step_names = [step.name for step in cfg.steps]
+    assert step_names == [
+        "normalize_activity_records",
+        "enrich_activity_quality",
+        "finalize_activity_records",
+    ]
+
+    from library.postprocess.activities import steps as activity_steps
+
+    assert cfg.steps[0].definition.func is activity_steps.normalize_activity_records
+    assert cfg.steps[1].definition.func is activity_steps.enrich_activity_quality
+    assert cfg.steps[2].definition.func is activity_steps.finalize_activity_records
+    assert normalize_pipeline_version(cfg.pipeline_version) is None
+    assert cfg.params["defaults"]["log_level"] == "INFO"
+
+
+def test_load_pipeline_config__applies_env_overrides(monkeypatch):
+    """Environment markers inside the YAML are expanded with defaults."""
+
+    monkeypatch.setenv("CHEMBL_DOCUMENT_PIPELINE_VERSION", "2024.1")
+    monkeypatch.setenv("POSTPROCESS_LOG_LEVEL", "DEBUG")
+
+    cfg = load_pipeline_config("documents")
+
+    assert cfg.pipeline_version == "2024.1"
+    assert cfg.params["defaults"]["log_level"] == "DEBUG"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, None),
+        ("", None),
+        ("auto", None),
+        ("default", None),
+        ("  2024.1  ", "2024.1"),
+    ],
+)
+def test_normalize_pipeline_version__cases(raw: str | None, expected: str | None) -> None:
+    """``normalize_pipeline_version`` trims sentinels and whitespace."""
+
+    assert normalize_pipeline_version(raw) == expected


### PR DESCRIPTION
## Summary
- add YAML configuration files for activities, assays, documents, and targets post-processing pipelines with environment-aware defaults
- introduce a UTF-8 safe loader to resolve step callables and apply the new configs across the step modules
- document the configuration behaviour and add unit tests for the loader

## Testing
- pytest tests/unit/postprocessing/test_pipeline_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fd8b69e48324a9d479f1bb609b2b