### PR TITLE
Add declarative pipeline configuration directory

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,18 @@
 """Configuration package exposing shared file-system paths."""
 from __future__ import annotations
 
-from .paths import CONFIG_DIR, DEFAULT_CONFIG_PATH, DICTIONARY_DIR, SCHEMA_DIR
+from .paths import (
+    CONFIG_DIR,
+    DEFAULT_CONFIG_PATH,
+    DICTIONARY_DIR,
+    PIPELINE_DIR,
+    SCHEMA_DIR,
+)
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/paths.py
+++ b/config/paths.py
@@ -7,5 +7,12 @@ CONFIG_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = CONFIG_DIR / "config.yaml"
 DICTIONARY_DIR = CONFIG_DIR / "dictionary"
 SCHEMA_DIR = CONFIG_DIR / "schema"
+PIPELINE_DIR = CONFIG_DIR / "pipeline"
 
-__all__ = ["CONFIG_DIR", "DEFAULT_CONFIG_PATH", "DICTIONARY_DIR", "SCHEMA_DIR"]
+__all__ = [
+    "CONFIG_DIR",
+    "DEFAULT_CONFIG_PATH",
+    "DICTIONARY_DIR",
+    "PIPELINE_DIR",
+    "SCHEMA_DIR",
+]

--- a/config/pipeline/activity.yaml
+++ b/config/pipeline/activity.yaml
@@ -1,0 +1,39 @@
+name: activity
+summary: >-
+  Retrieves activity measurements from the ChEMBL API, normalises derived
+  fields and exports a deterministic CSV annotated with pipeline metadata.
+schemas:
+  default: ActivitiesSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: activity.csv
+  dependencies:
+    - documents.csv
+    - targets.csv
+    - assays.csv
+    - testitems.csv
+outputs:
+  primary: activities.csv
+  artefacts:
+    - activities.csv.meta.yaml
+parameters:
+  column: activity.column
+  batch_size: activity.batch_size
+  timeout: activity.timeout
+  workers: activity.workers
+  limit: activity.limit
+  offset: activity.offset
+  dry_run: activity.dry_run
+steps:
+  - name: fetch_activities
+    description: Fetch activity payloads from the ChEMBL API in deterministic chunks.
+  - name: annotate_action_type
+    description: Derive action type and functionality columns from enrichment rules.
+  - name: annotate_properties
+    description: Flatten nested activity properties into summary strings and hashes.
+  - name: compute_bounds
+    description: Derive lower/upper bounds for measurements and normalise relations.
+  - name: finalize_export
+    description: Apply validation, append metadata columns, and write deterministic CSV artefacts.

--- a/config/pipeline/assay.yaml
+++ b/config/pipeline/assay.yaml
@@ -1,0 +1,29 @@
+name: assay
+summary: >-
+  Retrieves assay metadata from ChEMBL, enforces deterministic ordering, and
+  stamps exports with pipeline metadata for traceability.
+schemas:
+  default: AssaysSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: assay.csv
+  dependencies:
+    - documents.csv
+outputs:
+  primary: assays.csv
+  artefacts:
+    - assays.csv.meta.yaml
+parameters:
+  column: assay.column
+  batch_size: assay.batch_size
+  timeout: assay.timeout
+  limit: assay.limit
+steps:
+  - name: fetch_assays
+    description: Fetch assay records from the ChEMBL API.
+  - name: normalize_payload
+    description: Normalise columns, apply enrichment helpers, and coerce data types.
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.

--- a/config/pipeline/cellline.yaml
+++ b/config/pipeline/cellline.yaml
@@ -1,0 +1,28 @@
+name: cellline
+summary: >-
+  Downloads cell line metadata from ChEMBL and emits a deterministic CSV ready
+  for downstream joins.
+schemas:
+  default: CellLinesSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: cellline.csv
+outputs:
+  primary: cellline.csv
+  artefacts:
+    - cellline.csv.meta.yaml
+parameters:
+  column: cellline.column
+  batch_size: cellline.batch_size
+  timeout: cellline.timeout
+  limit: cellline.limit
+  offset: cellline.offset
+steps:
+  - name: fetch_cell_lines
+    description: Retrieve cell line records from the ChEMBL API.
+  - name: normalize_payload
+    description: Cleanse and align the payload with the export schema.
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.

