### PR TITLE
Enhance get-activities CLI output handling

### DIFF
--- a/docs/en/CLI_TOOLS.md
+++ b/docs/en/CLI_TOOLS.md
@@ -12,7 +12,7 @@ for debugging.
 | `library.utils.cli_tools.chunk_io_main` | `python -m library.utils.cli_tools.chunk_io_main --input data.csv --final-out copy.csv` | Stream CSV files in deterministic order. |
 | `library.utils.cli_tools.csv_utils_main` | `python -m library.utils.cli_tools.csv_utils_main --input data.csv --final-out clean.csv` | Re-serialise CSVs with consistent ordering. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main --log-level INFO` | Inspect pandas dtypes emitted by pipelines. |
-| `library.utils.cli_tools.get_activities` | `python -m library.utils.cli_tools.get_activities --limit 10` | Generate synthetic activity rows. |
+| `library.utils.cli_tools.get_activities` | `python -m library.utils.cli_tools.get_activities --limit 10 --output-csv output/activities_smoke.csv` | Generate synthetic activity rows and emit deterministic CSV + `.meta.yaml` artefacts for smoke runs. |
 | `library.utils.cli_tools.get_document_type` | `python -m library.utils.cli_tools.get_document_type --input docs.csv` | Classify document rows with bundled heuristics. |
 | `library.utils.cli_tools.get_input_initialisation` | `python -m library.utils.cli_tools.get_input_initialisation --same-doc a.xlsx --all-doc b.xlsx` | Merge Excel workbooks into canonical CSV. |
 | `library.utils.cli_tools.mapper_batch_main` | `python -m library.utils.cli_tools.mapper_batch_main --input ids.csv --final-out mapped.csv` | Batch mapping from ChEMBL IDs to UniProt accessions. |

--- a/docs/en/OVERVIEW.md
+++ b/docs/en/OVERVIEW.md
@@ -60,7 +60,7 @@ same arguments as their `python -m …` equivalents.
 | `table-quality` | `library.utils.cli_tools.table_quality_main:main` | Generate column-level quality profiles. |
 | `chunk-io` | `library.utils.cli_tools.chunk_io_main:main` | Stream CSV chunks while keeping ordering stable. |
 | `get-input-initialisation` | `library.utils.cli_tools.get_input_initialisation:main` | Merge Excel initialisation workbooks. |
-| `get-activities` | `library.utils.cli_tools.get_activities:main` | Emit synthetic activity rows for smoke tests. |
+| `get-activities` | `library.utils.cli_tools.get_activities:main` | Emit synthetic activity rows and deterministic CSV + `.meta.yaml` artefacts for smoke tests. |
 | `check-determinism` | `library.utils.cli_tools.check_determinism:main` | Compare CSV hashes across runs. |
 
 The dedicated reference [`USAGE.md`](./USAGE.md) (and

--- a/docs/en/USAGE.md
+++ b/docs/en/USAGE.md
@@ -325,7 +325,7 @@ functionality:
 | `mapper` | Interactive UniProt↔ChEMBL mapper backed by cached dictionaries. |
 | `chunk-io` | Stream CSV chunks with deterministic ordering. |
 | `get-input-initialisation` | Merge Excel initialisation templates into canonical CSV form. |
-| `get-activities` | Generate synthetic activity rows for smoke tests. |
+| `get-activities` | Generate synthetic activity rows and write deterministic CSV + `.meta.yaml` artefacts for smoke tests. |
 
 See [`guides/ADVANCED_SCENARIOS.md`](./guides/ADVANCED_SCENARIOS.md) for usage
 examples combining these utilities with the core pipelines.

--- a/docs/en/guides/USAGE.md
+++ b/docs/en/guides/USAGE.md
@@ -251,7 +251,7 @@ Use these modules for diagnostics, QA, or offline workflows. Each exposes a
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Re-serialise CSV files in deterministic chunks. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Normalise delimiters, quoting, and ordering for arbitrary CSV files. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Inspect pandas dtypes produced by the pipelines. |
-| `library.utils.cli_tools.get_activities` | `get-activities --limit 10` | Emit synthetic activity rows to verify logging and CLI wiring. |
+| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Emit synthetic activity rows and write deterministic CSV + `.meta.yaml` artefacts for smoke verification. |
 | `library.utils.cli_tools.get_document_type` | `get-document-type --input docs.csv` | Apply the bundled publication-type heuristics. |
 | `library.utils.cli_tools.get_input_initialisation` | `get-input-initialisation --same-doc init.xlsx --all-doc pairs.xlsx` | Combine Excel workbooks into canonical entity/relationship tables. |
 | `library.utils.cli_tools.mapper_main` | `mapper --input ids.csv --final-out mapped.csv --column target_chembl_id` | Interactive mapper for quick lookups. |

--- a/docs/ru/CLI_TOOLS.md
+++ b/docs/ru/CLI_TOOLS.md
@@ -11,7 +11,7 @@
 | `library.utils.cli_tools.chunk_io_main` | `python -m library.utils.cli_tools.chunk_io_main --input data.csv --final-out copy.csv` | Потоковая обработка CSV с сохранением порядка. |
 | `library.utils.cli_tools.csv_utils_main` | `python -m library.utils.cli_tools.csv_utils_main --input data.csv --final-out clean.csv` | Перезапись CSV с детерминированным порядком. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main --log-level INFO` | Просмотр типов pandas. |
