### PR TITLE
Align README and expand orchestration documentation

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -91,19 +91,22 @@ python scripts/get_data.py \
 | Tissue | `python scripts/get_tissue_data.py --input data/input/tissue.csv --final-out output/tissues.csv --chunk-size 50 --xref-sources uberon,efo,bto` | Resolves tissue metadata, merges ontology cross-references and normalises synonyms for downstream joins. Run separately before `get_activity_data` when tissue lookups are required. |
 | Cell line | `python scripts/get_cellline_data.py --input data/input/cellline.csv --final-out output/cellline.csv --batch-size 20 --limit 100` | Retrieves ChEMBL cell line records, normalises nullable identifiers and enforces deterministic ordering. |
 | Activity | `python scripts/get_activity_data.py --input data/input/activity.csv --final-out output/activities.csv --timeout 120 --limit 500 --offset 100 --workers 4 --dry-run` | Supports range controls (`--limit`, `--offset`), per-request timeouts, parallel fetching via `--workers` and a dry-run validation mode. |
+| Synthetic activities | `python scripts/get_activities.py --limit 25 --dry-run` | Generates deterministic dummy rows for smoke tests; accepts the same logging flags as other CLI tools. |
 
 Each pipeline writes a deterministic CSV, a `<name>.meta.yaml` metadata sidecar
 and table-quality reports under the same directory. The target pipeline also
 emits helper lookups named `organism.output.target_<stamp>.csv`,
 `isoform.output.target_<stamp>.csv`, `names.output.target_<stamp>.csv`, and
-`IUPHAR.output.target_<stamp>.csv` — all described in
+`IUPHAR.output.target_<stamp>.csv` — all detailed in
 [`docs/en/OUTPUT_TARGETS.md`](./docs/en/OUTPUT_TARGETS.md) and
-[`docs/ru/OUTPUT_TARGETS.md`](./docs/ru/OUTPUT_TARGETS.md). Refer to the
-[output reference](./docs/en/OUTPUT.md) for the complete specification.
+[`docs/ru/OUTPUT_TARGETS.md`](./docs/ru/OUTPUT_TARGETS.md). The isoform helper
+is produced by `library.postprocessing.target.process_targets`, a direct port of
+the original Power Query workbook that keeps every row byte-identical. Refer to
+the [output reference](./docs/en/OUTPUT.md) for the complete specification.
 
-Custom file names such as `targets.csv` still trigger the post-processing
-chain, so helper lookups are emitted even when the export deviates from the
-canonical `output.target_<stamp>.csv` pattern.
+Custom file names such as `targets.csv` still trigger this post-processing
+chain, so downstream helpers are generated even when the export deviates from
+the canonical `output.target_<stamp>.csv` pattern.
 
 ## Documentation
 
@@ -139,6 +142,48 @@ must produce:
 
 - `reports/test_report.json` — machine readable execution log
 - `reports/test_summary.md` — condensed Markdown summary
+
+`test_report.json` always exposes three top-level keys:
+
+```json
+{
+  "meta": {
+    "repo": "SatoryKono/ChEMBL_data_acquisition",
+    "commit": "<SHA>",
+    "branch": "<branch>",
+    "ts_utc": "<ISO8601>",
+    "duration_sec": 0.0,
+    "python": "3.11|3.12",
+    "pytest": "<version>",
+    "exit_code": 0
+  },
+  "summary": {
+    "total": 0,
+    "passed": 0,
+    "failed": 0,
+    "skipped": 0,
+    "xfailed": 0,
+    "xpassed": 0,
+    "error": 0,
+    "success_rate": 0.0
+  },
+  "tests": [
+    {
+      "nodeid": "tests/unit/test_module.py::test_case",
+      "status": "passed",
+      "duration_ms": 12.3,
+      "stdout": "",
+      "stderr": "",
+      "log": [],
+      "error": null
+    }
+  ]
+}
+```
+
+`test_summary.md` mirrors the counts and, for every failure or error, embeds the
+exact `error` message from the JSON report in a fenced code block. This makes it
+possible to triage failures using only the Markdown artefact.
 
 Smoke runs can use `pytest -q -k "not slow and not e2e"`, while full validation
 uses `pytest -q`. See [`docs/en/development/TESTING.md`](./docs/en/development/TESTING.md)

