### PR TITLE
Add YAML-driven postprocess pipeline configuration

### DIFF
--- a/README_postprocess.md
+++ b/README_postprocess.md
@@ -23,6 +23,27 @@ Keep these boundaries in mind when extending the stack: orchestration manages ho
 
 When contributing new steps, prefer pure functions or dataclasses over implicit globals so that the orchestrator can execute them both via CLI and programmatic workflows. Consult the [Architecture overview](docs/en/ARCHITECTURE.md) for the surrounding pipeline boundaries.
 
+## Pipeline configuration files
+
+Declarative YAML files under `config/pipeline/` list the default post-processing steps for each domain (`activities`, `assays`, `documents`, `targets`). Every file follows the schema below:
+
+```yaml
+pipeline_version: ${CHEMBL_DA_POSTPROCESS_VERSION:-dev}
+steps:
+  - name: normalize_activity_records
+    enabled: true
+    callable: library.postprocess.activities.steps:normalize_activity_records
+    params:
+      strip_columns:
+        - molecule_chembl_id
+```
+
+- `pipeline_version` supports `${VAR}` placeholders with optional `:-default` segments. When `CHEMBL_DA_POSTPROCESS_VERSION` is not defined, the loader falls back to `dev`.
+- Each `steps` entry resolves the `callable` using `library.postprocess.common.import_utils.resolve_dotted_path` and applies the supplied `params` as keyword arguments.
+- Disabled steps (`enabled: false`) remain in the YAML for auditability but are skipped at runtime.
+
+`library.postprocess.config.load_pipeline_config` reads the YAML using a UTF-8 safe loader and exposes both the resolved `StepDefinition` instances and the configured `pipeline_version`. Scripts and notebooks import `PIPELINE_STEPS`/`PIPELINE_VERSION` from the respective `library.postprocess.<domain>.steps` module to stay in sync with the declarative configuration.
+
 ## Schema validation strategy
 
 Schema definitions live under `library/schemas` and expose both dataclasses (`TargetsSchema`, `TestitemsSchema`, …) and `normalize_*` helpers. Downstream stages import these to coerce pandas frames into the canonical dtype mix, enforce required columns and reorder outputs before they hit disk. 【F:library/schemas/__init__.py†L1-L34】

--- a/config/paths.py
+++ b/config/paths.py
@@ -6,6 +6,13 @@ from pathlib import Path
 CONFIG_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
 DICTIONARY_DIR = CONFIG_DIR / "dictionary"
+PIPELINE_CONFIG_DIR = CONFIG_DIR / "pipeline"
 SCHEMA_DIR = CONFIG_DIR / "schema"
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_CONFIG_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/pipeline/activities.yaml
+++ b/config/pipeline/activities.yaml
@@ -1,0 +1,40 @@
+# Post-processing pipeline for ChEMBL activity exports.
+# The pipeline_version falls back to "dev" when CHEMBL_DA_POSTPROCESS_VERSION is not set.
+pipeline_version: ${CHEMBL_DA_POSTPROCESS_VERSION:-dev}
+steps:
+  - name: normalize_activity_records
+    enabled: true
+    callable: library.postprocess.activities.steps:normalize_activity_records
+    params:
+      strip_columns:
+        - molecule_chembl_id
+        - assay_chembl_id
+      uppercase_columns:
+        - standard_type
+        - standard_relation
+        - standard_units
+  - name: enrich_activity_quality
+    enabled: true
+    callable: library.postprocess.activities.steps:enrich_activity_quality
+    params:
+      comment_column: data_validity_comment
+      flag_column: quality_flag
+      positive_indicators:
+        - valid
+        - curated
+        - review
+  - name: finalize_activity_records
+    enabled: true
+    callable: library.postprocess.activities.steps:finalize_activity_records
+    params:
+      id_column: activity_id
+      string_columns:
+        - molecule_chembl_id
+        - assay_chembl_id
+        - standard_type
+        - standard_relation
+        - standard_units
+      order_columns:
+        - activity_id
+        - molecule_chembl_id
+        - assay_chembl_id

