### PR TITLE
Fix regex escapes in postprocess normalization steps

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -30,7 +30,7 @@ def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
                 normalised[column]
                 .astype("string")
                 .str.strip()
-                .str.replace("\s+", " ", regex=True)
+                .str.replace(r"\s+", " ", regex=True)
                 .str.upper()
             )
 

--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -28,7 +28,7 @@ def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
                 normalized[column]
                 .astype("string")
                 .str.strip()
-                .str.replace("\s+", " ", regex=True)
+                .str.replace(r"\s+", " ", regex=True)
                 .str.upper()
             )
     return normalized


### PR DESCRIPTION
## Summary
- use raw string regex patterns in activity and assay normalization steps to avoid syntax warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e512101d988324b2fc1217a9ce8035