### PR TITLE
Gracefully handle missing assay taxonomy dictionary

### DIFF
--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -18,19 +18,49 @@ from library.postprocess.common.config import (
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
-def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize string-based assay descriptors."""
+def normalize_assay_metadata(
+    df: pd.DataFrame,
+    *,
+    uppercase_categories: bool = True,
+    strip_whitespace: bool = True,
+    collapse_internal_whitespace: bool | None = None,
+) -> pd.DataFrame:
+    """Normalize string-based assay descriptors.
+
+    Parameters
+    ----------
+    df:
+        Input frame to normalize.
+    uppercase_categories:
+        When ``True`` (the default) categorical assay descriptors are converted to
+        upper-case.  Set to ``False`` to preserve the original casing while still
+        applying other configured clean-up rules.
+    strip_whitespace:
+        Remove leading and trailing whitespace around categorical values.  Enabled
+        by default for backwards compatibility with historical exports.
+    collapse_internal_whitespace:
+        Normalise consecutive whitespace characters inside categorical values.  If
+        ``None`` the value defaults to ``strip_whitespace`` to preserve the legacy
+        behaviour where both operations happened together.  Pass ``True`` or
+        ``False`` explicitly to override the coupling.
+    """
 
     normalized = df.copy(deep=True)
+    if collapse_internal_whitespace is None:
+        collapse_internal_whitespace = strip_whitespace
+
     for column in ["assay_type", "assay_test_type", "assay_format"]:
-        if column in normalized.columns:
-            normalized[column] = (
-                normalized[column]
-                .astype("string")
-                .str.strip()
-                .str.replace(r"\s+", " ", regex=True)
-                .str.upper()
-            )
+        if column not in normalized.columns:
+            continue
+
+        series = normalized[column].astype("string")
+        if strip_whitespace:
+            series = series.str.strip()
+        if collapse_internal_whitespace:
+            series = series.str.replace(r"\s+", " ", regex=True)
+        if uppercase_categories:
+            series = series.str.upper()
+        normalized[column] = series
     return normalized
 
 

--- a/library/postprocessing/assay_extended.py
+++ b/library/postprocessing/assay_extended.py
@@ -106,10 +106,19 @@ def _load_taxonomy_lookup_cached(dictionary_root: str) -> pd.DataFrame:
     root = Path(dictionary_root)
     candidate = root / "_taxonomy" / "taxonomy.csv"
     if not candidate.exists():
-        raise AssayExtendedError(
-            "taxonomy.csv not found; expected at "
-            f"'{candidate}'. Provide dictionary_dir pointing to the bundled dictionaries."
-    )
+        logger.warning(
+            "assay_extended_missing_taxonomy_dictionary",
+            path=str(candidate),
+            dictionary_root=str(root),
+        )
+        empty = pd.DataFrame(
+            {
+                "assay_tax_id": pd.Series(dtype="string"),
+                "assay_group_taxonomy": pd.Series(dtype="string"),
+                "assay_strain_taxonomy": pd.Series(dtype="string"),
+            }
+        )
+        return empty
 
     frame = helpers.read_csv_with_fallbacks(candidate)
     aliases = {

--- a/tests/postprocessing/test_assay_extended.py
+++ b/tests/postprocessing/test_assay_extended.py
@@ -90,7 +90,9 @@ def test_enrich_assay_metadata__fills_missing_fields(tmp_path: Path) -> None:
 
 
 @pytest.mark.postprocessing
-def test_enrich_assay_metadata__missing_taxonomy_dir_raises(tmp_path: Path) -> None:
+def test_enrich_assay_metadata__missing_taxonomy_dir_logs_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     dictionary_root = tmp_path
     (dictionary_root / "_assay").mkdir()
     (dictionary_root / "_document").mkdir()
@@ -108,5 +110,30 @@ def test_enrich_assay_metadata__missing_taxonomy_dir_raises(tmp_path: Path) -> N
 
     frame = pd.DataFrame({"assay_chembl_id": ["CHEMBL1"]})
 
-    with pytest.raises(AssayExtendedError):
-        enrich_assay_metadata(frame, dictionary_dir=dictionary_root)
+    with caplog.at_level("WARNING"):
+        result = enrich_assay_metadata(frame, dictionary_dir=dictionary_root)
+
+    assert "assay_extended_missing_taxonomy_dictionary" in caplog.text
+    assert list(result.columns) == [
+        "assay_chembl_id",
+        "assay_tax_id",
+        "assay_group",
+        "assay_strain",
+        "target_chembl_id",
+        "document_chembl_id",
+        "year",
+        "accession",
+    ]
+    assert result.loc[0, "assay_chembl_id"] == "CHEMBL1"
+    assert result["assay_tax_id"].isna().all()
+    assert result["assay_group"].isna().all()
+    assert result["assay_strain"].isna().all()
+    assert result["target_chembl_id"].isna().all()
+    assert result["document_chembl_id"].isna().all()
+    assert result["accession"].isna().all()
+    assert result["year"].isna().all()
+    assert str(result["assay_tax_id"].dtype) == "string"
+    assert str(result["assay_group"].dtype) == "string"
+    assert str(result["assay_strain"].dtype) == "string"
+    assert str(result["accession"].dtype) == "string"
+    assert str(result["year"].dtype) == "Int64"

--- a/tests/postprocessing/test_assay_steps.py
+++ b/tests/postprocessing/test_assay_steps.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.assays.steps import normalize_assay_metadata
+
+
+@pytest.mark.postprocessing
+@pytest.mark.usefixtures("deterministic_env")
+def test_normalize_assay_metadata__default_normalization() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["  primary  screen  "],
+            "assay_test_type": [" confirmatory   "],
+            "assay_format": [" cell based"],
+        }
+    )
+
+    result = normalize_assay_metadata(frame)
+
+    assert result.loc[0, "assay_type"] == "PRIMARY SCREEN"
+    assert result.loc[0, "assay_test_type"] == "CONFIRMATORY"
+    assert result.loc[0, "assay_format"] == "CELL BASED"
+    assert str(result["assay_type"].dtype) == "string"
+
+
+@pytest.mark.postprocessing
+@pytest.mark.usefixtures("deterministic_env")
+def test_normalize_assay_metadata__respects_disabled_flags() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["  primary  screen  "],
+            "assay_test_type": [" confirmatory   "],
+            "assay_format": [" cell based"],
+        }
+    )
+
+    result = normalize_assay_metadata(
+        frame,
+        uppercase_categories=False,
+        strip_whitespace=False,
+        collapse_internal_whitespace=False,
+    )
+
+    assert result.loc[0, "assay_type"] == "  primary  screen  "
+    assert result.loc[0, "assay_test_type"] == " confirmatory   "
+    assert result.loc[0, "assay_format"] == " cell based"
+    assert str(result["assay_type"].dtype) == "string"


### PR DESCRIPTION
## Summary
- log a warning and continue when the taxonomy dictionary is absent during assay enrichment
- allow `normalize_assay_metadata` to honour configuration flags and document the supported options
- add regression tests covering the missing-taxonomy flow and normalization overrides

## Testing
- pytest tests/postprocessing/test_assay_extended.py tests/postprocessing/test_assay_steps.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e52063bd3483249df61d75b62c4802