### PR TITLE
Add env-configurable pipeline defaults and extend config tests

### DIFF
--- a/README_postprocess.md
+++ b/README_postprocess.md
@@ -51,6 +51,8 @@ Available overrides:
 
 - `CHEMBL_ACTIVITY_PIPELINE_VERSION`, `CHEMBL_ASSAY_PIPELINE_VERSION`, `CHEMBL_DOCUMENT_PIPELINE_VERSION`, `CHEMBL_TARGET_PIPELINE_VERSION` — override the exported `pipeline_version` per domain; defaults to `auto`.
 - `POSTPROCESS_LOG_LEVEL` — baseline logger verbosity, defaulting to `INFO`.
+- `POSTPROCESS_DEFAULT_ENCODING` — shared file encoding for CSV loads/saves, defaulting to `utf-8`.
+- `POSTPROCESS_DEFAULT_CSV_SEPARATOR` — shared CSV delimiter, defaulting to `,`.
 
 ### Domain configuration defaults
 

--- a/config/pipeline/activities.yaml
+++ b/config/pipeline/activities.yaml
@@ -26,8 +26,8 @@ params:
     pipeline_version: "${CHEMBL_ACTIVITY_PIPELINE_VERSION:-auto}"
     log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
   io:
-    encoding: "utf-8"
-    csv_sep: ","
+    encoding: "${POSTPROCESS_DEFAULT_ENCODING:-utf-8}"
+    csv_sep: "${POSTPROCESS_DEFAULT_CSV_SEPARATOR:-,}"
   quality:
     missing_comment_flag: false
     comment_terms:

--- a/config/pipeline/assays.yaml
+++ b/config/pipeline/assays.yaml
@@ -26,8 +26,8 @@ params:
     pipeline_version: "${CHEMBL_ASSAY_PIPELINE_VERSION:-auto}"
     log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
   io:
-    encoding: "utf-8"
-    csv_sep: ","
+    encoding: "${POSTPROCESS_DEFAULT_ENCODING:-utf-8}"
+    csv_sep: "${POSTPROCESS_DEFAULT_CSV_SEPARATOR:-,}"
   flags:
     default_confirmatory: false
     fallback_assay_type: unknown

--- a/config/pipeline/documents.yaml
+++ b/config/pipeline/documents.yaml
@@ -24,8 +24,8 @@ params:
     pipeline_version: "${CHEMBL_DOCUMENT_PIPELINE_VERSION:-auto}"
     log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
   io:
-    encoding: "utf-8"
-    csv_sep: ","
+    encoding: "${POSTPROCESS_DEFAULT_ENCODING:-utf-8}"
+    csv_sep: "${POSTPROCESS_DEFAULT_CSV_SEPARATOR:-,}"
   enrichment:
     doi_lookup_timeout: 5
     enable_fallback_crossref: false

--- a/config/pipeline/targets.yaml
+++ b/config/pipeline/targets.yaml
@@ -27,8 +27,8 @@ params:
     pipeline_version: "${CHEMBL_TARGET_PIPELINE_VERSION:-auto}"
     log_level: "${POSTPROCESS_LOG_LEVEL:-INFO}"
   io:
-    encoding: "utf-8"
-    csv_sep: ","
+    encoding: "${POSTPROCESS_DEFAULT_ENCODING:-utf-8}"
+    csv_sep: "${POSTPROCESS_DEFAULT_CSV_SEPARATOR:-,}"
   enrichment:
     synonym_priority:
       - preferred_name

--- a/library/postprocess/common/import_utils.py
+++ b/library/postprocess/common/import_utils.py
@@ -81,4 +81,12 @@ def _format_expected_type(expected: type | tuple[type, ...]) -> str:
     return repr(expected)
 
 
-__all__ = ["ImportResolutionError", "import_by_path"]
+
+
+def resolve_dotted_path(path: str) -> Any:
+    """Backward compatible alias for :func:`import_by_path`."""
+
+    return import_by_path(path)
+
+
+__all__ = ["ImportResolutionError", "import_by_path", "resolve_dotted_path"]

