### PR TITLE
Handle unsupported postprocess step parameters gracefully

### DIFF
--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -1,6 +1,7 @@
 """Orchestration helpers for executing post-processing pipelines."""
 from __future__ import annotations
 
+import inspect
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from time import perf_counter
@@ -86,6 +87,47 @@ def _record_error(
     )
 
 
+def _prepare_step_arguments(
+    func: Any,
+    params: Mapping[str, Any],
+    *,
+    logger,
+    step_name: str,
+) -> dict[str, Any]:
+    """Return a mapping limited to arguments accepted by ``func``."""
+
+    if not params:
+        return {}
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - fallback for builtins
+        return dict(params)
+
+    has_var_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+    accepted: dict[str, Any] = {}
+    ignored: list[str] = []
+
+    for key, value in params.items():
+        if key in signature.parameters or has_var_kwargs:
+            accepted[key] = value
+        else:
+            ignored.append(key)
+
+    if ignored:
+        logger.warning(
+            "Step %s ignoring unsupported parameters: %s",
+            step_name,
+            ", ".join(sorted(ignored)),
+        )
+
+    return accepted
+
+
 def run_steps(
     df: pd.DataFrame,
     steps: Iterable[StepDefinition | StepTuple],
@@ -122,6 +164,12 @@ def run_steps(
 
     for index, step in enumerate(normalised_steps):
         params = dict(step.params)
+        call_params = _prepare_step_arguments(
+            step.func,
+            params,
+            logger=log,
+            step_name=step.name,
+        )
         frame = clone_dataframe(current)
         step_started_at = _now_iso()
         step_clock = perf_counter()
@@ -132,7 +180,7 @@ def run_steps(
         log.info("Starting step %s", step.name)
 
         try:
-            result = step.func(frame, **params)
+            result = step.func(frame, **call_params)
         except SchemaValidationError as exc:
             log.exception("Schema validation failed during step %s", step.name)
             _record_error(

--- a/tests/unit/postprocessing/test_runner.py
+++ b/tests/unit/postprocessing/test_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
 import pytest
 
@@ -94,3 +96,28 @@ def test_run_steps__accepts_tuple_step_specification() -> None:
     assert final["value"].tolist() == [10, 10]
     assert metadata.steps[0].name == "_with_constant"
     assert metadata.steps[0].parameters == {"column": "value", "value": 10}
+
+
+def test_run_steps__ignores_unsupported_parameters(caplog: pytest.LogCaptureFixture) -> None:
+    frame = pd.DataFrame({"seed": [5]}, dtype="int64")
+
+    steps = (
+        StepDefinition(
+            name="with_constant",
+            func=_with_constant,
+            params={"column": "value", "value": 7, "unexpected": "ignored"},
+        ),
+    )
+
+    test_logger = logging.getLogger("tests.postprocess.runner")
+    test_logger.handlers.clear()
+    test_logger.propagate = True
+
+    with caplog.at_level("WARNING", logger="tests.postprocess.runner"):
+        result, metadata = run_steps(frame, steps, logger=test_logger)
+
+    assert result["value"].tolist() == [7]
+    assert any(
+        "ignoring unsupported parameters" in record.message for record in caplog.records
+    )
+    assert metadata.steps[0].parameters["unexpected"] == "ignored"


### PR DESCRIPTION
## Summary
- guard post-processing step execution against unexpected parameters by filtering them and logging a warning
- add a unit test covering the new behaviour when extra parameters are supplied

## Testing
- pytest tests/unit/postprocessing/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e51d841ee88324aaecfa6d90cded81