### PR TITLE
Handle missing target_type during target postprocessing

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -158,16 +158,33 @@ def finalize_target_records(
     *,
     enforce_schema: bool = True,
     sort_by: Sequence[str] | None = None,
+    **_: object,
 ) -> pd.DataFrame:
     """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
 
     prepared = df.copy(deep=True)
-    for column in TARGET_SCHEMA.required_columns:
+
+    # Normalise a few legacy aliases that may appear in historical exports.
+    if "target_type" not in prepared.columns and "relationship" in prepared.columns:
+        prepared["target_type"] = prepared["relationship"]
+
+    required_columns = set(TARGET_SCHEMA.required_columns)
+    optional_columns = set(TARGET_SCHEMA.optional_columns)
+    expected_string_columns = required_columns.union(
+        {column for column, dtype in TARGET_SCHEMA.dtypes.items() if dtype == "string"}
+    )
+
+    for column in sorted(required_columns | optional_columns):
         if column not in prepared.columns:
             prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype="string")
-    for column in ["target_chembl_id", "pref_name", "target_type"]:
+
+    for column in expected_string_columns:
         if column in prepared.columns:
-            prepared[column] = prepared[column].astype("string")
+            prepared[column] = (
+                prepared[column]
+                .astype("string")
+                .replace({"": pd.NA})
+            )
 
     if enforce_schema:
         validated = validate_targets(prepared, context="target_finalization")

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -68,11 +68,13 @@ def test_finalize_target_records__fills_missing_required_columns() -> None:
 
     result = finalize_target_records(frame)
 
-    assert list(result.columns) == [
+    assert list(result.columns[:3]) == [
         "target_chembl_id",
         "pref_name",
         "target_type",
     ]
+    for column in ["organism", "target_class", "protein_family", "synonyms", "pipeline_version"]:
+        assert column in result.columns
     assert pd.isna(result.loc[0, "target_type"])
     assert str(result["target_type"].dtype) == "string"
     assert str(result["pref_name"].dtype) == "string"
@@ -85,11 +87,13 @@ def test_finalize_target_records__handles_empty_input_frame() -> None:
     result = finalize_target_records(frame)
 
     assert result.empty
-    assert list(result.columns) == [
+    assert list(result.columns[:3]) == [
         "target_chembl_id",
         "pref_name",
         "target_type",
     ]
+    for column in ["organism", "target_class", "protein_family", "synonyms", "pipeline_version"]:
+        assert column in result.columns
     assert str(result["target_chembl_id"].dtype) == "string"
     assert str(result["pref_name"].dtype) == "string"
     assert str(result["target_type"].dtype) == "string"
@@ -136,3 +140,18 @@ def test_finalize_target_records__supports_optional_flags(monkeypatch) -> None:
     )
 
     assert result["target_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+
+
+@pytest.mark.unit
+def test_finalize_target_records__populates_target_type_from_relationship() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL42"],
+            "pref_name": ["Some target"],
+            "relationship": ["SINGLE PROTEIN"],
+        }
+    )
+
+    result = finalize_target_records(frame)
+
+    assert result.loc[0, "target_type"] == "SINGLE PROTEIN"


### PR DESCRIPTION
## Summary
- make `finalize_target_records` resilient to missing target metadata by filling schema-required/optional columns and reusing legacy aliases
- normalise string columns and accept extra keyword arguments to avoid pipeline warnings
- extend unit tests to cover the new behaviour and legacy relationship fallback

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e52aac36c883249b07793f42ef4637