### PR TITLE
Add Markdown summary CLI for pytest reports

### DIFF
--- a/docs/en/development/CI_CD.md
+++ b/docs/en/development/CI_CD.md
@@ -7,7 +7,7 @@
 | Lint | `make lint` | Ensure formatting (`black`) and linting (`ruff`). |
 | Type check | `make typecheck` | Run `mypy` against `library/` and `scripts/`. |
 | Tests | `pytest -q --json-report --json-report-file=reports/test_report.json` | Execute entire test suite. |
-| Report summary | `python tools/make_md_summary.py reports/test_report.json reports/test_summary.md` | Produce Markdown summary for artefacts. |
+| Report summary | `make-md-summary --input reports/test_report.json --output reports/test_summary.md` | Produce Markdown summary for artefacts (paths default to `reports/`). |
 | Smoke pipelines (optional) | `make smoke` | Run orchestrator on bundled input data to ensure pipelines still succeed. |
 | Determinism (optional) | `check-determinism --baseline <prev> --candidate <curr>` | Detect unexpected output changes between runs. |
 

--- a/docs/en/development/RELEASE.md
+++ b/docs/en/development/RELEASE.md
@@ -16,7 +16,8 @@
 4. **Run quality gates**
    - `make lint && make typecheck`
    - `pytest -q --json-report --json-report-file=reports/test_report.json`
-   - `python tools/make_md_summary.py reports/test_report.json reports/test_summary.md`
+   - `python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md`
+     (arguments optional with defaults; console script: `make-md-summary`)
    - `make smoke`
    - `check-determinism` between previous release outputs and the new run (if available).
 

--- a/docs/en/development/TESTING.md
+++ b/docs/en/development/TESTING.md
@@ -62,7 +62,8 @@ examples to guarantee byte-for-byte parity.
 
 ```bash
 pytest --json-report --json-report-file=reports/test_report.json
-python tools/make_md_summary.py reports/test_report.json reports/test_summary.md
+python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md
+# defaults can be used directly via `python tools/make_md_summary.py` or `make-md-summary`
 ```
 
 The JSON report must include:

