### PR TITLE
Allow dictionary root sparse-index checksum variant

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -43,6 +43,8 @@ _SHA256_WILDCARD = "*"
 # dictionary root which, although harmless, change the directory hash.  The
 # manifest bundled with the repository might not list those variants yet, so we
 # extend the accepted checksum list at runtime to avoid false positives.
+WINDOWS_SPARSE_INDEX_CHECKSUM = "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15"
+
 _KNOWN_CHECKSUM_VARIANTS: Mapping[str, tuple[str, ...]] = {
     "dictionary_root": (
         "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a",
@@ -51,14 +53,14 @@ _KNOWN_CHECKSUM_VARIANTS: Mapping[str, tuple[str, ...]] = {
         "95f7a33a028aeeba9027b64f558e50ad25e76934782cc03ba14437fd8eff8476",
         # Windows 11 23H2 with Git 2.48 expands sparse indexes differently when
         # Python 3.13.1 is installed.  The working tree matches byte-for-byte but
-        # the directory hash becomes ``9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15``.
-        # Accept it at runtime to avoid spurious checksum failures on systems
-        # using the refreshed Git toolchain.
+        # the directory hash becomes ``WINDOWS_SPARSE_INDEX_CHECKSUM``.  Accept it
+        # at runtime to avoid spurious checksum failures on systems using the
+        # refreshed Git toolchain.
         # Windows 11 + Python 3.13 + Git 2.47.1 with NTFS compression enabled
         # stores alternate data streams for certain files under the dictionary
         # root.  The additional metadata is ignored when hashing but the
         # resulting directory order differs and yields the checksum below.
-        "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15",
+        WINDOWS_SPARSE_INDEX_CHECKSUM,
     ),
     "target_uniprot_cache": (
         "014e183b12959a4e5f060faf3b77c6a6d143cc00e0dd0121fdd1d1e51a210a2a",

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -118,7 +118,16 @@ def test_manifest_allows_windows_textmode_checksum() -> None:
     expected = {
         "efc69f6bb252d68bc7fde11ba98b09b24b0b8fd868fcd6d945eaca76b636f43a",
         "ac67acf2dcd801ffbe9d6e3aa95189af7c3e991fb3ddaaf8aab0be988d7d3224",
-        "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15",
+        dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM,
     }
 
     assert expected.issubset(sha256_values)
+
+
+@pytest.mark.unit
+def test_known_checksum_variants__includes_sparse_index_checksum(tmp_path: Path) -> None:
+    """The runtime allow-list should accept the new sparse-index checksum."""
+
+    variants = dictionaries._iter_additional_checksums("dictionary_root", base_dir=tmp_path)
+
+    assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants


### PR DESCRIPTION
## Summary
- expose the Windows sparse index checksum constant for the dictionary root allow-list
- assert the new checksum is present both in the manifest and the runtime overrides

## Testing
- pytest tests/unit/test_dictionary_resources.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e52594aaa48324a5fe0f76e71816cc