### PR TITLE
Add allowlist fallback for dictionary sparse index checksum

### DIFF
--- a/config/dictionary/manifest.allowlist.yaml
+++ b/config/dictionary/manifest.allowlist.yaml
@@ -1,0 +1,20 @@
+# Additional checksum variants observed on specific platforms.
+#
+# The values declared here complement the allow-list embedded in
+# ``library.resources.dictionaries``.  They let us accept freshly observed
+# platform-specific hashes without having to re-issue the full dictionary
+# bundle immediately.
+#
+# Each key maps to a dictionary resource name from ``manifest.yaml`` and the
+# associated value is a list of accepted SHA256 digests.
+#
+# See ``library/resources/dictionaries.py`` for more context about each
+# checksum variant and the platforms they cover.
+
+dictionary_root:
+  # Windows 11 (23H2) with Python 3.13.1 and Git 2.48 may rewrite sparse index
+  # metadata when expanding the checkout, yielding the checksum below even
+  # though the dictionary content is byte-identical to the POSIX export.
+  # Include it so checksum validation succeeds on the refreshed Windows
+  # toolchain without forcing developers to rebuild the dictionaries.
+  - "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15"

--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -31,6 +31,7 @@ _IGNORED_FILENAMES = {
     "desktop.ini",
     ".ds_store",
     ".rhistory",
+    _MANIFEST_ALLOWLIST_FILENAME,
 }
 
 _IGNORED_DIRNAMES = {"__pycache__", ".ipynb_checkpoints"}

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -222,6 +222,20 @@ def test_manifest_allows_latest_windows_sha256() -> None:
 
 
 @pytest.mark.unit
+def test_repository_allowlist_includes_sparse_index_checksum(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The repo-level allow-list must include the sparse index checksum variant."""
+
+    dictionaries._load_allowlist_cached.cache_clear()
+    monkeypatch.setattr(dictionaries, "_KNOWN_CHECKSUM_VARIANTS", {})
+
+    variants = dictionaries._iter_additional_checksums(
+        "dictionary_root", base_dir=DICTIONARY_DIR
+    )
+
+    assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
+
+
+@pytest.mark.unit
 def test_manifest_allows_latest_target_uniprot_checksum() -> None:
     """The manifest lists the newly observed UniProt cache checksum variant."""
 


### PR DESCRIPTION
## Summary
- add a repository-level `manifest.allowlist.yaml` so the bundled dictionaries accept the sparse index checksum observed on recent Windows toolchains
- ignore the allowlist file when hashing dictionary resources to keep existing checksums stable
- cover the new allowlist with a unit test that exercises the runtime checksum variants loader

## Testing
- pytest tests/unit/test_resources_dictionaries.py::test_repository_allowlist_includes_sparse_index_checksum -q

------
https://chatgpt.com/codex/tasks/task_e_68e5283baf8483249e39bec0d4fab161