### PR TITLE
Add identifier details to testitem enrichment missing flag logs

### DIFF
--- a/library/pipelines/testitem/enrichment.py
+++ b/library/pipelines/testitem/enrichment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,6 +58,18 @@ def _coerce_flag_values(series: pd.Series, column: str) -> tuple[pd.Series, set[
             result.append(pd.NA)
             unknown.add(text_lower)
     return pd.Series(result, index=series.index, dtype="boolean"), unknown
+
+
+def _summarise_identifiers(
+    values: Sequence[str], *, limit: int = 20
+) -> tuple[list[str], bool]:
+    """Return a truncated list of identifiers and whether truncation occurred."""
+
+    identifiers = list(values)
+    truncated = len(identifiers) > limit
+    if truncated:
+        identifiers = identifiers[:limit]
+    return identifiers, truncated
 
 
 def _load_sources(
@@ -212,14 +225,24 @@ def enrich(
             {value for value in parent_ids.dropna() if value not in known_ids}
         )
         if missing_children:
+            child_identifiers, child_truncated = _summarise_identifiers(
+                missing_children
+            )
             logger.warning(
                 "testitem_enrichment_missing_child_flags",
                 count=len(missing_children),
+                identifiers=child_identifiers,
+                truncated=child_truncated,
             )
         if missing_parents:
+            parent_identifiers, parent_truncated = _summarise_identifiers(
+                missing_parents
+            )
             logger.warning(
                 "testitem_enrichment_missing_parent_flags",
                 count=len(missing_parents),
+                identifiers=parent_identifiers,
+                truncated=parent_truncated,
             )
 
     for column, values in unknown_flags.items():

--- a/tests/integration/test_enrichment.py
+++ b/tests/integration/test_enrichment.py
@@ -45,7 +45,16 @@ def test_enrich__attaches_flags_and_parent(
     assert enriched["salt_chembl_id"].tolist() == ["CHEMBL1", pd.NA, "CHEMBL3"]
     assert enriched["natural_product"].dtype == "boolean"
     assert enriched["natural_product"].tolist() == [True, pd.NA, False]
-    assert any(event == "testitem_enrichment_missing_child_flags" for event, _ in events)
+    missing_child_event = next(
+        fields
+        for event, fields in events
+        if event == "testitem_enrichment_missing_child_flags"
+    )
+    assert missing_child_event == {
+        "count": 2,
+        "identifiers": ["CHEMBL2", "CHEMBL3"],
+        "truncated": False,
+    }
 
 
 @pytest.mark.integration
@@ -111,3 +120,58 @@ def test_enrich__missing_sources_gracefully_fills_columns(
     assert enriched["natural_product"].dtype == "boolean"
     assert events.count("testitem_enrichment_missing_hierarchy") == 1
     assert events.count("testitem_enrichment_missing_catalog") == 1
+
+
+@pytest.mark.integration
+def test_enrich__logs_missing_parent_identifiers(
+    tmp_path: Path, cfg, snapshot_resource, monkeypatch
+) -> None:
+    cfg.testitem_molecule_enrichment.enable = True
+    cfg.testitem_molecule_enrichment.sources.molecule_catalog_path = (
+        snapshot_resource / "molecule_catalog.csv"
+    )
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = (
+        snapshot_resource / "molecule_hierarchy.csv"
+    )
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **fields: object) -> None:
+        events.append((event, fields))
+
+    monkeypatch.setattr(enrichment.logger, "warning", _capture)
+
+    frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL999"],
+            "parent_molecule_chembl_id": ["CHEMBL404"],
+        }
+    )
+
+    enrichment.enrich(
+        frame,
+        cfg=cfg.testitem_molecule_enrichment,
+        io_cfg=cfg.io,
+    )
+
+    missing_child_event = next(
+        fields
+        for event, fields in events
+        if event == "testitem_enrichment_missing_child_flags"
+    )
+    missing_parent_event = next(
+        fields
+        for event, fields in events
+        if event == "testitem_enrichment_missing_parent_flags"
+    )
+
+    assert missing_child_event == {
+        "count": 1,
+        "identifiers": ["CHEMBL999"],
+        "truncated": False,
+    }
+    assert missing_parent_event == {
+        "count": 1,
+        "identifiers": ["CHEMBL404"],
+        "truncated": False,
+    }


### PR DESCRIPTION
## Summary
- include truncated identifier lists in missing flag warnings for the testitem enrichment pipeline
- extend integration coverage to verify warning payloads for missing child and parent identifiers

## Testing
- pytest tests/integration/test_enrichment.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e51df917b08324a3a1717723ae33ef