### PR TITLE
Guard molecule pref name cache with lock

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -17,6 +17,7 @@ del bootstrap_cli
 
 import argparse
 import sys
+import threading
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Callable
 from datetime import datetime, timezone
@@ -513,6 +514,7 @@ def _ensure_molecule_pref_name(
     cfg: Config,
     client: ChemblClient,
     cache: dict[str, str | None],
+    cache_lock: threading.Lock,
 ) -> pd.DataFrame:
     """Populate ``molecule_pref_name`` via the test item API when missing."""
 
@@ -541,8 +543,10 @@ def _ensure_molecule_pref_name(
 
     pending: list[str] = []
     for identifier in unique_ids:
-        if identifier not in cache:
-            pending.append(identifier)
+        with cache_lock:
+            if identifier not in cache:
+                cache[identifier] = None
+                pending.append(identifier)
 
     if pending:
         fields = list(cfg.testitem.fields)
@@ -571,11 +575,16 @@ def _ensure_molecule_pref_name(
                 .astype({"molecule_chembl_id": "string"})
             )
             for chembl_id, pref_name in mapped.itertuples(index=False):
-                cache[str(chembl_id)] = str(pref_name) if pd.notna(pref_name) else None
+                with cache_lock:
+                    cache[str(chembl_id)] = (
+                        str(pref_name) if pd.notna(pref_name) else None
+                    )
         for identifier in pending:
-            cache.setdefault(identifier, None)
+            with cache_lock:
+                cache.setdefault(identifier, None)
 
-    fill_map = {key: value for key, value in cache.items() if value}
+    with cache_lock:
+        fill_map = {key: value for key, value in cache.items() if value}
     if not fill_map:
         return result
 
@@ -993,6 +1002,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     last_error_context: dict[str, object] = {}
 
     pref_name_cache: dict[str, str | None] = {}
+    pref_name_cache_lock = threading.Lock()
 
     with ETLContext(cfg) as context:
         client = context.chembl_client
@@ -1111,7 +1121,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                         last_error_extra = None
                         last_error_context = {}
                         return _ensure_molecule_pref_name(
-                            result, cfg=cfg, client=client, cache=pref_name_cache
+                            result,
+                            cfg=cfg,
+                            client=client,
+                            cache=pref_name_cache,
+                            cache_lock=pref_name_cache_lock,
                         )
                 return pd.DataFrame(columns=ACTIVITY_COLUMNS)
 

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import pandas as pd
 import pytest
@@ -178,6 +180,56 @@ def test_run__skip_existing_matrix(
         assert "mode=skip_existing" in summary_events[-1]
     else:
         assert not summary_events
+
+
+def test_ensure_molecule_pref_name__thread_safe_cache(monkeypatch, cfg):
+    barrier = threading.Barrier(2)
+    cache: dict[str, str | None] = {}
+    cache_lock = threading.Lock()
+    cfg.testitem.fields = ["molecule_chembl_id", "pref_name"]
+
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL1", "CHEMBL1"],
+            "molecule_pref_name": pd.Series([pd.NA, pd.NA], dtype="string"),
+        }
+    )
+
+    responses = pd.DataFrame(
+        {"molecule_chembl_id": ["CHEMBL1"], "pref_name": ["Acetylsalicylic acid"]}
+    )
+
+    recorded_calls: list[Sequence[str]] = []
+    record_lock = threading.Lock()
+
+    def _fake_get_testitem(identifiers, **kwargs):
+        with record_lock:
+            recorded_calls.append(tuple(identifiers))
+        return responses
+
+    monkeypatch.setattr(get_activity_data.cl, "get_testitem", _fake_get_testitem)
+
+    def _invoke() -> pd.DataFrame:
+        barrier.wait()
+        return get_activity_data._ensure_molecule_pref_name(
+            frame,
+            cfg=cfg,
+            client=object(),
+            cache=cache,
+            cache_lock=cache_lock,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: _invoke(), range(2)))
+
+    assert len(recorded_calls) == 1
+    assert tuple(recorded_calls[0]) == ("CHEMBL1",)
+
+    expected_names = ["Acetylsalicylic acid", "Acetylsalicylic acid"]
+    for result in results:
+        assert result["molecule_pref_name"].tolist() == expected_names
+
+    assert cache["CHEMBL1"] == "Acetylsalicylic acid"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a shared lock in the activity pipeline to guard the molecule preferred-name cache
- synchronize cache membership checks and writes when enriching molecule names
- cover the concurrent access scenario with a unit test that ensures only one API request per identifier

## Testing
- pytest tests/unit/test_get_activity_data.py::test_ensure_molecule_pref_name__thread_safe_cache -q


------
https://chatgpt.com/codex/tasks/task_e_68e510e0111c8324953ba47373f6ab51