--- a/config/pipeline/document.yaml
+++ b/config/pipeline/document.yaml
@@ -1,0 +1,72 @@
+name: document
+summary: >-
+  Consolidates document metadata from the ChEMBL API and literature partners
+  (PubMed, Semantic Scholar, OpenAlex, CrossRef) before exporting curated CSVs.
+schemas:
+  chembl: DocumentsSchema
+  pubmed: PubMedDocumentsSchema
+  all: DocumentsSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: document.csv
+outputs:
+  modes:
+    chembl: documents_chembl.csv
+    pubmed: documents_pubmed.csv
+    all: documents.csv
+  artefacts:
+    - documents.csv.meta.yaml
+parameters:
+  shared:
+    openalex_rps: openalex.rps
+    crossref_rps: crossref.rps
+  modes:
+    chembl:
+      column: document.chembl.column
+      limit: document.chembl.limit
+      chunk_size: document.chembl.chunk_size
+      timeout: document.chembl.timeout
+    pubmed:
+      column: document.pubmed.column
+      limit: document.pubmed.limit
+      batch_size: document.pubmed.batch_size
+      workers: document.pubmed.workers
+      sleep: document.pubmed.sleep
+      timeout: sources.pubmed.timeout_read
+    all:
+      column: document.all.column
+      limit: document.all.limit
+      chunk_size: document.all.chunk_size
+      timeout: document.all.timeout
+      batch_size: document.all.batch_size
+      workers: document.all.workers
+      sleep: document.all.sleep
+      chembl_chunk_size: document.all.chunk_size
+      chembl_timeout: document.all.timeout
+      pubmed_sleep: document.all.sleep
+      pubmed_workers: document.all.workers
+      pubmed_batch_size: document.all.batch_size
+      pubmed_timeout: sources.pubmed.timeout_read
+steps:
+  - name: fetch_chembl_documents
+    description: Retrieve document metadata from the ChEMBL API.
+    applies_to:
+      - chembl
+      - all
+  - name: enrich_literature_partners
+    description: Query PubMed, Semantic Scholar, OpenAlex, and CrossRef for supplemental metadata.
+    applies_to:
+      - pubmed
+      - all
+  - name: merge_payloads
+    description: Merge ChEMBL and PubMed payloads and resolve canonical fields.
+    applies_to:
+      - all
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.
+    applies_to:
+      - chembl
+      - pubmed
+      - all

