### PR TITLE
Add import helper with validation and tests

### DIFF
--- a/library/postprocess/common/__init__.py
+++ b/library/postprocess/common/__init__.py
@@ -1,5 +1,6 @@
 """Shared utilities for postprocessing pipelines."""
 from . import logging
+from .import_utils import import_by_path
 from .io import clone_dataframe, ensure_dataframe
 from .schema import DataFrameSchema, coerce_types, validate_schema
 from .types import (
@@ -15,6 +16,7 @@ from .utils import run_steps
 __all__ = [
     "DataFrameSchema",
     "ImportResolutionError",
+    "import_by_path",
     "SchemaValidationError",
     "StepDefinition",
     "StepError",

--- a/library/postprocess/common/import_utils.py
+++ b/library/postprocess/common/import_utils.py
@@ -1,13 +1,18 @@
-"""Helpers for resolving dotted import paths for pipeline configuration."""
+"""Helpers for resolving import paths for pipeline configuration."""
 from __future__ import annotations
 
 import importlib
-from typing import Any
+from typing import Any, cast
 
 from .types import ImportResolutionError
 
+_DEFAULT_SENTINEL = object()
 
-def resolve_dotted_path(path: str) -> Any:
+
+def import_by_path(
+    path: str,
+    expected_type: type | tuple[type, ...] | object = _DEFAULT_SENTINEL,
+) -> Any:
     """Return the object referenced by ``path``.
 
     Parameters
@@ -15,6 +20,9 @@ def resolve_dotted_path(path: str) -> Any:
     path:
         Dotted path in the form ``"package.module:attribute"`` or
         ``"package.module.attribute"``.
+    expected_type:
+        Optional type or tuple of types that the imported object must be an
+        instance of. If omitted, the imported object must be callable.
     """
 
     module_path: str
@@ -31,18 +39,46 @@ def resolve_dotted_path(path: str) -> Any:
 
     try:
         module = importlib.import_module(module_path)
-    except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+    except ModuleNotFoundError as exc:
         raise ImportResolutionError(f"Cannot import module '{module_path}'") from exc
 
+    obj: Any
     if attribute is None:
-        return module
+        obj = module
+    else:
+        try:
+            obj = getattr(module, attribute)
+        except AttributeError as exc:
+            raise ImportResolutionError(
+                f"Module '{module_path}' has no attribute '{attribute}'"
+            ) from exc
 
-    try:
-        return getattr(module, attribute)
-    except AttributeError as exc:  # pragma: no cover - defensive
+    if expected_type is _DEFAULT_SENTINEL:
+        if not callable(obj):
+            raise ImportResolutionError(
+                f"Imported object '{path}' must be callable, got {type(obj).__name__}"
+            )
+        return obj
+
+    resolved_expected = cast(type | tuple[type, ...], expected_type)
+
+    if not isinstance(obj, resolved_expected):
+        expected_repr = _format_expected_type(resolved_expected)
         raise ImportResolutionError(
-            f"Module '{module_path}' has no attribute '{attribute}'"
-        ) from exc
+            f"Imported object '{path}' must be instance of {expected_repr}, "
+            f"got {type(obj).__name__}"
+        )
+
+    return obj
 
 
-__all__ = ["resolve_dotted_path"]
+def _format_expected_type(expected: type | tuple[type, ...]) -> str:
+    if isinstance(expected, tuple):
+        names = ", ".join(sorted({t.__name__ for t in expected}))
+        return f"({names})"
+    if isinstance(expected, type):
+        return expected.__name__
+    return repr(expected)
+
+
+__all__ = ["ImportResolutionError", "import_by_path"]

--- a/tests/unit/test_import_utils.py
+++ b/tests/unit/test_import_utils.py
@@ -1,0 +1,44 @@
+"""Tests for :mod:`library.postprocess.common.import_utils`."""
+from __future__ import annotations
+
+import pytest
+
+from library.postprocess.common.import_utils import ImportResolutionError, import_by_path
+
+
+@pytest.mark.unit
+def test_import_by_path__resolves_callable() -> None:
+    sqrt = import_by_path("math:sqrt")
+
+    assert sqrt(9) == 3
+
+
+@pytest.mark.unit
+def test_import_by_path__missing_module() -> None:
+    with pytest.raises(ImportResolutionError) as excinfo:
+        import_by_path("not_a_real_module:function")
+
+    assert "Cannot import module" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_import_by_path__missing_attribute() -> None:
+    with pytest.raises(ImportResolutionError) as excinfo:
+        import_by_path("math:not_real")
+
+    assert "has no attribute" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_import_by_path__non_callable_object_rejected() -> None:
+    with pytest.raises(ImportResolutionError) as excinfo:
+        import_by_path("math:pi")
+
+    assert "must be callable" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_import_by_path__custom_expected_type() -> None:
+    value = import_by_path("math:pi", expected_type=(int, float))
+
+    assert isinstance(value, float)


### PR DESCRIPTION
## Summary
- add an import_by_path helper that validates resolved objects and surfaces clear ImportResolutionError messages
- re-export import_by_path alongside existing postprocess utilities
- exercise success and failure scenarios for import_by_path with focused unit tests

## Testing
- pytest tests/unit/test_import_utils.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5005ea1a88324948947b8cf89d676