### PR TITLE
Handle pipeline parameters for target/document normalization

### DIFF
--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -1,6 +1,8 @@
 """Transformation steps for document postprocessing."""
 from __future__ import annotations
 
+import unicodedata
+
 import pandas as pd
  
 from library.postprocess.common import StepDefinition, run_steps
@@ -17,14 +19,32 @@ from library.postprocess.common.config import (
 from .schema import DOCUMENT_SCHEMA, validate_documents
 
 
-def normalize_document_fields(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_document_fields(
+    df: pd.DataFrame,
+    *,
+    trim_whitespace: bool = True,
+    normalise_unicode: bool = False,
+) -> pd.DataFrame:
     """Normalize whitespace and casing for textual document fields."""
 
     normalized = df.copy(deep=True)
     normalized.columns = [col.strip().lower() for col in normalized.columns]
-    for column in ["title", "journal", "doc_type"]:
-        if column in normalized.columns:
-            normalized[column] = normalized[column].astype("string").str.strip()
+
+    textual_columns = ["title", "journal", "doc_type"]
+    for column in textual_columns:
+        if column not in normalized.columns:
+            continue
+        series = normalized[column].astype("string")
+        if trim_whitespace:
+            series = series.str.strip().str.replace(r"\s+", " ", regex=True)
+        if normalise_unicode:
+            series = series.map(
+                lambda value: unicodedata.normalize("NFKC", value)
+                if not pd.isna(value)
+                else value
+            )
+        normalized[column] = series.replace({"": pd.NA})
+
     return normalized
 
 

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -17,17 +17,73 @@ from library.postprocess.common.config import (
 from .schema import TARGET_SCHEMA, validate_targets
 
 
-def normalize_target_fields(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize leading/trailing whitespace and ensure upper-case identifiers."""
+def normalize_target_fields(
+    df: pd.DataFrame,
+    *,
+    normalize_taxonomy: bool = False,
+    fill_missing_identifiers: bool = False,
+) -> pd.DataFrame:
+    """Normalize textual fields and optionally harmonise taxonomy metadata."""
 
     normalized = df.copy(deep=True)
+
     if "target_chembl_id" in normalized.columns:
-        normalized["target_chembl_id"] = (
-            normalized["target_chembl_id"].astype("string").str.strip().str.upper()
-        )
-    for column in ["pref_name", "organism"]:
+        chembl_ids = normalized["target_chembl_id"].astype("string").str.strip()
+        normalized["target_chembl_id"] = chembl_ids.str.upper()
+
+        if fill_missing_identifiers:
+            missing_mask = chembl_ids.replace({"": pd.NA}).isna()
+            fallback_columns = ["chembl_id", "target_id"]
+            for column in fallback_columns:
+                if not missing_mask.any():
+                    break
+                if column not in normalized.columns:
+                    continue
+                fallback = (
+                    normalized.loc[missing_mask, column]
+                    .astype("string")
+                    .str.strip()
+                    .replace({"": pd.NA})
+                )
+                normalized.loc[missing_mask, "target_chembl_id"] = (
+                    fallback.str.upper().fillna(normalized.loc[missing_mask, "target_chembl_id"])
+                )
+                chembl_ids = normalized["target_chembl_id"].astype("string")
+                missing_mask = chembl_ids.replace({"": pd.NA}).isna()
+
+    for column in ["pref_name", "organism", "target_type", "target_class", "protein_family", "synonyms"]:
         if column in normalized.columns:
-            normalized[column] = normalized[column].astype("string").str.strip()
+            normalized[column] = (
+                normalized[column]
+                    .astype("string")
+                    .str.strip()
+                    .replace({"": pd.NA})
+            )
+
+    if normalize_taxonomy:
+        taxonomy_columns = [
+            "organism",
+            "lineage_superkingdom",
+            "lineage_phylum",
+            "lineage_class",
+            "species_group_flag",
+        ]
+        for column in taxonomy_columns:
+            if column in normalized.columns:
+                normalized[column] = (
+                    normalized[column]
+                    .astype("string")
+                    .str.strip()
+                    .str.replace(r"\s+", " ", regex=True)
+                    .replace({"": pd.NA})
+                )
+
+        for column in ["taxon_id", "tax_id"]:
+            if column in normalized.columns:
+                normalized[column] = pd.to_numeric(
+                    normalized[column].astype("string").str.strip(), errors="coerce"
+                ).astype("Int64")
+
     return normalized
 
 

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.targets.steps import normalize_target_fields
+
+
+@pytest.mark.unit
+def test_normalize_target_fields__applies_taxonomy_and_identifier_normalization() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["  chembl123  ", None],
+            "pref_name": ["  Alpha  ", "Beta"],
+            "organism": ["  Homo sapiens  ", "  "],
+            "lineage_superkingdom": ["  Eukaryota  ", None],
+            "lineage_phylum": [None, "  Chordata"],
+            "taxon_id": [" 9606 ", ""],
+            "tax_id": ["9606", "  "],
+            "target_id": ["  chembl123  ", "CHEMBL999"],
+        }
+    )
+
+    result = normalize_target_fields(
+        frame,
+        normalize_taxonomy=True,
+        fill_missing_identifiers=True,
+    )
+
+    assert result.loc[0, "target_chembl_id"] == "CHEMBL123"
+    assert result.loc[1, "target_chembl_id"] == "CHEMBL999"
+    assert result.loc[0, "organism"] == "Homo sapiens"
+    assert pd.isna(result.loc[1, "organism"])
+    assert result.loc[0, "lineage_superkingdom"] == "Eukaryota"
+    assert result.loc[1, "lineage_phylum"] == "Chordata"
+    assert result["taxon_id"].tolist() == [9606, pd.NA]
+    assert result["tax_id"].tolist() == [9606, pd.NA]
+
+    # ensure the original dataframe was not mutated
+    assert frame.loc[0, "target_chembl_id"] == "  chembl123  "
+    assert frame.loc[1, "target_chembl_id"] is None
+
+
+@pytest.mark.unit
+def test_normalize_target_fields__without_optional_flags_preserves_extra_columns() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["chembl1"],
+            "pref_name": ["  Gamma"],
+            "taxon_id": [" 9606 "],
+        }
+    )
+
+    result = normalize_target_fields(frame)
+
+    assert result.loc[0, "target_chembl_id"] == "CHEMBL1"
+    assert result.loc[0, "pref_name"] == "Gamma"
+    assert result.loc[0, "taxon_id"] == " 9606 "

--- a/tests/unit/postprocessing/test_document_steps.py
+++ b/tests/unit/postprocessing/test_document_steps.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.documents.steps import normalize_document_fields
+
+
+@pytest.mark.unit
+def test_normalize_document_fields__applies_whitespace_and_unicode() -> None:
+    frame = pd.DataFrame(
+        {
+            "Title": ["  Cafe\u0301  "],
+            "Journal": ["  Journal   of   Testing  "],
+            "Doc_Type": ["  PREPRINT  "],
+        }
+    )
+
+    result = normalize_document_fields(
+        frame,
+        trim_whitespace=True,
+        normalise_unicode=True,
+    )
+
+    assert list(result.columns) == ["title", "journal", "doc_type"]
+    assert result.loc[0, "title"] == "Café"
+    assert result.loc[0, "journal"] == "Journal of Testing"
+    assert result.loc[0, "doc_type"] == "PREPRINT"
+    assert frame.loc[0, "Title"] == "  Cafe\u0301  "
+
+
+@pytest.mark.unit
+def test_normalize_document_fields__skips_whitespace_when_disabled() -> None:
+    frame = pd.DataFrame({"Title": ["  Example  "]})
+
+    result = normalize_document_fields(frame, trim_whitespace=False)
+
+    assert result.loc[0, "title"] == "  Example  "


### PR DESCRIPTION
## Summary
- allow the target normalization step to consume taxonomy and identifier parameters from the pipeline configuration
- update the document normalization step to honour whitespace and unicode normalisation flags
- add unit tests covering the new normalization behaviours for targets and documents

## Testing
- pytest tests/unit/postprocessing/test_document_steps.py tests/unit/postprocessing/target/test_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68e51aa1c4c483249ce96cfbe15d8579