### PR TITLE
Handle finalize step parameters for targets

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -1,7 +1,10 @@
 """Transformation steps for target postprocessing."""
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import pandas as pd
+from pandas.api.types import pandas_dtype
  
 from library.postprocess.common import StepDefinition, run_steps
 from library.postprocess.common.logging import PipelineRunMetrics
@@ -102,19 +105,69 @@ def enrich_target_synonyms(df: pd.DataFrame) -> pd.DataFrame:
     return enriched
 
 
-def finalize_target_records(df: pd.DataFrame) -> pd.DataFrame:
-    """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
+def _build_empty_column(index: pd.Index, dtype: str | type | None) -> pd.Series:
+    """Return an empty series matching ``index`` and ``dtype``."""
+
+    target_dtype = "string" if dtype is None else dtype
+    try:
+        resolved_dtype = pandas_dtype(target_dtype)
+    except TypeError:
+        resolved_dtype = pandas_dtype("string")
+    return pd.Series(pd.NA, index=index, dtype=resolved_dtype)
+
+
+def _expected_columns() -> list[str]:
+    """Return the set of columns that must exist before validation."""
+
+    return list(TARGET_SCHEMA.required_columns)
+
+
+def finalize_target_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    sort_by: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`.
+
+    Parameters
+    ----------
+    df:
+        The input frame produced by previous pipeline steps.
+    enforce_schema:
+        When ``True`` (default) run :func:`validate_targets` to apply schema
+        validation and canonical ordering. When ``False`` the function still
+        ensures required columns exist but skips the expensive validation pass.
+    sort_by:
+        Optional override for output ordering. Values not present in the frame
+        are ignored.
+    """
 
     prepared = df.copy(deep=True)
-    for column in TARGET_SCHEMA.required_columns:
-        if column not in prepared.columns:
-            prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype="string")
-    for column in ["target_chembl_id", "pref_name", "target_type"]:
-        if column in prepared.columns:
-            prepared[column] = prepared[column].astype("string")
+    index = prepared.index
 
-    validated = validate_targets(prepared, context="target_finalization")
-    return validated
+    for column in _expected_columns():
+        if column in prepared.columns:
+            continue
+        prepared[column] = _build_empty_column(index, TARGET_SCHEMA.dtypes.get(column))
+
+    for column, dtype in TARGET_SCHEMA.dtypes.items():
+        if column in prepared.columns:
+            prepared[column] = prepared[column].astype(dtype)
+
+    if sort_by:
+        sort_columns = [column for column in sort_by if column in prepared.columns]
+        if sort_columns:
+            prepared = prepared.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
+
+    if enforce_schema:
+        prepared = validate_targets(prepared, context="target_finalization")
+    elif TARGET_SCHEMA.column_order:
+        ordered_columns = [col for col in TARGET_SCHEMA.column_order if col in prepared.columns]
+        remaining = [col for col in prepared.columns if col not in ordered_columns]
+        prepared = prepared.loc[:, ordered_columns + remaining]
+
+    return prepared
 
 
 PIPELINE_CONFIG = load_pipeline_config("targets")

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from library.postprocess.targets.steps import (
-    finalize_target_records,
-    normalize_target_fields,
-)
+from library.postprocess.targets import steps
+from library.postprocess.targets.steps import finalize_target_records, normalize_target_fields
 
 
 @pytest.mark.unit
@@ -92,3 +90,46 @@ def test_finalize_target_records__handles_empty_input_frame() -> None:
     assert str(result["target_chembl_id"].dtype) == "string"
     assert str(result["pref_name"].dtype) == "string"
     assert str(result["target_type"].dtype) == "string"
+
+
+@pytest.mark.unit
+def test_finalize_target_records__supports_sort_override() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL2", "CHEMBL1"],
+            "pref_name": ["Beta", "Alpha"],
+            "target_type": ["type-b", "type-a"],
+        }
+    )
+
+    result = finalize_target_records(frame, enforce_schema=False, sort_by=["pref_name"])
+
+    assert result.loc[0, "pref_name"] == "Alpha"
+    assert result.loc[1, "pref_name"] == "Beta"
+    assert list(result.columns[:3]) == [
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+    ]
+
+
+@pytest.mark.unit
+def test_finalize_target_records__skips_schema_validation_when_disabled(monkeypatch) -> None:
+    calls: list[pd.DataFrame] = []
+
+    def _fake_validate(df: pd.DataFrame, *, context: str):  # pragma: no cover - sanity
+        calls.append(df)
+        return df
+
+    monkeypatch.setattr(steps, "validate_targets", _fake_validate)
+
+    frame = pd.DataFrame({"target_chembl_id": ["CHEMBL1"], "pref_name": ["Alpha"]})
+
+    result = finalize_target_records(frame, enforce_schema=False)
+
+    assert not calls
+    assert list(result.columns)[:3] == [
+        "target_chembl_id",
+        "pref_name",
+        "target_type",
+    ]


### PR DESCRIPTION
## Summary
- ensure the target finalization step backfills required columns with schema-aware defaults
- accept enforce_schema and sort_by parameters while keeping optional ordering logic deterministic
- expand target post-processing unit tests to cover the new behaviours

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68e529280b2c8324beaaf93e8234eb66