--- a/tests/unit/postprocessing/test_pipeline_config.py
+++ b/tests/unit/postprocessing/test_pipeline_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from library.postprocess.common.config import (
@@ -42,6 +44,158 @@ def test_load_pipeline_config__applies_env_overrides(monkeypatch):
 
     assert cfg.pipeline_version == "2024.1"
     assert cfg.params["defaults"]["log_level"] == "DEBUG"
+
+
+@pytest.mark.parametrize(
+    "config_name,module_path,env_var,expected_steps,extra_sections",
+    [
+        (
+            "activities",
+            "library.postprocess.activities.steps",
+            "CHEMBL_ACTIVITY_PIPELINE_VERSION",
+            (
+                (
+                    "normalize_activity_records",
+                    {
+                        "relation_normalization": True,
+                        "enforce_uppercase_units": True,
+                    },
+                ),
+                (
+                    "enrich_activity_quality",
+                    {
+                        "quality_terms": ["valid", "expert curated"],
+                        "default_quality_flag": False,
+                    },
+                ),
+                (
+                    "finalize_activity_records",
+                    {
+                        "enforce_schema": True,
+                        "numeric_identifier_dtype": "Int64",
+                    },
+                ),
+            ),
+            ("quality",),
+        ),
+        (
+            "assays",
+            "library.postprocess.assays.steps",
+            "CHEMBL_ASSAY_PIPELINE_VERSION",
+            (
+                (
+                    "normalize_assay_metadata",
+                    {
+                        "uppercase_categories": True,
+                        "strip_whitespace": True,
+                    },
+                ),
+                (
+                    "enrich_assay_flags",
+                    {
+                        "confirmatory_terms": ["confirm", "primary"],
+                        "default_flag": False,
+                    },
+                ),
+                (
+                    "finalize_assay_records",
+                    {
+                        "enforce_schema": True,
+                        "normalize_identifiers": True,
+                    },
+                ),
+            ),
+            ("flags",),
+        ),
+        (
+            "targets",
+            "library.postprocess.targets.steps",
+            "CHEMBL_TARGET_PIPELINE_VERSION",
+            (
+                (
+                    "normalize_target_fields",
+                    {
+                        "normalize_taxonomy": True,
+                        "fill_missing_identifiers": True,
+                    },
+                ),
+                (
+                    "enrich_target_synonyms",
+                    {
+                        "synonym_sources": ["chembl", "gtopdb"],
+                        "preferred_separator": "; ",
+                    },
+                ),
+                (
+                    "finalize_target_records",
+                    {
+                        "enforce_schema": True,
+                        "sort_by": ["target_chembl_id"],
+                    },
+                ),
+            ),
+            ("enrichment",),
+        ),
+        (
+            "documents",
+            "library.postprocess.documents.steps",
+            "CHEMBL_DOCUMENT_PIPELINE_VERSION",
+            (
+                (
+                    "normalize_document_fields",
+                    {
+                        "trim_whitespace": True,
+                        "normalise_unicode": True,
+                    },
+                ),
+                (
+                    "enrich_document_publication_year",
+                    {
+                        "fallback_year": 1900,
+                        "prefer_doi_year": True,
+                    },
+                ),
+                (
+                    "finalize_document_records",
+                    {
+                        "enforce_schema": True,
+                        "ensure_unique_ids": True,
+                    },
+                ),
+            ),
+            ("enrichment",),
+        ),
+    ],
+)
+def test_pipeline_configs__resolve_steps_and_defaults(
+    monkeypatch,
+    config_name,
+    module_path,
+    env_var,
+    expected_steps,
+    extra_sections,
+) -> None:
+    """Each domain config resolves callables and exposes deterministic defaults."""
+
+    monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.delenv("POSTPROCESS_LOG_LEVEL", raising=False)
+    monkeypatch.delenv("POSTPROCESS_DEFAULT_ENCODING", raising=False)
+    monkeypatch.delenv("POSTPROCESS_DEFAULT_CSV_SEPARATOR", raising=False)
+
+    module = importlib.import_module(module_path)
+    cfg = load_pipeline_config(config_name)
+
+    assert [step.name for step in cfg.steps] == [name for name, _ in expected_steps]
+    for step, (expected_name, expected_params) in zip(cfg.steps, expected_steps):
+        assert step.name == expected_name
+        assert step.definition.func is getattr(module, expected_name)
+        assert step.params == expected_params
+
+    assert cfg.params["defaults"]["log_level"] == "INFO"
+    assert cfg.params["io"]["encoding"] == "utf-8"
+    assert cfg.params["io"]["csv_sep"] == ","
+    for section in ("defaults", "io", *extra_sections):
+        assert section in cfg.params
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- allow overriding CSV encoding and separator defaults through environment placeholders in the post-processing configs
- document the new overrides and restore the resolve_dotted_path helper used by the UTF-8 loader
- expand the pipeline configuration unit tests to cover every domain and assert representative step parameters

## Testing
- pytest tests/unit/postprocessing/test_pipeline_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e5077365bc8324a391095dec008052