### PR TITLE
Ensure dictionary resources resolve to config paths and harden postprocess kwargs handling

### DIFF
--- a/library/postprocess/common/runner.py
+++ b/library/postprocess/common/runner.py
@@ -144,6 +144,30 @@ def _prepare_step_arguments(
     return accepted
 
 
+def _identify_unsupported_kwargs(func: Any, params: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return a tuple of keyword names not accepted by ``func``."""
+
+    if not params:
+        return ()
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return ()
+
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return ()
+
+    unsupported: list[str] = []
+    for key in params:
+        if key not in signature.parameters:
+            unsupported.append(key)
+    return tuple(unsupported)
+
+
 def run_steps(
     df: pd.DataFrame,
     steps: Iterable[StepDefinition | StepTuple],
@@ -204,7 +228,17 @@ def run_steps(
                 except TypeError as exc:
                     unexpected_keyword = _extract_unexpected_keyword(exc)
                     if unexpected_keyword is None or unexpected_keyword not in call_params:
-                        raise
+                        fallback = _identify_unsupported_kwargs(step.func, call_params)
+                        if not fallback:
+                            raise
+                        log.warning(
+                            "Step %s retrying without unsupported parameters: %s",
+                            step.name,
+                            ", ".join(sorted(fallback)),
+                        )
+                        for key in fallback:
+                            call_params.pop(key, None)
+                        continue
 
                     log.warning(
                         "Step %s retrying without unsupported parameter: %s",

--- a/library/postprocessing/activity_extended.py
+++ b/library/postprocessing/activity_extended.py
@@ -23,11 +23,12 @@ import numpy as np
 import pandas as pd
 
 from library.common.log import logger
+from config.paths import DICTIONARY_DIR
 
 from . import helpers
 
 _DEFAULT_SEARCH_DIR = Path("data/output")
-_DEFAULT_DICTIONARY_DIR = Path("config/dictionary")
+_DEFAULT_DICTIONARY_DIR = DICTIONARY_DIR
 _FILENAME_RE = re.compile(r"output\.activit(?:y|ies)_(\d{8})\.csv\Z")
 
 _REQUIRED_COLUMNS: frozenset[str] = frozenset(
@@ -299,7 +300,7 @@ def _latest_activity_export(search_dir: Path) -> Path:
     return candidates[-1][2]
 
 
-def _resolve_dictionary_root(dictionary_dir: Path | None) -> Path:
+def _resolve_dictionary_root(dictionary_dir: Path | str | None) -> Path:
     if dictionary_dir is None:
         return _DEFAULT_DICTIONARY_DIR
     return Path(dictionary_dir)
@@ -1463,7 +1464,7 @@ def process_activity_extended(
         )
 
     input_path = explicit_input or _latest_activity_export(resolved_search_dir)
-    dictionary_root = _resolve_dictionary_root(Path(dictionary_dir) if dictionary_dir is not None else None)
+    dictionary_root = _resolve_dictionary_root(dictionary_dir)
 
     frame = helpers.read_csv_strict(
         input_path,

--- a/library/postprocessing/assay_extended.py
+++ b/library/postprocessing/assay_extended.py
@@ -10,22 +10,23 @@ from typing import Iterable, Sequence
 import pandas as pd
 
 from library.common.log import logger
+from config.paths import DICTIONARY_DIR
 
 from . import helpers
 
 __all__ = ["AssayExtendedError", "enrich_assay_metadata"]
 
-_DEFAULT_DICTIONARY_DIR = Path("config/dictionary")
+_DEFAULT_DICTIONARY_DIR = DICTIONARY_DIR
 
 
 class AssayExtendedError(RuntimeError):
     """Raised when the assay enrichment workflow cannot proceed."""
 
 
-def _resolve_dictionary_root(dictionary_dir: Path | None) -> Path:
+def _resolve_dictionary_root(dictionary_dir: Path | str | None) -> Path:
     if dictionary_dir is None:
         return _DEFAULT_DICTIONARY_DIR
-    return dictionary_dir
+    return Path(dictionary_dir)
 
 
 def _normalise_column_key(name: str) -> str:
@@ -347,7 +348,7 @@ def enrich_assay_metadata(
 ) -> pd.DataFrame:
     """Return ``df`` enriched with dictionary-driven assay metadata."""
 
-    dictionary_root = _resolve_dictionary_root(Path(dictionary_dir) if dictionary_dir is not None else None)
+    dictionary_root = _resolve_dictionary_root(dictionary_dir)
     if not isinstance(dictionary_root, Path):  # pragma: no cover - defensive
         dictionary_root = Path(dictionary_root)
 

--- a/tests/unit/postprocessing/test_activity_extended_paths.py
+++ b/tests/unit/postprocessing/test_activity_extended_paths.py
@@ -1,0 +1,35 @@
+"""Unit tests for dictionary path resolution in activity post-processing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.paths import DICTIONARY_DIR
+from library.postprocessing import activity_extended
+
+
+@pytest.mark.unit
+def test_resolve_dictionary_root__defaults_to_config_directory(monkeypatch, tmp_path: Path) -> None:
+    """Default dictionary root should always match the config package resource."""
+
+    monkeypatch.chdir(tmp_path)
+
+    resolved = activity_extended._resolve_dictionary_root(None)
+
+    assert resolved == DICTIONARY_DIR
+    assert resolved.is_absolute()
+
+
+@pytest.mark.unit
+def test_resolve_dictionary_root__accepts_string_paths(tmp_path: Path) -> None:
+    """``dictionary_dir`` parameters passed as strings must resolve correctly."""
+
+    provided = tmp_path / "dictionary"
+    provided.mkdir()
+
+    resolved = activity_extended._resolve_dictionary_root(str(provided))
+
+    assert resolved == provided
+    assert isinstance(resolved, Path)

--- a/tests/unit/postprocessing/test_assay_extended.py
+++ b/tests/unit/postprocessing/test_assay_extended.py
@@ -1,0 +1,36 @@
+"""Unit tests for :mod:`library.postprocessing.assay_extended`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config.paths import DICTIONARY_DIR
+from library.postprocessing import assay_extended
+
+
+@pytest.mark.unit
+def test_resolve_dictionary_root__defaults_to_config_directory(monkeypatch, tmp_path: Path) -> None:
+    """Default dictionary path should always be anchored to the config package."""
+
+    # Changing the working directory mimics invocation from an arbitrary location.
+    monkeypatch.chdir(tmp_path)
+
+    resolved = assay_extended._resolve_dictionary_root(None)
+
+    assert resolved == DICTIONARY_DIR
+    assert resolved.is_absolute()
+
+
+@pytest.mark.unit
+def test_resolve_dictionary_root__accepts_string_paths(tmp_path: Path) -> None:
+    """Explicit dictionary_dir arguments should be normalised to ``Path`` instances."""
+
+    provided = tmp_path / "dictionary"
+    provided.mkdir()
+
+    resolved = assay_extended._resolve_dictionary_root(str(provided))
+
+    assert resolved == provided
+    assert isinstance(resolved, Path)

--- a/tests/unit/postprocessing/test_runner.py
+++ b/tests/unit/postprocessing/test_runner.py
@@ -160,3 +160,40 @@ def test_run_steps__recovers_from_runtime_parameter_mismatch(
         for record in caplog.records
     )
     assert metadata.steps[0].parameters["unexpected"] == "ignored"
+
+
+def test_run_steps__handles_unparsed_typeerror_messages(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    frame = pd.DataFrame({"seed": [5]}, dtype="int64")
+
+    steps = (
+        StepDefinition(
+            name="with_constant",
+            func=_with_constant,
+            params={"column": "value", "value": 13, "unexpected": "ignored"},
+        ),
+    )
+
+    def _no_keyword(_error):
+        return None
+
+    def _pass_through_prepare(func, params, *, logger, step_name):
+        return dict(params)
+
+    monkeypatch.setattr(runner, "_prepare_step_arguments", _pass_through_prepare)
+    monkeypatch.setattr(runner, "_extract_unexpected_keyword", _no_keyword)
+
+    test_logger = logging.getLogger("tests.postprocess.runner")
+    test_logger.handlers.clear()
+    test_logger.propagate = True
+
+    with caplog.at_level("WARNING", logger="tests.postprocess.runner"):
+        result, metadata = run_steps(frame, steps, logger=test_logger)
+
+    assert result["value"].tolist() == [13]
+    assert any(
+        "retrying without unsupported parameters" in record.message
+        for record in caplog.records
+    )
+    assert metadata.steps[0].parameters["unexpected"] == "ignored"


### PR DESCRIPTION
## Summary
- ensure the assay and activity enrichment workflows default to the packaged config/dictionary path
- normalise dictionary_dir inputs and cover the behaviour with focused unit tests
- make the postprocess runner drop unsupported kwargs even when TypeError messages cannot be parsed

## Testing
- pytest tests/unit/postprocessing/test_assay_extended.py tests/unit/postprocessing/test_activity_extended_paths.py tests/unit/postprocessing/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e5251c7d8c83249fa96b87ab77ad6c