### PR TITLE
Handle document publication year enrichment parameters

### DIFF
--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -48,16 +48,91 @@ def normalize_document_fields(
     return normalized
 
 
-def enrich_document_publication_year(df: pd.DataFrame) -> pd.DataFrame:
-    """Create a deterministic ``publication_year`` column."""
+_YEAR_VALID_RANGE = (1600, 2100)
+
+
+def _coerce_year(series: pd.Series) -> pd.Series:
+    """Return a nullable integer series containing plausible year values."""
+
+    numeric = pd.to_numeric(series, errors="coerce")
+    if numeric.empty:
+        return pd.Series(pd.NA, index=series.index, dtype="Int64")
+
+    lower, upper = _YEAR_VALID_RANGE
+    mask = numeric.between(lower, upper)
+    cleaned = numeric.where(mask)
+    return cleaned.round().astype("Int64")
+
+
+def enrich_document_publication_year(
+    df: pd.DataFrame,
+    *,
+    fallback_year: int | None = None,
+    prefer_doi_year: bool = False,
+    **_: object,
+) -> pd.DataFrame:
+    """Create a deterministic ``publication_year`` column.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame produced by earlier pipeline steps.
+    fallback_year:
+        Optional numeric year to use when no source provides a valid value.
+    prefer_doi_year:
+        When ``True``, favour years originating from external DOI metadata over the
+        ChEMBL export column.
+    """
+
+    if fallback_year is not None:
+        try:
+            fallback_value = int(fallback_year)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("fallback_year must be an integer") from exc
+        if not (_YEAR_VALID_RANGE[0] <= fallback_value <= _YEAR_VALID_RANGE[1]):
+            raise ValueError(
+                "fallback_year must be within the supported range "
+                f"{_YEAR_VALID_RANGE[0]}-{_YEAR_VALID_RANGE[1]}"
+            )
+    else:
+        fallback_value = None
 
     enriched = df.copy(deep=True)
-    if "year" in enriched.columns:
-        enriched["publication_year"] = pd.to_numeric(
-            enriched["year"], errors="coerce"
-        ).astype("Int64")
+    # Determine priority order for candidate columns.
+    supplemental_sources = [
+        "crossref.year",
+        "crossref.published",
+        "openalex.publication_year",
+        "openalex.year",
+        "scholar.year",
+        "pubmed.yearcompleted",
+        "pubmed.yearrevised",
+        "pubmed.year",
+    ]
+    primary_sources = ["year"]
+
+    if prefer_doi_year:
+        ordered_candidates = supplemental_sources + primary_sources
     else:
-        enriched["publication_year"] = pd.Series([pd.NA] * len(enriched), dtype="Int64")
+        ordered_candidates = primary_sources + supplemental_sources
+
+    publication_year = pd.Series(pd.NA, index=enriched.index, dtype="Int64")
+
+    for column in ordered_candidates:
+        if column not in enriched.columns:
+            continue
+        candidate = _coerce_year(enriched[column])
+        if candidate.isna().all():
+            continue
+        publication_year = publication_year.fillna(candidate)
+        if not publication_year.isna().any():
+            break
+
+    if fallback_value is not None:
+        fallback_series = pd.Series(fallback_value, index=enriched.index, dtype="Int64")
+        publication_year = publication_year.fillna(fallback_series)
+
+    enriched["publication_year"] = publication_year
     return enriched
 
 

--- a/tests/unit/postprocessing/test_document_steps.py
+++ b/tests/unit/postprocessing/test_document_steps.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from library.postprocess.documents.steps import normalize_document_fields
+from library.postprocess.documents.steps import (
+    enrich_document_publication_year,
+    normalize_document_fields,
+)
 
 
 @pytest.mark.unit
@@ -36,3 +39,36 @@ def test_normalize_document_fields__skips_whitespace_when_disabled() -> None:
     result = normalize_document_fields(frame, trim_whitespace=False)
 
     assert result.loc[0, "title"] == "  Example  "
+
+
+@pytest.mark.unit
+def test_enrich_document_publication_year__uses_year_and_fallback() -> None:
+    frame = pd.DataFrame({"year": ["2010", pd.NA, ""]})
+
+    result = enrich_document_publication_year(frame, fallback_year=1999)
+
+    expected = pd.Series([2010, 1999, 1999], dtype="Int64")
+    pd.testing.assert_series_equal(result["publication_year"], expected, check_names=False)
+
+
+@pytest.mark.unit
+def test_enrich_document_publication_year__prefers_external_sources_when_requested() -> None:
+    frame = pd.DataFrame(
+        {
+            "year": ["2001", "2002"],
+            "pubmed.yearcompleted": ["2005", pd.NA],
+        }
+    )
+
+    result = enrich_document_publication_year(frame, prefer_doi_year=True)
+
+    expected = pd.Series([2005, 2002], dtype="Int64")
+    pd.testing.assert_series_equal(result["publication_year"], expected, check_names=False)
+
+
+@pytest.mark.unit
+def test_enrich_document_publication_year__validates_fallback_range() -> None:
+    frame = pd.DataFrame({"year": [pd.NA]})
+
+    with pytest.raises(ValueError, match="supported range"):
+        enrich_document_publication_year(frame, fallback_year=1400)


### PR DESCRIPTION
## Summary
- accept configuration parameters in `enrich_document_publication_year` and apply prioritized year selection with validation
- add unit tests covering fallback handling, external year preference, and invalid configuration values

## Testing
- `pytest tests/unit/postprocessing/test_document_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_68e51ec2035083248eafe7834ca0050a