### PR TITLE
Add metadata-aware postprocess runner

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import RunnerResult, StepDefinition, run_steps
 
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
@@ -65,13 +65,13 @@ PIPELINE_STEPS = [
 
 def run_activity_pipeline(
     df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
-) -> pd.DataFrame:
-    """Execute the activity postprocessing steps."""
+) -> RunnerResult:
+    """Execute the activity postprocessing steps and return the result."""
 
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=ACTIVITY_SCHEMA,
+        post_schema=ACTIVITY_SCHEMA,
         pipeline_version=pipeline_version,
         logger=logger,
     )

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import RunnerResult, StepDefinition, run_steps
 
 from .schema import ASSAY_SCHEMA, validate_assays
 
@@ -59,13 +59,13 @@ PIPELINE_STEPS = [
 
 def run_assay_pipeline(
     df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
-) -> pd.DataFrame:
+) -> RunnerResult:
     """Run the assay postprocessing pipeline."""
 
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=ASSAY_SCHEMA,
+        post_schema=ASSAY_SCHEMA,
         pipeline_version=pipeline_version,
         logger=logger,
     )

--- a/library/postprocess/common/__init__.py
+++ b/library/postprocess/common/__init__.py
@@ -1,6 +1,13 @@
 """Shared utilities for postprocessing pipelines."""
 from . import logging
 from .io import clone_dataframe, ensure_dataframe