--- a/docs/en/guides/QUICK_START.md
+++ b/docs/en/guides/QUICK_START.md
@@ -63,7 +63,10 @@ Outputs are written to `output/` (create the directory beforehand or rely on
 ```bash
 pytest -q --disable-warnings
 pytest -q --json-report --json-report-file=reports/test_report.json
-python tools/make_md_summary.py reports/test_report.json reports/test_summary.md
+python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md
+# arguments are optional when using the default locations:
+# python tools/make_md_summary.py
+# make-md-summary
 ```
 
 Expect `reports/test_summary.md` to report ≥95 % success rate. Upload the JSON and

--- a/docs/ru/development/CI_CD.md
+++ b/docs/ru/development/CI_CD.md
@@ -7,7 +7,7 @@
 | Lint | `make lint` | Проверка формата (`black`) и стиля (`ruff`). |
 | Type check | `make typecheck` | `mypy` для `library/` и `scripts/`. |
 | Tests | `pytest -q --json-report --json-report-file=reports/test_report.json` | Полный прогон тестов. |
-| Report summary | `python tools/make_md_summary.py reports/test_report.json reports/test_summary.md` | Генерация Markdown-отчёта. |
+| Report summary | `make-md-summary --input reports/test_report.json --output reports/test_summary.md` | Генерация Markdown-отчёта (пути по умолчанию — `reports/`). |
 | Smoke (опция) | `make smoke` | Запуск оркестратора на тестовых данных. |
 | Determinism (опция) | `check-determinism --baseline <prev> --candidate <curr>` | Проверка изменений CSV между прогоном. |
 

--- a/docs/ru/development/RELEASE.md
+++ b/docs/ru/development/RELEASE.md
@@ -16,7 +16,8 @@
 4. **Качество**
    - `make lint && make typecheck`
    - `pytest -q --json-report --json-report-file=reports/test_report.json`
-   - `python tools/make_md_summary.py reports/test_report.json reports/test_summary.md`
+   - `python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md`
+     (аргументы можно опустить; консольный скрипт: `make-md-summary`)
    - `make smoke`
    - `check-determinism` против предыдущих выгрузок (если доступны).
 

--- a/docs/ru/development/TESTING.md
+++ b/docs/ru/development/TESTING.md
@@ -49,7 +49,8 @@ tests/
 
 ```bash
 pytest --json-report --json-report-file=reports/test_report.json
-python tools/make_md_summary.py reports/test_report.json reports/test_summary.md
+python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md
+# пути можно не указывать, если используете значения по умолчанию (`python tools/make_md_summary.py` или `make-md-summary`)
 ```
 
 JSON должен содержать блок `meta` с репозиторием, SHA, веткой, временем,

--- a/docs/ru/guides/QUICK_START.md
+++ b/docs/ru/guides/QUICK_START.md
@@ -62,7 +62,10 @@ python scripts/get_data.py \
 ```bash
 pytest -q --disable-warnings
 pytest -q --json-report --json-report-file=reports/test_report.json
-python tools/make_md_summary.py reports/test_report.json reports/test_summary.md
+python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md
+# аргументы можно опустить при использовании путей по умолчанию:
+# python tools/make_md_summary.py
+# make-md-summary
 ```
 
 В `reports/test_summary.md` ожидается ≥95 % успешных тестов. Артефакты из `reports/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ table-quality = "library.utils.cli_tools.table_quality_main:main"
 chunk-io = "library.utils.cli_tools.chunk_io_main:main"
 get-activities = "library.utils.cli_tools.get_activities:main"
 check-determinism = "library.utils.cli_tools.check_determinism:main"
+make-md-summary = "tools.make_md_summary:main"
 
 [tool.setuptools]
 include-package-data = true
@@ -80,8 +81,9 @@ include = [
   "config",
   "config.dictionary",
   "config.dictionary.*",
-  "scripts",
-  "scripts.*",
+  "scripts", 
+  "scripts.*", 
+  "tools",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,6 +60,9 @@ python tests/run_tests.py
 The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `(passed + xfailed) / max(1, total - skipped)`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success. All invocations also configure structured logging via `tests/run_tests.py` – log events are mirrored to `logs/run_tests_<YYYYMMDD>.log` (or the directory defined by `CHEMBL_DA_BASE_PATH`). Pass `--verbose` to lift the logger to DEBUG and forward the same verbosity to pytest’s log capture.
 
 
+When running pytest manually (e.g. `pytest --json-report --json-report-file=custom.json`), convert the structured JSON into Markdown via `python tools/make_md_summary.py --input <json> --output <markdown>` or the console entry point `make-md-summary`. Both arguments default to the standard `reports/` locations, so invoking `python tools/make_md_summary.py` is sufficient for the common workflow.
+
+
 To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tests/run_tests.py --pytest-args -m unit`. Combine `--verbose` with the forwarding flag to observe detailed DEBUG events in both the console and the generated log file.
 
 Individual modules can be targeted by pointing pytest at a directory, for example `pytest tests/unit` or `pytest tests/integration -k enrich` to filter by test name.

--- a/tools/make_md_summary.py
+++ b/tools/make_md_summary.py
@@ -1,0 +1,135 @@
+"""Render a Markdown summary from a structured pytest JSON report."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:  # pragma: no cover - import side effect
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.run_tests import build_summary_markdown
+
+DEFAULT_INPUT = Path("reports/test_report.json")
+DEFAULT_OUTPUT = Path("reports/test_summary.md")
+REQUIRED_SUMMARY_KEYS = {
+    "total",
+    "passed",
+    "failed",
+    "skipped",
+    "xfailed",
+    "xpassed",
+    "error",
+    "success_rate",
+}
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a Markdown summary from a structured pytest JSON report."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        default=DEFAULT_INPUT,
+        help=(
+            "Path to the structured JSON report produced by pytest. "
+            "Defaults to reports/test_report.json."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=(
+            "Destination path for the Markdown summary. "
+            "Defaults to reports/test_summary.md."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(f"Input report {path} does not exist") from exc
+    except OSError as exc:  # pragma: no cover - filesystem issues
+        raise RuntimeError(f"Unable to read input report {path}: {exc}") from exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Input report {path} is not valid JSON: {exc}") from exc
+
+
+def _write_summary(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _validate_report(report: dict[str, Any]) -> None:
+    if not isinstance(report, dict):
+        raise ValueError("Report payload must be a JSON object")
+
+    summary = report.get("summary")
+    if not isinstance(summary, dict):
+        raise ValueError("Report missing 'summary' section")
+
+    missing = REQUIRED_SUMMARY_KEYS - summary.keys()
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"Summary missing required keys: {missing_list}")
+
+    for key in REQUIRED_SUMMARY_KEYS - {"success_rate"}:
+        value = summary.get(key)
+        if not isinstance(value, int):
+            raise ValueError(
+                f"Summary field '{key}' must be an integer, got {type(value).__name__}"
+            )
+
+    success_rate = summary.get("success_rate")
+    if not isinstance(success_rate, (int, float)):
+        raise ValueError("Summary field 'success_rate' must be numeric")
+
+    tests = report.get("tests")
+    if not isinstance(tests, list):
+        raise ValueError("Report 'tests' section must be a list")
+    for index, entry in enumerate(tests):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Test entry at index {index} must be an object, got {type(entry).__name__}"
+            )
+
+    meta = report.get("meta")
+    if meta is not None and not isinstance(meta, dict):
+        raise ValueError("Report 'meta' section must be an object when present")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        report = _load_report(args.input)
+        _validate_report(report)
+        summary_markdown = build_summary_markdown(report)
+        _write_summary(args.output, summary_markdown)
+    except ValueError as exc:
+        print(f"Invalid report: {exc}", file=sys.stderr)
+        return 2
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a tools/make_md_summary.py helper that validates structured pytest JSON and renders the existing Markdown summary, with configurable input/output paths
- expose the helper via the make-md-summary console script and include the tools package in distribution metadata
- update CI, release, testing and quick-start guides (EN/RU) plus tests/README to document the new command and defaults

## Testing
- python tools/make_md_summary.py --input reports/test_report.json --output reports/test_summary.md

------
https://chatgpt.com/codex/tasks/task_e_68e5673cbc3483248113fa5357f7d542