### PR TITLE
Archive resolved activity log investigation report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ reports/*
 !reports/test_summary.md
 !reports/tests/
 !reports/code_review.md
+!reports/archive/
+!reports/archive/REPORT_activity_log_missing.md
 
 dictionary/_activity/pairs.csv
 /logs

--- a/REPORT_activity_log_missing.md
+++ b/REPORT_activity_log_missing.md
@@ -1,7 +1,0 @@
-# Activity log missing investigation
-
-| Potential cause | Confirmed | Comment | Fix |
-|-----------------|-----------|---------|-----|
-| Log directory resolved relative to the working directory when `CHEMBL_DA_BASE_PATH` is a relative path | ✅ | Reproduced by running `scripts/get_activity_data.py` from `scripts/` with `CHEMBL_DA_BASE_PATH=data`, which wrote logs to `scripts/data/logs` instead of the repository-level `logs`. | Normalise the log directory against the project root so relative paths are anchored consistently. |
-| Logger misconfiguration or missing handlers | ❌ | `setup_cli_logging` attaches a `FileHandler` and `logger.handlers` contains the expected entry during runs. | No change required. |
-| File permissions or missing directories | ❌ | `setup_cli_logging` creates the directory with `mkdir(parents=True, exist_ok=True)`; failures would raise an exception. | No change required. |

--- a/reports/archive/REPORT_activity_log_missing.md
+++ b/reports/archive/REPORT_activity_log_missing.md
@@ -1,0 +1,14 @@
+# Activity log missing investigation (archived)
+
+This note documents a historical bug where setting `CHEMBL_DA_BASE_PATH` to a relative
+location caused CLI scripts (for example, `scripts/get_activity_data.py`) to emit log files
+under the caller's working directory instead of the repository root. The regression was
+eliminated in [PR #1863](https://github.com/SatoryKono/ChEMBL_data_acquisition/pull/1863)
+(`608e842`) by resolving relative base paths against the project root inside
+`library/cli/logging.py`.
+
+To avoid drift, the behaviour is now covered by
+`tests/e2e/test_activity_logging.py::test_activity_logging__relative_env_base_anchored_to_repo_root`,
+which verifies that relative overrides create logs in the repository-level base directory.
+Refer to the issue and PR tracker for any future regressions instead of reusing this
+frozen finding.


### PR DESCRIPTION
## Summary
- move the resolved activity log investigation note into a dedicated reports archive
- document the historical fix and point readers to the PR and regression test instead of the frozen findings
- update the gitignore allow-list so the archived note remains tracked

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e5674ebb84832499e42aae8ac9eaee