### PR TITLE
Handle future params in target synonym enrichment

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -108,6 +108,7 @@ def enrich_target_synonyms(
     *,
     synonym_sources: Sequence[str] | None = None,
     preferred_separator: str = ", ",
+    **_: object,
 ) -> pd.DataFrame:
     """Aggregate synonyms from configured sources into a deterministic string column."""
 

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -119,6 +119,25 @@ def test_enrich_target_synonyms__combines_sources_with_separator() -> None:
 
 
 @pytest.mark.unit
+def test_enrich_target_synonyms__ignores_unrecognised_parameters() -> None:
+    frame = pd.DataFrame(
+        {
+            "synonyms": ["alpha"],
+            "chembl_synonyms": ["beta"],
+        }
+    )
+
+    result = enrich_target_synonyms(
+        frame,
+        synonym_sources=["chembl"],
+        preferred_separator="; ",
+        future_flag=True,
+    )
+
+    assert result["synonyms"].tolist() == ["alpha; beta"]
+
+
+@pytest.mark.unit
 def test_finalize_target_records__supports_optional_flags(monkeypatch) -> None:
     frame = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- ensure the target synonym enrichment post-processing step accepts and ignores unknown keyword parameters to remain compatible with pipeline configuration updates
- add a unit test covering the extra-parameter scenario so future regressions emit explicit failures instead of runtime warnings

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68e52cbe3078832488f2fa373af8a613