### PR TITLE
Cache PubChem server error requests to avoid repeated retries

### DIFF
--- a/library/clients/pubchem.py
+++ b/library/clients/pubchem.py
@@ -247,16 +247,19 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
         if cached.is_hit:
             logger.debug("cache_hit", url=url, rps=cfg.rps, status="hit")
             return cast(dict[str, Any], cached.payload)
-        miss_details = {
-            key: value
-            for key, value in (cached.details or {}).items()
-            if key != "timeout_stored_at"
-        }
-        if timeout_retry_in is not None:
-            miss_details["timeout_retry_in"] = timeout_retry_in
-        logger.debug(
-            "cache_hit",
-            url=url,
+            miss_details: dict[str, Any] = {}
+            for key, value in (cached.details or {}).items():
+                if key == "timeout_stored_at":
+                    continue
+                if key == "status":
+                    miss_details["http_status"] = value
+                else:
+                    miss_details[key] = value
+            if timeout_retry_in is not None:
+                miss_details["timeout_retry_in"] = timeout_retry_in
+            logger.debug(
+                "cache_hit",
+                url=url,
             rps=cfg.rps,
             status="miss",
             outcome=cached.outcome,
@@ -365,6 +368,12 @@ def make_request(url: str, cfg: PubChemCfg) -> dict[str, Any] | None:
                         **warning_context,
                     )
                     if attempt >= total_attempts:
+                        _store_cache_miss(
+                            url,
+                            cfg,
+                            reason,
+                            last_failure_details,
+                        )
                         logger.debug(
                             "request_fail",
                             url=url,

--- a/tests/unit/test_pubchem_client.py
+++ b/tests/unit/test_pubchem_client.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import pytest
+
+from library.clients import pubchem
+from library.config import PubChemCfg
+
+
+@dataclass
+class _DummyResponse:
+    status_code: int
+    headers: dict[str, Any]
+
+    def __enter__(self) -> "_DummyResponse":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object | None,
+    ) -> bool:
+        return False
+
+    def json(self) -> dict[str, Any]:
+        return {}
+
+
+class _DummySession:
+    def __init__(self, response_factory: Callable[[], _DummyResponse]) -> None:
+        self._response_factory = response_factory
+        self.calls: list[tuple[str, tuple[float, float]]] = []
+
+    def get(self, url: str, timeout: tuple[float, float]) -> _DummyResponse:
+        self.calls.append((url, timeout))
+        return self._response_factory()
+
+
+class _DummyLimiter:
+    def __init__(self) -> None:
+        self.acquires: int = 0
+
+    def acquire(self) -> None:
+        self.acquires += 1
+
+
+def test_make_request__caches_server_error_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = PubChemCfg()
+    cfg.retries = 1
+
+    url = (
+        f"{cfg.base.rstrip('/')}/compound/cid/64972/property/"
+        "MolecularFormula,IUPACName,IsomericSMILES,CanonicalSMILES,InChI,InChIKey/JSON"
+    )
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(pubchem, "sleep", lambda seconds: sleep_calls.append(float(seconds)))
+    limiter = _DummyLimiter()
+    monkeypatch.setattr(pubchem, "get_limiter", lambda *_args, **_kwargs: limiter)
+
+    def _response() -> _DummyResponse:
+        return _DummyResponse(503, {"Retry-After": "30"})
+
+    session = _DummySession(_response)
+    monkeypatch.setattr(pubchem, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(pubchem, "_CACHE", None)
+
+    first_result = pubchem.make_request(url, cfg)
+
+    assert first_result is None
+    assert len(session.calls) == cfg.retries + 1
+    assert sleep_calls == [30.0]
+    assert limiter.acquires == cfg.retries + 1
+
+    cache = pubchem._ensure_cache(cfg.cache_ttl, cfg.cache_maxsize)
+    entry = cache.get(url)
+    assert entry is not None
+    assert entry.outcome == "server_error"
+    assert entry.details == {"reason": "server_error", "status": 503, "retry_after": 30.0}
+
+    second_result = pubchem.make_request(url, cfg)
+
+    assert second_result is None
+    assert len(session.calls) == cfg.retries + 1
+    assert limiter.acquires == cfg.retries + 1
+    assert sleep_calls == [30.0]


### PR DESCRIPTION
## Summary
- store PubChem rate limit and server error failures in the in-memory cache to prevent repeated retries after exhausting attempts
- normalise cached miss logging so HTTP status codes no longer collide with cache status fields
- add a dedicated unit test covering cached server-error handling for PubChem make_request

## Testing
- pytest tests/unit/test_pubchem_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e5340e04108324aa8ff68308e8e787