### PR TITLE
Handle postprocess steps rejecting keyword arguments

### DIFF
--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from time import perf_counter
@@ -15,6 +16,9 @@ from .schema import DataFrameSchema, validate_schema
 from .types import SchemaValidationError, StepDefinition, StepError
 
 StepTuple = tuple[Any, ...]
+
+
+_UNEXPECTED_KEYWORD_RE = re.compile(r"unexpected keyword argument[s]? '([^']+)'")
 
 
 def _describe_dtypes(frame: pd.DataFrame) -> dict[str, str]:
@@ -128,6 +132,43 @@ def _prepare_step_arguments(
     return accepted
 
 
+def _unexpected_keyword_arguments(
+    error: TypeError, provided: Mapping[str, Any]
+) -> tuple[str, ...]:
+    """Extract unexpected keyword argument names from ``error``.
+
+    Parameters
+    ----------
+    error:
+        Type error raised by the callable.
+    provided:
+        Mapping of keyword arguments passed to the callable.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Sorted tuple of unexpected keyword names present both in the error
+        message and the provided mapping.  Empty when the error is unrelated to
+        keyword arguments.
+    """
+
+    if not provided:
+        return ()
+
+    message = str(error)
+    unexpected: set[str] = set()
+
+    for name in _UNEXPECTED_KEYWORD_RE.findall(message):
+        if name in provided:
+            unexpected.add(name)
+
+    if "takes no keyword arguments" in message:
+        unexpected.update(provided.keys())
+
+    ordered = tuple(sorted(unexpected))
+    return ordered
+
+
 def run_steps(
     df: pd.DataFrame,
     steps: Iterable[StepDefinition | StepTuple],
@@ -180,7 +221,27 @@ def run_steps(
         log.info("Starting step %s", step.name)
 
         try:
-            result = step.func(frame, **call_params)
+            attempt_params = dict(call_params)
+
+            while True:
+                try:
+                    result = step.func(frame, **attempt_params)
+                except TypeError as exc:
+                    unexpected = _unexpected_keyword_arguments(exc, attempt_params)
+                    if not unexpected:
+                        raise
+
+                    for name in unexpected:
+                        attempt_params.pop(name, None)
+
+                    log.warning(
+                        "Step %s rejected parameters: %s; retrying without them",
+                        step.name,
+                        ", ".join(sorted(unexpected)),
+                    )
+
+                    continue
+                break
         except SchemaValidationError as exc:
             log.exception("Schema validation failed during step %s", step.name)
             _record_error(

--- a/tests/unit/postprocessing/test_runner.py
+++ b/tests/unit/postprocessing/test_runner.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from library.postprocess.common import StepDefinition, run_steps
+from library.postprocess.common.types import StepError
 from library.postprocess.common.schema import DataFrameSchema
 from library.postprocess.common.types import SchemaValidationError
 
@@ -121,3 +122,57 @@ def test_run_steps__ignores_unsupported_parameters(caplog: pytest.LogCaptureFixt
         "ignoring unsupported parameters" in record.message for record in caplog.records
     )
     assert metadata.steps[0].parameters["unexpected"] == "ignored"
+
+
+def test_run_steps__retries_after_callable_rejects_parameters(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    frame = pd.DataFrame({"seed": [9]}, dtype="int64")
+
+    steps = (
+        StepDefinition(
+            name="with_constant",
+            func=_with_constant,
+            params={"column": "value", "value": 4, "unexpected": "ignored"},
+        ),
+    )
+
+    from library.postprocess.common import runner
+
+    original_signature = runner.inspect.signature
+
+    def failing_signature(func):
+        if func is _with_constant:
+            raise ValueError("no signature available")
+        return original_signature(func)
+
+    monkeypatch.setattr(runner.inspect, "signature", failing_signature)
+
+    test_logger = logging.getLogger("tests.postprocess.runner")
+    test_logger.handlers.clear()
+    test_logger.propagate = True
+
+    with caplog.at_level("WARNING", logger="tests.postprocess.runner"):
+        result, metadata = run_steps(frame, steps, logger=test_logger)
+
+    assert result["value"].tolist() == [4]
+    assert any("rejected parameters" in record.message for record in caplog.records)
+    assert metadata.steps[0].parameters["unexpected"] == "ignored"
+
+
+def test_run_steps__propagates_unrelated_type_errors() -> None:
+    frame = pd.DataFrame({"seed": [1]}, dtype="int64")
+
+    def _boom(df: pd.DataFrame, *, column: str) -> pd.DataFrame:
+        raise TypeError("boom")
+
+    steps = (
+        StepDefinition(
+            name="boom",
+            func=_boom,
+            params={"column": "value"},
+        ),
+    )
+
+    with pytest.raises(StepError, match="boom"):
+        run_steps(frame, steps)


### PR DESCRIPTION
## Summary
- make the postprocessing runner retry steps without unsupported keyword arguments and log the discarded parameters
- add unit tests demonstrating the retry behaviour and ensuring other TypeErrors are still surfaced

## Testing
- pytest tests/unit/postprocessing/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e522dd183083249889113b2c07a909