### PR TITLE
Improve document finalisation options

### DIFF
--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -136,8 +136,29 @@ def enrich_document_publication_year(
     return enriched
 
 
-def finalize_document_records(df: pd.DataFrame, **_: object) -> pd.DataFrame:
-    """Validate and order the DataFrame according to :data:`DOCUMENT_SCHEMA`."""
+def finalize_document_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    ensure_unique_ids: bool = False,
+    **_: object,
+) -> pd.DataFrame:
+    """Normalise terminal document rows and optionally validate the schema.
+
+    Parameters
+    ----------
+    df:
+        Input frame containing the document rows produced by the preceding
+        enrichment steps.
+    enforce_schema:
+        When ``True`` (the default) the output is validated against
+        :data:`DOCUMENT_SCHEMA`. Setting this flag to ``False`` can be useful
+        in exploratory runs where partial data is expected.
+    ensure_unique_ids:
+        Drop duplicated ``document_chembl_id`` values while keeping the first
+        occurrence. The operation is deterministic to guarantee idempotent
+        pipeline re-runs.
+    """
 
     prepared = df.copy(deep=True)
 
@@ -150,6 +171,32 @@ def finalize_document_records(df: pd.DataFrame, **_: object) -> pd.DataFrame:
 
     if "publication_year" in prepared.columns:
         prepared["publication_year"] = prepared["publication_year"].astype("Int64")
+
+    if ensure_unique_ids and "document_chembl_id" in prepared.columns:
+        prepared = (
+            prepared.drop_duplicates(subset=["document_chembl_id"], keep="first")
+            .reset_index(drop=True)
+        )
+    else:
+        prepared = prepared.reset_index(drop=True)
+
+    if not enforce_schema:
+        ordered = prepared
+        column_order = DOCUMENT_SCHEMA.column_order or ()
+        if column_order:
+            ordered_columns = [col for col in column_order if col in ordered.columns]
+            remaining = [col for col in ordered.columns if col not in ordered_columns]
+            if ordered_columns:
+                ordered = ordered.loc[:, ordered_columns + remaining]
+
+        sort_by = DOCUMENT_SCHEMA.sort_by or ()
+        if sort_by:
+            sort_columns = [col for col in sort_by if col in ordered.columns]
+            if sort_columns:
+                ordered = ordered.sort_values(sort_columns, kind="mergesort").reset_index(
+                    drop=True
+                )
+        return ordered
 
     validated = validate_documents(prepared, context="document_finalization")
     return validated

--- a/tests/unit/postprocessing/test_document_steps.py
+++ b/tests/unit/postprocessing/test_document_steps.py
@@ -92,3 +92,30 @@ def test_finalize_document_records__adds_missing_required_columns() -> None:
     assert result["document_chembl_id"].dtype == "string"
     assert result["title"].dtype == "string"
     assert result["doc_type"].dtype == "string"
+
+
+@pytest.mark.unit
+def test_finalize_document_records__deduplicates_when_requested() -> None:
+    frame = pd.DataFrame(
+        {
+            "document_chembl_id": ["CHEMBL1", "CHEMBL1", "CHEMBL2"],
+            "title": ["A", "B", "C"],
+            "doc_type": ["Journal", "Preprint", "Journal"],
+        }
+    )
+
+    result = finalize_document_records(frame, ensure_unique_ids=True)
+
+    assert result["document_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert result["title"].tolist() == ["A", "C"]
+
+
+@pytest.mark.unit
+def test_finalize_document_records__skips_validation_when_disabled() -> None:
+    frame = pd.DataFrame({"unexpected": [1]})
+
+    result = finalize_document_records(frame, enforce_schema=False)
+
+    assert "unexpected" in result.columns
+    # Missing required columns are injected even when validation is disabled.
+    assert all(column in result.columns for column in ("document_chembl_id", "title", "doc_type"))


### PR DESCRIPTION
## Summary
- extend `finalize_document_records` with `enforce_schema` and `ensure_unique_ids` controls
- keep document outputs deterministic when schema checks are disabled by reapplying ordering and sorting rules
- add unit coverage for deduplication and optional schema validation behaviour

## Testing
- pytest tests/unit/postprocessing/test_document_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68e52969e8c88324a1f549e684f35e1e