### PR TITLE
Handle missing assay taxonomy dictionary gracefully

### DIFF
--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,6 +1,9 @@
 """Transformation steps for assay postprocessing."""
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable
+
 import pandas as pd
 
  
@@ -18,46 +21,76 @@ from library.postprocess.common.config import (
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
-def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
+def normalize_assay_metadata(
+    df: pd.DataFrame,
+    *,
+    uppercase_categories: bool = True,
+    strip_whitespace: bool = True,
+    collapse_internal_whitespace: bool = True,
+) -> pd.DataFrame:
     """Normalize string-based assay descriptors."""
 
     normalized = df.copy(deep=True)
     for column in ["assay_type", "assay_test_type", "assay_format"]:
-        if column in normalized.columns:
-            normalized[column] = (
-                normalized[column]
-                .astype("string")
-                .str.strip()
-                .str.replace(r"\s+", " ", regex=True)
-                .str.upper()
-            )
+        if column not in normalized.columns:
+            continue
+        series = normalized[column].astype("string")
+        if strip_whitespace:
+            series = series.str.strip()
+        if collapse_internal_whitespace:
+            series = series.str.replace(r"\s+", " ", regex=True)
+        if uppercase_categories:
+            series = series.str.upper()
+        normalized[column] = series
     return normalized
 
 
-def enrich_assay_flags(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_assay_flags(
+    df: pd.DataFrame,
+    *,
+    confirmatory_terms: Iterable[str] | None = None,
+    default_flag: bool = False,
+) -> pd.DataFrame:
     """Introduce confirmatory flag based on assay type information."""
 
     enriched = df.copy(deep=True)
     type_series = enriched.get("assay_type")
-    if type_series is not None:
-        enriched["is_confirmatory"] = type_series.astype("string").str.contains(
-            "CONFIRM", case=False, na=False
-        )
-    else:
-        enriched["is_confirmatory"] = False
+    if type_series is None:
+        enriched["is_confirmatory"] = bool(default_flag)
+        return enriched
+
+    terms = tuple(term for term in (confirmatory_terms or ()) if term)
+    enriched["is_confirmatory"] = bool(default_flag)
+    if not terms:
+        return enriched
+
+    pattern = "|".join(re.escape(term) for term in terms)
+    matches = type_series.astype("string").str.contains(
+        pattern,
+        case=False,
+        na=False,
+    )
+    enriched.loc[matches, "is_confirmatory"] = True
     return enriched
 
 
-def finalize_assay_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_assay_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    normalize_identifiers: bool = True,
+) -> pd.DataFrame:
     """Apply schema validation and deterministic ordering."""
 
     prepared = df.copy(deep=True)
-    for column in ["assay_chembl_id", "assay_type", "assay_test_type", "description"]:
-        if column in prepared.columns:
-            prepared[column] = prepared[column].astype("string")
+    if normalize_identifiers:
+        for column in ["assay_chembl_id", "assay_type", "assay_test_type", "description"]:
+            if column in prepared.columns:
+                prepared[column] = prepared[column].astype("string")
 
-    validated = validate_assays(prepared, context="assay_finalization")
-    return validated
+    if enforce_schema:
+        return validate_assays(prepared, context="assay_finalization")
+    return prepared
 
 
 PIPELINE_CONFIG = load_pipeline_config("assays")

--- a/library/postprocess/common/types.py
+++ b/library/postprocess/common/types.py
@@ -11,7 +11,7 @@ import pandas as pd
 class StepFn(Protocol):
     """Protocol describing a pure DataFrame transformation."""
 
-    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, df: pd.DataFrame, /, **kwargs: Any) -> pd.DataFrame:
         """Return a new :class:`pandas.DataFrame` derived from ``df``."""
 
 

--- a/library/postprocessing/assay_extended.py
+++ b/library/postprocessing/assay_extended.py
@@ -10,6 +10,7 @@ from typing import Iterable, Sequence
 import pandas as pd
 
 from library.common.log import logger
+from library.resources.dictionaries import DictionaryManifestError, get_resource_path
 
 from . import helpers
 
@@ -106,10 +107,17 @@ def _load_taxonomy_lookup_cached(dictionary_root: str) -> pd.DataFrame:
     root = Path(dictionary_root)
     candidate = root / "_taxonomy" / "taxonomy.csv"
     if not candidate.exists():
