### PR TITLE
Ensure target postprocess finalization fills missing target_type

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -106,6 +106,9 @@ def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
 
     prepared = df.copy(deep=True)
+    for column in TARGET_SCHEMA.required_columns:
+        if column not in prepared.columns:
+            prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype="string")
     for column in ["target_chembl_id", "pref_name", "target_type"]:
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from library.postprocess.targets.steps import normalize_target_fields
+from library.postprocess.targets.steps import (
+    finalize_target_records,
+    normalize_target_fields,
+)
 
 
 @pytest.mark.unit
@@ -56,3 +59,36 @@ def test_normalize_target_fields__without_optional_flags_preserves_extra_columns
     assert result.loc[0, "target_chembl_id"] == "CHEMBL1"
     assert result.loc[0, "pref_name"] == "Gamma"
     assert result.loc[0, "taxon_id"] == " 9606 "
+
+
+@pytest.mark.unit
+def test_finalize_target_records__fills_missing_required_columns() -> None:
+    frame = pd.DataFrame({"target_chembl_id": ["CHEMBL1"], "pref_name": ["Alpha"]})
+
+    result = finalize_target_records(frame)
+
+    assert list(result.columns) == [
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+    ]
+    assert pd.isna(result.loc[0, "target_type"])
+    assert str(result["target_type"].dtype) == "string"
+    assert str(result["pref_name"].dtype) == "string"
+
+
+@pytest.mark.unit
+def test_finalize_target_records__handles_empty_input_frame() -> None:
+    frame = pd.DataFrame({"pref_name": []})
+
+    result = finalize_target_records(frame)
+
+    assert result.empty
+    assert list(result.columns) == [
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+    ]
+    assert str(result["target_chembl_id"].dtype) == "string"
+    assert str(result["pref_name"].dtype) == "string"
+    assert str(result["target_type"].dtype) == "string"


### PR DESCRIPTION
## Summary
- ensure the target postprocessing finalization step backfills required columns such as `target_type`
- add unit tests covering missing columns and empty-frame handling in the target postprocess steps

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68e526b39d20832494aafa4567ac067e