### PR TITLE
Add get activities CLI tests and report artifacts

### DIFF
--- a/tests/e2e/test_get_activities_cli_tool.py
+++ b/tests/e2e/test_get_activities_cli_tool.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from library.pipelines.activity import get_activities
+
+
+@pytest.mark.e2e
+def test_get_activities_cli__subprocess_execution(
+    tmp_path: Path, record_property
+) -> None:
+    limit = 5
+    project_root = Path(__file__).resolve().parents[2]
+
+    env = os.environ.copy()
+    pythonpath_parts = [str(project_root)]
+    existing = env.get("PYTHONPATH")
+    if existing:
+        pythonpath_parts.append(existing)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
+    command = [
+        sys.executable,
+        "-m",
+        "library.utils.cli_tools.get_activities",
+        "--limit",
+        str(limit),
+    ]
+
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert (
+        completed.returncode == 0
+    ), f"CLI execution failed: {completed.stderr or completed.stdout}"
+
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert any(
+        "generated" in line and f"count={limit}" in line for line in stdout_lines
+    ), completed.stdout
+
+    rows = get_activities(limit)
+    csv_path = tmp_path / "activities.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["activity_id"], lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    digest = hashlib.sha256(csv_path.read_bytes()).hexdigest()
+    expected_hash = "8ab1f75124c8cac1102f311897e36d9902a947b999b7143536281c266d98b28e"
+    assert digest == expected_hash
+
+    record_property("artifact_csv", str(csv_path))
+    record_property("artifact_hash", digest)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -43,6 +43,7 @@ class TestRecord:
     stderr: str
     log: list[dict[str, str]] = field(default_factory=list)
     error: str | None = None
+    artifacts: dict[str, object] = field(default_factory=dict)
 
 
 class ReportCollector:
@@ -102,6 +103,9 @@ class ReportCollector:
             if report.failed:
                 record.error = self._format_longrepr(report.longrepr)
 
+        for key, value in getattr(report, "user_properties", ()):
+            record.artifacts[key] = self._normalise_property_value(value)
+
     # helper methods ---------------------------------------------------
     @staticmethod
     def _determine_status(report: pytest.TestReport) -> str:
@@ -122,6 +126,12 @@ class ReportCollector:
         if hasattr(longrepr, "reprcrash"):
             return str(longrepr)
         return str(longrepr)
+
+    @staticmethod
+    def _normalise_property_value(value: object) -> object:
+        if isinstance(value, Path):
+            return str(value)
+        return value
 
     # synthesis --------------------------------------------------------
     def build_results(self) -> list[TestRecord]:
@@ -198,6 +208,7 @@ def _build_json(
                 "stderr": record.stderr,
                 "log": record.log,
                 "error": record.error,
+                "artifacts": record.artifacts,
             }
             for record in results
         ],
@@ -248,6 +259,22 @@ def _write_markdown(summary_path: Path, data: dict[str, Any]) -> None:
             lines.append(f"- `{nodeid}`: `{short}`")
     else:
         lines.append("## Failed / Error details")
+        lines.append("- none")
+
+    artifact_entries = [
+        (test["nodeid"], test["artifacts"])
+        for test in data["tests"]
+        if test.get("artifacts")
+    ]
+    if artifact_entries:
+        lines.append("")
+        lines.append("## Test artifacts")
+        for nodeid, artifacts in artifact_entries:
+            for name, value in sorted(artifacts.items()):
+                lines.append(f"- `{nodeid}`: {name} = `{value}`")
+    else:
+        lines.append("")
+        lines.append("## Test artifacts")
         lines.append("- none")
 
     summary_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from library.utils.cli_tools import get_activities
