### PR TITLE
Handle postprocess steps with unsupported config parameters

### DIFF
--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from time import perf_counter
@@ -54,6 +55,21 @@ def _coerce_step(entry: StepDefinition | StepTuple, index: int) -> StepDefinitio
 
 def _normalise_steps(steps: Iterable[StepDefinition | StepTuple]) -> tuple[StepDefinition, ...]:
     return tuple(_coerce_step(entry, index) for index, entry in enumerate(steps))
+
+
+_UNEXPECTED_KEYWORD_PATTERN = re.compile(
+    r"got an unexpected keyword argument ['\"](?P<name>[^'\"]+)['\"]"
+)
+
+
+def _extract_unexpected_keyword(error: TypeError) -> str | None:
+    """Return the keyword name when ``error`` signals an unexpected argument."""
+
+    message = str(error)
+    match = _UNEXPECTED_KEYWORD_PATTERN.search(message)
+    if match is not None:
+        return match.group("name")
+    return None
 
 
 def _record_error(
@@ -170,6 +186,7 @@ def run_steps(
             logger=log,
             step_name=step.name,
         )
+        call_params = dict(call_params)
         frame = clone_dataframe(current)
         step_started_at = _now_iso()
         step_clock = perf_counter()
@@ -180,7 +197,23 @@ def run_steps(
         log.info("Starting step %s", step.name)
 
         try:
-            result = step.func(frame, **call_params)
+            while True:
+                try:
+                    result = step.func(frame, **call_params)
+                    break
+                except TypeError as exc:
+                    unexpected_keyword = _extract_unexpected_keyword(exc)
+                    if unexpected_keyword is None or unexpected_keyword not in call_params:
+                        raise
+
+                    log.warning(
+                        "Step %s retrying without unsupported parameter: %s",
+                        step.name,
+                        unexpected_keyword,
+                    )
+                    call_params.pop(unexpected_keyword, None)
+
+            # normal execution path continues below once the loop breaks
         except SchemaValidationError as exc:
             log.exception("Schema validation failed during step %s", step.name)
             _record_error(

--- a/tests/unit/postprocessing/test_runner.py
+++ b/tests/unit/postprocessing/test_runner.py
@@ -5,6 +5,8 @@ import logging
 import pandas as pd
 import pytest
 
+from library.postprocess.common import runner
+
 from library.postprocess.common import StepDefinition, run_steps
 from library.postprocess.common.schema import DataFrameSchema
 from library.postprocess.common.types import SchemaValidationError
@@ -119,5 +121,42 @@ def test_run_steps__ignores_unsupported_parameters(caplog: pytest.LogCaptureFixt
     assert result["value"].tolist() == [7]
     assert any(
         "ignoring unsupported parameters" in record.message for record in caplog.records
+    )
+    assert metadata.steps[0].parameters["unexpected"] == "ignored"
+
+
+def test_run_steps__recovers_from_runtime_parameter_mismatch(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    frame = pd.DataFrame({"seed": [5]}, dtype="int64")
+
+    steps = (
+        StepDefinition(
+            name="with_constant",
+            func=_with_constant,
+            params={"column": "value", "value": 11, "unexpected": "ignored"},
+        ),
+    )
+
+    original_signature = runner.inspect.signature
+
+    def _raise_signature(func):
+        if func is _with_constant:
+            raise ValueError("no signature available")
+        return original_signature(func)
+
+    monkeypatch.setattr(runner.inspect, "signature", _raise_signature)
+
+    test_logger = logging.getLogger("tests.postprocess.runner")
+    test_logger.handlers.clear()
+    test_logger.propagate = True
+
+    with caplog.at_level("WARNING", logger="tests.postprocess.runner"):
+        result, metadata = run_steps(frame, steps, logger=test_logger)
+
+    assert result["value"].tolist() == [11]
+    assert any(
+        "retrying without unsupported parameter" in record.message
+        for record in caplog.records
     )
     assert metadata.steps[0].parameters["unexpected"] == "ignored"


### PR DESCRIPTION
## Summary
- make the post-processing runner resilient to TypeErrors caused by unexpected keyword arguments by retrying without unsupported parameters
- add a unit test that simulates missing inspect signatures to ensure the runner recovers gracefully

## Testing
- pytest tests/unit/postprocessing/test_runner.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e521e84a708324af9447c252a261bb