### PR TITLE
Handle parentless molecules in enrichment warnings

### DIFF
--- a/library/pipelines/testitem/enrichment.py
+++ b/library/pipelines/testitem/enrichment.py
@@ -221,8 +221,17 @@ def enrich(
         missing_children = sorted(
             {value for value in child_ids.dropna() if value not in known_ids}
         )
+        missing_parent_values = {
+            value for value in parent_ids.dropna() if value not in known_ids
+        }
+        missing_parentless_children: set[str] = set()
+        for child_value, parent_value in zip(child_ids, parent_ids):
+            if pd.isna(parent_value) and pd.notna(child_value):
+                child_text = str(child_value)
+                if child_text not in known_ids:
+                    missing_parentless_children.add(child_text)
         missing_parents = sorted(
-            {value for value in parent_ids.dropna() if value not in known_ids}
+            missing_parent_values | missing_parentless_children
         )
         if missing_children:
             child_identifiers, child_truncated = _summarise_identifiers(

--- a/tests/integration/test_enrichment.py
+++ b/tests/integration/test_enrichment.py
@@ -178,6 +178,73 @@ def test_enrich__logs_missing_parent_identifiers(
 
 
 @pytest.mark.integration
+def test_enrich__logs_parentless_children_as_missing_parent_flags(
+    tmp_path: Path, cfg, monkeypatch
+) -> None:
+    cfg.testitem_molecule_enrichment.enable = True
+    catalog_path = tmp_path / "catalog.csv"
+    hierarchy_path = tmp_path / "hierarchy.csv"
+
+    catalog_frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": ["CHEMBL0000001"],
+            "natural_product": ["1"],
+            "prodrug": ["0"],
+            "polymer_flag": ["0"],
+        }
+    )
+    catalog_frame.to_csv(catalog_path, index=False)
+
+    hierarchy_frame = pd.DataFrame(
+        {
+            "molecule_chembl_id": pd.Series(dtype="string"),
+            "parent_molecule_chembl_id": pd.Series(dtype="string"),
+        }
+    )
+    hierarchy_frame.to_csv(hierarchy_path, index=False)
+
+    cfg.testitem_molecule_enrichment.sources.molecule_catalog_path = catalog_path
+    cfg.testitem_molecule_enrichment.sources.molecule_hierarchy_path = hierarchy_path
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def _capture(event: str, **fields: object) -> None:
+        events.append((event, fields))
+
+    monkeypatch.setattr(enrichment.logger, "warning", _capture)
+
+    frame = pd.DataFrame({"molecule_chembl_id": ["CHEMBL2021616"]})
+
+    enrichment.enrich(
+        frame,
+        cfg=cfg.testitem_molecule_enrichment,
+        io_cfg=cfg.io,
+    )
+
+    missing_child_event = next(
+        fields
+        for event, fields in events
+        if event == "testitem_enrichment_missing_child_flags"
+    )
+    missing_parent_event = next(
+        fields
+        for event, fields in events
+        if event == "testitem_enrichment_missing_parent_flags"
+    )
+
+    assert missing_child_event == {
+        "count": 1,
+        "identifiers": ["CHEMBL2021616"],
+        "truncated": False,
+    }
+    assert missing_parent_event == {
+        "count": 1,
+        "identifiers": ["CHEMBL2021616"],
+        "truncated": False,
+    }
+
+
+@pytest.mark.integration
 def test_enrich__truncates_identifier_log_payload(
     tmp_path: Path, cfg, snapshot_resource, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure the enrichment warning logic treats parentless children as missing parent flag entries
- add an integration test that covers parentless molecules and validates both child and parent warning payloads

## Testing
- pytest tests/integration/test_enrichment.py


------
https://chatgpt.com/codex/tasks/task_e_68e52ddb0cdc8324a142c703f621ab37