### PR TITLE
Improve offline diagnostics for activity fetch

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -25,9 +25,15 @@ from functools import partial
 from itertools import islice
 from pathlib import Path
 from time import sleep, perf_counter
+from urllib.parse import urlsplit
 
 import pandas as pd
 import requests
+
+try:  # pragma: no cover - urllib3 is part of requests dependency chain
+    from urllib3.exceptions import NameResolutionError as _Urllib3NameResolutionError
+except Exception:  # pragma: no cover - defensive fallback for alternative stacks
+    _Urllib3NameResolutionError = None  # type: ignore[assignment]
 
 from library.integration import chembl_library as cl
 from library import cli
@@ -246,6 +252,61 @@ def _gather_http_diagnostics(cfg: Config, client: object) -> dict[str, object]:
             continue
         clean[key] = value
     return clean
+
+
+def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield ``exc`` and the causal/context chain preserving order."""
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        next_exc = current.__cause__ or current.__context__
+        current = next_exc if isinstance(next_exc, BaseException) else None
+
+
+def _is_name_resolution_error(exc: Exception) -> bool:
+    """Return ``True`` when ``exc`` or its causes indicate DNS failure."""
+
+    if isinstance(exc, requests.exceptions.RequestException):
+        for candidate in _iter_exception_chain(exc):
+            if (
+                _Urllib3NameResolutionError is not None
+                and isinstance(candidate, _Urllib3NameResolutionError)
+            ):
+                return True
+            message = str(candidate).strip().lower()
+            if (
+                "name resolution" in message
+                or "nameresolutionerror" in message
+                or "getaddrinfo failed" in message
+            ):
+                return True
+
+    message = str(exc).strip().lower()
+    if (
+        "name resolution" in message
+        or "nameresolutionerror" in message
+        or "getaddrinfo failed" in message
+    ):
+        return True
+    return False
+
+
+def _describe_network_failure(cfg: Config, exc: Exception) -> tuple[str | None, str | None]:
+    """Return a human readable hint and host when DNS failures are detected."""
+
+    if not _is_name_resolution_error(exc):
+        return None, None
+
+    base = getattr(cfg.api, "chembl_base", "")
+    host = urlsplit(str(base)).hostname or str(base) or "www.ebi.ac.uk"
+    hint = (
+        "Unable to resolve the ChEMBL API host. Check internet connectivity "
+        "or configure offline fixtures for testing environments."
+    )
+    return hint, host
 
 class _StreamingCSVStatistics:
     """Accumulate row and null counters while streaming CSV chunks."""
@@ -1039,6 +1100,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                         )
                     except (requests.RequestException, ValueError) as exc:
                         error_message = str(exc)
+                        network_hint, network_host = _describe_network_failure(cfg, exc)
                         context = {
                             "chunk_ids": list(id_list),
                             "chunk_size": len(id_list),
@@ -1047,6 +1109,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                             "batch_size": cfg.activity.batch_size,
                             "timeout": cfg.activity.timeout,
                         }
+                        if network_host:
+                            context["api_host"] = network_host
                         for key in (
                             "adapter_total",
                             "api_retries",
@@ -1063,8 +1127,21 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                             "msg": error_message,
                             "chunk_ids": context["chunk_ids"],
                         }
+                        if network_hint:
+                            last_error_extra["hint"] = network_hint
                         last_error_context = dict(log_context)
+                        if network_host:
+                            last_error_context.setdefault("api_host", network_host)
+                        if network_hint:
+                            last_error_context["network_hint"] = network_hint
                         if attempt >= attempts:
+                            if network_hint:
+                                logger.error(
+                                    "activity_fetch_network_error",
+                                    extra=last_error_extra,
+                                    hint=network_hint,
+                                    **log_context,
+                                )
                             if len(id_list) > 1 and _is_timeout_error(exc):
                                 split_context = dict(log_context)
                                 split_context["depth"] = depth

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 import pandas as pd
 import pytest
+import requests
 
 from library.pipelines.assay.chembl_assay import ACTIVITY_COLUMNS
 from library.postprocessing import activity_extended
@@ -363,6 +364,64 @@ def test_run_chembl__pipeline_failure_logs_error(cfg, tmp_path, monkeypatch) -> 
     assert exit_code == 1
     error_events = [event for level, event, _ in logger_stub.events if level == "error"]
     assert "activity_pipeline_failed" in error_events
+
+
+@pytest.mark.unit
+def test_run_chembl__network_resolution_failure_hint(
+    cfg, tmp_path, monkeypatch
+) -> None:
+    args = _make_args(tmp_path)
+    cfg.activity.limit = None
+    cfg.activity.batch_size = 2
+    cfg.retry.max_attempts = 1
+    cfg.io.output_dir = tmp_path
+
+    monkeypatch.setattr(
+        get_activity_data.io,
+        "read_ids",
+        lambda *_args, **_kwargs: iter(["ACT1", "ACT2"]),
+    )
+    monkeypatch.setattr("library.orchestration.context.ChemblClient", _DummyClient)
+
+    def fake_prepare_chunked_pipeline(*, fetch_config, fetch_chunk, csv_writer):
+        del fetch_config, csv_writer
+
+        def _fetcher() -> Iterable[pd.DataFrame]:
+            fetch_chunk(("ACT1",))
+            yield from ()
+
+        def _writer(*_args, **_kwargs):  # pragma: no cover - writer is not invoked
+            raise AssertionError("writer should not be called when fetch fails")
+
+        return _fetcher, _writer
+
+    monkeypatch.setattr(get_activity_data, "prepare_chunked_pipeline", fake_prepare_chunked_pipeline)
+
+    def fake_get_activities(*_args, **_kwargs):
+        raise requests.exceptions.ConnectionError(
+            "HTTPSConnectionPool(host='www.ebi.ac.uk', port=443): Max retries exceeded with url: "
+            "/chembl/api/data/activity.json (Caused by NameResolutionError('www.ebi.ac.uk'))"
+        )
+
+    monkeypatch.setattr(get_activity_data.cl, "get_activities", fake_get_activities)
+
+    logger_stub = _RecordingLogger()
+    monkeypatch.setattr(get_activity_data, "logger", logger_stub)
+
+    exit_code = get_activity_data.run_chembl(cfg, args)
+
+    assert exit_code == 1
+    network_events = [ctx for level, event, ctx in logger_stub.events if event == "activity_fetch_network_error"]
+    assert network_events, "network error event should be logged"
+    network_context = network_events[-1]
+    hint_from_context = network_context.get("hint") or network_context.get("extra", {}).get("hint")
+    assert isinstance(hint_from_context, str)
+    assert "resolve" in hint_from_context.lower()
+
+    failure_records = [ctx for level, event, ctx in logger_stub.events if event == "activity_pipeline_failed"]
+    assert failure_records
+    details_text = failure_records[-1].get("details") or ""
+    assert "network_hint" in details_text
 
 
 def test_main__dry_run_skip_limit(monkeypatch, tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary
- detect DNS/name resolution failures during activity fetches and derive human-friendly hints
- emit a dedicated `activity_fetch_network_error` log entry and propagate the hint into failure summaries
- cover the offline failure path with a new unit test exercising the CLI retry loop

## Testing
- pytest tests/unit/test_get_activity_data.py::test_run_chembl__network_resolution_failure_hint
- pytest tests/unit/test_get_activity_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e51056ca68832490ffc2e95eff093d