### PR TITLE
Promote scripts/run_tests.py as canonical runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ smoke: $(PYTHON_BIN)
 test-report: $(PYTHON_BIN)
         PYTHONHASHSEED=$${PYTHONHASHSEED:-0} \
         CHEMBL_DA_BASE_PATH=$(PWD)/tests/data \
-        $(PYTHON_BIN) -m scripts.run_test_suite --suite full --report-dir $(PWD)/reports
+        $(PYTHON_BIN) scripts/run_tests.py \
+                --json $(PWD)/reports/test_report.json \
+                --markdown $(PWD)/reports/test_summary.md
 
 get-activities: $(PYTHON_BIN)
         $(PYTHON_BIN) scripts/get_activities.py --limit $(ACTIVITY_LIMIT) --dry-run

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ must produce:
 - `reports/test_report.json` — machine readable execution log
 - `reports/test_summary.md` — condensed Markdown summary
 
+Use the canonical wrapper to collect both artefacts and enforce the ≥95 %
+success-rate gate:
+
+```bash
+python scripts/run_tests.py
+```
+
 `test_report.json` always exposes three top-level keys:
 
 ```json

--- a/README_postprocess.md
+++ b/README_postprocess.md
@@ -107,7 +107,7 @@ Consult `tests/conftest.py` for shared fixtures that enforce deterministic envir
 Run the wrapper to execute the suite, produce the JSON protocol and Markdown summary, and mirror logs under `logs/`:
 
 ```bash
