### PR TITLE
Log CLI activity generation summary

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -94,6 +94,11 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
 
     written_path = _write_output(frame, output_path, cfg=cfg)
     logger.info(
+        "generated",
+        output=str(written_path),
+        count=int(frame.shape[0]),
+    )
+    logger.info(
         "activity_pipeline_done",
         output=str(written_path),
         rows=int(frame.shape[0]),


### PR DESCRIPTION
## Summary
- log a structured `generated` event in the activity CLI tool so the emitted row count appears in stdout

## Testing
- pytest tests/e2e/test_get_activities_cli_tool.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e51967cb688324a69e9332d8a4dacd