-        raise AssayExtendedError(
-            "taxonomy.csv not found; expected at "
-            f"'{candidate}'. Provide dictionary_dir pointing to the bundled dictionaries."
-    )
+        fallback = _resolve_taxonomy_fallback(root)
+        if fallback is None:
+            raise AssayExtendedError(
+                "taxonomy.csv not found; expected at "
+                f"'{candidate}'. Provide dictionary_dir pointing to the bundled dictionaries."
+            )
+        logger.warning(
+            "taxonomy.csv missing under \"%s\"; continuing without taxonomy enrichment",
+            root,
+        )
+        return fallback
 
     frame = helpers.read_csv_with_fallbacks(candidate)
     aliases = {
@@ -146,6 +154,38 @@ def _load_taxonomy_lookup_cached(dictionary_root: str) -> pd.DataFrame:
 
 def _load_taxonomy_lookup(dictionary_root: Path) -> pd.DataFrame:
     return _load_taxonomy_lookup_cached(str(dictionary_root.resolve()))
+
+
+def _resolve_taxonomy_fallback(dictionary_root: Path) -> pd.DataFrame | None:
+    """Return an empty taxonomy lookup when the dictionary is incomplete.
+
+    Older dictionary bundles shipped without the taxonomy enrichment table.  The
+    enrichment step used to raise an :class:`AssayExtendedError` which prevented
+    the whole pipeline from finishing.  Returning an empty lookup keeps the
+    pipeline operational while emitting a warning encouraging users to refresh
+    their dictionaries.
+    """
+
+    try:
+        bundled_root = get_resource_path("dictionary_root")
+    except (DictionaryManifestError, KeyError):  # pragma: no cover - defensive
+        bundled_root = None
+
+    if bundled_root is not None and bundled_root.resolve() != dictionary_root.resolve():
+        # Custom dictionary roots must provide taxonomy data explicitly.
+        return None
+
+    fallback = pd.DataFrame(
+        {
+            "assay_tax_id": pd.Series(dtype="string"),
+            "assay_group_taxonomy": pd.Series(dtype="string"),
+            "assay_strain_taxonomy": pd.Series(dtype="string"),
+        }
+    )
+    return helpers.sort_power_query(
+        fallback,
+        ("assay_tax_id", "assay_group_taxonomy", "assay_strain_taxonomy"),
+    )
 
 
 @functools.lru_cache(maxsize=None)

--- a/tests/postprocessing/test_assay_extended.py
+++ b/tests/postprocessing/test_assay_extended.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from library.postprocessing import AssayExtendedError, enrich_assay_metadata
+from library.postprocessing import enrich_assay_metadata
 
 
 @pytest.mark.postprocessing
@@ -90,7 +90,9 @@ def test_enrich_assay_metadata__fills_missing_fields(tmp_path: Path) -> None:
 
 
 @pytest.mark.postprocessing
-def test_enrich_assay_metadata__missing_taxonomy_dir_raises(tmp_path: Path) -> None:
+def test_enrich_assay_metadata__missing_taxonomy_dir_logs_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     dictionary_root = tmp_path
     (dictionary_root / "_assay").mkdir()
     (dictionary_root / "_document").mkdir()
@@ -108,5 +110,9 @@ def test_enrich_assay_metadata__missing_taxonomy_dir_raises(tmp_path: Path) -> N
 
     frame = pd.DataFrame({"assay_chembl_id": ["CHEMBL1"]})
 
-    with pytest.raises(AssayExtendedError):
-        enrich_assay_metadata(frame, dictionary_dir=dictionary_root)
+    with caplog.at_level("WARNING"):
+        result = enrich_assay_metadata(frame, dictionary_dir=dictionary_root)
+
+    assert "taxonomy.csv missing" in " ".join(caplog.messages)
+    assert result.loc[0, "assay_chembl_id"] == "CHEMBL1"
+    assert pd.isna(result.loc[0, "assay_group"])

--- a/tests/unit/postprocessing/test_assay_steps.py
+++ b/tests/unit/postprocessing/test_assay_steps.py
@@ -1,0 +1,75 @@
+"""Unit tests for :mod:`library.postprocess.assays.steps`."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.assays import steps
+
+
+@pytest.mark.unit
+def test_normalize_assay_metadata__respects_parameters() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["  primary  screen  "],
+            "assay_test_type": ["Confirmatory"],
+            "assay_format": [" cell based "],
+        }
+    )
+
+    result = steps.normalize_assay_metadata(
+        frame,
+        uppercase_categories=False,
+        strip_whitespace=False,
+        collapse_internal_whitespace=True,
+    )
+
+    assert result.loc[0, "assay_type"] == " primary screen "
+    assert result.loc[0, "assay_test_type"] == "Confirmatory"
+    assert result.loc[0, "assay_format"] == " cell based "
+
+
+@pytest.mark.unit
+def test_enrich_assay_flags__custom_terms_and_default() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["Primary screen", "Follow-up assay"],
+        }
+    )
+
+    result = steps.enrich_assay_flags(
+        frame,
+        confirmatory_terms=("follow",),
+        default_flag=True,
+    )
+
+    assert result["is_confirmatory"].tolist() == [True, True]
+
+
+@pytest.mark.unit
+def test_finalize_assay_records__enforce_schema_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, pd.DataFrame] = {}
+
+    def _fake_validate(df: pd.DataFrame, *, context: str) -> pd.DataFrame:
+        captured["frame"] = df.copy()
+        captured["context"] = context
+        return df.assign(validated=True)
+
+    monkeypatch.setattr(steps, "validate_assays", _fake_validate)
+
+    frame = pd.DataFrame(
+        {
+            "assay_chembl_id": [123],
+            "assay_type": [" confirm "],
+        }
+    )
+
+    enforced = steps.finalize_assay_records(frame, enforce_schema=True)
+    assert captured["context"] == "assay_finalization"
+    assert bool(enforced.loc[0, "validated"]) is True
+    assert str(captured["frame"]["assay_chembl_id"].dtype) == "string"
+
+    captured.clear()
+    skipped = steps.finalize_assay_records(frame, enforce_schema=False, normalize_identifiers=False)
+    assert "frame" not in captured
+    assert skipped.equals(frame)


### PR DESCRIPTION
## Summary
- add keyword-aware assay post-processing steps so pipeline parameters are honoured
- fall back to an empty taxonomy lookup with a warning when bundled dictionaries lack taxonomy.csv
- cover the new behaviours with targeted unit tests

## Testing
- pytest tests/unit/postprocessing/test_assay_steps.py tests/postprocessing/test_assay_extended.py


------
https://chatgpt.com/codex/tasks/task_e_68e5200148b48324a3a7b664f8eec7fe