-python tests/run_tests.py
+python scripts/run_tests.py
 ```
 
 The script runs pytest, writes `reports/test_report.json`, renders `reports/test_summary.md`, checks the ≥95 % success-rate threshold and persists structured logs for regression triage. Pass `--pytest-args` to forward options (for example `--pytest-args -m unit`) and `--verbose` for DEBUG-level logs. 【F:tests/README.md†L58-L87】

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -1,188 +1,51 @@
-"""Run the full pytest suite and export structured reports."""
+"""Compatibility wrapper delegating to :mod:`scripts.run_tests`."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import logging
 import os
-from dataclasses import dataclass, asdict
-from datetime import datetime
+import sys
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Sequence
 
-import pytest
-
-
-from library.common.logging_setup import LoggerConfig, configure_logger
-from library.cli.logging import setup_cli_logging
+from scripts import run_tests
 
 
-SUCCESS_RATE_THRESHOLD = 0.95
-
-
-logger = logging.getLogger(__name__)
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
-TEST_DIRECTORIES = (
-    ROOT_DIR / "tests" / "unit",
-    ROOT_DIR / "tests" / "integration",
-    ROOT_DIR / "tests" / "postprocessing",
-    ROOT_DIR / "tests" / "e2e",
+_DEPRECATION_MESSAGE = (
+    "scripts.run_test_suite is deprecated and will be removed in a future "
+    "release. Use `python scripts/run_tests.py` instead."
 )
 
-
-@dataclass
-class TestResult:
-    """Serializable representation of a single pytest outcome."""
-
-    name: str
-    status: str
-    duration: float
-    message: str
-    log_path: str | None
+_DEFAULT_JSON_NAME = "test_report.json"
+_DEFAULT_MARKDOWN_NAME = "test_summary.md"
 
 
-class JsonReportPlugin:
-    """Collect pytest results and persist optional per-suite logs."""
-
-    def __init__(self, log_path: Path) -> None:
-        self._log_path = log_path
-        self._results: dict[str, TestResult] = {}
-
-    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:  # type: ignore[override]
-        entry = self._results.get(report.nodeid)
-        if entry is None:
-            entry = TestResult(
-                name=report.nodeid,
-                status="passed",
-                duration=0.0,
-                message="",
-                log_path=str(self._log_path) if self._log_path else None,
-            )
-            self._results[report.nodeid] = entry
-
-        entry.duration += report.duration
-
-        if report.outcome == "failed":
-            entry.status = "failed"
-            entry.message = _format_longrepr(report.longrepr)
-        elif report.outcome == "skipped":
-            entry.status = "skipped"
-            entry.message = _format_longrepr(report.longrepr)
-
-    @property
-    def results(self) -> list[TestResult]:
-        return list(self._results.values())
-
-
-def _format_longrepr(longrepr: Any) -> str:
-    if isinstance(longrepr, tuple) and len(longrepr) == 3:
-        return str(longrepr[2])
-    if hasattr(longrepr, "longreprtext"):
-        return str(longrepr.longreprtext)  # pragma: no cover - compatibility guard
-    return str(longrepr)
-
-
-def summarize_results(results: Sequence[TestResult]) -> dict[str, Any]:
-    total = len(results)
-    passed = sum(1 for item in results if item.status == "passed")
-    failed = sum(1 for item in results if item.status == "failed")
-    skipped = sum(1 for item in results if item.status == "skipped")
-    duration = sum(item.duration for item in results)
-    success_rate = 1.0 if total == 0 else passed / total
-
-    return {
-        "total": total,
-        "passed": passed,
-        "failed": failed,
-        "skipped": skipped,
-        "duration": duration,
-        "success_rate": success_rate,
-    }
-
-
-def _write_json(report_path: Path, results: Sequence[TestResult], exit_code: int, summary: dict[str, Any]) -> None:
-    payload = {
-        "generated_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        "exit_code": exit_code,
-        "summary": summary,
-        "tests": [asdict(result) for result in results],
-    }
-    report_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-
-
-def _write_summary(
-    summary_path: Path,
-    results: Sequence[TestResult],
-    exit_code: int,
-    summary: dict[str, Any],
-) -> None:
-    total = summary["total"]
-    passed = summary["passed"]
-    failed = summary["failed"]
-    skipped = summary["skipped"]
-    duration = summary["duration"]
-    success_rate = summary["success_rate"] * 100
-
-    lines = [
-        "# Test suite summary",
-        "",
-        f"* Generated at: {datetime.utcnow().isoformat(timespec='seconds')}Z",
-        f"* Exit code: {exit_code}",
-        f"* Tests collected: {total}",
-        f"* Passed: {passed}",
-        f"* Failed: {failed}",
-        f"* Skipped: {skipped}",
-        f"* Cumulative duration: {duration:.2f}s",
-        f"* Success rate: {success_rate:.2f}%",
-        "",
-        "## Failing tests" if failed else "## Failing tests",
-    ]
-
-    if failed:
-        for item in results:
-            if item.status != "failed":
-                continue
-            lines.extend(
-                [
-                    f"- `{item.name}` ({item.duration:.2f}s)",
-                    f"  - Log: `{item.log_path}`" if item.log_path else "  - Log: not captured",
-                    "  - Message:",
-                    "    ```",
-                    *[f"    {line}" for line in item.message.splitlines() or ["<no message>"]],
-                    "    ```",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    skipped_section_header = "## Skipped tests"
-    lines.append("")
-    lines.append(skipped_section_header)
-    if skipped:
-        for item in results:
-            if item.status != "skipped":
-                continue
-            lines.extend(
-                [
-                    f"- `{item.name}` ({item.duration:.2f}s)",
-                    f"  - Reason: {item.message or 'not provided'}",
-                ]
-            )
-    else:
-        lines.append("- None")
-
-    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+def _preprocess_argv(argv: Sequence[str] | None) -> list[str]:
+    if not argv:
+        return []
+    processed: list[str] = []
+    skip_dashdash = False
+    for token in argv:
+        if token == "--pytest-args":
+            skip_dashdash = True
+            processed.append(token)
+            continue
+        if skip_dashdash and token == "--":
+            skip_dashdash = False
+            continue
+        processed.append(token)
+    return processed
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Execute pytest with reporting helpers.")
-    parser.add_argument("--suite", default="full", help="Label for the executed suite (used in log naming).")
+    parser = argparse.ArgumentParser(
+        description="Execute pytest with reporting helpers (deprecated wrapper)."
+    )
+    parser.add_argument("--suite", default="full", help="Ignored legacy option.")
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help="Enable debug logging for the CLI and pytest log capture.",
+        help="Enable DEBUG logging in the delegated runner.",
     )
     parser.add_argument(
         "--report-dir",
@@ -193,21 +56,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pytest-args",
         nargs=argparse.REMAINDER,
-        help="Additional arguments forwarded to pytest after '--'.",
+        help="Additional pytest arguments forwarded after '--'.",
     )
     return parser
-
-
-def _has_explicit_targets(extra_args: Sequence[str] | None) -> bool:
-    if not extra_args:
-        return False
-    for token in extra_args:
-        if token == "--":
-            continue
-        if token.startswith("-"):
-            continue
-        return True
-    return False
 
 
 def _normalise_extra_args(extra_args: Sequence[str] | None) -> list[str]:
@@ -218,62 +69,34 @@ def _normalise_extra_args(extra_args: Sequence[str] | None) -> list[str]:
     return list(extra_args)
 
 
