### PR TITLE
Handle legacy kwargs in assay normalization

### DIFF
--- a/library/postprocess/assays/steps.py
+++ b/library/postprocess/assays/steps.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import logging
 from typing import Sequence
 
 import pandas as pd
@@ -21,12 +22,16 @@ from library.postprocess.common.config import (
 from .schema import ASSAY_SCHEMA, validate_assays
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 def normalize_assay_metadata(
     df: pd.DataFrame,
     *,
     uppercase_categories: bool = True,
     strip_whitespace: bool = True,
     collapse_internal_whitespace: bool | None = None,
+    **extra_kwargs: object,
 ) -> pd.DataFrame:
     """Normalize string-based assay descriptors.
 
@@ -47,6 +52,12 @@ def normalize_assay_metadata(
         behaviour where both operations happened together.  Pass ``True`` or
         ``False`` explicitly to override the coupling.
     """
+
+    if extra_kwargs:
+        _LOGGER.debug(
+            "normalize_assay_metadata ignoring unsupported parameters: %s",
+            ", ".join(sorted(extra_kwargs)),
+        )
 
     normalized = df.copy(deep=True)
     if collapse_internal_whitespace is None:

--- a/tests/postprocessing/test_assay_steps.py
+++ b/tests/postprocessing/test_assay_steps.py
@@ -55,6 +55,26 @@ def test_normalize_assay_metadata__respects_disabled_flags() -> None:
 
 @pytest.mark.postprocessing
 @pytest.mark.usefixtures("deterministic_env")
+def test_normalize_assay_metadata__ignores_unknown_parameters() -> None:
+    frame = pd.DataFrame(
+        {
+            "assay_type": ["primary"],
+            "assay_format": ["cell"],
+            "assay_test_type": ["screen"],
+        }
+    )
+
+    result = normalize_assay_metadata(frame, uppercase_categories=False, unsupported_flag=True)
+
+    expected = frame.copy()
+    for column in expected.columns:
+        expected[column] = expected[column].astype("string")
+
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.postprocessing
+@pytest.mark.usefixtures("deterministic_env")
 def test_enrich_assay_flags__applies_custom_terms() -> None:
     frame = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- allow `normalize_assay_metadata` to ignore unsupported keyword arguments so legacy pipeline definitions continue to run
- add a regression test covering the new fallback behaviour

## Testing
- pytest tests/postprocessing/test_assay_steps.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e527cb46a08324a0d0278364f2daa1