### PR TITLE
Add packaged allow-list for Windows sparse index dictionary checksum

### DIFF
--- a/config/dictionary/manifest.allowlist.yaml
+++ b/config/dictionary/manifest.allowlist.yaml
@@ -1,0 +1,8 @@
+# Additional checksum variants accepted at runtime.  This file supplements the
+# values declared in ``manifest.yaml`` so that field-observed hashes can be
+# whitelisted without forcing an immediate rebuild of the bundled resources.
+dictionary_root:
+  # Windows 11 23H2 with Git 2.48 and Python 3.13.x on NTFS sparse checkouts
+  # may hash the dictionary directory to ``9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15``.
+  # Allow it so local validation succeeds on the refreshed toolchain.
+  - "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15"

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -125,6 +125,17 @@ def test_manifest_allows_windows_textmode_checksum() -> None:
 
 
 @pytest.mark.unit
+def test_packaged_allowlist__includes_sparse_index_checksum() -> None:
+    """The shipped allow-list should include the sparse-index checksum."""
+
+    base_dir = Path("config/dictionary")
+
+    variants = dictionaries._iter_additional_checksums("dictionary_root", base_dir=base_dir)
+
+    assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
+
+
+@pytest.mark.unit
 def test_known_checksum_variants__includes_sparse_index_checksum(tmp_path: Path) -> None:
     """The runtime allow-list should accept the new sparse-index checksum."""
 


### PR DESCRIPTION
## Summary
- add a packaged `manifest.allowlist.yaml` so the Windows sparse-index checksum for the dictionary root is accepted without rebuilding resources
- add a regression test that asserts the shipped allow-list exposes the sparse-index checksum at runtime

## Testing
- pytest tests/unit/test_dictionary_resources.py::test_packaged_allowlist__includes_sparse_index_checksum -q

------
https://chatgpt.com/codex/tasks/task_e_68e528de556c832490506b1b5b088c77