--- a/config/pipeline/assays.yaml
+++ b/config/pipeline/assays.yaml
@@ -1,0 +1,32 @@
+# Post-processing pipeline for ChEMBL assay exports.
+# The pipeline_version falls back to "dev" when CHEMBL_DA_POSTPROCESS_VERSION is not set.
+pipeline_version: ${CHEMBL_DA_POSTPROCESS_VERSION:-dev}
+steps:
+  - name: normalize_assay_metadata
+    enabled: true
+    callable: library.postprocess.assays.steps:normalize_assay_metadata
+    params:
+      categorical_columns:
+        - assay_type
+        - assay_test_type
+        - assay_format
+  - name: enrich_assay_flags
+    enabled: true
+    callable: library.postprocess.assays.steps:enrich_assay_flags
+    params:
+      type_column: assay_type
+      flag_column: is_confirmatory
+      positive_indicators:
+        - confirm
+        - screening
+  - name: finalize_assay_records
+    enabled: true
+    callable: library.postprocess.assays.steps:finalize_assay_records
+    params:
+      string_columns:
+        - assay_chembl_id
+        - assay_type
+        - assay_test_type
+        - description
+      sort_columns:
+        - assay_chembl_id

--- a/config/pipeline/documents.yaml
+++ b/config/pipeline/documents.yaml
@@ -1,0 +1,29 @@
+# Post-processing pipeline for ChEMBL document exports.
+# The pipeline_version falls back to "dev" when CHEMBL_DA_POSTPROCESS_VERSION is not set.
+pipeline_version: ${CHEMBL_DA_POSTPROCESS_VERSION:-dev}
+steps:
+  - name: normalize_document_fields
+    enabled: true
+    callable: library.postprocess.documents.steps:normalize_document_fields
+    params:
+      lowercase_columns: true
+      strip_columns:
+        - title
+        - journal
+        - doc_type
+  - name: enrich_document_publication_year
+    enabled: true
+    callable: library.postprocess.documents.steps:enrich_document_publication_year
+    params:
+      source_column: year
+      target_column: publication_year
+  - name: finalize_document_records
+    enabled: true
+    callable: library.postprocess.documents.steps:finalize_document_records
+    params:
+      string_columns:
+        - document_chembl_id
+        - title
+        - doc_type
+      sort_columns:
+        - document_chembl_id

--- a/config/pipeline/targets.yaml
+++ b/config/pipeline/targets.yaml
@@ -1,0 +1,28 @@
+# Post-processing pipeline for ChEMBL target exports.
+# The pipeline_version falls back to "dev" when CHEMBL_DA_POSTPROCESS_VERSION is not set.
+pipeline_version: ${CHEMBL_DA_POSTPROCESS_VERSION:-dev}
+steps:
+  - name: normalize_target_fields
+    enabled: true
+    callable: library.postprocess.targets.steps:normalize_target_fields
+    params:
+      id_column: target_chembl_id
+      strip_columns:
+        - pref_name
+        - organism
+  - name: enrich_target_synonyms
+    enabled: true
+    callable: library.postprocess.targets.steps:enrich_target_synonyms
+    params:
+      synonyms_column: synonyms
+      separator: ","
+  - name: finalize_target_records
+    enabled: true
+    callable: library.postprocess.targets.steps:finalize_target_records
+    params:
+      string_columns:
+        - target_chembl_id
+        - pref_name
+        - target_type
+      sort_columns:
+        - target_chembl_id