-| `library.utils.cli_tools.get_activities` | `python -m library.utils.cli_tools.get_activities --limit 10` | Синтетические активности. |
+| `library.utils.cli_tools.get_activities` | `python -m library.utils.cli_tools.get_activities --limit 10 --output-csv output/activities_smoke.csv` | Синтетические активности с записью детерминированного CSV и `.meta.yaml` для smoke-запусков. |
 | `library.utils.cli_tools.get_document_type` | `python -m library.utils.cli_tools.get_document_type --input docs.csv` | Классификация документов. |
 | `library.utils.cli_tools.get_input_initialisation` | `python -m library.utils.cli_tools.get_input_initialisation --same-doc a.xlsx --all-doc b.xlsx` | Объединение Excel-шаблонов. |
 | `library.utils.cli_tools.mapper_batch_main` | `python -m library.utils.cli_tools.mapper_batch_main --input ids.csv --final-out mapped.csv` | Пакетное сопоставление ChEMBL↔UniProt. |

--- a/docs/ru/OVERVIEW.md
+++ b/docs/ru/OVERVIEW.md
@@ -61,7 +61,7 @@
 | `table-quality` | `library.utils.cli_tools.table_quality_main:main` | Формирует отчёты качества по колонкам. |
 | `chunk-io` | `library.utils.cli_tools.chunk_io_main:main` | Потоковое чтение/запись CSV с сохранением порядка. |
 | `get-input-initialisation` | `library.utils.cli_tools.get_input_initialisation:main` | Объединяет Excel-книги инициализации. |
-| `get-activities` | `library.utils.cli_tools.get_activities:main` | Генерирует синтетические активности для смоук-тестов. |
+| `get-activities` | `library.utils.cli_tools.get_activities:main` | Генерирует синтетические активности и детерминированные CSV + `.meta.yaml` артефакты для смоук-тестов. |
 | `check-determinism` | `library.utils.cli_tools.check_determinism:main` | Сравнивает хэши CSV между запусками. |
 
 Подробные сценарии приведены в [`USAGE.md`](./USAGE.md) и английской

--- a/docs/ru/USAGE.md
+++ b/docs/ru/USAGE.md
@@ -319,6 +319,6 @@ python scripts/get_cellline_data.py \
 | `mapper` | Интерактивное сопоставление UniProt↔ChEMBL на основе кешей. |
 | `chunk-io` | Потоковая обработка CSV с сохранением порядка. |
 | `get-input-initialisation` | Объединение Excel-шаблонов инициализации в канонический CSV. |
