### PR TITLE
docs: refresh variant 1 post-processing notes

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -76,6 +76,9 @@ below to navigate the canonical English sources:
 | Dictionaries & glossary | [`reference/DICTIONARIES.md`](./reference/DICTIONARIES.md) | [`../ru/reference/DICTIONARIES.md`](../ru/reference/DICTIONARIES.md) |
 | Post-processing runbook | [`guides/POSTPROCESSING_RUNBOOK.md`](./guides/POSTPROCESSING_RUNBOOK.md) | [`../ru/guides/POSTPROCESSING_RUNBOOK.md`](../ru/guides/POSTPROCESSING_RUNBOOK.md) |
 
+For a description of the current Variant 1 modular post-processing pipeline,
+refer to [`../postprocessing_variant1_tasks.md`](../postprocessing_variant1_tasks.md).
+
 All English files have a one-to-one Russian counterpart with identical structure
 and headings to simplify cross-referencing.
 

--- a/docs/postprocessing_variant1_tasks.md
+++ b/docs/postprocessing_variant1_tasks.md
@@ -1,53 +1,88 @@
-# Variant 1 Post-processing Pipeline — Implementation Tasks
+# Variant 1 Post-processing Pipeline — Current Architecture and Roadmap
 
-## Overview
-This document enumerates the implementation backlog required to introduce the modular post-processing pipeline (Variant 1) to the ChEMBL ETL project. The work is split into milestones that can be delivered incrementally while keeping the current scripts operational.
+The Variant 1 modular post-processing pipeline is fully integrated into the ETL
+scripts and replaces the historical ad-hoc helpers. This note summarises the
+current state, highlights the implementation anchors, and captures the remaining
+ideas that have not yet been prioritised.
 
-## Milestone 0 — Discovery & Alignment
-- [ ] Confirm current post-processing entry points in `scripts/get_*.py` and existing helpers under `library/postprocessing/`.
-- [ ] Align with data consumers on the list of mandatory outputs per entity (`target`, `activity`, etc.).
-- [ ] Collect configuration requirements (environment-specific overrides, secrets handling, default locations).
+## Implemented scope
 
-## Milestone 1 — Core Infrastructure
-- [ ] Implement `library/postprocessing/base.py` with `PostprocessingStep`, `PipelineContext`, and result typing (DataFrame in/out contract).
-- [ ] Add registration decorator (`register_step`) and central registry with uniqueness validation per table/step name.
-- [ ] Provide `PipelineRunner` capable of reading YAML definitions, loading registered steps, and executing them sequentially.
-- [ ] Define structured error handling and logging hooks (warn vs error) aligned with deterministic logging policy.
+- **Core execution layer.** Transformation steps are represented by
+  `StepDefinition` dataclasses and executed sequentially through
+  `run_steps`, which provides schema validation hooks, defensive argument
+  filtering, and per-step timing/shape metrics. The implementation lives in
+  [`library/postprocess/common/types.py`](../library/postprocess/common/types.py)
+  and [`library/postprocess/common/runner.py`](../library/postprocess/common/runner.py).
+- **Declarative configuration.** Pipelines are described via YAML files under
+  [`config/pipeline/*.yaml`](../config/pipeline/), resolved through
+  [`library/postprocess/common/config.py`](../library/postprocess/common/config.py).
+  The loader expands environment placeholders, validates callable signatures, and
+  exposes ordered `StepDefinition` collections for the runner.
+- **Schema governance.** Canonical output schemas, column ordering rules, and
+  deterministic sorting helpers are defined per domain in the `schema.py` files
+  (for example, [`library/postprocess/activities/schema.py`](../library/postprocess/activities/schema.py)).
+  The shared helpers in [`library/postprocess/common/schema.py`](../library/postprocess/common/schema.py)
+  enforce the contract before/after each pipeline run.
+- **Domain step libraries.** Each entity exposes a `steps.py` module that houses
+  pure DataFrame transforms and a lazily loaded `PIPELINE_STEPS` tuple sourced
+  from the declarative configuration. Examples include
+  [`library/postprocess/documents/steps.py`](../library/postprocess/documents/steps.py),
+  [`library/postprocess/assays/steps.py`](../library/postprocess/assays/steps.py),
+  [`library/postprocess/activities/steps.py`](../library/postprocess/activities/steps.py),
+  and [`library/postprocess/targets/steps.py`](../library/postprocess/targets/steps.py).
+- **Metrics and reporting.** The execution layer captures structured per-step
+  telemetry and final run summaries through
+  [`library/postprocess/common/logging.py`](../library/postprocess/common/logging.py).
+  CLI entry points collect these metrics and persist JSON reports by delegating to
+  [`library/postprocess/common/utils.py`](../library/postprocess/common/utils.py).
+- **Integration with ETL scripts.** Entity scripts such as
+  [`scripts/get_document_data.py`](../scripts/get_document_data.py),
+  [`scripts/get_assay_data.py`](../scripts/get_assay_data.py),
+  [`scripts/get_activity_data.py`](../scripts/get_activity_data.py), and
+  [`scripts/get_target_data.py`](../scripts/get_target_data.py)
+  load the exported CSVs, execute the Variant 1 pipeline, and attach the metrics
+  artefacts to the existing logging/QA flow.
 
-## Milestone 2 — Configuration Layer
-- [ ] Design YAML schema for step sequences under `config/postprocessing/<table>.yaml` (incl. optional kwargs, gating flags).
-- [ ] Extend `config.schema.json` with a section for the post-processing pipeline; generate JSON schema for validation.
-- [ ] Implement loader/validator that merges defaults and table-specific overrides while checking schema compliance.
-- [ ] Provide tooling to diff/validate configs (CLI command or `make validate-config-postprocessing`).
+Together these components cover Milestones 0–4 of the original plan: discovery,
+core infrastructure, declarative configuration, migration of legacy logic, and
+QA automation have been delivered by the referenced modules.
 
