### PR TITLE
Enhance target finalization fallback

### DIFF
--- a/library/postprocess/targets/steps.py
+++ b/library/postprocess/targets/steps.py
@@ -165,8 +165,19 @@ def finalize_target_records(
     prepared = df.copy(deep=True)
 
     # Normalise a few legacy aliases that may appear in historical exports.
-    if "target_type" not in prepared.columns and "relationship" in prepared.columns:
-        prepared["target_type"] = prepared["relationship"]
+    if "target_type" not in prepared.columns:
+        fallback_columns = (
+            "relationship",
+            "target_type_description",
+            "target_type_desc",
+            "target_type_name",
+            "targettype",
+            "type",
+        )
+        for alias in fallback_columns:
+            if alias in prepared.columns:
+                prepared["target_type"] = prepared[alias]
+                break
 
     required_columns = set(TARGET_SCHEMA.required_columns)
     optional_columns = set(TARGET_SCHEMA.optional_columns)

--- a/tests/unit/postprocessing/target/test_steps.py
+++ b/tests/unit/postprocessing/target/test_steps.py
@@ -155,3 +155,19 @@ def test_finalize_target_records__populates_target_type_from_relationship() -> N
     result = finalize_target_records(frame)
 
     assert result.loc[0, "target_type"] == "SINGLE PROTEIN"
+
+
+@pytest.mark.unit
+def test_finalize_target_records__populates_target_type_from_description() -> None:
+    frame = pd.DataFrame(
+        {
+            "target_chembl_id": ["CHEMBL9000"],
+            "pref_name": ["Example target"],
+            "target_type_description": ["PROTEIN COMPLEX"],
+        }
+    )
+
+    result = finalize_target_records(frame)
+
+    assert result.loc[0, "target_type"] == "PROTEIN COMPLEX"
+    assert str(result["target_type"].dtype) == "string"


### PR DESCRIPTION
## Summary
- extend the target finalization step to recognise additional legacy columns when populating `target_type`
- add a regression test covering the `target_type_description` alias

## Testing
- pytest tests/unit/postprocessing/target/test_steps.py -k "target_type" -q

------
https://chatgpt.com/codex/tasks/task_e_68e52deea9c883249e26cdcc568984f1