### PR TITLE
Fix activity CLI logging and postprocess parameter handling

### DIFF
--- a/library/postprocess/activities/steps.py
+++ b/library/postprocess/activities/steps.py
@@ -1,6 +1,8 @@
 """Transformation steps for the activity postprocessing pipeline."""
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import pandas as pd
 
  
@@ -18,49 +20,89 @@ from library.postprocess.common.config import (
 from .schema import ACTIVITY_SCHEMA, validate_activities
 
 
-def normalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    relation_normalization: bool = True,
+    enforce_uppercase_units: bool = True,
+) -> pd.DataFrame:
     """Normalize string columns and enforce consistent naming."""
 
     normalised = df.copy(deep=True)
     normalised.columns = [col.strip().lower() for col in normalised.columns]
 
-    for column in ["standard_type", "standard_relation", "standard_units"]:
-        if column in normalised.columns:
-            normalised[column] = (
-                normalised[column]
-                .astype("string")
-                .str.strip()
-                .str.replace(r"\s+", " ", regex=True)
-                .str.upper()
-            )
+    def _clean_column(column: str, *, uppercase: bool) -> None:
+        if column not in normalised.columns:
+            return
+        series = (
+            normalised[column]
+            .astype("string")
+            .str.strip()
+            .str.replace(r"\s+", " ", regex=True)
+        )
+        if uppercase:
+            series = series.str.upper()
+        normalised[column] = series
+
+    _clean_column("standard_type", uppercase=True)
+    _clean_column("standard_relation", uppercase=relation_normalization)
+    _clean_column("standard_units", uppercase=enforce_uppercase_units)
 
     return normalised
 
 
-def enrich_activity_quality(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_activity_quality(
+    df: pd.DataFrame,
+    *,
+    quality_terms: Sequence[str] | None = None,
+    default_quality_flag: bool = False,
+) -> pd.DataFrame:
     """Add deterministic quality flags based on data validity comments."""
 
     enriched = df.copy(deep=True)
     if "data_validity_comment" in enriched.columns:
         comment_series = enriched["data_validity_comment"].fillna("").astype("string")
-        enriched["quality_flag"] = comment_series.str.contains("valid", case=False)
+        lowered = comment_series.str.lower()
+        terms = [str(term).strip().lower() for term in quality_terms or () if str(term).strip()]
+        if not terms:
+            terms = ["valid"]
+        matches = pd.Series(False, index=lowered.index, dtype="boolean")
+        for term in terms:
+            matches = matches | lowered.str.contains(term, na=False)
+        enriched["quality_flag"] = matches.fillna(default_quality_flag)
     else:
-        enriched["quality_flag"] = False
+        enriched["quality_flag"] = bool(default_quality_flag)
 
     return enriched
 
 
-def finalize_activity_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_activity_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    numeric_identifier_dtype: str = "Int64",
+) -> pd.DataFrame:
     """Validate and reorder the DataFrame according to :data:`ACTIVITY_SCHEMA`."""
 
     prepared = df.copy(deep=True)
     if "activity_id" in prepared.columns:
-        prepared["activity_id"] = pd.to_numeric(prepared["activity_id"], errors="coerce").astype(
-            "Int64"
-        )
-    for column in ["molecule_chembl_id", "assay_chembl_id", "standard_type", "standard_relation", "standard_units"]:
+        coerced = pd.to_numeric(prepared["activity_id"], errors="coerce")
+        try:
+            prepared["activity_id"] = coerced.astype(numeric_identifier_dtype)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            prepared["activity_id"] = coerced.astype("Int64")
+    for column in [
+        "molecule_chembl_id",
+        "assay_chembl_id",
+        "standard_type",
+        "standard_relation",
+        "standard_units",
+    ]:
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
+
+    if not enforce_schema:
+        return prepared
 
     validated = validate_activities(prepared, context="activity_finalization")
     return validated

--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -93,11 +93,13 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         output_path = Path(output_candidate)
 
     written_path = _write_output(frame, output_path, cfg=cfg)