-## Milestone 3 — Migration of Existing Logic
-- [ ] Move existing helper functions into dedicated `library/postprocessing/<table>/steps/` modules.
-- [ ] Refactor each helper into a `PostprocessingStep` subclass with deterministic I/O and context usage.
-- [ ] Update scripts (`scripts/get_target_data.py`, etc.) to invoke `PipelineRunner` after main CSV export.
-- [ ] Maintain backward compatibility by ensuring generated files match current naming and sorting conventions.
+## Operational model
 
-## Milestone 4 — Testing & Quality Gates
-- [ ] Create unit tests for `PostprocessingStep` base behaviors and registry validation under `tests/unit/postprocessing/`.
-- [ ] Add integration tests covering YAML-driven pipelines with fixture CSVs (`tests/integration/postprocessing/`).
-- [ ] Introduce deterministic e2e tests for at least one entity (e.g., `target`) that execute CLI path and assert outputs and logging.
-- [ ] Ensure reports (`reports/test_report.json`, `reports/test_summary.md`) capture new suites and maintain ≥95% success rate.
+1. **Config resolution.** The ETL script determines which pipeline to run and
+   resolves the matching YAML file from `config/pipeline`. Environment variables
+   (for example `CHEMBL_DOCUMENT_PIPELINE_VERSION`) can override defaults without
+   editing the repository configuration.
+2. **Runner bootstrap.** The loader materialises an ordered list of steps and
+   passes it to `run_steps` together with optional pre/post `DataFrameSchema`
+   contracts supplied by each domain module.
+3. **Step execution.** Each step receives a defensive copy of the DataFrame and
+   only the parameters declared in the callable signature. Unsupported keyword
+   arguments are logged and dropped to keep runs deterministic.
+4. **Schema enforcement.** Pre- and post-run validations coerce column order,
+   ensure required fields, and detect dtype mismatches. Failures raise
+   `SchemaValidationError`, which is surfaced to the CLI and reported via the
+   metrics payload.
+5. **Reporting.** On success the runner stores the final frame with an optional
+   `pipeline_version` attribute, records timing/shape deltas per step, and builds
+   a JSON summary that is persisted under `reports/` alongside QA artefacts.
 
-## Milestone 5 — Tooling & Documentation
-- [ ] Update developer docs (`docs/` and README) with instructions for authoring new steps and configuring YAML.
-- [ ] Provide code templates/snippets for new step classes and testing patterns.
-- [ ] Add `make` or CLI commands for running only post-processing pipelines (e.g., `make postprocess TARGET=target`).
-- [ ] Prepare onboarding checklist for future step contributions (coding standards, deterministic behaviors, review checklist).
+## Further improvements
 
-## Milestone 6 — Rollout & Maintenance
-- [ ] Plan phased rollout by table (toggle via YAML) with rollback strategy.
-- [ ] Instrument logging/metrics to track pipeline duration and failures per step after rollout.
-- [ ] Schedule periodic config reviews to prune unused steps and ensure registry hygiene.
-- [ ] Document maintenance responsibilities and escalation path for post-processing failures.
+The following ideas remain open for future iterations:
 
----
+- Extend `config.schema.json` with a section dedicated to post-processing
+  pipelines so that declarative configs can be validated outside of runtime
+  loading.
+- Provide a lightweight CLI/Make wrapper (e.g. `make postprocess TABLE=targets`)
+  to execute Variant 1 pipelines independently from the full ETL scripts.
+- Publish contributor templates/snippets for new post-processing steps and tests
+  to simplify onboarding.
+- Document ownership and on-call expectations for the post-processing layer in
+  the development handbook.
+- Add richer end-to-end fixtures that cover degraded inputs (empty files,
+  malformed headers) to harden the integration tests beyond the current happy
+  paths.
 
-### Traceability to Requirements
-- Modular step classes with YAML-driven orchestration → Milestones 1–3.
-- Deterministic, testable pipeline with ≥95% success rate → Milestone 4.
-- Configuration and developer enablement via docs/tooling → Milestone 5.
-- Sustainable operations and monitoring → Milestone 6.
+These items replace the unfinished portions of Milestones 5–6 from the original
+backlog and can be pulled in as the pipeline evolves.

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -76,6 +76,9 @@ flowchart TD
 | Справочники и глоссарий | [`../en/reference/DICTIONARIES.md`](../en/reference/DICTIONARIES.md) | [`reference/DICTIONARIES.md`](./reference/DICTIONARIES.md) |
 | Руководство по постобработке | [`../en/guides/POSTPROCESSING_RUNBOOK.md`](../en/guides/POSTPROCESSING_RUNBOOK.md) | [`guides/POSTPROCESSING_RUNBOOK.md`](./guides/POSTPROCESSING_RUNBOOK.md) |
 
+Текущее описание модульной постобработки (вариант 1) доступно в
+[`../postprocessing_variant1_tasks.md`](../postprocessing_variant1_tasks.md).
+
 У английских и русских файлов совпадают структура и заголовки, что облегчает
 сопоставление версий.
 


### PR DESCRIPTION
## Summary
- rewrite `docs/postprocessing_variant1_tasks.md` to describe the implemented Variant 1 post-processing architecture and outline future improvements
- link the English and Russian documentation indexes to the updated overview

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e561bad8948324b949ecbd4b4bb36e