### PR TITLE
Fix assay completion handling and align activity postprocess config

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,69 +1,131 @@
 """Transformation steps for the activity postprocessing pipeline."""
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
+
 import pandas as pd
 
  
 from library.postprocess.common import StepDefinition, run_steps
 from library.postprocess.common.logging import PipelineRunMetrics
- 
+
 from library.pipelines.common.metadata import get_pipeline_version
- 
+
 from library.postprocess.common.config import (
     load_pipeline_config,
     normalize_pipeline_version,
 )
- 
+
+from library.processing.activity.bounds import _normalize_relation as _canonical_relation
+
 
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
 
-def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize string columns and enforce consistent naming."""
+def normalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    relation_normalization: bool = False,
+    enforce_uppercase_units: bool = True,
+) -> pd.DataFrame:
+    """Normalise textual activity fields and enforce consistent naming.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Raw activity frame to normalise.
+    relation_normalization : bool, optional
+        When ``True`` apply canonical mapping to ``standard_relation`` values
+        (for example ``">"``/">="`` → ``">="``). Defaults to ``False`` to
+        preserve legacy behaviour.
+    enforce_uppercase_units : bool, optional
+        When ``True`` coerce ``standard_units`` to uppercase after trimming
+        whitespace. Defaults to ``True`` for backwards compatibility.
+    """
 
     normalised = df.copy(deep=True)
     normalised.columns = [col.strip().lower() for col in normalised.columns]
 
-    for column in ["standard_type", "standard_relation", "standard_units"]:
-        if column in normalised.columns:
-            normalised[column] = (
-                normalised[column]
-                .astype("string")
-                .str.strip()
-                .str.replace("\s+", " ", regex=True)
-                .str.upper()
-            )
+    target_columns = ["standard_type", "standard_relation", "standard_units"]
+    for column in target_columns:
+        if column not in normalised.columns:
+            continue
+
+        series = (
+            normalised[column]
+            .astype("string")
+            .str.strip()
+            .str.replace(r"\s+", " ", regex=True)
+        )
+
+        if column == "standard_relation" and relation_normalization:
+            normalised[column] = series.map(_canonical_relation).astype("string")
+        else:
+            if column == "standard_units" and not enforce_uppercase_units:
+                normalised[column] = series
+            else:
+                normalised[column] = series.str.upper()
 
     return normalised
 
 
-def enrich_activity_quality(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_activity_quality(
+    df: pd.DataFrame,
+    *,
+    quality_terms: Sequence[str] | None = None,
+    default_quality_flag: bool = False,
+) -> pd.DataFrame:
     """Add deterministic quality flags based on data validity comments."""
 
     enriched = df.copy(deep=True)
+    terms = [term for term in (quality_terms or ("valid",)) if term]
+
     if "data_validity_comment" in enriched.columns:
         comment_series = enriched["data_validity_comment"].fillna("").astype("string")
-        enriched["quality_flag"] = comment_series.str.contains("valid", case=False)
+        if terms:
+            pattern = "|".join(re.escape(term) for term in terms)
+            matches = comment_series.str.contains(pattern, case=False, regex=True)
+        else:
+            matches = pd.Series(False, index=enriched.index, dtype="boolean")
+        enriched["quality_flag"] = matches.fillna(default_quality_flag)
     else:
-        enriched["quality_flag"] = False
+        enriched["quality_flag"] = pd.Series(
+            [default_quality_flag] * len(enriched), index=enriched.index, dtype="boolean"
+        )
 
     return enriched
 
 
-def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    numeric_identifier_dtype: str | type | None = "Int64",
+) -> pd.DataFrame:
     """Validate and reorder the DataFrame according to :data:`ACTIVITY_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    if "activity_id" in prepared.columns:
-        prepared["activity_id"] = pd.to_numeric(prepared["activity_id"], errors="coerce").astype(
-            "Int64"
-        )
-    for column in ["molecule_chembl_id", "assay_chembl_id", "standard_type", "standard_relation", "standard_units"]:
+    if "activity_id" in prepared.columns and numeric_identifier_dtype is not None:
+        numeric_series = pd.to_numeric(prepared["activity_id"], errors="coerce")
+        try:
+            prepared["activity_id"] = numeric_series.astype(numeric_identifier_dtype)
+        except TypeError:
+            prepared["activity_id"] = numeric_series.astype("Int64")
+
+    for column in [
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_units",
+    ]:
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
 
-    validated = validate_activities(prepared, context="activity_finalization")
-    return validated
+    if enforce_schema:
+        return validate_activities(prepared, context="activity_finalization")
+    return prepared
 
 
 PIPELINE_CONFIG = load_pipeline_config("activities")

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -441,37 +441,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     ]
     if dropped_columns_report:
         logger.info(
-        "Dropped columns from output.assay_*: %s",
-        ", ".join(dropped_columns_report),
-    )
+            "Dropped columns from output.assay_*: %s",
+            ", ".join(dropped_columns_report),
+        )
     else:
         logger.info("Dropped columns from output.assay_*: <none>")
-
-
-def _generate_assay_postprocess_metrics(
-    cfg: Config,
-    output_path: Path,
-    *,
-    logger: Logger,
-    processed_rows: int | None = None,
-):
-    """Run the postprocess pipeline for metrics and emit a JSON report."""
-
-    extras: dict[str, Any] | None = None
-    if processed_rows is not None:
-        extras = {"processed_rows": processed_rows}
-
-    return collect_postprocess_metrics(
-        table="assay",
-        output_path=output_path,
-        csv_sep=cfg.io.csv_sep,
-        csv_encoding=cfg.io.csv_encoding,
-        output_dir=cfg.io.output_dir,
-        runner=run_assay_postprocess,
-        logger=logger,
-        pipeline_version=get_pipeline_version(),
-        report_extras=extras,
-    )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)
@@ -526,6 +500,32 @@ def _generate_assay_postprocess_metrics(
         )
 
     return exit_code
+
+
+def _generate_assay_postprocess_metrics(
+    cfg: Config,
+    output_path: Path,
+    *,
+    logger: Logger,
+    processed_rows: int | None = None,
+):
+    """Run the postprocess pipeline for metrics and emit a JSON report."""
+
+    extras: dict[str, Any] | None = None
+    if processed_rows is not None:
+        extras = {"processed_rows": processed_rows}
+
+    return collect_postprocess_metrics(
+        table="assay",
+        output_path=output_path,
+        csv_sep=cfg.io.csv_sep,
+        csv_encoding=cfg.io.csv_encoding,
+        output_dir=cfg.io.output_dir,
+        runner=run_assay_postprocess,
+        logger=logger,
+        pipeline_version=get_pipeline_version(),
+        report_extras=extras,
+    )
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -69,6 +69,11 @@ class _RecordingLogger:
     def error(self, event: str, *args: object, **kwargs: object) -> None:
         self._record("error", event, args, dict(kwargs))
 
+    def exception(self, event: str, *args: object, **kwargs: object) -> None:
+        payload = dict(kwargs)
+        payload.setdefault("exc_info", True)
+        self._record("exception", event, args, payload)
+
 
 @pytest.fixture()
 def activity_resource_dir(snapshot_resource: Path) -> Path:


### PR DESCRIPTION
## Summary
- ensure `scripts/get_assay_data` logs completion details and returns the CLI exit code
- update activity postprocess steps to honour YAML parameters for relation/quality/unit handling
- extend the integration test logger stub with `exception` to match the runtime logger interface

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5114155e0832496c0e2a044339f35