### PR TITLE
Define cache sentinels for activity pipeline cache lookups

### DIFF
--- a/scripts/get_activity_data.py
+++ b/scripts/get_activity_data.py
@@ -114,6 +114,10 @@ __all__ = (
 )
 
 
+_CACHE_MISS = object()
+_CACHE_IN_PROGRESS = object()
+
+
 _ACTIVITY_REQUIRED_COLUMNS: tuple[str, ...] = tuple(
     name for name, column in ActivitiesSchema.columns.items() if column.required
 )


### PR DESCRIPTION
## Summary
- define the cache miss and in-progress sentinel objects used by the activity pipeline cache
- prevent NameError crashes when ensuring molecule preferred names during activity retrieval

## Testing
- pytest -q *(fails: tests/e2e/test_get_activities_cli_tool.py::test_get_activities_cli__subprocess_execution expects legacy output string)*

------
https://chatgpt.com/codex/tasks/task_e_68e51a2fdae0832499772773426931e1