--- a/library/postprocess/activities/__init__.py
+++ b/library/postprocess/activities/__init__.py
@@ -2,6 +2,7 @@
 from .schema import ACTIVITY_SCHEMA, validate_activities
 from .steps import (
     PIPELINE_STEPS,
+    PIPELINE_VERSION,
     enrich_activity_quality,
     finalize_activity_records,
     normalize_activity_records,
@@ -11,6 +12,7 @@ from .steps import (
 __all__ = [
     "ACTIVITY_SCHEMA",
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "enrich_activity_quality",
     "finalize_activity_records",
     "normalize_activity_records",

--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,20 +1,32 @@
 """Transformation steps for the activity postprocessing pipeline."""
 from __future__ import annotations
 
+from typing import Iterable, Sequence
+
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import run_steps
+from library.postprocess.config import load_pipeline_config
 
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
 
-def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    strip_columns: Sequence[str] | None = None,
+    uppercase_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Normalize string columns and enforce consistent naming."""
 
     normalised = df.copy(deep=True)
     normalised.columns = [col.strip().lower() for col in normalised.columns]
 
-    for column in ["standard_type", "standard_relation", "standard_units"]:
+    for column in strip_columns or ():
+        if column in normalised.columns:
+            normalised[column] = normalised[column].astype("string").str.strip()
+
+    for column in uppercase_columns or ("standard_type", "standard_relation", "standard_units"):
         if column in normalised.columns:
             normalised[column] = (
                 normalised[column]
@@ -27,40 +39,62 @@ def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
     return normalised
 
 
-def enrich_activity_quality(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_activity_quality(
+    df: pd.DataFrame,
+    *,
+    comment_column: str = "data_validity_comment",
+    flag_column: str = "quality_flag",
+    positive_indicators: Iterable[str] | None = None,
+) -> pd.DataFrame:
     """Add deterministic quality flags based on data validity comments."""
 
     enriched = df.copy(deep=True)
-    if "data_validity_comment" in enriched.columns:
-        comment_series = enriched["data_validity_comment"].fillna("").astype("string")
-        enriched["quality_flag"] = comment_series.str.contains("valid", case=False)
+    indicators = {value.lower() for value in (positive_indicators or ("valid",))}
+    if comment_column in enriched.columns:
+        comment_series = enriched[comment_column].fillna("").astype("string")
+        enriched[flag_column] = comment_series.str.lower().apply(
+            lambda value: any(token in value for token in indicators)
+        )
     else:
-        enriched["quality_flag"] = False
+        enriched[flag_column] = False
 
     return enriched
 
 
-def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    id_column: str = "activity_id",
+    string_columns: Sequence[str] | None = None,
+    order_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Validate and reorder the DataFrame according to :data:`ACTIVITY_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    if "activity_id" in prepared.columns:
-        prepared["activity_id"] = pd.to_numeric(prepared["activity_id"], errors="coerce").astype(
-            "Int64"
-        )
-    for column in ["molecule_chembl_id", "assay_chembl_id", "standard_type", "standard_relation", "standard_units"]:
+    if id_column in prepared.columns:
+        prepared[id_column] = pd.to_numeric(prepared[id_column], errors="coerce").astype("Int64")
+    for column in string_columns or (
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_units",
+    ):
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if order_columns:
+        ordered = [col for col in order_columns if col in prepared.columns]
+        remaining = [col for col in prepared.columns if col not in ordered]
+        prepared = prepared.loc[:, [*ordered, *remaining]]
 
     validated = validate_activities(prepared, context="activity_finalization")
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_activity_records", normalize_activity_records),
-    StepDefinition("enrich_activity_quality", enrich_activity_quality),
-    StepDefinition("finalize_activity_records", finalize_activity_records),
-]
+_PIPELINE = load_pipeline_config("activities")
+PIPELINE_VERSION = _PIPELINE.pipeline_version
+PIPELINE_STEPS = _PIPELINE.steps
 
 
 def run_activity_pipeline(
@@ -68,17 +102,19 @@ def run_activity_pipeline(
 ) -> pd.DataFrame:
     """Execute the activity postprocessing steps."""
 
+    version = pipeline_version or PIPELINE_VERSION
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=ACTIVITY_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=version,
         logger=logger,
     )
 
 
 __all__ = [
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "finalize_activity_records",
     "normalize_activity_records",
     "run_activity_pipeline",

--- a/library/postprocess/assays/__init__.py
+++ b/library/postprocess/assays/__init__.py
@@ -2,6 +2,7 @@
 from .schema import ASSAY_SCHEMA, validate_assays
 from .steps import (
     PIPELINE_STEPS,
+    PIPELINE_VERSION,
     enrich_assay_flags,
     finalize_assay_records,
     normalize_assay_metadata,
@@ -11,6 +12,7 @@ from .steps import (
 __all__ = [
     "ASSAY_SCHEMA",
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "enrich_assay_flags",
     "finalize_assay_records",
     "normalize_assay_metadata",

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,18 +1,25 @@
 """Transformation steps for assay postprocessing."""
 from __future__ import annotations
 
+from typing import Iterable, Sequence
+
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import run_steps
+from library.postprocess.config import load_pipeline_config
 
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
-def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_assay_metadata(
+    df: pd.DataFrame,
+    *,
+    categorical_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Normalize string-based assay descriptors."""
 
     normalized = df.copy(deep=True)
-    for column in ["assay_type", "assay_test_type", "assay_format"]:
+    for column in categorical_columns or ("assay_type", "assay_test_type", "assay_format"):
         if column in normalized.columns:
             normalized[column] = (
                 normalized[column]
@@ -24,37 +31,57 @@ def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
     return normalized
 
 
-def enrich_assay_flags(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_assay_flags(
+    df: pd.DataFrame,
+    *,
+    type_column: str = "assay_type",
+    flag_column: str = "is_confirmatory",
+    positive_indicators: Iterable[str] | None = None,
+) -> pd.DataFrame:
     """Introduce confirmatory flag based on assay type information."""
 
     enriched = df.copy(deep=True)
-    type_series = enriched.get("assay_type")
-    if type_series is not None:
-        enriched["is_confirmatory"] = type_series.astype("string").str.contains(
-            "CONFIRM", case=False, na=False
+    positive = {value.lower() for value in (positive_indicators or ("confirm",))}
+    if type_column in enriched.columns:
+        series = enriched[type_column].astype("string").str.lower()
+        enriched[flag_column] = series.apply(
+            lambda value: any(token in value for token in positive)
         )
     else:
-        enriched["is_confirmatory"] = False
+        enriched[flag_column] = False
     return enriched
 
 
-def finalize_assay_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_assay_records(
+    df: pd.DataFrame,
+    *,
+    string_columns: Sequence[str] | None = None,
+    sort_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Apply schema validation and deterministic ordering."""
 
     prepared = df.copy(deep=True)
-    for column in ["assay_chembl_id", "assay_type", "assay_test_type", "description"]:
+    for column in string_columns or (
+        "assay_chembl_id",
+        "assay_type",
+        "assay_test_type",
+        "description",
+    ):
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if sort_columns:
+        existing = [col for col in sort_columns if col in prepared.columns]
+        if existing:
+            prepared = prepared.sort_values(existing, kind="mergesort").reset_index(drop=True)
 
     validated = validate_assays(prepared, context="assay_finalization")
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_assay_metadata", normalize_assay_metadata),
-    StepDefinition("enrich_assay_flags", enrich_assay_flags),
-    StepDefinition("finalize_assay_records", finalize_assay_records),
-]
+_PIPELINE = load_pipeline_config("assays")
+PIPELINE_VERSION = _PIPELINE.pipeline_version
+PIPELINE_STEPS = _PIPELINE.steps
 
 
 def run_assay_pipeline(
@@ -62,17 +89,19 @@ def run_assay_pipeline(
 ) -> pd.DataFrame:
     """Run the assay postprocessing pipeline."""
 
+    version = pipeline_version or PIPELINE_VERSION
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=ASSAY_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=version,
         logger=logger,
     )
 
 
 __all__ = [
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "finalize_assay_records",
     "normalize_assay_metadata",
     "run_assay_pipeline",

--- a/library/postprocess/config.py
+++ b/library/postprocess/config.py
@@ -1,0 +1,176 @@
+"""Load post-processing pipeline configurations from YAML files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import os
+import re
+
+import yaml
+
+from config.paths import PIPELINE_CONFIG_DIR
+
+from .common.import_utils import resolve_dotted_path
+from .common.types import StepDefinition
+
+__all__ = ["PipelineConfig", "PipelineStep", "load_pipeline_config"]
+
+
+_ENV_PATTERN = re.compile(r"\$\{([^:{}\s]+)(:-([^{}]*))?\}")
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """Declarative description of a configured pipeline step."""
+
+    name: str
+    dotted_path: str
+    enabled: bool
+    params: Mapping[str, Any]
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Fully resolved pipeline configuration."""
+
+    name: str
+    pipeline_version: str
+    steps: tuple[StepDefinition, ...]
+    raw_steps: tuple[PipelineStep, ...]
+
+
+def _interpolate_environment(raw: str, env: Mapping[str, str]) -> str:
+    """Expand ``${VAR}`` or ``${VAR:-default}`` placeholders in *raw*."""
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        default = match.group(3)
+        value = env.get(key)
+        if value is None:
+            return default or ""
+        return value
+
+    expanded = _ENV_PATTERN.sub(_replace, raw)
+    expanded = os.path.expandvars(expanded)
+    expanded = os.path.expanduser(expanded)
+    return expanded
+
+
+def _load_yaml(path: Path, env: Mapping[str, str]) -> Mapping[str, Any]:
+    """Return parsed YAML from *path* with environment interpolation."""
+
+    raw = path.read_text(encoding="utf-8")
+    interpolated = _interpolate_environment(raw, env)
+    data = yaml.safe_load(interpolated) or {}
+    if not isinstance(data, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError(f"pipeline config at {path} must be a mapping")
+    return data
+
+
+def _coerce_mapping(value: Any, *, context: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{context} must be a mapping")
+    return value
+
+
+def _build_step(config: PipelineStep) -> StepDefinition:
+    func = resolve_dotted_path(config.dotted_path)
+
+    if config.params:
+
+        def _wrapped(df, _func=func, _params=dict(config.params)):
+            return _func(df, **_params)
+
+        step_func = _wrapped
+    else:
+
+        def _wrapped(df, _func=func):
+            return _func(df)
+
+        step_func = _wrapped
+
+    return StepDefinition(config.name, step_func, config.description)
+
+
+def _parse_steps(data: Iterable[Any], *, name: str) -> tuple[PipelineStep, ...]:
+    steps: list[PipelineStep] = []
+    for index, entry in enumerate(data, start=1):
+        if not isinstance(entry, Mapping):
+            raise TypeError(f"step #{index} in pipeline '{name}' must be a mapping")
+        raw_name = entry.get("name")
+        if raw_name is None:
+            raise ValueError(f"step #{index} in pipeline '{name}' missing 'name'")
+        step_name = str(raw_name)
+        if not step_name.strip():
+            raise ValueError(f"step #{index} in pipeline '{name}' missing 'name'")
+        dotted = entry.get("callable")
+        if not isinstance(dotted, str) or not dotted:
+            raise ValueError(
+                f"step '{step_name}' in pipeline '{name}' missing callable"
+            )
+        enabled = bool(entry.get("enabled", True))
+        params = _coerce_mapping(entry.get("params"), context=f"step '{step_name}' params")
+        description_value = entry.get("description")
+        description = str(description_value) if description_value is not None else None
+        steps.append(
+            PipelineStep(
+                name=step_name,
+                dotted_path=dotted,
+                enabled=enabled,
+                params=params,
+                description=description,
+            )
+        )
+    return tuple(steps)
+
+
+def _load_pipeline(path: Path, *, env: Mapping[str, str]) -> PipelineConfig:
+    data = _load_yaml(path, env)
+    pipeline_version = str(data.get("pipeline_version", "")) or "dev"
+    raw_steps_data = data.get("steps") or []
+    if not isinstance(raw_steps_data, list):
+        raise TypeError(f"pipeline '{path.stem}' steps must be a list")
+    parsed_steps = _parse_steps(raw_steps_data, name=path.stem)
+    active_steps = [step for step in parsed_steps if step.enabled]
+    definitions = tuple(_build_step(step) for step in active_steps)
+    return PipelineConfig(
+        name=path.stem,
+        pipeline_version=pipeline_version,
+        steps=definitions,
+        raw_steps=parsed_steps,
+    )
+
+
+@lru_cache(maxsize=None)
+def _load_pipeline_cached(name: str, base_dir: str | None) -> PipelineConfig:
+    base = Path(base_dir) if base_dir is not None else PIPELINE_CONFIG_DIR
+    path = (base / f"{name}.yaml").resolve()
+    if not path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"pipeline configuration not found: {path}")
+    return _load_pipeline(path, env=dict(os.environ))
+
+
+def load_pipeline_config(
+    name: str,
+    *,
+    base_dir: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> PipelineConfig:
+    """Return the resolved pipeline configuration for *name*."""
+
+    if env is None:
+        base_str = None if base_dir is None else str(base_dir)
+        return _load_pipeline_cached(name, base_str)
+
+    base = base_dir or PIPELINE_CONFIG_DIR
+    path = (base / f"{name}.yaml").resolve()
+    if not path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"pipeline configuration not found: {path}")
+    return _load_pipeline(path, env=dict(env))

--- a/library/postprocess/documents/__init__.py
+++ b/library/postprocess/documents/__init__.py
@@ -2,6 +2,7 @@
 from .schema import DOCUMENT_SCHEMA, validate_documents
 from .steps import (
     PIPELINE_STEPS,
+    PIPELINE_VERSION,
     enrich_document_publication_year,
     finalize_document_records,
     normalize_document_fields,
@@ -11,6 +12,7 @@ from .steps import (
 __all__ = [
     "DOCUMENT_SCHEMA",
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "enrich_document_publication_year",
     "finalize_document_records",
     "normalize_document_fields",

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -1,44 +1,70 @@
 """Transformation steps for document postprocessing."""
 from __future__ import annotations
 
+from typing import Sequence
+
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import run_steps
+from library.postprocess.config import load_pipeline_config
 
 from .schema import DOCUMENT_SCHEMA, validate_documents
 
 
-def normalize_document_fields(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_document_fields(
+    df: pd.DataFrame,
+    *,
+    lowercase_columns: bool = True,
+    strip_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Normalize whitespace and casing for textual document fields."""
 
     normalized = df.copy(deep=True)
-    normalized.columns = [col.strip().lower() for col in normalized.columns]
-    for column in ["title", "journal", "doc_type"]:
+    if lowercase_columns:
+        normalized.columns = [col.strip().lower() for col in normalized.columns]
+    else:
+        normalized.columns = [col.strip() for col in normalized.columns]
+    for column in strip_columns or ("title", "journal", "doc_type"):
         if column in normalized.columns:
             normalized[column] = normalized[column].astype("string").str.strip()
     return normalized
 
 
-def enrich_document_publication_year(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_document_publication_year(
+    df: pd.DataFrame,
+    *,
+    source_column: str = "year",
+    target_column: str = "publication_year",
+) -> pd.DataFrame:
     """Create a deterministic ``publication_year`` column."""
 
     enriched = df.copy(deep=True)
-    if "year" in enriched.columns:
-        enriched["publication_year"] = pd.to_numeric(
-            enriched["year"], errors="coerce"
-        ).astype("Int64")
+    if source_column in enriched.columns:
+        enriched[target_column] = pd.to_numeric(enriched[source_column], errors="coerce").astype(
+            "Int64"
+        )
     else:
-        enriched["publication_year"] = pd.Series([pd.NA] * len(enriched), dtype="Int64")
+        enriched[target_column] = pd.Series([pd.NA] * len(enriched), dtype="Int64")
     return enriched
 
 
-def finalize_document_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_document_records(
+    df: pd.DataFrame,
+    *,
+    string_columns: Sequence[str] | None = None,
+    sort_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`DOCUMENT_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    for column in ["document_chembl_id", "title", "doc_type"]:
+    for column in string_columns or ("document_chembl_id", "title", "doc_type"):
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if sort_columns:
+        existing = [col for col in sort_columns if col in prepared.columns]
+        if existing:
+            prepared = prepared.sort_values(existing, kind="mergesort").reset_index(drop=True)
 
     if "publication_year" in prepared.columns:
         prepared["publication_year"] = prepared["publication_year"].astype("Int64")
@@ -47,11 +73,9 @@ def finalize_document_records(df: pd.DataFrame) -> pd.DataFrame:
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_document_fields", normalize_document_fields),
-    StepDefinition("enrich_document_publication_year", enrich_document_publication_year),
-    StepDefinition("finalize_document_records", finalize_document_records),
-]
+_PIPELINE = load_pipeline_config("documents")
+PIPELINE_VERSION = _PIPELINE.pipeline_version
+PIPELINE_STEPS = _PIPELINE.steps
 
 
 def run_document_pipeline(
@@ -59,17 +83,19 @@ def run_document_pipeline(
 ) -> pd.DataFrame:
     """Run the document postprocessing pipeline."""
 
+    version = pipeline_version or PIPELINE_VERSION
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=DOCUMENT_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=version,
         logger=logger,
     )
 
 
 __all__ = [
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "finalize_document_records",
     "normalize_document_fields",
     "run_document_pipeline",

--- a/library/postprocess/targets/__init__.py
+++ b/library/postprocess/targets/__init__.py
@@ -2,6 +2,7 @@
 from .schema import TARGET_SCHEMA, validate_targets
 from .steps import (
     PIPELINE_STEPS,
+    PIPELINE_VERSION,
     enrich_target_synonyms,
     finalize_target_records,
     normalize_target_fields,
@@ -10,6 +11,7 @@ from .steps import (
 
 __all__ = [
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "TARGET_SCHEMA",
     "enrich_target_synonyms",
     "finalize_target_records",

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -1,59 +1,86 @@
 """Transformation steps for target postprocessing."""
 from __future__ import annotations
 
+from typing import Sequence
+
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import run_steps
+from library.postprocess.config import load_pipeline_config
 
 from .schema import TARGET_SCHEMA, validate_targets
 
 
-def normalize_target_fields(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_target_fields(
+    df: pd.DataFrame,
+    *,
+    id_column: str = "target_chembl_id",
+    strip_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Normalize leading/trailing whitespace and ensure upper-case identifiers."""
 
     normalized = df.copy(deep=True)
-    if "target_chembl_id" in normalized.columns:
-        normalized["target_chembl_id"] = (
-            normalized["target_chembl_id"].astype("string").str.strip().str.upper()
-        )
-    for column in ["pref_name", "organism"]:
+    if id_column in normalized.columns:
+        normalized[id_column] = normalized[id_column].astype("string").str.strip().str.upper()
+    for column in strip_columns or ("pref_name", "organism"):
         if column in normalized.columns:
             normalized[column] = normalized[column].astype("string").str.strip()
     return normalized
 
 
-def enrich_target_synonyms(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_target_synonyms(
+    df: pd.DataFrame,
+    *,
+    synonyms_column: str = "synonyms",
+    separator: str = ",",
+) -> pd.DataFrame:
     """Ensure synonyms column is deterministically ordered."""
 
     enriched = df.copy(deep=True)
-    if "synonyms" in enriched.columns:
-        enriched["synonyms"] = (
-            enriched["synonyms"].fillna("")
+    if synonyms_column in enriched.columns:
+        joiner = f"{separator} " if separator and not separator.endswith(" ") else separator
+        enriched[synonyms_column] = (
+            enriched[synonyms_column]
+            .fillna("")
             .astype("string")
             .apply(
-                lambda value: ", ".join(sorted(part.strip() for part in value.split(",") if part.strip()))
+                lambda value: joiner.join(
+                    sorted(
+                        part.strip()
+                        for part in str(value).split(separator)
+                        if part and part.strip()
+                    )
+                )
             )
         )
     return enriched
 
 
-def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_target_records(
+    df: pd.DataFrame,
+    *,
+    string_columns: Sequence[str] | None = None,
+    sort_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    for column in ["target_chembl_id", "pref_name", "target_type"]:
+    for column in string_columns or ("target_chembl_id", "pref_name", "target_type"):
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if sort_columns:
+        existing = [col for col in sort_columns if col in prepared.columns]
+        if existing:
+            prepared = prepared.sort_values(existing, kind="mergesort").reset_index(drop=True)
 
     validated = validate_targets(prepared, context="target_finalization")
     return validated
 
 
-PIPELINE_STEPS = [
-    StepDefinition("normalize_target_fields", normalize_target_fields),
-    StepDefinition("enrich_target_synonyms", enrich_target_synonyms),
-    StepDefinition("finalize_target_records", finalize_target_records),
-]
+_PIPELINE = load_pipeline_config("targets")
+PIPELINE_VERSION = _PIPELINE.pipeline_version
+PIPELINE_STEPS = _PIPELINE.steps
 
 
 def run_target_pipeline(
@@ -61,17 +88,19 @@ def run_target_pipeline(
 ) -> pd.DataFrame:
     """Run the target postprocessing pipeline."""
 
+    version = pipeline_version or PIPELINE_VERSION
     return run_steps(
         df,
         PIPELINE_STEPS,
         schema=TARGET_SCHEMA,
-        pipeline_version=pipeline_version,
+        pipeline_version=version,
         logger=logger,
     )
 
 
 __all__ = [
     "PIPELINE_STEPS",
+    "PIPELINE_VERSION",
     "finalize_target_records",
     "normalize_target_fields",
     "run_target_pipeline",


### PR DESCRIPTION
## Summary
- add declarative post-processing pipeline YAMLs for activities, assays, targets, and documents with env-aware defaults
- introduce a UTF-8 YAML loader that interpolates environment placeholders and exposes pipeline step definitions
- update post-processing step implementations to honour configurable parameters and document the new configuration workflow

## Testing
- pytest tests/unit/postprocessing -q

------
https://chatgpt.com/codex/tasks/task_e_68e4fe976e8c8324b4e4967dbabe7144