### PR TITLE
Fix assay dictionary resolution and respect pipeline step parameters

### DIFF
--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,50 +1,100 @@
 """Transformation steps for assay postprocessing."""
+
 from __future__ import annotations
+
+import re
+from collections.abc import Sequence
 
 import pandas as pd
 
- 
+
 from library.postprocess.common import StepDefinition, run_steps
-from library.postprocess.common.logging import PipelineRunMetrics
- 
-from library.pipelines.common.metadata import get_pipeline_version
- 
 from library.postprocess.common.config import (
     load_pipeline_config,
     normalize_pipeline_version,
 )
- 
+from library.postprocess.common.logging import PipelineRunMetrics
+
+from library.pipelines.common.metadata import get_pipeline_version
 
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
-def normalize_assay_metadata(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize string-based assay descriptors."""
+_DEFAULT_CATEGORICAL_COLUMNS: tuple[str, ...] = (
+    "assay_type",
+    "assay_test_type",
+    "assay_format",
+)
+
+
+def normalize_assay_metadata(
+    df: pd.DataFrame,
+    *,
+    uppercase_categories: bool = True,
+    strip_whitespace: bool = True,
+    collapse_whitespace: bool = True,
+    target_columns: Sequence[str] | None = None,
+    **_unused: object,
+) -> pd.DataFrame:
+    """Normalize string-based assay descriptors.
+
+    Parameters mirror the declarative pipeline configuration so the CLI can
+    tweak behaviour without requiring code changes.  ``_unused`` captures any
+    forward-compatible options while keeping the transformation pure.
+    """
 
     normalized = df.copy(deep=True)
-    for column in ["assay_type", "assay_test_type", "assay_format"]:
-        if column in normalized.columns:
-            normalized[column] = (
-                normalized[column]
-                .astype("string")
-                .str.strip()
-                .str.replace(r"\s+", " ", regex=True)
-                .str.upper()
-            )
+    columns = tuple(target_columns) if target_columns is not None else _DEFAULT_CATEGORICAL_COLUMNS
+    for column in columns:
+        if column not in normalized.columns:
+            continue
+        series = normalized[column].astype("string")
+        if strip_whitespace:
+            series = series.str.strip()
+        if collapse_whitespace:
+            series = series.str.replace(r"\s+", " ", regex=True)
+        if uppercase_categories:
+            series = series.str.upper()
+        normalized[column] = series
     return normalized
 
 
-def enrich_assay_flags(df: pd.DataFrame) -> pd.DataFrame:
+def enrich_assay_flags(
+    df: pd.DataFrame,
+    *,
+    confirmatory_terms: Sequence[str] | None = None,
+    default_flag: bool = False,
+    case_sensitive: bool = False,
+    **_unused: object,
+) -> pd.DataFrame:
     """Introduce confirmatory flag based on assay type information."""
 
     enriched = df.copy(deep=True)
     type_series = enriched.get("assay_type")
-    if type_series is not None:
-        enriched["is_confirmatory"] = type_series.astype("string").str.contains(
-            "CONFIRM", case=False, na=False
+    if type_series is None:
+        enriched["is_confirmatory"] = pd.Series(
+            bool(default_flag), index=enriched.index, dtype="bool"
         )
-    else:
-        enriched["is_confirmatory"] = False
+        return enriched
+
+    terms = tuple(
+        str(term)
+        for term in (confirmatory_terms or ("confirm",))
+        if str(term).strip()
+    )
+    if not terms:
+        enriched["is_confirmatory"] = pd.Series(
+            bool(default_flag), index=enriched.index, dtype="bool"
+        )
+        return enriched
+
+    pattern = "|".join(re.escape(term) for term in terms)
+    matches = (
+        type_series.astype("string")
+        .str.contains(pattern, case=case_sensitive, na=default_flag)
+        .astype("bool")
+    )
+    enriched["is_confirmatory"] = matches
     return enriched
 
 

--- a/library/postprocessing/assay_extended.py
+++ b/library/postprocessing/assay_extended.py
@@ -9,13 +9,14 @@ from typing import Iterable, Sequence
 
 import pandas as pd
 
+from config.paths import DICTIONARY_DIR
 from library.common.log import logger
 
 from . import helpers
 
 __all__ = ["AssayExtendedError", "enrich_assay_metadata"]
 
-_DEFAULT_DICTIONARY_DIR = Path("config/dictionary")
+_DEFAULT_DICTIONARY_DIR = DICTIONARY_DIR
 
 
 class AssayExtendedError(RuntimeError):

--- a/tests/unit/postprocessing/test_assay_steps.py
+++ b/tests/unit/postprocessing/test_assay_steps.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from library.postprocess.assays import steps
+
+
+@pytest.mark.unit
+def test_normalize_assay_metadata__applies_flags() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["  confirm assay  "],
+            "assay_test_type": ["Primary   screen"],
+            "assay_format": ["Plate-based "],
+        }
+    )
+
+    result = steps.normalize_assay_metadata(frame)
+
+    assert result.loc[0, "assay_type"] == "CONFIRM ASSAY"
+    assert result.loc[0, "assay_test_type"] == "PRIMARY SCREEN"
+    assert result.loc[0, "assay_format"] == "PLATE-BASED"
+
+    custom = steps.normalize_assay_metadata(frame, uppercase_categories=False)
+    assert custom.loc[0, "assay_type"] == "confirm assay"
+    assert custom.loc[0, "assay_test_type"] == "Primary screen"
+
+
+@pytest.mark.unit
+def test_normalize_assay_metadata__retains_leading_whitespace_when_requested() -> None:
+    frame = pd.DataFrame({"assay_type": ["  Primary   screen"], "assay_format": [pd.NA]})
+
+    result = steps.normalize_assay_metadata(
+        frame,
+        strip_whitespace=False,
+        uppercase_categories=False,
+    )
+
+    assert result.loc[0, "assay_type"].startswith(" ")
+    assert result.loc[0, "assay_type"].endswith("screen")
+
+
+@pytest.mark.unit
+def test_enrich_assay_flags__uses_configured_terms() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": [
+                "Primary confirmation",
+                "screening",
+                pd.NA,
+            ]
+        }
+    )
+
+    result = steps.enrich_assay_flags(
+        frame,
+        confirmatory_terms=("primary", "confirm"),
+        default_flag=False,
+    )
+
+    assert result["is_confirmatory"].tolist() == [True, False, False]
+
+
+@pytest.mark.unit
+def test_enrich_assay_flags__missing_column_uses_default_flag() -> None:
+    frame = pd.DataFrame({"assay_format": ["plate"]})
+
+    result = steps.enrich_assay_flags(frame, default_flag=True)
+
+    assert result["is_confirmatory"].tolist() == [True]


### PR DESCRIPTION
## Summary
- resolve the default assay dictionary root via `config.paths.DICTIONARY_DIR` so bundled CSVs are found consistently
- extend assay postprocessing steps to accept the declarative pipeline options for normalization and flag enrichment
- add unit coverage for the updated normalization and confirmatory flag logic

## Testing
- pytest tests/unit/postprocessing/test_assay_steps.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5210bb460832482b82bbc45960ba9