--- a/config/pipeline/target.yaml
+++ b/config/pipeline/target.yaml
@@ -1,0 +1,98 @@
+name: target
+summary: >-
+  Harmonises targets from ChEMBL, UniProt, and Guide to PHARMACOLOGY, merges
+  partner annotations, and emits deterministic exports for downstream joins.
+schemas:
+  chembl: TargetsSchema
+  uniprot: TargetsSchema
+  iuphar: TargetsSchema
+  all: TargetsSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: target.csv
+outputs:
+  commands:
+    chembl: targets_chembl.csv
+    uniprot: targets_uniprot.csv
+    iuphar: targets_iuphar.csv
+    all: targets.csv
+  artefacts:
+    - targets.csv.meta.yaml
+parameters:
+  commands:
+    chembl:
+      column: target.chembl.column
+      chunk_size: target.chembl.chunk_size
+      timeout: target.chembl.timeout
+      limit: target.chembl.limit
+      offset: target.chembl.offset
+    uniprot:
+      column: target.uniprot.column
+      chunk_size: target.uniprot.chunk_size
+      timeout: target.uniprot.timeout
+      limit: target.uniprot.limit
+      offset: target.uniprot.offset
+      data_dir: target.uniprot.data_dir
+    iuphar:
+      column: target.iuphar.column
+      chunk_size: target.iuphar.chunk_size
+      timeout: target.iuphar.timeout
+      limit: target.iuphar.limit
+      offset: target.iuphar.offset
+      target_csv: target.iuphar.target_csv
+      family_csv: target.iuphar.family_csv
+    all:
+      column: target.all.column
+      chunk_size: target.all.chunk_size
+      timeout: target.all.timeout
+      limit: target.all.limit
+      offset: target.all.offset
+      data_dir: target.all.data_dir
+      target_csv: target.all.target_csv
+      family_csv: target.all.family_csv
+      uniprot_column: target.all.uniprot_column
+      chembl_out: target.all.chembl_out
+      uniprot_out: target.all.uniprot_out
+      iuphar_out: target.all.iuphar_out
+      chembl_column: target.chembl.column
+      chembl_chunk_size: target.chembl.chunk_size
+      chembl_timeout: target.chembl.timeout
+      chembl_limit: target.chembl.limit
+      chembl_offset: target.chembl.offset
+      uniprot_chunk_size: target.uniprot.chunk_size
+      uniprot_timeout: target.uniprot.timeout
+      uniprot_limit: target.uniprot.limit
+      uniprot_offset: target.uniprot.offset
+      iuphar_chunk_size: target.iuphar.chunk_size
+      iuphar_timeout: target.iuphar.timeout
+      iuphar_limit: target.iuphar.limit
+      iuphar_offset: target.iuphar.offset
+steps:
+  - name: fetch_chembl_targets
+    description: Retrieve target metadata from the ChEMBL API.
+    applies_to:
+      - chembl
+      - all
+  - name: fetch_uniprot_annotations
+    description: Load UniProt classification and component details.
+    applies_to:
+      - uniprot
+      - all
+  - name: fetch_iuphar_annotations
+    description: Enrich with Guide to PHARMACOLOGY relationships and families.
+    applies_to:
+      - iuphar
+      - all
+  - name: merge_sources
+    description: Combine partner payloads into a unified target export.
+    applies_to:
+      - all
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.
+    applies_to:
+      - chembl
+      - uniprot
+      - iuphar
+      - all

--- a/config/pipeline/testitem.yaml
+++ b/config/pipeline/testitem.yaml
@@ -1,0 +1,32 @@
+name: testitem
+summary: >-
+  Fetches compound metadata from the ChEMBL and PubChem APIs, reconciles parent
+  relationships, and emits deterministic exports for downstream pipelines.
+schemas:
+  default: TestitemsSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: testitem.csv
+  dependencies:
+    - testitem_molecule_catalog.csv
+outputs:
+  primary: testitems.csv
+  artefacts:
+    - testitems.csv.meta.yaml
+parameters:
+  column: testitem.column
+  batch_size: testitem.batch_size
+  timeout: testitem.timeout
+  limit: testitem.limit
+  offset: testitem.offset
+steps:
+  - name: read_identifiers
+    description: Load and validate identifier column from the input CSV.
+  - name: fetch_chembl_metadata
+    description: Query ChEMBL for compound metadata and normalised properties.
+  - name: enrich_pubchem
+    description: Resolve PubChem identifiers and merge additional annotations.
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.

--- a/config/pipeline/tissue.yaml
+++ b/config/pipeline/tissue.yaml
@@ -1,0 +1,28 @@
+name: tissue
+summary: >-
+  Retrieves tissue metadata from ChEMBL, normalises identifiers, and exports a
+  deterministic CSV for reporting.
+schemas:
+  default: TissuesSchema
+pipeline_version:
+  column: pipeline_version
+  description: chembl-data-acquisition package version stamped on every row.
+inputs:
+  primary: tissue.csv
+outputs:
+  primary: tissue.csv
+  artefacts:
+    - tissue.csv.meta.yaml
+parameters:
+  column: tissue.column
+  batch_size: tissue.batch_size
+  timeout: tissue.timeout
+  limit: tissue.limit
+  offset: tissue.offset
+steps:
+  - name: fetch_tissues
+    description: Retrieve tissue metadata from the ChEMBL API.
+  - name: normalize_payload
+    description: Cleanse codes, harmonise identifiers, and align schema order.
+  - name: finalize_export
+    description: Validate results, add metadata columns, and write deterministic CSV artefacts.