-def _default_test_targets() -> list[str]:
-    return [str(path) for path in TEST_DIRECTORIES if path.exists()]
+def _emit_warning(message: str) -> None:
+    print(f"WARNING: {message}", file=sys.stderr, flush=True)
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(_preprocess_argv(argv))
 
-    report_dir: Path = args.report_dir
-    report_dir.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("PYTHONHASHSEED", "0")
 
-    if "PYTHONHASHSEED" not in os.environ:
-        os.environ["PYTHONHASHSEED"] = "0"
+    report_dir = Path(args.report_dir)
+    json_path = report_dir / _DEFAULT_JSON_NAME
+    markdown_path = report_dir / _DEFAULT_MARKDOWN_NAME
 
-    level = "DEBUG" if args.verbose else "INFO"
-    base_logger_cfg = LoggerConfig(level=level, logger_name="run_test_suite")
+    run_args: list[str] = ["--json", str(json_path), "--markdown", str(markdown_path)]
+    if args.verbose:
+        run_args.insert(0, "--verbose")
 
-    with setup_cli_logging("run_test_suite", base_logger_cfg) as logging_ctx:
-        configure_logger(logging_ctx.log_cfg)
+    extra_args = _normalise_extra_args(args.pytest_args)
+    if extra_args:
+        run_args.append("--")
+        run_args.extend(extra_args)
 
-        log_path = logging_ctx.log_path
-        extra_args = _normalise_extra_args(args.pytest_args)
+    _emit_warning(_DEPRECATION_MESSAGE)
+    if args.suite and args.suite != "full":
+        _emit_warning(f"Ignoring legacy --suite value: {args.suite}")
 
-        pytest_args = [
-            f"--log-file={log_path}",
-            f"--log-file-level={logging_ctx.log_cfg.level}",
-            "--maxfail=0",
-        ]
-
-        if not _has_explicit_targets(extra_args):
-            pytest_args.extend(_default_test_targets())
-
-        pytest_args.extend(extra_args)
-
-        plugin = JsonReportPlugin(log_path)
-        pytest_exit_code = pytest.main(pytest_args, plugins=[plugin])
-        exit_code = int(pytest_exit_code)
-
-        results = plugin.results
-        summary = summarize_results(results)
-
-        if summary["success_rate"] < SUCCESS_RATE_THRESHOLD:
-            logger.error(
-                "Success rate %.2f%% is below the required threshold of %.2f%%",
-                summary["success_rate"] * 100,
-                SUCCESS_RATE_THRESHOLD * 100,
-            )
-            if exit_code == 0:
-                exit_code = 1
-
-        json_path = report_dir / "test_report.json"
-        summary_path = report_dir / "test_summary.md"
-        _write_json(json_path, results, exit_code, summary)
-        _write_summary(summary_path, results, exit_code, summary)
-
-    return int(exit_code)
+    return int(run_tests.main(run_args))
 
 
 if __name__ == "__main__":

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,8 @@ The test suite is organised around the key scenarios of the ChEMBL data acquisit
 - `e2e/` – deterministic end-to-end runs of the test-item pipeline on synthetic fixtures, including export idempotence.
 - `resources/` – small CSV snapshots used by the integration and e2e scenarios.
 
-Standalone smoke checks that previously lived alongside `tests/run_tests.py` were moved into the directories above:
+Standalone smoke checks that previously lived alongside the legacy `tests/run_tests.py`
+wrapper were moved into the directories above:
 
 - activity column filtering helpers now reside in `tests/unit/test_activity_output_columns.py`;
 - assay output pruning checks live in `tests/unit/test_assay_output_columns.py`;
@@ -51,23 +52,24 @@ The scenarios exercise success and failure paths for `get_testitem_data`, `get_d
 
 ## Running tests and generating reports
 
-Install dependencies (see the repository `README.md`) and run the suite via the reporting wrapper:
+Install dependencies (see the repository `README.md`) and run the suite via the canonical
+reporting wrapper:
 
 ```bash
