### PR TITLE
Handle optional parameters in target postprocessing steps

### DIFF
--- a/library/postprocess/common/types.py
+++ b/library/postprocess/common/types.py
@@ -11,7 +11,7 @@ import pandas as pd
 class StepFn(Protocol):
     """Protocol describing a pure DataFrame transformation."""
 
-    def __call__(self, df: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, df: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
         """Return a new :class:`pandas.DataFrame` derived from ``df``."""
 
 

--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -1,6 +1,9 @@
 """Transformation steps for target postprocessing."""
 from __future__ import annotations
 
+from collections.abc import Sequence
+import re
+
 import pandas as pd
  
 from library.postprocess.common import StepDefinition, run_steps
@@ -87,22 +90,75 @@ def normalize_target_fields(
     return normalized
 
 
-def enrich_target_synonyms(df: pd.DataFrame) -> pd.DataFrame:
-    """Ensure synonyms column is deterministically ordered."""
+_SYNONYM_SPLIT_PATTERN = re.compile(r"[|;,]")
+
+
+def _tokenise_synonyms(value: object) -> list[str]:
+    if value is None or pd.isna(value):
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    parts = _SYNONYM_SPLIT_PATTERN.split(text)
+    return [part.strip() for part in parts if part and part.strip()]
+
+
+def enrich_target_synonyms(
+    df: pd.DataFrame,
+    *,
+    synonym_sources: Sequence[str] | None = None,
+    preferred_separator: str = ", ",
+) -> pd.DataFrame:
+    """Aggregate synonyms from configured sources into a deterministic string column."""
 
     enriched = df.copy(deep=True)
+    synonym_columns: list[str] = []
+
     if "synonyms" in enriched.columns:
-        enriched["synonyms"] = (
-            enriched["synonyms"].fillna("")
-            .astype("string")
-            .apply(
-                lambda value: ", ".join(sorted(part.strip() for part in value.split(",") if part.strip()))
-            )
-        )
+        synonym_columns.append("synonyms")
+
+    if synonym_sources:
+        for source in synonym_sources:
+            column_name = f"{source}_synonyms"
+            if column_name in enriched.columns and column_name not in synonym_columns:
+                synonym_columns.append(column_name)
+
+    if not synonym_columns:
+        return enriched
+
+    def _merge_row(row: pd.Series) -> object:
+        seen: set[str] = set()
+        ordered_tokens: list[str] = []
+
+        for column in synonym_columns:
+            tokens = _tokenise_synonyms(row.get(column))
+            for token in tokens:
+                marker = token.casefold()
+                if marker in seen:
+                    continue
+                seen.add(marker)
+                ordered_tokens.append(token)
+
+        if not ordered_tokens:
+            return pd.NA
+
+        return preferred_separator.join(ordered_tokens)
+
+    enriched["synonyms"] = (
+        enriched.apply(_merge_row, axis=1)
+        .astype("string")
+        .replace({"": pd.NA})
+    )
+
     return enriched
 
 
-def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
+def finalize_target_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    sort_by: Sequence[str] | None = None,
+) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
 
     prepared = df.copy(deep=True)
@@ -113,7 +169,24 @@ def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
         if column in prepared.columns:
             prepared[column] = prepared[column].astype("string")
 
-    validated = validate_targets(prepared, context="target_finalization")
+    if enforce_schema:
+        validated = validate_targets(prepared, context="target_finalization")
+    else:
+        ordered_columns: list[str] = []
+        if TARGET_SCHEMA.column_order:
+            ordered_columns.extend(
+                column for column in TARGET_SCHEMA.column_order if column in prepared.columns
+            )
+        remaining = [
+            column for column in prepared.columns if column not in ordered_columns
+        ]
+        validated = prepared.loc[:, ordered_columns + remaining] if ordered_columns else prepared
+
+    if sort_by:
+        sort_columns = [column for column in sort_by if column in validated.columns]
+        if sort_columns:
+            validated = validated.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
+
     return validated
 
 

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from library.postprocess.targets.steps import (
+    enrich_target_synonyms,
     finalize_target_records,
     normalize_target_fields,
 )
@@ -92,3 +93,46 @@ def test_finalize_target_records__handles_empty_input_frame() -> None:
     assert str(result["target_chembl_id"].dtype) == "string"
     assert str(result["pref_name"].dtype) == "string"
     assert str(result["target_type"].dtype) == "string"
+
+
+@pytest.mark.unit
+def test_enrich_target_synonyms__combines_sources_with_separator() -> None:
+    frame = pd.DataFrame(
+        {
+            "synonyms": ["beta | Alpha", None],
+            "chembl_synonyms": ["alpha; delta", "theta"],
+            "gtopdb_synonyms": ["gamma, beta", ""],
+        }
+    )
+
+    result = enrich_target_synonyms(
+        frame,
+        synonym_sources=["chembl", "gtopdb"],
+        preferred_separator="; ",
+    )
+
+    assert result["synonyms"].tolist() == ["beta; Alpha; delta; gamma", "theta"]
+
+
+@pytest.mark.unit
+def test_finalize_target_records__supports_optional_flags(monkeypatch) -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL2", "CHEMBL1"],
+            "pref_name": ["Beta", "Alpha"],
+            "target_type": ["protein", "protein"],
+        }
+    )
+
+    monkeypatch.setattr(
+        "library.postprocess.targets.steps.validate_targets",
+        lambda *args, **kwargs: pytest.fail("validate_targets should not be called"),
+    )
+
+    result = finalize_target_records(
+        frame,
+        enforce_schema=False,
+        sort_by=["target_chembl_id"],
+    )
+
+    assert result["target_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]


### PR DESCRIPTION
## Summary
- allow pipeline step callables to accept keyword parameters by widening the StepFn protocol
- merge target synonyms deterministically while honouring configured sources and separators
- support optional schema enforcement and custom sorting in the target finalisation step

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e528dd751c8324aa468bb4ae2269b3