--- a/docs/en/architecture/PIPELINE_CONFIG_SCHEMA.md
+++ b/docs/en/architecture/PIPELINE_CONFIG_SCHEMA.md
@@ -1,0 +1,81 @@
+# Pipeline configuration schema
+
+All pipeline CLIs share declarative metadata stored under `config/pipeline/`.
+Every `<table>.yaml` file describes how the corresponding CLI behaves: which
+steps are enabled, the configuration parameters that may be overridden from the
+command line, the expected inputs/outputs, and the metadata columns stamped on
+exports.  The files are consumed by
+`library.pipelines.configuration.load_pipeline_config`, which returns
+`PipelineConfig` dataclasses for downstream tooling.
+
+```pycon
+>>> from library.pipelines.configuration import load_pipeline_config
+>>> cfg = load_pipeline_config("activity")
+>>> cfg.name
+'activity'
+>>> cfg.parameters.mapping_for()
+{'column': 'activity.column', 'batch_size': 'activity.batch_size', ...}
+```
+
+The loader automatically resolves the installed package version when a file uses
+`pipeline_version: value: auto` and exposes convenience helpers to merge
+parameter mappings per mode/command.
+
+## Top-level keys
+
+| Key                | Type                          | Description |
+|--------------------|-------------------------------|-------------|
+| `name`             | string                        | Canonical pipeline identifier. Defaults to the filename stem when omitted. |
+| `summary`          | string (optional)             | Human-readable description used in docs and diagnostics. |
+| `schemas`          | mapping                       | Mapping of variant → Pandera schema name applied to the export. Use `default` when a pipeline has a single schema. |
+| `pipeline_version` | string or mapping             | Describes the metadata column stamped on exports. Accepts either a column name (`pipeline_version: pipeline_version`) or a mapping with `column`, optional `description`, and optional `value`. The loader resolves `value: auto` to the installed package version. |
+| `inputs`           | mapping (optional)            | Declares the input artefacts. Recognised keys: `primary` (string) and `dependencies` (list of strings). Additional keys are preserved verbatim in `PipelineIO.variants`. |
+| `outputs`          | mapping (optional)            | Declares the output artefacts using the same structure as `inputs`. Common variants include `modes`/`commands` for multi-stage pipelines and `artefacts` for sidecars. |
+| `parameters`       | mapping (optional)            | Maps CLI options to configuration paths. Accepts inline key/value pairs for defaults and nested mappings under `default`, `shared`, `modes`, and `commands`. |
+| `steps`            | sequence (optional)           | Ordered list describing logical pipeline stages. Each entry is a mapping documented below. |
+
+### Parameter mappings
+
+The `parameters` section supports four buckets:
+
+- Inline key/value pairs or a `default` mapping for options shared by all
+  variants.
+- `shared`: applied in addition to the defaults for every variant.
+- `modes`: mapping of mode name → parameters. Used by the document pipeline.
+- `commands`: mapping of sub-command name → parameters. Used by the target
+  pipeline.
+
+The loader exposes `PipelineParameters.mapping_for(mode="all")` and
+`PipelineParameters.mapping_for(command="chembl")` helpers to merge the
+appropriate dictionaries.
+
+### Step entries
+
+Each `steps` entry can define the following keys:
+
+| Key           | Type                | Description |
+|---------------|---------------------|-------------|
+| `name`        | string              | Identifier for the stage. |
+| `description` | string (optional)   | Human-readable summary shown in docs and manifests. |
+| `enabled`     | bool/string (optional) | When present, overrides the default `True`. Values other than explicit `false`/`0`/`no` are treated as enabled. |
+| `depends_on`  | list of strings (optional) | Declares upstream stages that must finish before this stage runs. |
+| `produces`    | list of strings (optional) | Declares artefacts created by the stage. |
+| `applies_to`  | string or list of strings (optional) | Restricts the step to specific modes/commands (e.g. `chembl`, `pubmed`, `all`). |
+
+Steps allow downstream tooling (for example the orchestrator) to render clearer
+execution plans without hard-coding descriptions.
+
+## Adding a new pipeline definition
+
+1. Create `config/pipeline/<name>.yaml` following the structure above.
+2. Populate `schemas` with the Pandera schema(s) used by the CLI.
+3. Declare the `pipeline_version` column. Use `value: auto` to resolve the
+   current package version at runtime.
+4. List default and variant-specific CLI parameters under `parameters` so that
+   automation can build accurate config override mappings.
+5. Describe the logical steps executed by the pipeline under `steps`.
+6. Update or add unit tests covering `library.pipelines.configuration` if you
+   introduce new keys so that schema regressions are caught early.
+
+Refer to existing files such as `config/pipeline/activity.yaml` and
+`config/pipeline/document.yaml` for concrete examples.

