### PR TITLE
Accept Windows dictionary checksum variant through allowlist

### DIFF
--- a/config/dictionary/manifest.allowlist.yaml
+++ b/config/dictionary/manifest.allowlist.yaml
@@ -1,0 +1,8 @@
+# Additional checksum variants accepted by the dictionary loader.
+#
+# The values defined here are merged with the entries declared in
+# ``manifest.yaml`` so that developers on platforms with divergent newline
+# normalisation (e.g. recent Windows + Git combinations) can still execute the
+# pipeline without rebuilding the bundled dictionaries.
+dictionary_root:
+  - "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15"

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -122,3 +122,24 @@ def test_manifest_allows_windows_textmode_checksum() -> None:
     }
 
     assert expected.issubset(sha256_values)
+
+
+@pytest.mark.unit
+def test_manifest_allowlist_accepts_latest_windows_checksum() -> None:
+    """The allowlist supplements the manifest with new checksum variants."""
+
+    allowlist_path = Path("config/dictionary/manifest.allowlist.yaml")
+    payload = yaml.safe_load(allowlist_path.read_text(encoding="utf-8"))
+
+    assert "dictionary_root" in payload
+
+    entries = payload["dictionary_root"]
+    if isinstance(entries, str):
+        checksums = {entries}
+    else:
+        checksums = set(entries)
+
+    assert (
+        "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15"
+        in checksums
+    )


### PR DESCRIPTION
## Summary
- add a manifest allowlist entry so the dictionary loader accepts the Windows Git 2.48 checksum variant
- add a regression test that ensures the new allowlist entry is kept in sync

## Testing
- pytest tests/unit/test_dictionary_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68e5255ee7a88324a8dfe78e7d6fbdb8