+
+
+class _LoggerStub:
+    """Capture structured logging events emitted by the CLI."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def bind(self, **_: object) -> "_LoggerStub":  # pragma: no cover - interface parity
+        return self
+
+    def info(self, event: str, **data: object) -> None:
+        self.events.append(("info", event, dict(data)))
+
+    def warning(self, event: str, **data: object) -> None:  # pragma: no cover - defensive
+        self.events.append(("warning", event, dict(data)))
+
+    def error(self, event: str, **data: object) -> None:  # pragma: no cover - defensive
+        self.events.append(("error", event, dict(data)))
+
+
+@pytest.mark.unit
+def test_main__limit_forwarded_to_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id\nCHEMBL1\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    observed: dict[str, int] = {}
+
+    def _fake_get_activities(limit: int) -> list[dict[str, int]]:
+        observed["limit"] = limit
+        return [{"activity_id": idx} for idx in range(limit)]
+
+    monkeypatch.setattr(
+        "library.pipelines.activity.get_activities",
+        _fake_get_activities,
+    )
+    monkeypatch.setattr(get_activities, "get_activities", _fake_get_activities)
+
+    writer_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original_prepare = get_activities.cli.prepare_io_paths
+
+    def _prepare_io_paths(args: object, *, output_stem: str | None = None) -> None:
+        original_prepare(args, output_stem=output_stem)
+        setattr(args, "writer", lambda *a, **kw: writer_calls.append((a, kw)))
+
+    monkeypatch.setattr(get_activities.cli, "prepare_io_paths", _prepare_io_paths)
+    monkeypatch.setattr(get_activities.cli, "configure_logger", lambda *_a, **_k: None)
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(get_activities, "logger", logger_stub)
+
+    exit_code = get_activities.main(
+        [
+            "--input",
+            str(input_csv),
+            "--final-out",
+            str(output_csv),
+            "--limit",
+            "7",
+        ]
+    )
+
+    assert exit_code == 0
+    assert observed["limit"] == 7
+    assert writer_calls == []
+    assert ("info", "generated", {"count": 7}) in logger_stub.events
+
+
+@pytest.mark.unit
+def test_main__dry_run_skips_fetch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("id\nCHEMBL1\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    called: dict[str, bool] = {"value": False}
+
+    def _unexpected_call(limit: int) -> list[dict[str, int]]:  # pragma: no cover - defensive
+        called["value"] = True
+        return [{"activity_id": limit}]
+
+    monkeypatch.setattr(
+        "library.pipelines.activity.get_activities",
+        _unexpected_call,
+    )
+    monkeypatch.setattr(get_activities, "get_activities", _unexpected_call)
+
+    writer_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    original_prepare = get_activities.cli.prepare_io_paths
+
+    def _prepare_io_paths(args: object, *, output_stem: str | None = None) -> None:
+        original_prepare(args, output_stem=output_stem)
+        setattr(args, "writer", lambda *a, **kw: writer_calls.append((a, kw)))
+
+    monkeypatch.setattr(get_activities.cli, "prepare_io_paths", _prepare_io_paths)
+    monkeypatch.setattr(get_activities.cli, "configure_logger", lambda *_a, **_k: None)
+
+    logger_stub = _LoggerStub()
+    monkeypatch.setattr(get_activities, "logger", logger_stub)
+
+    exit_code = get_activities.main(
+        [
+            "--input",
+            str(input_csv),
+            "--final-out",
+            str(output_csv),
+            "--limit",
+            "5",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    assert called["value"] is False
+    assert writer_calls == []
+    assert ("info", "dry_run", {"limit": 5}) in logger_stub.events


### PR DESCRIPTION
## Summary
- add unit tests for the get_activities helper covering --limit and --dry-run handling with stubbed pipeline fetches
- add an end-to-end subprocess test for the get_activities CLI and persist its CSV/hash as recorded artifacts
- extend tests/run_tests.py to capture pytest user properties as artifacts in both JSON and Markdown reports

## Testing
- pytest tests/unit/scripts/test_get_activities_cli.py tests/e2e/test_get_activities_cli_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68e510e1f72083248e5f9a250b19f5b3