### PR TITLE
Fix document postprocessing missing required columns

### DIFF
--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -136,12 +136,16 @@ def enrich_document_publication_year(
     return enriched
 
 
-def finalize_document_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_document_records(df: pd.DataFrame, **_: object) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`DOCUMENT_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    for column in ["document_chembl_id", "title", "doc_type"]:
-        if column in prepared.columns:
+
+    required_string_columns = ["document_chembl_id", "title", "doc_type"]
+    for column in required_string_columns:
+        if column not in prepared.columns:
+            prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype="string")
+        else:
             prepared[column] = prepared[column].astype("string")
 
     if "publication_year" in prepared.columns:

--- a/tests/unit/postprocessing/test_document_steps.py
+++ b/tests/unit/postprocessing/test_document_steps.py
@@ -5,6 +5,7 @@ import pytest
 
 from library.postprocess.documents.steps import (
     enrich_document_publication_year,
+    finalize_document_records,
     normalize_document_fields,
 )
 
@@ -72,3 +73,22 @@ def test_enrich_document_publication_year__validates_fallback_range() -> None:
 
     with pytest.raises(ValueError, match="supported range"):
         enrich_document_publication_year(frame, fallback_year=1400)
+
+
+@pytest.mark.unit
+def test_finalize_document_records__adds_missing_required_columns() -> None:
+    frame = pd.DataFrame({"document_chembl_id": ["CHEMBL1"]})
+
+    result = finalize_document_records(frame)
+
+    assert list(result.columns[:3]) == [
+        "document_chembl_id",
+        "title",
+        "doc_type",
+    ]
+    assert result.loc[0, "document_chembl_id"] == "CHEMBL1"
+    assert pd.isna(result.loc[0, "title"])
+    assert pd.isna(result.loc[0, "doc_type"])
+    assert result["document_chembl_id"].dtype == "string"
+    assert result["title"].dtype == "string"
+    assert result["doc_type"].dtype == "string"


### PR DESCRIPTION
## Summary
- ensure `finalize_document_records` backfills required columns before schema validation
- add a unit test covering document finalization without `title`/`doc_type`

## Testing
- pytest tests/unit/postprocessing/test_document_steps.py


------
https://chatgpt.com/codex/tasks/task_e_68e5260c048c83249b7894e23f9cae0a