### PR TITLE
Remove duplicate generated log emission

### DIFF
--- a/library/utils/cli_tools/get_activities.py
+++ b/library/utils/cli_tools/get_activities.py
@@ -93,7 +93,6 @@ def run(cfg: Config, args: argparse.Namespace) -> int:
         output_path = Path(output_candidate)
 
     written_path = _write_output(frame, output_path, cfg=cfg)
-    logger.info("generated", count=int(frame.shape[0]))
     logger.info(
         "activity_generated",
         count=int(frame.shape[0]),

--- a/tests/unit/scripts/test_get_activities_cli.py
+++ b/tests/unit/scripts/test_get_activities_cli.py
@@ -73,7 +73,11 @@ def test_main__limit_forwarded_to_pipeline(
     assert exit_code == 0
     assert observed["limit"] == 7
     assert writer_calls == []
-    assert ("info", "generated", {"count": 7}) in logger_stub.events
+    assert (
+        "info",
+        "generated",
+        {"count": 7, "output": str(output_csv)},
+    ) in logger_stub.events
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- remove the redundant generated log without an output path from the get_activities CLI
- ensure the CLI unit test expects the structured generated event with both count and output

## Testing
- pytest tests/unit/scripts/test_get_activities_cli.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e574643ac0832482d4e1ba30672c50