### PR TITLE
Include identifiers in enrichment missing flag warnings

### DIFF
--- a/library/pipelines/testitem/enrichment.py
+++ b/library/pipelines/testitem/enrichment.py
@@ -215,11 +215,13 @@ def enrich(
             logger.warning(
                 "testitem_enrichment_missing_child_flags",
                 count=len(missing_children),
+                identifiers=missing_children,
             )
         if missing_parents:
             logger.warning(
                 "testitem_enrichment_missing_parent_flags",
                 count=len(missing_parents),
+                identifiers=missing_parents,
             )
 
     for column, values in unknown_flags.items():

--- a/tests/integration/test_enrichment.py
+++ b/tests/integration/test_enrichment.py
@@ -45,7 +45,12 @@ def test_enrich__attaches_flags_and_parent(
     assert enriched["salt_chembl_id"].tolist() == ["CHEMBL1", pd.NA, "CHEMBL3"]
     assert enriched["natural_product"].dtype == "boolean"
     assert enriched["natural_product"].tolist() == [True, pd.NA, False]
-    assert any(event == "testitem_enrichment_missing_child_flags" for event, _ in events)
+    missing_child_events = [
+        fields for event, fields in events if event == "testitem_enrichment_missing_child_flags"
+    ]
+    assert missing_child_events == [
+        {"count": 2, "identifiers": ["CHEMBL2", "CHEMBL3"]}
+    ]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- include the missing molecule identifiers in enrichment missing flag warnings so investigations have actionable context
- extend the enrichment integration test to assert the warning payload now includes identifiers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e51e23dad88324876434e782750fb1