### PR TITLE
Handle missing assay dictionaries gracefully

### DIFF
--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -1,8 +1,9 @@
 """Transformation steps for assay postprocessing."""
 from __future__ import annotations
 
+import logging
 import re
-from typing import Sequence
+from typing import Any, Sequence
 
 import pandas as pd
 
@@ -21,12 +22,16 @@ from library.postprocess.common.config import (
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
+_LOG = logging.getLogger(__name__)
+
+
 def normalize_assay_metadata(
     df: pd.DataFrame,
     *,
     uppercase_categories: bool = True,
     strip_whitespace: bool = True,
     collapse_internal_whitespace: bool | None = None,
+    **kwargs: Any,
 ) -> pd.DataFrame:
     """Normalize string-based assay descriptors.
 
@@ -47,6 +52,12 @@ def normalize_assay_metadata(
         behaviour where both operations happened together.  Pass ``True`` or
         ``False`` explicitly to override the coupling.
     """
+
+    if kwargs:
+        _LOG.warning(
+            "normalize_assay_metadata ignoring unsupported parameters: %s",
+            ", ".join(sorted(map(str, kwargs.keys()))),
+        )
 
     normalized = df.copy(deep=True)
     if collapse_internal_whitespace is None:

--- a/library/postprocessing/assay_extended.py
+++ b/library/postprocessing/assay_extended.py
@@ -10,12 +10,31 @@ from typing import Iterable, Sequence
 import pandas as pd
 
 from library.common.log import logger
+from library.resources.dictionaries import DictionaryManifestError, get_resource_path
 
 from . import helpers
 
 __all__ = ["AssayExtendedError", "enrich_assay_metadata"]
 
-_DEFAULT_DICTIONARY_DIR = Path("config/dictionary")
+
+
+def _default_dictionary_dir() -> Path:
+    """Return the bundled dictionary directory when available.
+
+    The helper falls back to the repository-relative ``config/dictionary`` path
+    when the manifest cannot be consulted (for example during editable installs
+    before package data is built).  This keeps local development environments
+    working while still preferring the validated manifest location when
+    possible.
+    """
+
+    try:
+        return get_resource_path("dictionary_root")
+    except (DictionaryManifestError, FileNotFoundError, KeyError):
+        return Path("config/dictionary")
+
+
+_DEFAULT_DICTIONARY_DIR = _default_dictionary_dir()
 
 
 class AssayExtendedError(RuntimeError):

--- a/tests/postprocessing/test_assay_steps.py
+++ b/tests/postprocessing/test_assay_steps.py
@@ -55,6 +55,20 @@ def test_normalize_assay_metadata__respects_disabled_flags() -> None:
 
 @pytest.mark.postprocessing
 @pytest.mark.usefixtures("deterministic_env")
+def test_normalize_assay_metadata__ignores_unknown_parameters(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    frame = pd.DataFrame({"assay_type": ["primary"]})
+
+    with caplog.at_level("WARNING"):
+        result = normalize_assay_metadata(frame, legacy_flag=True)
+
+    assert "normalize_assay_metadata ignoring unsupported parameters" in caplog.text
+    assert result.loc[0, "assay_type"] == "PRIMARY"
+
+
+@pytest.mark.postprocessing
+@pytest.mark.usefixtures("deterministic_env")
 def test_enrich_assay_flags__applies_custom_terms() -> None:
     frame = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- resolve the default assay dictionary directory via the manifest and fall back to the repository path when necessary
- allow `normalize_assay_metadata` to ignore unexpected keyword parameters while logging a warning for visibility
- cover the relaxed keyword handling with a regression test

## Testing
- `pytest tests/postprocessing/test_assay_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e5255247ac8324bc484ce61be6c407