### PR TITLE
Fix architecture docs library link paths

### DIFF
--- a/docs/en/architecture/ARCHITECTURE.md
+++ b/docs/en/architecture/ARCHITECTURE.md
@@ -78,7 +78,7 @@ invoked separately.
 
 Alternative workflows can be described in YAML and supplied via
 `--pipeline-registry`. The loader in
-[`library/pipelines/registry.py`](../../library/pipelines/registry.py) validates
+[`library/pipelines/registry.py`](../../../library/pipelines/registry.py) validates
 the structure and allows callers to swap in bespoke callables, change execution
 order or skip steps without modifying code.
 

--- a/docs/ru/architecture/ARCHITECTURE.md
+++ b/docs/ru/architecture/ARCHITECTURE.md
@@ -76,7 +76,7 @@ flowchart LR
 
 Альтернативные сценарии можно описать в YAML и передать через
 `--pipeline-registry`. Модуль
-[`library/pipelines/registry.py`](../../library/pipelines/registry.py)
+[`library/pipelines/registry.py`](../../../library/pipelines/registry.py)
 проверяет структуру и позволяет менять порядок шагов, подменять вызываемые
 функции или пропускать этапы без изменения исходников.
 


### PR DESCRIPTION
## Summary
- correct the architecture documentation links in English and Russian so they resolve to the repository root
- verified the updated relative paths point to `library/pipelines/registry.py`

## Testing
- python spot-check to ensure the resolved paths exist

------
https://chatgpt.com/codex/tasks/task_e_68e566b2dbfc8324ab756d64739bfdb8