### PR TITLE
Guard pref name cache updates across threads

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -19,6 +19,7 @@ import argparse
 import sys
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Callable
+from threading import Lock
 from datetime import datetime, timezone
 
 from functools import partial
@@ -124,6 +125,10 @@ _ACTIVITY_REQUIRED_DTYPES: dict[str, object] = {
 }
 
 _ORIGINAL_IO_WRITE_CSV = io.write_csv
+
+
+_CACHE_MISS = object()
+_CACHE_IN_PROGRESS = object()
 
 
 _EXTENDED_ACTIVITY_DTYPES: dict[str, str] = {
@@ -574,6 +579,7 @@ def _ensure_molecule_pref_name(
     cfg: Config,
     client: ChemblClient,
     cache: dict[str, str | None],
+    cache_lock: Lock,
     chunk_failures: ChunkFailureTracker | None = None,
 ) -> pd.DataFrame:
     """Populate ``molecule_pref_name`` via the test item API when missing."""
@@ -602,9 +608,19 @@ def _ensure_molecule_pref_name(
         return result
 
     pending: list[str] = []
-    for identifier in unique_ids:
-        if identifier not in cache:
-            pending.append(identifier)
+    wait_for: set[str] = set()
+
+    with cache_lock:
+        for identifier in unique_ids:
+            cache_key = str(identifier)
+            current = cache.get(cache_key, _CACHE_MISS)
+            if current is _CACHE_IN_PROGRESS:
+                wait_for.add(cache_key)
+                continue
+            if current is not _CACHE_MISS:
+                continue
+            cache[cache_key] = _CACHE_IN_PROGRESS
+            pending.append(cache_key)
 
     if pending:
         fields = list(cfg.testitem.fields)
@@ -631,6 +647,7 @@ def _ensure_molecule_pref_name(
             if chunk_failures is not None:
                 chunk_failures.add_failure(tuple(pending), error_message)
             lookup = pd.DataFrame(columns=["molecule_chembl_id", "pref_name"])
+        resolved: set[str] = set()
         if not lookup.empty and {"molecule_chembl_id", "pref_name"}.issubset(lookup.columns):
             mapped = (
                 lookup[["molecule_chembl_id", "pref_name"]]
@@ -638,11 +655,35 @@ def _ensure_molecule_pref_name(
                 .astype({"molecule_chembl_id": "string"})
             )
             for chembl_id, pref_name in mapped.itertuples(index=False):
-                cache[str(chembl_id)] = str(pref_name) if pd.notna(pref_name) else None
-        for identifier in pending:
-            cache.setdefault(identifier, None)
+                value = str(pref_name) if pd.notna(pref_name) else None
+                cache_key = str(chembl_id)
+                with cache_lock:
+                    cache[cache_key] = value
+                resolved.add(cache_key)
+        missing = [identifier for identifier in pending if identifier not in resolved]
+        if missing:
+            with cache_lock:
+                for identifier in missing:
+                    cache[identifier] = None
 
-    fill_map = {key: value for key, value in cache.items() if value}
+    if wait_for:
+        while True:
+            with cache_lock:
+                outstanding = [
+                    identifier
+                    for identifier in wait_for
+                    if cache.get(identifier, _CACHE_MISS) is _CACHE_IN_PROGRESS
+                ]
+            if not outstanding:
+                break
+            sleep(0)
+
+    with cache_lock:
+        fill_map = {
+            key: value
+            for key, value in cache.items()
+            if value and value is not _CACHE_IN_PROGRESS
+        }
     if not fill_map:
         return result
 
@@ -1060,6 +1101,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     last_error_context: dict[str, object] = {}
 
     pref_name_cache: dict[str, str | None] = {}
+    pref_name_cache_lock = Lock()
 
     with ETLContext(cfg) as context:
         client = context.chembl_client
@@ -1198,6 +1240,7 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
                             cfg=cfg,
                             client=client,
                             cache=pref_name_cache,
+                            cache_lock=pref_name_cache_lock,
                             chunk_failures=chunk_failures,
                         )
                 return pd.DataFrame(columns=ACTIVITY_COLUMNS)

--- a/tests/unit/test_get_activity_data.py
+++ b/tests/unit/test_get_activity_data.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import argparse
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Iterable
+from threading import Event, Lock
+from typing import Iterable, Sequence
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -13,6 +17,15 @@ import requests
 from library.pipelines.assay.chembl_assay import ACTIVITY_COLUMNS
 from library.postprocessing import activity_extended
 from scripts import get_activity_data
+
+
+def _make_pref_name_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series(["CHEMBL1", "CHEMBL2"], dtype="string"),
+            "molecule_pref_name": pd.Series([pd.NA, pd.NA], dtype="string"),
+        }
+    )
 
 
 def _make_args(tmp_path: Path) -> argparse.Namespace:
@@ -114,6 +127,89 @@ def test_run_chembl__dry_run_short_circuits(cfg, tmp_path, monkeypatch) -> None:
     ]
     assert completion_events
     assert "mode=dry_run" in completion_events[-1]