-python tests/run_tests.py
+python scripts/run_tests.py
 ```
 
-The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `(passed + xfailed) / max(1, total - skipped)`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success. All invocations also configure structured logging via `tests/run_tests.py` – log events are mirrored to `logs/run_tests_<YYYYMMDD>.log` (or the directory defined by `CHEMBL_DA_BASE_PATH`). Pass `--verbose` to lift the logger to DEBUG and forward the same verbosity to pytest’s log capture.
+The command executes `pytest` with the default configuration, writes the full protocol to `reports/test_report.json` and produces a human readable summary in `reports/test_summary.md`. Both artefacts contain Git metadata, timing information, a per-test breakdown and the overall success rate. The JSON payload exposes a `summary` section (totals and a `success_rate` ratio computed as `(passed + xfailed) / max(1, total - skipped)`, ranging from 0.0 to 1.0), while the Markdown file includes a `Success rate: NN.NN%` bullet for quick inspection. The wrapper enforces the ≥95% success-rate policy: if the computed ratio drops below the threshold, it emits an error log and returns a non-zero exit code even when pytest itself reports success. All invocations also configure structured logging via `scripts/run_tests.py` – log events are mirrored to `logs/run_tests_<YYYYMMDD>.log` (or the directory defined by `CHEMBL_DA_BASE_PATH`). Pass `--verbose` to lift the logger to DEBUG and forward the same verbosity to pytest’s log capture.
 
 
 When running pytest manually (e.g. `pytest --json-report --json-report-file=custom.json`), convert the structured JSON into Markdown via `python tools/make_md_summary.py --input <json> --output <markdown>` or the console entry point `make-md-summary`. Both arguments default to the standard `reports/` locations, so invoking `python tools/make_md_summary.py` is sufficient for the common workflow.
 
 
-To focus on a subset, pass extra arguments after `--pytest-args`, for example `python tests/run_tests.py --pytest-args -m unit`. Combine `--verbose` with the forwarding flag to observe detailed DEBUG events in both the console and the generated log file.
+To focus on a subset, pass extra arguments after `--pytest-args`, for example `python scripts/run_tests.py --pytest-args -m unit`. Combine `--verbose` with the forwarding flag to observe detailed DEBUG events in both the console and the generated log file.
 
 Individual modules can be targeted by pointing pytest at a directory, for example `pytest tests/unit` or `pytest tests/integration -k enrich` to filter by test name.
 
-When developing additional scenarios, keep the guardrails documented in `tests/conftest.py` (seed fixing, network ban, temporary directories) to preserve reproducibility. All new tests should emit deterministic output so that `tests/run_tests.py` can regenerate the reports without spurious diffs.
+When developing additional scenarios, keep the guardrails documented in `tests/conftest.py` (seed fixing, network ban, temporary directories) to preserve reproducibility. All new tests should emit deterministic output so that `scripts/run_tests.py` can regenerate the reports without spurious diffs.
 
 ## End-to-end scenario checklist
 

--- a/tests/unit/scripts/test_run_test_suite.py
+++ b/tests/unit/scripts/test_run_test_suite.py
@@ -1,190 +1,125 @@
-"""Unit tests for the scripts.run_test_suite helper."""
+"""Unit tests for the deprecated :mod:`scripts.run_test_suite` wrapper."""
 
 from __future__ import annotations
 
-import json
-import logging
-from contextlib import contextmanager
-import io
+import os
 from pathlib import Path
-from types import SimpleNamespace
+from typing import Sequence
 
 import pytest
 
 from scripts import run_test_suite
 
 
-def _make_result(name: str, status: str, *, duration: float = 0.1, message: str = "") -> run_test_suite.TestResult:
-    return run_test_suite.TestResult(
-        name=name,
-        status=status,
-        duration=duration,
-        message=message,
-        log_path=None,
+class _RunTestsSpy:
+    def __init__(self) -> None:
+        self.calls: list[Sequence[str]] = []
+        self.exit_code = 0
+
+    def main(self, args: Sequence[str] | None = None) -> int:
+        self.calls.append(tuple(args or []))
+        return self.exit_code
+
+
+@pytest.fixture(autouse=True)
+def _reset_hashseed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTHONHASHSEED", raising=False)
+
+
+@pytest.mark.unit
+def test_main__delegates_to_run_tests_with_default_paths(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    spy = _RunTestsSpy()
+    spy.exit_code = 7
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
+
+    exit_code = run_test_suite.main([])
+
+    assert exit_code == 7
+    assert spy.calls == [
+        (
+            "--json",
+            str(Path("reports") / "test_report.json"),
+            "--markdown",
+            str(Path("reports") / "test_summary.md"),
+        )
+    ]
+    stderr = capsys.readouterr().err.lower()
+    assert "deprecated" in stderr
+
+
+@pytest.mark.unit
+def test_main__forwards_pytest_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    spy = _RunTestsSpy()
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
+
+    exit_code = run_test_suite.main(
+        ["--pytest-args", "--", "-k", "unit", "tests/unit/test_demo.py"]
     )
 
-
-@pytest.mark.unit
-def test_write_reports__includes_success_rate(tmp_path: Path) -> None:
-    plugin = run_test_suite.JsonReportPlugin(tmp_path / "suite.log")
-    plugin._results = {
-        "tests::passed": _make_result("tests::passed", "passed"),
-        "tests::failed": _make_result("tests::failed", "failed", message="boom"),
-    }
-
-    results = plugin.results
-    summary = run_test_suite.summarize_results(results)
-
-    json_path = tmp_path / "test_report.json"
-    run_test_suite._write_json(json_path, results, exit_code=0, summary=summary)
-    payload = json.loads(json_path.read_text(encoding="utf-8"))
-
-    assert "success_rate" in payload["summary"]
-    assert pytest.approx(payload["summary"]["success_rate"]) == 0.5
-
-    md_path = tmp_path / "test_summary.md"
-    run_test_suite._write_summary(md_path, results, exit_code=0, summary=summary)
-    summary_text = md_path.read_text(encoding="utf-8")
-
-    assert "* Success rate: 50.00%" in summary_text
-
-    empty_summary = run_test_suite.summarize_results([])
-    assert empty_summary["success_rate"] == pytest.approx(1.0)
-
-
-@pytest.mark.unit
-def test_main__returns_error_when_success_rate_below_threshold(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    log_path = tmp_path / "suite.log"
-
-    captured_cfgs: list[run_test_suite.LoggerConfig] = []
-
-    def fake_configure_logger(cfg: run_test_suite.LoggerConfig, *_: object, **__: object) -> object:
-        captured_cfgs.append(cfg)
-        return object()
-
-    @contextmanager
-    def fake_setup_cli_logging(script_name: str, log_cfg: run_test_suite.LoggerConfig, *_: object, **__: object):
-        assert script_name == "run_test_suite"
-        stream = io.StringIO()
-        cloned_cfg = run_test_suite.LoggerConfig(
-            level=log_cfg.level,
-            run_id=log_cfg.run_id,
-            redact_secrets=log_cfg.redact_secrets,
-            stream=stream,
-            handlers=list(log_cfg.handlers),
-            logger_name=log_cfg.logger_name,
+    assert exit_code == 0
+    assert spy.calls == [
+        (
+            "--json",
+            str(Path("reports") / "test_report.json"),
+            "--markdown",
+            str(Path("reports") / "test_summary.md"),
+            "--",
+            "-k",
+            "unit",
+            "tests/unit/test_demo.py",
         )
-        yield SimpleNamespace(log_path=log_path, log_cfg=cloned_cfg, console_stream=stream)
-
-    monkeypatch.setattr(run_test_suite, "configure_logger", fake_configure_logger)
-    monkeypatch.setattr(run_test_suite, "setup_cli_logging", fake_setup_cli_logging)
-
-    def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
-        plugin: run_test_suite.JsonReportPlugin = plugins[0]
-        log_path = str(plugin._log_path)
-        assert captured_cfgs, "configure_logger should be called before pytest executes"
-        assert f"--log-file={log_path}" in pytest_args
-        assert f"--log-file-level={captured_cfgs[-1].level}" in pytest_args
-        plugin._results = {
-            **{
-                f"tests::pass_{index}": run_test_suite.TestResult(
-                    name=f"tests::pass_{index}",
-                    status="passed",
-                    duration=0.1,
-                    message="",
-                    log_path=log_path,
-                )
-                for index in range(18)
-            },
-            "tests::fail": run_test_suite.TestResult(
-                name="tests::fail",
-                status="failed",
-                duration=0.1,
-                message="boom",
-                log_path=log_path,
-            ),
-        }
-        return 0
-
-    monkeypatch.setattr(run_test_suite.pytest, "main", fake_pytest_main)
-
-    caplog.set_level(logging.ERROR)
-    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo"])
-
-    assert run_test_suite.SUCCESS_RATE_THRESHOLD == pytest.approx(0.95)
-    assert exit_code == 1
-    assert "below the required threshold" in caplog.text
-    assert captured_cfgs and captured_cfgs[-1].level == "INFO"
-    assert captured_cfgs[-1].logger_name == "run_test_suite"
-
-    report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
-    assert report_payload["summary"]["success_rate"] < run_test_suite.SUCCESS_RATE_THRESHOLD
+    ]
 
 
 @pytest.mark.unit
-def test_main__passes_when_success_rate_meets_threshold(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    log_path = tmp_path / "suite.log"
-    captured_cfgs: list[run_test_suite.LoggerConfig] = []
+def test_main__respects_verbose_and_report_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    spy = _RunTestsSpy()
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
 
-    def fake_configure_logger(cfg: run_test_suite.LoggerConfig, *_: object, **__: object) -> object:
-        captured_cfgs.append(cfg)
-        return object()
-
-    @contextmanager
-    def fake_setup_cli_logging(script_name: str, log_cfg: run_test_suite.LoggerConfig, *_: object, **__: object):
-        assert script_name == "run_test_suite"
-        stream = io.StringIO()
-        cloned_cfg = run_test_suite.LoggerConfig(
-            level=log_cfg.level,
-            run_id=log_cfg.run_id,
-            redact_secrets=log_cfg.redact_secrets,
-            stream=stream,
-            handlers=list(log_cfg.handlers),
-            logger_name=log_cfg.logger_name,
-        )
-        yield SimpleNamespace(log_path=log_path, log_cfg=cloned_cfg, console_stream=stream)
-
-    monkeypatch.setattr(run_test_suite, "configure_logger", fake_configure_logger)
-    monkeypatch.setattr(run_test_suite, "setup_cli_logging", fake_setup_cli_logging)
-
-    def fake_pytest_main(pytest_args, plugins):  # type: ignore[override]
-        plugin: run_test_suite.JsonReportPlugin = plugins[0]
-        log_path = str(plugin._log_path)
-        assert captured_cfgs, "configure_logger should be called before pytest executes"
-        assert f"--log-file={log_path}" in pytest_args
-        plugin._results = {
-            **{
-                f"tests::pass_{index}": run_test_suite.TestResult(
-                    name=f"tests::pass_{index}",
-                    status="passed",
-                    duration=0.1,
-                    message="",
-                    log_path=log_path,
-                )
-                for index in range(19)
-            },
-            "tests::skip": run_test_suite.TestResult(
-                name="tests::skip",
-                status="skipped",
-                duration=0.1,
-                message="not run",
-                log_path=log_path,
-            ),
-        }
-        return 0
-
-    monkeypatch.setattr(run_test_suite.pytest, "main", fake_pytest_main)
-
-    caplog.set_level(logging.ERROR)
-    exit_code = run_test_suite.main(["--report-dir", str(tmp_path), "--suite", "demo", "--verbose"])
+    exit_code = run_test_suite.main(["--verbose", "--report-dir", str(tmp_path)])
 
     assert exit_code == 0
-    assert "below the required threshold" not in caplog.text
-    assert captured_cfgs and captured_cfgs[-1].level == "DEBUG"
+    assert spy.calls == [
+        (
+            "--verbose",
+            "--json",
+            str(tmp_path / "test_report.json"),
+            "--markdown",
+            str(tmp_path / "test_summary.md"),
+        )
+    ]
 
-    report_payload = json.loads((tmp_path / "test_report.json").read_text(encoding="utf-8"))
-    assert report_payload["summary"]["success_rate"] >= run_test_suite.SUCCESS_RATE_THRESHOLD
+
+@pytest.mark.unit
+def test_main__sets_pythonhashseed_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    spy = _RunTestsSpy()
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
+
+    run_test_suite.main([])
+
+    assert os.environ["PYTHONHASHSEED"] == "0"
+
+
+@pytest.mark.unit
+def test_main__preserves_existing_pythonhashseed(monkeypatch: pytest.MonkeyPatch) -> None:
+    spy = _RunTestsSpy()
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
+    monkeypatch.setenv("PYTHONHASHSEED", "123")
+
+    run_test_suite.main([])
+
+    assert os.environ["PYTHONHASHSEED"] == "123"
+
+
+@pytest.mark.unit
+def test_main__emits_warning_for_custom_suite(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    spy = _RunTestsSpy()
+    monkeypatch.setattr(run_test_suite.run_tests, "main", spy.main)
+
+    run_test_suite.main(["--suite", "nightly"])
+
+    stderr = capsys.readouterr().err
+    assert "deprecated" in stderr.lower()
+    assert "nightly" in stderr


### PR DESCRIPTION
## Summary
- replace the legacy run_test_suite helper with a thin wrapper around scripts/run_tests.py and emit a deprecation warning
- update developer tooling and documentation to reference the canonical scripts/run_tests.py entrypoint
- refresh run_test_suite unit coverage to assert delegation, warning, and environment behaviour

## Testing
- pytest tests/unit/scripts/test_run_test_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68e56fdf487c8324919ab6dc75dfac5c