+from .runner import (
+    RunnerMetadata,
+    RunnerResult,
+    SchemaCheckReport,
+    StepReport,
+    run_steps,
+)
 from .schema import DataFrameSchema, coerce_types, validate_schema
 from .types import (
     ImportResolutionError,
@@ -10,14 +17,17 @@ from .types import (
     StepFn,
     StepIterable,
 )
-from .utils import run_steps
 
 __all__ = [
     "DataFrameSchema",
     "ImportResolutionError",
+    "RunnerMetadata",
+    "RunnerResult",
+    "SchemaCheckReport",
     "SchemaValidationError",
     "StepDefinition",
     "StepError",
+    "StepReport",
     "StepFn",
     "StepIterable",
     "clone_dataframe",

--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -1,0 +1,333 @@
+"""Execution utilities for postprocessing pipelines."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+
+import pandas as pd
+
+from . import logging as logging_utils
+from .io import clone_dataframe, ensure_dataframe
+from .schema import DataFrameSchema, validate_schema
+from .types import (
+    SchemaValidationError,
+    StepDefinition,
+    StepError,
+    StepIterable,
+    StepLike,
+)
+
+
+@dataclass(frozen=True)
+class SchemaCheckReport:
+    """Summary of a schema validation stage."""
+
+    schema: str
+    duration_seconds: float
+    status: Literal["success", "error"]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class StepReport:
+    """Execution statistics for a single pipeline step."""
+
+    name: str
+    parameters: Mapping[str, Any]
+    duration_seconds: float
+    rows_before: int
+    rows_after: int | None
+    row_delta: int | None
+    columns_before: tuple[str, ...]
+    columns_after: tuple[str, ...] | None
+    column_delta: int | None
+    added_columns: tuple[str, ...]
+    removed_columns: tuple[str, ...]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RunnerMetadata:
+    """Aggregated metadata about a pipeline run."""
+
+    pipeline_version: str | None
+    steps: tuple[StepReport, ...]
+    pre_schema: SchemaCheckReport | None
+    post_schema: SchemaCheckReport | None
+
+
+@dataclass(frozen=True)
+class RunnerResult:
+    """Return value of :func:`run_steps`."""
+
+    frame: pd.DataFrame
+    metadata: RunnerMetadata
+
+
+def _normalise_step(step: StepLike) -> StepDefinition:
+    if isinstance(step, StepDefinition):
+        return step
+
+    if callable(step):
+        name = getattr(step, "__name__", "step")
+        return StepDefinition(name, step)
+
+    if isinstance(step, tuple):
+        if len(step) == 1:
+            (func,) = step
+            if not callable(func):
+                raise TypeError("Step tuple must contain callables")
+            name = getattr(func, "__name__", "step")
+            return StepDefinition(name, func)
+        if len(step) == 2:
+            first, second = step
+            if isinstance(first, str) and callable(second):
+                return StepDefinition(first, second)
+            if callable(first):
+                func = first
+                params = second
+                if params is not None and not isinstance(params, Mapping):
+                    raise TypeError("Step parameters must be provided as a mapping")
+                name = getattr(func, "__name__", "step")
+                return StepDefinition(name, func, parameters=params)
+        if len(step) == 3:
+            name, func, params = step
+            if not isinstance(name, str) or not callable(func):
+                raise TypeError("Step tuple must be (name, callable, params)")
+            if params is not None and not isinstance(params, Mapping):
+                raise TypeError("Step parameters must be provided as a mapping")
+            return StepDefinition(name, func, parameters=params)
+
+    raise TypeError(f"Unsupported step specification: {step!r}")
+
+
+def _coerce_steps(steps: StepIterable) -> tuple[StepDefinition, ...]:
+    return tuple(_normalise_step(step) for step in steps)
+
+
+def _sorted_parameters(params: Mapping[str, Any]) -> Mapping[str, Any]:
+    if not params:
+        return MappingProxyType({})
+    ordered = {key: params[key] for key in sorted(params)}
+    return MappingProxyType(ordered)
+
+
+def run_steps(
+    df: pd.DataFrame,
+    steps: StepIterable,
+    *,
+    pre_schema: DataFrameSchema | None = None,
+    post_schema: DataFrameSchema | None = None,
+    pipeline_version: str | None = None,
+    logger=None,
+) -> RunnerResult:
+    """Execute ``steps`` sequentially returning the processed DataFrame and metadata."""
+
+    log = logger or logging_utils.get_logger()
+    current = ensure_dataframe(df, copy=True)
+    if pipeline_version is not None:
+        current.attrs["pipeline_version"] = pipeline_version
+
+    step_reports: list[StepReport] = []
+    pre_schema_report: SchemaCheckReport | None = None
+    post_schema_report: SchemaCheckReport | None = None
+
+    if pre_schema is not None:
+        log.info("Validating input schema (%s)", pre_schema.__class__.__name__)
+        start = perf_counter()
+        try:
+            current = validate_schema(current, pre_schema, context="pipeline.pre_schema")
+        except SchemaValidationError as exc:
+            duration = perf_counter() - start
+            pre_schema_report = SchemaCheckReport(
+                schema=pre_schema.__class__.__name__,
+                duration_seconds=duration,
+                status="error",
+                error=f"{exc.__class__.__name__}: {exc}",
+            )
+            raise
+        else:
+            duration = perf_counter() - start
+            pre_schema_report = SchemaCheckReport(
+                schema=pre_schema.__class__.__name__,
+                duration_seconds=duration,
+                status="success",
+            )
+            if pipeline_version is not None:
+                current.attrs["pipeline_version"] = pipeline_version
+
+    for step in _coerce_steps(steps):
+        log.info("Starting step %s", step.name)
+        before_columns: tuple[str, ...] = tuple(current.columns)
+        before_rows = current.shape[0]
+        start = perf_counter()
+        params = dict(step.parameters)
+        error_message: str | None = None
+        try:
+            next_df = step.func(clone_dataframe(current), **params)
+        except SchemaValidationError as exc:
+            error_message = f"{exc.__class__.__name__}: {exc}"
+            duration = perf_counter() - start
+            step_reports.append(
+                StepReport(
+                    name=step.name,
+                    parameters=_sorted_parameters(params),
+                    duration_seconds=duration,
+                    rows_before=before_rows,
+                    rows_after=None,
+                    row_delta=None,
+                    columns_before=before_columns,
+                    columns_after=None,
+                    column_delta=None,
+                    added_columns=(),
+                    removed_columns=(),
+                    error=error_message,
+                )
+            )
+            raise
+        except StepError as exc:
+            error_message = f"{exc.__class__.__name__}: {exc}"
+            duration = perf_counter() - start
+            step_reports.append(
+                StepReport(
+                    name=step.name,
+                    parameters=_sorted_parameters(params),
+                    duration_seconds=duration,
+                    rows_before=before_rows,
+                    rows_after=None,
+                    row_delta=None,
+                    columns_before=before_columns,
+                    columns_after=None,
+                    column_delta=None,
+                    added_columns=(),
+                    removed_columns=(),
+                    error=error_message,
+                )
+            )
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            error_message = f"{exc.__class__.__name__}: {exc}"
+            duration = perf_counter() - start
+            step_reports.append(
+                StepReport(
+                    name=step.name,
+                    parameters=_sorted_parameters(params),
+                    duration_seconds=duration,
+                    rows_before=before_rows,
+                    rows_after=None,
+                    row_delta=None,
+                    columns_before=before_columns,
+                    columns_after=None,
+                    column_delta=None,
+                    added_columns=(),
+                    removed_columns=(),
+                    error=error_message,
+                )
+            )
+            raise StepError(step.name, str(exc), cause=exc) from exc
+
+        duration = perf_counter() - start
+        if not isinstance(next_df, pd.DataFrame):
+            error_message = "Step did not return a pandas.DataFrame"
+            step_reports.append(
+                StepReport(
+                    name=step.name,
+                    parameters=_sorted_parameters(params),
+                    duration_seconds=duration,
+                    rows_before=before_rows,
+                    rows_after=None,
+                    row_delta=None,
+                    columns_before=before_columns,
+                    columns_after=None,
+                    column_delta=None,
+                    added_columns=(),
+                    removed_columns=(),
+                    error=error_message,
+                )
+            )
+            raise StepError(step.name, error_message)
+
+        next_df = ensure_dataframe(next_df, copy=True)
+        if pipeline_version is not None:
+            next_df.attrs["pipeline_version"] = pipeline_version
+
+        after_columns: tuple[str, ...] = tuple(next_df.columns)
+        after_rows = next_df.shape[0]
+        added_columns = tuple(col for col in after_columns if col not in before_columns)
+        removed_columns = tuple(col for col in before_columns if col not in after_columns)
+        row_delta = after_rows - before_rows
+        column_delta = len(after_columns) - len(before_columns)
+
+        log.info(
+            "Completed step %s | rows=%s->%s | cols=%s->%s | +%s | -%s",
+            step.name,
+            before_rows,
+            after_rows,
+            len(before_columns),
+            len(after_columns),
+            ",".join(added_columns) or "-",
+            ",".join(removed_columns) or "-",
+        )
+
+        step_reports.append(
+            StepReport(
+                name=step.name,
+                parameters=_sorted_parameters(params),
+                duration_seconds=duration,
+                rows_before=before_rows,
+                rows_after=after_rows,
+                row_delta=row_delta,
+                columns_before=before_columns,
+                columns_after=after_columns,
+                column_delta=column_delta,
+                added_columns=added_columns,
+                removed_columns=removed_columns,
+                error=None,
+            )
+        )
+
+        current = next_df
+
+    if post_schema is not None:
+        log.info("Validating output schema (%s)", post_schema.__class__.__name__)
+        start = perf_counter()
+        try:
+            current = validate_schema(current, post_schema, context="pipeline.post_schema")
+        except SchemaValidationError as exc:
+            duration = perf_counter() - start
+            post_schema_report = SchemaCheckReport(
+                schema=post_schema.__class__.__name__,
+                duration_seconds=duration,
+                status="error",
+                error=f"{exc.__class__.__name__}: {exc}",
+            )
+            raise
+        else:
+            duration = perf_counter() - start
+            post_schema_report = SchemaCheckReport(
+                schema=post_schema.__class__.__name__,
+                duration_seconds=duration,
+                status="success",
+            )
+            if pipeline_version is not None:
+                current.attrs["pipeline_version"] = pipeline_version
+
+    metadata = RunnerMetadata(
+        pipeline_version=pipeline_version,
+        steps=tuple(step_reports),
+        pre_schema=pre_schema_report,
+        post_schema=post_schema_report,
+    )
+
+    return RunnerResult(frame=current, metadata=metadata)
+
+
+__all__ = [
+    "RunnerMetadata",
+    "RunnerResult",
+    "SchemaCheckReport",
+    "StepReport",
+    "run_steps",
+]

--- a/library/postprocess/common/types.py
+++ b/library/postprocess/common/types.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Protocol
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Optional, Protocol, Tuple, Union
 
 import pandas as pd
 
@@ -10,7 +11,7 @@ import pandas as pd
 class StepFn(Protocol):
     """Protocol describing a pure DataFrame transformation."""
 
-    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, df: pd.DataFrame, **params: Any) -> pd.DataFrame:  # pragma: no cover - structural
         """Return a new :class:`pandas.DataFrame` derived from ``df``."""
 
 
@@ -21,10 +22,21 @@ class StepDefinition:
     name: str
     func: StepFn
     description: Optional[str] = None
+    parameters: Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
         if not callable(self.func):
             raise TypeError("StepDefinition.func must be callable")
+        if self.parameters is None:
+            object.__setattr__(self, "parameters", MappingProxyType({}))
+        elif isinstance(self.parameters, Mapping):
+            object.__setattr__(
+                self,
+                "parameters",
+                MappingProxyType(dict(self.parameters)),
+            )
+        else:
+            raise TypeError("StepDefinition.parameters must be a mapping if provided")
 
 
 class StepError(RuntimeError):
@@ -45,7 +57,15 @@ class ImportResolutionError(RuntimeError):
     """Raised when a dotted import path cannot be resolved."""
 
 
-StepIterable = Iterable[StepDefinition]
+StepLike = Union[
+    StepDefinition,
+    StepFn,
+    Tuple[StepFn],
+    Tuple[StepFn, Mapping[str, Any] | None],
+    Tuple[str, StepFn],
+    Tuple[str, StepFn, Mapping[str, Any] | None],
+]
+StepIterable = Iterable[StepLike]
 
 
 __all__ = [

--- a/library/postprocess/common/utils.py
+++ b/library/postprocess/common/utils.py
@@ -1,72 +1,12 @@
-"""Pipeline orchestration utilities for postprocessing transformations."""
+"""Compatibility shims for legacy imports."""
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from .runner import RunnerMetadata, RunnerResult, SchemaCheckReport, StepReport, run_steps
 
-import pandas as pd
-
-from . import logging as logging_utils
-from .io import clone_dataframe, ensure_dataframe
-from .schema import DataFrameSchema, validate_schema
-from .types import SchemaValidationError, StepDefinition, StepError, StepIterable
-
-
-def run_steps(
-    df: pd.DataFrame,
-    steps: StepIterable,
-    *,
-    schema: DataFrameSchema | None = None,
-    pipeline_version: str | None = None,
-    logger=None,
-) -> pd.DataFrame:
-    """Execute ``steps`` sequentially returning the processed DataFrame."""
-
-    log = logger or logging_utils.get_logger()
-    current = ensure_dataframe(df, copy=True)
-    if pipeline_version is not None:
-        current.attrs["pipeline_version"] = pipeline_version
-
-    for step in steps:
-        log.info("Starting step %s", step.name)
-        before_columns = list(current.columns)
-        before_shape = current.shape
-        try:
-            next_df = step.func(clone_dataframe(current))
-        except SchemaValidationError:
-            raise
-        except StepError:
-            raise
-        except Exception as exc:  # pragma: no cover - defensive
-            raise StepError(step.name, str(exc), cause=exc) from exc
-
-        if not isinstance(next_df, pd.DataFrame):
-            raise StepError(step.name, "step did not return a pandas.DataFrame")
-
-        next_df = ensure_dataframe(next_df, copy=True)
-        if pipeline_version is not None:
-            next_df.attrs["pipeline_version"] = pipeline_version
-
-        added_columns = [col for col in next_df.columns if col not in before_columns]
-        removed_columns = [col for col in before_columns if col not in next_df.columns]
-        log.info(
-            "Completed step %s | rows=%s->%s | cols=%s->%s | +%s | -%s",
-            step.name,
-            before_shape[0],
-            next_df.shape[0],
-            before_shape[1],
-            next_df.shape[1],
-            ",".join(added_columns) or "-",
-            ",".join(removed_columns) or "-",
-        )
-        current = next_df
-
-    if schema is not None:
-        log.info("Validating final schema (%s)", schema.__class__.__name__)
-        current = validate_schema(current, schema, context="pipeline")
-        if pipeline_version is not None:
-            current.attrs["pipeline_version"] = pipeline_version
-
-    return current
-
-
-__all__ = ["run_steps"]
+__all__ = [
+    "RunnerMetadata",
+    "RunnerResult",
+    "SchemaCheckReport",
+    "StepReport",
+    "run_steps",
+]

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import RunnerResult, StepDefinition, run_steps
 
 from .schema import DOCUMENT_SCHEMA, validate_documents
 
@@ -56,13 +56,13 @@ PIPELINE_STEPS = [
 
 def run_document_pipeline(
     df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
-) -> pd.DataFrame:
+) -> RunnerResult:
     """Run the document postprocessing pipeline."""
 
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=DOCUMENT_SCHEMA,
+        post_schema=DOCUMENT_SCHEMA,
         pipeline_version=pipeline_version,
         logger=logger,
     )

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common import RunnerResult, StepDefinition, run_steps
 
 from .schema import TARGET_SCHEMA, validate_targets
 
@@ -58,13 +58,13 @@ PIPELINE_STEPS = [
 
 def run_target_pipeline(
     df: pd.DataFrame, *, pipeline_version: str | None = None, logger=None
-) -> pd.DataFrame:
+) -> RunnerResult:
     """Run the target postprocessing pipeline."""
 
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=TARGET_SCHEMA,
+        post_schema=TARGET_SCHEMA,
         pipeline_version=pipeline_version,
         logger=logger,
     )

--- a/tests/unit/test_postprocess_runner.py
+++ b/tests/unit/test_postprocess_runner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.common import (
+    DataFrameSchema,
+    RunnerResult,
+    StepDefinition,
+    run_steps,
+)
+
+
+@pytest.mark.unit
+def test_run_steps__applies_steps_and_records_metadata() -> None:
+    frame = pd.DataFrame({"value": [1, 2]})
+
+    schema = DataFrameSchema(required_columns=("value",), optional_columns=("total",))
+
+    def add_constant(df: pd.DataFrame, increment: int) -> pd.DataFrame:
+        result = df.copy()
+        result["value"] = result["value"] + increment
+        return result
+
+    def add_total(df: pd.DataFrame, source: str) -> pd.DataFrame:
+        result = df.copy()
+        result["total"] = result[source].cumsum()
+        return result
+
+    result = run_steps(
+        frame,
+        [
+            StepDefinition("add_constant", add_constant, parameters={"increment": 2}),
+            ("add_total", add_total, {"source": "value"}),
+        ],
+        post_schema=schema,
+        pipeline_version="1.2.3",
+    )
+
+    assert isinstance(result, RunnerResult)
+    assert result.frame.attrs["pipeline_version"] == "1.2.3"
+    assert result.metadata.pipeline_version == "1.2.3"
+    assert result.metadata.pre_schema is None
+    assert result.metadata.post_schema is not None
+    assert result.metadata.post_schema.status == "success"
+
+    assert result.frame["value"].tolist() == [3, 4]
+    assert result.frame["total"].tolist() == [3, 7]
+
+    step_one, step_two = result.metadata.steps
+    assert step_one.name == "add_constant"
+    assert step_one.parameters["increment"] == 2
+    assert step_one.row_delta == 0
+    assert step_one.column_delta == 0
+    assert step_one.error is None
+
+    assert step_two.name == "add_total"
+    assert step_two.parameters["source"] == "value"
+    assert step_two.column_delta == 1
+    assert step_two.added_columns == ("total",)
+    assert step_two.error is None
+
+
+@pytest.mark.unit
+def test_run_steps__validates_input_schema() -> None:
+    frame = pd.DataFrame({"value": [1]})
+
+    schema = DataFrameSchema(required_columns=("value",))
+
+    def identity(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    result = run_steps(
+        frame,
+        [identity],
+        pre_schema=schema,
+        post_schema=schema,
+        pipeline_version="0.0.1",
+    )
+
+    assert result.metadata.pre_schema is not None
+    assert result.metadata.pre_schema.status == "success"
+    assert result.metadata.post_schema is not None
+    assert result.metadata.post_schema.status == "success"
+    assert result.frame.attrs["pipeline_version"] == "0.0.1"


### PR DESCRIPTION
## Summary
- add a dedicated postprocess runner that records per-step metadata, schema checks, and pipeline version
- extend step definitions to accept keyword parameters and update pipeline entrypoints to return runner results with post-schema validation
- cover the new runner behaviour with unit tests that assert metadata contents

## Testing
- pytest tests/unit/test_postprocess_runner.py


------
https://chatgpt.com/codex/tasks/task_e_68e5005f5034832495ac1e3364a74586