### PR TITLE
Summarize parent lookup warning payloads

### DIFF
--- a/library/pipelines/testitem/catalog.py
+++ b/library/pipelines/testitem/catalog.py
@@ -46,6 +46,18 @@ _PARENT_SOURCE_PRIORITY: Mapping[str, int] = {
 }
 
 
+def _summarise_identifiers(
+    values: Sequence[str], *, limit: int = 20
+) -> tuple[list[str], bool]:
+    """Return a sorted, truncated list of identifiers for structured logging."""
+
+    identifiers = sorted({str(value) for value in values})
+    truncated = len(identifiers) > limit
+    if truncated:
+        identifiers = identifiers[:limit]
+    return identifiers, truncated
+
+
 @dataclass
 class ParentEnrichmentPreparation:
     """Intermediate data required to attach parent identifiers."""
@@ -487,10 +499,12 @@ def attach_parent_molecule_ids(
     )
 
     if skip_full_sync:
+        identifiers, truncated = _summarise_identifiers(missing_ids)
         logger.warning(
             "parent_lookup_full_sync_skipped_parentless",
             count=len(missing_ids),
-            identifiers=missing_ids,
+            identifiers=identifiers,
+            truncated=truncated,
         )
         source_resolved = PARENT_LOOKUP_SOURCE_SKIPPED
     elif missing_ids and catalog is None and needs_full_sync:
@@ -523,10 +537,12 @@ def attach_parent_molecule_ids(
             uncovered_children = len(missing_ids)
 
     if missing_ids:
+        identifiers, truncated = _summarise_identifiers(missing_ids)
         logger.warning(
             "parent_lookup_missing_parents",
             count=len(missing_ids),
-            identifiers=missing_ids,
+            identifiers=identifiers,
+            truncated=truncated,
         )
 
     refreshed_parent = normalised_child.map(parent_map).astype("string")

--- a/tests/integration/test_parent_lookup.py
+++ b/tests/integration/test_parent_lookup.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from library.config import MoleculeCatalogCfg
+from library.pipelines.testitem import catalog
+
+
+def _stub_parent_catalog_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace parent catalog I/O helpers with deterministic stubs."""
+
+    monkeypatch.setattr(catalog, "query_parent_catalog", lambda *args, **kwargs: {})
+    monkeypatch.setattr(catalog, "load_parent_catalog", lambda *args, **kwargs: {})
+    monkeypatch.setattr(catalog, "update_parent_catalog_cache", lambda *args, **kwargs: None)
+    monkeypatch.setattr(catalog, "write_parent_catalog_cache", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        catalog.molecule_catalog,
+        "fetch_parent_catalog_for",
+        lambda *args, **kwargs: {},
+    )
+
+
+def _build_catalog_cfg(tmp_path: Path) -> MoleculeCatalogCfg:
+    return MoleculeCatalogCfg(
+        cache_path=tmp_path / "parent_catalog.json",
+        sqlite_path=tmp_path / "parent_catalog.sqlite",
+    )
+
+
+def _capture_warnings(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, dict[str, object]]]:
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **fields: object) -> None:
+        events.append((event, fields))
+
+    monkeypatch.setattr(catalog.logger, "warning", _capture)
+    return events
+
+
+def _run_parent_lookup(
+    child_ids: list[str],
+    *,
+    cfg: MoleculeCatalogCfg,
+    api_cfg,
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, dict[str, object]]]:
+    _stub_parent_catalog_calls(monkeypatch)
+    events = _capture_warnings(monkeypatch)
+
+    client = MagicMock(spec=catalog.ChemblClient)
+    frame = pd.DataFrame({"molecule_chembl_id": child_ids})
+
+    catalog.attach_parent_molecule_ids(
+        frame,
+        client=client,
+        api_cfg=api_cfg,
+        catalog_cfg=cfg,
+        timeout=1.0,
+        catalog=None,
+    )
+
+    return events
+
+
+def _extract_event(
+    events: list[tuple[str, dict[str, object]]], name: str
+) -> dict[str, object]:
+    return next(fields for event, fields in events if event == name)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "child_ids, truncated",
+    [
+        (
+            [
+                "CHEMBL0005",
+                "CHEMBL0002",
+                "CHEMBL0003",
+            ],
+            False,
+        ),
+        (
+            [
+                f"CHEMBL{value:07d}"
+                for value in range(1024, 998, -1)
+            ],
+            True,
+        ),
+    ],
+    ids=["no-truncation", "truncated"],
+)
+def test_attach_parent_molecule_ids__summarises_identifier_payload(
+    child_ids: list[str],
+    truncated: bool,
+    tmp_path,
+    cfg,
+    monkeypatch,
+) -> None:
+    catalog_cfg = _build_catalog_cfg(tmp_path)
+    events = _run_parent_lookup(
+        child_ids,
+        cfg=catalog_cfg,
+        api_cfg=cfg.api,
+        monkeypatch=monkeypatch,
+    )
+
+    expected_identifiers = sorted(child_ids)
+    if truncated:
+        assert len(expected_identifiers) > 20
+        expected_identifiers = expected_identifiers[:20]
+
+    skip_event = _extract_event(
+        events, "parent_lookup_full_sync_skipped_parentless"
+    )
+    missing_event = _extract_event(events, "parent_lookup_missing_parents")
+
+    for payload in (skip_event, missing_event):
+        assert payload["count"] == len(child_ids)
+        assert payload["identifiers"] == expected_identifiers
+        assert payload["truncated"] is truncated


### PR DESCRIPTION
## Summary
- add structured identifier summarisation for parent lookup warning logs
- ensure parent lookup warnings include truncation metadata and sorted payloads
- introduce integration coverage for parent lookup logging behaviour

## Testing
- `pytest tests/integration/test_parent_lookup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e526cb5fe083249eca7426de537136