--- a/library/pipelines/configuration.py
+++ b/library/pipelines/configuration.py
@@ -1,0 +1,303 @@
+"""Loader for declarative pipeline metadata stored under :mod:`config.pipeline`."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from config.paths import PIPELINE_DIR
+from library.pipelines.common.metadata import get_pipeline_version
+
+__all__ = [
+    "PipelineConfig",
+    "PipelineIO",
+    "PipelineParameters",
+    "PipelineStepConfig",
+    "PipelineVersionInfo",
+    "list_pipeline_configs",
+    "load_pipeline_config",
+]
+
+
+@dataclass(frozen=True)
+class PipelineVersionInfo:
+    """Metadata describing the pipeline version column used in exports."""
+
+    column: str
+    value: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class PipelineStepConfig:
+    """Declarative description of a pipeline step."""
+
+    name: str
+    description: str | None
+    enabled: bool
+    depends_on: tuple[str, ...]
+    produces: tuple[str, ...]
+    applies_to: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PipelineParameters:
+    """Structured mapping of CLI parameters to configuration paths."""
+
+    default: Mapping[str, str]
+    shared: Mapping[str, str]
+    modes: Mapping[str, Mapping[str, str]]
+    commands: Mapping[str, Mapping[str, str]]
+
+    def mapping_for(self, *, mode: str | None = None, command: str | None = None) -> dict[str, str]:
+        """Return a merged mapping using ``mode``/``command`` specific overrides."""
+
+        mapping: dict[str, str] = dict(self.default)
+        if self.shared:
+            mapping.update(self.shared)
+        if mode is not None and mode in self.modes:
+            mapping.update(self.modes[mode])
+        if command is not None and command in self.commands:
+            mapping.update(self.commands[command])
+        return mapping
+
+
+@dataclass(frozen=True)
+class PipelineIO:
+    """Inputs or outputs declared for a pipeline."""
+
+    primary: str | None
+    dependencies: tuple[str, ...]
+    variants: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Complete declarative definition of a pipeline."""
+
+    name: str
+    summary: str | None
+    schemas: Mapping[str, str]
+    pipeline_version: PipelineVersionInfo
+    inputs: PipelineIO
+    outputs: PipelineIO
+    parameters: PipelineParameters
+    steps: tuple[PipelineStepConfig, ...]
+
+
+def _coerce_str(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"pipeline config field '{field}' must be a non-empty string")
+    return value.strip()
+
+
+def _coerce_optional_str(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    return _coerce_str(value, field=field)
+
+
+def _coerce_str_sequence(value: Any, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (_coerce_str(value, field=field),)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        items: list[str] = []
+        for idx, item in enumerate(value):
+            items.append(_coerce_str(item, field=f"{field}[{idx}]"))
+        return tuple(items)
+    raise TypeError(f"pipeline config field '{field}' must be a string or sequence of strings")
+
+
+def _coerce_mapping_str_str(value: Any, *, field: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"pipeline config field '{field}' must be a mapping")
+    result: dict[str, str] = {}
+    for key, val in value.items():
+        result[_coerce_str(key, field=f"{field} key")] = _coerce_str(val, field=f"{field}[{key}]")
+    return result
+
+
+def _parse_pipeline_version(data: Mapping[str, Any], *, name: str) -> PipelineVersionInfo:
+    raw = data.get("pipeline_version")
+    if raw is None:
+        raise KeyError(f"pipeline '{name}' is missing 'pipeline_version'")
+    column: str
+    description: str | None = None
+    value: str | None = None
+    if isinstance(raw, str):
+        column = _coerce_str(raw, field="pipeline_version")
+    elif isinstance(raw, Mapping):
+        column = _coerce_str(raw.get("column"), field="pipeline_version.column")
+        description = _coerce_optional_str(raw.get("description"), field="pipeline_version.description")
+        raw_value = raw.get("value")
+        if raw_value is not None:
+            value = _coerce_str(raw_value, field="pipeline_version.value")
+    else:
+        raise TypeError("pipeline_version must be a string or mapping")
+    if value is None or value.lower() == "auto":
+        value = get_pipeline_version()
+    return PipelineVersionInfo(column=column, value=value, description=description)
+
+
+def _parse_steps(data: Mapping[str, Any]) -> tuple[PipelineStepConfig, ...]:
+    raw_steps = data.get("steps")
+    if raw_steps is None:
+        return ()
+    if not isinstance(raw_steps, Sequence) or isinstance(raw_steps, (str, bytes, bytearray)):
+        raise TypeError("pipeline 'steps' must be a sequence of mappings")
+    steps: list[PipelineStepConfig] = []
+    for index, entry in enumerate(raw_steps):
+        if not isinstance(entry, Mapping):
+            raise TypeError(f"pipeline step at index {index} must be a mapping")
+        name = _coerce_str(entry.get("name"), field=f"steps[{index}].name")
+        description = _coerce_optional_str(entry.get("description"), field=f"steps[{index}].description")
+        enabled_raw = entry.get("enabled", True)
+        if enabled_raw in (None, "", "auto"):
+            enabled = True
+        elif isinstance(enabled_raw, bool):
+            enabled = enabled_raw
+        else:
+            enabled = str(enabled_raw).lower() not in {"false", "0", "no", "off"}
+        depends_on = _coerce_str_sequence(entry.get("depends_on"), field=f"steps[{index}].depends_on")
+        produces = _coerce_str_sequence(entry.get("produces"), field=f"steps[{index}].produces")
+        applies_to = _coerce_str_sequence(entry.get("applies_to"), field=f"steps[{index}].applies_to")
+        steps.append(
+            PipelineStepConfig(
+                name=name,
+                description=description,
+                enabled=enabled,
+                depends_on=depends_on,
+                produces=produces,
+                applies_to=applies_to,
+            )
+        )
+    return tuple(steps)
+
+
+def _parse_parameters(data: Mapping[str, Any]) -> PipelineParameters:
+    raw_params = data.get("parameters")
+    if raw_params is None:
+        return PipelineParameters(default={}, shared={}, modes={}, commands={})
+    if not isinstance(raw_params, Mapping):
+        raise TypeError("pipeline 'parameters' must be a mapping")
+    default: dict[str, str] = {}
+    shared: dict[str, str] = {}
+    modes: dict[str, dict[str, str]] = {}
+    commands: dict[str, dict[str, str]] = {}
+
+    def _consume_plain_entries(entries: Mapping[str, Any], *, dest: dict[str, str], prefix: str) -> None:
+        for key, value in entries.items():
+            if key in {"shared", "modes", "commands", "default"}:
+                continue
+            if isinstance(value, Mapping):
+                raise TypeError(
+                    "nested mappings within 'parameters' must be under the 'shared', 'modes', "
+                    "'commands', or 'default' keys"
+                )
+            dest[_coerce_str(key, field=f"parameters.{prefix}{key}")] = _coerce_str(
+                value, field=f"parameters.{prefix}{key}"
+            )
+
+    if "default" in raw_params:
+        default.update(_coerce_mapping_str_str(raw_params.get("default"), field="parameters.default"))
+    _consume_plain_entries(raw_params, dest=default, prefix="")
+    shared.update(_coerce_mapping_str_str(raw_params.get("shared"), field="parameters.shared"))
+
+    raw_modes = raw_params.get("modes")
+    if raw_modes is not None:
+        if not isinstance(raw_modes, Mapping):
+            raise TypeError("parameters.modes must be a mapping")
+        for mode, mapping in raw_modes.items():
+            modes[_coerce_str(mode, field="parameters.modes key")] = _coerce_mapping_str_str(
+                mapping, field=f"parameters.modes.{mode}"
+            )
+
+    raw_commands = raw_params.get("commands")
+    if raw_commands is not None:
+        if not isinstance(raw_commands, Mapping):
+            raise TypeError("parameters.commands must be a mapping")
+        for command, mapping in raw_commands.items():
+            commands[_coerce_str(command, field="parameters.commands key")] = _coerce_mapping_str_str(
+                mapping, field=f"parameters.commands.{command}"
+            )
+
+    return PipelineParameters(default=default, shared=shared, modes=modes, commands=commands)
+
+
+def _parse_io_section(data: Mapping[str, Any], *, field: str) -> PipelineIO:
+    raw_io = data.get(field)
+    if raw_io is None:
+        return PipelineIO(primary=None, dependencies=(), variants={})
+    if not isinstance(raw_io, Mapping):
+        raise TypeError(f"pipeline '{field}' must be a mapping")
+    primary = raw_io.get("primary")
+    dependencies = raw_io.get("dependencies")
+    variants = {k: v for k, v in raw_io.items() if k not in {"primary", "dependencies"}}
+    primary_str = _coerce_optional_str(primary, field=f"{field}.primary")
+    deps = _coerce_str_sequence(dependencies, field=f"{field}.dependencies")
+    return PipelineIO(primary=primary_str, dependencies=deps, variants=variants)
+
+
+def _parse_schemas(data: Mapping[str, Any], *, name: str) -> dict[str, str]:
+    raw = data.get("schemas")
+    if raw is None:
+        raise KeyError(f"pipeline '{name}' is missing the 'schemas' section")
+    return _coerce_mapping_str_str(raw, field="schemas")
+
+
+def _ensure_directory(path: Path) -> Path:
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"pipeline configuration directory not found: {resolved}")
+    return resolved
+
+
+@lru_cache(maxsize=None)
+def list_pipeline_configs(directory: Path | None = None) -> tuple[str, ...]:
+    """Return the available pipeline configuration names."""
+
+    base = _ensure_directory(Path(directory) if directory else PIPELINE_DIR)
+    names = sorted(path.stem for path in base.glob("*.yaml"))
+    return tuple(names)
+
+
+@lru_cache(maxsize=None)
+def load_pipeline_config(name: str, *, directory: Path | None = None) -> PipelineConfig:
+    """Return the parsed declarative configuration for ``name``."""
+
+    if not name:
+        raise ValueError("pipeline name must be provided")
+    base = _ensure_directory(Path(directory) if directory else PIPELINE_DIR)
+    path = base / f"{name}.yaml"
+    if not path.exists():
+        available = ", ".join(list_pipeline_configs(directory=base))
+        raise FileNotFoundError(f"pipeline configuration not found: {path} (available: {available})")
+    with path.open("r", encoding="utf-8") as handle:
+        raw_data = yaml.safe_load(handle) or {}
+    if not isinstance(raw_data, Mapping):
+        raise TypeError(f"pipeline configuration '{path}' must contain a mapping")
+    cfg_name = _coerce_str(raw_data.get("name", name), field="name")
+    summary = _coerce_optional_str(raw_data.get("summary"), field="summary")
+    schemas = _parse_schemas(raw_data, name=cfg_name)
+    pipeline_version = _parse_pipeline_version(raw_data, name=cfg_name)
+    parameters = _parse_parameters(raw_data)
+    steps = _parse_steps(raw_data)
+    inputs = _parse_io_section(raw_data, field="inputs")
+    outputs = _parse_io_section(raw_data, field="outputs")
+    return PipelineConfig(
+        name=cfg_name,
+        summary=summary,
+        schemas=schemas,
+        pipeline_version=pipeline_version,
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        steps=steps,
+    )

--- a/tests/unit/test_pipeline_config_loader.py
+++ b/tests/unit/test_pipeline_config_loader.py
@@ -1,0 +1,57 @@
+"""Tests for :mod:`library.pipelines.configuration`."""
+
+from __future__ import annotations
+
+from library.pipelines.common.metadata import get_pipeline_version
+from library.pipelines.configuration import (
+    load_pipeline_config,
+    list_pipeline_configs,
+)
+
+
+def test_list_pipeline_configs_contains_known_tables() -> None:
+    names = set(list_pipeline_configs())
+    expected = {
+        "activity",
+        "assay",
+        "cellline",
+        "document",
+        "target",
+        "testitem",
+        "tissue",
+    }
+    assert expected.issubset(names)
+
+
+def test_activity_pipeline_config_parameters_and_steps() -> None:
+    cfg = load_pipeline_config("activity")
+    assert cfg.pipeline_version.column == "pipeline_version"
+    assert cfg.pipeline_version.value == get_pipeline_version()
+    mapping = cfg.parameters.mapping_for()
+    assert mapping["timeout"] == "activity.timeout"
+    assert mapping["dry_run"] == "activity.dry_run"
+    step_names = {step.name for step in cfg.steps}
+    assert "fetch_activities" in step_names
+    assert "finalize_export" in step_names
+
+
+def test_document_pipeline_modes_and_shared_parameters() -> None:
+    cfg = load_pipeline_config("document")
+    shared = cfg.parameters.mapping_for()
+    assert shared["openalex_rps"] == "openalex.rps"
+    pubmed_mapping = cfg.parameters.mapping_for(mode="pubmed")
+    assert pubmed_mapping["sleep"] == "document.pubmed.sleep"
+    all_mapping = cfg.parameters.mapping_for(mode="all")
+    assert all_mapping["chembl_chunk_size"] == "document.all.chunk_size"
+    step_lookup = {step.name: step for step in cfg.steps}
+    assert "enrich_literature_partners" in step_lookup
+    assert "pubmed" in step_lookup["enrich_literature_partners"].applies_to
+
+
+def test_target_pipeline_commands_mapping() -> None:
+    cfg = load_pipeline_config("target")
+    chembl_map = cfg.parameters.mapping_for(command="chembl")
+    assert chembl_map["chunk_size"] == "target.chembl.chunk_size"
+    all_map = cfg.parameters.mapping_for(command="all")
+    assert all_map["chembl_chunk_size"] == "target.chembl.chunk_size"
+    assert all_map["target_csv"] == "target.all.target_csv"


### PR DESCRIPTION
## Summary
- add per-pipeline YAML configuration files that describe steps, inputs/outputs, CLI parameter mappings, and pipeline metadata
- document the shared schema for pipeline configuration files to aid future additions
- provide a loader for pipeline configurations with accompanying unit tests

## Testing
- pytest tests/unit/test_pipeline_config_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68e5005dbebc8324a9d9f6aa3f817673