### PR TITLE
Fix activity CLI logging and align postprocess steps with config

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,66 +1,156 @@
 """Transformation steps for the activity postprocessing pipeline."""
 from __future__ import annotations
 
+import re
+from typing import Iterable, Sequence
+
 import pandas as pd
 
- 
-from library.postprocess.common import StepDefinition, run_steps
+
+from library.postprocess.common import run_steps
 from library.postprocess.common.logging import PipelineRunMetrics
- 
+
 from library.pipelines.common.metadata import get_pipeline_version
- 
+
 from library.postprocess.common.config import (
     load_pipeline_config,
     normalize_pipeline_version,
 )
- 
+
 
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
 
-def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize string columns and enforce consistent naming."""
+def _normalise_string_series(
+    series: pd.Series,
+    *,
+    uppercase: bool = False,
+) -> pd.Series:
+    """Return ``series`` coerced to ``StringDtype`` with whitespace collapsed."""
+
+    normalised = (
+        series.astype("string")
+        .str.strip()
+        .str.replace(r"\s+", " ", regex=True)
+    )
+    if uppercase:
+        normalised = normalised.str.upper()
+    return normalised
+
+
+def normalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    relation_normalization: bool = True,
+    enforce_uppercase_units: bool = True,
+) -> pd.DataFrame:
+    """Normalize core activity metadata columns.
+
+    Parameters are aligned with :mod:`config.pipeline.activities` so callers can
+    toggle specific coercions without editing the implementation. The defaults
+    preserve the historical behaviour of trimming whitespace and uppercasing
+    relation/unit fields.
+    """
 
     normalised = df.copy(deep=True)
     normalised.columns = [col.strip().lower() for col in normalised.columns]
 
-    for column in ["standard_type", "standard_relation", "standard_units"]:
-        if column in normalised.columns:
-            normalised[column] = (
-                normalised[column]
-                .astype("string")
-                .str.strip()
-                .str.replace(r"\s+", " ", regex=True)
-                .str.upper()
-            )
+    if "standard_type" in normalised.columns:
+        normalised["standard_type"] = _normalise_string_series(
+            normalised["standard_type"], uppercase=True
+        )
+
+    if "standard_relation" in normalised.columns:
+        normalised["standard_relation"] = _normalise_string_series(
+            normalised["standard_relation"], uppercase=relation_normalization
+        )
+    if "standard_units" in normalised.columns:
+        normalised["standard_units"] = _normalise_string_series(
+            normalised["standard_units"], uppercase=enforce_uppercase_units
+        )
 
     return normalised
 
 
-def enrich_activity_quality(df: pd.DataFrame) -> pd.DataFrame:
+def _prepare_quality_terms(terms: Iterable[str] | None) -> tuple[str, ...]:
+    """Return lower-cased quality terms stripped of whitespace."""
+
+    if not terms:
+        return ()
+    prepared: list[str] = []
+    for term in terms:
+        text = str(term).strip().lower()
+        if text:
+            prepared.append(text)
+    return tuple(prepared)
+
+
+def enrich_activity_quality(
+    df: pd.DataFrame,
+    *,
+    quality_terms: Sequence[str] | None = None,
+    default_quality_flag: bool = False,
+) -> pd.DataFrame:
     """Add deterministic quality flags based on data validity comments."""
 
     enriched = df.copy(deep=True)
-    if "data_validity_comment" in enriched.columns:
-        comment_series = enriched["data_validity_comment"].fillna("").astype("string")
-        enriched["quality_flag"] = comment_series.str.contains("valid", case=False)
+    prepared_terms = _prepare_quality_terms(quality_terms)
+    if quality_terms is None and not prepared_terms:
+        effective_terms: tuple[str, ...] = ("valid",)
     else:
-        enriched["quality_flag"] = False
+        effective_terms = prepared_terms
 
+    base_flag = pd.Series(bool(default_quality_flag), index=enriched.index)
+    column = enriched.get("data_validity_comment")
+    if column is None:
+        enriched["quality_flag"] = base_flag.astype(bool)
+        return enriched
+
+    comment_series = column.fillna("").astype("string")
+    if effective_terms:
+        pattern = "|".join(re.escape(term) for term in effective_terms)
+        matches = comment_series.str.contains(pattern, case=False, regex=True)
+        quality_series = matches.fillna(bool(default_quality_flag)).astype(bool)
+    else:
+        quality_series = base_flag.astype(bool)
+
+    enriched["quality_flag"] = quality_series
     return enriched
 
 
-def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    numeric_identifier_dtype: str | type[str] = "Int64",
+) -> pd.DataFrame:
     """Validate and reorder the DataFrame according to :data:`ACTIVITY_SCHEMA`."""
 
     prepared = df.copy(deep=True)
     if "activity_id" in prepared.columns:
-        prepared["activity_id"] = pd.to_numeric(prepared["activity_id"], errors="coerce").astype(
-            "Int64"
-        )
-    for column in ["molecule_chembl_id", "assay_chembl_id", "standard_type", "standard_relation", "standard_units"]:
+        numeric = pd.to_numeric(prepared["activity_id"], errors="coerce")
+        try:
+            prepared["activity_id"] = pd.Series(
+                pd.array(numeric, dtype=numeric_identifier_dtype),
+                index=prepared.index,
+            )
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(
+                "numeric_identifier_dtype must be a valid pandas nullable integer dtype"
+            ) from exc
+
+    for column in [
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_units",
+    ]:
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if not enforce_schema:
+        return prepared
 
     validated = validate_activities(prepared, context="activity_finalization")
     return validated

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -93,6 +93,12 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         output_path = Path(output_candidate)
 
     written_path = _write_output(frame, output_path, cfg=cfg)
+    logger.info("generated", count=int(frame.shape[0]))
+    logger.info(
+        "activity_generated",
+        count=int(frame.shape[0]),
+        output=str(written_path),
+    )
     logger.info(
         "activity_pipeline_done",
         output=str(written_path),
@@ -107,6 +113,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, args, log_cfg = parse_args(argv)
     log_cfg.level = args.log_level
     structured_logger = cli.configure_logger(log_cfg)
+    if structured_logger is None:  # pragma: no cover - exercised via CLI tests
+        structured_logger = logger
     structured_logger.info("pipeline_start", run_id=log_cfg.run_id)
 
     try:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -443,37 +443,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     ]
     if dropped_columns_report:
         logger.info(
-        "Dropped columns from output.assay_*: %s",
-        ", ".join(dropped_columns_report),
-    )
+            "Dropped columns from output.assay_*: %s",
+            ", ".join(dropped_columns_report),
+        )
     else:
         logger.info("Dropped columns from output.assay_*: <none>")
-
-
-def _generate_assay_postprocess_metrics(
-    cfg: Config,
-    output_path: Path,
-    *,
-    logger: Logger,
-    processed_rows: int | None = None,
-):
-    """Run the postprocess pipeline for metrics and emit a JSON report."""
-
-    extras: dict[str, Any] | None = None
-    if processed_rows is not None:
-        extras = {"processed_rows": processed_rows}
-
-    return collect_postprocess_metrics(
-        table="assay",
-        output_path=output_path,
-        csv_sep=cfg.io.csv_sep,
-        csv_encoding=cfg.io.csv_encoding,
-        output_dir=cfg.io.output_dir,
-        runner=run_assay_postprocess,
-        logger=logger,
-        pipeline_version=get_pipeline_version(),
-        report_extras=extras,
-    )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)
@@ -528,6 +502,32 @@ def _generate_assay_postprocess_metrics(
         )
 
     return exit_status
+
+
+def _generate_assay_postprocess_metrics(
+    cfg: Config,
+    output_path: Path,
+    *,
+    logger: Logger,
+    processed_rows: int | None = None,
+):
+    """Run the postprocess pipeline for metrics and emit a JSON report."""
+
+    extras: dict[str, Any] | None = None
+    if processed_rows is not None:
+        extras = {"processed_rows": processed_rows}
+
+    return collect_postprocess_metrics(
+        table="assay",
+        output_path=output_path,
+        csv_sep=cfg.io.csv_sep,
+        csv_encoding=cfg.io.csv_encoding,
+        output_dir=cfg.io.output_dir,
+        runner=run_assay_postprocess,
+        logger=logger,
+        pipeline_version=get_pipeline_version(),
+        report_extras=extras,
+    )
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary
- align the activity postprocess step implementations with the YAML configuration by adding parameterized normalization, quality flagging, and identifier coercion behaviour
- update the get_activities CLI to emit the legacy `generated` log line, a structured activity summary, and tolerate mocked structured loggers
- ensure the assay pipeline still emits completion metrics and delegates to the postprocess metrics helper after moving the helper to a standalone function

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e516792cbc8324a7018cc9e997c26a