### PR TITLE
Improve dictionary checksum mismatch guidance

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -369,9 +369,13 @@ def _parse_manifest(base_dir: Path | None = None) -> Mapping[str, DictionaryReso
 
         sha256_actual = _compute_sha256(absolute_path)
         if sha256_actual not in sha256_expected:
+            allowlist_path = manifest_root / _MANIFEST_ALLOWLIST_FILENAME
+            env_hint = f"{_ENV_CHECKSUM_ALLOWLIST}={name}={sha256_actual}"
             raise DictionaryManifestError(
                 "Checksum mismatch for resource"
-                f" {name!r}: expected one of {sha256_expected}, got {sha256_actual}"
+                f" {name!r}: expected one of {sha256_expected}, got {sha256_actual}. "
+                "If this digest is valid for your platform, add it to the allow-list at "
+                f"{allowlist_path} or export {env_hint} before rerunning."
             )
 
         parsed[name] = DictionaryResource(

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -131,3 +131,32 @@ def test_known_checksum_variants__includes_sparse_index_checksum(tmp_path: Path)
     variants = dictionaries._iter_additional_checksums("dictionary_root", base_dir=tmp_path)
 
     assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
+
+
+@pytest.mark.unit
+def test_parse_manifest__checksum_mismatch_hint(tmp_path: Path) -> None:
+    """Checksum mismatches should include remediation hints in the error message."""
+
+    manifest_dir = tmp_path / "dictionary"
+    manifest_dir.mkdir()
+
+    manifest_payload = {
+        "resources": {
+            "dictionary_root": {
+                "path": ".",
+                "version": "test",
+                "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "generator": "tools/build_dictionary_resources.py",
+            }
+        }
+    }
+    manifest_path = manifest_dir / "manifest.yaml"
+    manifest_path.write_text(yaml.safe_dump(manifest_payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(dictionaries.DictionaryManifestError) as exc_info:
+        dictionaries._parse_manifest(base_dir=manifest_dir)
+
+    message = str(exc_info.value)
+    assert "manifest.allowlist.yaml" in message
+    assert dictionaries._ENV_CHECKSUM_ALLOWLIST in message
+    assert "dictionary_root" in message


### PR DESCRIPTION
## Summary
- expand the checksum mismatch error to suggest updating the dictionary allow-list or exporting the override environment variable
- add a regression test that asserts the new guidance is emitted when the manifest hash does not match

## Testing
- pytest tests/unit/test_dictionary_resources.py -k checksum_mismatch_hint -q

------
https://chatgpt.com/codex/tasks/task_e_68e52aaeace88324b36bcd41ddd9b067