### PR TITLE
Pin pytest-json-report for pytest 8.4 compatibility

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -54,6 +54,7 @@ Pygments==2.19.2
 pyproject_hooks==1.2.0
 pytest==8.4.2
 pytest-cov==6.3.0
+pytest-json-report==1.5.0
 python-dateutil==2.9.0.post0
 pytokens==0.1.10
 pytz==2025.2


### PR DESCRIPTION
## Summary
- pin pytest-json-report 1.5.0 in the lockfile so the test runner can generate JSON output alongside pytest 8.4

## Testing
- python -m pip install -r requirements-lock.txt
- python -m scripts.run_tests

------
https://chatgpt.com/codex/tasks/task_e_68e56708d3ac832482f4ae99898cac60