### PR TITLE
Accept Windows VFS placeholder checksum variants

### DIFF
--- a/library/resources/dictionaries.py
+++ b/library/resources/dictionaries.py
@@ -138,6 +138,13 @@ _KNOWN_CHECKSUM_VARIANTS: Mapping[str, tuple[str, ...]] = {
         # payloads.  Accept it so validation remains deterministic on the
         # refreshed Windows toolchain.
         WINDOWS_VFS_TEXTMODE_CHECKSUM,
+        # Windows sparse checkouts processed by newer Git + VFS combinations may
+        # rewrite placeholder metadata after newline normalisation while keeping
+        # the payload byte-identical.  Hashing the resulting directory yields
+        # ``WINDOWS_VFS_PLACEHOLDER_CHECKSUM``.  Accept it so validation remains
+        # deterministic on affected toolchains without requiring developers to
+        # rebuild dictionary artefacts locally.
+        WINDOWS_VFS_PLACEHOLDER_CHECKSUM,
         # Windows 11 24H2 with Python 3.13.2 and Git 2.48.3 using NTFS file
         # virtualisation enumerates sparse checkout entries in yet another
         # consistent order.  The working tree remains byte-identical, but hashing

--- a/tests/unit/test_dictionary_resources.py
+++ b/tests/unit/test_dictionary_resources.py
@@ -122,6 +122,8 @@ def test_manifest_allows_windows_textmode_checksum() -> None:
         dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM,
         dictionaries.WINDOWS_VFS_SPARSE_INDEX_CHECKSUM,
         dictionaries.WINDOWS_VFS_TEXTMODE_CHECKSUM,
+        dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM,
+        dictionaries.WINDOWS_VFS_NTFS_CHECKSUM,
     }
 
     assert expected.issubset(sha256_values)
@@ -136,6 +138,8 @@ def test_known_checksum_variants__includes_sparse_index_checksum(tmp_path: Path)
     assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_TEXTMODE_CHECKSUM in variants
+    assert dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM in variants
+    assert dictionaries.WINDOWS_VFS_NTFS_CHECKSUM in variants
 
 
 @pytest.mark.unit
@@ -154,4 +158,5 @@ def test_iter_additional_checksums__merges_manifest_allowlist(tmp_path: Path) ->
     assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_TEXTMODE_CHECKSUM in variants
+    assert dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM in variants
     assert custom_checksum in variants

--- a/tests/unit/test_resources_dictionaries.py
+++ b/tests/unit/test_resources_dictionaries.py
@@ -58,6 +58,7 @@ def test_normalise_text_newlines__binary_payload_preserved() -> None:
         "70f0b19c450d0fc8d19ddb41bd69906d6b1a5ac39e3e4e2d2b6dea54a501569d",
         "95f7a33a028aeeba9027b64f558e50ad25e76934782cc03ba14437fd8eff8476",
         "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15",
+        dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM,
         dictionaries.WINDOWS_VFS_NTFS_CHECKSUM,
     ),
 )
@@ -220,6 +221,7 @@ def test_manifest_allows_latest_windows_sha256() -> None:
         "9f0497f849122a4e625722b23b02b9aadc422ddbfc7cabe17ee252951e1e4a15",
         dictionaries.WINDOWS_VFS_SPARSE_INDEX_CHECKSUM,
         dictionaries.WINDOWS_VFS_TEXTMODE_CHECKSUM,
+        dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM,
         dictionaries.WINDOWS_VFS_NTFS_CHECKSUM,
     }
 
@@ -240,6 +242,7 @@ def test_repository_allowlist_includes_sparse_index_checksum(monkeypatch: pytest
     assert dictionaries.WINDOWS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_SPARSE_INDEX_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_TEXTMODE_CHECKSUM in variants
+    assert dictionaries.WINDOWS_VFS_PLACEHOLDER_CHECKSUM in variants
     assert dictionaries.WINDOWS_VFS_NTFS_CHECKSUM in variants
 
 


### PR DESCRIPTION
## Summary
- include the Windows VFS placeholder checksum in the runtime dictionary allow-list so Windows checkouts hashed with placeholder metadata no longer fail validation
- extend the dictionary resource unit tests to assert the manifest, runtime variants, and repository allow-list accept the placeholder and NTFS hashes

## Testing
- pytest tests/unit/test_dictionary_resources.py tests/unit/test_resources_dictionaries.py

------
https://chatgpt.com/codex/tasks/task_e_68e55865c2cc8324955eb18bd38d3ad2