### PR TITLE
Handle document finalization options

### DIFF
--- a/library/postprocess/documents/steps.py
+++ b/library/postprocess/documents/steps.py
@@ -136,8 +136,30 @@ def enrich_document_publication_year(
     return enriched
 
 
-def finalize_document_records(df: pd.DataFrame, **_: object) -> pd.DataFrame:
-    """Validate and order the DataFrame according to :data:`DOCUMENT_SCHEMA`."""
+def finalize_document_records(
+    df: pd.DataFrame,
+    *,
+    enforce_schema: bool = True,
+    ensure_unique_ids: bool = False,
+    unique_id_column: str = "document_chembl_id",
+    **_: object,
+) -> pd.DataFrame:
+    """Normalize terminal document output and optionally enforce invariants.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by preceding pipeline steps.
+    enforce_schema:
+        When ``True`` (default) the result is validated against
+        :data:`DOCUMENT_SCHEMA` prior to being returned.
+    ensure_unique_ids:
+        Drop duplicate records using ``unique_id_column`` as the key. The first
+        occurrence of a duplicated identifier is preserved.
+    unique_id_column:
+        Column name used when ``ensure_unique_ids`` is enabled. Defaults to
+        ``"document_chembl_id"``.
+    """
 
     prepared = df.copy(deep=True)
 
@@ -150,6 +172,17 @@ def finalize_document_records(df: pd.DataFrame, **_: object) -> pd.DataFrame:
 
     if "publication_year" in prepared.columns:
         prepared["publication_year"] = prepared["publication_year"].astype("Int64")
+
+    if ensure_unique_ids and unique_id_column in prepared.columns:
+        identifier_series = prepared[unique_id_column]
+        if not pd.api.types.is_string_dtype(identifier_series.dtype):
+            identifier_series = identifier_series.astype("string")
+        duplicates = identifier_series.duplicated(keep="first")
+        if duplicates.any():
+            prepared = prepared.loc[~duplicates].reset_index(drop=True)
+
+    if not enforce_schema:
+        return prepared
 
     validated = validate_documents(prepared, context="document_finalization")
     return validated

--- a/tests/unit/postprocessing/test_document_steps.py
+++ b/tests/unit/postprocessing/test_document_steps.py
@@ -92,3 +92,30 @@ def test_finalize_document_records__adds_missing_required_columns() -> None:
     assert result["document_chembl_id"].dtype == "string"
     assert result["title"].dtype == "string"
     assert result["doc_type"].dtype == "string"
+
+
+@pytest.mark.unit
+def test_finalize_document_records__skips_schema_enforcement_when_disabled() -> None:
+    frame = pd.DataFrame({"unexpected": ["value"]})
+
+    result = finalize_document_records(frame, enforce_schema=False)
+
+    assert "unexpected" in result.columns
+    # Required columns are still present but schema coercion is skipped.
+    assert set(["document_chembl_id", "title", "doc_type"]).issubset(result.columns)
+
+
+@pytest.mark.unit
+def test_finalize_document_records__removes_duplicate_identifiers_when_requested() -> None:
+    frame = pd.DataFrame(
+        {
+            "document_chembl_id": ["CHEMBL1", "CHEMBL1", "CHEMBL2"],
+            "title": ["A", "Duplicate", "B"],
+            "doc_type": ["JOURNAL", "JOURNAL", "PREPRINT"],
+        }
+    )
+
+    result = finalize_document_records(frame, ensure_unique_ids=True)
+
+    assert result["document_chembl_id"].tolist() == ["CHEMBL1", "CHEMBL2"]
+    assert result["title"].tolist() == ["A", "B"]


### PR DESCRIPTION
## Summary
- add support for enforce_schema and ensure_unique_ids parameters in the document finalization step
- ensure duplicate document identifiers are dropped deterministically before schema validation
- extend document step unit tests to cover schema skipping and identifier deduplication scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e529c2ae588324bc3d278ed49be2ea