### PR TITLE
Accept Windows checksum variant for taxonomy assay lookup dictionary

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -75,6 +75,15 @@ _KNOWN_CHECKSUM_VARIANTS: Mapping[str, tuple[str, ...]] = {
         # updated toolchain without forcing a rebuild of dictionary artifacts.
         "3fa041266066939dcbe2fb356f9055d2845fb4a46d874fef682c02d4314542cc",
     ),
+    "taxonomy_assay_lookup": (
+        # Windows Git 2.47.1 normalises the assay taxonomy lookup CSV using
+        # ``\r\n`` newlines even when the repository bundles ``\n``.  The
+        # payload is byte-identical after normalisation but hashing the file on
+        # that toolchain yields the checksum below.  Accept it so validation
+        # succeeds for developers on Windows without requiring a dictionary
+        # rebuild.
+        "0ec9e4342890f9e0f5457d58133fbca291ac30dd8dd133b8d4f2fac82e798c69",
+    ),
 }
 
 _ENV_CHECKSUM_ALLOWLIST = "CHEMBL_DICTIONARY_CHECKSUM_ALLOWLIST"

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -124,6 +124,42 @@ def test_parse_manifest__accepts_target_cache_checksum_variants(
 
 
 @pytest.mark.unit
+def test_parse_manifest__accepts_taxonomy_lookup_checksum_variant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The taxonomy lookup dictionary honours the Windows-specific checksum."""
+
+    manifest_dir = tmp_path / "dictionary"
+    manifest_dir.mkdir()
+    manifest_path = manifest_dir / "manifest.yaml"
+    manifest_payload = {
+        "version": 1,
+        "resources": {
+            "taxonomy_assay_lookup": {
+                "path": "_taxonomy/taxonomy.csv",
+                "version": "test",
+                "sha256": ["dc81f4becc78bce0d3d8561a3c6ae20cac9cfa46762bed4d9af43a8cb8c6b8ab"],
+                "generator": "tests/generator.py",
+            }
+        },
+    }
+    manifest_path.write_text(yaml.safe_dump(manifest_payload, sort_keys=False), encoding="utf-8")
+
+    monkeypatch.setattr(
+        dictionaries,
+        "_compute_sha256",
+        lambda path: "0ec9e4342890f9e0f5457d58133fbca291ac30dd8dd133b8d4f2fac82e798c69",
+    )
+
+    resources = dictionaries._parse_manifest(base_dir=manifest_dir)
+
+    assert (
+        resources["taxonomy_assay_lookup"].sha256
+        == "0ec9e4342890f9e0f5457d58133fbca291ac30dd8dd133b8d4f2fac82e798c69"
+    )
+
+
+@pytest.mark.unit
 def test_parse_manifest__allowlist_file_extends_checksums(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add the Windows-specific checksum variant for `taxonomy_assay_lookup` to the runtime allow-list used by the dictionary loader
- cover the new checksum path with a regression unit test to keep manifest validation cross-platform

## Testing
- pytest tests/unit/test_resources_dictionaries.py

------
https://chatgpt.com/codex/tasks/task_e_68e525f2c03c83248480287aa2612329