### PR TITLE
Enforce pipeline step parameter compatibility

### DIFF
--- a/library/postprocess/common/config.py
+++ b/library/postprocess/common/config.py
@@ -1,6 +1,7 @@
 """Helpers for loading declarative post-processing pipeline configuration."""
 from __future__ import annotations
 
+import inspect
 import os
 import re
 from dataclasses import dataclass
@@ -166,6 +167,8 @@ def _load_step(entry: Any, index: int) -> ConfiguredStep:
             f"resolved object for step '{name}' is not callable: {callable_path}"
         )
 
+    _validate_step_parameters(func, params, step_name=name)
+
     definition = StepDefinition(
         name=name,
         func=func,
@@ -179,6 +182,33 @@ def _load_step(entry: Any, index: int) -> ConfiguredStep:
         params=params,
         description=description,
     )
+
+
+def _validate_step_parameters(func: Any, params: Mapping[str, Any], *, step_name: str) -> None:
+    """Ensure that every configured parameter is supported by ``func``."""
+
+    if not params:
+        return
+
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return
+
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return
+
+    unsupported = sorted(
+        key for key in params.keys() if key not in signature.parameters
+    )
+    if unsupported:
+        formatted = ", ".join(unsupported)
+        raise PipelineConfigError(
+            f"step '{step_name}' defines unsupported parameters: {formatted}"
+        )
 
 
 def _expand_environment(value: Any, env: Mapping[str, str]) -> Any:

--- a/tests/unit/postprocessing/test_pipeline_config.py
+++ b/tests/unit/postprocessing/test_pipeline_config.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import importlib
+from textwrap import dedent
 
 import pytest
 
 from library.postprocess.common.config import (
+    PipelineConfigError,
     load_pipeline_config,
     normalize_pipeline_version,
 )
@@ -196,6 +198,29 @@ def test_pipeline_configs__resolve_steps_and_defaults(
     assert cfg.params["io"]["csv_sep"] == ","
     for section in ("defaults", "io", *extra_sections):
         assert section in cfg.params
+
+
+def test_load_pipeline_config__errors_on_unsupported_step_parameters(tmp_path):
+    """A clear error is raised when a step lists unsupported parameters."""
+
+    config_text = dedent(
+        """
+        pipeline_version: "auto"
+        enabled_steps:
+          - name: normalize_document_fields
+            callable: "library.postprocess.documents.steps:normalize_document_fields"
+            params:
+              unexpected: true
+        """
+    )
+    config_path = tmp_path / "documents_invalid.yaml"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    with pytest.raises(
+        PipelineConfigError,
+        match="step 'normalize_document_fields' defines unsupported parameters: unexpected",
+    ):
+        load_pipeline_config("documents", path=config_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- validate pipeline step parameters during pipeline configuration loading to surface unsupported keywords early
- add a regression test that asserts misconfigured steps raise a clear PipelineConfigError

## Testing
- pytest tests/unit/postprocessing/test_pipeline_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e52c8f34788324b5bb458c5ce5ff35