### PR TITLE
Add MIT license file and update packaging metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ChEMBL Data Acquisition contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE
 include library/py.typed
 include library/qa/document_schema_crosswalk.yaml

--- a/README.md
+++ b/README.md
@@ -188,3 +188,7 @@ possible to triage failures using only the Markdown artefact.
 Smoke runs can use `pytest -q -k "not slow and not e2e"`, while full validation
 uses `pytest -q`. See [`docs/en/development/TESTING.md`](./docs/en/development/TESTING.md)
 for fixtures, determinism requirements and coverage targets.
+
+## License
+
+The project is distributed under the [MIT License](./LICENSE).

--- a/README_EN.md
+++ b/README_EN.md
@@ -188,3 +188,7 @@ possible to triage failures using only the Markdown artefact.
 Smoke runs can use `pytest -q -k "not slow and not e2e"`, while full validation
 uses `pytest -q`. See [`docs/en/development/TESTING.md`](./docs/en/development/TESTING.md)
 for fixtures, determinism requirements and coverage targets.
+
+## License
+
+The project is distributed under the [MIT License](./LICENSE).

--- a/README_RU.md
+++ b/README_RU.md
@@ -174,3 +174,7 @@ python scripts/get_data.py \
 Для смоук-прогона подойдёт `pytest -q -k "not slow and not e2e"`, полный набор —
 `pytest -q`. Детали фикстур, требований к детерминизму и целям по покрытию см. в
 [`docs/ru/development/TESTING.md`](./docs/ru/development/TESTING.md).
+
+## Лицензия
+
+Проект распространяется по [лицензии MIT](./LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.3"
 description = "Utilities for downloading and processing biological data from public APIs."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
-license = {text = "MIT"}
+license = {file = "LICENSE"}
 authors = [
   {name = "ChEMBL Team"}
 ]
@@ -72,6 +72,7 @@ check-determinism = "library.utils.cli_tools.check_determinism:main"
 
 [tool.setuptools]
 include-package-data = true
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 include = [


### PR DESCRIPTION
## Summary
- add an MIT `LICENSE` file at the repository root and reference it from the documentation
- include the license file in sdist and wheel artefacts via `MANIFEST.in` and packaging metadata updates

## Testing
- python -m build --wheel
- python -m pip install --quiet dist/chembl_data_acquisition-0.1.3-py3-none-any.whl --target /tmp/chembl_pkg

------
https://chatgpt.com/codex/tasks/task_e_68e5671377408324a43d26c6b6e7443e