### PR TITLE
Fix CLI limit propagation for test item pipeline

### DIFF
--- a/scripts/get_testitem_data.py
+++ b/scripts/get_testitem_data.py
@@ -568,6 +568,8 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     options = TestitemPipelineOptions(
         input_csv=Path(args.input_csv),
         output_csv=output_path,
+        limit=getattr(args, "limit", None),
+        offset=getattr(args, "offset", None),
     )
     return run_testitem_pipeline(cfg, options)
 
@@ -597,7 +599,9 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
     if not isinstance(metadata_obj, ConfigMetadata):
         metadata_obj = None
     output_source = "cli" if getattr(args, "final_out", None) else "derived"
-    limit_value = getattr(cfg.testitem, "limit", None)
+    limit_value = getattr(args, "limit", None)
+    if limit_value is None:
+        limit_value = getattr(cfg.testitem, "limit", None)
     offset_value = getattr(args, "offset", getattr(cfg.testitem, "offset", None))
     logger.info(
         "testitem_pipeline_start",

--- a/tests/unit/test_get_testitem_data.py
+++ b/tests/unit/test_get_testitem_data.py
@@ -153,6 +153,37 @@ def test_run_chembl__passes_options(cfg: Config, tmp_path: Path, monkeypatch: py
     assert options.output_csv == output_csv
 
 
+def test_run_chembl__passes_limit_and_offset(
+    cfg: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("molecule_chembl_id\nCHEMBL1\nCHEMBL2\n", encoding="utf-8")
+    output_csv = tmp_path / "output.csv"
+
+    captured: dict[str, object] = {}
+
+    def fake_run_pipeline(config: Config, options: get_testitem_data.TestitemPipelineOptions) -> int:
+        captured["options"] = options
+        return 0
+
+    monkeypatch.setattr(get_testitem_data, "run_testitem_pipeline", fake_run_pipeline)
+
+    args = argparse.Namespace(
+        input_csv=input_csv,
+        final_out=output_csv,
+        limit=5,
+        offset=2,
+    )
+
+    exit_code = get_testitem_data.run_chembl(cfg, args)
+
+    assert exit_code == 0
+    options = captured["options"]
+    assert isinstance(options, get_testitem_data.TestitemPipelineOptions)
+    assert options.limit == 5
+    assert options.offset == 2
+
+
 def test_run__skip_existing_without_force(
     cfg: Config,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- propagate CLI limit and offset arguments to the test item pipeline options and logging metadata
- add unit coverage to ensure limit and offset are forwarded to the pipeline runner

## Testing
- pytest tests/unit/test_get_testitem_data.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e51ad85e348324962cf3e94fec2e4d