--- a/docs/en/architecture/ARCHITECTURE.md
+++ b/docs/en/architecture/ARCHITECTURE.md
@@ -14,22 +14,27 @@ flowchart LR
         A6[get-tissue-data]
     end
     subgraph Library
+        B0[library/orchestration]
         B1[library/clients]
         B2[library/pipelines]
         B3[library/qa]
         B4[library/utils]
+        B5[library/reporting]
     end
     subgraph Resources
         C1[config/config.yaml]
         C2[config/dictionary]
     end
 
-    A0 --> A1 & A2 & A3 & A4 & A5
+    A0 --> B0
+    B0 --> A1 & A2 & A3 & A4 & A5
     A6 -.->|reference tables| A5
     A1 & A2 & A3 & A4 & A5 --> B2
     B2 --> B1
     B2 --> B3
     B2 --> B4
+    B0 --> B2
+    B2 --> B5
     B2 --> C1
     B2 --> C2
 ```
@@ -40,6 +45,8 @@ lookups are required, operators run `get_tissue_data` manually to refresh the
 reference tables before the activity join. Pipelines import reusable components
 from `library/`:
 
+- `library/orchestration` — workflow registry, shared execution context helpers
+  and retry coordination used by `get_data.py`, tests and bespoke automation.
 - `library/clients` — HTTP clients with retry and throttling logic for ChEMBL,
   UniProt, PubMed, OpenAlex, CrossRef, PubChem.
 - `library/pipelines` — Fetching, transformation and export logic for each
@@ -49,6 +56,8 @@ from `library/`:
   item → activity subset.
 - `library/utils` — CLI helpers, deterministic CSV I/O, configuration loaders,
   logging bootstrap and file system utilities.
+- `library/reporting` — run manifests, metadata reconciliation and table-quality
+  aggregation helpers shared between orchestrated runs and standalone stages.
 - `library/qa` & `library/table_quality.py` — Schema validation, quality
   profiling and metadata writers.
 

--- a/docs/ru/architecture/ARCHITECTURE.md
+++ b/docs/ru/architecture/ARCHITECTURE.md
@@ -14,22 +14,27 @@ flowchart LR
         A6[get-tissue-data]
     end
     subgraph Library
+        B0[library/orchestration]
         B1[library/clients]
         B2[library/pipelines]
         B3[library/qa]
         B4[library/utils]
+        B5[library/reporting]
     end
     subgraph Resources
         C1[config/config.yaml]
         C2[config/dictionary]
     end
 
-    A0 --> A1 & A2 & A3 & A4 & A5
+    A0 --> B0
+    B0 --> A1 & A2 & A3 & A4 & A5
     A6 -.->|справочники| A5
     A1 & A2 & A3 & A4 & A5 --> B2
     B2 --> B1
     B2 --> B3
     B2 --> B4
+    B0 --> B2
+    B2 --> B5
     B2 --> C1
     B2 --> C2
 ```
@@ -39,6 +44,8 @@ flowchart LR
 запускают отдельно, чтобы подготовить справочники перед объединением активностей.
 Внутри используются общие компоненты `library/`:
 
+- `library/orchestration` — реестр шагов, общий контекст выполнения и координация
+  ретраев, которые используют `get_data.py`, тесты и кастомные сценарии.
 - `library/clients` — HTTP-клиенты с ретраями и лимитами для ChEMBL, UniProt,
   PubMed, OpenAlex, CrossRef, PubChem.
 - `library/pipelines` — логика загрузки, трансформации и экспорта по
@@ -47,6 +54,8 @@ flowchart LR
   объекты → активности», все подпакеты доступны для ручного запуска.
 - `library/utils` — вспомогательные утилиты: CLI-бустрап, детерминированное I/O,
   загрузка конфигурации.
+- `library/reporting` — генерация манифестов запусков, слияние метаданных и
+  агрегация QC, общие для оркестратора и отдельных пайплайнов.
 - `library/qa` и `library/table_quality.py` — валидация Pandera, профили качества,
   формирование метаданных.
 


### PR DESCRIPTION
## Summary
- synchronised `README_EN.md` with the canonical README so the CLI quick reference and testing artefact specification match the current pipeline behaviour
- updated the English and Russian architecture overviews to show the orchestration/reporting modules and document their responsibilities

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e53507a1348324b224bf3cc7dc8fc8