+    row_count = int(frame.shape[0])
     logger.info(
         "activity_pipeline_done",
         output=str(written_path),
-        rows=int(frame.shape[0]),
+        rows=row_count,
     )
+    logger.info("generated", count=row_count)
     return 0
 
 
@@ -107,6 +109,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser, args, log_cfg = parse_args(argv)
     log_cfg.level = args.log_level
     structured_logger = cli.configure_logger(log_cfg)
+    if structured_logger is None:  # pragma: no cover - compatibility with tests
+        structured_logger = logger
     structured_logger.info("pipeline_start", run_id=log_cfg.run_id)
 
     try:

--- a/scripts/get_assay_data.py
+++ b/scripts/get_assay_data.py
@@ -443,37 +443,11 @@ def run_chembl(cfg: Config, args: argparse.Namespace) -> int:
     ]
     if dropped_columns_report:
         logger.info(
-        "Dropped columns from output.assay_*: %s",
-        ", ".join(dropped_columns_report),
-    )
+            "Dropped columns from output.assay_*: %s",
+            ", ".join(dropped_columns_report),
+        )
     else:
         logger.info("Dropped columns from output.assay_*: <none>")
-
-
-def _generate_assay_postprocess_metrics(
-    cfg: Config,
-    output_path: Path,
-    *,
-    logger: Logger,
-    processed_rows: int | None = None,
-):
-    """Run the postprocess pipeline for metrics and emit a JSON report."""
-
-    extras: dict[str, Any] | None = None
-    if processed_rows is not None:
-        extras = {"processed_rows": processed_rows}
-
-    return collect_postprocess_metrics(
-        table="assay",
-        output_path=output_path,
-        csv_sep=cfg.io.csv_sep,
-        csv_encoding=cfg.io.csv_encoding,
-        output_dir=cfg.io.output_dir,
-        runner=run_assay_postprocess,
-        logger=logger,
-        pipeline_version=get_pipeline_version(),
-        report_extras=extras,
-    )
 
     if limit is not None:
         logger.info("process_limit", limit=processed_ids)
@@ -528,6 +502,32 @@ def _generate_assay_postprocess_metrics(
         )
 
     return exit_status
+
+
+def _generate_assay_postprocess_metrics(
+    cfg: Config,
+    output_path: Path,
+    *,
+    logger: Logger,
+    processed_rows: int | None = None,
+):
+    """Run the postprocess pipeline for metrics and emit a JSON report."""
+
+    extras: dict[str, Any] | None = None
+    if processed_rows is not None:
+        extras = {"processed_rows": processed_rows}
+
+    return collect_postprocess_metrics(
+        table="assay",
+        output_path=output_path,
+        csv_sep=cfg.io.csv_sep,
+        csv_encoding=cfg.io.csv_encoding,
+        output_dir=cfg.io.output_dir,
+        runner=run_assay_postprocess,
+        logger=logger,
+        pipeline_version=get_pipeline_version(),
+        report_extras=extras,
+    )
 
 
 def run(cfg: Config, args: argparse.Namespace) -> int:

--- a/tests/integration/test_get_activity_data_pipeline.py
+++ b/tests/integration/test_get_activity_data_pipeline.py
@@ -69,6 +69,11 @@ class _RecordingLogger:
     def error(self, event: str, *args: object, **kwargs: object) -> None:
         self._record("error", event, args, dict(kwargs))
 
+    def exception(self, event: str, *args: object, **kwargs: object) -> None:
+        payload = dict(kwargs)
+        payload.setdefault("exc_info", True)
+        self._record("error", event, args, payload)
+
 
 @pytest.fixture()
 def activity_resource_dir(snapshot_resource: Path) -> Path:


### PR DESCRIPTION
## Summary
- allow activity postprocess steps to accept configuration parameters and normalise fields accordingly
- ensure the get-activities CLI always logs pipeline start and generated counts even when the logger factory is stubbed
- restore assay pipeline completion logging and return code propagation while keeping integration stubs compatible

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e517dee0ec832490b8695f84995b68