### PR TITLE
Add jitter handling to compute_backoff_delay

### DIFF
--- a/library/common/fetch_retry.py
+++ b/library/common/fetch_retry.py
@@ -81,9 +81,12 @@ def compute_backoff_delay(attempt: int, retry_cfg: RetryCfg) -> float:
     if attempt <= 0:
         raise ValueError("attempt must be a positive integer")
     factor = retry_cfg.backoff_factor
-    if factor <= 0:
-        return 0.0
-    delay = factor * (2 ** (attempt - 1))
+    jitter = retry_cfg.build_jitter()
+    delay = 0.0
+    if factor > 0:
+        delay = factor * (2 ** (attempt - 1))
+    if jitter is not None:
+        delay += jitter(retry_cfg.backoff_factor)
     cap = retry_cfg.backoff_cap
     if cap is not None:
         delay = min(delay, cap)

--- a/tests/unit/test_fetch_retry.py
+++ b/tests/unit/test_fetch_retry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+from library.common.fetch_retry import compute_backoff_delay
+from library.config import RetryCfg
+
+
+def test_compute_backoff_delay__deterministic_with_seed() -> None:
+    retry_cfg = RetryCfg(backoff_factor=1.25, backoff_cap=None, jitter_seed=7)
+    delays_first = [compute_backoff_delay(attempt, retry_cfg) for attempt in range(1, 5)]
+
+    retry_cfg_same_seed = RetryCfg(backoff_factor=1.25, backoff_cap=None, jitter_seed=7)
+    delays_second = [compute_backoff_delay(attempt, retry_cfg_same_seed) for attempt in range(1, 5)]
+
+    assert delays_first == delays_second
+
+
+def test_compute_backoff_delay__adds_jitter_before_cap() -> None:
+    retry_cfg = RetryCfg(backoff_factor=2.0, backoff_cap=3.5, jitter_seed=11)
+    jitter = RetryCfg(backoff_factor=2.0, backoff_cap=3.5, jitter_seed=11).build_jitter()
+    assert jitter is not None
+
+    attempt = 2
+    base_delay = retry_cfg.backoff_factor * (2 ** (attempt - 1))
+    expected = min(base_delay + jitter(retry_cfg.backoff_factor), retry_cfg.backoff_cap)
+
+    assert compute_backoff_delay(attempt, retry_cfg) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- update compute_backoff_delay to apply optional jitter before enforcing the cap
- add unit tests covering deterministic jitter behaviour and cap handling

## Testing
- pytest tests/unit/test_fetch_retry.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e510deba1883248411fea66ab9e4f7