### PR TITLE
Fix raw dump writer permissions on Windows

### DIFF
--- a/scripts/get_target_data.py
+++ b/scripts/get_target_data.py
@@ -22,6 +22,7 @@ del bootstrap_cli
 
 # ruff: noqa: E402
 import argparse
+import os
 import sys
 import shutil
 from collections.abc import Iterator, Mapping, Sequence
@@ -31,6 +32,7 @@ import math
 from inspect import signature
 from itertools import islice
 from pathlib import Path
+import stat
 from typing import IO, Any, cast
 
 from datetime import datetime, timezone
@@ -1134,6 +1136,35 @@ def _raw_output_path(base: Path) -> Path:
     return base.with_name(f"{base.stem}{RAW_SUFFIX}{suffix}")
 
 
+def _prepare_raw_destination(destination: Path) -> None:
+    """Ensure the raw dump destination can be written to safely."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if not destination.exists():
+        return
+
+    try:
+        destination.unlink()
+    except PermissionError:
+        writable_mode = stat.S_IRUSR | stat.S_IWUSR
+        writable_mode |= getattr(stat, "S_IWRITE", 0)
+        try:
+            os.chmod(destination, writable_mode)
+        except OSError as exc:  # pragma: no cover - defensive guard
+            raise OSError(
+                f"failed to prepare raw dump destination: {exc}"
+            ) from exc
+
+        try:
+            destination.unlink()
+        except OSError as exc:
+            raise OSError(
+                f"failed to prepare raw dump destination: {exc}"
+            ) from exc
+    except OSError as exc:  # pragma: no cover - defensive guard
+        raise OSError(f"failed to prepare raw dump destination: {exc}") from exc
+
+
 class _RawDumpStreamWriter:
     """Stream ChEMBL raw payloads to disk without accumulating chunks."""
 
@@ -1151,7 +1182,7 @@ class _RawDumpStreamWriter:
         self._rows_written = 0
         self._columns: list[str] | None = None
         self._frames: list[pd.DataFrame] | None = [] if self._is_parquet else None
-        self.destination.parent.mkdir(parents=True, exist_ok=True)
+        _prepare_raw_destination(destination)
         self._destination_opened = False
 
     @property

--- a/tests/unit/test_get_target_data.py
+++ b/tests/unit/test_get_target_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import stat
 from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
@@ -112,6 +113,70 @@ def test_is_supported_target_export__cases(
 )
 def test_split_uniprot_tokens__cases(value: str, tokens: list[str]) -> None:
     assert list(get_target_data._split_uniprot_tokens(value)) == tokens
+
+
+def test_prepare_raw_destination__removes_existing(tmp_path: Path) -> None:
+    destination = tmp_path / "raw.csv"
+    destination.write_text("old", encoding="utf-8")
+
+    get_target_data._prepare_raw_destination(destination)
+
+    assert not destination.exists()
+    assert destination.parent.exists()
+
+
+def test_prepare_raw_destination__handles_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "raw.csv"
+    destination.write_text("old", encoding="utf-8")
+
+    unlink_calls = {"count": 0}
+    original_unlink = get_target_data.Path.unlink
+
+    def _fake_unlink(self: Path, *args: object, **kwargs: object) -> None:
+        if self == destination and unlink_calls["count"] == 0:
+            unlink_calls["count"] += 1
+            raise PermissionError("denied")
+        unlink_calls["count"] += 1
+        original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        get_target_data.Path, "unlink", _fake_unlink, raising=False
+    )
+
+    chmod_modes: list[int] = []
+
+    def _fake_chmod(path: Path, mode: int) -> None:
+        if path == destination:
+            chmod_modes.append(mode)
+
+    monkeypatch.setattr(get_target_data.os, "chmod", _fake_chmod)
+
+    get_target_data._prepare_raw_destination(destination)
+
+    assert unlink_calls["count"] >= 2
+    expected_mode = stat.S_IRUSR | stat.S_IWUSR | getattr(stat, "S_IWRITE", 0)
+    assert chmod_modes == [expected_mode]
+    assert not destination.exists()
+
+
+def test_prepare_raw_destination__raises_when_unlink_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "raw.csv"
+    destination.write_text("old", encoding="utf-8")
+
+    def _always_fail(*args: object, **kwargs: object) -> None:
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(
+        get_target_data.Path, "unlink", _always_fail, raising=False
+    )
+    monkeypatch.setattr(get_target_data.os, "chmod", lambda *_, **__: None)
+
+    with pytest.raises(OSError):
+        get_target_data._prepare_raw_destination(destination)
 
 
 def test_collect_uniprot_candidate_columns__orders_columns(cfg: Config) -> None:


### PR DESCRIPTION
## Summary
- ensure the raw ChEMBL dump destination is recreated safely before writing
- add unit tests covering permission handling and failure modes for raw dumps

## Testing
- pytest tests/unit/test_get_target_data.py -k "prepare_raw_destination"


------
https://chatgpt.com/codex/tasks/task_e_68e53ccc3c58832481a21f3e35a7d59d