### PR TITLE
Add configurable postprocess runner with step metadata support

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -79,7 +79,7 @@ def run_activity_pipeline(
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=ACTIVITY_SCHEMA,
+        post_schema=ACTIVITY_SCHEMA,
         pipeline_version=resolved_version,
         logger=logger,
     )

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -73,7 +73,7 @@ def run_assay_pipeline(
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=ASSAY_SCHEMA,
+        post_schema=ASSAY_SCHEMA,
         pipeline_version=resolved_version,
         logger=logger,
     )

--- a/library/postprocess/common/__init__.py
+++ b/library/postprocess/common/__init__.py
@@ -2,6 +2,7 @@
 from . import logging
 from .import_utils import import_by_path
 from .io import clone_dataframe, ensure_dataframe
+from .runner import run_steps
 from .schema import DataFrameSchema, coerce_types, validate_schema
 from .types import (
     ImportResolutionError,
@@ -11,7 +12,7 @@ from .types import (
     StepFn,
     StepIterable,
 )
-from .utils import collect_postprocess_metrics, infer_pipeline_version, run_steps
+from .utils import collect_postprocess_metrics, infer_pipeline_version
 
 __all__ = [
     "DataFrameSchema",

--- a/library/postprocess/common/config.py
+++ b/library/postprocess/common/config.py
@@ -11,7 +11,7 @@ import yaml
 
 from config.paths import PIPELINE_DIR
 
-from .import_utils import resolve_dotted_path
+from .import_utils import import_by_path
 from .types import StepDefinition
 
 __all__ = [
@@ -160,13 +160,18 @@ def _load_step(entry: Any, index: int) -> ConfiguredStep:
     if not isinstance(params, dict):
         raise PipelineConfigError(f"step '{name}' parameters must be expressed as a mapping")
 
-    func = resolve_dotted_path(callable_path)
+    func = import_by_path(callable_path)
     if not callable(func):  # pragma: no cover - defensive guard
         raise PipelineConfigError(
             f"resolved object for step '{name}' is not callable: {callable_path}"
         )
 
-    definition = StepDefinition(name=name, func=func, description=description)
+    definition = StepDefinition(
+        name=name,
+        func=func,
+        description=description,
+        params=params,
+    )
     return ConfiguredStep(
         name=name,
         callable_path=callable_path,

--- a/library/postprocess/common/logging.py
+++ b/library/postprocess/common/logging.py
@@ -56,6 +56,17 @@ class SchemaDiff:
 
 
 @dataclass(slots=True)
+class StepErrorInfo:
+    """Structured representation of a step failure."""
+
+    type: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": self.type, "message": self.message}
+
+
+@dataclass(slots=True)
 class StepMetrics:
     """Metrics captured for a single transformation step."""
 
@@ -68,6 +79,8 @@ class StepMetrics:
     output_rows: int
     output_columns: int
     schema_diff: SchemaDiff = field(default_factory=SchemaDiff)
+    parameters: dict[str, Any] = field(default_factory=dict)
+    error: StepErrorInfo | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a dictionary representation suitable for JSON output."""
@@ -80,6 +93,8 @@ class StepMetrics:
             "input": {"rows": self.input_rows, "columns": self.input_columns},
             "output": {"rows": self.output_rows, "columns": self.output_columns},
             "schema_diff": self.schema_diff.to_dict(),
+            "parameters": dict(self.parameters),
+            "error": self.error.to_dict() if self.error else None,
         }
 
 
@@ -204,6 +219,7 @@ def execute_step(
     frame: pd.DataFrame,
     *,
     logger: logging.Logger,
+    params: Mapping[str, Any] | None = None,
 ) -> tuple[pd.DataFrame, StepMetrics]:
     """Execute ``func`` capturing timing and schema mutations."""
 
@@ -213,8 +229,9 @@ def execute_step(
     before_dtypes = _describe_dtypes(frame)
     input_rows, input_columns = frame.shape
 
+    parameters = dict(params or {})
     logger.info("Starting step %s", step_name)
-    result = func(frame)
+    result = func(frame, **parameters)
 
     completed_at = _now_iso()
     duration_s = _duration_seconds(start_clock)
@@ -253,6 +270,7 @@ def execute_step(
         output_rows=output_rows,
         output_columns=output_columns,
         schema_diff=diff,
+        parameters=parameters,
     )
     return result, metrics
 
@@ -292,6 +310,7 @@ def dump_report(
 __all__ = [
     "PipelineRunMetrics",
     "SchemaDiff",
+    "StepErrorInfo",
     "StepMetrics",
     "ValidationMetrics",
     "build_report_payload",

--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -1,0 +1,276 @@
+"""Orchestration helpers for executing post-processing pipelines."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Any
+
+import pandas as pd
+
+from . import logging as logging_utils
+from .io import clone_dataframe, ensure_dataframe
+from .schema import DataFrameSchema, validate_schema
+from .types import SchemaValidationError, StepDefinition, StepError
+
+StepTuple = tuple[Any, ...]
+
+
+def _describe_dtypes(frame: pd.DataFrame) -> dict[str, str]:
+    return {column: str(dtype) for column, dtype in frame.dtypes.items()}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _coerce_step(entry: StepDefinition | StepTuple, index: int) -> StepDefinition:
+    if isinstance(entry, StepDefinition):
+        return entry
+
+    if isinstance(entry, tuple):
+        if len(entry) == 2:
+            func, params = entry
+            name = getattr(func, "__name__", f"step_{index}")
+        elif len(entry) == 3:
+            name, func, params = entry
+        else:  # pragma: no cover - defensive guard
+            raise TypeError(
+                "Step tuples must be of the form (callable, params) or (name, callable, params)"
+            )
+
+        if not callable(func):
+            raise TypeError(f"Step #{index} is not callable: {func!r}")
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise TypeError(f"Step #{index} parameters must be a mapping, got {type(params)!r}")
+
+        return StepDefinition(name=name, func=func, params=params)
+
+    raise TypeError(f"Unsupported step entry at position {index}: {entry!r}")
+
+
+def _normalise_steps(steps: Iterable[StepDefinition | StepTuple]) -> tuple[StepDefinition, ...]:
+    return tuple(_coerce_step(entry, index) for index, entry in enumerate(steps))
+
+
+def _record_error(
+    *,
+    metrics: logging_utils.PipelineRunMetrics,
+    step_name: str,
+    started_at: str,
+    start_clock: float,
+    input_rows: int,
+    input_columns: int,
+    params: Mapping[str, Any],
+    error: BaseException,
+) -> None:
+    metrics.steps.append(
+        logging_utils.StepMetrics(
+            name=step_name,
+            started_at=started_at,
+            completed_at=_now_iso(),
+            duration_s=perf_counter() - start_clock,
+            input_rows=input_rows,
+            input_columns=input_columns,
+            output_rows=input_rows,
+            output_columns=input_columns,
+            schema_diff=logging_utils.SchemaDiff(),
+            parameters=dict(params),
+            error=logging_utils.StepErrorInfo(
+                type=error.__class__.__name__,
+                message=str(error),
+            ),
+        )
+    )
+
+
+def run_steps(
+    df: pd.DataFrame,
+    steps: Iterable[StepDefinition | StepTuple],
+    *,
+    pipeline_version: str | None = None,
+    pre_schema: DataFrameSchema | None = None,
+    post_schema: DataFrameSchema | None = None,
+    logger=None,
+) -> tuple[pd.DataFrame, logging_utils.PipelineRunMetrics]:
+    """Execute ``steps`` sequentially and return the transformed frame and metadata."""
+
+    log = logger or logging_utils.get_logger()
+    current = ensure_dataframe(df, copy=True)
+    if pipeline_version is not None:
+        current.attrs["pipeline_version"] = pipeline_version
+
+    normalised_steps = _normalise_steps(steps)
+
+    pipeline_started_at = _now_iso()
+    pipeline_timer = perf_counter()
+    metrics = logging_utils.PipelineRunMetrics(
+        pipeline_version=pipeline_version,
+        started_at=pipeline_started_at,
+        input_rows=current.shape[0],
+        input_columns=current.shape[1],
+    )
+
+    if pre_schema is not None:
+        schema_name = pre_schema.__class__.__name__
+        log.info("Validating input schema (%s)", schema_name)
+        current = validate_schema(current, pre_schema, context="pre_pipeline")
+        if pipeline_version is not None:
+            current.attrs["pipeline_version"] = pipeline_version
+
+    for index, step in enumerate(normalised_steps):
+        params = dict(step.params)
+        frame = clone_dataframe(current)
+        step_started_at = _now_iso()
+        step_clock = perf_counter()
+        input_rows, input_columns = frame.shape
+        before_columns = list(frame.columns)
+        before_dtypes = _describe_dtypes(frame)
+
+        log.info("Starting step %s", step.name)
+
+        try:
+            result = step.func(frame, **params)
+        except SchemaValidationError as exc:
+            log.exception("Schema validation failed during step %s", step.name)
+            _record_error(
+                metrics=metrics,
+                step_name=step.name,
+                started_at=step_started_at,
+                start_clock=step_clock,
+                input_rows=input_rows,
+                input_columns=input_columns,
+                params=params,
+                error=exc,
+            )
+            raise
+        except StepError as exc:
+            log.exception("Step %s raised StepError", step.name)
+            _record_error(
+                metrics=metrics,
+                step_name=step.name,
+                started_at=step_started_at,
+                start_clock=step_clock,
+                input_rows=input_rows,
+                input_columns=input_columns,
+                params=params,
+                error=exc,
+            )
+            raise
+        except TypeError as exc:  # pragma: no cover - defensive guard
+            log.exception("Step %s encountered a TypeError", step.name)
+            _record_error(
+                metrics=metrics,
+                step_name=step.name,
+                started_at=step_started_at,
+                start_clock=step_clock,
+                input_rows=input_rows,
+                input_columns=input_columns,
+                params=params,
+                error=exc,
+            )
+            raise StepError(step.name, str(exc), cause=exc) from exc
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log.exception("Step %s failed with an unexpected error", step.name)
+            _record_error(
+                metrics=metrics,
+                step_name=step.name,
+                started_at=step_started_at,
+                start_clock=step_clock,
+                input_rows=input_rows,
+                input_columns=input_columns,
+                params=params,
+                error=exc,
+            )
+            raise StepError(step.name, str(exc), cause=exc) from exc
+
+        next_df = ensure_dataframe(result, copy=True)
+        completed_at = _now_iso()
+        duration = perf_counter() - step_clock
+        output_rows, output_columns = next_df.shape
+        after_columns = list(next_df.columns)
+        after_dtypes = _describe_dtypes(next_df)
+        diff = logging_utils.compute_schema_diff(
+            before_columns,
+            before_dtypes,
+            after_columns,
+            after_dtypes,
+        )
+
+        log.info(
+            "Completed step %s | duration=%.3fs | rows=%s->%s | cols=%s->%s | added=%s | removed=%s | types=%s",
+            step.name,
+            duration,
+            input_rows,
+            output_rows,
+            input_columns,
+            output_columns,
+            ",".join(diff.added) or "-",
+            ",".join(diff.removed) or "-",
+            ", ".join(
+                f"{column}: {change['from']} -> {change['to']}"
+                for column, change in diff.type_changes.items()
+            )
+            or "-",
+        )
+
+        if pipeline_version is not None:
+            next_df.attrs["pipeline_version"] = pipeline_version
+
+        metrics.steps.append(
+            logging_utils.StepMetrics(
+                name=step.name,
+                started_at=step_started_at,
+                completed_at=completed_at,
+                duration_s=duration,
+                input_rows=input_rows,
+                input_columns=input_columns,
+                output_rows=output_rows,
+                output_columns=output_columns,
+                schema_diff=diff,
+                parameters=params,
+            )
+        )
+
+        current = next_df
+
+    if post_schema is not None:
+        schema_name = post_schema.__class__.__name__
+        validation_started_at = _now_iso()
+        validation_clock = perf_counter()
+        log.info("Validating final schema (%s)", schema_name)
+        current = validate_schema(current, post_schema, context="pipeline")
+        validation_duration = perf_counter() - validation_clock
+        validation_completed_at = _now_iso()
+        if pipeline_version is not None:
+            current.attrs["pipeline_version"] = pipeline_version
+        metrics.validation = logging_utils.ValidationMetrics(
+            schema=schema_name,
+            started_at=validation_started_at,
+            completed_at=validation_completed_at,
+            duration_s=validation_duration,
+        )
+        log.info(
+            "Schema validation completed | schema=%s | duration=%.3fs | rows=%s | cols=%s",
+            schema_name,
+            validation_duration,
+            current.shape[0],
+            current.shape[1],
+        )
+
+    metrics.finalize(
+        output_rows=current.shape[0],
+        output_columns=current.shape[1],
+        duration_s=perf_counter() - pipeline_timer,
+    )
+
+    if pipeline_version is not None:
+        current.attrs["pipeline_version"] = pipeline_version
+
+    return current, metrics
+
+
+__all__ = ["run_steps"]
+

--- a/library/postprocess/common/types.py
+++ b/library/postprocess/common/types.py
@@ -1,8 +1,9 @@
 """Shared type hints and dataclasses for postprocessing steps."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Optional, Protocol
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Optional, Protocol
 
 import pandas as pd
 
@@ -21,10 +22,13 @@ class StepDefinition:
     name: str
     func: StepFn
     description: Optional[str] = None
+    params: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:  # pragma: no cover - dataclass validation
         if not callable(self.func):
             raise TypeError("StepDefinition.func must be callable")
+        params = dict(self.params)
+        object.__setattr__(self, "params", MappingProxyType(params))
 
 
 class StepError(RuntimeError):

--- a/library/postprocess/common/utils.py
+++ b/library/postprocess/common/utils.py
@@ -1,95 +1,11 @@
 """Pipeline orchestration utilities for postprocessing transformations."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
-from time import perf_counter
 from typing import Any, Callable, Mapping
 import pandas as pd
 
 from . import logging as logging_utils
-from .io import clone_dataframe, ensure_dataframe
-from .schema import DataFrameSchema, validate_schema
-from .types import SchemaValidationError, StepError, StepIterable
-
-
-def run_steps(
-    df: pd.DataFrame,
-    steps: StepIterable,
-    *,
-    schema: DataFrameSchema | None = None,
-    pipeline_version: str | None = None,
-    logger=None,
-) -> tuple[pd.DataFrame, logging_utils.PipelineRunMetrics]:
-    """Execute ``steps`` sequentially and return the DataFrame and metrics."""
-
-    log = logger or logging_utils.get_logger()
-    current = ensure_dataframe(df, copy=True)
-    if pipeline_version is not None:
-        current.attrs["pipeline_version"] = pipeline_version
-
-    started_at = datetime.now(timezone.utc).isoformat()
-    pipeline_timer = perf_counter()
-    metrics = logging_utils.PipelineRunMetrics(
-        pipeline_version=pipeline_version,
-        started_at=started_at,
-        input_rows=current.shape[0],
-        input_columns=current.shape[1],
-    )
-
-    for step in steps:
-        try:
-            next_df, step_metrics = logging_utils.execute_step(
-                step.name,
-                step.func,
-                clone_dataframe(current),
-                logger=log,
-            )
-        except SchemaValidationError:
-            raise
-        except StepError:
-            raise
-        except TypeError as exc:  # pragma: no cover - defensive
-            raise StepError(step.name, str(exc), cause=exc) from exc
-        except Exception as exc:  # pragma: no cover - defensive
-            raise StepError(step.name, str(exc), cause=exc) from exc
-
-        next_df = ensure_dataframe(next_df, copy=True)
-        if pipeline_version is not None:
-            next_df.attrs["pipeline_version"] = pipeline_version
-        metrics.steps.append(step_metrics)
-        current = next_df
-
-    if schema is not None:
-        schema_name = schema.__class__.__name__
-        validation_start = perf_counter()
-        validation_started_at = datetime.now(timezone.utc).isoformat()
-        log.info("Validating final schema (%s)", schema_name)
-        current = validate_schema(current, schema, context="pipeline")
-        validation_duration = perf_counter() - validation_start
-        validation_completed_at = datetime.now(timezone.utc).isoformat()
-        if pipeline_version is not None:
-            current.attrs["pipeline_version"] = pipeline_version
-        metrics.validation = logging_utils.ValidationMetrics(
-            schema=schema_name,
-            started_at=validation_started_at,
-            completed_at=validation_completed_at,
-            duration_s=validation_duration,
-        )
-        log.info(
-            "Schema validation completed | schema=%s | duration=%.3fs | rows=%s | cols=%s",
-            schema_name,
-            validation_duration,
-            current.shape[0],
-            current.shape[1],
-        )
-
-    metrics.finalize(
-        output_rows=current.shape[0],
-        output_columns=current.shape[1],
-        duration_s=perf_counter() - pipeline_timer,
-    )
-    return current, metrics
 
 
 def infer_pipeline_version(frame: pd.DataFrame) -> str | None:
@@ -170,4 +86,4 @@ def collect_postprocess_metrics(
     return metrics, report_path
 
 
-__all__ = ["collect_postprocess_metrics", "infer_pipeline_version", "run_steps"]
+__all__ = ["collect_postprocess_metrics", "infer_pipeline_version"]

--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -69,7 +69,7 @@ def run_document_pipeline(
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=DOCUMENT_SCHEMA,
+        post_schema=DOCUMENT_SCHEMA,
         pipeline_version=resolved_version,
         logger=logger,
     )

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -71,7 +71,7 @@ def run_target_pipeline(
     return run_steps(
         df,
         PIPELINE_STEPS,
-        schema=TARGET_SCHEMA,
+        post_schema=TARGET_SCHEMA,
         pipeline_version=resolved_version,
         logger=logger,
     )

--- a/tests/unit/postprocessing/test_runner.py
+++ b/tests/unit/postprocessing/test_runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common.schema import DataFrameSchema
+from library.postprocess.common.types import SchemaValidationError
+
+
+def _with_constant(
+    df: pd.DataFrame, *, column: str, value: int
+) -> pd.DataFrame:  # pragma: no cover - exercised via tests
+    result = df.copy(deep=True)
+    result[column] = value
+    return result
+
+
+def _add_columns(
+    df: pd.DataFrame, *, target: str, left: str, right: str
+) -> pd.DataFrame:  # pragma: no cover - exercised via tests
+    result = df.copy(deep=True)
+    result[target] = result[left] + result[right]
+    return result
+
+
+def test_run_steps__applies_parameters_and_records_metadata() -> None:
+    source = pd.DataFrame({"seed": [1, 2]}, dtype="int64")
+
+    steps = (
+        StepDefinition(
+            name="with_constant",
+            func=_with_constant,
+            params={"column": "value", "value": 3},
+        ),
+        StepDefinition(
+            name="combine_columns",
+            func=_add_columns,
+            params={"target": "total", "left": "seed", "right": "value"},
+        ),
+    )
+
+    schema = DataFrameSchema(
+        required_columns=("seed", "value", "total"),
+        dtypes={"seed": "int64", "value": "int64", "total": "int64"},
+    )
+
+    frame, metadata = run_steps(
+        source,
+        steps,
+        pipeline_version="2024.1",
+        post_schema=schema,
+    )
+
+    assert list(frame.columns) == ["seed", "value", "total"]
+    assert frame["value"].tolist() == [3, 3]
+    assert frame["total"].tolist() == [4, 5]
+
+    assert "value" not in source.columns  # original frame remains untouched
+    assert "pipeline_version" not in source.attrs
+
+    assert frame.attrs["pipeline_version"] == "2024.1"
+    assert metadata.pipeline_version == "2024.1"
+
+    assert len(metadata.steps) == 2
+    assert metadata.steps[0].parameters == {"column": "value", "value": 3}
+    assert metadata.steps[0].error is None
+    assert metadata.steps[1].parameters["target"] == "total"
+
+
+def test_run_steps__validates_input_schema_before_steps() -> None:
+    frame = pd.DataFrame({"unexpected": [1]}, dtype="int64")
+    pre_schema = DataFrameSchema(required_columns=("seed",))
+
+    with pytest.raises(SchemaValidationError):
+        run_steps(
+            frame,
+            (),
+            pipeline_version="2024.1",
+            pre_schema=pre_schema,
+        )
+
+
+def test_run_steps__accepts_tuple_step_specification() -> None:
+    frame = pd.DataFrame({"seed": [0, 1]}, dtype="int64")
+
+    final, metadata = run_steps(
+        frame,
+        ((_with_constant, {"column": "value", "value": 10}),),
+        pipeline_version="2024.2",
+        post_schema=DataFrameSchema(required_columns=("seed", "value")),
+    )
+
+    assert final["value"].tolist() == [10, 10]
+    assert metadata.steps[0].name == "_with_constant"
+    assert metadata.steps[0].parameters == {"column": "value", "value": 10}


### PR DESCRIPTION
## Summary
- add a dedicated postprocessing runner that applies parameterised steps, optional pre/post schema checks, and enriches pipeline metadata
- extend common step definitions and logging metrics to retain step parameters and error details while surfacing the pipeline version on frames
- update domain pipelines to use the new runner signature and add unit tests covering runner behaviour and tuple-based step specs

## Testing
- `pytest tests/unit/postprocessing/test_pipeline_config.py`
- `pytest tests/unit/postprocessing/test_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68e5075a658883248f458c2f45a6b7c9