+
+
+def test_ensure_molecule_pref_name__concurrent_single_fetch(monkeypatch) -> None:
+    cfg = SimpleNamespace(
+        api=SimpleNamespace(),
+        testitem=SimpleNamespace(
+            fields=["pref_name"],
+            batch_size=10,
+            timeout=5.0,
+            request_limit=5,
+        ),
+    )
+
+    frame = _make_pref_name_frame()
+    cache: dict[str, str | None] = {}
+    cache_lock = Lock()
+
+    call_records: list[tuple[str, ...]] = []
+    ready = Event()
+    proceed = Event()
+
+    def fake_get_testitem(
+        identifiers: Sequence[str],
+        *,
+        cfg,
+        client,
+        chunk_size,
+        timeout,
+        fields,
+        page_limit,
+    ) -> pd.DataFrame:
+        call_records.append(tuple(identifiers))
+        ready.set()
+        if not proceed.wait(timeout=1):
+            pytest.fail("proceed event was not set")
+        return pd.DataFrame(
+            {
+                "molecule_chembl_id": pd.Series(
+                    [str(identifier) for identifier in identifiers], dtype="string"
+                ),
+                "pref_name": pd.Series(
+                    [f"name-{identifier}" for identifier in identifiers], dtype="string"
+                ),
+            }
+        )
+
+    monkeypatch.setattr(get_activity_data.cl, "get_testitem", fake_get_testitem)
+
+    def worker() -> pd.DataFrame:
+        return get_activity_data._ensure_molecule_pref_name(
+            frame,
+            cfg=cfg,
+            client=object(),
+            cache=cache,
+            cache_lock=cache_lock,
+        )
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(worker) for _ in range(4)]
+        if not ready.wait(timeout=1):
+            proceed.set()
+            pytest.fail("cl.get_testitem was not invoked")
+        proceed.set()
+        results = [future.result() for future in futures]
+
+    expected_series = pd.Series(["name-CHEMBL1", "name-CHEMBL2"], dtype="string")
+    for result in results:
+        pd.testing.assert_series_equal(
+            result["molecule_pref_name"],
+            expected_series.reindex(result.index),
+            check_names=False,
+        )
+
+    identifier_calls = Counter()
+    for entry in call_records:
+        identifier_calls.update(entry)
+
+    assert identifier_calls == Counter({"CHEMBL1": 1, "CHEMBL2": 1})
+    assert len(call_records) == 1
+
+    with cache_lock:
+        assert cache["CHEMBL1"] == "name-CHEMBL1"
+        assert cache["CHEMBL2"] == "name-CHEMBL2"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- guard the activity pref-name cache with a shared lock and in-progress sentinel values to avoid duplicate remote lookups
- pass the new cache lock through the activity pipeline execution path
- add a concurrency-focused unit test that asserts the Chembl test-item client is called only once per identifier

## Testing
- pytest tests/unit/test_get_activity_data.py -k concurrent -q

------
https://chatgpt.com/codex/tasks/task_e_68e515c577008324ad3709012932fe4c