-| `get-activities` | Создание синтетических записей активностей для smoke-тестов. |
+| `get-activities` | Создание синтетических активностей и детерминированных CSV + `.meta.yaml` для smoke-тестов. |
 
 Примеры сложных сценариев см. в [`guides/ADVANCED_SCENARIOS.md`](./guides/ADVANCED_SCENARIOS.md).

--- a/docs/ru/guides/USAGE.md
+++ b/docs/ru/guides/USAGE.md
@@ -242,7 +242,7 @@ get-testitem-data --input data/input/testitem.csv \
 | `library.utils.cli_tools.chunk_io_main` | `chunk-io --input data.csv --final-out copy.csv` | Потоковое чтение/запись CSV с сохранением порядка. |
 | `library.utils.cli_tools.csv_utils_main` | `csv-utils --input data.csv --final-out clean.csv --sep ,` | Нормализация разделителей, кавычек и порядка колонок. |
 | `library.utils.cli_tools.dtype_inspector_main` | `python -m library.utils.cli_tools.dtype_inspector_main` | Диагностика типов pandas-таблиц. |
-| `library.utils.cli_tools.get_activities` | `get-activities --limit 10` | Генерация тестовых активностей для проверки логов и CLI. |
+| `library.utils.cli_tools.get_activities` | `get-activities --limit 10 --output-csv output/activities_smoke.csv` | Генерация тестовых активностей с записью детерминированного CSV и `.meta.yaml` для smoke-проверок. |
 | `library.utils.cli_tools.get_document_type` | `get-document-type --input docs.csv` | Применение встроенных правил классификации публикаций. |
 | `library.utils.cli_tools.get_input_initialisation` | `get-input-initialisation --same-doc init.xlsx --all-doc pairs.xlsx` | Объединение Excel-книг инициализации. |
 | `library.utils.cli_tools.mapper_main` | `mapper --input ids.csv --final-out mapped.csv --column target_chembl_id` | Интерактивный маппер UniProt/ChEMBL. |

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -3,29 +3,22 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-from library import cli
+import pandas as pd
+
+from library import cli, io
 from library.common.log import logger
+from library.config import Config, ConfigError, ensure_dirs, print_config
 from library.pipelines.activity import get_activities
 
 
 def parse_args(
     argv: Sequence[str] | None = None,
-) -> tuple[argparse.Namespace, cli.LoggerConfig]:
-    """Parse command-line arguments.
+) -> tuple[argparse.ArgumentParser, argparse.Namespace, cli.LoggerConfig]:
+    """Return parser, parsed arguments and logging configuration."""
 
-    Parameters
-    ----------
-    argv
-        Optional sequence of arguments for unit testing.
-
-    Returns
-    -------
-    tuple[argparse.Namespace, cli.LoggerConfig]
-        Parsed arguments and logging configuration.
-    """
     parser, log_cfg = cli.build_parser("Generate dummy activity data", column="id")
 
     def _limit(value: str) -> int:
@@ -50,46 +43,109 @@ def parse_args(
     input_path = getattr(args, "input_csv", None)
     output_stem = Path(input_path).stem if input_path else None
     cli.prepare_io_paths(args, output_stem=output_stem)
-    return args, log_cfg
+    return parser, args, log_cfg
 
 
-def run(limit: int, dry_run: bool) -> int:
-    """Execute the activity generation pipeline.
+def _frame_from_records(records: Iterable[dict[str, object]]) -> pd.DataFrame:
+    """Return a dataframe built from synthetic activity records."""
 
-    Parameters
-    ----------
-    limit
-        Number of activities to generate.
-    dry_run
-        If ``True``, only log the intention without generating data.
+    frame = pd.DataFrame(list(records))
+    if frame.empty:
+        return pd.DataFrame(columns=["activity_id"], dtype="Int64")
+    return frame
 
-    Returns
-    -------
-    int
-        Zero on success, non-zero on failure.
-    """
-    if dry_run:
-        logger.info("dry_run", limit=limit)
+
+def _write_output(frame: pd.DataFrame, output_path: Path, *, cfg: Config) -> Path:
+    """Persist ``frame`` and accompanying metadata to ``output_path``."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    written = io.write_csv(frame, output_path, cfg=cfg)
+    io.write_meta_yaml(
+        written,
+        cfg=cfg,
+        columns=list(frame.columns),
+        dtypes={col: str(dtype) for col, dtype in frame.dtypes.items()},
+    )
+    return written
+
+
+def run(cfg: Config, args: argparse.Namespace) -> int:
+    """Execute the activity generation pipeline."""
+
+    if args.dry_run:
+        logger.info("dry_run", limit=args.limit)
         return 0
 
-    activities = get_activities(limit)
-    logger.info("generated", count=len(activities))
+    try:
+        frame = _frame_from_records(get_activities(args.limit))
+    except ValueError as exc:
+        logger.error("invalid_arguments", error=str(exc))
+        return 1
+
+    output_candidate = getattr(args, "output_csv", None)
+    input_candidate = getattr(args, "input_csv", None)
+    if output_candidate in (None, argparse.SUPPRESS):
+        fallback_input = input_candidate or Path("activities.csv")
+        output_path = io.default_output_path(fallback_input, cfg.io)
+        args.output_csv = output_path
+        setattr(args, "final_out", output_path)
+    else:
+        output_path = Path(output_candidate)
+
+    written_path = _write_output(frame, output_path, cfg=cfg)
+    logger.info(
+        "activity_pipeline_done",
+        output=str(written_path),
+        rows=int(frame.shape[0]),
+    )
     return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Command-line entry point.
+    """Command-line entry point."""
 
-    Notes
-    -----
-    Path options ``--base-path``, ``--input-dir`` and ``--output-dir`` are
-    respected when resolving CLI inputs.
-    """
-    args, log_cfg = parse_args(argv)
+    parser, args, log_cfg = parse_args(argv)
     log_cfg.level = args.log_level
-    cli.configure_logger(log_cfg)
-    return run(limit=args.limit, dry_run=args.dry_run)
+    structured_logger = cli.configure_logger(log_cfg)
+    structured_logger.info("pipeline_start", run_id=log_cfg.run_id)
+
+    try:
+        cfg: Config = cli.apply_config_overrides(args, parser, args.config)
+    except (ConfigError, FileNotFoundError, ValueError) as exc:
+        logger.error("config_error", error=str(exc), config=str(args.config))
+        structured_logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+
+    if args.print_config:
+        print_config(cfg)
+        cli.configure_logger(log_cfg)
+        structured_logger.info("pipeline_done", run_id=log_cfg.run_id)
+        return 0
+
+    try:
+        ensure_dirs(cfg)
+    except (ValueError, TypeError) as exc:
+        logger.error("config_error", error=str(exc), config=str(args.config))
+        structured_logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        logger.error("setup_fail", error=str(exc))
+        structured_logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+
+    try:
+        exit_code = run(cfg, args)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("run_fail", exc=exc)
+        structured_logger.info("pipeline_fail", run_id=log_cfg.run_id)
+        return 1
+
+    if exit_code == 0:
+        structured_logger.info("pipeline_done", run_id=log_cfg.run_id)
+    else:
+        structured_logger.info("pipeline_fail", run_id=log_cfg.run_id)
+    return exit_code
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- load configuration in the lightweight get-activities CLI, generate the dataframe from get_activities, and persist deterministic CSV plus metadata
- emit activity_pipeline_done logging alongside pipeline lifecycle events for the stub activity export
- update the English/Russian CLI references so smoke instructions mention the CSV + .meta.yaml artefacts

## Testing
- `python -m library.utils.cli_tools.get_activities --limit 2 --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68e50f5d5bbc8324960f6feb6c233d2a