### PR TITLE
Fix chunk failure tracker stats and resolver compatibility

### DIFF
--- a/library/common/fetch_retry.py
+++ b/library/common/fetch_retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final
+from typing import Any
 
 from ..config import Config, RetryCfg
 from ..sidecar import SidecarErrors
@@ -17,9 +17,6 @@ class _ChunkFailure:
 
     chunk_ids: list[str]
     error: str
-
-
-_EMPTY_STATS: Final[dict[str, Any]] = {}
 
 
 class ChunkFailureTracker:
@@ -47,7 +44,7 @@ class ChunkFailureTracker:
         """Return aggregated statistics for persisted metadata files."""
 
         if not self._failures:
-            return _EMPTY_STATS
+            return {}
         unique_ids = sorted(
             {
                 identifier

--- a/library/postprocess/common/import_utils.py
+++ b/library/postprocess/common/import_utils.py
@@ -83,10 +83,19 @@ def _format_expected_type(expected: type | tuple[type, ...]) -> str:
 
 
 
-def resolve_dotted_path(path: str) -> Any:
-    """Backward compatible alias for :func:`import_by_path`."""
+def resolve_dotted_path(
+    path: str,
+    expected_type: type | tuple[type, ...] | object = _DEFAULT_SENTINEL,
+) -> Any:
+    """Backward compatible alias for :func:`import_by_path`.
 
-    return import_by_path(path)
+    Legacy declarative pipeline configurations may invoke
+    :func:`resolve_dotted_path` with an ``expected_type`` argument.  The
+    helper mirrors :func:`import_by_path` so that both modern and legacy call
+    sites behave identically.
+    """
+
+    return import_by_path(path, expected_type=expected_type)
 
 
 __all__ = ["ImportResolutionError", "import_by_path", "resolve_dotted_path"]

--- a/tests/unit/test_fetch_retry.py
+++ b/tests/unit/test_fetch_retry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from library.common.fetch_retry import compute_backoff_delay
+from library.common.fetch_retry import ChunkFailureTracker, compute_backoff_delay
 from library.config import RetryCfg
 
 
@@ -26,3 +26,27 @@ def test_compute_backoff_delay__adds_jitter_before_cap() -> None:
     expected = min(base_delay + jitter(retry_cfg.backoff_factor), retry_cfg.backoff_cap)
 
     assert compute_backoff_delay(attempt, retry_cfg) == pytest.approx(expected)
+
+
+def test_chunk_failure_tracker_stats__returns_fresh_mapping_when_empty() -> None:
+    tracker = ChunkFailureTracker()
+
+    first = tracker.stats()
+    first["custom"] = "value"
+
+    second = tracker.stats()
+
+    assert first is not second
+    assert second == {}
+
+
+def test_chunk_failure_tracker_stats__does_not_share_lists() -> None:
+    tracker = ChunkFailureTracker()
+    tracker.add_failure(["A", "B"], "boom")
+
+    first = tracker.stats()
+    first["chunk_fetch_failure_ids"].append("C")
+
+    second = tracker.stats()
+
+    assert second["chunk_fetch_failure_ids"] == ["A", "B"]

--- a/tests/unit/test_import_utils.py
+++ b/tests/unit/test_import_utils.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 
 import pytest
 
-from library.postprocess.common.import_utils import ImportResolutionError, import_by_path
+from pathlib import Path
+
+from library.postprocess.common.import_utils import (
+    ImportResolutionError,
+    import_by_path,
+    resolve_dotted_path,
+)
 
 
 @pytest.mark.unit
@@ -42,3 +48,16 @@ def test_import_by_path__custom_expected_type() -> None:
     value = import_by_path("math:pi", expected_type=(int, float))
 
     assert isinstance(value, float)
+
+
+@pytest.mark.unit
+def test_resolve_dotted_path__supports_expected_type_argument() -> None:
+    result = resolve_dotted_path("pathlib.Path", expected_type=type)
+
+    assert result is Path
+
+
+@pytest.mark.unit
+def test_resolve_dotted_path__raises_for_unmatched_expected_type() -> None:
+    with pytest.raises(ImportResolutionError):
+        resolve_dotted_path("pathlib.Path", expected_type=int)


### PR DESCRIPTION
## Summary
- ensure `ChunkFailureTracker.stats` returns a fresh mapping to avoid shared state mutations
- allow `resolve_dotted_path` to accept an `expected_type` argument for legacy YAML compatibility
- extend unit coverage for the updated fetch retry tracker and resolver helper

## Testing
- `pytest tests/unit/test_import_utils.py tests/unit/test_fetch_retry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e51dd1904c832487ffcd6bb6f0b3dd