### PR TITLE
Fix target postprocessing when target_type column is missing

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 import re
 
 import pandas as pd
+
+_STRING_DTYPE = pd.StringDtype()
  
 from library.postprocess.common import StepDefinition, run_steps
 from library.postprocess.common.logging import PipelineRunMetrics
@@ -162,12 +164,18 @@ def finalize_target_records(
     """Validate and order the DataFrame according to :data:`TARGET_SCHEMA`."""
 
     prepared = df.copy(deep=True)
+
     for column in TARGET_SCHEMA.required_columns:
         if column not in prepared.columns:
-            prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype="string")
+            prepared[column] = pd.Series(pd.NA, index=prepared.index, dtype=_STRING_DTYPE)
+
     for column in ["target_chembl_id", "pref_name", "target_type"]:
         if column in prepared.columns:
-            prepared[column] = prepared[column].astype("string")
+            prepared[column] = (
+                prepared[column]
+                .astype(_STRING_DTYPE)
+                .replace({"": pd.NA})
+            )
 
     if enforce_schema:
         validated = validate_targets(prepared, context="target_finalization")

--- a/tests/integration/test_target_postprocess_table.py
+++ b/tests/integration/test_target_postprocess_table.py
@@ -9,6 +9,7 @@ import pytest
 
 from library.config import Config
 from library.pipelines.target import helpers
+from library.postprocess.targets.steps import run_target_pipeline
 
 INPUT_FILE = "target_postprocess_power_query_input.csv"
 EXPECTED_FILE = "target_postprocess_power_query_expected.csv"
@@ -57,3 +58,20 @@ def test_postprocess_target_table__is_idempotent(
     second_run = second_output.read_bytes()
 
     assert first_run == second_run == expected_path.read_bytes()
+
+
+@pytest.mark.integration
+def test_run_target_pipeline__adds_missing_target_type() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL1000", "CHEMBL2000"],
+            "pref_name": ["Example 1", "Example 2"],
+        }
+    )
+
+    result, metrics = run_target_pipeline(frame)
+
+    assert "target_type" in result.columns
+    assert result["target_type"].isna().all()
+    assert str(result["target_type"].dtype) == "string"
+    assert metrics.output_rows == 2


### PR DESCRIPTION
## Summary
- ensure `finalize_target_records` backfills missing required columns using pandas' dedicated string dtype
- normalise blank strings to `NA` when finalising mandatory target metadata fields
- add an integration regression test that runs the target pipeline without a `target_type` column and asserts metrics

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py::test_finalize_target_records__fills_missing_required_columns
- pytest tests/integration/test_target_postprocess_table.py::test_run_target_pipeline__adds_missing_target_type

------
https://chatgpt.com/codex/tasks/task_e_68e52b2872a4832496249c233130a1ed